### PR TITLE
Add diagnostics for XQuery prolog tokeniser gaps

### DIFF
--- a/src/xpath/unit_tests.cpp
+++ b/src/xpath/unit_tests.cpp
@@ -6,9 +6,11 @@
 #include <parasol/modules/xpath.h>
 #include "xpath.h"
 #include "api/xquery_prolog.h"
+#include "parse/xpath_tokeniser.h"
 
 #include <iostream>
 #include <sstream>
+#include <string>
 
 //********************************************************************************************************************
 // Test helper functions
@@ -141,6 +143,129 @@ static void test_prolog_api() {
 //********************************************************************************************************************
 // Prolog Integration Tests
 
+static const char *token_type_name(XPathTokenType Type)
+{
+   switch (Type)
+   {
+      case XPathTokenType::IDENTIFIER: return "IDENTIFIER";
+      case XPathTokenType::MODULE: return "MODULE";
+      case XPathTokenType::IMPORT: return "IMPORT";
+      case XPathTokenType::OPTION: return "OPTION";
+      case XPathTokenType::ORDER: return "ORDER";
+      case XPathTokenType::COLLATION: return "COLLATION";
+      case XPathTokenType::ORDERING: return "ORDERING";
+      case XPathTokenType::COPY_NAMESPACES: return "COPY_NAMESPACES";
+      case XPathTokenType::DECIMAL_FORMAT: return "DECIMAL_FORMAT";
+      case XPathTokenType::SCHEMA: return "SCHEMA";
+      case XPathTokenType::DEFAULT: return "DEFAULT";
+      case XPathTokenType::COLON: return "COLON";
+      case XPathTokenType::ASSIGN: return "ASSIGN";
+      default: return "(unclassified)";
+   }
+}
+
+static void test_tokeniser_prolog_keywords()
+{
+   std::cout << "\n--- Investigating Prolog Tokeniser Coverage ---\n" << std::endl;
+
+   // Progress marker (2024-10-17): capturing current behaviour before adding DECLARE/FUNCTION/VARIABLE tokens.
+
+   XPathTokeniser tokeniser;
+
+   auto function_tokens = tokeniser.tokenize("declare function local:square($x) { $x * $x }");
+   test_assert(function_tokens.size() >= 6, "Function declaration token count",
+      "Tokeniser should emit tokens for sample prolog function");
+
+   if (!function_tokens.empty())
+   {
+      bool declare_keyword = function_tokens[0].type not_eq XPathTokenType::IDENTIFIER;
+      std::string declare_message = "Tokeniser reports 'declare' as " +
+         std::string(token_type_name(function_tokens[0].type));
+      test_assert(declare_keyword, "Prolog keyword: declare",
+         declare_message.c_str());
+   }
+
+   if (function_tokens.size() > 1)
+   {
+      bool function_keyword = function_tokens[1].type not_eq XPathTokenType::IDENTIFIER;
+      std::string function_message = "Tokeniser reports 'function' as " +
+         std::string(token_type_name(function_tokens[1].type));
+      test_assert(function_keyword, "Prolog keyword: function",
+         function_message.c_str());
+   }
+
+   if (function_tokens.size() > 3)
+   {
+      bool colon_classified = function_tokens[3].type IS XPathTokenType::COLON;
+      test_assert(colon_classified, "QName prefix separator",
+         "Colon between prefix and local name should be tokenised as COLON");
+   }
+
+   auto variable_tokens = tokeniser.tokenize("declare variable $value := 1");
+   test_assert(variable_tokens.size() >= 5, "Variable declaration token count",
+      "Tokeniser should emit tokens for sample variable declaration");
+
+   if (!variable_tokens.empty())
+   {
+      bool declare_keyword = variable_tokens[0].type not_eq XPathTokenType::IDENTIFIER;
+      std::string declare_message = "Tokeniser reports 'declare' as " +
+         std::string(token_type_name(variable_tokens[0].type));
+      test_assert(declare_keyword, "Prolog keyword reuse: declare",
+         declare_message.c_str());
+   }
+
+   if (variable_tokens.size() > 1)
+   {
+      bool variable_keyword = variable_tokens[1].type not_eq XPathTokenType::IDENTIFIER;
+      std::string variable_message = "Tokeniser reports 'variable' as " +
+         std::string(token_type_name(variable_tokens[1].type));
+      test_assert(variable_keyword, "Prolog keyword: variable",
+         variable_message.c_str());
+   }
+
+   if (variable_tokens.size() > 4)
+   {
+      bool assign_token = variable_tokens[4].type IS XPathTokenType::ASSIGN;
+      test_assert(assign_token, "Variable assignment operator",
+         "':=' should be tokenised as ASSIGN for prolog variables");
+   }
+
+   auto namespace_tokens = tokeniser.tokenize("declare namespace ex = \"http://example.org\"");
+   test_assert(namespace_tokens.size() >= 4, "Namespace declaration token count",
+      "Tokeniser should emit tokens for namespace declaration");
+
+   if (!namespace_tokens.empty())
+   {
+      bool declare_keyword = namespace_tokens[0].type not_eq XPathTokenType::IDENTIFIER;
+      std::string declare_message = "Tokeniser reports 'declare' as " +
+         std::string(token_type_name(namespace_tokens[0].type));
+      test_assert(declare_keyword, "Prolog keyword reuse: declare (namespace)",
+         declare_message.c_str());
+   }
+
+   if (namespace_tokens.size() > 1)
+   {
+      bool namespace_keyword = namespace_tokens[1].type not_eq XPathTokenType::IDENTIFIER;
+      std::string namespace_message = "Tokeniser reports 'namespace' as " +
+         std::string(token_type_name(namespace_tokens[1].type));
+      test_assert(namespace_keyword, "Prolog keyword: namespace",
+         namespace_message.c_str());
+   }
+
+   auto external_tokens = tokeniser.tokenize("declare variable $flag external");
+   test_assert(external_tokens.size() >= 5, "External variable token count",
+      "Tokeniser should emit tokens for external variable declaration");
+
+   if (external_tokens.size() > 4)
+   {
+      bool external_keyword = external_tokens[4].type not_eq XPathTokenType::IDENTIFIER;
+      std::string external_message = "Tokeniser reports 'external' as " +
+         std::string(token_type_name(external_tokens[4].type));
+      test_assert(external_keyword, "Prolog keyword: external",
+         external_message.c_str());
+   }
+}
+
 static void test_prolog_in_xpath() {
    std::cout << "\n--- Testing Prolog Integration ---\n" << std::endl;
 
@@ -216,6 +341,7 @@ void UnitTest(APTR Meta)
    reset_test_counters();
 
    // Run test suites
+   test_tokeniser_prolog_keywords();
    test_prolog_api();
    test_prolog_in_xpath();
 


### PR DESCRIPTION
## Summary
- add a tokeniser-focused unit test suite that highlights missing prolog keyword handling for declare/function/variable/namespace/external
- include a dated progress marker so future sessions can see what behaviour is still pending
- hook the new diagnostics into the existing xp::UnitTest harness alongside the prior prolog API checks

## Testing
- `cmake --build build/agents --config FastBuild --target xpath --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68f22ff3eccc832eadd3b87e3bcbceb1