### PR TITLE
Integrate prolog-aware evaluation for XQuery functions and variables

### DIFF
--- a/docs/plans/XQUERY_PROLOG_PLAN.md
+++ b/docs/plans/XQUERY_PROLOG_PLAN.md
@@ -505,33 +505,33 @@ Each phase should land with targeted regression tests using existing Fluid-based
 #### Phase 3: Evaluation Integration
 
 **Evaluator Threading:**
-- [ ] Update `XPathEvaluator` constructor to accept compiled query root
-- [ ] Set `context.prolog = query_root.get_prolog()` in evaluator initialisation
-- [ ] Set `context.module_cache = query_root.get_module_cache()` in evaluator initialisation
-- [ ] Thread compiled query pointer through `evaluate_xpath_expression()` entry point
-- [ ] Thread compiled query pointer through `find_tag()` entry point
+- [x] Update `XPathEvaluator` constructor to accept compiled query root
+- [x] Set `context.prolog = query_root.get_prolog()` in evaluator initialisation
+- [x] Set `context.module_cache = query_root.get_module_cache()` in evaluator initialisation
+- [x] Thread compiled query pointer through `evaluate_xpath_expression()` entry point
+- [x] Thread compiled query pointer through `find_tag()` entry point
 
 **Function Resolution:**
-- [ ] Update `evaluate_function_call()` to check prolog before built-in library
-- [ ] Implement `evaluate_user_defined_function()` method
-- [ ] Implement parameter binding with `VariableBindingGuard`
-- [ ] Implement function body evaluation with proper scoping
-- [ ] Add arity checking and error reporting
-- [ ] Add external function detection and error handling
-- [ ] Support recursive function calls
+- [x] Update `evaluate_function_call()` to check prolog before built-in library
+- [x] Implement `evaluate_user_defined_function()` method
+- [x] Implement parameter binding with `VariableBindingGuard`
+- [x] Implement function body evaluation with proper scoping
+- [x] Add arity checking and error reporting
+- [x] Add external function detection and error handling
+- [x] Support recursive function calls
 
 **Variable Resolution:**
-- [ ] Implement variable lookup helper checking dynamic context first
-- [ ] Extend variable lookup to consult prolog declared variables
-- [ ] Evaluate variable initialiser expressions when needed
-- [ ] Add external variable detection and error handling
-- [ ] Integrate module variable resolution via cache
+- [x] Implement variable lookup helper checking dynamic context first
+- [x] Extend variable lookup to consult prolog declared variables
+- [x] Evaluate variable initialiser expressions when needed
+- [x] Add external variable detection and error handling
+- [ ] Integrate module variable resolution via cache *(pending module loading support)*
 
 **Module Resolution:**
-- [ ] Implement module cache lookup in `evaluate_function_call()`
+- [x] Implement module cache lookup in `evaluate_function_call()` *(records imports and validates cache availability)*
 - [ ] Implement deferred module loading via `fetch_or_load()`
-- [ ] Add module import error handling
-- [ ] Add unsupported feature diagnostics when cache unavailable
+- [x] Add module import error handling
+- [x] Add unsupported feature diagnostics when cache unavailable
 
 **Prolog Settings Enforcement:**
 - [ ] Implement `boundary-space` behavior in element constructors

--- a/src/xpath/xpath.cpp
+++ b/src/xpath/xpath.cpp
@@ -339,7 +339,7 @@ ERR Evaluate(objXML *XML, APTR Query, XPathValue **Result)
       SetResourceMgr(xpv, &glXPVManager);
       new (xpv) XPathVal(); // Placement new to construct a dummy XPathVal object
 
-      XPathEvaluator eval(xml);
+      XPathEvaluator eval(xml, compiled_path);
       auto err = eval.evaluate_xpath_expression(*compiled_path, (XPathVal *)xpv);
       if (err != ERR::Okay) {
          FreeResource(xpv);
@@ -397,7 +397,7 @@ ERR Query(objXML *XML, APTR Query, FUNCTION *Callback)
    xml->ErrorMsg.clear();
    (void)xml->getMap(); // Ensure the tag ID and ParentID values are defined
 
-   XPathEvaluator eval(xml);
+   XPathEvaluator eval(xml, (XPathNode *)Query);
    return eval.find_tag(*(XPathNode *)Query, 0); // Returns ERR:Search if no match
 }
 


### PR DESCRIPTION
## Summary
- attach compiled prolog and module cache handles when constructing the XPath evaluator
- resolve user-defined functions and variables from the XQuery prolog with guards and diagnostics
- update the phase 3 plan to reflect the new evaluator support

## Testing
- `cmake --build build/agents --config FastBuild --target xpath --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68f17fcfc7bc832ea7a85bf8a6ed6246