### PR TITLE
Add phase 1 parser implementation plan

### DIFF
--- a/docs/plans/LUAJIT_PARSER_REDESIGN.md
+++ b/docs/plans/LUAJIT_PARSER_REDESIGN.md
@@ -1,0 +1,66 @@
+# LuaJIT Parser Redesign Plan
+
+## Overview
+The LuaJIT parser living in `src/fluid/luajit-2.1/src/parser` was mechanically converted to C++20 but it still mirrors the original C implementation. Bytecode emission is interwoven with parsing logic, register allocation is manually coordinated through free functions, and parser state lives in globally shared structs. These patterns make it hard to add new Fluid language features and are brittle when we attempt larger refactors. This document captures the weak points that surfaced during the review and lays out a phased redesign strategy.
+
+## Current Weak Points
+
+### 1. Parsing and bytecode emission are fused together
+* Functions such as `LexState::expr_table` both parse tokens and emit instructions, making it impossible to unit-test parsing independently from bytecode layout and forcing every feature change to reason about registers mid-parse.【F:src/fluid/luajit-2.1/src/parser/parse_expr.cpp†L144-L205】
+* Compound assignment helpers (`assign_if_empty`, `assign_compound`) replicate this pattern, weaving control-flow and register juggling directly into the parser instead of emitting from a well-defined IR.【F:src/fluid/luajit-2.1/src/parser/parse_stmt.cpp†L64-L199】
+* Because expression parsing mutates `FuncState` on the fly, we cannot cleanly stage optimisations, speculative parsing, or backtracking.
+
+### 2. Parser state is still C-style, global, and difficult to reason about
+* Error handling is still driven by free functions on `LexState`/`FuncState`, so callers manually thread raw pointers everywhere instead of working with richer parser context objects.【F:src/fluid/luajit-2.1/src/parser/parse_core.cpp†L7-L67】【F:src/fluid/luajit-2.1/src/parser/parse_internal.h†L14-L198】
+* `LexState` and `FuncState` expose their internals directly, which encourages accidental invariants (e.g., manually toggling `fs->freereg`) and prevents us from isolating passes such as syntax validation, semantic analysis, and emission.
+* There is no structured tracing or recovery; we cannot, for example, construct an AST to report multiple syntax errors in one pass.
+
+### 3. Expression descriptors and flags remain low-level
+* `ExpDesc` still uses a C `struct` with manually managed unions and bitfields, plus helper functions that operate on raw flags rather than encapsulated behaviour.【F:src/fluid/luajit-2.1/src/parser/parse_types.h†L17-L120】
+* Concepts were introduced but we are not leveraging them to enforce invariants (e.g., no dedicated type for “resolved register expression”). This keeps downstream code dependent on `ExpDesc`’s layout and limits the benefits of C++20.
+* Expression flags continue to be cleared manually through global helpers, which is error-prone and makes ownership of temporary registers unclear.【F:src/fluid/luajit-2.1/src/parser/parse_internal.h†L68-L105】
+
+### 4. Register and jump management is brittle
+* Register handling still lives in plain C functions (`bcreg_reserve`, `expr_discharge`, etc.) that take raw `FuncState*` arguments, so nothing stops callers from skipping required book-keeping or freeing registers out of order.【F:src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp†L7-L200】
+* Higher-level code is forced to duplicate table bases and indexes by hand before evaluating RHS expressions, which is both verbose and easy to get wrong when adding new operators.【F:src/fluid/luajit-2.1/src/parser/parse_stmt.cpp†L151-L199】
+* Jump lists rely on callers understanding how to patch BC instructions manually via `JumpListView`, keeping implicit coupling between parse-time control-flow and bytecode layout.【F:src/fluid/luajit-2.1/src/parser/parse_internal.h†L24-L66】
+
+### 5. Limited testability and instrumentation
+* Because parsing, semantic analysis, and emission are intertwined, we cannot unit-test many helpers without spinning up an entire `FuncState`. Debugging currently depends on bytecode dumps rather than structured diagnostics or trace logs.
+* There is no systematic way to validate invariants (register depth, pending jumps) other than assertions, which makes regressions harder to catch before runtime.
+
+## Proposed Redesign (Phased)
+
+### Phase 1 – Build a modern parser context and typed token stream
+1. Introduce a `ParserContext` object that owns `LexState`, `FuncState`, allocator references, and an error collector. Provide lightweight `ParserResult`/`ParserStatus` structs (or `std::expected` equivalents) so helpers can return status without throwing.
+2. Replace ad-hoc token helpers with a `TokenView`/`Lookahead` class that exposes typed tokens (`enum class TokenKind` + payload variant) so expression/statement parsers can work with strongly-typed data instead of re-reading `LexState` globals.
+3. Wrap common operations (`match`, `consume`, `expect`) in context-aware methods that record errors instead of immediately aborting, laying the groundwork for better diagnostics.
+4. Update existing modules to consume the new interfaces while still emitting bytecode directly; this phase focuses on isolating state and clarifying APIs so subsequent phases can swap implementations underneath.
+
+### Phase 2 – Introduce an intermediate AST/IR layer
+1. Define lightweight AST/IR node types (e.g., `ExprNode`, `StmtNode`) that capture the semantic structure of Fluid code without binding to registers. Use `std::variant`, `std::vector`, and `std::unique_ptr` to express recursive shapes.
+2. Rework `expr_*` and `stmt_*` functions to build AST nodes using the new typed tokens, leaving `FuncState` untouched during parsing. Error recovery can now operate on AST boundaries.
+3. Implement an `IrEmitter` pass that walks the AST and emits LuaJIT bytecode, retaining optimised patterns (folding, table templates) but isolating them from syntax parsing. This emitter becomes the sole owner of `FuncState` and register allocation.
+4. Provide hooks for future passes (e.g., AST transforms for new Fluid features) by designing the node structures and traversal APIs with extensibility in mind.
+
+### Phase 3 – Rebuild register, jump, and expression management
+1. Replace the global register helpers with a `RegisterAllocator` class that enforces lifetimes via RAII objects (e.g., `AllocatedRegister`, `RegisterSpan`). This allocator should expose explicit methods for duplicating table bases/indexes so compound operations no longer need to hand-roll copies.【F:src/fluid/luajit-2.1/src/parser/parse_stmt.cpp†L151-L199】
+2. Encapsulate `ExpDesc` behaviour inside a class hierarchy or tagged union that knows how to discharge itself into the allocator, removing the need for external functions such as `expr_discharge`. Persist convenient constructors (nil/number/string) but hide raw flag manipulation behind methods.
+3. Turn `JumpListView` into a higher-level `ControlFlowGraph` helper that models pending jumps as structured nodes instead of patching BC instructions inline. The emitter can then translate CFG edges into BC when finalising a block, greatly reducing manual patching sites.【F:src/fluid/luajit-2.1/src/parser/parse_internal.h†L24-L66】
+4. Add debug-only verification hooks on the allocator/CFG to assert invariants (slot depth, unresolved jumps) at phase boundaries instead of scattering assertions across the parser.
+
+### Phase 4 – Modernise operator and statement implementations
+1. Rewrite operator handling (`parse_operators.cpp`, `expr_table`, compound assignments, ternaries, etc.) to operate on the AST + allocator abstractions. Many of the handwritten register juggling steps should disappear once operators work with value categories and temporaries managed by the allocator.【F:src/fluid/luajit-2.1/src/parser/parse_expr.cpp†L144-L205】【F:src/fluid/luajit-2.1/src/parser/parse_stmt.cpp†L64-L199】
+2. Model statement forms (loops, defers, continue/break) as dedicated node types so new Fluid constructs can be slotted in without rewriting large switch statements.
+3. Where we still need immediate emission for performance (e.g., constant folding), keep that logic inside the emitter but guard it with clear contracts (inputs/outputs) and unit tests.
+
+### Phase 5 – Instrumentation, testing, and migration
+1. Introduce parser-level unit tests that operate on the AST (syntax only) and emitter-level tests that check bytecode for representative patterns. This decouples behavioural tests from integration-only Fluid scripts.
+2. Add tracing hooks (compile-time toggles) inside `ParserContext`, `RegisterAllocator`, and `IrEmitter` to log high-level events for debugging without sprinkling `printf` statements in production code.
+3. Plan a staged rollout: gate the new pipeline behind a build flag, run both parsers in parallel (old vs. new) in debug builds, and diff bytecode output to gain confidence before removing the legacy path.
+4. Document migration guidelines so future contributors know how to extend the parser using the new abstractions (e.g., “add a new AST node, extend the emitter visitor, add unit tests”).
+
+## Next Steps
+1. Prototype the `ParserContext`/typed token APIs and convert a small subset of expressions to ensure the new scaffolding covers real scenarios.
+2. Agree on the AST/IR schema and emitter responsibilities, including how much optimisation should happen per phase.
+3. Schedule incremental conversions (expressions, statements, control-flow) so we can land improvements without destabilising the parser.

