### PR TITLE
Fix XPath ExprSingle parsing and constructor coverage

### DIFF
--- a/src/xml/tests/test_xpath_constructors.fluid
+++ b/src/xml/tests/test_xpath_constructors.fluid
@@ -70,10 +70,39 @@ function testDocumentConstructor()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Attribute and sequence content should merge correctly inside constructors
+
+function testConstructorAttributeSequences()
+   local xml = obj.new("xml", { statement = '<root/>' })
+
+   local mergedCount = tonumber(xml.getKey('count(element wrapper { (attribute first { "1" }, attribute second { "2" }), element child { "value" } }/@*)'))
+   assert(mergedCount == 2, 'Element constructor should merge attribute sequences into the result, got ' .. tostring(mergedCount))
+
+   local mergedAttr = xml.getKey('string(element wrapper { (attribute first { "1" }, attribute second { "2" }), element child { "value" } }/@second)')
+   assert(mergedAttr == '2', 'Element constructor should preserve attribute values from sequences, got ' .. nz(mergedAttr, 'NIL'))
+
+   local firstChild = xml.getKey('name((element wrapper { (attribute first { "1" }, attribute second { "2" }), element child { "value" } }/node())[1])')
+   assert(firstChild == 'child', 'Element constructor should retain subsequent child nodes after attributes, got ' .. nz(firstChild, 'NIL'))
+
+   local dynamicAttr = xml.getKey('string((let $attrs := (attribute id { "main" }, attribute role { "admin" }) return element wrapper { $attrs, text { "ready" } })/@role)')
+   assert(dynamicAttr == 'admin', 'Element constructor should append dynamic attribute sequences before content, got ' .. nz(dynamicAttr, 'NIL'))
+
+   local firstText = xml.getKey('string((let $attrs := (attribute id { "main" }) return element wrapper { $attrs, text { "ready" }, "!" })/text()[1])')
+   assert(firstText == 'ready', 'Element constructor should keep constructed text content before atomic values, got ' .. nz(firstText, 'NIL'))
+
+   local secondText = xml.getKey('string((let $attrs := (attribute id { "main" }) return element wrapper { $attrs, text { "ready" }, "!" })/text()[2])')
+   assert(secondText == '!', 'Element constructor should append atomic values as subsequent text nodes, got ' .. nz(secondText, 'NIL'))
+
+   local combinedText = xml.getKey('concat((let $attrs := (attribute id { "main" }) return element wrapper { $attrs, text { "ready" }, "!" })/text()[1], (let $attrs := (attribute id { "main" }) return element wrapper { $attrs, text { "ready" }, "!" })/text()[2])')
+   assert(combinedText == 'ready!', 'Element constructor should preserve text node ordering when combined explicitly, got ' .. nz(combinedText, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 
 return {
    tests = {
       'testDirectConstructorEvaluation', 'testComputedConstructors',
-      'testNonElementConstructors', 'testDocumentConstructor'
+      'testNonElementConstructors', 'testDocumentConstructor',
+      'testConstructorAttributeSequences'
    }
 }

--- a/src/xpath/functions/func_nodeset.cpp
+++ b/src/xpath/functions/func_nodeset.cpp
@@ -114,6 +114,7 @@ XPathVal XPathFunctionLibrary::function_local_name(const std::vector<XPathVal> &
 
    if (target_attribute) {
       std::string_view name = target_attribute->Name;
+      if (!name.empty() and name.front() IS '?') return XPathVal(std::string(name.substr(1)));
       auto colon = name.find(':');
       if (colon IS std::string::npos) return XPathVal(std::string(name));
       return XPathVal(std::string(name.substr(colon + 1)));
@@ -123,6 +124,7 @@ XPathVal XPathFunctionLibrary::function_local_name(const std::vector<XPathVal> &
    if (target_node->Attribs.empty()) return XPathVal(std::string());
 
    std::string_view node_name = target_node->Attribs[0].Name;
+   if (!node_name.empty() and node_name.front() IS '?') return XPathVal(std::string(node_name.substr(1)));
    if (node_name.empty()) return XPathVal(std::string());
 
    auto colon = node_name.find(':');
@@ -205,6 +207,8 @@ XPathVal XPathFunctionLibrary::function_name(const std::vector<XPathVal> &Args, 
    if (not target_node) return XPathVal(std::string());
    if (target_node->Attribs.empty()) return XPathVal(std::string());
 
-   return XPathVal(target_node->Attribs[0].Name);
+   std::string name = target_node->Attribs[0].Name;
+   if (!name.empty() and name.front() IS '?') name.erase(0, 1);
+   return XPathVal(std::move(name));
 }
 

--- a/src/xpath/xpath_parser.h
+++ b/src/xpath/xpath_parser.h
@@ -28,6 +28,7 @@ class XPathParser {
 
    // Grammar rule methods
    std::unique_ptr<XPathNode> parse_expr();
+   std::unique_ptr<XPathNode> parse_expr_single();
    std::unique_ptr<XPathNode> parse_flwor_expr();
    std::unique_ptr<XPathNode> parse_or_expr();
    std::unique_ptr<XPathNode> parse_and_expr();


### PR DESCRIPTION
## Summary
- ensure the XPath parser uses ExprSingle for FLWOR bindings, quantified expressions, and function arguments so commas no longer over-consume expressions
- prevent duplicate constructor attributes while merging sequence content and strip internal prefixes from processing-instruction names
- add regression coverage for constructor attribute sequences and mixed text content

## Testing
- cmake --build build/agents --config FastBuild --parallel
- cmake --install build/agents
- ctest --build-config FastBuild --test-dir build/agents -L xml


------
https://chatgpt.com/codex/tasks/task_e_68eea053d170832eb3954fbddf781e9f