### PR TITLE
Refine XPath sequence tests for installed environment

### DIFF
--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -27,6 +27,7 @@ flute_test (${MOD}_parsing "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xml_parsing.f
 flute_test (${MOD}_namespaces "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_namespaces.fluid")
 flute_test (${MOD}_variables "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_setvariable.fluid")
 flute_test (${MOD}_xpath_func_ext "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_func_ext.fluid")
+flute_test (${MOD}_xpath_sequences "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_sequences.fluid")
 
 if (INSTALL_TESTS)
    add_executable (test_xml_count_debug "tests/test_count_debug.cpp")

--- a/src/xml/tests/test_xpath_sequences.fluid
+++ b/src/xml/tests/test_xpath_sequences.fluid
@@ -1,0 +1,174 @@
+-- XPath sequence function tests
+
+   include 'xml'
+
+local sequence_document = table.concat({
+   '<root>',
+      '<empty/>',
+      '<numbers>',
+         '<value code="one" order="1">1</value>',
+         '<value code="two" order="2">2</value>',
+         '<value code="three" order="3">3</value>',
+      '</numbers>',
+      '<duplicates>',
+         '<value>alpha</value>',
+         '<value>beta</value>',
+         '<value>alpha</value>',
+         '<value>gamma</value>',
+      '</duplicates>',
+      '<order>',
+         '<step pos="1"/>',
+         '<step pos="3"/>',
+         '<step pos="4"/>',
+      '</order>',
+      '<codes>',
+         '<code>1</code>',
+         '<code>2</code>',
+         '<code>3</code>',
+      '</codes>',
+      '<optional>',
+         '<value>42</value>',
+      '</optional>',
+      '<single>',
+         '<value>99</value>',
+      '</single>',
+   '</root>'
+})
+
+local function createSequenceXml()
+   return obj.new("xml", { statement = sequence_document })
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Validate empty() behaviour
+
+function testEmptyFunction()
+   local xml = createSequenceXml()
+
+   local emptyValue = xml.getKey('empty(/root/empty/item)')
+   assert(emptyValue == 'true', "empty should return true for missing nodes, got " .. nz(emptyValue, 'NIL'))
+
+   local nonEmptyValue = xml.getKey('empty(/root/numbers/value)')
+   assert(nonEmptyValue == 'false', "empty should return false for existing nodes, got " .. nz(nonEmptyValue, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Verify index-of returns all matching positions
+
+function testIndexOfFunction()
+   local xml = createSequenceXml()
+
+   local matchCount = tonumber(xml.getKey('count(index-of(/root/duplicates/value, "alpha"))'))
+   assert(matchCount == 2, "index-of should report two matches, got " .. tostring(matchCount))
+
+   local firstMatch = tonumber(xml.getKey('index-of(/root/duplicates/value, "alpha")[1]'))
+   assert(firstMatch == 1, "index-of should report first occurrence at position 1, got " .. tostring(firstMatch))
+
+   local secondMatch = tonumber(xml.getKey('index-of(/root/duplicates/value, "alpha")[2]'))
+   assert(secondMatch == 3, "index-of should report second occurrence at position 3, got " .. tostring(secondMatch))
+
+   local numericMatch = tonumber(xml.getKey('index-of(/root/numbers/value, "2")[1]'))
+   assert(numericMatch == 2, "index-of should locate numeric content at the correct position, got " .. tostring(numericMatch))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Distinct values should preserve first occurrence order
+
+function testDistinctValuesFunction()
+   local xml = createSequenceXml()
+
+   local totalValues = tonumber(xml.getKey('count(distinct-values(/root/duplicates/value))'))
+   assert(totalValues == 3, "distinct-values should return three unique entries, got " .. tostring(totalValues))
+
+   local firstValue = xml.getKey('distinct-values(/root/duplicates/value)[1]')
+   assert(firstValue == 'alpha', "distinct-values should keep first occurrence of alpha, got " .. nz(firstValue, 'NIL'))
+
+   local secondValue = xml.getKey('distinct-values(/root/duplicates/value)[2]')
+   assert(secondValue == 'beta', "distinct-values should keep beta in second position, got " .. nz(secondValue, 'NIL'))
+
+   local thirdValue = xml.getKey('distinct-values(/root/duplicates/value)[3]')
+   assert(thirdValue == 'gamma', "distinct-values should keep gamma as last entry, got " .. nz(thirdValue, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- insert-before, remove and reverse sequence operations
+
+function testInsertRemoveReverse()
+   local xml = createSequenceXml()
+
+   local insertFirst = xml.getKey('insert-before(/root/order/step/@pos, 2, "2")[1]')
+   assert(insertFirst == '1', "insert-before should retain first element, got " .. nz(insertFirst, 'NIL'))
+
+   local insertSecond = xml.getKey('insert-before(/root/order/step/@pos, 2, "2")[2]')
+   assert(insertSecond == '2', "insert-before should place new value at position 2, got " .. nz(insertSecond, 'NIL'))
+
+   local insertThird = xml.getKey('insert-before(/root/order/step/@pos, 2, "2")[3]')
+   assert(insertThird == '3', "insert-before should shift original third element, got " .. nz(insertThird, 'NIL'))
+
+   local insertFourth = xml.getKey('insert-before(/root/order/step/@pos, 2, "2")[4]')
+   assert(insertFourth == '4', "insert-before should append remaining element, got " .. nz(insertFourth, 'NIL'))
+
+   local removedFirst = xml.getKey('remove(/root/codes/code, 2)[1]')
+   assert(removedFirst == '1', "remove should keep first element, got " .. nz(removedFirst, 'NIL'))
+
+   local removedSecond = xml.getKey('remove(/root/codes/code, 2)[2]')
+   assert(removedSecond == '3', "remove should drop middle element, got " .. nz(removedSecond, 'NIL'))
+
+   local reverseFirst = xml.getKey('reverse(/root/codes/code)[1]')
+   assert(reverseFirst == '3', "reverse should place last element first, got " .. nz(reverseFirst, 'NIL'))
+
+   local reverseSecond = xml.getKey('reverse(/root/codes/code)[2]')
+   assert(reverseSecond == '2', "reverse should place middle element second, got " .. nz(reverseSecond, 'NIL'))
+
+   local reverseThird = xml.getKey('reverse(/root/codes/code)[3]')
+   assert(reverseThird == '1', "reverse should place first element last, got " .. nz(reverseThird, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- subsequence, unordered and deep-equal checks
+
+function testSubsequenceDeepEqual()
+   local xml = createSequenceXml()
+
+   local subseqFirst = xml.getKey('subsequence(/root/duplicates/value, 2, 2)[1]')
+   assert(subseqFirst == 'beta', "subsequence should extract beta as first result, got " .. nz(subseqFirst, 'NIL'))
+
+   local subseqSecond = xml.getKey('subsequence(/root/duplicates/value, 2, 2)[2]')
+   assert(subseqSecond == 'alpha', "subsequence should extract alpha as second result, got " .. nz(subseqSecond, 'NIL'))
+
+   local unorderedEqual = xml.getKey('deep-equal(unordered(/root/codes/code), /root/codes/code)')
+   assert(unorderedEqual == 'true', "unordered should preserve all members, got " .. nz(unorderedEqual, 'NIL'))
+
+   local deepEqualTrue = xml.getKey('deep-equal(/root/codes/code, /root/codes/code)')
+   assert(deepEqualTrue == 'true', "deep-equal should return true for identical sequences, got " .. nz(deepEqualTrue, 'NIL'))
+
+   local deepEqualFalse = xml.getKey('deep-equal(/root/codes/code, remove(/root/codes/code, 3))')
+   assert(deepEqualFalse == 'false', "deep-equal should detect differing lengths, got " .. nz(deepEqualFalse, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Cardinality helper functions
+
+function testCardinalityFunctions()
+   local xml = createSequenceXml()
+
+   local zeroOneValue = tonumber(xml.getKey('number(zero-or-one(/root/optional/value))'))
+   assert(zeroOneValue == 42, "zero-or-one should return the single item, got " .. tostring(zeroOneValue))
+
+   local zeroOneEmpty = tonumber(xml.getKey('count(zero-or-one(/root/missing/value))'))
+   assert(zeroOneEmpty == 0, "zero-or-one should allow empty sequence, got " .. tostring(zeroOneEmpty))
+
+   local oneOrMoreCount = tonumber(xml.getKey('count(one-or-more(/root/codes/code))'))
+   assert(oneOrMoreCount == 3, "one-or-more should keep all items, got " .. tostring(oneOrMoreCount))
+
+   local exactlyOne = tonumber(xml.getKey('number(exactly-one(/root/single/value))'))
+   assert(exactlyOne == 99, "exactly-one should return the single value, got " .. tostring(exactlyOne))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+return {
+   tests = {
+      'testEmptyFunction', 'testIndexOfFunction', 'testDistinctValuesFunction',
+      'testInsertRemoveReverse', 'testSubsequenceDeepEqual', 'testCardinalityFunctions'
+   }
+}

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -196,6 +196,18 @@ class XPathFunctionLibrary {
    static XPathValue function_false(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_lang(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_exists(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_index_of(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_empty(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_distinct_values(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_insert_before(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_remove(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_reverse(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_subsequence(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_unordered(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_deep_equal(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_zero_or_one(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_one_or_more(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_exactly_one(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_number(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_sum(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_floor(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
## Summary
- update the XPath sequence Flute tests to build a reusable sample document for exercising sequence operators
- replace unsupported string-join usage with position-based assertions so index-of, distinct-values, insert-before, remove, reverse, subsequence, deep-equal, and cardinality helpers run correctly

## Testing
- cmake --build build/agents --target xml -j 8
- cmake --install build/agents
- ctest --test-dir build/agents -R xml_xpath_sequences


------
https://chatgpt.com/codex/tasks/task_e_68da6d9d4cc8832eb7b4ddc7731707ee