### PR TITLE
Prevent ParserContext::match from leaking Lua stack entries

### DIFF
--- a/docs/plans/PARSER_P1.md
+++ b/docs/plans/PARSER_P1.md
@@ -84,3 +84,7 @@ Phase 1 establishes the foundational infrastructure required for the later parse
 * Parser helpers compile against `ParserContext` without direct access to global parser structs for the migrated pilot areas.
 * Typed tokens, diagnostics, and context utilities are covered by tests and used in at least one expression + statement path.
 * Legacy behaviour (single-error abort, direct bytecode emission) remains intact, ensuring later phases can focus on AST/IR work with confidence in the new scaffolding.
+
+## Phase 1 Status (Implemented)
+* Introduced `ParserContext`, diagnostics, and typed token stream scaffolding. `expr_primary` and `parse_local` use the new helpers while retaining legacy fallbacks.
+* Added a lightweight Fluid regression script `src/fluid/tests/parser_phase1.fluid`. Run it with `parasol --log-warning src/fluid/tests/parser_phase1.fluid` after building to verify the migrated surfaces parse and execute normally.

--- a/docs/plans/PARSER_P2.md
+++ b/docs/plans/PARSER_P2.md
@@ -1,0 +1,67 @@
+# LuaJIT Parser Redesign – Phase 2 Implementation Plan
+
+## Objectives
+Phase 2 severs the direct coupling between syntax parsing and bytecode emission by constructing a lightweight abstract syntax / intermediate representation (AST/IR) for Fluid programs. The parser will consume the Phase 1 typed token stream to build tree nodes that model expressions and statements independently of registers. Bytecode emission is deferred to a dedicated pass so semantic analysis, diagnostics, and future language features can operate on structured data instead of raw `FuncState` mutation.
+
+## Deliverables
+1. A set of AST/IR node definitions that capture all Fluid expressions, statements, and control-flow constructs parsed today, along with helper factories and traversal utilities.
+2. Parser entry points (`expr_*`, `stmt_*`, and top-level helpers) that return AST nodes (or `ParserResult<AstNode>` equivalents) while leaving `FuncState` untouched.
+3. An `IrEmitter` (or equivalent visitor) that lowers AST nodes to LuaJIT bytecode, managing register allocation and control-flow patching internally while preserving existing optimisations.
+4. Debugging hooks and diagnostics that operate on AST boundaries, enabling clearer error reporting and easier instrumentation.
+5. Documentation and regression tests that describe how to construct, serialise, and emit AST nodes, ensuring future phases can extend the pipeline safely.
+
+## Step-by-Step Plan
+
+### 1. Define the AST/IR schema
+1. Catalogue every expression and statement form handled under `src/fluid/luajit-2.1/src/parser` (prefix expressions, suffix operations, literals, control-flow statements, function literals, etc.) and describe the required operands, spans, and attributes for each.
+2. Create `ast_nodes.h/.cpp` (or extend `parse_types.h`) to house:
+   * Core node tags (`enum class AstNodeKind`), identifier/literal wrappers, and source span metadata shared across nodes.
+   * Expression node structs (`LiteralExpr`, `BinaryExpr`, `TableCtorExpr`, `CallExpr`, etc.) expressed via `std::variant` or tagged unions that own child nodes through `std::unique_ptr`/`std::vector`.
+   * Statement node structs (`LocalStmt`, `AssignmentStmt`, `IfStmt`, `LoopStmt`, `DeferStmt`, etc.) that explicitly encode nested blocks and labels.
+3. Provide builder helpers (`make_literal`, `make_call`, `make_block`) that validate invariants (e.g., operand counts) and attach diagnostic context.
+4. Define lightweight views/iterators for node collections (block statements, function parameters) so later passes can traverse without leaking internal storage details.
+5. Document the schema inside the new header, including ownership semantics and extension guidelines (e.g., how to add a new operator node).
+
+### 2. Thread AST construction through the parser
+1. Update `ParserContext` (Phase 1 deliverable) with factories or allocators for AST nodes if pooled allocation becomes necessary, otherwise rely on standard containers but document lifetime expectations.
+2. Modify expression parsing functions (`expr_primary`, `expr_prefix`, `expr_binop`, etc.) to build and return AST nodes:
+   * Replace `ExpDesc` mutation with `ParserResult<ExprNode>` outputs.
+   * Use typed token helpers to attach `Token` spans to nodes for later diagnostics.
+3. Perform the same rewrite for statement parsers (`parse_local`, `parse_if`, `parse_loop`, `parse_block`, etc.), ensuring scope/label information is represented structurally (e.g., `BlockNode` with explicit child vectors) rather than via raw stack manipulation.
+4. Introduce transitional adapters where immediate emission is still required (e.g., complex table constructors) so the rest of the parser can migrate incrementally without regressing behaviour. These adapters should convert AST nodes back into the legacy `ExpDesc` path only when unavoidable and be annotated for removal.
+5. Extend diagnostics to report at node boundaries (e.g., “invalid break outside loop” attaches to the `BreakStmt` node) using the span metadata stored on nodes.
+
+### 3. Implement the IR emission pass
+1. Create `ir_emitter.h/.cpp` that exposes an `IrEmitter` class responsible for walking AST nodes and invoking legacy bytecode helpers. The emitter owns `FuncState`, register allocation, jump management, and any pending constant folding.
+2. Define visitor entry points (`emit_block(const BlockNode&)`, `emit_expr(const ExprNode&)`, `emit_stmt(const StmtNode&)`) that translate nodes into bytecode while respecting existing optimisations (e.g., tail calls, constant folding, loop invariants).
+3. Encapsulate register allocation within the emitter for this phase, even if the full Phase 3 allocator is not yet available. Provide interim helper classes (e.g., `TempRegister`) that mimic RAII semantics to prepare for Phase 3’s allocator refactor.
+4. Ensure control-flow constructs use structured patching APIs inside the emitter (e.g., helper methods to create jump lists for `if`/`loop` nodes) rather than manipulating `BCPos` manually in parser code.
+5. Add hooks so later phases can swap the emitter implementation or insert transformation passes between parsing and emission (e.g., AST rewrites for new language features).
+
+### 4. Integrate parsing and emission boundaries
+1. Decide on a top-level parse contract: e.g., `ParserContext::parse_chunk()` returns `ParserResult<BlockNode>` which, on success, is passed to `IrEmitter::emit(BlockNode&)`. Document this handshake in both headers.
+2. Update callers (`lj_parse`, module loaders) to instantiate the emitter and feed it the AST after a successful parse. Maintain a feature flag that can re-enable the legacy direct emission path for debugging during the migration.
+3. Provide conversion helpers or logging utilities to diff AST-driven bytecode against the legacy output for representative Fluid scripts, easing validation.
+4. Record instrumentation (trace logs or debug dumps) at the parse/emission boundary to help Phase 5 introduce deeper testing. These dumps should include node kinds, child counts, and token spans for reproducibility.
+
+### 5. Testing, validation, and performance safeguards
+1. Add parser-level unit tests (or scripted Fluid snippets) that assert the produced AST shape for canonical inputs (literal expressions, nested tables, loops, function literals). Consider serialising nodes to a debug JSON/text format purely for tests.
+2. Extend existing regression scripts (e.g., `src/fluid/tests/parser_phase1.fluid`) or add new ones dedicated to Phase 2 to ensure AST parsing covers success and failure modes.
+3. Implement bytecode comparison harnesses that run both the legacy and AST-driven emitters (guarded by a build flag) and assert bytecode equivalence for curated samples. Failures should produce actionable diffs.
+4. Profile parsing/emission time on representative workloads to ensure the extra AST allocation overhead stays within acceptable limits; document mitigation strategies (arena allocators, node pooling) if necessary.
+
+### 6. Documentation and developer enablement
+1. Update `docs/plans/LUAJIT_PARSER_REDESIGN.md` Phase 2 section summary (once implementation begins) with progress notes, caveats, and links to the new files.
+2. Create contributor notes (either inline in headers or a short guide under `docs/plans/`) describing how to add new AST nodes, how the emitter visitor should be extended, and how diagnostics tie into spans.
+3. Capture troubleshooting steps for AST/emitter mismatches (e.g., enabling trace dumps, running the bytecode diff harness) to accelerate onboarding for future maintainers.
+
+## Dependencies and Risks
+* **Incremental migration:** Because rewriting all parser entry points simultaneously is risky, schedule the conversion in slices (expressions first, then statements) and maintain temporary bridging code. Clearly annotate any hybrid paths.
+* **Memory pressure:** AST construction introduces additional allocations. Investigate arena allocators or object pools if profiling shows regressions, and provide instrumentation toggles to measure node counts.
+* **Emitter parity:** Any behavioural drift between the new emitter and the legacy inline emission can break Fluid programs. The bytecode diff harness and feature flag are critical for safe rollout.
+
+## Success Criteria
+* Parser functions return AST nodes and no longer mutate `FuncState` directly during syntax analysis for the migrated surfaces.
+* The new emitter reproduces existing bytecode layouts for the covered constructs, validated via automated comparisons.
+* Diagnostics and tracing operate on AST spans, enabling clearer error reporting and groundwork for future multi-error recovery.
+* Documentation and tests describe the AST schema, emission contract, and validation procedures, ensuring subsequent phases (register allocator rewrite, operator modernisation) have a stable platform.