--- a/docs/plans/PARSER_PHASE1.md
+++ b/docs/plans/PARSER_PHASE1.md
@@ -1,0 +1,86 @@
+# LuaJIT Parser Redesign – Phase 1 Implementation Plan
+
+## Objectives
+Phase 1 establishes the foundational infrastructure required for the later parser refactors described in `docs/plans/LUAJIT_PARSER_REDESIGN.md`. The focus is isolating parser state, clarifying token handling, and providing structured error reporting while continuing to emit bytecode directly. This plan enumerates the concrete steps needed to deliver those capabilities with minimal disruption to current functionality.
+
+## Deliverables
+1. `ParserContext` (and supporting data types) that own parser-wide resources, expose lifecycle helpers, and offer status reporting.
+2. A typed token representation (`TokenKind`, payload variants, iterators/lookahead helpers) plus integration with the existing lexer.
+3. Context-aware utilities for token consumption and expectation tracking, wired into representative parser entry points.
+4. Error collection/reporting scaffolding that enables multiple diagnostics per parse without immediate abort.
+5. Migration of a pilot surface area (e.g., expression prefix parsing + a simple statement) to validate the new interfaces.
+
+## Step-by-Step Plan
+
+### 1. Establish the ParserContext scaffolding
+1. Inventory ownership boundaries inside `src/fluid/luajit-2.1/src/parser` (LexState, FuncState, GC-managed allocators, diagnostics, VM state hooks). Document the intended lifetime semantics in code comments.
+2. Create `parser_context.h/.cpp` that defines `ParserContext` with the following members:
+   * References/pointers to `LexState`, `FuncState`, allocator, and `lua_State`.
+   * `ParserConfig` struct capturing feature toggles (e.g., future AST gating) and tracing flags.
+   * `ParserDiagnostics` object (see step 4) embedded by value to avoid dynamic allocation.
+3. Provide RAII-friendly construction helpers:
+   * `ParserContext::from(LexState&, FuncState&, Allocator&, ParserConfig)` to initialise derived state (e.g., token stream adapter).
+   * `ParserSession` lightweight guard that temporarily overrides context options (useful for nested parses like function literals).
+4. Replace direct uses of `LexState*`/`FuncState*` in shared helpers (start with `parse_core.cpp` utilities) to accept `ParserContext&`. Maintain overloads for legacy call sites using inline wrappers while migration is in progress.
+5. Add `ParserResult<T>` alias (using `std::expected<T, ParserError>` or bespoke struct) along with convenience constructors `ok(T)` and `fail(ParserError)`. Ensure headers avoid C++ exception semantics per repository rules.
+
+### 2. Build the typed token system
+1. Define `enum class TokenKind` in `token_types.h` that covers all tokens produced by `lex_next` plus Fluid extensions (defer, ??, ?=, continue, etc.). Align names with existing `TK_*` constants to simplify the migration map.
+2. Implement `struct TokenPayload` as a tagged union (e.g., `std::variant<std::monostate, double, TValue*, GCstr*, BCIns>`). Provide helper constructors (`Token::number(double)`, `Token::name(GCstr*)`, etc.) that perform any necessary conversions.
+3. Create `class Token` encapsulating `TokenKind kind`, `TokenPayload payload`, source span metadata (line, column, absolute offset), and helper predicates (`is_identifier()`, `is_literal()`).
+4. Write `TokenStreamAdapter` in `token_stream.h/.cpp` that wraps the legacy lexer:
+   * `Token TokenStreamAdapter::current() const;`
+   * `Token TokenStreamAdapter::peek(std::size_t lookahead);`
+   * `Token TokenStreamAdapter::advance();`
+   * `void TokenStreamAdapter::sync_from_lex(LexState&)` for recovery.
+5. Integrate the adapter into `ParserContext` so consumers can access `context.tokens()` instead of touching `LexState` directly. Maintain backwards compatibility by exposing the underlying `LexState&` for code that has not migrated yet.
+6. Update diagnostic helpers to accept `Token` spans to support future multi-token error messages.
+
+### 3. Implement context-aware token utilities
+1. Add member functions on `ParserContext` (or a nested `TokenCursor`) for recurring patterns:
+   * `bool match(TokenKind)` – advances when the current token matches, records expectation otherwise.
+   * `Token consume(TokenKind, ParserErrorCode)` – asserts presence and emits structured error entries via diagnostics when absent.
+   * `bool check(TokenKind)` – lookahead without advancing.
+   * `Token expect_identifier(ParserErrorCode)` – ensures identifier payload and emits consistent messaging.
+2. Ensure these helpers emit `ParserResult<Token>` so callers can branch on success rather than relying on `lua_assert`.
+3. Replace ad-hoc checks in a pilot set of functions (e.g., `expr_primary`, `expr_prefix`, and `stmt_local`) to use the new helpers, keeping behaviour identical while reducing direct lexing.
+4. Add unit-style regression tests (or targeted Fluid scripts executed via `parasol`) that cover typical success/failure paths to verify no behaviour drift. Capture commands in plan for future automation.
+
+### 4. Introduce structured diagnostics
+1. Define `ParserDiagnostic` struct capturing severity, message ID/enum, formatted message, and source span.
+2. Implement `ParserDiagnostics` container that stores a bounded vector (configurable in `ParserConfig`). Provide APIs:
+   * `void report(ParserDiagnostic)`
+   * `bool has_errors() const`
+   * `std::span<const ParserDiagnostic> entries() const`
+3. Extend `ParserContext` to expose `diagnostics()` for read-only access and `emit_error(...)` helpers that format messages from tokens plus extra context.
+4. Retrofit existing fatal error pathways (`lj_lex_error`, `lj_parse_error`) to delegate to `ParserDiagnostics` while still triggering the old behaviour (e.g., abort on first error) until a later phase relaxes it. This ensures instrumentation is live even before multi-error support ships.
+5. Document new diagnostic codes/messages in-line (and optionally within `docs/wiki/System-Error-Codes.md` once semantics stabilise).
+
+### 5. Validate via pilot migrations
+1. Select representative parser entry points:
+   * Expression path: `expr_primary` + `expr_prefix`.
+   * Statement path: `stmt_local` or another simple construct without complex register interactions.
+2. Convert these functions to:
+   * Receive `ParserContext&`.
+   * Use the typed token helpers for control flow.
+   * Return `ParserResult<ExpDesc>` (or equivalent) to surface parsing failures upstream.
+3. Update callers and surrounding helpers to propagate `ParserResult` without altering bytecode emission.
+4. Add targeted unit/integration tests that parse contrived snippets covering identifiers, literals, and failure cases to demonstrate diagnostics accumulation.
+5. Write migration notes (inline comments + updates to `docs/plans/LUAJIT_PARSER_REDESIGN.md` if necessary) capturing patterns discovered during the pilot, informing later phases on anticipated complexities.
+
+### 6. Integration and hardening tasks
+1. Add build-time toggles (e.g., `PARASOL_PARSER_TRACE`) to gate verbose tracing via `ParserContext` for debugging.
+2. Ensure new headers are included in `CMakeLists.txt` and `pkg` exports so downstream modules can reference them when the parser becomes reusable.
+3. Run the existing parser regression suites (Fluid scripts, if available) to confirm the Phase 1 changes are non-breaking. Capture invocation commands in commit messages for traceability.
+4. Perform code-style and rule compliance checks (British English spelling, macro usage, `and`/`or`, `IS` macros) before landing.
+5. Update `docs/plans/LUAJIT_PARSER_REDESIGN.md` “Next Steps” once Phase 1 completes to reflect the availability of the new infrastructure.
+
+## Dependencies and Risks
+* **Incremental adoption:** Maintain compatibility layers (inline wrappers, fallback error paths) so we can migrate subsystems gradually without touching every parser file at once.
+* **Performance impact:** Introduce profiling hooks early to ensure the typed token adapter does not degrade hot paths. Consider small-object optimisations for `Token` payload storage.
+* **Memory lifetime:** Clarify whether `Token` payloads own or reference Lua VM data (strings, TValue). Document invariants to avoid dangling references when GC runs during parsing.
+
+## Success Criteria
+* Parser helpers compile against `ParserContext` without direct access to global parser structs for the migrated pilot areas.
+* Typed tokens, diagnostics, and context utilities are covered by tests and used in at least one expression + statement path.
+* Legacy behaviour (single-error abort, direct bytecode emission) remains intact, ensuring later phases can focus on AST/IR work with confidence in the new scaffolding.


### PR DESCRIPTION
## Summary
- add a dedicated plan for executing Phase 1 of the LuaJIT parser redesign, covering objectives, deliverables, and detailed steps for context scaffolding, typed tokens, diagnostics, and pilot migrations
- document dependencies, risks, and success criteria so later phases can build on the groundwork

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a61d2663c832eaee136ac1625ba84)