### PR TITLE
Add regression coverage for if-empty table constructors

### DIFF
--- a/src/fluid/tests/test_if_empty.fluid
+++ b/src/fluid/tests/test_if_empty.fluid
@@ -95,6 +95,20 @@ function testTable()
 
    local v = t ? { 'Nothing' }
    assert(v['a'] is 1, "Failed table case: expected table, got '" .. tostring(v) .. "'")
+
+   local v = t ? { b = 2 }
+   assert(v['a'] is 1, "Failed table case: expected original table when RHS is a constructor, got '" .. tostring(v) .. "'")
+
+   local v = t ? { nested = { x = 1 } }
+   assert(v['a'] is 1, "Failed nested table case: expected original table when RHS is nested constructor, got '" .. tostring(v) .. "'")
+
+   local arr = { 1, 2, 3 }
+   local v = arr ? { 9, 9, 9 }
+   assert(v[1] is 1, "Failed array table case: expected original array when RHS is constructor, got '" .. tostring(v) .. "'")
+
+   local empty = nil
+   local v = empty ? { default = true }
+   assert(v.default is true, "Failed nil LHS table case: expected default table, got '" .. tostring(v) .. "'")
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expand `fluid_if_empty` test coverage with regression cases for table constructor fallbacks
- update the parenthesized table constructor plan to reference the new coverage and document current failures

## Testing
- ctest --test-dir build/agents --output-on-failure -R fluid_if_empty

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913eafd4c4c832e8449623cccfcca81)