### PR TITLE
[Fluid] Simplify comparison emission and decouple RegisterAllocator

### DIFF
--- a/src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp
+++ b/src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp
@@ -109,21 +109,7 @@ void RegisterAllocator::release_expression(ExpDesc *Expression)
    if (Expression->k IS ExpKind::NonReloc) {
       BCReg reg = Expression->u.s.info;
       BCReg expected_top = reg + 1;
-
-      // Check if this is a comparison operand that needs special handling
-      if ((Expression->flags & ExprFlag::ComparisonOperand) != ExprFlag::None) {
-         // For comparison operands, we need to release them even if they're not at the top
-         // because the comparison instruction has already consumed their values.
-         // We can only safely do this if the register is at the top of the stack.
-
-         if (reg >= this->func_state->nactvar and expected_top IS this->func_state->freereg) {
-            // Register is at top - release it normally
-            this->func_state->freereg = reg;
-         }
-         // If not at top, we can't release it without corrupting the stack
-      }
-      else if (reg >= this->func_state->nactvar and expected_top IS this->func_state->freereg) {
-         // Normal case: only release if the register is at the top of the stack
+      if (reg >= this->func_state->nactvar and expected_top IS this->func_state->freereg) {
          this->release_span_internal(reg, 1, expected_top);
       }
    }

--- a/src/fluid/luajit-2.1/src/parser/parse_types.h
+++ b/src/fluid/luajit-2.1/src/parser/parse_types.h
@@ -44,8 +44,7 @@ enum class ExpKind : uint8_t {
 enum class ExprFlag : uint8_t {
    None = 0x00u,
    PostfixIncStmt = 0x01u,
-   HasRhsReg = 0x02u,
-   ComparisonOperand = 0x04u  // Expression was discharged for a comparison operator
+   HasRhsReg = 0x02u
 };
 
 enum class FuncScopeFlag : uint8_t {


### PR DESCRIPTION
This pull request refactors how comparison operator operands are handled during code generation and register allocation in the LuaJIT parser. The main change is the removal of the `ComparisonOperand` flag and its associated logic, simplifying the release of registers after comparison instructions and improving code clarity and maintainability.

### Refactoring comparison operand handling

* Removed the use of the `ComparisonOperand` flag from `ExprFlag` and eliminated all logic that tagged expressions as comparison operands. (`src/fluid/luajit-2.1/src/parser/parse_types.h`, [src/fluid/luajit-2.1/src/parser/parse_types.hL47-R47](diffhunk://#diff-e017e09337fb6566bccd4189546ef6fc6b4f6e755b220e5ec3dcdb734b6e7216L47-R47))
* Refactored `bcemit_comp` to emit the comparison instruction before releasing operand registers, and now explicitly releases registers directly rather than through `release_expression`, maximizing register reuse for adjacent temporaries. (`src/fluid/luajit-2.1/src/parser/parse_operators.cpp`, [src/fluid/luajit-2.1/src/parser/parse_operators.cppL169-R185](diffhunk://#diff-bcf6dc20aaeaae6a4d06ff61fa55746c873b6bf42ded610bf4432b8e73046f6cL169-R185))

### Simplification of register allocation logic

* Simplified `RegisterAllocator::release_expression` by removing special handling for comparison operands; now only releases registers if they are at the top of the stack, reducing complexity and potential for stack corruption. (`src/fluid/luajit-2.1/src/parser/parse_regalloc.cpp`, [src/fluid/luajit-2.1/src/parser/parse_regalloc.cppL112-L126](diffhunk://#diff-01008966799d2abe428bee09c3373d0d72c0597bfec17a393d7fe9155200c6c8L112-L126))