### PR TITLE
[Fluid] Moved LuaJIT files in lib/ and parser/

### DIFF
--- a/docs/plans/PARSER_P2.md
+++ b/docs/plans/PARSER_P2.md
@@ -50,6 +50,12 @@ Phase 2 severs the direct coupling between syntax parsing and bytecode emission 
 3. Implement bytecode comparison harnesses that run both the legacy and AST-driven emitters (guarded by a build flag) and assert bytecode equivalence for curated samples. Failures should produce actionable diffs.
 4. Profile parsing/emission time on representative workloads to ensure the extra AST allocation overhead stays within acceptable limits; document mitigation strategies (arena allocators, node pooling) if necessary.
 
+NOTE:
+- Unit tests can be added to lj_parse_tests.cpp and are executed by running the Flute script `src/fluid/tests/test_unit_tests.fluid` directly.  Use printf or cout for sending output.
+- The `--jit:trace` commandline option enables the associated diagnosis options in make_parser_config()
+- The `--jit:diagnose` commandline option enables the associated tracing options in make_parser_config()
+- Additional commandline options can be added to fluid.cpp in the MODInit() function if necessary.
+
 ### 6. Documentation and developer enablement
 1. Update `docs/plans/LUAJIT_PARSER_REDESIGN.md` Phase 2 section summary (once implementation begins) with progress notes, caveats, and links to the new files.
 2. Create contributor notes (either inline in headers or a short guide under `docs/plans/`) describing how to add new AST nodes, how the emitter visitor should be extended, and how diagnostics tie into spans.

--- a/src/core/defs/core.fdl
+++ b/src/core/defs/core.fdl
@@ -716,7 +716,7 @@ using ModExpunge = ERR (*)(void);
 using ModTest    = void (*)(CSTRING, int *, int *);
 
   ]])
