### PR TITLE
Use constexpr for compile-time constants

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -510,7 +510,7 @@ struct ClassRecord {
    std::string Header;
    std::string Icon;
 
-   static const int MIN_SIZE = sizeof(CLASSID) + sizeof(CLASSID) + sizeof(int) + (sizeof(int) * 4);
+   static constexpr int MIN_SIZE = sizeof(CLASSID) + sizeof(CLASSID) + sizeof(int) + (sizeof(int) * 4);
 
    ClassRecord() { }
 

--- a/src/core/lib_events.cpp
+++ b/src/core/lib_events.cpp
@@ -13,7 +13,7 @@ Name: Events
 
 #include "defs.h"
 
-static const std::array<CSTRING, int(EVG::END)> glEventGroups = {
+static constexpr std::array<CSTRING, int(EVG::END)> glEventGroups = {
    nullptr,
    "filesystem",
    "network",

--- a/src/core/tests/memory_locking.cpp
+++ b/src/core/tests/memory_locking.cpp
@@ -80,15 +80,15 @@ static void * test_locking(void *Arg)
 //********************************************************************************************************************
 // Allocate and free sets of memory blocks at random intervals.
 
-static const int TOTAL_ALLOC = 2000;
+static constexpr int glTotalAlloc = 2000;
 
 static void * test_allocation(void *Arg)
 {
-   APTR memory[TOTAL_ALLOC];
+   APTR memory[glTotalAlloc];
 
    int i, j;
    int start = 0;
-   for (i=0; i < TOTAL_ALLOC; i++) {
+   for (i=0; i < glTotalAlloc; i++) {
       AllocMemory(1024, MEM::DATA|MEM::NO_CLEAR, &memory[i], nullptr);
       if (rand() % 10 > 7) {
          for (j=start; j < i; j++) {

--- a/src/launcher/fluid.cpp
+++ b/src/launcher/fluid.cpp
@@ -17,7 +17,7 @@ static bool glTime = false;
 static STRING glProcedure = nullptr;
 static STRING glTargetFile = nullptr;
 
-static const char glHelp[] = {
+static constexpr char glHelp[] = {
 "Usage: fluid [options...] script.fluid [--arg1=v1 --arg2=v2 ...]\n\
 \n\
 Special options are:\n\

--- a/src/launcher/parasol.cpp
+++ b/src/launcher/parasol.cpp
@@ -36,7 +36,7 @@ static bool glBackstage = false;
 
 static ERR exec_source(CSTRING, int, const std::string);
 
-static const char glHelp[] = {
+static constexpr char glHelp[] = {
 "This command-line program can execute Fluid scripts and PARC files developed for the Parasol framework.\n\
 \n\
    parasol [options] [script.ext] arg1 arg2=value ...\n\


### PR DESCRIPTION
## Summary
- adopt constexpr for the event group lookup table to ensure compile-time initialization
- promote several global help strings and configuration constants to constexpr for clarity
- update the memory locking test constants to constexpr with consistent naming

## Testing
- cmake --build build/agents --config FastBuild --parallel

------
https://chatgpt.com/codex/tasks/task_e_68ecd8770c50832eb40d9803ce844ce1