### PR TITLE
Fix ?? presence detection for prefix increment expressions

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/lj_parse_expr.c
+++ b/src/fluid/luajit-2.1/src/parser/lj_parse_expr.c
@@ -179,8 +179,9 @@ static int token_starts_expression(LexToken tok)
    case TK_function:
    case TK_name:
    case '{':
-   case '(': 
+   case '(':
    case TK_not:
+   case TK_plusplus:
    case '-':
    case '~':
    case '#':


### PR DESCRIPTION
## Summary
- treat TK_plusplus as a valid expression start so ?? followed by prefix increments remains a binary if-empty operator

## Testing
- cmake --build build/agents --config Release --parallel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170591ef8c832eb9c7cf46eb5c3ae5)