### PR TITLE
Update defer keyword implementation plan

### DIFF
--- a/docs/plans/defer-keyword.md
+++ b/docs/plans/defer-keyword.md
@@ -1,174 +1,164 @@
 # Alternative Defer Keyword Implementation Plan
 
-## Overview
+## Status & Scope
 
-This plan replaces the previous `defer` keyword strategy with a lightweight approach that reuses
-Fluid's existing anonymous function support. Instead of introducing bespoke bytecode and runtime
-plumbing, the parser lowers each `defer` block into an anonymous function that is stored in an
-internally generated local variable flagged for deferred execution. When the variable leaves scope
-its flagged closure runs automatically, preserving the familiar scope-based, LIFO, and error-safe
-semantics expected of `defer`.
+**Status:** 📝 Draft ready for implementation review  
+**Priority:** ⭐⭐⭐⭐ High  
+**Estimated Effort:** 10–14 hours (parser + VM + tests)
 
-**Status:** 📝 Draft proposal – awaiting implementation sign-off
+This plan replaces the earlier heavy-weight proposal for a Fluid `defer`
+keyword with a keep-it-simple approach that relies entirely on LuaJIT's
+existing anonymous function machinery. Each `defer` statement is lowered
+into an ordinary closure stored in a synthetic local. Scope management code
+records those locals and emits standard `function` creation/call bytecode to
+execute them when the scope unwinds. No bespoke opcodes or exotic runtime
+subsystems are introduced.
 
-**Priority:** ⭐⭐⭐⭐ High
+## Investigation Summary
 
-**Estimated Effort:** 10–14 hours (including parser, VM, and tests)
+- **Scope tracking:** `FuncScope` in `lj_parse.c` already captures scope depth
+  and is unwound via `fscope_begin()`/`fscope_end()`, giving us a natural hook
+  for registering and releasing deferred closures without reworking parser
+  control flow.【F:src/fluid/luajit-2.1/src/lj_parse.c†L1650-L1687】
+- **Local storage:** `var_new()`/`var_add()` (same file) allocate locals and
+  keep metadata in `LexState->vstack`, so synthetic locals can piggy-back on
+  the same infrastructure without affecting register allocation rules.【F:src/fluid/luajit-2.1/src/lj_parse.c†L1404-L1460】
+- **Function literals:** `parse_body()` produces closures through the regular
+  `BC_FNEW` path; reusing it keeps closure semantics and GC integration
+  consistent with user-authored anonymous functions.【F:src/fluid/luajit-2.1/src/lj_parse.c†L2358-L2408】
+- **Control-transfer exits:** `parse_return()` and `parse_stmt()` are the
+  choke points for generating `return`, `break`, and `continue` bytecode, so
+  inserting defer unwinding there covers all explicit exits.【F:src/fluid/luajit-2.1/src/lj_parse.c†L3333-L3413】【F:src/fluid/luajit-2.1/src/lj_parse.c†L3648-L3711】
+- **Error unwinding:** Runtime upvalue closure logic (`BC_UCLO` handling in
+  the interpreter/JIT back-ends) already runs on both normal and exceptional
+  paths, providing a single place to trigger deferred calls once the parser
+  guarantees a `BC_UCLO` before every scope exit that owns defers.【F:src/fluid/luajit-2.1/src/lj_parse.c†L1671-L1687】【F:src/fluid/luajit-2.1/src/lj_dispatch.c†L392-L421】
 
-## Goals and Non-Goals
+## Guiding Principles (KISS)
 
-### Goals
+1. **Reuse closures:** Defer blocks compile to ordinary anonymous functions;
+   no new proto flags or GC structures.
+2. **Leverage existing bytecode:** Emitted sequences stick to `BC_FNEW`,
+   `BC_MOV`, `BC_CALL`, and `BC_UCLO` so the VM and recorder stay untouched.
+3. **Minimal metadata:** Track deferred locals alongside existing scope data—
+   no auxiliary stacks in the VM unless the parser cannot express the unwind.
+4. **One unwind path:** Scope exits, control-flow jumps, and VM errors all
+   converge on the same helper so semantics remain predictable.
 
-- Provide scope-based deferred execution with LIFO ordering, guaranteed invocation, and standard Lua
-  closure capture semantics.
-- Minimise new infrastructure by mapping `defer` to anonymous functions managed like existing local
-  variables.
-- Maintain compatibility with existing tooling (bytecode dumper, recorder, etc.) by avoiding new
-  opcodes where possible.
-- Keep the implementation maintainable and easy to reason about for contributors familiar with Lua
-  function handling.
+## Phased Implementation
 
