### PR TITLE
Start phase 1 of XQuery dispatch modernisation

### DIFF
--- a/docs/plans/XQUERY_DISPATCH_MODERNISATION.md
+++ b/docs/plans/XQUERY_DISPATCH_MODERNISATION.md
@@ -24,9 +24,9 @@ The refactoring follows a **pragmatic hybrid approach** that:
 ## Progress Checklist
 
 - [ ] Phase 1: Centralised Dispatch Table
-  - [ ] Step 1.1: Create Handler Type Alias
-  - [ ] Step 1.2: Declare Handler Methods
-  - [ ] Step 1.3: Create Dispatch Table
+  - [x] Step 1.1: Create Handler Type Alias
+  - [x] Step 1.2: Declare Handler Methods
+  - [x] Step 1.3: Create Dispatch Table *(initial table added with high-impact node types; remaining entries will be populated as handlers are extracted)*
   - [ ] Step 1.4: Refactor evaluate_expression() to Use Dispatch Table
   - [ ] Step 1.5: Extract Inline Handlers
   - [ ] Step 1.6: Testing Strategy for Phase 1

--- a/src/xquery/xquery.h
+++ b/src/xquery/xquery.h
@@ -1107,6 +1107,8 @@ struct XPathContext {
    XPathContext() = default;
 };
 
+struct SequenceTypeInfo;
+
 class XPathEvaluator : public XPathErrorReporter {
    public:
 
@@ -1149,6 +1151,9 @@ class XPathEvaluator : public XPathErrorReporter {
    };
 
    using PredicateHandler = PredicateResult (XPathEvaluator::*)(const XPathNode *, uint32_t);
+
+   // Handler for a specific XQuery node type evaluation
+   using NodeEvaluationHandler = XPathVal (XPathEvaluator::*)(const XPathNode *, uint32_t);
 
    std::vector<XPathContext> context_stack;
 
@@ -1199,6 +1204,30 @@ class XPathEvaluator : public XPathErrorReporter {
    XPathVal evaluate_comment_constructor(const XPathNode *Node, uint32_t CurrentPrefix);
    XPathVal evaluate_pi_constructor(const XPathNode *Node, uint32_t CurrentPrefix);
    XPathVal evaluate_document_constructor(const XPathNode *Node, uint32_t CurrentPrefix);
+
+   // Expression node type handlers
+   XPathVal handle_empty_sequence(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_number(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_literal(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_cast_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_treat_as_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_instance_of_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_castable_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_typeswitch_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_union_node(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_conditional(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_let_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_for_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_quantified_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_filter(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_path(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_unary_op(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_binary_op(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_expression_wrapper(const XPathNode *Node, uint32_t CurrentPrefix);
+   XPathVal handle_variable_reference(const XPathNode *Node, uint32_t CurrentPrefix);
+
+   std::optional<bool> matches_sequence_type(const XPathVal &Value, const SequenceTypeInfo &SequenceInfo,
+      const XPathNode *ContextNode);
 
    void expand_axis_candidates(const AxisMatch &ContextEntry, AxisType Axis,
       const XPathNode *NodeTest, uint32_t CurrentPrefix, std::vector<AxisMatch> &FilteredMatches);


### PR DESCRIPTION
## Summary
- add the NodeEvaluationHandler alias and declare dedicated expression handlers in XPathEvaluator
- introduce reusable matches_sequence_type helper and initial handler implementations for simple node kinds
- add a central NODE_HANDLERS map with early dispatch support and update the plan checklist to reflect progress

## Testing
- cmake --build build/agents --config FastBuild --target xquery --parallel

------
https://chatgpt.com/codex/tasks/task_e_6904e6544404832e91e591bc912f83cf