### PR TITLE
Handle XPVT map and array values throughout XQuery

### DIFF
--- a/src/xquery/api/xquery_functions.cpp
+++ b/src/xquery/api/xquery_functions.cpp
@@ -1070,6 +1070,11 @@ static void append_numbers_from_value(const XPathVal &Value, std::vector<double>
       case XPVT::NodeSet:
          append_numbers_from_nodeset(Value, Numbers);
          break;
+      case XPVT::Map:
+      case XPVT::Array:
+         // Function items cannot be coerced into numeric values. They are intentionally ignored
+         // so that mixed sequences can still contribute their numeric members.
+         break;
    }
 }
 

--- a/src/xquery/eval/eval_flwor.cpp
+++ b/src/xquery/eval/eval_flwor.cpp
@@ -193,6 +193,13 @@ static size_t hash_xpath_group_value(const XPathVal &Value)
 
          return combined;
       }
+
+      case XPVT::Map:
+      case XPVT::Array: {
+         std::string summary = Value.to_string();
+         size_t hashed = std::hash<std::string>{}(summary);
+         return combine_group_hash(seed, hashed);
+      }
    }
 
    return seed;

--- a/src/xquery/eval/eval_values.cpp
+++ b/src/xquery/eval/eval_values.cpp
@@ -2398,6 +2398,8 @@ ERR XPathEvaluator::evaluate_top_level_expression(const XPathNode *Node, uint32_
       case XPVT::Date:
       case XPVT::Time:
       case XPVT::DateTime:
+      case XPVT::Map:
+      case XPVT::Array:
          return ERR::Okay;
    }
 

--- a/src/xquery/functions/func_documents.cpp
+++ b/src/xquery/functions/func_documents.cpp
@@ -489,6 +489,11 @@ XPathVal XPathFunctionLibrary::function_idref(const std::vector<XPathVal> &Args,
          case XPVT::Number:
             if (not std::isnan(arg.NumberValue)) add_tokens(arg.to_string());
             break;
+
+         case XPVT::Map:
+         case XPVT::Array:
+            // Maps and arrays cannot contribute IDREF tokens.
+            break;
       }
    }
 

--- a/src/xquery/functions/func_nodeset.cpp
+++ b/src/xquery/functions/func_nodeset.cpp
@@ -63,6 +63,11 @@ XPathVal XPathFunctionLibrary::function_id(const std::vector<XPathVal> &Args, co
          case XPVT::Number:
             if (not std::isnan(Value.NumberValue)) add_tokens(Value.to_string());
             break;
+
+         case XPVT::Map:
+         case XPVT::Array:
+            // Maps and arrays cannot contribute ID tokens.
+            break;
       }
    };
 

--- a/src/xquery/functions/function_library.cpp
+++ b/src/xquery/functions/function_library.cpp
@@ -281,6 +281,12 @@ size_t XPathFunctionLibrary::estimate_concat_size(const std::vector<XPathVal> &A
             else if (not arg.node_set_string_values.empty()) total += arg.node_set_string_values[0].length();
             else total += 64; // Conservative estimate for node content
             break;
+         case XPVT::Map:
+         case XPVT::Array: {
+            std::string summary = arg.to_string();
+            total += summary.length();
+            break;
+         }
       }
    }
    return total;


### PR DESCRIPTION
## Summary
- add explicit XPVT::Map and XPVT::Array handling in numeric extraction, concatenation sizing, ID/IDREF token collection, and FLWOR group hashing so structured function items behave predictably
- allow map/array results from top-level expressions to succeed instead of surfacing spurious failures

## Testing
- `cmake --build build/agents --config Release --target xquery --parallel`
- `cmake --build build/agents --config Release --target parasol_cmd --parallel`
- `cmake --install build/agents`
- `ctest --build-config Release --test-dir build/agents -L xquery --output-on-failure`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cece29da4832e85619f0379ae4ba9)