-  
+
   struct("ModHeader", { comment="Module file header", restrict="c" }, [[
     int(MHF) Flags                 # Special flags, type of function table wanted from the Core
     cstr Definitions               # Module definition string, usable by run-time languages such as Fluid

--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -621,10 +621,10 @@ endif ()
 
 set (FLUID_SOURCES "${MOD}.cpp" "fluid_module.cpp" "fluid_thread.cpp" "fluid_struct.cpp" "fluid_processing.cpp"
    "fluid_number.cpp" "fluid_functions.cpp" "fluid_objects.cpp" "fluid_array.cpp" "fluid_regex.cpp"
-   "fluid_io.cpp" "fluid_class.cpp" 
+   "fluid_io.cpp" "fluid_class.cpp"
    "${LUAJIT_SRC}/lib/lj_lib.cpp"
    "${LUAJIT_SRC}/lib/lj_load.cpp"
-   "${LUAJIT_SRC}/parser/lj_parse.cpp" 
+   "${LUAJIT_SRC}/parser/lj_parse.cpp"
    "${LUAJIT_SRC}/parser/lj_lex.cpp"
    "${LUAJIT_SRC}/parser/lj_parse_tests.cpp")
 
@@ -647,9 +647,14 @@ target_link_libraries (${MOD} PRIVATE
    ${FFI_LINK}
    ${LUAJIT_LINK}
    ${MATH_LINK}) # The link order matters, math must come last
-   
+
+target_compile_definitions(${MOD} PRIVATE
+   LUAJIT_DISABLE_FFI
+   LUAJIT_DISABLE_BUFFER
+   LUAJIT_ENABLE_LUA52COMPAT)
+
 if (ENABLE_UNIT_TESTS)
-   target_compile_definitions(${MOD} PRIVATE "ENABLE_UNIT_TESTS")
+   target_compile_definitions(${MOD} PRIVATE ENABLE_UNIT_TESTS)
 endif ()
 
 if (DISABLE_DISPLAY)

--- a/src/fluid/defs.h
+++ b/src/fluid/defs.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #define LUA_COMPILED "-- $FLUID:compiled"
 constexpr int SIZE_READ = 1024;
@@ -10,6 +11,12 @@ constexpr int SIZE_READ = 1024;
 #include <parasol/modules/regex.h>
 #include <thread>
 #include <string_view>
+
+#include "lauxlib.h"
+
+#if !defined(LUAJIT_DISABLE_FFI) or !defined(LUAJIT_DISABLE_BUFFER) or !defined(LUAJIT_ENABLE_LUA52COMPAT)
+#error "Expected LUAJIT flags are not defined."
+#endif
 
 using namespace pf;
 
@@ -45,6 +52,8 @@ extern OBJECTPTR modFluid;
 extern OBJECTPTR modRegex;
 extern OBJECTPTR glFluidContext;
 extern OBJECTPTR clFluid;
+extern bool glJITTrace;
+extern bool glJITDiagnose;
 extern ankerl::unordered_dense::map<std::string, uint32_t> glStructSizes;
 
 //********************************************************************************************************************

--- a/src/fluid/luajit-2.1/src/parser/lj_parse.cpp
+++ b/src/fluid/luajit-2.1/src/parser/lj_parse.cpp
@@ -1,5 +1,5 @@
 // Lua parser
-// 
+//
 // Copyright (C) 2025 Paul Manias
 
 #define lj_parse_c
@@ -55,19 +55,25 @@ static const struct {
 #include "parser/parse_expr.cpp"
 #include "parser/parse_operators.cpp"
 #include "parser/parse_stmt.cpp"
+#include "../../../defs.h"
 
-static ParserConfig make_parser_config(lua_State& state)
+static ParserConfig make_parser_config(lua_State &State)
 {
-   (void)state;
+   pf::Log log("FluidParser");
    ParserConfig config;
-#if defined(PARASOL_PARSER_COLLECT_DIAGNOSTICS)
-   config.abort_on_error = false;
-   config.max_diagnostics = 32;
-#endif
-#if defined(PARASOL_PARSER_TRACE)
-   config.trace_tokens = true;
-   config.trace_expectations = true;
-#endif
+
+   if (glJITDiagnose) {
+      log.msg("JIT diagnostic mode enabled.");
+      config.abort_on_error = false;
+      config.max_diagnostics = 32;
+   }
+
+   if (glJITTrace) {
+      log.msg("JIT trace mode enabled.");
+      config.trace_tokens = true;
+      config.trace_expectations = true;
+   }
+
    return config;
 }
 

--- a/src/fluid/luajit-2.1/src/parser/parse_stmt.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_stmt.cpp
@@ -952,10 +952,10 @@ bool LexState::parse_stmt(ParserContext &Context)
       case TokenKind::ContinueToken: this->parse_continue(); break;
       case TokenKind::BreakToken: this->parse_break(); break;
       case TokenKind::Semicolon: Context.tokens().advance(); break;
-      case TokenKind::DoToken: 
-         Context.tokens().advance(); 
-         this->parse_block(Context); 
-         this->lex_match(TK_end, TK_do, line); 
+      case TokenKind::DoToken:
+         Context.tokens().advance();
+         this->parse_block(Context);
+         this->lex_match(TK_end, TK_do, line);
          break;
       default: this->parse_call_assign(Context); break;
    }

--- a/src/fluid/luajit-2.1/src/parser/parser_context.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parser_context.cpp
@@ -306,7 +306,7 @@ void ParserContext::emit_error(ParserErrorCode code, const Token& token, std::st
    diagnostic.message.assign(message.begin(), message.end());
    diagnostic.token = token;
    this->diag.report(diagnostic);
-   
+
    if (this->current_config.trace_expectations) {
       this->log_trace("error", token, message);
    }
@@ -366,12 +366,12 @@ void ParserContext::log_trace(const char* channel, const Token& token, std::stri
    std::string name = this->describe_token(token);
    BCLine line = token.span().line;
    BCLine column = token.span().column;
-   
+
    if (note.empty()) {
       log.detail("%s: %s (line %d, column %d)\n", channel, name.c_str(), (int)line, (int)column);
       return;
    }
-   
+
    log.detail("%s: %s (line %d, column %d) - %.*s\n", channel, name.c_str(), (int)line, (int)column,
       (int)note.size(), note.data());
 }

--- a/src/xquery/unit_tests.cpp
+++ b/src/xquery/unit_tests.cpp
@@ -303,7 +303,7 @@ static void test_parser_operator_cache_population()
    test_assert(flags.unary_negate_cached, "Unary operator '-' cache", "Parser should cache negation operator kind");
 }
 
-static void test_prolog_in_xpath() 
+static void test_prolog_in_xpath()
 {
    pf::Log log("PrologInXPath");
 


### PR DESCRIPTION
This pull request updates the build configuration in `src/fluid/CMakeLists.txt` to refine how LuaJIT source files are included. The main changes are to remove broad pattern-based inclusion of LuaJIT library and parser sources and instead explicitly add only the necessary source files to the build. This helps prevent unwanted files from being compiled and makes the build process more predictable.

**Build configuration improvements:**

* Removed pattern-based inclusion of all files in `lib/` and `parser/` directories from the `LUAJIT_CORE_SOURCES` and `LUAJIT_DEP_LJ_H` lists for both MSVC and non-MSVC builds, reducing the risk of compiling unnecessary files. [[1]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL158-L159) [[2]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL168-L169) [[3]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL532-L533) [[4]](diffhunk://#diff-6df7630e443bdfa9f67a391d68f5aaf7f788835481d02efdf6490f23ce4beb0fL612-L613)

* Explicitly added only the required LuaJIT source files (`lj_lib.cpp`, `lj_load.cpp`, `lj_parse.cpp`, `lj_lex.cpp`, `lj_parse_tests.cpp`) to the `FLUID_SOURCES` list, ensuring only necessary files are compiled.