--- a/src/fluid/luajit-2.1/src/parser/lj_parse.cpp
+++ b/src/fluid/luajit-2.1/src/parser/lj_parse.cpp
@@ -43,6 +43,11 @@ static const struct {
   {1,1,nullptr,0}                     // TERNARY
 };
 
+#include "parser/token_types.h"
+#include "parser/token_types.cpp"
+#include "parser/token_stream.cpp"
+#include "parser/parser_diagnostics.cpp"
+#include "parser/parser_context.cpp"
 #include "parser/parse_types.h"
 #include "parser/parse_internal.h"
 #include "parser/parse_core.cpp"

--- a/src/fluid/luajit-2.1/src/parser/parser_context.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parser_context.cpp
@@ -1,0 +1,174 @@
+#include "parser/parser_context.h"
+
+#include "lj_parse.h"
+
+ParserAllocator ParserAllocator::from(lua_State* state)
+{
+   ParserAllocator allocator;
+   allocator.userdata = (void*)state;
+   return allocator;
+}
+
+ParserContext ParserContext::from(LexState& lex_state, FuncState& func_state, ParserAllocator allocator,
+   ParserConfig config)
+{
+   return ParserContext(lex_state, func_state, *lex_state.L, allocator, config);
+}
+
+ParserContext::ParserContext(LexState& lex_state, FuncState& func_state, lua_State& lua_state,
+   ParserAllocator allocator, ParserConfig config)
+   : lex_state(&lex_state)
+   , func_state(&func_state)
+   , lua_state(&lua_state)
+   , allocator(allocator)
+   , current_config(config)
+   , token_stream(lex_state)
+{
+   this->diag.set_limit(config.max_diagnostics);
+}
+
+LexState& ParserContext::lex() const
+{
+   return *this->lex_state;
+}
+
+FuncState& ParserContext::func() const
+{
+   return *this->func_state;
+}
+
+lua_State& ParserContext::lua() const
+{
+   return *this->lua_state;
+}
+
+ParserDiagnostics& ParserContext::diagnostics()
+{
+   return this->diag;
+}
+
+const ParserDiagnostics& ParserContext::diagnostics() const
+{
+   return this->diag;
+}
+
+TokenStreamAdapter& ParserContext::tokens()
+{
+   return this->token_stream;
+}
+
+const TokenStreamAdapter& ParserContext::tokens() const
+{
+   return this->token_stream;
+}
+
+ParserConfig ParserContext::config() const
+{
+   return this->current_config;
+}
+
+void ParserContext::override_config(const ParserConfig& config)
+{
+   this->current_config = config;
+   this->diag.set_limit(config.max_diagnostics);
+}
+
+void ParserContext::restore_config(const ParserConfig& config)
+{
+   this->current_config = config;
+   this->diag.set_limit(config.max_diagnostics);
+}
+
+ParserResult<Token> ParserContext::match(TokenKind kind)
+{
+   Token current = this->tokens().current();
+   if (current.is(kind)) {
+      this->token_stream.advance();
+      return ParserResult<Token>::success(current);
+   }
+
+   if (this->current_config.trace_expectations) {
+      std::string expectation = this->format_expected_message(kind);
+      ParserDiagnostic diagnostic;
+      diagnostic.severity = ParserDiagnosticSeverity::Info;
+      diagnostic.code = ParserErrorCode::ExpectedToken;
+      diagnostic.message = expectation;
+      diagnostic.token = current;
+      this->diag.report(diagnostic);
+   }
+
+   ParserError error = this->make_error(ParserErrorCode::ExpectedToken, current, std::string_view{});
+   return ParserResult<Token>::failure(error);
+}
+
+ParserResult<Token> ParserContext::consume(TokenKind kind, ParserErrorCode code)
+{
+   auto result = this->match(kind);
+   if (result.ok()) return result;
+
+   std::string expectation = this->format_expected_message(kind);
+   Token current = this->tokens().current();
+   this->emit_error(code, current, expectation);
+   return ParserResult<Token>::failure(this->make_error(code, current, expectation));
+}
+
+bool ParserContext::check(TokenKind kind) const
+{
+   return this->tokens().current().is(kind);
+}
+
+ParserResult<Token> ParserContext::expect_identifier(ParserErrorCode code)
+{
+   Token current = this->tokens().current();
+   if (current.is_identifier()) {
+      this->token_stream.advance();
+      return ParserResult<Token>::success(current);
+   }
+   this->emit_error(code, current, "expected identifier");
+   return ParserResult<Token>::failure(this->make_error(code, current, "expected identifier"));
+}
+
+std::string ParserContext::format_expected_message(TokenKind kind) const
+{
+   const char* name = token_kind_name(kind, this->lex());
+   std::string message = std::string("expected ") + name;
+   if ((LexToken)kind <= TK_OFS) {
+      lua_pop(this->lua_state, 1);
+   }
+   return message;
+}
+
+ParserError ParserContext::make_error(ParserErrorCode code, const Token& token, std::string_view message)
+{
+   ParserError error;
+   error.code = code;
+   error.token = token;
+   error.message.assign(message.begin(), message.end());
+   return error;
+}
+
+void ParserContext::emit_error(ParserErrorCode code, const Token& token, std::string_view message)
+{
+   ParserDiagnostic diagnostic;
+   diagnostic.severity = ParserDiagnosticSeverity::Error;
+   diagnostic.code = code;
+   diagnostic.message.assign(message.begin(), message.end());
+   diagnostic.token = token;
+   this->diag.report(diagnostic);
+   if (this->current_config.abort_on_error) {
+      this->lex_state->err_token(token.raw());
+   }
+}
+
+ParserSession::ParserSession(ParserContext& context, ParserConfig config)
+   : ctx(&context)
+   , previous(context.config())
+{
+   this->ctx->override_config(config);
+}
+
+ParserSession::~ParserSession()
+{
+   this->ctx->restore_config(this->previous);
+}
+

