### PR TITLE
[Tiri/Core] Replace linear bit-scan loops with C++20 <bit> operations

### DIFF
--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -45,6 +45,8 @@ The task object that represents the active process can be acquired from ~Current
  #include <stdio.h>
 #endif
 
+#include <bit>
+
 #include "../defs.h"
 #include <kotuku/main.h>
 
@@ -1739,7 +1741,9 @@ static ERR GET_AffinityMask(extTask *Self, int64_t *Value)
 
    // Convert cpu_set_t to bitmask
    int64_t mask = 0;
-   for (int cpu = 0; cpu < CPU_SETSIZE; cpu++) {
+   constexpr int max_mask_bits = sizeof(mask) * 8;
+   const int max_cpu = (CPU_SETSIZE < max_mask_bits) ? CPU_SETSIZE : max_mask_bits;
+   for (int cpu = 0; cpu < max_cpu; cpu++) {
       if (CPU_ISSET(cpu, &cpuset)) {
          mask |= (1LL << cpu);
       }
@@ -1765,10 +1769,11 @@ static ERR SET_AffinityMask(extTask *Self, int64_t Value)
    CPU_ZERO(&cpuset);
 
    // Convert bitmask to cpu_set_t
-   for (int cpu = 0; cpu < CPU_SETSIZE; cpu++) {
-      if (Value & (1LL << cpu)) {
-         CPU_SET(cpu, &cpuset);
-      }
+   auto mask = uint64_t(Value);
+   while (mask) {
+      int cpu = int(std::countr_zero(mask));
+      CPU_SET(cpu, &cpuset);
+      mask &= mask - 1;
    }
 
    // Set affinity for current process

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -55,6 +55,8 @@
 #define lj_err_c
 #define LUA_CORE
 
+#include <bit>
+
 #include <kotuku/main.h>
 
 #include "lj_obj.h"
@@ -126,26 +128,28 @@ static TValue * unwind_close_handlers(lua_State *L, TValue *frame, TValue *errob
 
    TValue *base = frame + 1;
    TValue *current_err = errobj;
-   for (int slot = 63; slot >= 0; slot--) {
-      if (closeslots & (1ULL << slot)) {
-         TValue *o = base + slot;
-         // Verify slot is within valid frame range: must be >= base and < L->top
-         if (o >= base and o < L->top and !tvisnil(o) and !tvisfalse(o)) {
-            int errcode = lj_meta_close(L, o, current_err);
-            if (errcode != 0) {
-               // Per Lua 5.4: error in __close replaces the original error.
-               // The new error is at L->top - 1 after the failed pcall.
-               // Continue calling other __close handlers with the new error.
-               current_err = L->top - 1;
-               // Update _G.__close_err with the new error
-               if (env) {
-                  GCstr *key = lj_str_newlit(L, "__close_err");
-                  TValue *slot = lj_tab_setstr(L, env, key);
-                  copyTV(L, slot, current_err);
-                  lj_gc_anybarriert(L, env);
-               }
-               copyTV(L, &L->close_err, current_err);
+   uint64_t pending_slots = closeslots;
+   while (pending_slots) {
+      int slot = int(std::bit_width(pending_slots) - 1);
+      pending_slots ^= uint64_t(1) << slot;
+
+      TValue *o = base + slot;
+      // Verify slot is within valid frame range: must be >= base and < L->top
+      if (o >= base and o < L->top and !tvisnil(o) and !tvisfalse(o)) {
+         int errcode = lj_meta_close(L, o, current_err);
+         if (errcode != 0) {
+            // Per Lua 5.4: error in __close replaces the original error.
+            // The new error is at L->top - 1 after the failed pcall.
+            // Continue calling other __close handlers with the new error.
+            current_err = L->top - 1;
+            // Update _G.__close_err with the new error
+            if (env) {
+               GCstr *key = lj_str_newlit(L, "__close_err");
+               TValue *slot = lj_tab_setstr(L, env, key);
+               copyTV(L, slot, current_err);
+               lj_gc_anybarriert(L, env);
             }
+            copyTV(L, &L->close_err, current_err);
          }
       }
    }
@@ -191,24 +195,29 @@ static TValue* unwind_close_try_block(lua_State *L, TValue* frame, TValue* errob
    lj_assertL(base >= tvref(L->stack) and base <= tvref(L->maxstack), "unwind_close_try_block: base out of range (%p)", base);
 
    TValue *current_err = errobj;
-   for (int slot = 63; slot >= min_slot_index; slot--) {
-      if (closeslots & (1ULL << slot)) {
-         TValue *o = base + slot;
+   uint64_t pending_slots = closeslots;
+   if (min_slot_index >= 64) pending_slots = 0;
+   else if (min_slot_index > 0) pending_slots &= ~((uint64_t(1) << min_slot_index) - 1);
 
-         // Only close if: slot is within valid stack range and not already nil/false
+   while (pending_slots) {
+      int slot = int(std::bit_width(pending_slots) - 1);
+      pending_slots ^= uint64_t(1) << slot;
 
-         if (o >= base and o < L->top and !tvisnil(o) and !tvisfalse(o)) {
-            int errcode = lj_meta_close(L, o, current_err);
-            if (errcode != 0) {
-               current_err = L->top - 1;
-               if (env) {
-                  GCstr *key = lj_str_newlit(L, "__close_err");
-                  TValue *slot_tv = lj_tab_setstr(L, env, key);
-                  copyTV(L, slot_tv, current_err);
-                  lj_gc_anybarriert(L, env);
-               }
-               copyTV(L, &L->close_err, current_err);
+      TValue *o = base + slot;
+
+      // Only close if: slot is within valid stack range and not already nil/false
+
+      if (o >= base and o < L->top and !tvisnil(o) and !tvisfalse(o)) {
+         int errcode = lj_meta_close(L, o, current_err);
+         if (errcode != 0) {
+            current_err = L->top - 1;
+            if (env) {
+               GCstr *key = lj_str_newlit(L, "__close_err");
+               TValue *slot_tv = lj_tab_setstr(L, env, key);
+               copyTV(L, slot_tv, current_err);
+               lj_gc_anybarriert(L, env);
             }
+            copyTV(L, &L->close_err, current_err);
          }
       }
    }

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -5,6 +5,7 @@
 // Copyright (C) 1994-2011 Lua.org, PUC-Rio. See Copyright Notice in lua.h
 
 #include <stdio.h>
+#include <bit>
 #include <cctype>
 
 #define lib_base_c
@@ -41,6 +42,13 @@
 #include "debug/error_guard.h"
 
 #define LJLIB_MODULE_base
+
+static uint64_t low_bit_mask(int32_t Count)
+{
+   if (Count <= 0) return 0;
+   if (Count >= 64) return ~uint64_t(0);
+   return (uint64_t(1) << Count) - 1;
+}
 
 //********************************************************************************************************************
 // The implementation of assert() is a little strange in that it is specifically geared towards being optimised by
@@ -433,14 +441,19 @@ LJLIB_CF(__filter)      LJLIB_REC(.)
 
    // Values to filter start at position 4 (index 3, 0-based)
    int32_t value_count = nargs - 3;
+   int32_t masked_count = count;
+   int32_t trailing_start = count;
+   if (masked_count < 0) masked_count = 0;
+   if (masked_count > value_count) masked_count = value_count;
+   if (masked_count > 64) masked_count = 64;
+   if (trailing_start < 0) trailing_start = 0;
+   if (trailing_start > value_count) trailing_start = value_count;
+   uint64_t active_mask = mask & low_bit_mask(masked_count);
 
    // First pass: count how many values we'll keep (for stack check)
 
-   int32_t out_count = 0;
-   for (int32_t i = 0; i < value_count; i++) {
-      bool keep = (i < count) ? ((mask & (1ULL << i)) != 0) : trailing_keep;
-      if (keep) out_count++;
-   }
+   int32_t out_count = int32_t(std::popcount(active_mask));
+   if (trailing_keep and (trailing_start < value_count)) out_count += value_count - trailing_start;
 
    // Ensure we have enough stack space
 
@@ -455,9 +468,15 @@ LJLIB_CF(__filter)      LJLIB_REC(.)
    TValue *dst = L->base;      // Overwrite from the start
 
    int32_t written = 0;
-   for (int32_t i = 0; i < value_count; i++) {
-      bool keep = (i < count) ? ((mask & (1ULL << i)) != 0) : trailing_keep;
-      if (keep) {
+   uint64_t pending_mask = active_mask;
+   while (pending_mask) {
+      int32_t i = int32_t(std::countr_zero(pending_mask));
+      if (dst + written != src + i) copyTV(L, dst + written, src + i);
+      written++;
+      pending_mask &= pending_mask - 1;
+   }
+   if (trailing_keep) {
+      for (int32_t i = trailing_start; i < value_count; i++) {
          if (dst + written != src + i) copyTV(L, dst + written, src + i);
          written++;
       }

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -21,6 +21,8 @@
 #define lj_ffrecord_c
 #define LUA_CORE
 
+#include <bit>
+
 #include "lj_obj.h"
 #include "lj_err.h"
 #include "lj_buf.h"
@@ -51,6 +53,13 @@
 
 // Type of handler to record a fast function.
 typedef void (* RecordFunc)(jit_State* J, RecordFFData* rd);
+
+static uint64_t low_bit_mask(int32_t Count)
+{
+   if (Count <= 0) return 0;
+   if (Count >= 64) return ~uint64_t(0);
+   return (uint64_t(1) << Count) - 1;
+}
 
 //********************************************************************************************************************
 // Get runtime value of int argument.
@@ -371,15 +380,29 @@ static void recff___filter(jit_State* J, RecordFFData* rd)
    ptrdiff_t n = ptrdiff_t(J->maxslot);
    ptrdiff_t value_start = 3;  // Values start at slot 3
    ptrdiff_t value_count = n - value_start;
+   int32_t masked_count = count;
+   ptrdiff_t trailing_start = count;
+   if (masked_count < 0) masked_count = 0;
+   if (masked_count > value_count) masked_count = int32_t(value_count);
+   if (masked_count > 64) masked_count = 64;
+   if (trailing_start < 0) trailing_start = 0;
+   if (trailing_start > value_count) trailing_start = value_count;
+   uint64_t active_mask = mask & low_bit_mask(masked_count);
 
    // Build output by copying kept values
    int32_t out_idx = 0;
-   for (ptrdiff_t i = 0; i < value_count; i++) {
-      bool keep;
-      if (i < count) keep = (mask & (1ULL << i)) != 0;
-      else keep = trailing_keep;
-
-      if (keep) {
+   uint64_t pending_mask = active_mask;
+   while (pending_mask) {
+      ptrdiff_t i = ptrdiff_t(std::countr_zero(pending_mask));
+      TRef tr = J->base[value_start + i];
+      if (tr) {
+         J->base[out_idx] = tr;
+         out_idx++;
+      }
+      pending_mask &= pending_mask - 1;
+   }
+   if (trailing_keep) {
+      for (ptrdiff_t i = trailing_start; i < value_count; i++) {
          TRef tr = J->base[value_start + i];
          if (tr) {
             J->base[out_idx] = tr;

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -591,7 +591,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_result_filter_expr(const Token &Star
    // A mask of all 1s up to explicit_count means (1 << count) - 1
 
    auto &f = filter.value_ref();
-   uint64_t all_kept_mask = (f.explicit_count > 0) ? ((1ULL << f.explicit_count) - 1) : 0;
+   uint64_t all_kept_mask;
+   if (f.explicit_count IS 0) all_kept_mask = 0;
+   else if (f.explicit_count >= 64) all_kept_mask = ~uint64_t(0);
+   else all_kept_mask = (uint64_t(1) << f.explicit_count) - 1;
    if (f.trailing_keep and f.keep_mask IS all_kept_mask) return expr;  // No filtering needed, just return the call expression
 
    SourceSpan span = combine_spans(StartToken.span(), expr.value_ref()->span);


### PR DESCRIPTION
Refactors bit-iteration loops across the Tiri JIT (__filter implementation and recording, close-slot unwinding) and Task CPU affinity code to use std::countr_zero, std::bit_width, and std::popcount instead of scanning all 64 positions.  Also fixes latent UB from shift-by-64 when explicit_count >= 64 in the filter expression parser.