### PR TITLE
[Tiri] Bug sweep: event subscription order, processing.flush, struct indexing, and regex captures

### DIFF
--- a/src/tiri/tests/test_io.tiri
+++ b/src/tiri/tests/test_io.tiri
@@ -228,6 +228,20 @@ end
    file:close()
 end
 
+@Test(labels=['io', 'file']) function FileFlushClosedHandle()
+   test_path = glTestFolder .. 'test_flush_closed.txt'
+   file = io.open(test_path, 'w')
+   assert(file, 'Failed to open file for closed flush test')
+   glTestFiles:push(test_path)
+
+   file:close()
+   try
+      file:flush()
+   success
+      error('file:flush() on a closed handle should throw an error')
+   end
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Lines iteration tests
 

--- a/src/tiri/tests/test_processing.tiri
+++ b/src/tiri/tests/test_processing.tiri
@@ -147,6 +147,12 @@ end
    -- If we get here without error, the test passes
 end
 
+@Test function ProcessingObjectFlushExists()
+   proc = processing.new()
+   assert(type(proc.flush) is 'function', 'proc.flush should be a function')
+   proc.flush()
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function TaskReturnsObject()

--- a/src/tiri/tests/test_regex.tiri
+++ b/src/tiri/tests/test_regex.tiri
@@ -152,6 +152,11 @@ end
    assert(all_matches[1][0] is '456', "Second match should be '456'")
    assert(all_matches[1][1] is '456', "Second capture group should be '456'")
 
+   captured_char = regex.new('(b)').search(' ab')
+   assert(#captured_char is 1, 'Should find captured character preceded by alphabetic text')
+   assert(captured_char[0][0] is 'b', "Full match should be 'b'")
+   assert(captured_char[0][1] is 'b', "Capture group should be 'b'")
+
    -- Test with no matches
    no_matches = digit_regex.search('hello world')
    assert(no_matches is nil, "Should return nil for no matches")

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -412,6 +412,7 @@ static ERR TIRI_DataFeed(objScript *Self, struct acDataFeed *Args)
                      process_error(Self, "Data Receipt Callback");
                   }
                }
+               else lua_pop(prv->Lua, 2);
 
             SetResource(RES::LOG_DEPTH, step);
 
@@ -1082,7 +1083,7 @@ static ERR register_interfaces(objScript *Self)
    reg_func_prototype("include", {}, { TiriType::Str }, FProtoFlags::Variadic);
    reg_func_prototype("require", { TiriType::Table }, { TiriType::Str });
    reg_func_prototype("msg", {}, { TiriType::Str }, FProtoFlags::Variadic);
-   reg_func_prototype("subscribeEvent", { TiriType::Any, TiriType::Num }, { TiriType::Str, TiriType::Func });
+   reg_func_prototype("subscribeEvent", { TiriType::Num, TiriType::Any }, { TiriType::Str, TiriType::Func });
    reg_func_prototype("unsubscribeEvent", {}, { TiriType::Any });
    reg_func_prototype("MAKESTRUCT", { TiriType::Any }, { TiriType::Str });
 

--- a/src/tiri/tiri_class_methods.cpp
+++ b/src/tiri/tiri_class_methods.cpp
@@ -43,7 +43,7 @@ static int append_dump_chunk([[maybe_unused]] lua_State *, const void *Chunk, si
    if ((not bytes) or (not Chunk)) return 1;
    if (not Size) return 0; // End of dump signaled.
 
-   std::span<const uint8_t> data_span(static_cast<const uint8_t *>(Chunk), Size);
+   std::span<const uint8_t> data_span((const uint8_t *)Chunk, Size);
    bytes->insert(bytes->end(), data_span.begin(), data_span.end());
    return 0;
 }
@@ -720,6 +720,12 @@ static ERR TIRI_GetProcedureID(objScript *Self, struct sc::GetProcedureID *Args)
    }
 
    lua_getglobal(prv->Lua, Args->Procedure);
