### PR TITLE
[Fluid] Optimised the CMake build file

### DIFF
--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -312,10 +312,11 @@ else ()
    add_custom_command(
       OUTPUT ${BUILDVM_ARCH_H}
       COMMAND ${CMAKE_COMMAND} -E env TARGET_GENDIR=${LUAJIT_BUILD_DIR} ${CMAKE_COMMAND} -P ${DYNASM_SCRIPT}
-      DEPENDS ${MINILUA_TARGET} ${LUAJIT_ARCH_DETECT} ${LUAJIT_DYNASM_DIR}/dynasm.lua
+      DEPENDS ${MINILUA_TARGET} ${LUAJIT_ARCH_DETECT} ${LUAJIT_DYNASM_DIR}/dynasm.lua ${DYNASM_SCRIPT}
          "${LUAJIT_SRC}/lj_arch.h" "${LUAJIT_SRC}/lua.h" "${LUAJIT_SRC}/luaconf.h"
          "${LUAJIT_SRC}/vm_x64.dasc" "${LUAJIT_SRC}/vm_x86.dasc" "${LUAJIT_SRC}/vm_arm.dasc"
          "${LUAJIT_SRC}/vm_arm64.dasc" "${LUAJIT_SRC}/vm_ppc.dasc" "${LUAJIT_SRC}/vm_mips.dasc"
+          "${LUAJIT_BUILD_DIR}/test_arch.c"
       COMMENT "Generating buildvm_arch.h via dynasm"
       VERBATIM
    )
@@ -404,14 +405,6 @@ else ()
       )
    endif ()
 
-   # Compile amalgamated source and create static library using CMake
-   # This replaces manual compilation and ar commands with proper CMake targets
-
-   file(GLOB LUAJIT_AMALG_SOURCES
-      "${LUAJIT_SRC}/lj_*.c"
-      "${LUAJIT_SRC}/lib_*.c"
-   )
-
    if (WIN32)
       # MinGW: Create library from VM object and amalgamated source
       add_library(luajit_lib STATIC "${LUAJIT_SRC}/ljamalg.c" ${LUAJIT_VM_OBJ})
@@ -440,8 +433,9 @@ else ()
    )
 
    target_compile_definitions(luajit_lib PRIVATE
-      ${LUAJIT_COMMON_DEFS}
       LUAJIT_UNWIND_EXTERNAL
+      LUAJIT_DISABLE_FFI
+      LUAJIT_ENABLE_LUA52COMPAT
       LUA_ROOT="${CMAKE_INSTALL_PREFIX}"
    )
 


### PR DESCRIPTION
This pull request refactors and modernizes the LuaJIT build process in the `src/fluid/CMakeLists.txt` file. The changes simplify platform detection, consolidate architecture and dynasm processing, and use proper CMake targets and properties for building and linking LuaJIT. The result is a more maintainable and portable build system that leverages CMake's capabilities instead of custom scripts and manual commands.

**Build system modernization and simplification:**

* Switched from string to list variables for compiler flags and definitions, ensuring proper handling of flags in CMake (`LUAJIT_COMMON_DEFS`, `LUAJIT_NON_MSVC_DEFS`, `LUAJIT_HOST_CFLAGS`, etc.).
* Removed custom helper functions for platform-specific executable and math library handling, replacing them with direct use of CMake variables and logic (`MINILUA_TARGET`, `LUAJIT_MATH_LIB`, `BUILDVM_TARGET`) [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL46-L70) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL153-R151) [[3]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL369-R340).

**Architecture detection and dynasm integration:**

* Consolidated architecture detection and dynasm flag processing into a single CMake script (`run_dynasm.cmake`), eliminating intermediate files and streamlining the workflow [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL219-R240) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL286-R299) [[3]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL331-R315).
* Removed redundant custom commands and scripts for architecture and dynasm flag generation, relying on the new unified script and updated dependencies.

**CMake target improvements:**

* Replaced manual compilation and static library creation with proper CMake `add_library` targets, using `target_compile_options`, `target_compile_definitions`, and `target_include_directories` for configuration [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL438-R419) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fR431-R465).
* Added an INTERFACE library (`luajit_interface`) to encapsulate LuaJIT usage requirements, improving modularity and linking for dependent targets [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fR116-R120) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fR431-R465).

**Linking and usage in the fluid module:**

* Updated the fluid module to link against the new `luajit_interface` target and removed redundant compile definitions, ensuring correct dependency handling and cleaner build configuration.

These changes make the build process more robust, easier to maintain, and better aligned with CMake best practices.