### PR TITLE
Refine XPath module hint resolution helpers

### DIFF
--- a/src/xpath/api/xquery_prolog.cpp
+++ b/src/xpath/api/xquery_prolog.cpp
@@ -77,7 +77,7 @@ CompiledXPath * XQueryModuleCache::fetch_or_load(std::string_view URI, const XQu
       if (not letter_is_alpha) return false;
       if (value[1] IS ':') {
          char slash = value[2];
-         constexpr char backslash = (char)92;
+         constexpr char backslash = '\\';
          return (slash IS '/') or (slash IS backslash);
       }
       return false;


### PR DESCRIPTION
## Summary
- introduce a reusable helper for detecting Windows-style drive paths during module resolution
- simplify module location hint deduplication with `std::ranges::any_of`
- add the necessary standard headers to support the refactored helpers

## Testing
- cmake --build build/agents --config FastBuild --target xpath --parallel

------
https://chatgpt.com/codex/tasks/task_e_68fe238731f0832e8b7db7e0adfd0515