### PR TITLE
Fix whitespace handling in XPath direct constructors

### DIFF
--- a/src/xml/tests/test_xpath_constructors.fluid
+++ b/src/xml/tests/test_xpath_constructors.fluid
@@ -19,6 +19,23 @@ function testDirectConstructorEvaluation()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Direct constructors should preserve literal whitespace inside element content
+
+function testDirectConstructorWhitespace()
+   local xml = obj.new("xml", { statement = '<root/>' })
+
+   local singleSpace = xml.getKey('string(<a>hello world</a>)')
+   assert(singleSpace == 'hello world', 'Direct constructor should preserve single spaces, got ' .. nz(singleSpace, 'NIL'))
+
+   local leading = xml.getKey('string(<a>  padded  </a>)')
+   assert(leading == '  padded  ', 'Direct constructor should retain leading and trailing spaces, got ' .. nz(leading, 'NIL'))
+
+   local multiline = xml.getKey([[string(<a>line 1
+   line 2</a>)]])
+   assert(multiline == "line 1\n   line 2", 'Direct constructor should keep newline indentation, got ' .. nz(multiline, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Computed constructors should honour dynamic names and content expressions
 
 function testComputedConstructors()
@@ -101,7 +118,7 @@ end
 
 return {
    tests = {
-      'testDirectConstructorEvaluation', 'testComputedConstructors',
+      'testDirectConstructorEvaluation', 'testDirectConstructorWhitespace', 'testComputedConstructors',
       'testNonElementConstructors', 'testDocumentConstructor',
       'testConstructorAttributeSequences'
    }

--- a/src/xpath/xpath_ast.h
+++ b/src/xpath/xpath_ast.h
@@ -105,6 +105,7 @@ enum class XPathTokenType {
    PI_END,            // ?>
 
    // Special tokens
+   TEXT_CONTENT,      // literal content inside direct constructors
    END_OF_INPUT,
    UNKNOWN
 };


### PR DESCRIPTION
## Summary
- emit dedicated TEXT_CONTENT tokens for direct constructor text and suspend whitespace skipping while outside start tags
- track constructor expression brace depth so embedded expressions continue to tokenize correctly
- add Flute regression coverage for whitespace preservation in direct constructors

## Testing
- cmake --build build/agents --config FastBuild --target xpath --parallel
- cmake --install build/agents
- ctest --build-config FastBuild --test-dir build/agents -R xml_xpath_constructors --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68eead3bbf98832ea18bf783c20d80ed