### PR TITLE
Fix XPath fn:exists handling for empty string values

### DIFF
--- a/src/xml/xpath/xpath_functions.cpp
+++ b/src/xml/xpath/xpath_functions.cpp
@@ -1191,23 +1191,16 @@ XPathValue XPathFunctionLibrary::function_exists(const std::vector<XPathValue> &
    if (value.type IS XPathValueType::NodeSet) {
       if (not value.node_set.empty()) return XPathValue(true);
 
-      if (value.node_set_string_override.has_value()) {
-         return XPathValue(!value.node_set_string_override->empty());
-      }
+      if (value.node_set_string_override.has_value()) return XPathValue(true);
 
-      if (not value.node_set_string_values.empty()) {
-         for (const std::string &entry : value.node_set_string_values) {
-            if (!entry.empty()) return XPathValue(true);
-         }
-         return XPathValue(false);
-      }
+      if (not value.node_set_string_values.empty()) return XPathValue(true);
 
       if (not value.node_set_attributes.empty()) return XPathValue(true);
 
       return XPathValue(false);
    }
 
-   return XPathValue(!value.is_empty());
+   return XPathValue(true);
 }
 
 XPathValue XPathFunctionLibrary::function_number(const std::vector<XPathValue> &Args, const XPathContext &Context) {


### PR DESCRIPTION
## Summary
- update fn:exists so string overrides and value vectors count as items even when their text is empty
- return true for non-node sequences to match XPath semantics for atomic values

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d7dd97d3ac832ea6c3896cfe55d74a