--- a/src/fluid/luajit-2.1/src/parser/parser_context.h
+++ b/src/fluid/luajit-2.1/src/parser/parser_context.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "parser/parser_diagnostics.h"
+#include "parser/token_stream.h"
+
+struct ParserAllocator {
+   void* userdata = nullptr;
+
+   static ParserAllocator from(lua_State* state);
+};
+
+struct ParserConfig {
+   uint32_t max_diagnostics = 8;
+   bool abort_on_error = true;
+   bool trace_tokens = false;
+   bool trace_expectations = false;
+};
+
+struct ParserError {
+   ParserErrorCode code = ParserErrorCode::None;
+   std::string message;
+   Token token;
+};
+
+template<typename T>
+class ParserResult {
+public:
+   ParserResult() = default;
+
+   static ParserResult<T> success(const T& value)
+   {
+      ParserResult<T> result;
+      result.has_value = true;
+      result.value = value;
+      return result;
+   }
+
+   static ParserResult<T> failure(const ParserError& error)
+   {
+      ParserResult<T> result;
+      result.has_value = false;
+      result.error = error;
+      return result;
+   }
+
+   [[nodiscard]] bool ok() const { return this->has_value; }
+   [[nodiscard]] const T& value_ref() const { return this->value; }
+   [[nodiscard]] T& value_ref() { return this->value; }
+   [[nodiscard]] const ParserError& error_ref() const { return this->error; }
+
+private:
+   bool has_value = false;
+   T value;
+   ParserError error;
+};
+
+class ParserContext {
+public:
+   static ParserContext from(LexState& lex_state, FuncState& func_state, ParserAllocator allocator,
+      ParserConfig config = ParserConfig{});
+
+   ParserContext(LexState& lex_state, FuncState& func_state, lua_State& lua_state,
+      ParserAllocator allocator, ParserConfig config);
+
+   LexState& lex() const;
+   FuncState& func() const;
+   lua_State& lua() const;
+
+   ParserDiagnostics& diagnostics();
+   const ParserDiagnostics& diagnostics() const;
+
+   TokenStreamAdapter& tokens();
+   const TokenStreamAdapter& tokens() const;
+
+   ParserConfig config() const;
+   void override_config(const ParserConfig& config);
+   void restore_config(const ParserConfig& config);
+
+   ParserResult<Token> match(TokenKind kind);
+   ParserResult<Token> consume(TokenKind kind, ParserErrorCode code);
+   bool check(TokenKind kind) const;
+   ParserResult<Token> expect_identifier(ParserErrorCode code);
+
+   void emit_error(ParserErrorCode code, const Token& token, std::string_view message);
+
+private:
+   std::string format_expected_message(TokenKind kind) const;
+   ParserError make_error(ParserErrorCode code, const Token& token, std::string_view message);
+
+   LexState* lex_state;
+   FuncState* func_state;
+   lua_State* lua_state;
+   ParserAllocator allocator;
+   ParserConfig current_config;
+   ParserDiagnostics diag;
+   TokenStreamAdapter token_stream;
+};
+
+class ParserSession {
+public:
+   ParserSession(ParserContext& context, ParserConfig config);
+   ~ParserSession();
+
+private:
+   ParserContext* ctx;
+   ParserConfig previous;
+};
+

