### PR TITLE
Modernize fluid_objects.cpp for C++20

### DIFF
--- a/src/fluid/fluid_objects.cpp
+++ b/src/fluid/fluid_objects.cpp
@@ -18,6 +18,9 @@ through obj.find(), push_object(), or children created with some_object.new() ar
 #include <parasol/modules/fluid.h>
 #include <parasol/strings.hpp>
 #include <inttypes.h>
+#include <string_view>
+#include <ranges>
+#include <algorithm>
 
 #include "lua.h"
 #include "lualib.h"
@@ -33,51 +36,51 @@ template<class... Args> void RMSG(Args...) {
 static uint32_t OJH_init, OJH_free, OJH_lock, OJH_children, OJH_detach, OJH_get, OJH_new, OJH_state, OJH_state_dep, OJH_getKey;
 static uint32_t OJH_set, OJH_setKey, OJH_delayCall, OJH_exists, OJH_subscribe, OJH_unsubscribe;
 
-static int object_action_call_args(lua_State *);
-static int object_method_call_args(lua_State *);
-static int object_action_call(lua_State *);
-static int object_method_call(lua_State *);
-static int get_results(lua_State *, const FunctionField *, const int8_t *);
-static ERR set_object_field(lua_State *, OBJECTPTR, CSTRING, int);
+[[nodiscard]] static int object_action_call_args(lua_State *);
+[[nodiscard]] static int object_method_call_args(lua_State *);
+[[nodiscard]] static int object_action_call(lua_State *);
+[[nodiscard]] static int object_method_call(lua_State *);
+[[nodiscard]] static int get_results(lua_State *, const FunctionField *, const int8_t *);
+[[nodiscard]] static ERR set_object_field(lua_State *, OBJECTPTR, CSTRING, int);
 
-static int object_children(lua_State *);
-static int object_delaycall(lua_State *);
-static int object_detach(lua_State *);
-static int object_exists(lua_State *);
-static int object_free(lua_State *);
-static int object_get(lua_State *);
-static int object_getkey(lua_State *);
-static int object_init(lua_State *);
-static int object_lock(lua_State *);
-static int object_newchild(lua_State *);
-static int object_newindex(lua_State *);
-static int object_set(lua_State *);
-static int object_setkey(lua_State *);
-static int object_state(lua_State *);
-static int object_state_dep(lua_State *);
-static int object_subscribe(lua_State *);
-static int object_unsubscribe(lua_State *);
+[[nodiscard]] static int object_children(lua_State *);
+[[nodiscard]] static int object_delaycall(lua_State *);
+[[nodiscard]] static int object_detach(lua_State *);
+[[nodiscard]] static int object_exists(lua_State *);
+[[nodiscard]] static int object_free(lua_State *);
+[[nodiscard]] static int object_get(lua_State *);
+[[nodiscard]] static int object_getkey(lua_State *);
+[[nodiscard]] static int object_init(lua_State *);
+[[nodiscard]] static int object_lock(lua_State *);
+[[nodiscard]] static int object_newchild(lua_State *);
+[[nodiscard]] static int object_newindex(lua_State *);
+[[nodiscard]] static int object_set(lua_State *);
+[[nodiscard]] static int object_setkey(lua_State *);
+[[nodiscard]] static int object_state(lua_State *);
+[[nodiscard]] static int object_state_dep(lua_State *);
+[[nodiscard]] static int object_subscribe(lua_State *);
+[[nodiscard]] static int object_unsubscribe(lua_State *);
 
-static int object_get_id(lua_State *, const obj_read &, object *);
-static int object_get_rgb(lua_State *, const obj_read &, object *);
-static int object_get_array(lua_State *, const obj_read &, object *);
-static int object_get_struct(lua_State *, const obj_read &, object *);
-static int object_get_string(lua_State *, const obj_read &, object *);
-static int object_get_object(lua_State *, const obj_read &, object *);
-static int object_get_ptr(lua_State *, const obj_read &, object *);
-static int object_get_double(lua_State *, const obj_read &, object *);
-static int object_get_large(lua_State *, const obj_read &, object *);
-static int object_get_ulong(lua_State *, const obj_read &, object *);
-static int object_get_long(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_id(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_rgb(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_array(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_struct(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_string(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_object(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_ptr(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_double(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_large(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_ulong(lua_State *, const obj_read &, object *);
+[[nodiscard]] static int object_get_long(lua_State *, const obj_read &, object *);
 
-static ERR object_set_array(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_function(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_object(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_ptr(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_double(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_lookup(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_oid(lua_State *, OBJECTPTR, Field *, int);
-static ERR object_set_number(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_array(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_function(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_object(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_ptr(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_double(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_lookup(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_oid(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_number(lua_State *, OBJECTPTR, Field *, int);
 
 //********************************************************************************************************************
 
@@ -91,36 +94,36 @@ inline void SET_CONTEXT(lua_State *Lua, APTR Function) {
    lua_pushcclosure(Lua, (lua_CFunction)Function, 1); // C function to call, +1 value for the object reference
 }
 
-static int stack_object_children(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_children); return 1; }
-static int stack_object_delayCall(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_delaycall); return 1; }
-static int stack_object_detach(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_detach); return 1; }
-static int stack_object_exists(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_exists); return 1; }
-static int stack_object_free(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_free); return 1; }
-static int stack_object_get(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_get); return 1; }
-static int stack_object_getKey(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_getkey); return 1; }
-static int stack_object_init(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_init); return 1; }
-static int stack_object_lock(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_lock); return 1; }
-static int stack_object_newchild(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_newchild); return 1; }
-static int stack_object_set(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_set); return 1; }
-static int stack_object_setKey(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_setkey); return 1; }
-static int stack_object_state(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_state); return 1; }
-static int stack_object_state_dep(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_state_dep); return 1; }
-static int stack_object_subscribe(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_subscribe); return 1; }
-static int stack_object_unsubscribe(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_unsubscribe); return 1; }
+[[nodiscard]] static int stack_object_children(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_children); return 1; }
+[[nodiscard]] static int stack_object_delayCall(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_delaycall); return 1; }
+[[nodiscard]] static int stack_object_detach(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_detach); return 1; }
+[[nodiscard]] static int stack_object_exists(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_exists); return 1; }
+[[nodiscard]] static int stack_object_free(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_free); return 1; }
+[[nodiscard]] static int stack_object_get(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_get); return 1; }
+[[nodiscard]] static int stack_object_getKey(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_getkey); return 1; }
+[[nodiscard]] static int stack_object_init(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_init); return 1; }
+[[nodiscard]] static int stack_object_lock(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_lock); return 1; }
+[[nodiscard]] static int stack_object_newchild(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_newchild); return 1; }
+[[nodiscard]] static int stack_object_set(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_set); return 1; }
+[[nodiscard]] static int stack_object_setKey(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_setkey); return 1; }
+[[nodiscard]] static int stack_object_state(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_state); return 1; }
+[[nodiscard]] static int stack_object_state_dep(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_state_dep); return 1; }
+[[nodiscard]] static int stack_object_subscribe(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_subscribe); return 1; }
+[[nodiscard]] static int stack_object_unsubscribe(lua_State *Lua, const obj_read &Handle, object *def) { SET_CONTEXT(Lua, (APTR)object_unsubscribe); return 1; }
 
 //********************************************************************************************************************
 // Hash designed to handle cases like `UID` -> `uid` and `RGBValue` -> `rgbValue`
 
