### PR TITLE
Refine XPath tokenizer keyword handling

### DIFF
--- a/src/xml/xpath/xpath_ast.h
+++ b/src/xml/xpath/xpath_ast.h
@@ -9,6 +9,11 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
 //********************************************************************************************************************
 // XPath Tokenization Infrastructure
 

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -134,7 +134,7 @@ bool XPathParser::has_errors() const
    return !errors.empty();
 }
 
-std::vector<std::string> XPathParser::get_errors() const
+const std::vector<std::string> & XPathParser::get_errors() const
 {
    return errors;
 }

--- a/src/xml/xpath/xpath_parser.h
+++ b/src/xml/xpath/xpath_parser.h
@@ -78,7 +78,7 @@ class XPathParser {
    // Error handling
    void report_error(std::string_view Message);
    bool has_errors() const;
-   std::vector<std::string> get_errors() const;
+   const std::vector<std::string> & get_errors() const;
 
    private:
    std::vector<std::string> errors;

--- a/src/xml/xpath/xpath_tokenizer.h
+++ b/src/xml/xpath/xpath_tokenizer.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <ankerl/unordered_dense.h>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -14,9 +12,6 @@ class XPathTokenizer
    std::string_view input;
    size_t position;
    size_t length;
-
-   static ankerl::unordered_dense::map<std::string_view, std::string> interned_strings;
-   static void initialize_interned_strings();
 
    [[nodiscard]] bool is_alpha(char c) const;
    [[nodiscard]] bool is_digit(char c) const;
@@ -42,4 +37,3 @@ class XPathTokenizer
    [[nodiscard]] char current() const;
    void advance();
 };
-


### PR DESCRIPTION
This pull request refactors and modernizes the XPath tokenizer and parser codebase, focusing on simplifying keyword/operator handling and improving error reporting efficiency. The most significant changes include replacing manual keyword/operator matching with modern C++ constructs, removing legacy interned string infrastructure, and optimizing error reporting interfaces.

### Tokenizer and Keyword/Operator Handling Improvements
* Replaced manual keyword and operator matching in `xpath_tokenizer.cpp` with `constexpr std::array` mappings and modern C++ algorithms (`std::ranges::find_if`), making the code more maintainable and efficient.
* Removed legacy interned string infrastructure and related static initialization logic, eliminating unnecessary complexity and dependencies (including `ankerl/unordered_dense` and `mutex`).

### Error Reporting Optimization
* Changed the `get_errors()` method in `XPathParser` to return a const reference to the internal error vector instead of copying, improving performance and interface clarity.

### Miscellaneous Code Cleanups
* Added missing standard library includes to `xpath_ast.h` for improved portability and compilation reliability.
* Minor cleanups in `xpath_tokenizer.h`, such as removing trailing whitespace and unused code.

These changes collectively modernize the codebase, improve performance, and make future maintenance easier.