--- a/src/fluid/luajit-2.1/src/parser/parser_diagnostics.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parser_diagnostics.cpp
@@ -1,0 +1,36 @@
+#include "parser/parser_diagnostics.h"
+
+ParserDiagnostics::ParserDiagnostics()
+   : limit(8)
+{
+}
+
+void ParserDiagnostics::set_limit(uint32_t new_limit)
+{
+   this->limit = new_limit;
+}
+
+void ParserDiagnostics::report(const ParserDiagnostic& diagnostic)
+{
+   if (this->storage.size() >= this->limit) return;
+   this->storage.push_back(diagnostic);
+}
+
+bool ParserDiagnostics::has_errors() const
+{
+   for (const auto& entry : this->storage) {
+      if (entry.severity IS ParserDiagnosticSeverity::Error) return true;
+   }
+   return false;
+}
+
+std::span<const ParserDiagnostic> ParserDiagnostics::entries() const
+{
+   return std::span<const ParserDiagnostic>(this->storage.data(), this->storage.size());
+}
+
+void ParserDiagnostics::clear()
+{
+   this->storage.clear();
+}
+

--- a/src/fluid/luajit-2.1/src/parser/parser_diagnostics.h
+++ b/src/fluid/luajit-2.1/src/parser/parser_diagnostics.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <span>
+#include <string>
+#include <vector>
+
+#include "parser/token_types.h"
+
+enum class ParserDiagnosticSeverity : uint8_t {
+   Info,
+   Warning,
+   Error
+};
+
+enum class ParserErrorCode : uint16_t {
+   None = 0,
+   UnexpectedToken,
+   ExpectedToken,
+   ExpectedIdentifier,
+   UnexpectedEndOfFile,
+   InternalInvariant
+};
+
+struct ParserDiagnostic {
+   ParserDiagnosticSeverity severity = ParserDiagnosticSeverity::Error;
+   ParserErrorCode code = ParserErrorCode::UnexpectedToken;
+   std::string message;
+   Token token;
+};
+
+class ParserDiagnostics {
+public:
+   ParserDiagnostics();
+
+   void set_limit(uint32_t limit);
+   void report(const ParserDiagnostic& diagnostic);
+   [[nodiscard]] bool has_errors() const;
+   [[nodiscard]] std::span<const ParserDiagnostic> entries() const;
+   void clear();
+
+private:
+   uint32_t limit;
+   std::vector<ParserDiagnostic> storage;
+};
+

