### PR TITLE
Fix literal attribute storage in XQuery parser

### DIFF
--- a/src/xquery/parse/xquery_parser.cpp
+++ b/src/xquery/parse/xquery_parser.cpp
@@ -2869,11 +2869,16 @@ std::unique_ptr<XPathNode> XPathParser::parse_direct_constructor()
       else {
          XPathAttributeValuePart literal_part;
          literal_part.is_expression = false;
-         std::string_view literal_text = attribute_token.text;
-         if (!token_storage) token_storage = std::make_shared<TokenBuffer>();
-         literal_text = token_storage->write_copy(literal_text);
-         literal_part.text = literal_text;
-         literal_part.text_kind = TokenTextKind::ArenaOwned;
+         if (attribute_token.text_kind == TokenTextKind::BorrowedInput) {
+            std::string_view literal_text = attribute_token.text;
+            if (!token_storage) token_storage = std::make_shared<TokenBuffer>();
+            literal_text = token_storage->write_copy(literal_text);
+            literal_part.text = literal_text;
+            literal_part.text_kind = TokenTextKind::ArenaOwned;
+         } else {
+            literal_part.text = attribute_token.text;
+            literal_part.text_kind = attribute_token.text_kind;
+         }
          parts.push_back(std::move(literal_part));
       }
 


### PR DESCRIPTION
## Summary
- copy literal attribute constructor values into the shared TokenBuffer so AST nodes own their data
- mark copied literal attribute parts as arena-owned to avoid dangling string_views

## Testing
- cmake --build build/agents --config Release --target xquery --parallel

------
https://chatgpt.com/codex/tasks/task_e_6907da4bb7e8832ebb7351899581dc2a