+   if (not lua_isfunction(prv->Lua, -1)) {
+      lua_pop(prv->Lua, 1);
+      log.warning("Failed to resolve function name '%s' to an ID.", Args->Procedure);
+      return ERR::NotFound;
+   }
+
    auto id = luaL_ref(prv->Lua, LUA_REGISTRYINDEX);
    if ((id != LUA_REFNIL) and (id != LUA_NOREF)) {
       Args->ProcedureID = id;

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -72,7 +72,8 @@ static void receive_event(kt::Event *Info, int InfoSize, APTR CallbackMeta)
    lua_rawgeti(prv->Lua, LUA_REGISTRYINDEX, intptr_t(CallbackMeta));
 
    lua_pushnumber(prv->Lua, Info->EventID);
-   if (lua_pcall(prv->Lua, 1, 0, 0)) {
+   lua_newtable(prv->Lua);
+   if (lua_pcall(prv->Lua, 2, 0, 0)) {
       process_error(Script, "Event Subscription");
    }
 
@@ -194,12 +195,13 @@ int fcmd_subscribe_event(lua_State *Lua)
       if (auto error = SubscribeEvent(event_id, C_FUNCTION(receive_event, client_function), &handle); error IS ERR::Okay) {
          auto prv = (prvTiri *)Lua->script->ChildPrivate;
          prv->EventList.emplace_back(client_function, event_id, handle);
-         lua_pushlightuserdata(Lua, handle); // 1: Handle
-         lua_pushinteger(Lua, int(error)); // 2: Error code
+         lua_pushinteger(Lua, int(error)); // 1: Error code
+         lua_pushlightuserdata(Lua, handle); // 2: Handle
       }
       else {
-         lua_pushnil(Lua); // Handle
+         luaL_unref(Lua, LUA_REGISTRYINDEX, client_function);
          lua_pushinteger(Lua, int(error)); // Error code
+         lua_pushnil(Lua); // Handle
       }
       return 2;
    }

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -613,7 +613,9 @@ static int file_close(lua_State *Lua)
 static int file_flush(lua_State *Lua)
 {
    if (auto handle = check_file_handle(Lua, 1)) {
-      acFlush(GetObjectPtr(handle->file_id));
+      auto file = GetObjectPtr(handle->file_id);
+      if (not file) luaL_error(Lua, ERR::InvalidState);
+      acFlush(file);
       lua_pushboolean(Lua, 1);
       return 1;
    }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -208,6 +208,11 @@ static int processing_signal(lua_State *Lua)
 static int processing_flush(lua_State *Lua)
 {
    Lua->script->clearFlag(NF::SIGNALLED);
+   if (auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing")) {
+      for (auto &entry : *fp->Signals) {
+         entry.Object->clearFlag(NF::SIGNALLED);
+      }
+   }
    return 0;
 }
 
@@ -345,13 +350,9 @@ static int processing_get(lua_State *Lua)
          return 1;
       }
       else if (std::string_view("flush") IS fieldname) {
-         Lua->script->clearFlag(NF::SIGNALLED);
-         if (auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing")) {
-            for (auto &entry : *fp->Signals) {
-               entry.Object->clearFlag(NF::SIGNALLED);
-            }
-         }
-         return 0;
+         lua_pushvalue(Lua, 1);
+         lua_pushcclosure(Lua, &processing_flush, 1);
+         return 1;
       }
       else luaL_error(Lua, "Unrecognised index '%s'", fieldname);
    }

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -66,7 +66,7 @@ static ERR match_many(int Index, std::vector<std::string_view> &Captures, size_t
       const std::string_view &full_match = Captures[0];
       const std::string_view &first_group = Captures[1];
 
-      if ((full_match.size() == first_group.size()) and (full_match.size() > 0) and (MatchStart <= Meta.subject.size())) {
+      if ((full_match.size() > 1) and (full_match.size() IS first_group.size()) and (MatchStart <= Meta.subject.size())) {
          auto preceding_char = (uint8_t)Meta.subject[MatchStart - 1];
          auto match_char = (uint8_t)full_match.front();
 

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -181,7 +181,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
                   else if (field.ArraySize IS - 1); // Pointer to a null-terminated array
                   else if (lua_istable(Lua, -1) and (type & (FD_FLOAT|FD_DOUBLE|FD_INT64|FD_INT|FD_WORD|FD_BYTE))) { // Embedded, fixed size array
                      for (int i = 0; i < field.ArraySize; i++) {
-                        lua_pushinteger(Lua, i + 1); // Lua arrays are 1-based
+                        lua_pushinteger(Lua, i);
                         lua_gettable(Lua, -2); // Get value at index
                         if (type & FD_FLOAT)       ((float *)address)[i]   = lua_tonumber(Lua, -1);
                         else if (type & FD_DOUBLE) ((double *)address)[i]  = lua_tonumber(Lua, -1);
@@ -267,7 +267,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
          else if (field.ArraySize IS -1) { // Pointer to a null-terminated array.
             if (type & FD_STRUCT) {
                if (glStructs.contains(std::string_view(field.StructRef))) {
-                  if (((CPTR *)address)[0]) make_any_array(Lua, type, field.StructRef, -1, address);
+                  if (((CPTR *)address)[0]) make_any_array(Lua, type, field.StructRef, -1, ((CPTR *)address)[0]);
                   else lua_pushnil(Lua);
                }
                else lua_pushnil(Lua);
@@ -761,7 +761,7 @@ static int struct_get(lua_State *Lua)
                         auto vector = (kt::vector<int> *)(address);
                         lua_createarray(Lua, vector->size(), ff_to_element(field.Type), (APTR *)vector->data(), ARRAY_CACHED, field.StructRef);
                      }
-                     else lua_createarray(Lua, array_size, ff_to_element(field.Type), (APTR *)address, ARRAY_CACHED, field.StructRef);
+                     else lua_createarray(Lua, array_size, ff_to_element(field.Type), ((APTR *)address)[0], ARRAY_CACHED, field.StructRef);
                   }
                   else push_struct(Lua->script, ((APTR *)address)[0], field.StructRef, false, false);
                }

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -761,7 +761,7 @@ static int struct_get(lua_State *Lua)
                         auto vector = (kt::vector<int> *)(address);
                         lua_createarray(Lua, vector->size(), ff_to_element(field.Type), (APTR *)vector->data(), ARRAY_CACHED, field.StructRef);
                      }
-                     else lua_createarray(Lua, array_size, ff_to_element(field.Type), ((APTR *)address)[0], ARRAY_CACHED, field.StructRef);
+                     else lua_createarray(Lua, array_size, ff_to_element(field.Type), (APTR *)address, ARRAY_CACHED, field.StructRef);
                   }
                   else push_struct(Lua->script, ((APTR *)address)[0], field.StructRef, false, false);
                }


### PR DESCRIPTION
* Fixed subscribeEvent return value order (error code first, then handle) 
* fixed receive_event to pass EventID + table to callbacks; processing.flush now returns a callable closure instead of executing on field access
* file:flush() throws on closed handles
* struct fixed-array indexing corrected to 0-based
* null-terminated struct pointer array passes correct data address
* lua_createarray for pointer fields passes dereferenced address
* regex match_many condition fixed for single-char captures preceded by alphabetic text
* GetProcedureID validates function existence before referencing
* stack imbalance corrected in DataFeed callback path
* subscribeEvent prototype return types corrected
* tests added for flush on closed file handle, processing.flush callable, and regex single-char capture.