### PR TITLE
Improve OpenSSL detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,20 @@ if (NOT DISABLE_SSL)
    if (WIN32)
       # Win32 SSL support is supported natively
    else ()
-      set (OPENSSL_USE_STATIC_LIBS TRUE)
-      include (FindOpenSSL)
+      # Prefer shared OpenSSL libraries so typical Linux installations
+      # (which only provide shared builds) are accepted.  Static builds
+      # still attempt a static OpenSSL fallback afterwards.
+      set (OPENSSL_USE_STATIC_LIBS FALSE)
+      find_package (OpenSSL QUIET)
+      if (NOT OpenSSL_FOUND AND PARASOL_STATIC)
+         foreach (_openssl_var IN ITEMS OpenSSL_DIR OPENSSL_CRYPTO_LIBRARY OPENSSL_SSL_LIBRARY OPENSSL_LIBRARIES OPENSSL_INCLUDE_DIR)
+            if (DEFINED ${_openssl_var})
+               unset (${_openssl_var} CACHE)
+            endif ()
+         endforeach ()
+         set (OPENSSL_USE_STATIC_LIBS TRUE)
+         find_package (OpenSSL QUIET)
+      endif ()
       if (NOT OpenSSL_FOUND)
          set (DISABLE_SSL TRUE)
       endif ()


### PR DESCRIPTION
## Summary
- prefer shared OpenSSL libraries during configuration so SSL stays enabled on systems that only ship shared builds
- fall back to static OpenSSL detection automatically when building Parasol statically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c67f64178832ea69532672e3ee989)