### PR TITLE
Refine Fluid postfix increment handling

### DIFF
--- a/src/fluid/luajit-2.1/src/lj_lex.c
+++ b/src/fluid/luajit-2.1/src/lj_lex.c
@@ -457,7 +457,6 @@ int lj_lex_setup(lua_State *L, LexState *ls)
   ls->lookahead = TK_eof;  /* No look-ahead token. */
   ls->linenumber = 1;
   ls->lastline = 1;
-  ls->postinc_pending = 0;
   ls->endmark = 0;
   lex_next(ls);  /* Read-ahead first char. */
   if (ls->c == 0xef && ls->p + 2 <= ls->pe && (uint8_t)ls->p[0] == 0xbb &&

--- a/src/fluid/luajit-2.1/src/lj_lex.h
+++ b/src/fluid/luajit-2.1/src/lj_lex.h
@@ -78,7 +78,6 @@ typedef struct LexState {
   BCInsLine *bcstack;	/* Stack for bytecode instructions/line numbers. */
   MSize sizebcstack;	/* Size of bytecode stack. */
   uint32_t level;	/* Syntactical nesting level. */
-  uint8_t postinc_pending;	/* Tracks pending postfix increment statements. */
   int endmark;		/* Trust bytecode end marker, even if not at EOF. */
 } LexState;
 


### PR DESCRIPTION
## Summary
- replace the parser-wide postfix increment flag with an ExpDesc aux bit
- mark postfix increments as statements directly on the expression descriptor

## Testing
- cmake --build build/agents --config Release --parallel
- cmake --install build/agents --config Release
- build/agents-install/parasol --gfx-driver=headless --no-crash-handler --log-warning src/fluid/tests/test_compound.fluid

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691116b3957c832e9990e0b49ec48092)