### PR TITLE
Prevent parser trace diagnostics from hiding errors

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/parser_diagnostics.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parser_diagnostics.cpp
@@ -14,8 +14,15 @@ void ParserDiagnostics::set_limit(uint32_t new_limit)
 
 void ParserDiagnostics::report(const ParserDiagnostic& diagnostic)
 {
-   if (this->storage.size() >= this->limit) return;
+   bool counts_against_limit = diagnostic.severity IS ParserDiagnosticSeverity::Error
+      or diagnostic.severity IS ParserDiagnosticSeverity::Warning;
+
+   if (counts_against_limit and this->counted_entries >= this->limit) return;
+
    this->storage.push_back(diagnostic);
+   if (counts_against_limit) {
+      this->counted_entries += 1;
+   }
 }
 
 bool ParserDiagnostics::has_errors() const
@@ -34,5 +41,6 @@ std::span<const ParserDiagnostic> ParserDiagnostics::entries() const
 void ParserDiagnostics::clear()
 {
    this->storage.clear();
+   this->counted_entries = 0;
 }
 

--- a/src/fluid/luajit-2.1/src/parser/parser_diagnostics.h
+++ b/src/fluid/luajit-2.1/src/parser/parser_diagnostics.h
@@ -42,6 +42,7 @@ public:
 
 private:
    uint32_t limit;
+   uint32_t counted_entries = 0;
    std::vector<ParserDiagnostic> storage;
 };
 


### PR DESCRIPTION
## Summary
- ensure ParserDiagnostics only enforces the bounded diagnostic limit for warnings and errors so Info-level trace entries generated by ParserContext::match no longer crowd out real syntax errors

## Testing
- `cmake --build build/agents --config Release --target fluid --parallel`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc74b32c4832ea1aa51342b0b258e)