### PR TITLE
[Fluid] Added table.empty() method

### DIFF
--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -464,7 +464,7 @@ endif ()
 # Register Flute tests
 
 set (FLUID_TESTS
-   catch io nz object processing regex struct threads xml strings math array compound bitshift bitwise orq presence blank ternary
+   catch io nz object processing regex struct threads xml strings math array compound bitshift bitwise orq presence blank ternary table
 )
 
 foreach (TEST_NAME ${FLUID_TESTS})

--- a/src/fluid/fluid_functions.cpp
+++ b/src/fluid/fluid_functions.cpp
@@ -80,7 +80,7 @@ int fcmd_raise(lua_State *Lua)
 //   end,
 //   function(Exception)
 //      // Exception handler
-//      print("Code: " .. nz(Exception.code,"LUA") .. ", Message: " .. Exception.message)
+//      print("Code: " .. (Exception.code ? "LUA") .. ", Message: " .. Exception.message)
 //   end)
 //
 // As above, but the handler is only called if certain codes are raised.  Any mismatched errors will throw to the parent code.
@@ -829,16 +829,7 @@ int fcmd_arg(lua_State *Lua)
 }
 
 //********************************************************************************************************************
-// Returns the 2nd argument if the 1st argument is evaluated as nil, zero, an empty string, table or array.  Otherwise
-// the 1st argument is returned.
-//
-// If the 2nd argument is not given, nil is returned if the 1st argument is evaluated as being empty, otherwise 1 is
-// returned.
-//
-// Usage: result = nz(checkval, zeroval)
-//
-// 'nz' is short for 'nonzero' and its use can be described as 'if checkval is non zero then return checkval, else
-// return zeroval'.
+// DEPRECATED
 
 int fcmd_nz(lua_State *Lua)
 {

--- a/src/fluid/tests/test_table.fluid
+++ b/src/fluid/tests/test_table.fluid
@@ -1,0 +1,57 @@
+-- Flute tests for table.empty()
+
+function test_nil_and_empty()
+   -- nil is treated as an empty table
+   assert(table.empty(nil) is true, "nil should be considered empty")
+
+   -- empty table literal
+   local t = {}
+   assert(table.empty(t) is true, "{} should be empty")
+end
+
+function test_array_and_hash()
+   -- Non-empty array part
+   local arr = {1}
+   assert(table.empty(arr) is false, "Array with one element should not be empty")
+
+   -- Non-empty hash part
+   local map = { a = 1 }
+   assert(table.empty(map) is false, "Hash with one key should not be empty")
+end
+
+function test_sparse_and_holes()
+   -- Sparse array with only a high index populated
+   local t = {}
+   t[100] = 1
+   assert(table.empty(t) is false, "Sparse table with an entry should not be empty")
+
+   -- Table with only holes (all nil)
+   local holes = {}
+   holes[1] = nil
+   holes[2] = nil
+   assert(table.empty(holes) is true, "Table with only nil entries should be empty")
+end
+
+function test_clear_and_mutation()
+   local t = { a = 5, 7 }
+   assert(table.empty(t) is false, "Initially non-empty table should not be empty")
+
+   -- Use table.clear() provided by our LuaJIT patch to clear the table
+   table.clear(t)
+   assert(table.empty(t) is true, "table.clear() should result in an empty table")
+
+   -- Re-populate and re-check
+   t[1] = 10
+   assert(table.empty(t) is false, "Re-populated table should not be empty")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+   return {
+      tests = {
+         'test_nil_and_empty',
+         'test_array_and_hash',
+         'test_sparse_and_holes',
+         'test_clear_and_mutation'
+      }
+   }


### PR DESCRIPTION
This pull request introduces a new native function, `table.empty()`, to the LuaJIT table library, enabling efficient and accurate detection of empty tables in both array and hash forms. It also adds comprehensive tests for this new functionality and updates the build configuration to include these tests. Additionally, minor documentation and legacy code adjustments are made.

### Table Library Enhancements

* Added a native implementation of `table.empty()` in `lib_table.c`, which returns true for nil or empty tables and false otherwise, mirroring Parasol's user-facing helpers.
* Registered `table.empty()` in the LuaJIT table library initialization to make it available to scripts.

### Testing Improvements

* Added a new test file `test_table.fluid` with thorough coverage for `table.empty()`, including cases for nil, empty tables, array/hashes, sparse tables, holes, and table mutation.
* Updated the CMake build configuration to include the new `table` test in the `FLUID_TESTS` list, ensuring it runs with other Flute tests.

### Documentation and Code Maintenance

* Marked the legacy `fcmd_nz` function as deprecated in its documentation.
* Updated example code in a comment to clarify Lua ternary usage syntax.