-### Non-Goals
+### Phase 1 – Lexical & Grammar Wiring
+1. Extend `TKDEF` in `lj_lex.h` with the reserved word `_ (defer)` so
+   the lexer interns it like other keywords; the token tables in `lj_lex.c`
+   update automatically.【F:src/fluid/luajit-2.1/src/lj_lex.h†L14-L26】
+2. Teach `parse_stmt()` to recognise `TK_defer` and dispatch to a new
+   `parse_defer()` helper placed near other statement parsers.【F:src/fluid/luajit-2.1/src/lj_parse.c†L3648-L3711】
+3. Add syntax diagnostics in `parse_defer()` to demand `defer ... end`
+   blocks (matching existing Fluid keyword error messaging).
 
-- Extending the syntax beyond `defer()` blocks (e.g. `defer call()` inline forms).
-- Altering function calling conventions or closure representation.
-- Introducing new bytecode instructions or VM subsystems unless absolutely unavoidable.
+**Exit criteria:** Keyword tokenises correctly; trivial script containing
+`defer end` is parsed (even if semantics are stubbed).
 
-## High-Level Design
+### Phase 2 – Parser Data Model for Deferred Locals
+1. Introduce a lightweight `DeferInfo` (e.g. `{MSize scope_top; BCReg slot;}`)
+   stored on a growable array inside `LexState`; snapshot/restore the stack in
+   `fs_init()`/`fs_finish()` so nested functions inherit outer state cleanly.【F:src/fluid/luajit-2.1/src/lj_parse.c†L2004-L2030】
+2. Extend `FuncScope` with a `defer_top` watermark captured in
+   `fscope_begin()`; this marks the first deferred closure owned by the scope
+   without touching existing flag bits.【F:src/fluid/luajit-2.1/src/lj_parse.c†L1650-L1669】
+3. When `parse_defer()` lowers a block, allocate a synthetic local via
+   `var_new_fixed()` / `var_add()`, emit the closure with `parse_body()`, and
+   push `{scope_top = fs->bl->defer_top, slot = new_local_slot}` onto the
+   `DeferInfo` stack.
 
-1. **Parser desugaring:**
-   - On encountering `defer() ... end`, emit bytecode equivalent to declaring an anonymous function
-     and storing it in a fresh internal local (e.g. `local @defer#1 = function() ... end`).
-   - Mark the created prototype (or closure) with a new `PROTOTYPE_FLAG_DEFER` (boolean field if no
-     spare flags exist).
-   - Record the synthetic local in the current scope's defer stack to retain LIFO ordering.
+**Exit criteria:** Parser state accurately tracks deferred locals, nested
+scopes maintain LIFO order, and no bytecode is emitted yet.
 
-2. **Scope unwinding:**
-   - Augment scope exit logic to iterate recorded deferred locals in reverse order, invoking any
-     closure whose prototype carries the defer flag.
-   - Ensure all exit paths trigger the same unwinding: normal scope end, `return`, `break`,
-     `continue`, and error unwinds.
+### Phase 3 – Lowering `defer` to Closure Storage
+1. Inside `parse_defer()`, after parsing the block body:
+   - Discharge the resulting closure into the synthetic local register using
+     `expr_toreg()`.
+   - Prevent user code from reading the internal local by marking the
+     corresponding `VarInfo` entry with a new `VSTACK_DEFER` flag bit.
+2. Ensure registers stay contiguous: reserve one slot before emitting the
+   closure so `fs->freereg` remains consistent with `nactvar`.
+3. Emit `var_add()` so lifetime metadata matches the enclosing scope; this
+   allows `var_remove()` to retire the local during unwinding without special
+   cases.
 
-3. **Runtime integration:**
-   - Reuse existing function call helpers (`lj_vm_call`, etc.) when executing deferred closures.
-   - Guarantee execution even on error by chaining to the existing error unwinder; deferred calls run
-     in protected mode and propagate the first failure after all handlers execute.
+**Exit criteria:** Compiled chunk shows a stored closure in bytecode (e.g. via
+`luajit -bl`) while the helper that actually executes it is still a stub.
 
-4. **State representation:**
-   - Introduce a lightweight `DeferInfo` stack per scope/function to track synthetic locals (register
-     indices or slots) and their counts for reverse traversal.
-   - No new garbage-collected structures are required because closures already participate in GC via
-     existing locals/upvalues.
+### Phase 4 – Unified Scope-Unwind Emission
+1. Implement `emit_scope_defers(FuncState *fs, FuncScope *scope)` that pops
+   all `DeferInfo` entries newer than `scope->defer_top` and, for each,
+   generates:
+   - `BC_MOV` into a scratch base register (reuse `fs->freereg`).
+   - `BC_CALL` with zero arguments and zero expected results.
+   This helper runs *before* `var_remove()` so the registers stay alive.
+2. Call the helper from `fscope_end()` when a scope owns at least one defer.
+   Emit a guarding `BC_UCLO` (re-using the existing instruction already
+   produced for upvalues) so the VM executes the unwind even on error exits.
+3. For immediate exits (`return`, `break`, `continue`, tail jumps), invoke the
+   same helper prior to emitting their final instruction to cover control flow
+   that bypasses `fscope_end()`.
+4. Update the goto/break fix-up logic so patched jump targets land *after*
+   the emitted defer sequence, preserving ordering guarantees.
 
