### PR TITLE
Added support for tagging unstable / stable builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
   tag-stable:
     name: Tag as Stable
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: stable-tag
       cancel-in-progress: false
@@ -167,6 +169,8 @@ jobs:
   tag-unstable:
     name: Tag as Unstable
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: unstable-tag
       cancel-in-progress: false


### PR DESCRIPTION
This pull request adds automated tagging for stable and unstable builds in the GitHub Actions CI workflow. When a build runs on the `master` branch, the workflow will now automatically update the `STABLE` or `UNSTABLE` git tags based on the test results, making it easier to track the latest successful and failed builds.

Automated tagging workflow:

* Added a new `tag-stable` job to the `.github/workflows/ci.yml` file that creates or moves the `STABLE` tag to the latest commit on `master` if all tests pass. The tag is updated with a timestamped message and pushed to the remote repository.
* Added a new `tag-unstable` job to the `.github/workflows/ci.yml` file that creates or moves the `UNSTABLE` tag to the latest commit on `master` if tests fail. The tag is updated with a timestamped message and pushed to the remote repository.