### PR TITLE
Fix BOM offset tracking in lexer

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/lj_lex.cpp
+++ b/src/fluid/luajit-2.1/src/parser/lj_lex.cpp
@@ -567,7 +567,11 @@ LexState::LexState(lua_State* L, lua_Reader Rfunc, void* Rdata, std::string_view
    lex_next(this);  //  Read-ahead first char.
    if (this->c IS 0xef and this->p + 2 <= this->pe and (uint8_t)this->p[0] IS 0xbb and
       (uint8_t)this->p[1] IS 0xbf) {  // Skip UTF-8 BOM (if buffered).
-      this->p += 2;
+      constexpr size_t skipped_bom_bytes = 2;
+      this->p += skipped_bom_bytes;
+      this->current_offset += skipped_bom_bytes;
+      this->next_offset += skipped_bom_bytes;
+      this->line_start_offset += skipped_bom_bytes;
       lex_next(this);
       header = 1;
    }


### PR DESCRIPTION
## Summary
- ensure UTF-8 BOM skipping keeps byte, line, and column offsets in sync

## Testing
- cmake --build build/agents --config Release --target luajit-2.1 --parallel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b242de1c4832eb88decb63d9031b9)