### PR TITLE
Fix register handling for Fluid if-empty operator

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/lj_parse_types.h
+++ b/src/fluid/luajit-2.1/src/parser/lj_parse_types.h
@@ -60,6 +60,9 @@ typedef struct ExpDesc {
 #define EXP_AUX_PAYLOAD_MASK     (~EXP_AUX_FLAG_MASK)
 #define exp_aux_flags(aux)       ((aux) & EXP_AUX_FLAG_MASK)
 #define exp_aux_payload(aux)     ((aux) & EXP_AUX_PAYLOAD_MASK)
+#define exp_aux_payload_encode(reg)   ((((uint32_t)(reg)) + 1u) & EXP_AUX_PAYLOAD_MASK)
+#define exp_aux_payload_has(aux)      (exp_aux_payload(aux) != 0u)
+#define exp_aux_payload_decode(aux)   (exp_aux_payload(aux) - 1u)
 
 // Macros for expressions.
 #define expr_hasjump(e)      ((e)->t != (e)->f)


### PR DESCRIPTION
## Summary
- keep runtime left-hand values in their original register while reserving a dedicated RHS slot for the Fluid if-empty operator
- copy the RHS result into place only when the LHS is extended-falsey and release the temporary register afterward
- add Fluid regression coverage for table operands on both sides of the operator

## Testing
- ctest --build-config Release --test-dir build/agents -L fluid

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133807c930832e8eb2418369395102)