### PR TITLE
Fix control flow graph segfaults in parser

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/ir_emitter.cpp
+++ b/src/fluid/luajit-2.1/src/parser/ir_emitter.cpp
@@ -604,7 +604,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_while_stmt(const LoopStmtPayload& paylo
    }
    ControlFlowEdge condexit = condexit_result.value_ref();
 
-   ControlFlowEdge loop = this->control_flow.make_unconditional();
+   ControlFlowEdge loop;
    {
       FuncScope loop_scope;
       ScopeGuard guard(fs, &loop_scope, FuncScopeFlag::Loop);
@@ -632,7 +632,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_repeat_stmt(const LoopStmtPayload& payl
    FuncState* fs = &this->func_state;
    BCPos loop = fs->lasttarget = fs->pc;
    BCPos iter = NO_JMP;
-   ControlFlowEdge condexit = this->control_flow.make_false_edge();
+   ControlFlowEdge condexit;
    bool inner_has_upvals = false;
 
    FuncScope outer_scope;

--- a/src/fluid/luajit-2.1/src/parser/parse_control_flow.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_control_flow.cpp
@@ -150,7 +150,6 @@ void ControlFlowGraph::mark_resolved(size_t Index)
 {
    if (Index >= this->edges.size()) return;
    this->edges[Index].resolved = true;
-   this->edges[Index].head = NO_JMP;
 }
 
 void ControlFlowGraph::append_edge(size_t Index, BCPos Head)


### PR DESCRIPTION
Fixed three bugs in the ControlFlowGraph implementation:

1. **Unresolved edges in emit_while_stmt**: Line 607 created an edge via make_unconditional() that was immediately abandoned when reassigned on line 611. Fixed by declaring an empty edge instead.

2. **Unresolved edges in emit_repeat_stmt**: Line 635 created an edge via make_false_edge() that was immediately abandoned when reassigned on line 653. Fixed by declaring an empty edge instead.

3. **Head cleared after patching**: mark_resolved() was clearing the edge head to NO_JMP after patching. This broke emit_numeric_for_stmt which needs to query loopend.head() after calling patch_head() to pass the jump position to fscope_loop_continue(). Fixed by preserving the head value in mark_resolved().

All 25 fluid tests now pass.

Relates to src/fluid/luajit-2.1/src/parser/ir_emitter.cpp:607,635,744 Relates to src/fluid/luajit-2.1/src/parser/parse_control_flow.cpp:149-154