--- a/src/fluid/luajit-2.1/src/parser/token_stream.cpp
+++ b/src/fluid/luajit-2.1/src/parser/token_stream.cpp
@@ -1,0 +1,32 @@
+#include "parser/token_stream.h"
+
+#include "lj_lex.h"
+
+TokenStreamAdapter::TokenStreamAdapter(LexState& state)
+   : lex_state(&state)
+{
+}
+
+Token TokenStreamAdapter::current() const
+{
+   return Token::from_current(*this->lex_state);
+}
+
+Token TokenStreamAdapter::peek(size_t lookahead) const
+{
+   if (lookahead IS 0) return this->current();
+   if (lookahead IS 1) return Token::from_lookahead(*this->lex_state);
+   return this->current();
+}
+
+Token TokenStreamAdapter::advance()
+{
+   this->lex_state->next();
+   return this->current();
+}
+
+void TokenStreamAdapter::sync_from_lex(LexState& state)
+{
+   this->lex_state = &state;
+}
+

--- a/src/fluid/luajit-2.1/src/parser/token_stream.h
+++ b/src/fluid/luajit-2.1/src/parser/token_stream.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "parser/token_types.h"
+
+class TokenStreamAdapter {
+public:
+   explicit TokenStreamAdapter(LexState& state);
+
+   [[nodiscard]] Token current() const;
+   [[nodiscard]] Token peek(size_t lookahead) const;
+   Token advance();
+   void sync_from_lex(LexState& state);
+
+private:
+   LexState* lex_state;
+};
+

