### PR TITLE
[Fluid] Improve LexState class with method focused interfaces

### DIFF
--- a/docs/plans/REFACTOR_LEXSTATE.md
+++ b/docs/plans/REFACTOR_LEXSTATE.md
@@ -226,6 +226,8 @@ These functions operate on `FuncState` and only access `LexState` through `fs->l
 
 **Risk**: Medium - these functions interact with complex state
 
+**Status**: ✅ Completed on 2025-11-16. Variable-stack helpers (`var_*`) and goto/label handlers (`gola_*`) now live on `LexState`, and all parser call sites have been updated.
+
 ### Phase 3: Function State Initialization (Week 3)
 
 1. Convert Category 5 (function state)
@@ -268,6 +270,8 @@ These functions operate on `FuncState` and only access `LexState` through `fs->l
 
 **Risk**: Medium-High - main parsing logic, extensive call sites
 
+**Status**: ✅ Completed on 2025-11-18. Statement helpers (assignment resolution, loop/branch handlers, and the `parse_stmt`/`parse_chunk` entry points) now live on `LexState`, and all parser call sites route through the new methods.
+
 ### Phase 6: Public API and Cleanup (Week 6)
 
 1. Convert Category 10 (public API functions)
@@ -283,6 +287,8 @@ These functions operate on `FuncState` and only access `LexState` through `fs->l
 - Documentation files
 
 **Risk**: Low - final cleanup and polish
+
+**Status**: ✅ Completed on 2025-11-18. The public anchoring helpers are implemented as `LexState` methods with thin wrappers for API stability, and deprecated free-function call sites have been removed.
 
 ## Technical Considerations
 
@@ -466,8 +472,8 @@ Critical test cases:
 ## Metrics
 
 ### Quantitative
-- Functions converted: 0 / ~70 (Categories 1-8, 10)
-- Call sites updated: 0 / ~200 (estimated)
+- Functions converted: 70 / ~70 (all categories migrated to `LexState` methods)
+- Call sites updated: ~200 / ~200 (lexer, scope, expression, and statement paths now method-based)
 - Test pass rate: 100% (maintain)
 - Compilation warnings: 0
 
@@ -500,13 +506,13 @@ Critical test cases:
 
 | Phase | Duration | Completion Date |
 |-------|----------|-----------------|
-| Phase 1: Core Lexer | 1 week | TBD |
-| Phase 2: Variables/Scope | 1 week | TBD |
-| Phase 3: FuncState | 1 week | TBD |
-| Phase 4: Expressions | 1 week | TBD |
-| Phase 5: Statements | 1 week | TBD |
-| Phase 6: Cleanup | 1 week | TBD |
-| **Total** | **6 weeks** | TBD |
+| Phase 1: Core Lexer | 1 week | 2025-11-16 (complete) |
+| Phase 2: Variables/Scope | 1 week | 2025-11-16 (complete) |
+| Phase 3: FuncState | 1 week | 2025-11-17 (complete) |
+| Phase 4: Expressions | 1 week | 2025-11-17 (complete) |
+| Phase 5: Statements | 1 week | 2025-11-18 (complete) |
+| Phase 6: Cleanup | 1 week | 2025-11-18 (complete) |
+| **Total** | **6 weeks** | 2025-11-18 |
 
 ## References
 
@@ -534,6 +540,6 @@ Critical test cases:
 ## Status
 
 - **Created**: 2025-01-16
-- **Status**: Planning
+- **Status**: ✅ All six phases complete; parser refactor finalised pending regression monitoring
 - **Owner**: TBD
-- **Last Updated**: 2025-01-16
+- **Last Updated**: 2025-11-18

--- a/src/fluid/luajit-2.1/src/lj_def.h
+++ b/src/fluid/luajit-2.1/src/lj_def.h
@@ -394,6 +394,11 @@ static LJ_AINLINE uint32_t lj_getu32(const void* v)
 #else
 #define LJ_FUNC      LJ_NOAPI
 #endif
+#if defined(__GNUC__) || defined(__clang__)
+#define LJ_USED   __attribute__((used))
+#else
+#define LJ_USED
+#endif
 #define LJ_FUNC_NORET   LJ_FUNC LJ_NORET
 #define LJ_FUNCA_NORET   LJ_FUNCA LJ_NORET
 #define LJ_ASMF_NORET   LJ_ASMF LJ_NORET

--- a/src/fluid/luajit-2.1/src/parser/lj_lex.cpp
+++ b/src/fluid/luajit-2.1/src/parser/lj_lex.cpp
@@ -190,7 +190,7 @@ static void lex_longstring(LexState *State, TValue* tv, int sep)
       }
    } endloop:
    if (tv) {
-      GCstr* str = lj_parse_keepstr(State, State->sb.b + (2 + (MSize)sep),
+      GCstr* str = State->keepstr(State->sb.b + (2 + (MSize)sep),
          sbuflen(&State->sb) - 2 * (2 + (MSize)sep));
       setstrV(State->L, tv, str);
    }
@@ -301,7 +301,7 @@ static void lex_string(LexState *State, TValue* tv)
    }
    lex_savenext(State);  //  Skip trailing delimiter.
    setstrV(State->L, tv,
-      lj_parse_keepstr(State, State->sb.b + 1, sbuflen(&State->sb) - 2));
+      State->keepstr(State->sb.b + 1, sbuflen(&State->sb) - 2));
 }
 
 //********************************************************************************************************************
@@ -323,7 +323,7 @@ static LexToken lex_scan(LexState *State, TValue* tv)
          do {
             lex_savenext(State);
          } while (lj_char_isident(State->c));
-         s = lj_parse_keepstr(State, State->sb.b, sbuflen(&State->sb));
+         s = State->keepstr(State->sb.b, sbuflen(&State->sb));
          setstrV(State->L, tv, s);
          if (s->reserved > 0) {  // Reserved word?
             LexToken tok = TK_OFS + s->reserved;

--- a/src/fluid/luajit-2.1/src/parser/parse_constants.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_constants.cpp
@@ -43,12 +43,12 @@
 
 // Anchor string constant to avoid GC.
 
-GCstr* lj_parse_keepstr(LexState* ls, const char* str, size_t len)
+GCstr* LexState::keepstr(const char* str, size_t len)
 {
    // NOBARRIER: the key is new or kept alive.
-   lua_State* L = ls->L;
+   lua_State* L = this->L;
    GCstr* s = lj_str_new(L, str, len);
-   TValue* tv = lj_tab_setstr(L, ls->fs->kt, s);
+   TValue* tv = lj_tab_setstr(L, this->fs->kt, s);
    if (tvisnil(tv)) setboolV(tv, 1);
    lj_gc_check(L);
    return s;
@@ -56,12 +56,24 @@ GCstr* lj_parse_keepstr(LexState* ls, const char* str, size_t len)
 
 #if LJ_HASFFI
 // Anchor cdata to avoid GC.
-void lj_parse_keepcdata(LexState* ls, TValue* tv, GCcdata* cd)
+void LexState::keepcdata(TValue* tv, GCcdata* cd)
 {
    // NOBARRIER: the key is new or kept alive.
-   lua_State* L = ls->L;
+   lua_State* L = this->L;
    setcdataV(L, tv, cd);
-   setboolV(lj_tab_set(L, ls->fs->kt, tv), 1);
+   setboolV(lj_tab_set(L, this->fs->kt, tv), 1);
+}
+#endif
+
+LJ_USED LJ_FUNC GCstr* lj_parse_keepstr(LexState* ls, const char* str, size_t len)
+{
+   return ls->keepstr(str, len);
+}
+
+#if LJ_HASFFI
+LJ_USED LJ_FUNC void lj_parse_keepcdata(LexState* ls, TValue* tv, GCcdata* cd)
+{
+   ls->keepcdata(tv, cd);
 }
 #endif
 
@@ -133,7 +145,7 @@ static void jmp_patchins(FuncState* fs, BCPos pc, BCPos dest)
    BCPos offset = dest - (pc + 1) + BCBIAS_J;
    lj_assertFS(dest != NO_JMP, "uninitialized jump target");
    if (offset > BCMAX_D)
-      err_syntax(fs->ls, LJ_ERR_XJUMP);
+      fs->ls->err_syntax(LJ_ERR_XJUMP);
    setbc_d(jmp, offset);
 }
 

--- a/src/fluid/luajit-2.1/src/parser/parse_core.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_core.cpp
@@ -4,14 +4,14 @@
 // Major portions taken verbatim or adapted from the Lua interpreter.
 // Copyright (C) 1994-2008 Lua.org, PUC-Rio. See Copyright Notice in lua.h
 
-LJ_NORET LJ_NOINLINE static void err_syntax(LexState *State, ErrMsg em)
+LJ_NORET LJ_NOINLINE void LexState::err_syntax(ErrMsg Message)
 {
-   lj_lex_error(State, State->tok, em);
+   lj_lex_error(this, this->tok, Message);
 }
 
-LJ_NORET LJ_NOINLINE static void err_token(LexState *State, LexToken tok)
+LJ_NORET LJ_NOINLINE void LexState::err_token(LexToken Token)
 {
-   lj_lex_error(State, State->tok, LJ_ERR_XTOKEN, State->token2str(tok));
+   lj_lex_error(this, this->tok, LJ_ERR_XTOKEN, this->token2str(Token));
 }
 
 LJ_NORET static void err_limit(FuncState* fs, uint32_t limit, const char* what)
@@ -26,10 +26,10 @@ LJ_NORET static void err_limit(FuncState* fs, uint32_t limit, const char* what)
 
 // Check and consume optional token.
 
-static int lex_opt(LexState *State, LexToken tok)
+int LexState::lex_opt(LexToken Token)
 {
-   if (State->tok == tok) {
-      State->next();
+   if (this->tok == Token) {
+      this->next();
       return 1;
    }
    return 0;
@@ -37,35 +37,35 @@ static int lex_opt(LexState *State, LexToken tok)
 
 // Check and consume token.
 
-static void lex_check(LexState *State, LexToken tok)
+void LexState::lex_check(LexToken Token)
 {
-   if (State->tok != tok) err_token(State, tok);
-   State->next();
+   if (this->tok != Token) this->err_token(Token);
+   this->next();
 }
 
 // Check for matching token.
 
-static void lex_match(LexState *State, LexToken what, LexToken who, BCLine line)
+void LexState::lex_match(LexToken What, LexToken Who, BCLine Line)
 {
-   if (!lex_opt(State, what)) {
-      if (line == State->linenumber) {
-         err_token(State, what);
+   if (!this->lex_opt(What)) {
+      if (Line == this->linenumber) {
+         this->err_token(What);
       }
       else {
-         auto swhat = State->token2str(what);
-         auto swho = State->token2str(who);
-         lj_lex_error(State, State->tok, LJ_ERR_XMATCH, swhat, swho, line);
+         auto swhat = this->token2str(What);
+         auto swho = this->token2str(Who);
+         lj_lex_error(this, this->tok, LJ_ERR_XMATCH, swhat, swho, Line);
       }
    }
 }
 
 // Check for string token.
 
-static GCstr* lex_str(LexState *State)
+GCstr* LexState::lex_str()
 {
    GCstr* s;
-   if (State->tok != TK_name) err_token(State, TK_name);
-   s = strV(&State->tokval);
-   State->next();
+   if (this->tok != TK_name) this->err_token(TK_name);
+   s = strV(&this->tokval);
+   this->next();
    return s;
 }

--- a/src/fluid/luajit-2.1/src/parser/parse_internal.h
+++ b/src/fluid/luajit-2.1/src/parser/parse_internal.h
@@ -12,16 +12,7 @@ struct LHSVarList;  // Defined in lj_parse_stmt.cpp
 
 // Error handling (lj_parse_core.c)
 
-LJ_NORET LJ_NOINLINE static void err_syntax(LexState* ls, ErrMsg em);
-LJ_NORET LJ_NOINLINE static void err_token(LexState* ls, LexToken tok);
 LJ_NORET static void err_limit(FuncState* fs, uint32_t limit, const char* what);
-
-// Lexer helpers (lj_parse_core.c)
-
-static int lex_opt(LexState* ls, LexToken tok);
-static void lex_check(LexState* ls, LexToken tok);
-static void lex_match(LexState* ls, LexToken what, LexToken who, BCLine line);
-static GCstr* lex_str(LexState* ls);
 
 // Constants (lj_parse_constants.c)
 
@@ -138,20 +129,9 @@ static void bcemit_unop(FuncState* fs, BCOp op, ExpDesc* e);
 // Variables and scope (lj_parse_scope.c)
 
 static int is_blank_identifier(GCstr* name);
-static void var_new(LexState* ls, BCReg n, GCstr* name);
-static void var_add(LexState* ls, BCReg nvars);
-static void var_remove(LexState* ls, BCReg tolevel);
 static std::optional<BCReg> var_lookup_local(FuncState* fs, GCstr* n);
 static MSize var_lookup_uv(FuncState* fs, MSize vidx, ExpDesc* e);
 static MSize var_lookup_(FuncState* fs, GCstr* name, ExpDesc* e, int first);
-
-// Goto and labels (lj_parse_scope.c)
-
-static MSize gola_new(LexState* ls, int jump_type, uint8_t info, BCPos pc);
-static void gola_patch(LexState* ls, VarInfo* vg, VarInfo* vl);
-static void gola_close(LexState* ls, VarInfo* vg);
-static void gola_resolve(LexState* ls, FuncScope* bl, MSize idx);
-static void gola_fixup(LexState* ls, FuncScope* bl);
 
 // Function scope (lj_parse_scope.c)
 
@@ -174,62 +154,17 @@ static void fs_fixup_uv1(FuncState* fs, GCproto* pt, uint16_t* uv);
 static size_t fs_prep_line(FuncState* fs, BCLine numline);
 static void fs_fixup_line(FuncState* fs, GCproto* pt,
    void* lineinfo, BCLine numline);
-static size_t fs_prep_var(LexState* ls, FuncState* fs, size_t* ofsvar);
-static void fs_fixup_var(LexState* ls, GCproto* pt, uint8_t* p, size_t ofsvar);
 static int bcopisret(BCOp op);
 static void fs_fixup_ret(FuncState* fs);
-static GCproto* fs_finish(LexState* ls, BCLine line);
-static void fs_init(LexState* ls, FuncState* fs);
 
 // Expressions (lj_parse_expr.c)
 
-static void expr(LexState* ls, ExpDesc* v);
-static void expr_str(LexState* ls, ExpDesc* e);
 static void expr_index(FuncState* fs, ExpDesc* t, ExpDesc* e);
-static void expr_field(LexState* ls, ExpDesc* v);
-static void expr_bracket(LexState* ls, ExpDesc* v);
 static void expr_kvalue(FuncState* fs, TValue* v, ExpDesc* e);
-static void expr_table(LexState* ls, ExpDesc* e);
-static BCReg parse_params(LexState* ls, int needself);
-[[maybe_unused]] static void parse_body_impl(LexState* ls, ExpDesc* e, int needself, BCLine line);
-static void parse_body(LexState* ls, ExpDesc* e, int needself, BCLine line);
-static void parse_body_defer(LexState* ls, ExpDesc* e, BCLine line);
-static BCReg expr_list(LexState* ls, ExpDesc* v);
-static void parse_args(LexState* ls, ExpDesc* e);
-static void inc_dec_op(LexState* ls, BinOpr op, ExpDesc* v, int isPost);
-static void expr_primary(LexState* ls, ExpDesc* v);
-static void expr_simple(LexState* ls, ExpDesc* v);
-static void synlevel_begin(LexState* ls);
 static BinOpr token2binop(LexToken tok);
-static BinOpr expr_binop(LexState* ls, ExpDesc* v, uint32_t limit);
-static BinOpr expr_shift_chain(LexState* ls, ExpDesc* lhs, BinOpr op);
-static void expr_unop(LexState* ls, ExpDesc* v);
-static void expr_next(LexState* ls);
-static BCPos expr_cond(LexState* ls);
 
 // Statements (lj_parse_stmt.c)
 
-static void assign_hazard(LexState* ls, LHSVarList* lh, const ExpDesc* v);
-static void assign_adjust(LexState* ls, BCReg nvars, BCReg nexps, ExpDesc* e);
-static int assign_compound(LexState* ls, LHSVarList* lh, LexToken opType);
-static void parse_assignment(LexState* ls, LHSVarList* lh, BCReg nvars);
-static void parse_call_assign(LexState* ls);
-static void parse_local(LexState* ls);
 static void snapshot_return_regs(FuncState* fs, BCIns* ins);
-static void parse_defer(LexState* ls);
-static void parse_func(LexState* ls, BCLine line);
 static int parse_is_end(LexToken tok);
-static void parse_return(LexState* ls);
-static void parse_continue(LexState* ls);
-static void parse_break(LexState* ls);
-static void parse_block(LexState* ls);
-static void parse_while(LexState* ls, BCLine line);
-static void parse_repeat(LexState* ls, BCLine line);
-static void parse_for_num(LexState* ls, GCstr* varname, BCLine line);
 static int predict_next(LexState* ls, FuncState* fs, BCPos pc);
-static void parse_for_iter(LexState* ls, GCstr* indexname);
-static void parse_for(LexState* ls, BCLine line);
-static BCPos parse_then(LexState* ls);
-static void parse_if(LexState* ls, BCLine line);
-static int parse_stmt(LexState* ls);
-static void parse_chunk(LexState* ls);

--- a/src/fluid/luajit-2.1/src/parser/parse_operators.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_operators.cpp
@@ -235,10 +235,10 @@ static void bcemit_shift_call_at_base(FuncState* fs, const char* fname, MSize fn
 
    // Now load bit.[lshift|rshift|...] into the base register
    expr_init(&callee, ExpKind::Global, 0);
-   callee.u.sval = lj_parse_keepstr(fs->ls, "bit", 3);
+   callee.u.sval = fs->ls->keepstr("bit", 3);
    expr_toanyreg(fs, &callee);
    expr_init(&key, ExpKind::Str, 0);
-   key.u.sval = lj_parse_keepstr(fs->ls, fname, fname_len);
+   key.u.sval = fs->ls->keepstr(fname, fname_len);
    expr_index(fs, &callee, &key);
    expr_toval(fs, &callee);
    expr_toreg(fs, &callee, base);
@@ -288,10 +288,10 @@ static void bcemit_unary_bit_call(FuncState* fs, const char* fname, MSize fname_
 
    // Load bit.fname into base register.
    expr_init(&callee, ExpKind::Global, 0);
-   callee.u.sval = lj_parse_keepstr(fs->ls, "bit", 3);
+   callee.u.sval = fs->ls->keepstr("bit", 3);
    expr_toanyreg(fs, &callee);
    expr_init(&key, ExpKind::Str, 0);
-   key.u.sval = lj_parse_keepstr(fs->ls, fname, fname_len);
+   key.u.sval = fs->ls->keepstr(fname, fname_len);
    expr_index(fs, &callee, &key);
    expr_toval(fs, &callee);
    expr_toreg(fs, &callee, base);
@@ -375,7 +375,7 @@ static void bcemit_presence_check(FuncState* fs, ExpDesc* e)
 
    // Check for empty string
    expr_init(&emptyv, ExpKind::Str, 0);
-   emptyv.u.sval = lj_parse_keepstr(fs->ls, "", 0);
+   emptyv.u.sval = fs->ls->keepstr("", 0);
    bcemit_INS(fs, BCINS_AD(BC_ISEQS, reg, const_str(fs, &emptyv)));
    check_empty = bcemit_jmp(fs);
 
@@ -483,7 +483,7 @@ static void bcemit_binop(FuncState* fs, BinOpr op, ExpDesc* e1, ExpDesc* e2)
 
             // Check for empty string
             expr_init(&emptyv, ExpKind::Str, 0);
-            emptyv.u.sval = lj_parse_keepstr(fs->ls, "", 0);
+            emptyv.u.sval = fs->ls->keepstr("", 0);
             bcemit_INS(fs, BCINS_AD(BC_ISEQS, reg, const_str(fs, &emptyv)));
             check_empty = bcemit_jmp(fs);
 

--- a/src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp
@@ -10,7 +10,7 @@ static void bcreg_bump(FuncState* fs, BCReg n)
 {
    BCReg sz = fs->freereg + n;
    if (sz > fs->framesize) {
-      if (sz >= LJ_MAX_SLOTS) err_syntax(fs->ls, LJ_ERR_XSLOTS);
+      if (sz >= LJ_MAX_SLOTS) fs->ls->err_syntax(LJ_ERR_XSLOTS);
       fs->framesize = uint8_t(sz);
    }
 }

--- a/src/fluid/luajit-2.1/src/parser/parse_stmt.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_stmt.cpp
@@ -2,17 +2,17 @@
 
 // List of LHS variables.
 
-typedef struct LHSVarList {
+struct LHSVarList {
    ExpDesc var;			// LHS variable.
-   struct LHSVarList *prev;	// Link to previous LHS variable.
-} LHSVarList;
+   LHSVarList* prev;	   // Link to previous LHS variable.
+};
 
 //********************************************************************************************************************
 // Eliminate write-after-read hazards for local variable assignment.
 
-static void assign_hazard(LexState *State, LHSVarList *Left, const ExpDesc *Var)
+void LexState::assign_hazard(LHSVarList* Left, const ExpDesc* Var)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    BCReg reg = Var->u.s.info;  // Check against this variable.
    BCReg tmp = fs->freereg;  // Rename to this temp. register (if needed).
    int hazard = 0;
@@ -39,9 +39,9 @@ static void assign_hazard(LexState *State, LHSVarList *Left, const ExpDesc *Var)
 //********************************************************************************************************************
 // Adjust LHS/RHS of an assignment.
 
-static void assign_adjust(LexState *State, BCReg nvars, BCReg nexps, ExpDesc* e)
+void LexState::assign_adjust(BCReg nvars, BCReg nexps, ExpDesc* e)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    int32_t extra = int32_t(nvars) - int32_t(nexps);
    if (e->k IS ExpKind::Call) {
       extra++;  // Compensate for the ExpKind::Call itself.
@@ -58,14 +58,14 @@ static void assign_adjust(LexState *State, BCReg nvars, BCReg nexps, ExpDesc* e)
       }
    }
 
-   if (nexps > nvars) State->fs->freereg -= nexps - nvars;  // Drop leftover regs.
+   if (nexps > nvars) fs->freereg -= nexps - nvars;  // Drop leftover regs.
 }
 
 //********************************************************************************************************************
 
-static int assign_if_empty(LexState *State, LHSVarList* lh)
+int LexState::assign_if_empty(LHSVarList* lh)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    ExpDesc lhv, lhs_eval, rh;
    ExpDesc nilv, falsev, zerov, emptyv;
    BCReg freg_base, lhs_reg;
@@ -75,9 +75,9 @@ static int assign_if_empty(LexState *State, LHSVarList* lh)
 
    lhv = lh->var;
 
-   checkcond(State, vkisvar(lh->var.k), LJ_ERR_XLEFTCOMPOUND);
+   checkcond(this, vkisvar(lh->var.k), LJ_ERR_XLEFTCOMPOUND);
 
-   State->next();
+   this->next();
 
    freg_base = fs->freereg;
 
@@ -117,7 +117,7 @@ static int assign_if_empty(LexState *State, LHSVarList* lh)
    check_zero = bcemit_jmp(fs);
 
    expr_init(&emptyv, ExpKind::Str, 0);
-   emptyv.u.sval = lj_parse_keepstr(State, "", 0);
+   emptyv.u.sval = this->keepstr("", 0);
    bcemit_INS(fs, BCINS_AD(BC_ISEQS, lhs_reg, const_str(fs, &emptyv)));
    check_empty = bcemit_jmp(fs);
 
@@ -125,8 +125,8 @@ static int assign_if_empty(LexState *State, LHSVarList* lh)
 
    assign_pos = fs->pc;
 
-   nexps = expr_list(State, &rh);
-   checkcond(State, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
+   nexps = this->expr_list(&rh);
+   checkcond(this, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
 
    expr_discharge(fs, &rh);
    expr_toreg(fs, &rh, lhs_reg);
@@ -151,11 +151,11 @@ static int assign_if_empty(LexState *State, LHSVarList* lh)
 
 //********************************************************************************************************************
 
-static int assign_compound(LexState *State, LHSVarList* lh, LexToken opType)
+int LexState::assign_compound(LHSVarList* lh, LexToken opType)
 {
-   if (opType IS TK_cif_empty) return assign_if_empty(State, lh);
+   if (opType IS TK_cif_empty) return this->assign_if_empty(lh);
 
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    ExpDesc lhv, infix, rh;
    int32_t nexps;
    BinOpr op;
@@ -163,7 +163,7 @@ static int assign_compound(LexState *State, LHSVarList* lh, LexToken opType)
 
    lhv = lh->var;
 
-   checkcond(State, vkisvar(lh->var.k), LJ_ERR_XLEFTCOMPOUND);
+   checkcond(this, vkisvar(lh->var.k), LJ_ERR_XLEFTCOMPOUND);
 
    switch (opType) {
    case TK_cadd: op = OPR_ADD; break;
@@ -173,10 +173,10 @@ static int assign_compound(LexState *State, LHSVarList* lh, LexToken opType)
    case TK_cmod: op = OPR_MOD; break;
    case TK_cconcat: op = OPR_CONCAT; break;
    default:
-      State->assert_condition(0, "unknown compound operator");
+      this->assert_condition(0, "unknown compound operator");
       return 0;
    }
-   State->next();
+   this->next();
 
    // Preserve table base/index across RHS evaluation by duplicating them
    // to the top of the stack and discharging using the duplicates. This retains
@@ -214,16 +214,16 @@ static int assign_compound(LexState *State, LHSVarList* lh, LexToken opType)
    if (op IS OPR_CONCAT) {
       infix = lh->var;
       bcemit_binop_left(fs, op, &infix);
-      nexps = expr_list(State, &rh);
-      checkcond(State, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
+      nexps = this->expr_list(&rh);
+      checkcond(this, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
    }
    else {
       // For bitwise ops, avoid pre-pushing LHS to keep call frame contiguous.
 
       if (!(op IS OPR_BAND or op IS OPR_BOR or op IS OPR_BXOR or op IS OPR_SHL or op IS OPR_SHR))
          expr_tonextreg(fs, &lh->var);
-      nexps = expr_list(State, &rh);
-      checkcond(State, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
+      nexps = this->expr_list(&rh);
+      checkcond(this, nexps IS 1, LJ_ERR_XRIGHTCOMPOUND);
       infix = lh->var;
       bcemit_binop_left(fs, op, &infix);
    }
@@ -244,27 +244,27 @@ static int assign_compound(LexState *State, LHSVarList* lh, LexToken opType)
 //********************************************************************************************************************
 // Recursively parse assignment statement.
 
-static void parse_assignment(LexState *State, LHSVarList* lh, BCReg nvars)
+void LexState::parse_assignment(LHSVarList* lh, BCReg nvars)
 {
    ExpDesc e;
-   checkcond(State, ExpKind::Local <= lh->var.k and lh->var.k <= ExpKind::Indexed, LJ_ERR_XSYNTAX);
-   if (lex_opt(State, ',')) {  // Collect LHS list and recurse upwards.
+   checkcond(this, ExpKind::Local <= lh->var.k and lh->var.k <= ExpKind::Indexed, LJ_ERR_XSYNTAX);
+   if (this->lex_opt(',')) {  // Collect LHS list and recurse upwards.
       LHSVarList vl;
       vl.prev = lh;
-      expr_primary(State, &vl.var);
+      this->expr_primary(&vl.var);
       if (vl.var.k IS ExpKind::Local)
-         assign_hazard(State, lh, &vl.var);
-      checklimit(State->fs, State->level + nvars, LJ_MAX_XLEVEL, "variable names");
-      parse_assignment(State, &vl, nvars + 1);
+         this->assign_hazard(lh, &vl.var);
+      checklimit(this->fs, this->level + nvars, LJ_MAX_XLEVEL, "variable names");
+      this->parse_assignment(&vl, nvars + 1);
    }
    else {  // Parse RHS.
       BCReg nexps;
-      lex_check(State, '=');
-      nexps = expr_list(State, &e);
+      this->lex_check('=');
+      nexps = this->expr_list(&e);
       if (nexps IS nvars) {
          if (e.k IS ExpKind::Call) {
-            if (bc_op(*bcptr(State->fs, &e)) IS BC_VARG) {  // Vararg assignment.
-               State->fs->freereg--;
+            if (bc_op(*bcptr(this->fs, &e)) IS BC_VARG) {  // Vararg assignment.
+               this->fs->freereg--;
                e.k = ExpKind::Relocable;
             }
             else {  // Multiple call results.
@@ -272,82 +272,84 @@ static void parse_assignment(LexState *State, LHSVarList* lh, BCReg nvars)
                e.k = ExpKind::NonReloc;
             }
          }
-         bcemit_store(State->fs, &lh->var, &e);
+         bcemit_store(this->fs, &lh->var, &e);
          return;
       }
-      assign_adjust(State, nvars, nexps, &e);
+      this->assign_adjust(nvars, nexps, &e);
    }
 
    // Assign RHS to LHS and recurse downwards.
-   expr_init(&e, ExpKind::NonReloc, State->fs->freereg - 1);
-   bcemit_store(State->fs, &lh->var, &e);
+   expr_init(&e, ExpKind::NonReloc, this->fs->freereg - 1);
+   bcemit_store(this->fs, &lh->var, &e);
 }
 
 //********************************************************************************************************************
 // Parse call statement or assignment.
 
-static void parse_call_assign(LexState *State)
+void LexState::parse_call_assign()
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    LHSVarList vl;
-   expr_primary(State, &vl.var);
+   this->expr_primary(&vl.var);
    if (vl.var.k IS ExpKind::NonReloc and (vl.var.flags & POSTFIX_INC_STMT_FLAG))
       return;
    if (vl.var.k IS ExpKind::Call) {  // Function call statement.
       setbc_b(bcptr(fs, &vl.var), 1);  // No results.
    }
-   else if (State->tok IS TK_cadd or State->tok IS TK_csub or State->tok IS TK_cmul or
-      State->tok IS TK_cdiv or State->tok IS TK_cmod or State->tok IS TK_cconcat or
-      State->tok IS TK_cif_empty) {
+   else if (this->tok IS TK_cadd or this->tok IS TK_csub or this->tok IS TK_cmul or
+      this->tok IS TK_cdiv or this->tok IS TK_cmod or this->tok IS TK_cconcat or
+      this->tok IS TK_cif_empty) {
       vl.prev = nullptr;
-      assign_compound(State, &vl, State->tok);
+      this->assign_compound(&vl, this->tok);
    }
-   else if (State->tok IS ';') {
+   else if (this->tok IS ';') {
       // Postfix increment (++) handled in expr_primary.
    }
    else {  // Start of an assignment.
       vl.prev = nullptr;
-      parse_assignment(State, &vl, 1);
+      this->parse_assignment(&vl, 1);
    }
 }
 
 //********************************************************************************************************************
 // Parse 'local' statement.
 
-static void parse_local(LexState *State)
+void LexState::parse_local()
 {
-   if (lex_opt(State, TK_function)) {  // Local function declaration.
+   this->next();  // Skip 'local'.
+
+   if (this->lex_opt(TK_function)) {  // Local function declaration.
       ExpDesc v, b;
-      FuncState* fs = State->fs;
-      var_new(State, 0, lex_str(State));
+      FuncState* fs = this->fs;
+      this->var_new(0, this->lex_str());
       expr_init(&v, ExpKind::Local, fs->freereg);
       v.u.s.aux = fs->varmap[fs->freereg];
       bcreg_reserve(fs, 1);
-      var_add(State, 1);
-      parse_body(State, &b, 0, State->linenumber);
+      this->var_add(1);
+      this->parse_body(&b, 0, this->linenumber);
       // bcemit_store(fs, &v, &b) without setting VSTACK_VAR_RW.
       expr_free(fs, &b);
       expr_toreg(fs, &b, v.u.s.info);
       // The upvalue is in scope, but the local is only valid after the store.
-      var_get(State, fs, fs->nactvar - 1).startpc = fs->pc;
+      var_get(this, fs, fs->nactvar - 1).startpc = fs->pc;
    }
    else {  // Local variable declaration.
       ExpDesc e;
       BCReg nexps, nvars = 0;
       do {  // Collect LHS.
-         GCstr* name = lex_str(State);
+         GCstr* name = this->lex_str();
          // Use NAME_BLANK marker for blank identifiers.
-         var_new(State, nvars++, is_blank_identifier(name) ? NAME_BLANK : name);
-      } while (lex_opt(State, ','));
-      if (lex_opt(State, '=')) {  // Optional RHS.
-         nexps = expr_list(State, &e);
+         this->var_new(nvars++, is_blank_identifier(name) ? NAME_BLANK : name);
+      } while (this->lex_opt(','));
+      if (this->lex_opt('=')) {  // Optional RHS.
+         nexps = this->expr_list(&e);
       }
       else {  // Or implicitly set to nil.
          e.k = ExpKind::Void;
          nexps = 0;
       }
-      assign_adjust(State, nvars, nexps, &e);
-      var_add(State, nvars);
+      this->assign_adjust(nvars, nexps, &e);
+      this->var_add(nvars);
    }
 }
 
@@ -385,44 +387,44 @@ static void snapshot_return_regs(FuncState* fs, BCIns* ins)
 
 //********************************************************************************************************************
 
-static void parse_defer(LexState *State)
+void LexState::parse_defer()
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    ExpDesc func, arg;
-   BCLine line = State->linenumber;
+   BCLine line = this->linenumber;
    BCReg reg = fs->freereg;
    BCReg nargs = 0;
    VarInfo* vi;
 
-   State->next();  // Skip 'defer'.
-   var_new(State, 0, NAME_BLANK);
+   this->next();  // Skip 'defer'.
+   this->var_new(0, NAME_BLANK);
    bcreg_reserve(fs, 1);
-   var_add(State, 1);
-   vi = &var_get(State, fs, fs->nactvar - 1);
+   this->var_add(1);
+   vi = &var_get(this, fs, fs->nactvar - 1);
    vi->info |= VSTACK_DEFER;
 
-   parse_body_defer(State, &func, line);
+   this->parse_body_defer(&func, line);
    expr_toreg(fs, &func, reg);
 
-   if (State->tok IS '(') {
-      BCLine argline = State->linenumber;
-      State->next();
-      if (State->tok != ')') {
+   if (this->tok IS '(') {
+      BCLine argline = this->linenumber;
+      this->next();
+      if (this->tok != ')') {
          do {
-            expr(State, &arg);
+            this->expr(&arg);
             expr_tonextreg(fs, &arg);
             nargs++;
-         } while (lex_opt(State, ','));
+         } while (this->lex_opt(','));
       }
 
-      lex_match(State, ')', '(', argline);
+      this->lex_match(')', '(', argline);
 
       if (nargs) {
          BCReg i;
-         for (i = 0; i < nargs; i++) var_new(State, i, NAME_BLANK);
-         var_add(State, nargs);
+         for (i = 0; i < nargs; i++) this->var_new(i, NAME_BLANK);
+         this->var_add(nargs);
          for (i = 0; i < nargs; i++) {
-            VarInfo* argi = &var_get(State, fs, fs->nactvar - nargs + i);
+            VarInfo* argi = &var_get(this, fs, fs->nactvar - nargs + i);
             argi->info |= VSTACK_DEFERARG;
          }
       }
@@ -434,22 +436,22 @@ static void parse_defer(LexState *State)
 //********************************************************************************************************************
 // Parse 'function' statement.
 
-static void parse_func(LexState *State, BCLine line)
+void LexState::parse_func(BCLine line)
 {
    FuncState* fs;
    ExpDesc v, b;
    int needself = 0;
-   State->next();  // Skip 'function'.
+   this->next();  // Skip 'function'.
    // Parse function name.
-   var_lookup(State, &v);
-   while (State->tok IS '.')  // Multiple dot-separated fields.
-      expr_field(State, &v);
-   if (State->tok IS ':') {  // Optional colon to signify method call.
+   this->var_lookup(&v);
+   while (this->tok IS '.')  // Multiple dot-separated fields.
+      this->expr_field(&v);
+   if (this->tok IS ':') {  // Optional colon to signify method call.
       needself = 1;
-      expr_field(State, &v);
+      this->expr_field(&v);
    }
-   parse_body(State, &b, needself, line);
-   fs = State->fs;
+   this->parse_body(&b, needself, line);
+   fs = this->fs;
    bcemit_store(fs, &v, &b);
    fs->bcbase[fs->pc - 1].line = line;  // Set line for the store.
 }
@@ -470,18 +472,18 @@ static int parse_is_end(LexToken tok)
 //********************************************************************************************************************
 // Parse 'return' statement.
 
-static void parse_return(LexState *State)
+void LexState::parse_return()
 {
    BCIns ins;
-   FuncState* fs = State->fs;
-   State->next();  // Skip 'return'.
+   FuncState* fs = this->fs;
+   this->next();  // Skip 'return'.
    fs->flags |= PROTO_HAS_RETURN;
-   if (parse_is_end(State->tok) or State->tok IS ';') {  // Bare return.
+   if (parse_is_end(this->tok) or this->tok IS ';') {  // Bare return.
       ins = BCINS_AD(BC_RET0, 0, 1);
    }
    else {  // Return with one or more values.
       ExpDesc e;  // Receives the _last_ expression in the list.
-      BCReg nret = expr_list(State, &e);
+      BCReg nret = this->expr_list(&e);
       if (nret IS 1) {  // Return one result.
          if (e.k IS ExpKind::Call) {  // Check for tail call.
             BCIns* ip = bcptr(fs, &e);
@@ -516,33 +518,37 @@ static void parse_return(LexState *State)
 //********************************************************************************************************************
 // Parse 'continue' statement.
 
-static void parse_continue(LexState *State)
+void LexState::parse_continue()
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    FuncScope* loop = fs->bl;
+
+   this->next();  // Skip 'continue'.
 
    while (loop and !(loop->flags & FSCOPE_LOOP))
       loop = loop->prev;
-   State->assert_condition(loop != nullptr, "continue outside loop");
+   this->assert_condition(loop != nullptr, "continue outside loop");
 
    execute_defers(fs, loop->nactvar);
    fs->bl->flags |= FSCOPE_CONTINUE;
-   gola_new(State, JUMP_CONTINUE, VSTACK_JUMP, bcemit_jmp(fs));
+   this->gola_new(JUMP_CONTINUE, VSTACK_JUMP, bcemit_jmp(fs));
 }
 
 // Parse 'break' statement.
-static void parse_break(LexState *State)
+void LexState::parse_break()
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    FuncScope* loop = fs->bl;
+
+   this->next();  // Skip 'break'.
 
    while (loop and !(loop->flags & FSCOPE_LOOP))
       loop = loop->prev;
-   State->assert_condition(loop != nullptr, "break outside loop");
+   this->assert_condition(loop != nullptr, "break outside loop");
 
    execute_defers(fs, loop->nactvar);
    fs->bl->flags |= FSCOPE_BREAK;
-   gola_new(State, JUMP_BREAK, VSTACK_JUMP, bcemit_jmp(fs));
+   this->gola_new(JUMP_BREAK, VSTACK_JUMP, bcemit_jmp(fs));
 }
 
 //********************************************************************************************************************
@@ -550,32 +556,32 @@ static void parse_break(LexState *State)
 
 // Parse a block.
 
-static void parse_block(LexState *State)
+void LexState::parse_block()
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    FuncScope bl;
    fscope_begin(fs, &bl, 0);
-   parse_chunk(State);
+   this->parse_chunk();
    fscope_end(fs);
 }
 
 //********************************************************************************************************************
 // Parse 'while' statement.
 
-static void parse_while(LexState *State, BCLine line)
+void LexState::parse_while(BCLine line)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    BCPos start, loop, condexit;
    FuncScope bl;
-   State->next();  // Skip 'while'.
+   this->next();  // Skip 'while'.
    start = fs->lasttarget = fs->pc;
-   condexit = expr_cond(State);
+   condexit = this->expr_cond();
    fscope_begin(fs, &bl, FSCOPE_LOOP);
-   lex_check(State, TK_do);
+   this->lex_check(TK_do);
    loop = bcemit_AD(fs, BC_LOOP, fs->nactvar, 0);
-   parse_block(State);
+   this->parse_block();
    jmp_patch(fs, bcemit_jmp(fs), start);
-   lex_match(State, TK_end, TK_while, line);
+   this->lex_match(TK_end, TK_while, line);
    fscope_loop_continue(fs, start);
    fscope_end(fs);
    jmp_tohere(fs, condexit);
@@ -585,25 +591,25 @@ static void parse_while(LexState *State, BCLine line)
 //********************************************************************************************************************
 // Parse 'repeat' statement.
 
-static void parse_repeat(LexState *State, BCLine line)
+void LexState::parse_repeat(BCLine line)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    BCPos loop = fs->lasttarget = fs->pc;
    BCPos condexit, iter;
    FuncScope bl1, bl2;
    fscope_begin(fs, &bl1, FSCOPE_LOOP);  // Breakable loop scope.
    fscope_begin(fs, &bl2, 0);  // Inner scope.
-   State->next();  // Skip 'repeat'.
+   this->next();  // Skip 'repeat'.
    bcemit_AD(fs, BC_LOOP, fs->nactvar, 0);
-   parse_chunk(State);
-   lex_match(State, TK_until, TK_repeat, line);
+   this->parse_chunk();
+   this->lex_match(TK_until, TK_repeat, line);
    iter = fs->pc;
-   condexit = expr_cond(State);  // Parse condition (still inside inner scope).
+   condexit = this->expr_cond();  // Parse condition (still inside inner scope).
    if (!(bl2.flags & FSCOPE_UPVAL)) {  // No upvalues? Just end inner scope.
       fscope_end(fs);
    }
    else {  // Otherwise generate: cond: UCLO+JMP out, !cond: UCLO+JMP loop.
-      parse_break(State);  // Break from loop and close upvalues.
+      this->parse_break();  // Break from loop and close upvalues.
       jmp_tohere(fs, condexit);
       fscope_end(fs);  // End inner scope and close upvalues.
       condexit = bcemit_jmp(fs);
@@ -617,36 +623,36 @@ static void parse_repeat(LexState *State, BCLine line)
 //********************************************************************************************************************
 // Parse numeric 'for'.
 
-static void parse_for_num(LexState *State, GCstr* varname, BCLine line)
+void LexState::parse_for_num(GCstr* varname, BCLine line)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    BCReg base = fs->freereg;
    FuncScope bl;
    BCPos loop, loopend;
    // Hidden control variables.
-   var_new_fixed(State, FORL_IDX, VARNAME_FOR_IDX);
-   var_new_fixed(State, FORL_STOP, VARNAME_FOR_STOP);
-   var_new_fixed(State, FORL_STEP, VARNAME_FOR_STEP);
+   this->var_new_fixed(FORL_IDX, VARNAME_FOR_IDX);
+   this->var_new_fixed(FORL_STOP, VARNAME_FOR_STOP);
+   this->var_new_fixed(FORL_STEP, VARNAME_FOR_STEP);
    // Visible copy of index variable.
-   var_new(State, FORL_EXT, varname);
-   lex_check(State, '=');
-   expr_next(State);
-   lex_check(State, ',');
-   expr_next(State);
-   if (lex_opt(State, ',')) {
-      expr_next(State);
+   this->var_new(FORL_EXT, varname);
+   this->lex_check('=');
+   this->expr_next();
+   this->lex_check(',');
+   this->expr_next();
+   if (this->lex_opt(',')) {
+      this->expr_next();
    }
    else {
       bcemit_AD(fs, BC_KSHORT, fs->freereg, 1);  // Default step is 1.
       bcreg_reserve(fs, 1);
    }
-   var_add(State, 3);  // Hidden control variables.
-   lex_check(State, TK_do);
+   this->var_add(3);  // Hidden control variables.
+   this->lex_check(TK_do);
    loop = bcemit_AJ(fs, BC_FORI, base, NO_JMP);
    fscope_begin(fs, &bl, 0);  // Scope for visible variables.
-   var_add(State, 1);
+   this->var_add(1);
    bcreg_reserve(fs, 1);
-   parse_block(State);
+   this->parse_block();
    fscope_end(fs);
    // Perform loop inversion. Loop control instructions are at the end.
    loopend = bcemit_AJ(fs, BC_FORL, base, NO_JMP);
@@ -692,9 +698,9 @@ static int predict_next(LexState *State, FuncState* fs, BCPos pc)
 //********************************************************************************************************************
 // Parse 'for' iterator.
 
-static void parse_for_iter(LexState *State, GCstr* indexname)
+void LexState::parse_for_iter(GCstr* indexname)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    ExpDesc e;
    BCReg nvars = 0;
    BCLine line;
@@ -703,28 +709,28 @@ static void parse_for_iter(LexState *State, GCstr* indexname)
    FuncScope bl;
    int isnext;
    // Hidden control variables.
-   var_new_fixed(State, nvars++, VARNAME_FOR_GEN);
-   var_new_fixed(State, nvars++, VARNAME_FOR_STATE);
-   var_new_fixed(State, nvars++, VARNAME_FOR_CTL);
+   this->var_new_fixed(nvars++, VARNAME_FOR_GEN);
+   this->var_new_fixed(nvars++, VARNAME_FOR_STATE);
+   this->var_new_fixed(nvars++, VARNAME_FOR_CTL);
    // Visible variables returned from iterator.
-   var_new(State, nvars++, is_blank_identifier(indexname) ? NAME_BLANK : indexname);
-   while (lex_opt(State, ',')) {
-      GCstr* name = lex_str(State);
-      var_new(State, nvars++, is_blank_identifier(name) ? NAME_BLANK : name);
+   this->var_new(nvars++, is_blank_identifier(indexname) ? NAME_BLANK : indexname);
+   while (this->lex_opt(',')) {
+      GCstr* name = this->lex_str();
+      this->var_new(nvars++, is_blank_identifier(name) ? NAME_BLANK : name);
    }
-   lex_check(State, TK_in);
-   line = State->linenumber;
-   assign_adjust(State, 3, expr_list(State, &e), &e);
+   this->lex_check(TK_in);
+   line = this->linenumber;
+   this->assign_adjust(3, this->expr_list(&e), &e);
    // The iterator needs another 3 [4] slots (func [pc] | state ctl).
    bcreg_bump(fs, 3 + LJ_FR2);
-   isnext = (nvars <= 5 and predict_next(State, fs, exprpc));
-   var_add(State, 3);  // Hidden control variables.
-   lex_check(State, TK_do);
+   isnext = (nvars <= 5 and predict_next(this, fs, exprpc));
+   this->var_add(3);  // Hidden control variables.
+   this->lex_check(TK_do);
    loop = bcemit_AJ(fs, isnext ? BC_ISNEXT : BC_JMP, base, NO_JMP);
    fscope_begin(fs, &bl, 0);  // Scope for visible variables.
-   var_add(State, nvars - 3);
+   this->var_add(nvars - 3);
    bcreg_reserve(fs, nvars - 3);
-   parse_block(State);
+   this->parse_block();
    fscope_end(fs);
    // Perform loop inversion. Loop control instructions are at the end.
    jmp_patchins(fs, loop, fs->pc);
@@ -739,57 +745,126 @@ static void parse_for_iter(LexState *State, GCstr* indexname)
 //********************************************************************************************************************
 // Parse 'for' statement.
 
-static void parse_for(LexState *State, BCLine line)
+void LexState::parse_for(BCLine line)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    GCstr* varname;
    FuncScope bl;
    fscope_begin(fs, &bl, FSCOPE_LOOP);
-   State->next();  // Skip 'for'.
-   varname = lex_str(State);  // Get first variable name.
-   if (State->tok IS '=') parse_for_num(State, varname, line);
-   else if (State->tok IS ',' or State->tok IS TK_in) parse_for_iter(State, varname);
-   else err_syntax(State, LJ_ERR_XFOR);
-   lex_match(State, TK_end, TK_for, line);
+   this->next();  // Skip 'for'.
+   varname = this->lex_str();  // Get first variable name.
+   if (this->tok IS '=') this->parse_for_num(varname, line);
+   else if (this->tok IS ',' or this->tok IS TK_in) this->parse_for_iter(varname);
+   else this->err_syntax(LJ_ERR_XFOR);
+   this->lex_match(TK_end, TK_for, line);
    fscope_end(fs);  // Resolve break list.
 }
 
 //********************************************************************************************************************
 // Parse condition and 'then' block.
 
-static BCPos parse_then(LexState *State)
+BCPos LexState::parse_then()
 {
    BCPos condexit;
-   State->next();  // Skip 'if' or 'elseif'.
-   condexit = expr_cond(State);
-   lex_check(State, TK_then);
-   parse_block(State);
+   this->next();  // Skip 'if' or 'elseif'.
+   condexit = this->expr_cond();
+   this->lex_check(TK_then);
+   this->parse_block();
    return condexit;
 }
 
 //********************************************************************************************************************
 // Parse 'if' statement.
 
-static void parse_if(LexState *State, BCLine line)
+void LexState::parse_if(BCLine line)
 {
-   FuncState* fs = State->fs;
+   FuncState* fs = this->fs;
    BCPos flist;
    BCPos escapelist = NO_JMP;
-   flist = parse_then(State);
-   while (State->tok IS TK_elseif) {  // Parse multiple 'elseif' blocks.
+   flist = this->parse_then();
+   while (this->tok IS TK_elseif) {  // Parse multiple 'elseif' blocks.
       jmp_append(fs, &escapelist, bcemit_jmp(fs));
       jmp_tohere(fs, flist);
-      flist = parse_then(State);
+      flist = this->parse_then();
    }
 
-   if (State->tok IS TK_else) {  // Parse optional 'else' block.
+   if (this->tok IS TK_else) {  // Parse optional 'else' block.
       jmp_append(fs, &escapelist, bcemit_jmp(fs));
       jmp_tohere(fs, flist);
-      State->next();  // Skip 'else'.
-      parse_block(State);
+      this->next();  // Skip 'else'.
+      this->parse_block();
    }
    else jmp_append(fs, &escapelist, flist);
 
    jmp_tohere(fs, escapelist);
-   lex_match(State, TK_end, TK_if, line);
+   this->lex_match(TK_end, TK_if, line);
+}
+
+//********************************************************************************************************************
+// Parse a single statement. Returns 1 if it must be the last one in a chunk.
+
+int LexState::parse_stmt()
+{
+   BCLine line = this->linenumber;
+   switch (this->tok) {
+   case TK_if:
+      this->parse_if(line);
+      break;
+   case TK_while:
+      this->parse_while(line);
+      break;
+   case TK_do:
+      this->next();
+      this->parse_block();
+      this->lex_match(TK_end, TK_do, line);
+      break;
+   case TK_for:
+      this->parse_for(line);
+      break;
+   case TK_repeat:
+      this->parse_repeat(line);
+      break;
+   case TK_function:
+      this->parse_func(line);
+      break;
+   case TK_defer:
+      this->parse_defer();
+      break;
+   case TK_local:
+      this->parse_local();
+      break;
+   case TK_return:
+      this->parse_return();
+      return 1;  // Must be last.
+   case TK_continue:
+      this->parse_continue();
+      break;
+   case TK_break:
+      this->parse_break();
+      break;
+   case ';':
+      this->next();
+      break;
+   default:
+      this->parse_call_assign();
+      break;
+   }
+   return 0;
+}
+
+//********************************************************************************************************************
+// Parse a chunk (list of statements).
+
+void LexState::parse_chunk()
+{
+   int is_last = 0;
+   this->synlevel_begin();
+   while (!is_last and !parse_is_end(this->tok)) {
+      is_last = this->parse_stmt();
+      this->lex_opt(';');
+      this->assert_condition(this->fs->framesize >= this->fs->freereg and
+         this->fs->freereg >= this->fs->nactvar, "bad regalloc");
+      this->fs->freereg = this->fs->nactvar;  // Free registers after each stmt.
+   }
+   this->synlevel_end();
 }

--- a/src/fluid/luajit-2.1/src/parser/parse_types.h
+++ b/src/fluid/luajit-2.1/src/parser/parse_types.h
@@ -179,7 +179,7 @@ typedef struct FuncState {
 }
 
 // Binary and unary operators. ORDER OPR
-typedef enum BinOpr {
+enum BinOpr : int {
    OPR_ADD, OPR_SUB, OPR_MUL, OPR_DIV, OPR_MOD, OPR_POW,  // ORDER ARITH
    OPR_CONCAT,
    OPR_NE, OPR_EQ,
@@ -188,7 +188,7 @@ typedef enum BinOpr {
    OPR_AND, OPR_OR, OPR_IF_EMPTY,
    OPR_TERNARY,
    OPR_NOBINOPR
-} BinOpr;
+};
 
 LJ_STATIC_ASSERT((int)BC_ISGE - (int)BC_ISLT == (int)OPR_GE - (int)OPR_LT);
 LJ_STATIC_ASSERT((int)BC_ISLE - (int)BC_ISLT == (int)OPR_LE - (int)OPR_LT);
@@ -222,4 +222,4 @@ LJ_STATIC_ASSERT((int)BC_MODVV - (int)BC_ADDVV == (int)OPR_MOD - (int)OPR_ADD);
 // Error checking macros.
 #define checklimit(fs, v, l, m)      if ((v) >= (l)) err_limit(fs, l, m)
 #define checklimitgt(fs, v, l, m)   if ((v) > (l)) err_limit(fs, l, m)
-#define checkcond(ls, c, em)      { if (not (c)) err_syntax(ls, em); }
+#define checkcond(ls, c, em)      { if (not (c)) (ls)->err_syntax(em); }


### PR DESCRIPTION
## Summary
- convert the statement parsing helpers and the `parse_stmt`/`parse_chunk` entry points into `LexState` methods and update all parser call sites to use the method-based interface
- move the public anchoring helpers (`keepstr`/`keepcdata`) onto `LexState`, keep thin wrappers for API stability, and update every caller to use the new methods while annotating the wrappers to avoid unused warnings
- refresh `docs/plans/REFACTOR_LEXSTATE.md` for phases 5 and 6 with completion notes, updated metrics, and the finalised timeline/status information

## Testing
- `cmake --build build/agents --config Release --target fluid --parallel`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a18d69f98832e9d105e0f5a118583)