### PR TITLE
Fix QName handling for function calls and variable bindings

### DIFF
--- a/docs/plans/XQUERY_PROLOG_PLAN.md
+++ b/docs/plans/XQUERY_PROLOG_PLAN.md
@@ -499,6 +499,7 @@ Each phase should land with targeted regression tests using existing Fluid-based
 
 **Name Resolution During Parsing:**
 - [x] Apply namespace bindings immediately when parsed
+- [x] Accept prefixed QNames in function calls and variable bindings throughout the expression grammar
 - [ ] Normalise function QNames using `default function namespace`
 - [ ] Normalise module import namespaces for cache lookup consistency
 - [ ] Record base URI in prolog when inherited from document

--- a/src/xpath/parse/xpath_parser.h
+++ b/src/xpath/parse/xpath_parser.h
@@ -115,6 +115,8 @@ class XPathParser {
       return peek().type IS type;
    }
 
+   [[nodiscard]] bool is_function_call_ahead(size_t Index) const;
+
    [[nodiscard]] inline bool match(XPathTokenType type) {
       if (check(type)) {
          advance();


### PR DESCRIPTION
## Summary
- recognise prefixed QNames when deciding between function calls, literals, and paths in the XPath parser
- parse QName bindings in FLWOR clauses, quantified expressions, and variable references to eliminate namespace token errors
- record the QName support work in the XQuery prolog implementation plan

## Testing
- ctest --build-config FastBuild --test-dir build/agents -R xml_xquery_prolog

------
https://chatgpt.com/codex/tasks/task_e_68f2469d1830832eb0d2d36beac9cd6b