-static uint32_t field_hash(CSTRING Name) {
+[[nodiscard]] static uint32_t field_hash(std::string_view Name) {
    uint32_t hash = 5381;
-   int k = 0;
-   while (Name[k] and std::isupper(Name[k])) {
+   size_t k = 0;
+   while ((k < Name.size()) and std::isupper(Name[k])) {
       hash = char_hash(std::tolower(Name[k]), hash);
-      if (!Name[++k]) break;
-      if ((!Name[k+1]) or (std::isupper(Name[k+1]))) continue;
+      if (++k >= Name.size()) break;
+      if ((k + 1 >= Name.size()) or (std::isupper(Name[k+1]))) continue;
       else break;
    }
-   while (Name[k]) {
+   while (k < Name.size()) {
       hash = char_hash(Name[k], hash);
       k++;
    }
@@ -129,7 +132,7 @@ static uint32_t field_hash(CSTRING Name) {
 
 //********************************************************************************************************************
 
-static int obj_jump_method(lua_State *Lua, const obj_read &Handle, object *def)
+[[nodiscard]] static int obj_jump_method(lua_State *Lua, const obj_read &Handle, object *def)
 {
    lua_pushvalue(Lua, 1); // Arg1: Duplicate the object reference
    lua_pushlightuserdata(Lua, Handle.Data); // Arg2: Method lookup table
@@ -146,8 +149,8 @@ inline void build_read_table(object *Def)
 {
    if (Def->ReadTable) return;
 
-   if (auto it = glClassReadTable.find(Def->Class); it != glClassReadTable.end()) {
-      Def->ReadTable = &it->second;
+   if (glClassReadTable.contains(Def->Class)) {
+      Def->ReadTable = &glClassReadTable[Def->Class];
       return;
    }
 
@@ -155,7 +158,7 @@ inline void build_read_table(object *Def)
 
    // Every possible action is hashed because both sub-class and base-class actions require support.
 
-   for (int code=1; code < int(AC::END); code++) {
+   for (auto code : std::views::iota(1, int(AC::END))) {
       auto hash = simple_hash(glActions[code].Name, simple_hash("ac"));
       jmp.insert(obj_read(hash, glJumpActions[code]));
    }
@@ -163,10 +166,11 @@ inline void build_read_table(object *Def)
    MethodEntry *methods;
    int total_methods;
    if (Def->Class->get(FID_Methods, methods, total_methods) IS ERR::Okay) {
-      for (int i=1; i < total_methods; i++) {
-         if (methods[i].MethodID != AC::NIL) {
-            auto hash = simple_hash(methods[i].Name, simple_hash("mt"));
-            jmp.insert(obj_read(hash, obj_jump_method, &methods[i]));
+      auto methods_span = std::span(methods, total_methods);
+      for (auto& method : methods_span | std::views::drop(1)) {
+         if (method.MethodID != AC::NIL) {
+            auto hash = simple_hash(method.Name, simple_hash("mt"));
+            jmp.insert(obj_read(hash, obj_jump_method, &method));
          }
       }
    }
@@ -176,31 +180,30 @@ inline void build_read_table(object *Def)
    if (Def->Class->get(FID_Dictionary, dict, total_dict) IS ERR::Okay) {
       jmp.insert(obj_read(simple_hash("id"), object_get_id));
 
-      for (int i=0; i < total_dict; i++) {
-         if (!(dict[i].Flags & FDF_R)) continue;
+      auto dict_span = std::span(dict, total_dict);
+      for (auto& field : dict_span | std::views::filter([](const auto& f) { return f.Flags & FDF_R; })) {
+         auto hash = field_hash(field.Name);
 
-         auto hash = field_hash(dict[i].Name);
-
-         if (dict[i].Flags & FD_ARRAY) {
-            if (dict[i].Flags & FD_RGB) jmp.insert(obj_read(hash, object_get_rgb, &dict[i]));
-            else jmp.insert(obj_read(hash, object_get_array, &dict[i]));
+         if (field.Flags & FD_ARRAY) {
+            if (field.Flags & FD_RGB) jmp.insert(obj_read(hash, object_get_rgb, &field));
+            else jmp.insert(obj_read(hash, object_get_array, &field));
          }
-         else if (dict[i].Flags & FD_STRUCT) jmp.insert(obj_read(hash, object_get_struct, &dict[i]));
-         else if (dict[i].Flags & FD_STRING) jmp.insert(obj_read(hash, object_get_string, &dict[i]));
-         else if (dict[i].Flags & FD_POINTER) {
-            if (dict[i].Flags & (FD_OBJECT|FD_LOCAL)) { // Writing to an integral is permitted if marked as writeable.
-               jmp.insert(obj_read(hash, object_get_object, &dict[i]));
+         else if (field.Flags & FD_STRUCT) jmp.insert(obj_read(hash, object_get_struct, &field));
+         else if (field.Flags & FD_STRING) jmp.insert(obj_read(hash, object_get_string, &field));
+         else if (field.Flags & FD_POINTER) {
+            if (field.Flags & (FD_OBJECT|FD_LOCAL)) { // Writing to an integral is permitted if marked as writeable.
+               jmp.insert(obj_read(hash, object_get_object, &field));
             }
-            else jmp.insert(obj_read(hash, object_get_ptr, &dict[i]));
+            else jmp.insert(obj_read(hash, object_get_ptr, &field));
          }
-         else if (dict[i].Flags & FD_DOUBLE) jmp.insert(obj_read(hash, object_get_double, &dict[i]));
-         else if (dict[i].Flags & FD_INT64) jmp.insert(obj_read(hash, object_get_large, &dict[i]));
-         else if (dict[i].Flags & FD_INT) {
-            if (dict[i].Flags & FD_UNSIGNED) jmp.insert(obj_read(hash, object_get_ulong, &dict[i]));
-            else jmp.insert(obj_read(hash, object_get_long, &dict[i]));
+         else if (field.Flags & FD_DOUBLE) jmp.insert(obj_read(hash, object_get_double, &field));
+         else if (field.Flags & FD_INT64) jmp.insert(obj_read(hash, object_get_large, &field));
+         else if (field.Flags & FD_INT) {
+            if (field.Flags & FD_UNSIGNED) jmp.insert(obj_read(hash, object_get_ulong, &field));
+            else jmp.insert(obj_read(hash, object_get_long, &field));
          }
-         else if (dict[i].Flags & FD_FUNCTION); // Unsupported
-         else pf::Log().warning("Unable to support field %s.%s for reading", Def->Class->Name, dict[i].Name);
+         else if (field.Flags & FD_FUNCTION); // Unsupported
+         else pf::Log().warning("Unable to support field %s.%s for reading", Def->Class->Name, field.Name);
       }
    }
 
@@ -227,47 +230,46 @@ inline void build_read_table(object *Def)
 
 //********************************************************************************************************************
 
-inline WRITE_TABLE * get_write_table(object *Def)
+[[nodiscard]] inline WRITE_TABLE * get_write_table(object *Def)
 {
    if (!Def->WriteTable) {
-      if (auto it = glClassWriteTable.find(Def->Class); it != glClassWriteTable.end()) {
-         Def->WriteTable = &it->second;
+      if (glClassWriteTable.contains(Def->Class)) {
+         Def->WriteTable = &glClassWriteTable[Def->Class];
       }
       else {
          WRITE_TABLE jmp;
          Field *dict;
          int total_dict;
          if (Def->Class->get(FID_Dictionary, dict, total_dict) IS ERR::Okay) {
-            for (int i=0; i < total_dict; i++) {
-               if (dict[i].Flags & (FD_W|FD_I)) {
-                  char ch[2] = { dict[i].Name[0], 0 };
-                  if ((ch[0] >= 'A') and (ch[0] <= 'Z')) ch[0] = ch[0] - 'A' + 'a';
-                  auto hash = simple_hash(dict[i].Name+1, simple_hash(ch));
+            auto dict_span = std::span(dict, total_dict);
+            for (auto& field : dict_span | std::views::filter([](const auto& f) { return f.Flags & (FD_W|FD_I); })) {
+               char ch[2] = { field.Name[0], 0 };
+               if ((ch[0] >= 'A') and (ch[0] <= 'Z')) ch[0] = ch[0] - 'A' + 'a';
+               auto hash = simple_hash(field.Name+1, simple_hash(ch));
 
-                  if (dict[i].Flags & FD_ARRAY) {
-                     jmp.insert(obj_write(hash, object_set_array, &dict[i]));
+               if (field.Flags & FD_ARRAY) {
+                  jmp.insert(obj_write(hash, object_set_array, &field));
+               }
+               else if (field.Flags & FD_FUNCTION) {
+                  jmp.insert(obj_write(hash, object_set_function, &field));
+               }
+               else if (field.Flags & FD_POINTER) {
+                  if (field.Flags & (FD_OBJECT|FD_LOCAL)) {
+                     jmp.insert(obj_write(hash, object_set_object, &field));
                   }
-                  else if (dict[i].Flags & FD_FUNCTION) {
-                     jmp.insert(obj_write(hash, object_set_function, &dict[i]));
-                  }
-                  else if (dict[i].Flags & FD_POINTER) {
-                     if (dict[i].Flags & (FD_OBJECT|FD_LOCAL)) {
-                        jmp.insert(obj_write(hash, object_set_object, &dict[i]));
-                     }
-                     else jmp.insert(obj_write(hash, object_set_ptr, &dict[i]));
-                  }
-                  else if (dict[i].Flags & (FD_DOUBLE|FD_FLOAT)) {
-                     jmp.insert(obj_write(hash, object_set_double, &dict[i]));
-                  }
-                  else if (dict[i].Flags & (FD_FLAGS|FD_LOOKUP)) {
-                     jmp.insert(obj_write(hash, object_set_lookup, &dict[i]));
-                  }
-                  else if (dict[i].Flags & FD_OBJECT) { // Object ID
-                     jmp.insert(obj_write(hash, object_set_oid, &dict[i]));
-                  }
-                  else if (dict[i].Flags & (FD_INT|FD_INT64)) {
-                     jmp.insert(obj_write(hash, object_set_number, &dict[i]));
-                  }
+                  else jmp.insert(obj_write(hash, object_set_ptr, &field));
+               }
+               else if (field.Flags & (FD_DOUBLE|FD_FLOAT)) {
+                  jmp.insert(obj_write(hash, object_set_double, &field));
+               }
+               else if (field.Flags & (FD_FLAGS|FD_LOOKUP)) {
+                  jmp.insert(obj_write(hash, object_set_lookup, &field));
+               }
+               else if (field.Flags & FD_OBJECT) { // Object ID
+                  jmp.insert(obj_write(hash, object_set_oid, &field));
+               }
+               else if (field.Flags & (FD_INT|FD_INT64)) {
+                  jmp.insert(obj_write(hash, object_set_number, &field));
                }
             }
          }
@@ -283,7 +285,7 @@ inline WRITE_TABLE * get_write_table(object *Def)
 // Any Read accesses to the object will pass through here.  The requested key must exist in the hashed jump-table for
 // the targeted class, or an error will be returned.
 
-static int object_index(lua_State *Lua)
+[[nodiscard]] static int object_index(lua_State *Lua)
 {
    if (auto def = (struct object *)luaL_checkudata(Lua, 1, "Fluid.obj")) {
       auto keyname = luaL_checkstring(Lua, 2);
@@ -296,7 +298,9 @@ static int object_index(lua_State *Lua)
       }
 
       build_read_table(def);
-      if (auto func = def->ReadTable->find(obj_read(simple_hash(keyname))); func != def->ReadTable->end()) {
+      auto hash_key = obj_read(simple_hash(keyname));
+      if (def->ReadTable->contains(hash_key)) {
+         auto func = def->ReadTable->find(hash_key);
          return func->Call(Lua, *func, def);
       }
       else {
@@ -312,7 +316,7 @@ static int object_index(lua_State *Lua)
 
 //********************************************************************************************************************
 
-static ACTIONID get_action_info(lua_State *Lua, CLASSID ClassID, CSTRING action, const FunctionField **Args)
+[[nodiscard]] static ACTIONID get_action_info(lua_State *Lua, CLASSID ClassID, CSTRING action, const FunctionField **Args)
 {
    pf::Log log;
 
@@ -320,8 +324,8 @@ static ACTIONID get_action_info(lua_State *Lua, CLASSID ClassID, CSTRING action,
       action += 2;
    }
    else {
-      auto it = glActionLookup.find(action);
-      if (it != glActionLookup.end()) {
+      if (glActionLookup.contains(action)) {
+         auto it = glActionLookup.find(action);
          *Args = glActions[int(it->second)].Args;
          return it->second;
       }
@@ -362,7 +366,7 @@ static ACTIONID get_action_info(lua_State *Lua, CLASSID ClassID, CSTRING action,
 ** Never returns nil, errors are immediately thrown.
 */
 
-static int object_new(lua_State *Lua)
+[[nodiscard]] static int object_new(lua_State *Lua)
 {
    pf::Log log("obj.new");
    CSTRING class_name;
@@ -477,8 +481,8 @@ static int object_state(lua_State *Lua)
    // collection cycles.
 
    pf::Log log(__FUNCTION__);
-   auto it = prv->StateMap.find(def->UID);
-   if (it != prv->StateMap.end()) {
+   if (prv->StateMap.contains(def->UID)) {
+      auto it = prv->StateMap.find(def->UID);
       lua_rawgeti(Lua, LUA_REGISTRYINDEX, it->second);
       return 1;
    }
@@ -606,7 +610,7 @@ static int object_newchild(lua_State *Lua)
 //********************************************************************************************************************
 // Throws exceptions.  Used for returning objects to the user.
 
-object * push_object(lua_State *Lua, OBJECTPTR Object)
+[[nodiscard]] object * push_object(lua_State *Lua, OBJECTPTR Object)
 {
    if (auto newobject = (object *)lua_newuserdata(Lua, sizeof(object))) {
       clearmem(newobject, sizeof(object));
@@ -629,7 +633,7 @@ object * push_object(lua_State *Lua, OBJECTPTR Object)
 //********************************************************************************************************************
 // Guaranteed to not throw exceptions.
 
-ERR push_object_id(lua_State *Lua, OBJECTID ObjectID)
+[[nodiscard]] ERR push_object_id(lua_State *Lua, OBJECTID ObjectID)
 {
    if (!ObjectID) { lua_pushnil(Lua); return ERR::Okay; }
 
@@ -658,7 +662,7 @@ ERR push_object_id(lua_State *Lua, OBJECTID ObjectID)
 ** The fluid object itself can be found by using the name "self".
 */
 
-static int object_find_ptr(lua_State *Lua, OBJECTPTR obj)
+[[nodiscard]] static int object_find_ptr(lua_State *Lua, OBJECTPTR obj)
 {
    // Private objects discovered by obj.find() have to be treated as an external reference at all times
    // (access must controlled by access_object() and release_object() calls).
@@ -677,7 +681,7 @@ static int object_find_ptr(lua_State *Lua, OBJECTPTR obj)
    return 1;
 }
 
-static int object_find(lua_State *Lua)
+[[nodiscard]] static int object_find(lua_State *Lua)
 {
    pf::Log log("object.find");
    CSTRING object_name;
@@ -731,7 +735,7 @@ static int object_find(lua_State *Lua)
 //
 // Returns the MetaClass for an object, representing it as an inspectable object.
 
-static int object_class(lua_State *Lua)
+[[nodiscard]] static int object_class(lua_State *Lua)
 {
    object *query;
    if (!(query = (object *)get_meta(Lua, 1, "Fluid.obj"))) {
@@ -971,16 +975,15 @@ static int object_unsubscribe(lua_State *Lua)
    log.trace("Object: %d, Action: %s", def->UID, action);
 
    auto prv = (prvFluid *)Lua->Script->ChildPrivate;
-   for (auto it=prv->ActionList.begin(); it != prv->ActionList.end(); ) {
-      if ((it->ObjectID IS def->UID) and
-          ((action_id IS AC::NIL) or (it->ActionID IS action_id))) {
-         luaL_unref(Lua, LUA_REGISTRYINDEX, it->Function);
-         if (it->Reference) luaL_unref(Lua, LUA_REGISTRYINDEX, it->Reference);
-         it = prv->ActionList.erase(it);
-         continue;
+   std::erase_if(prv->ActionList, [&](auto& item) {
+      bool should_remove = (item.ObjectID IS def->UID) and
+                           ((action_id IS AC::NIL) or (item.ActionID IS action_id));
+      if (should_remove) {
+         luaL_unref(Lua, LUA_REGISTRYINDEX, item.Function);
+         if (item.Reference) luaL_unref(Lua, LUA_REGISTRYINDEX, item.Reference);
       }
-      it++;
-   }
+      return should_remove;
+   });
 
    return 0;
 }
@@ -1000,7 +1003,7 @@ static int object_delaycall(lua_State *Lua)
 // Fluid's environment.  This is commonplace for UI objects.  In addition the object's class may have been removed if
 // the termination process is running during an expunge.
 
-static int object_destruct(lua_State *Lua)
+[[nodiscard]] static int object_destruct(lua_State *Lua)
 {
    if (auto def = (object *)luaL_checkudata(Lua, 1, "Fluid.obj")) {
       while (def->AccessCount > 0) release_object(def);
@@ -1060,7 +1063,7 @@ static int object_init(lua_State *Lua)
 //********************************************************************************************************************
 // Prints the object interface as the object ID, e.g. #-10513
 
-static int object_tostring(lua_State *Lua)
+[[nodiscard]] static int object_tostring(lua_State *Lua)
 {
    if (auto def = (object *)luaL_checkudata(Lua, 1, "Fluid.obj")) {
       pf::Log log("obj.tostring");
@@ -1075,7 +1078,7 @@ static int object_tostring(lua_State *Lua)
 // Support for pairs() allows the meta fields of the object to be iterated.  Note that in next_pair(), the object
 // interface isn't used but could be pushed as an upvalue if needed.
 
-static int object_next_pair(lua_State *Lua)
+[[nodiscard]] static int object_next_pair(lua_State *Lua)
 {
    auto fields = (Field *)lua_touserdata(Lua, lua_upvalueindex(1));
    int field_total = lua_tointeger(Lua, lua_upvalueindex(2));
@@ -1092,7 +1095,7 @@ static int object_next_pair(lua_State *Lua)
    else return 0; // Terminates the iteration
 }
 
-static int object_pairs(lua_State *Lua)
+[[nodiscard]] static int object_pairs(lua_State *Lua)
 {
    if (auto def = (object *)luaL_checkudata(Lua, 1, "Fluid.obj")) {
       Field *fields;
@@ -1113,7 +1116,7 @@ static int object_pairs(lua_State *Lua)
 //********************************************************************************************************************
 // Similar to pairs(), but returns each field index and its name.
 
-static int object_next_ipair(lua_State *Lua)
+[[nodiscard]] static int object_next_ipair(lua_State *Lua)
 {
    auto fields = (Field *)lua_touserdata(Lua, lua_upvalueindex(1));
    int field_total = lua_tointeger(Lua, lua_upvalueindex(2));
@@ -1127,7 +1130,7 @@ static int object_next_ipair(lua_State *Lua)
    else return 0; // Terminates the iteration
 }
 
-static int object_ipairs(lua_State *Lua)
+[[nodiscard]] static int object_ipairs(lua_State *Lua)
 {
    if (auto def = (object *)luaL_checkudata(Lua, 1, "Fluid.obj")) {
       Field *fields;


### PR DESCRIPTION
Applied high and medium priority C++20 modernizations to fluid_objects.cpp:

High Priority Changes:
- Added [[nodiscard]] attributes to 50+ functions that return important values
- Replaced find() != end() patterns with .contains() for cleaner map lookups
- Replaced manual iterator removal with std::erase_if in object_unsubscribe()
- Updated field_hash() to use std::string_view instead of CSTRING

Medium Priority Changes:
- Added C++20 ranges and views (std::views::iota, std::views::filter, std::span)
- Converted index-based loops to range-based loops with views for better expressiveness
- Used std::span for array parameters in build_read_table() and get_write_table()

Benefits:
- Improved type safety with [[nodiscard]] preventing accidental value discards
- More expressive and maintainable code with ranges/views
- Better performance potential with string_view avoiding unnecessary copies
- Cleaner intent with .contains() vs find() != end() pattern
- Safer container manipulation with std::erase_if

All changes maintain compatibility with project coding standards (IS macro, and/or operators). Successfully compiled and tested with fluid module build.