-## Detailed Implementation Steps
+**Exit criteria:** Runtime reaches defer closures in normal execution paths,
+with bytecode limited to the existing instruction set.
 
-### Step 1 – Parser Support
+### Phase 5 – Error-Unwind Integration
+1. Audit interpreter/JIT `BC_UCLO` handlers (`vm_*.dasc`, `lj_dispatch.c`)
+   to confirm they execute on both normal scope exits and VM errors. If a
+   scope containing defers lacks an auto-generated `BC_UCLO`, update the
+   parser to insert one explicitly when `emit_scope_defers()` runs.【F:src/fluid/luajit-2.1/src/lj_dispatch.c†L392-L421】
+2. Add a C helper (e.g. `lj_vm_defer_run(lua_State *L, TValue *base, BCReg n)`) that
+   expects the closures to be stored contiguously on the stack and calls them
+   via `lj_vm_pcall()` to suppress cascading errors.
+3. Adjust each architecture backend’s `BC_UCLO` case to invoke the helper
+   immediately before closing upvalues when the compiler signalled pending
+   defers (e.g. via a flag stored in `GCproto` or an unused slot in the stack
+   frame header). Aim to re-use existing registers so no new bytecode format is
+   required.
+4. Extend `lj_record.c` to record the helper call as an ordinary function call
+   so traces remain valid.
 
-**Files:** `src/fluid/luajit-2.1/src/lj_parse.c`, `src/fluid/luajit-2.1/src/lj_parse.h`
+**Exit criteria:** Injected runtime helper runs during `pcall`-captured errors
+and during normal unwinds; tests that throw within deferred scopes still see
+all defers executed exactly once.
 
-1. Add a `defer_depth` (or vector) field to scope metadata to record the number of synthetic defer
-   locals currently active.
-2. Extend `parse_defer()` to:
-   - Allocate a fresh internal local (reusing existing helpers for temporary locals).
-   - Parse the block body as a standard anonymous function.
-   - Mark the resulting function prototype with a `PROTO_DFLAG` or new boolean (see Step 2).
-   - Push the local's register index onto the scope's defer stack.
-3. Ensure nested scopes inherit outer defer stacks while maintaining their own counts for LIFO
-   unwinding.
+### Phase 6 – Tooling, Tests, and Documentation
+1. **Testing:**
+   - Create a dedicated Fluid test script exercising ordering, nesting, and
+     error propagation. Place it under `src/fluid/tests/` and wire it into the
+     CTest suite.
+   - Add micro-benchmarks / sanity checks to ensure minimal overhead when no
+     defers are present.
+2. **Tooling:** Update the bytecode dumper/disassembler paths (if needed) to
+   annotate the synthetic locals, making debugging easier.
+3. **Documentation:** Refresh the Fluid reference manual with syntax and
+   semantics, emphasising the closure-based lowering and error behaviour.
 
-### Step 2 – Prototype Flagging
+**Exit criteria:** Automated tests demonstrate correctness; developer-facing
+materials describe usage clearly.
 
