### PR TITLE
Improved LuaJIT Build Process

### DIFF
--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -28,8 +28,8 @@ set (LUAJIT_VMDEF_LUA "${LUAJIT_BUILD_DIR}/jit/vmdef.lua")
 
 # Common LuaJIT compile definitions
 set (LUAJIT_COMMON_DEFS "LUAJIT_ENABLE_LUA52COMPAT")
-# Non-MSVC builds disable FFI and need additional flags
-set (LUAJIT_NON_MSVC_DEFS "-DLUAJIT_DISABLE_FFI -DLUAJIT_ENABLE_LUA52COMPAT")
+# Non-MSVC builds disable FFI and need additional flags (as a CMake list for proper expansion)
+set (LUAJIT_NON_MSVC_DEFS "-DLUAJIT_DISABLE_FFI" "-DLUAJIT_ENABLE_LUA52COMPAT")
 
 # We build FFI as a release build in all situations because ASAN doesn't like Debug builds of FFI.
 # Activate BUILD_ALWAYS if you're working on the library code.


### PR DESCRIPTION
This pull request refactors and modernizes the LuaJIT build integration in `src/fluid/CMakeLists.txt`. The main changes include extracting common build configuration, improving cross-platform support, and replacing the previous `ExternalProject_Add` approach for non-MSVC platforms with a direct CMake-based build pipeline. This results in a cleaner, more maintainable, and more reliable LuaJIT build process.

**Build system refactoring and modernization:**

* Extracted common LuaJIT build configuration, such as generated headers and build directories, to the top-level scope for reuse between MSVC and non-MSVC builds.
* Removed duplicated build directory and generated header definitions from the MSVC-specific block, relying on the shared configuration instead.
* Updated MSVC build to use the shared `LUAJIT_COMMON_DEFS` variable for compile definitions, simplifying configuration.

**Non-MSVC cross-platform build improvements:**

* Replaced the previous `ExternalProject_Add` approach with a native CMake pipeline, including custom commands for host tool compilation, architecture detection, code generation, and static library creation. This makes the build more robust and easier to debug.
* Added architecture detection and dynamic code generation steps for LuaJIT, ensuring the correct VM assembly is built for the target platform.

These changes make the LuaJIT build integration more maintainable, portable, and easier to extend for future requirements.