### PR TITLE
[Fluid] Fix bitwise and concatenation operators in phase 4 parser

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/ir_emitter.cpp
+++ b/src/fluid/luajit-2.1/src/parser/ir_emitter.cpp
@@ -1502,8 +1502,15 @@ ParserResult<ExpDesc> IrEmitter::emit_binary_expr(const BinaryExprPayload& paylo
       // Comparison operators (NE, EQ, LT, GE, LE, GT)
       this->operator_emitter.emit_comparison(opr, &lhs, &rhs);
    }
+   else if (opr IS OPR_CONCAT or opr IS OPR_BAND or opr IS OPR_BOR or opr IS OPR_BXOR or opr IS OPR_SHL or opr IS OPR_SHR) {
+      // CONCAT and bitwise operators need special legacy handling
+      // CONCAT uses special CAT bytecode chaining, bitwise ops emit bit.* library calls
+      // Keep using bcemit_binop until these are migrated to OperatorEmitter
+      glLegacyHelperCalls.record(LegacyHelperKind::Binop, "emit_binary_expr/concat_or_bitwise");
+      bcemit_binop(&this->func_state, opr, &lhs, &rhs);
+   }
    else {
-      // Arithmetic and bitwise operators (ADD, SUB, MUL, DIV, MOD, POW, CONCAT, BAND, BOR, BXOR, SHL, SHR)
+      // Arithmetic operators (ADD, SUB, MUL, DIV, MOD, POW)
       this->operator_emitter.emit_binary_arith(opr, &lhs, &rhs);
    }
 


### PR DESCRIPTION
Issue: Commit 52c250b introduced a bug where bitwise operators (<<, >>, &, |, ^) and string concatenation (..) were incorrectly routed to bcemit_arith(), which only handles arithmetic operators (ADD, SUB, MUL, DIV, MOD, POW).

Root Cause:
- In IrEmitter::emit_binary_expr(), the routing logic assumed all non-comparison, non-logical operators could be handled by emit_binary_arith()
- Bitwise operators need bcemit_bit_call() to emit bit.lshift/bit.rshift/etc. calls
- CONCAT needs special CAT bytecode chaining handled by bcemit_binop()

Symptoms:
- Bitwise shift expressions like "1 << 2 << 3" produced incorrect results (1 instead of 32)
- String concatenation caused segmentation faults due to incorrect register usage
- test-concat.fluid crashed with Signal 11 (invalid memory access)

Fix:
- Added explicit routing for CONCAT and bitwise operators (BAND, BOR, BXOR, SHL, SHR)
- These operators now use bcemit_binop() which has the correct legacy handlers
- Arithmetic operators (ADD, SUB, MUL, DIV, MOD, POW) continue using OperatorEmitter
- Added tracking comment for future migration when these operators are moved to OperatorEmitter

Testing:
- test-concat.fluid now runs successfully without crashes
- Bitwise shift operations produce correct results (1 << 2 << 3 = 32)
- String concatenation works correctly
- Bytecode output matches legacy parser exactly