-**Files:** `src/fluid/luajit-2.1/src/lj_proto.h`, `src/fluid/luajit-2.1/src/lj_parse.c`
-
-1. Add a `PROTO_HAS_DEFER` flag (or reuse a spare bit) to `GCproto` to mark compiled closures created
-   from `defer` blocks.
-2. Set the flag when lowering defer functions in the parser.
-3. Provide a helper macro/function `proto_is_defer(proto)` for readability.
-
-### Step 3 – Scope Exit Execution
-
-**Files:** `src/fluid/luajit-2.1/src/lj_parse.c`, `src/fluid/luajit-2.1/src/lj_record.c`,
-`src/fluid/luajit-2.1/src/lj_vm.h`, `src/fluid/luajit-2.1/src/lj_vm*.c`
-
-1. Extend `fscope_end()`, `parse_return()`, `parse_break()`, and `parse_continue()` to emit a helper
-   that will call `lj_vm_defer_unwind()` before releasing locals.
-2. Implement `lj_vm_defer_unwind(FuncState *fs, BCReg base, uint8_t count)` (exact signature TBD)
-   that:
-   - Iterates deferred locals from newest to oldest.
-   - For each flagged closure, executes it via the existing call mechanism, passing zero arguments.
-   - Runs handlers in protected mode; if a handler errors, store the error and continue unwinding,
-     rethrowing after completion.
-3. Ensure error unwinds (longjmp paths) also trigger the helper by hooking into existing panic/error
-   paths that already iterate active locals.
-
-### Step 4 – Bytecode & VM Adjustments
-
-**Files:** `src/fluid/luajit-2.1/src/lj_bcemit.c`, `src/fluid/luajit-2.1/src/lj_vm*.c`
-
-1. Verify that storing the anonymous function in a local reuses existing bytecode (`BC_FNEW`,
-   `BC_MOV`, etc.) without modification.
-2. If a dedicated unwind helper is required, implement it in C and call from generated bytecode using
-   existing call patterns (e.g. through fast functions or helper stubs) to avoid new opcodes.
-3. Confirm that tail returns and VARG clean-up paths also run `lj_vm_defer_unwind()` before
-   completion.
-
-### Step 5 – Tooling and Debugging Support
-
-**Files:** `src/fluid/luajit-2.1/src/lj_bcwrite.c`, `src/fluid/luajit-2.1/src/lj_disasm.c`,
-`docs/wiki/Fluid-Reference-Manual.md`
-
-1. Ensure bytecode writers/disassemblers annotate deferred closures (e.g. comment or flag) using the
-   new prototype bit.
-2. Update documentation to describe the lowered form and execution semantics.
-
-### Step 6 – Testing
-
-**Files:** `src/fluid/tests/test_defer.fluid` (new or existing), regression harness scripts
-
-1. Add Fluid tests verifying:
-   - Basic scope defer execution order.
-   - Nested scopes with defer.
-   - Interaction with `return`, `break`, `continue`, and errors.
-   - Closure capture of mutable variables.
-   - Multiple defers ensuring LIFO behaviour.
-2. Include VM error propagation tests (handler failure followed by successful handlers).
-
-## Potential Risks & Mitigations
+## Risk Log & Mitigations
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| Missing flag bits on `GCproto` | Medium | Introduce a dedicated boolean field if no flag bit is available. |
-| Error unwinding gaps | High | Audit all scope-exit paths and share a single `defer_unwind` helper invoked everywhere. |
-| Interaction with existing optimisations (JIT) | Medium | Update recorder to treat flagged closures like standard functions; add guard tests. |
-| Performance overhead | Low | Only synthetic locals with defer flag incur the extra check; ensure helper returns quickly when no defer entries exist. |
-
-## Rollout Strategy
-
-1. Implement parser and runtime changes behind a compile-time flag if incremental rollout is
-   preferred (optional).
-2. Land feature behind hidden config until documentation and tests are complete.
-3. Remove old plan references and update developer documentation upon completion.
-
-## Open Questions
-
-- Should deferred closures accept arguments? The sugar can evaluate arguments immediately and store
-  them in local temporaries, matching Go semantics; confirm whether this is required for initial
-  rollout.
-- Is additional tooling needed to surface deferred closures in stack traces?
+| Missing stack metadata for error unwinds | High | Validate the `BC_UCLO` execution path early; if gaps exist, add an explicit proto flag so the VM can detect scopes with defers. |
+| Register pressure in tight scopes | Medium | Always reserve scratch registers via `bcreg_reserve()` and release them promptly; add regression tests with nested defers to monitor stack growth. |
+| JIT trace divergence | Medium | Ensure the helper call is traceable and side-effect free beyond invoking closures; extend `lj_record.c` if needed. |
+| User-visible synthetic locals | Low | Flag `VarInfo` entries so debugger/introspection tools can hide them. |
 
 ## Success Criteria
 
-- All semantic guarantees (scope-based execution, LIFO ordering, guaranteed execution on all exit
-  paths, and closure capture) pass the new test suite.
-- No new bytecode instructions are introduced, and existing tooling continues to function without
-  modification.
-- Implementation complexity is markedly lower than the previous plan, facilitating easier long-term
-  maintenance.
+- `defer` executes closures in strict LIFO order across normal exits and error
+  unwinds, matching Go-style semantics.
+- Generated bytecode continues to use only existing instructions, verified by
+  `luajit -bl` and the recorder.
+- Fluid tests covering the new keyword pass alongside the existing suite.
+- Documentation clearly explains the sugar and its limitations.
 
-## References
-
-- Existing `function` and closure implementation in LuaJIT (`lj_parse.c`, `lj_vm*.c`).
-- Go `defer` semantics for behavioural comparison.
-- Current `defer-keyword.md` plan (superseded by this simplified design).
-
-**Last Updated:** 2025-02-XX
+**Last Updated:** 2025-02-15


### PR DESCRIPTION
## Summary
- refresh the defer keyword design plan with a KISS-friendly approach that reuses existing LuaJIT closures
- document detailed investigation findings and guiding principles for scope tracking and unwinding
- lay out phased implementation steps, risks, and success criteria for parser, VM, and tooling updates

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa4250238832eb72c8d9fcf12312b)