### PR TITLE
[Tiri] Fix Lua stack leaks in all register_*_class() helpers

### DIFF
--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -625,4 +625,6 @@ void register_async_class(lua_State *Lua)
    reg_iface_prototype("async", "pending", { TiriType::Num }, { TiriType::Object });
    reg_iface_prototype("async", "script",  {}, { TiriType::Object, TiriType::Func });
    reg_iface_prototype("async", "wait",    { TiriType::Num }, { TiriType::Any, TiriType::Num });
+
+   lua_pop(Lua, 2); // Drop the Tiri.async metatable and the async library table
 }

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -1053,14 +1053,18 @@ static ERR register_interfaces(objScript *Self)
 
    auto prv = (prvTiri *)Self->ChildPrivate;
 
+#ifndef NDEBUG
+   int stack_top = lua_gettop(prv->Lua);
+#endif
+
    register_io_class(prv->Lua);
    register_module_class(prv->Lua);
    register_regex_class(prv->Lua);
    register_struct_class(prv->Lua);
    register_async_class(prv->Lua);
-   #ifndef DISABLE_DISPLAY
-      register_input_class(prv->Lua);
-   #endif
+#ifndef DISABLE_DISPLAY
+   register_input_class(prv->Lua);
+#endif
    register_number_class(prv->Lua);
    register_processing_class(prv->Lua);
 
@@ -1088,6 +1092,11 @@ static ERR register_interfaces(objScript *Self)
    reg_func_prototype("MAKESTRUCT", { TiriType::Any }, { TiriType::Str });
 
    load_include(Self, "core");
+
+#ifndef NDEBUG
+   int stack_delta = lua_gettop(prv->Lua) - stack_top;
+   if (stack_delta) log.warning("Lua initialisation left %d value(s) on the Lua stack.", stack_delta);
+#endif
 
    return ERR::Okay;
 }

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -533,6 +533,8 @@ void register_input_class(lua_State *Lua)
    luaL_openlib(Lua, nullptr, inputlib_methods, 0);
    luaL_openlib(Lua, "input", inputlib_functions, 0);
 
+   lua_pop(Lua, 2); // Drop the Tiri.input metatable and the input library table
+
    // Register input interface prototypes for compile-time type inference
    reg_iface_prototype("input", "subscribe", { TiriType::Any }, { TiriType::Num, TiriType::Any, TiriType::Num, TiriType::Func });
    reg_iface_prototype("input", "keyboard", { TiriType::Any }, { TiriType::Any, TiriType::Func });

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -864,6 +864,8 @@ void register_io_class(lua_State *Lua)
    lua_pushnumber(Lua, CONST_STDERR);
    lua_setfield(Lua, -2, "stderr");
 
+   lua_pop(Lua, 3); // Drop the Tiri.file metatable, Tiri.io metatable, and io library table
+
    // Register io interface prototypes for compile-time type inference
    reg_iface_prototype("io", "open", { TiriType::Any }, { TiriType::Str, TiriType::Str });
    reg_iface_prototype("io", "close", { TiriType::Bool }, { TiriType::Any });

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -1152,6 +1152,8 @@ void register_module_class(lua_State *Lua)
 
    log.trace("Registering module interface.");
 
+   int stack_top = lua_gettop(Lua);
+
    luaL_newmetatable(Lua, "Tiri.mod");
    lua_pushstring(Lua, "Tiri.mod");
    lua_setfield(Lua, -2, "__name");
@@ -1161,6 +1163,11 @@ void register_module_class(lua_State *Lua)
 
    luaL_openlib(Lua, nullptr, modlib_methods, 0);
    luaL_openlib(Lua, "mod", modlib_functions, 0);
+
+   lua_pop(Lua, 2); // Drop the Tiri.mod metatable and the mod library table
+
+   int stack_delta = lua_gettop(Lua) - stack_top;
+   if (stack_delta) log.warning("Module registration left %d value(s) on the Lua stack.", stack_delta);
 
    // Register mod interface prototypes for compile-time type inference
    reg_iface_prototype("mod", "load", { TiriType::Any }, { TiriType::Str });

--- a/src/tiri/tiri_number.cpp
+++ b/src/tiri/tiri_number.cpp
@@ -166,6 +166,8 @@ static int number_tostring(lua_State *Lua)
 
 void register_number_class(lua_State *Lua)
 {
+   kt::Log log(__FUNCTION__);
+
    static const luaL_Reg numlib_functions[] = {
       { "int",    number_i32 },
       { "int64",  number_i64 },
@@ -183,8 +185,9 @@ void register_number_class(lua_State *Lua)
       { nullptr, nullptr }
    };
 
-   kt::Log log(__FUNCTION__);
    log.trace("Registering number interface.");
+
+   int stack_top = lua_gettop(Lua);
 
    luaL_newmetatable(Lua, "Tiri.num");
    lua_pushstring(Lua, "Tiri.num");
@@ -195,4 +198,9 @@ void register_number_class(lua_State *Lua)
 
    luaL_openlib(Lua, nullptr, numlib_methods, 0);
    luaL_openlib(Lua, "num", numlib_functions, 0);
+
+   lua_pop(Lua, 2); // Drop the Tiri.num metatable and the num library table
+
+   int stack_delta = lua_gettop(Lua) - stack_top;
+   if (stack_delta) log.warning("Number registration left %d value(s) on the Lua stack.", stack_delta);
 }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -457,6 +457,8 @@ void register_processing_class(lua_State *Lua)
 
    luaL_openlib(Lua, "processing", processinglib_functions, 0);
 
+   lua_pop(Lua, 2); // Drop the Tiri.processing metatable and the processing library table
+
    // Register processing interface prototypes for compile-time type inference
    reg_iface_prototype("processing", "new", { TiriType::Any }, { TiriType::Table });
    reg_iface_prototype("processing", "collect", { TiriType::Num }, { TiriType::Str, TiriType::Table });

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -684,7 +684,9 @@ void register_regex_class(lua_State *Lua)
       lua_setfield(Lua, -2, "REPLACE_FIRST_ONLY");
    }
 
-   lua_pop(Lua, 1); // Remove regex table from stack
+   lua_pop(Lua, 1); // Remove regex table fetched via lua_getglobal
+
+   lua_pop(Lua, 2); // Drop the Tiri.regex metatable and the regex library table
 
    // Register regex interface prototypes for compile-time type inference
    reg_iface_prototype("regex", "new", { TiriType::Any }, { TiriType::Str, TiriType::Num });

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -929,4 +929,6 @@ void register_struct_class(lua_State *Lua)
    luaL_openlib(Lua, nullptr, structlib_methods, 0);
 
    luaL_openlib(Lua, "struct", structlib_functions, 0);
+
+   lua_pop(Lua, 2); // Drop the Tiri.struct metatable and the struct library table
 }


### PR DESCRIPTION
Each registration helper was leaving its metatable and global library table on the stack after luaL_newmetatable + luaL_openlib(libname, ...), accumulating 17 dead values on the main Lua stack at startup.  Added lua_pop() calls to balance every helper: lua_pop(Lua, 3) for register_io_class (two metatables plus the io library table) and lua_pop(Lua, 2) for all remaining helpers. Diagnostics added to register_module_class, register_number_class, and register_interfaces now stay silent and serve as regression guards.