### PR TITLE
[Core, Tiri] Fix resource leaks and object lifecycle issues

### DIFF
--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -513,6 +513,8 @@ static ERR AUDIO_Free(extAudio *Self)
 
    if (Self->Timer) { UpdateTimer(Self->Timer, 0); Self->Timer = nullptr; }
 
+   glSoundChannels.erase(Self->UID);
+
    acDeactivate(Self);
 
    if (Self->MixBuffer) { FreeResource(Self->MixBuffer); Self->MixBuffer = nullptr; }

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -408,8 +408,7 @@ static ERR msg_action(APTR Custom, int MsgID, int MsgType, APTR Message, int Msg
 
    if ((action->ObjectID) and (action->ActionID != AC::NIL)) {
       OBJECTPTR obj;
-      ERR error;
-      if ((error = AccessObject(action->ObjectID, 5000, &obj)) IS ERR::Okay) {
+      if (auto error = AccessObject(action->ObjectID, 5000, &obj); error IS ERR::Okay) {
          if (action->SendArgs IS false) {
             obj->setFlag(NF::MESSAGE);
             Action(action->ActionID, obj, nullptr);
@@ -433,11 +432,9 @@ static ERR msg_action(APTR Custom, int MsgID, int MsgType, APTR Message, int Msg
             }
          }
       }
-      else {
-         if ((error != ERR::NoMatchingObject) and (error != ERR::MarkedForDeletion)) {
-            if (action->ActionID > AC::NIL) log.warning("Could not gain access to object %d to execute action %s.", action->ObjectID, action_id_name(action->ActionID));
-            else log.warning("Could not gain access to object %d to execute method %d.", action->ObjectID, int(action->ActionID));
-         }
+      else if ((error != ERR::NoMatchingObject) and (error != ERR::MarkedForDeletion)) {
+         if (action->ActionID > AC::NIL) log.warning("Could not gain access to object %d to execute action %s.", action->ObjectID, action_id_name(action->ActionID));
+         else log.warning("Could not gain access to object %d to execute method %d.", action->ObjectID, int(action->ActionID));
       }
    }
    else log.warning("Action message %s specifies an object ID of #%d.", action_id_name(action->ActionID), action->ObjectID);

--- a/src/core/lib_locking.cpp
+++ b/src/core/lib_locking.cpp
@@ -390,7 +390,7 @@ ERR AccessMemory(MEMORYID MemoryID, MEM Flags, int MilliSeconds, APTR *Result)
          *Result = mem->second.Address;
          return ERR::Okay;
       }
-      else log.traceWarning("Cannot find memory ID #%d", MemoryID); // This is not uncommon, so trace only
+      else log.trace("Cannot find memory ID #%d", MemoryID); // Attempting a non-existing ID is allowed, so trace only
    }
    else return log.warning(ERR::SystemLocked);
 

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -219,7 +219,19 @@ struct actionmonitor {
       move.ObjectID = 0;
    }
 
-   actionmonitor& operator=(actionmonitor &&move) = default;
+   actionmonitor& operator=(actionmonitor &&move) noexcept
+   {
+      if (this != &move) {
+         Object = move.Object;
+         Args = move.Args;
+         Function = move.Function;
+         Reference = move.Reference;
+         ActionID = move.ActionID;
+         ObjectID = move.ObjectID;
+         move.ObjectID = 0;
+      }
+      return *this;
+   }
 };
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -259,6 +259,27 @@ void notify_action(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
          }
 
          SetResource(RES::LOG_DEPTH, depth);
+
+         if (ActionID IS AC::Free) {
+            std::erase_if(prv->ActionList, [&](auto &item) {
+               if (item.ObjectID IS Object->UID) {
+                  if (item.Function) {
+                     luaL_unref(prv->Lua, LUA_REGISTRYINDEX, item.Function);
+                     item.Function = 0;
+                  }
+                  if (item.Reference) {
+                     luaL_unref(prv->Lua, LUA_REGISTRYINDEX, item.Reference);
+                     item.Reference = 0;
+                  }
+
+                  // The object is already being destroyed, so suppress destructor-time unsubscribe attempts.
+                  item.ObjectID = 0;
+                  return true;
+               }
+               else return false;
+            });
+         }
+
          return;
       }
    }


### PR DESCRIPTION
- Audio: erase glSoundChannels entry on Audio object free to prevent stale channel entries
- Core/Task: refactor msg_action error path to use if-init statement and flatten else nesting
- Core/Locking: downgrade traceWarning to trace for non-existing memory ID lookups
- Tiri/defs: implement explicit move-assignment for actionmonitor to correctly zero ObjectID on moved-from instances
- Tiri: clean up ActionList subscriptions in notify_action when AC::Free fires, releasing Lua refs and suppressing destructor-time unsubscribe attempts