### PR TITLE
Review CMakeLists.txt files in src directory

### DIFF
--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -55,8 +55,6 @@ if (BUILD_DEFS) # Customised idl_c() equivalent, this is for defining the output
    add_dependencies (build_headers display_defs)
 endif ()
 
-link_directories(X11_INCLUDE_DIR)
-
    CHECK_C_SOURCE_COMPILES ("
 #include <X11/Xlib.h>
 #include <X11/extensions/Xxf86dga.h>

--- a/src/link/CMakeLists.txt
+++ b/src/link/CMakeLists.txt
@@ -5,9 +5,9 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON) # Enables -fPIC and -fPIE in gcc
 
 if (WIN32)
    add_library(init-win STATIC init-win.cpp)
-   target_include_directories (init-win PRIVATE "${PROJECT_SOURCE_DIR}/core/include")
+   target_include_directories (init-win PRIVATE "${PROJECT_SOURCE_DIR}/include")
 else ()
    add_library(init-unix STATIC init-unix.cpp)
-   target_include_directories (init-unix PRIVATE "${PROJECT_SOURCE_DIR}/core/include")
+   target_include_directories (init-unix PRIVATE "${PROJECT_SOURCE_DIR}/include")
    target_link_libraries (init-unix PRIVATE dl)
 endif ()

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library (xml_schema OBJECT
 
 target_include_directories (xml_schema PRIVATE "${PROJECT_SOURCE_DIR}/include")
 set_target_properties (xml_schema PROPERTIES CXX_STANDARD 20 POSITION_INDEPENDENT_CODE ON)
-add_dependencies (xml build_headers)
+add_dependencies (xml_schema build_headers)
 
 # Module Code
 


### PR DESCRIPTION
Fixed three critical build configuration issues:

1. src/link/CMakeLists.txt: Corrected invalid include path
   - Changed from non-existent 'core/include' to 'include'
   - Affects both init-win and init-unix library targets

2. src/display/CMakeLists.txt: Removed malformed link_directories() command
   - Removed 'link_directories(X11_INCLUDE_DIR)' which was incorrect on multiple levels
   - This line had no effect and served no purpose

3. src/xml/CMakeLists.txt: Fixed incorrect dependency declaration
   - Changed 'add_dependencies(xml build_headers)' to 'add_dependencies(xml_schema build_headers)'
   - Ensures xml_schema object library properly depends on generated headers
   - Matches the pattern used for xml_unescape library