--- a/src/fluid/luajit-2.1/src/parser/token_types.cpp
+++ b/src/fluid/luajit-2.1/src/parser/token_types.cpp
@@ -1,0 +1,97 @@
+#include "parser/token_types.h"
+
+#include <cmath>
+
+#include "lj_obj.h"
+
+TokenPayload::TokenPayload()
+{
+   this->has_payload = false;
+   this->owner = nullptr;
+}
+
+void TokenPayload::assign(lua_State* state, const TValue& value)
+{
+   this->owner = state;
+   copyTV(state, &this->payload, &value);
+   this->has_payload = true;
+}
+
+GCstr* TokenPayload::as_string() const
+{
+   if (!this->has_payload) return nullptr;
+   if (!tvisstr(&this->payload)) return nullptr;
+   return strV(&this->payload);
+}
+
+double TokenPayload::as_number() const
+{
+   if (!this->has_payload) return 0.0;
+   if (tvisnum(&this->payload)) return numV(&this->payload);
+   return 0.0;
+}
+
+Token Token::from_current(LexState& state)
+{
+   Token token;
+   token.token_kind = to_token_kind(state.tok);
+   token.raw_token = state.tok;
+   token.source.line = state.linenumber;
+   token.source.column = 0;
+   token.source.offset = 0;
+   token.data.assign(state.L, state.tokval);
+   return token;
+}
+
+Token Token::from_lookahead(LexState& state)
+{
+   Token token;
+   LexToken lookahead = (state.lookahead != TK_eof) ? state.lookahead : state.lookahead_token();
+   token.token_kind = to_token_kind(lookahead);
+   token.raw_token = lookahead;
+   token.source.line = state.linenumber;
+   token.source.column = 0;
+   token.source.offset = 0;
+   token.data.assign(state.L, state.lookaheadval);
+   return token;
+}
+
+bool Token::is_identifier() const
+{
+   return this->token_kind IS TokenKind::Identifier;
+}
+
+bool Token::is_literal() const
+{
+   switch (this->token_kind) {
+   case TokenKind::Number:
+   case TokenKind::String:
+   case TokenKind::Nil:
+   case TokenKind::TrueToken:
+   case TokenKind::FalseToken:
+      return true;
+   default:
+      return false;
+   }
+}
+
+bool Token::is_eof() const
+{
+   return this->token_kind IS TokenKind::EndOfFile;
+}
+
+GCstr* Token::identifier() const
+{
+   return this->data.as_string();
+}
+
+TokenKind to_token_kind(LexToken token)
+{
+   return (TokenKind)token;
+}
+
+const char* token_kind_name(TokenKind kind, LexState& lex)
+{
+   return lex.token2str((LexToken)kind);
+}
+

