### PR TITLE
Adopt C++20 using aliases in core modules

### DIFF
--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -112,8 +112,8 @@ For information about the HTTP protocol, please refer to the official protocol w
 constexpr int MAX_AUTH_RETRIES = 5;
 constexpr int HASHLEN = 16;
 constexpr int HASHHEXLEN = 32;
-typedef char HASH[HASHLEN];
-typedef char HASHHEX[HASHHEXLEN+1];
+using HASH = char[HASHLEN];
+using HASHHEX = char[HASHHEXLEN+1];
 
 // Security limits
 constexpr int64_t MAX_CONTENT_LENGTH = 10LL * 1024 * 1024 * 1024; // 10GB max

--- a/src/link/init-unix.cpp
+++ b/src/link/init-unix.cpp
@@ -22,8 +22,8 @@ This file is in the public domain and may be distributed and modified without re
 
 struct CoreBase *CoreBase;
 static APTR glCoreHandle = nullptr;
-typedef ERR OPENCORE(struct OpenInfo *, struct CoreBase **);
-typedef void CLOSECORE(void);
+using OPENCORE = ERR(struct OpenInfo *, struct CoreBase **);
+using CLOSECORE = void(void);
 static CLOSECORE *CloseCore = nullptr;
 #else
 static struct CoreBase *CoreBase; // Dummy

--- a/src/link/init-win.cpp
+++ b/src/link/init-win.cpp
@@ -16,8 +16,8 @@ extern "C" {
 DLLCALL APTR WINAPI GetProcAddress(APTR, CSTRING);
 DLLCALL int WINAPI FreeLibrary(APTR);
 }
-typedef ERR OPENCORE(struct OpenInfo *, struct CoreBase **);
-typedef void CLOSECORE(void);
+using OPENCORE = ERR(struct OpenInfo *, struct CoreBase **);
+using CLOSECORE = void(void);
 
 struct CoreBase *CoreBase;
 static APTR find_core(char *PathBuffer, int Size);
@@ -56,7 +56,7 @@ extern "C" const char * init_parasol(int argc, CSTRING *argv)
    info.Error = ERR::Okay;
    info.Flags = OPF::ARGS|OPF::ERROR;
 
-   if (OpenCore(&info, &CoreBase) == ERR::Okay) return nullptr;
+   if (OpenCore(&info, &CoreBase) IS ERR::Okay) return nullptr;
    else if (info.Error IS ERR::CoreVersion) {
       return "This program requires the latest version of the Parasol framework.\nPlease visit www.parasol.ws to upgrade.";
    }

--- a/src/svg/anim.h
+++ b/src/svg/anim.h
@@ -96,8 +96,8 @@ public:
       spline_point(pf::POINT<float> pPoint, float pAngle) : point(pPoint), angle(pAngle) { }
    };
 
-   typedef std::vector<float> DISTANCES;
-   typedef std::vector<spline_point> SPLINE_POINTS;
+   using DISTANCES = std::vector<float>;
+   using SPLINE_POINTS = std::vector<spline_point>;
 
    class spline_path {
    public:

--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -97,8 +97,8 @@ struct ParseState {
    }
 };
 
-typedef objXML::TAGS TAGS;
-typedef objXML::CURSOR CURSOR;
+using TAGS = objXML::TAGS;
+using CURSOR = objXML::CURSOR;
 
 //********************************************************************************************************************
 // Generic lookup templates with concepts


### PR DESCRIPTION
## Summary
- replace legacy typedefs with modern using aliases in HTTP digest helpers and XML cursor helpers
- update SVG animation support types to use using aliases for improved readability
- align POSIX and Windows core initialisers on using-based function aliases and adhere to the IS comparison macro on Windows

## Testing
- cmake --build build/agents --config FastBuild --parallel

------
https://chatgpt.com/codex/tasks/task_e_68ecd01e5834832eb278648df5c52fb7