### PR TITLE
[Fluid] Improved CMake file for building with MinGW

### DIFF
--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -340,7 +340,7 @@ else ()
    add_custom_command(
       OUTPUT ${LUAJIT_BUILD_DIR}/dasm_aflags.txt
       COMMAND ${CMAKE_COMMAND} -P ${ARCH_DETECT_SCRIPT}
-      DEPENDS "${LUAJIT_SRC}/lj_arch.h"
+      DEPENDS "${LUAJIT_SRC}/lj_arch.h" ${ARCH_DETECT_SCRIPT}
       COMMENT "Detecting architecture flags for dynasm"
       VERBATIM
    )


### PR DESCRIPTION
This pull request updates the CMake build process for LuaJIT in the `src/fluid/CMakeLists.txt` file, focusing on improved cross-platform compatibility and more robust architecture detection. The main changes remove the legacy MinGW-specific build logic and introduce a new mechanism to dynamically extract and apply architecture flags for the dynasm code generator, making the build more reliable and maintainable.

**Build system cleanup and modernization:**

* Removed legacy MinGW-specific logic and the original LuaJIT Makefile build path, consolidating all non-MSVC builds to use the CMake-based LuaJIT build system. [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL10-L15) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL136-L150)

**Architecture detection and dynasm integration:**

* Added a CMake script (`detect_arch_flags.cmake`) to preprocess `lj_arch.h` and extract architecture-specific defines, generating a flags file (`dasm_aflags.txt`) for dynasm. This ensures dynasm receives the correct flags for the target architecture.
* Updated the dynasm invocation to read and apply the generated architecture flags, improving the reliability of code generation for different architectures.
* Added a custom command to generate the dynasm flags file as part of the build process, and updated dependencies to ensure correct build ordering.