--- a/src/fluid/luajit-2.1/src/parser/token_types.h
+++ b/src/fluid/luajit-2.1/src/parser/token_types.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "lj_lex.h"
+
+struct SourceSpan {
+   BCLine line = 0;
+   BCLine column = 0;
+   size_t offset = 0;
+};
+
+// Strongly typed representation of lexer tokens.
+enum class TokenKind : uint16_t {
+   Unknown = 0,
+#define TOKEN_KIND_ENUM(name) name = TK_##name,
+#define TOKEN_KIND_ENUM_SYM(name, sym) name = TK_##name,
+   Identifier = TK_name,
+   Number = TK_number,
+   String = TK_string,
+   Nil = TK_nil,
+   TrueToken = TK_true,
+   FalseToken = TK_false,
+   Function = TK_function,
+   Local = TK_local,
+   EndToken = TK_end,
+   ReturnToken = TK_return,
+   If = TK_if,
+   Else = TK_else,
+   ElseIf = TK_elseif,
+   For = TK_for,
+   WhileToken = TK_while,
+   Repeat = TK_repeat,
+   Until = TK_until,
+   BreakToken = TK_break,
+   ContinueToken = TK_continue,
+   DeferToken = TK_defer,
+   AndToken = TK_and,
+   OrToken = TK_or,
+   NotToken = TK_not,
+   IsToken = TK_is,
+   TernarySep = TK_ternary_sep,
+   Dots = TK_dots,
+   Cat = TK_concat,
+   Equal = TK_eq,
+   NotEqual = TK_ne,
+   LessEqual = TK_le,
+   GreaterEqual = TK_ge,
+   ShiftLeft = TK_shl,
+   ShiftRight = TK_shr,
+   CompoundAdd = TK_cadd,
+   CompoundSub = TK_csub,
+   CompoundMul = TK_cmul,
+   CompoundDiv = TK_cdiv,
+   CompoundMod = TK_cmod,
+   CompoundConcat = TK_cconcat,
+   CompoundIfEmpty = TK_cif_empty,
+   Presence = TK_if_empty,
+   PlusPlus = TK_plusplus,
+   EndOfFile = TK_eof,
+#undef TOKEN_KIND_ENUM
+#undef TOKEN_KIND_ENUM_SYM
+   LeftParen = '(',
+   RightParen = ')',
+   LeftBrace = '{',
+   RightBrace = '}',
+   LeftBracket = '[',
+   RightBracket = ']',
+   Dot = '.',
+   Colon = ':',
+   Comma = ',',
+   Semicolon = ';',
+   Equals = '=',
+   Plus = '+',
+   Minus = '-',
+   Multiply = '*',
+   Divide = '/',
+   Modulo = '%',
+   Question = '?'
+};
+
+[[nodiscard]] const char* token_kind_name(TokenKind kind, LexState& lex);
+
+struct TokenPayload {
+   TokenPayload();
+   void assign(lua_State* state, const TValue& value);
+
+   [[nodiscard]] bool has_value() const { return this->has_payload; }
+   [[nodiscard]] const TValue& value() const { return this->payload; }
+   [[nodiscard]] GCstr* as_string() const;
+   [[nodiscard]] double as_number() const;
+
+private:
+   bool has_payload = false;
+   TValue payload;
+   lua_State* owner = nullptr;
+};
+
+class Token {
+public:
+   Token() = default;
+
+   [[nodiscard]] static Token from_current(LexState& state);
+   [[nodiscard]] static Token from_lookahead(LexState& state);
+
+   [[nodiscard]] TokenKind kind() const { return this->token_kind; }
+   [[nodiscard]] LexToken raw() const { return this->raw_token; }
+   [[nodiscard]] SourceSpan span() const { return this->source; }
+   [[nodiscard]] bool is(TokenKind kind) const { return this->token_kind IS kind; }
+   [[nodiscard]] bool is_identifier() const;
+   [[nodiscard]] bool is_literal() const;
+   [[nodiscard]] bool is_eof() const;
+   [[nodiscard]] const TokenPayload& payload() const { return this->data; }
+   [[nodiscard]] GCstr* identifier() const;
+
+private:
+   TokenKind token_kind = TokenKind::Unknown;
+   LexToken raw_token = 0;
+   SourceSpan source;
+   TokenPayload data;
+};
+
+TokenKind to_token_kind(LexToken token);
+

--- a/src/fluid/tests/parser_phase1.fluid
+++ b/src/fluid/tests/parser_phase1.fluid
@@ -1,0 +1,18 @@
+-- Phase 1 parser smoke test covering local declarations and primary expressions.
+local function phase1_sum(a, b)
+   local total = a + b
+   return total
+end
+
+local function phase1_local_bindings(value)
+   local function offset(delta)
+      return delta + value
+   end
+
+   local lhs, rhs = value, offset(2)
+   return lhs + rhs
+end
+
+local result = phase1_sum(4, 3)
+local locals = phase1_local_bindings(6)
+print('parser.phase1', result, locals)


### PR DESCRIPTION
## Summary
- avoid formatting expectation strings inside `ParserContext::match` unless a diagnostic is emitted
- add a helper that formats expectation messages once and pops any temporary Lua strings before returning
- have `consume` create a fresh error message when needed so optional `match` calls no longer leave Lua stack garbage

## Testing
- `cmake --build build/agents --config Release --parallel`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a810c5244832ea549e0540d76fc38)