### PR TITLE
Document XPath implementation structure

### DIFF
--- a/src/xml/xpath/xpath_ast.cpp
+++ b/src/xml/xpath/xpath_ast.cpp
@@ -1,7 +1,20 @@
 //********************************************************************************************************************
 // XPath AST Core Structures Implementation
 //********************************************************************************************************************
+//
+// This translation unit intentionally remains lightweight: the bulk of the Abstract Syntax Tree
+// (AST) implementation for XPath lives in the accompanying header so that the evaluator can keep
+// node construction inlined and allocation-free.  The file documents the architectural intent for
+// the AST layer and serves as the staging point for any future behavioural extensions that require
+// out-of-line definitions (for example, tree normalisation passes or diagnostics helpers).
+//
+// The AST types describe a minimal, dependency-free hierarchy that mirrors the XPath grammar used
+// by the parser.  Each node stores its role in an expression (location paths, steps, operators,
+// literal values, and so on) alongside a small vector of child nodes.  The header exposes inline
+// conveniences for traversal and construction, while this source file is available for
+// implementations that may need stateful logic, additional validation, or other functionality that
+// would otherwise bloat the header.  Keeping the structure centralised also ensures that the
+// evaluator, parser, and optimiser layers share a consistent view of the tree.
 
-// This file contains only the core AST structure definitions.
-// The actual implementation is primarily header-only for these simple data structures.
-// Any future complex AST manipulation methods would go here.
+// Currently no out-of-line methods are required; this file exists as a placeholder so that the
+// build system has a stable compilation unit to link against when optional AST behaviour is added.

--- a/src/xml/xpath/xpath_functions.cpp
+++ b/src/xml/xpath/xpath_functions.cpp
@@ -1,4 +1,19 @@
+//********************************************************************************************************************
 // XPath Function Library and Value System Implementation
+//********************************************************************************************************************
+//
+// XPath expressions depend on a rich set of standard functions and a loosely typed value model.  This
+// file provides both: XPathValue encapsulates conversions between node-sets, numbers, booleans, and
+// strings, while the function registry offers implementations of the core function library required by
+// the evaluator.  The code emphasises fidelity to the XPath 1.0 specification—string coercions mirror
+// the spec's edge cases, numeric conversions preserve NaN semantics, and node-set operations respect
+// document order guarantees enforced elsewhere in the module.
+//
+// The implementation is intentionally self-contained.  The evaluator interacts with XPathValue to
+// manipulate intermediate results and delegates built-in function invocations to the routines defined
+// below.  Keeping the behaviour consolidated here simplifies future extensions (for example, adding
+// namespace-aware functions or performance-focused helpers) without polluting the evaluator with
+// coercion details.
 
 #include "xpath_functions.h"
 #include "../xml.h"
@@ -16,6 +31,7 @@
 
 namespace {
 
+// Format a double according to XPath 1.0 number-to-string rules.
 std::string format_xpath_number(double Value)
 {
    if (std::isnan(Value)) return std::string("NaN");
@@ -52,6 +68,7 @@ bool XPathValue::to_boolean() const {
    return false;
 }
 
+// Convert a string to a number using XPath's relaxed numeric parsing rules.
 double XPathValue::string_to_number(const std::string &Value)
 {
    if (Value.empty()) return std::numeric_limits<double>::quiet_NaN();
@@ -65,6 +82,7 @@ double XPathValue::string_to_number(const std::string &Value)
    return result;
 }
 
+// Obtain the string-value of a node, following XPath's definition for text and element nodes.
 std::string XPathValue::node_string_value(XMLTag *Node)
 {
    if (!Node) return std::string();
@@ -139,6 +157,7 @@ size_t XPathValue::size() const {
 
 namespace {
 
+// Walk up the tree to locate a namespace declaration corresponding to the requested prefix.
 std::string find_in_scope_namespace(XMLTag *Node, extXML *Document, const std::string &Prefix)
 {
    XMLTag *current = Node;

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1,4 +1,17 @@
+//********************************************************************************************************************
 // XPath Tokenizer and Parser Implementation
+//********************************************************************************************************************
+//
+// The parser transforms raw XPath source into the structured representation consumed by the evaluator.
+// It begins with a character-level tokenizer that understands XPath's contextual grammar—treating the
+// asterisk differently depending on predicate state, tracking bracket and parenthesis depth, and
+// recognising identifiers, literals, and operators.  The resulting token stream feeds a recursive
+// descent parser that builds an explicit AST mirroring the production rules handled by the evaluator.
+//
+// The code is split between lightweight lexical helpers (contained in the tokenizer) and the parsing
+// routines that emit XPathNode instances.  Keeping both stages together simplifies debugging: the
+// parser can make nuanced decisions based on how tokens were generated, and the evaluator benefits
+// from a consistent interpretation of ambiguous constructs.
 
 //********************************************************************************************************************
 // XPathTokenizer Implementation
@@ -56,6 +69,7 @@ bool XPathTokenizer::has_more() const {
    return position < length;
 }
 
+// Produce a token stream while preserving context so operators like '*' are classified correctly.
 std::vector<XPathToken> XPathTokenizer::tokenize(std::string_view XPath) {
    input = XPath;
    position = 0;


### PR DESCRIPTION
## Summary
- expand the file-level documentation across the XPath AST, axis traversal, evaluator, function library, and parser sources so the purpose of each unit is clear to maintainers
- add targeted inline comments that describe key traversal, context-management, and conversion helpers to aid future readers of the XPath implementation

## Testing
- `cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON`
- `cmake --build build/agents --config Release --target xml -j 8`


------
https://chatgpt.com/codex/tasks/task_e_68d530448b24832e9f06ba102d2ca695