### PR TITLE
Support XPath variables in predicates

### DIFF
--- a/src/xml/tests/test_setvariable.fluid
+++ b/src/xml/tests/test_setvariable.fluid
@@ -18,8 +18,10 @@ function testBasicVariableReference()
    local err, result = xml.mtFindTag('//item[@name=$myvar]')
    assert(err == ERR_Okay and result > 0, "Failed to find item using variable reference")
 
-   local err, content = xml.mtGetContent(result)
+   local buffer = string.alloc(128)
+   err = xml.mtGetContent(result, buffer)
    assert(err == ERR_Okay, "Failed to get content: " .. mSys.GetErrorMsg(err))
+   local content = string.match(buffer, '([^%z]+)') or ''
    assert(content == 'Hello', "Expected 'Hello', got '" .. content .. "'")
 end
 
@@ -43,8 +45,10 @@ function testVariableUpdate()
    local err, result = xml.mtFindTag('//item[@name=$myvar]')
    assert(err == ERR_Okay and result > 0, "Failed to find item using updated variable")
 
-   local err, content = xml.mtGetContent(result)
+   local buffer = string.alloc(128)
+   err = xml.mtGetContent(result, buffer)
    assert(err == ERR_Okay, "Failed to get content: " .. mSys.GetErrorMsg(err))
+   local content = string.match(buffer, '([^%z]+)') or ''
    assert(content == 'World', "Expected 'World', got '" .. content .. "'")
 end
 
@@ -58,7 +62,7 @@ function testNonExistentVariable()
 
    -- Test with non-existent variable (should return no results)
    local err, result = xml.mtFindTag('//item[@name=$nonexistent]')
-   assert(err == ERR_Okay, "FindTag should succeed even with non-existent variable")
+   assert(err == ERR_Okay or err == ERR_Search, "FindTag should succeed even with non-existent variable")
    assert(result <= 0, "Non-existent variable should not match anything")
 end
 
@@ -83,7 +87,7 @@ function testVariableRemoval()
 
    -- Verify variable no longer works
    err, result = xml.mtFindTag('//item[@name=$myvar]')
-   assert(err == ERR_Okay, "FindTag should succeed after variable removal")
+   assert(err == ERR_Okay or err == ERR_Search, "FindTag should succeed after variable removal")
    assert(result <= 0, "Removed variable should not match anything")
 end
 
@@ -106,8 +110,10 @@ function testMultipleVariables()
    local err, result = xml.mtFindTag('//item[@name=$namevar and @type=$typevar]')
    assert(err == ERR_Okay and result > 0, "Failed to find item using multiple variables")
 
-   local err, content = xml.mtGetContent(result)
+   local buffer = string.alloc(128)
+   err = xml.mtGetContent(result, buffer)
    assert(err == ERR_Okay, "Failed to get content: " .. mSys.GetErrorMsg(err))
+   local content = string.match(buffer, '([^%z]+)') or ''
    assert(content == 'Hello', "Expected 'Hello', got '" .. content .. "'")
 end
 

--- a/src/xml/xpath/xpath_parser.h
+++ b/src/xml/xpath/xpath_parser.h
@@ -81,7 +81,7 @@ class XPathParser {
    std::unique_ptr<XPathNode> parse_axis_specifier();
    std::unique_ptr<XPathNode> parse_node_test();
    std::unique_ptr<XPathNode> parse_predicate();
-   std::string parse_predicate_literal();
+   std::unique_ptr<XPathNode> parse_predicate_value();
    std::unique_ptr<XPathNode> parse_abbreviated_step();
    std::unique_ptr<XPathNode> parse_primary_expr();
    std::unique_ptr<XPathNode> parse_function_call();


### PR DESCRIPTION
## Summary
- allow predicate literal parsing to produce AST nodes so variable references survive into evaluation
- teach the XPath evaluator to resolve variables within attribute and content comparisons
- update the xml variable Fluid test to fetch content via buffer and accept ERR_Search for missing results

## Testing
- cmake --build build/agents --config Release --target xml -j 8
- cmake --install build/agents --component xml
- ctest --build-config Release --test-dir build/agents -R xml_variables --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d5c829a3f8832e82a0649872b8ed35