### PR TITLE
[Fluid] Integrate object bytecodes into the JIT

### DIFF
--- a/src/fluid/luajit-2.1/src/lj_ircall.h
+++ b/src/fluid/luajit-2.1/src/lj_ircall.h
@@ -213,6 +213,9 @@ typedef struct CCallInfo {
   /* Try-except exception handling */ \
   _(ANY,        lj_try_enter,      4,  FS, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \
+  /* Native object field access */ \
+  _(ANY,        lj_object_gets,    4,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        jit_object_set,    4,   S, NIL, CCI_L|CCI_T) \
   \
   // End of list.
 

--- a/src/fluid/luajit-2.1/src/lj_ircall.h
+++ b/src/fluid/luajit-2.1/src/lj_ircall.h
@@ -215,7 +215,7 @@ typedef struct CCallInfo {
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \
   /* Native object field access */ \
   _(ANY,        lj_object_gets,    4,   S, NIL, CCI_L|CCI_T) \
-  _(ANY,        jit_object_set,    4,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_object_sets,    4,   S, NIL, CCI_L|CCI_T) \
   \
   // End of list.
 

--- a/src/fluid/luajit-2.1/src/lj_record.cpp
+++ b/src/fluid/luajit-2.1/src/lj_record.cpp
@@ -2484,9 +2484,9 @@ static TRef rec_object_set(jit_State *J, RecordOps *ops)
    if (not tref_isobject(obj_ref)) lj_trace_err(J, LJ_TRERR_BADTYPE);
    TRef key_ref = ops->rc;  // Get the string key reference - BC_OGETS/OSETS use ~RC for the constant index
 
-   // jit_object_set(L, obj, key, val)
+   // lj_object_sets(L, obj, key, val)
    TRef tmp_ref = rec_tmpref(J, ops->ra, IRTMPREF_IN1);
-   lj_ir_call(J, IRCALL_jit_object_set, obj_ref, key_ref, tmp_ref);
+   lj_ir_call(J, IRCALL_lj_object_sets, obj_ref, key_ref, tmp_ref);
    return 0;
 }
 

--- a/src/fluid/luajit-2.1/src/runtime/lj_object.cpp
+++ b/src/fluid/luajit-2.1/src/runtime/lj_object.cpp
@@ -252,11 +252,6 @@ extern "C" void lj_object_sets(lua_State *L, GCobject *Obj, GCstr *Key, TValue *
    else luaL_error(L, ERR::AccessObject);
 }
 
-extern "C" void jit_object_set(lua_State *L, GCobject *Obj, GCstr *Key, TValue *Val)
-{
-   lj_object_sets(L, Obj, Key, Val);
-}
-
 //********************************************************************************************************************
 // JIT field type lookup - returns the IR type for a field.  Returns -1 if field not found or unknown type.  This
 // function must have no side effects as it is called during JIT recording.

--- a/src/fluid/luajit-2.1/src/runtime/lj_object.h
+++ b/src/fluid/luajit-2.1/src/runtime/lj_object.h
@@ -5,6 +5,7 @@
 
 #include "lj_obj.h"
 #include "lj_gc.h"
+#include "lj_ir.h"
 #include <parasol/main.h>
 
 extern GCobject * lj_object_new(lua_State *, OBJECTID, OBJECTPTR, class objMetaClass *, uint8_t);
@@ -16,3 +17,7 @@ extern int lj_object_ipairs(lua_State *);
 // Fast path bytecode handlers for BC_OGETS and BC_OSETS
 extern "C" void lj_object_gets(lua_State *, GCobject *, GCstr *, TValue *);
 extern "C" void lj_object_sets(lua_State *, GCobject *, GCstr *, TValue *);
+
+extern "C" void jit_object_set(lua_State *, GCobject *, GCstr *, TValue *);
+
+extern "C" int ir_object_field_type(GCobject *Obj, GCstr *Key);

--- a/src/fluid/luajit-2.1/src/runtime/lj_object.h
+++ b/src/fluid/luajit-2.1/src/runtime/lj_object.h
@@ -18,6 +18,4 @@ extern int lj_object_ipairs(lua_State *);
 extern "C" void lj_object_gets(lua_State *, GCobject *, GCstr *, TValue *);
 extern "C" void lj_object_sets(lua_State *, GCobject *, GCstr *, TValue *);
 
-extern "C" void jit_object_set(lua_State *, GCobject *, GCstr *, TValue *);
-
 extern "C" int ir_object_field_type(GCobject *Obj, GCstr *Key);


### PR DESCRIPTION
This pull request adds support for native object field access in the JIT compiler, enabling efficient handling of object field get and set operations (`BC_OGETS` and `BC_OSETS`) in recorded traces. The main changes introduce new JIT-recorder logic for these opcodes, helper functions for safe and efficient field access, and a mechanism for type inference of object fields during JIT recording.

**JIT Integration for Native Object Field Access:**

- Added new IR call definitions for `lj_object_gets` and `jit_object_set` to the JIT call table, enabling the JIT to emit calls for object field get/set operations.
- Implemented `rec_object_get` and `rec_object_set` functions in `lj_record.cpp` to handle `BC_OGETS` and `BC_OSETS` opcodes during JIT recording, including type inference using the new `ir_object_field_type` function. [[1]](diffhunk://#diff-8f5ba2e5ec30a4236c44e93953e828f932452b74cf631dd99e1dfc3013a3c590R2456-R2492) [[2]](diffhunk://#diff-8f5ba2e5ec30a4236c44e93953e828f932452b74cf631dd99e1dfc3013a3c590R2804-R2813)
- Registered the new object opcodes in the JIT instruction dispatcher to trigger the above logic.

**Runtime Support for JIT Field Access:**

- Added `jit_object_set` function to `lj_object.cpp` for setting object fields from JIT traces, handling stack management and error cases safely.
- Added `ir_object_field_type` function to provide side-effect-free field type lookup for use by the JIT recorder, supporting accurate type inference for optimized code generation.

**Header and Dependency Updates:**

- Updated includes in `lj_record.cpp`, `lj_object.cpp`, and `lj_object.h` to ensure proper access to IR and object-related definitions. [[1]](diffhunk://#diff-8f5ba2e5ec30a4236c44e93953e828f932452b74cf631dd99e1dfc3013a3c590R31) [[2]](diffhunk://#diff-4cc671301806204a3c05236049125220124ca102f9b1105351751545878d8f28R9) [[3]](diffhunk://#diff-c251fb42713cad9924fd9cbe62d8293b5e686dae3e1747655db3670c6d7c22fdR8)
- Declared new JIT helper functions in `lj_object.h` for use by the JIT and runtime.

These changes collectively enhance the JIT's ability to optimize native object field accesses, improving performance for code that manipulates objects with fields.