### PR TITLE
[Tiri] Fix URL parsing bugs and register new tests

### DIFF
--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -53,7 +53,7 @@ rxPathSegment    = <{ regex.new('([^\\/]+)') }>
 -- Percent-encode a string for safe URL use
 
 url.encode = function(str, extraChars)
-   str ?? return
+   if str is nil then return nil end
 
    chars_to_encode = RESERVED_CHARS.general .. RESERVED_CHARS.query
    if extraChars then chars_to_encode = chars_to_encode .. extraChars end
@@ -62,7 +62,7 @@ url.encode = function(str, extraChars)
    result = {}
    for i = 0, #str-1 do
       c = str:sub(i, i+1)
-      if chars_to_encode:find(c, 1, true) then
+      if chars_to_encode:find(c, 0, true) then
          table.insert(result, string.format('%%%02X', string.byte(c)))
       else
          table.insert(result, c)
@@ -75,7 +75,7 @@ end
 -- Percent-encode with spaces as plus signs (for form data)
 
 url.encodePlus = function(str, extraChars)
-   str ?? return
+   if str is nil then return nil end
 
    encoded = url.encode(str, extraChars)
    if encoded then
@@ -235,14 +235,14 @@ url.parse = function(urlString)
 
    fragPos = remaining:find('#')
    if fragPos then
-      components.fragment = remaining:sub(fragPos)
-      remaining = remaining:sub(0, fragPos)
+      components.fragment = remaining:sub(fragPos + 1)
+      remaining = fragPos is 0 ? '' :> remaining:sub(0, fragPos)
    end
 
-   queryPos = remaining:find('?', 1, true)
+   queryPos = remaining:find('?', 0, true)
    if queryPos then
-      components.query = remaining:sub(queryPos)
-      remaining = remaining:sub(0, queryPos)
+      components.query = remaining:sub(queryPos + 1)
+      remaining = queryPos is 0 ? '' :> remaining:sub(0, queryPos)
    end
 
    schemeMatch = rxScheme.extract(remaining)
@@ -256,15 +256,15 @@ url.parse = function(urlString)
       remaining = remaining:sub(2) -- Remove //
 
       -- Find the end of authority (next /, ?, #, or end of string)
-      pathStart = remaining:find('/') or (#remaining + 1)
-      authority = remaining:sub(0, pathStart - 1)
+      pathStart = remaining:find('/') or #remaining
+      authority = remaining:sub(0, pathStart)
       remaining = remaining:sub(pathStart)
 
       -- Extract auth (user:pass@)
       authEnd = authority:find('@')
       if authEnd then
-         components.auth = authority:sub(0, authEnd - 1)
-         authority = authority:sub(authEnd)
+         components.auth = authority:sub(0, authEnd)
+         authority = authority:sub(authEnd + 1)
       end
 
       -- Handle IPv6 addresses [host]:port
@@ -277,10 +277,10 @@ url.parse = function(urlString)
          end
       else
          -- Handle regular host:port
-         colonPos = authority:find(':', 1, true)
+         colonPos = authority:find(':', 0, true)
          if colonPos then
-            components.host = authority:sub(0, colonPos - 1)
-            portStr = authority:sub(colonPos)
+            components.host = authority:sub(0, colonPos)
+            portStr = authority:sub(colonPos + 1)
             if portStr != '' then
                components.port = tonumber(portStr)
             end
@@ -299,8 +299,8 @@ url.parse = function(urlString)
    if components.path then
       paramPos = components.path:find(';')
       if paramPos then
-         components.params = components.path:sub(paramPos)
-         components.path = components.path:sub(0, paramPos - 1)
+         components.params = components.path:sub(paramPos + 1)
+         components.path = components.path:sub(0, paramPos)
       end
    end
 
@@ -388,7 +388,7 @@ url.defrag = function(urlString)
 
    fragPos = urlString:find('#')
    if fragPos then
-      base = urlString:sub(0, fragPos - 1)
+      base = fragPos is 0 ? '' :> urlString:sub(0, fragPos)
       fragment = urlString:sub(fragPos + 1)
       return base, fragment
    end
@@ -464,7 +464,7 @@ url.normalize = function(path)
    for start, stop, cap in rxPathSegment.findAll(path) do
       local segment = cap[0]
       if segment is '..' then
-         if #segments > 0 and segments[#segments] != '..' then
+         if #segments > 0 and segments[#segments - 1] != '..' then
             table.remove(segments)
          elseif not isAbsolute then
             table.insert(segments, '..')

--- a/src/network/tests/test_client_server.tiri
+++ b/src/network/tests/test_client_server.tiri
@@ -18,6 +18,7 @@ function printableState(State)
       NTC_CONNECTING -> 'CONNECTING'
       NTC_DISCONNECTED -> 'DISCONNECTED'
       NTC_HANDSHAKING -> 'HANDSHAKING'
+      NTC_RESOLVING -> 'RESOLVING'
       else -> tostring(State)
    end
 end
@@ -58,7 +59,7 @@ end
 
 @Test function ClientServer()
    proc = processing.new({ timeout = 5.0 })
-   
+
    server_buffer = string.alloc(1024)
 
    sockServer = obj.new('netsocket', {

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -735,7 +735,7 @@ set (TIRI_TESTS
    jitoptions fstring const import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from flow table_slice
-   try_except import processing metatables with thunk_table_index debug
+   try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -1,0 +1,449 @@
+-- Flute tests for numeric type edge cases and limitations.
+-- Covers IEEE 754 double precision behaviour, special values, precision boundaries,
+-- integer/float coercion, bitwise overflow, and the num.* explicit type system.
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath() end
+
+----------------------------------------------------------------------------------------------------------------------
+-- IEEE 754 special values: NaN
+
+@Test function NanNotEqualToItself()
+   nan = 0 / 0
+   assert(not (nan is nan), 'NaN should not equal itself')
+end
+
+@Test function NanArithmeticPropagation()
+   nan = 0 / 0
+   assert(not (nan + 1 is nan + 1), 'NaN + 1 should still be NaN (not equal to itself)')
+   assert(not (nan * 0 is 0), 'NaN * 0 should be NaN, not 0')
+   assert(not (nan - nan is 0), 'NaN - NaN should be NaN, not 0')
+end
+
+@Test function NanComparisonAlwaysFalse()
+   nan = 0 / 0
+   assert(not (nan > 0), 'NaN > 0 should be false')
+   assert(not (nan < 0), 'NaN < 0 should be false')
+   assert(not (nan >= 0), 'NaN >= 0 should be false')
+   assert(not (nan <= 0), 'NaN <= 0 should be false')
+end
+
+@Test function NanTypeIsNumber()
+   nan = 0 / 0
+   assert(type(nan) is 'number', 'type(NaN) should be number')
+end
+
+@Test function NanDetection()
+   nan = 0 / 0
+   -- Standard NaN detection: a value that is not equal to itself
+   is_nan = not (nan is nan)
+   assert(is_nan, 'NaN detection via self-inequality should work')
+
+   -- Non-NaN values should not trigger this
+   assert(42 is 42, 'Normal number should equal itself')
+   assert(0 is 0, 'Zero should equal itself')
+   assert(math.huge is math.huge, 'Infinity should equal itself')
+end
+
+@Test function NanFromInvalidMathOps()
+   assert(not (math.sqrt(-1) is math.sqrt(-1)), 'sqrt(-1) should produce NaN')
+   assert(not (math.log(-1) is math.log(-1)), 'log(-1) should produce NaN')
+   assert(not (math.asin(2) is math.asin(2)), 'asin(2) should produce NaN')
+   assert(not (math.acos(2) is math.acos(2)), 'acos(2) should produce NaN')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- IEEE 754 special values: Infinity
+
+@Test function InfinityFromDivisionByZero()
+   assert(1 / 0 is math.huge, '1/0 should produce positive infinity')
+   assert(-1 / 0 is -math.huge, '-1/0 should produce negative infinity')
+end
+
+@Test function InfinityArithmetic()
+   inf = math.huge
+   assert(inf + 1 is inf, 'Infinity + 1 should be infinity')
+   assert(inf + inf is inf, 'Infinity + infinity should be infinity')
+   assert(inf * 2 is inf, 'Infinity * 2 should be infinity')
+   assert(-inf * 2 is -inf, '-Infinity * 2 should be -infinity')
+   assert(1 / inf is 0, '1 / infinity should be 0')
+end
+
+@Test function InfinityComparisonOrdering()
+   inf = math.huge
+   assert(inf > 1e308, 'Infinity should be greater than 1e308')
+   assert(-inf < -1e308, '-Infinity should be less than -1e308')
+   assert(inf > -inf, 'Positive infinity should be greater than negative infinity')
+end
+
+@Test function InfinityProducesNan()
+   inf = math.huge
+   -- Indeterminate forms should produce NaN
+   result = inf - inf
+   assert(not (result is result), 'Infinity - infinity should be NaN')
+   result = inf / inf
+   assert(not (result is result), 'Infinity / infinity should be NaN')
+   result = 0 * inf
+   assert(not (result is result), '0 * infinity should be NaN')
+end
+
+@Test function InfinityNegation()
+   assert(-math.huge is -(math.huge), 'Negating infinity should produce negative infinity')
+   assert(-(-math.huge) is math.huge, 'Double negation of infinity should produce positive infinity')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- IEEE 754 special values: Signed zero
+
+@Test function PositiveAndNegativeZero()
+   pos_zero = 0.0
+   neg_zero = -0.0
+   -- IEEE 754: positive and negative zero compare as equal
+   assert(pos_zero is neg_zero, 'Positive and negative zero should be equal')
+   -- But they can be distinguished via division
+   assert(1 / pos_zero is math.huge, '1 / +0.0 should be +infinity')
+   assert(1 / neg_zero is -math.huge, '1 / -0.0 should be -infinity')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Floating-point precision
+
+@Test function DecimalRepresentationPrecision()
+   -- Classic IEEE 754 precision issue
+   sum = 0.1 + 0.2
+   assert(not (sum is 0.3), '0.1 + 0.2 should not exactly equal 0.3 due to IEEE 754')
+   assert(math.abs(sum - 0.3) < 1e-15, '0.1 + 0.2 should be very close to 0.3')
+end
+
+@Test function PrecisionLossWithLargeNumbers()
+   -- Doubles have ~15-17 significant digits
+   large = 1e16
+   assert(large + 1 is large, '1e16 + 1 should lose the +1 due to precision limits')
+   smaller = 1e15
+   assert(smaller + 1 != smaller, '1e15 + 1 should still differ (within precision)')
+end
+
+@Test function PrecisionNearMaxSafeInteger()
+   -- 2^53 is the boundary where consecutive integers can no longer be represented
+   safe_max = 2 ** 53  -- 9007199254740992
+   assert(safe_max + 1 is safe_max, '2^53 + 1 should equal 2^53 (precision lost)')
+   below_max = 2 ** 53 - 1  -- 9007199254740991
+   assert(below_max + 1 != below_max, '(2^53 - 1) + 1 should differ')
+end
+
+@Test function SubnormalNumbers()
+   -- Smallest normal double is ~2.2e-308; subnormals go below that
+   tiny = 5e-324  -- Smallest representable positive double (subnormal)
+   assert(tiny > 0, 'Smallest subnormal should be greater than zero')
+   assert(tiny / 2 is 0, 'Halving smallest subnormal should underflow to zero')
+end
+
+@Test function PrecisionOfRoundTrip()
+   -- Values that should round-trip exactly
+   exact_values = { 0.5, 0.25, 0.125, 0.0625 }  -- Powers of 2 fractions
+   for i = 0, #exact_values - 1 do
+      v = exact_values[i]
+      assert(v * 2 / 2 is v, f'Power-of-2 fraction {v} should round-trip exactly')
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Large and extreme values
+
+@Test function LargeDoubleValues()
+   large = 1.7976931348623157e+308  -- Near max double
+   assert(large > 0, 'Near-max double should be positive')
+   assert(large * 2 is math.huge, 'Doubling near-max should overflow to infinity')
+end
+
+@Test function SmallDoubleValues()
+   small = 2.2250738585072014e-308  -- Near min normal double
+   assert(small > 0, 'Near-min normal double should be positive')
+   assert(small != 0, 'Near-min normal double should not equal zero')
+end
+
+@Test function ExponentialOverflow()
+   assert(math.exp(710) is math.huge, 'exp(710) should overflow to infinity')
+end
+
+@Test function ExponentialUnderflow()
+   result = math.exp(-744)
+   assert(result > 0, 'exp(-744) should produce a tiny positive subnormal')
+   assert(result < 1e-300, 'exp(-744) should be extremely small')
+   -- True underflow to zero requires a more extreme exponent
+   result2 = math.exp(-750)
+   assert(result2 is 0, 'exp(-750) should underflow to 0')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Integer and float interaction
+
+@Test function IntegerDivisionBehaviour()
+   -- Division always produces a float in Lua/Tiri
+   result = 10 / 3
+   assert(math.abs(result - 3.3333333333333335) < 1e-14, '10/3 should be approximately 3.333...')
+end
+
+@Test function IntegerPreservationInArithmetic()
+   -- Operations that should stay as exact integers
+   assert(7 * 8 is 56, '7 * 8 should be exactly 56')
+   assert(100 - 37 is 63, '100 - 37 should be exactly 63')
+   assert(2 ** 10 is 1024, '2^10 should be exactly 1024')
+end
+
+@Test function FloorAndCeilWithIntegers()
+   assert(math.floor(3.9) is 3, 'floor(3.9) should be 3')
+   assert(math.floor(-3.1) is -4, 'floor(-3.1) should be -4')
+   assert(math.ceil(3.1) is 4, 'ceil(3.1) should be 4')
+   assert(math.ceil(-3.9) is -3, 'ceil(-3.9) should be -3')
+end
+
+@Test function ModfSplitsParts()
+   int_part, frac_part = math.modf(3.75)
+   assert(int_part is 3, 'Integer part of 3.75 should be 3')
+   assert(math.abs(frac_part - 0.75) < 1e-15, 'Fractional part of 3.75 should be 0.75')
+
+   int_part, frac_part = math.modf(-2.25)
+   assert(int_part is -2, 'Integer part of -2.25 should be -2')
+   assert(math.abs(frac_part - (-0.25)) < 1e-15, 'Fractional part of -2.25 should be -0.25')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Modulo and remainder edge cases
+
+@Test function ModuloWithNegativeOperands()
+   -- Tiri/Lua % follows the sign of the divisor (Euclidean-style)
+   assert(7 % 3 is 1, '7 % 3 should be 1')
+   assert(-7 % 3 is 2, '-7 % 3 should be 2 (sign of divisor)')
+   assert(7 % -3 is -2, '7 % -3 should be -2 (sign of divisor)')
+   assert(-7 % -3 is -1, '-7 % -3 should be -1 (sign of divisor)')
+end
+
+@Test function ModuloWithFloats()
+   result = 5.5 % 2.0
+   assert(math.abs(result - 1.5) < 1e-15, '5.5 % 2.0 should be 1.5')
+end
+
+@Test function FmodConsistency()
+   -- fmod should match % behaviour for positive values
+   assert(math.fmod(7, 3) is 7 % 3, 'fmod(7,3) should match 7 % 3')
+   assert(math.fmod(5.5, 2.0) is 5.5 % 2.0, 'fmod(5.5, 2.0) should match 5.5 % 2.0')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Bitwise operations: 32-bit overflow and coercion
+
+@Test function BitwiseCoercionRoundsFloat()
+   -- Bitwise ops convert to 32-bit signed int via tobit (rounds to nearest)
+   assert((3.7 | 0) is 4, '3.7 should round to 4 in bitwise context')
+   assert((3.2 | 0) is 3, '3.2 should round to 3 in bitwise context')
+   assert((-1.9 | 0) is -2, '-1.9 should round to -2 in bitwise context')
+   assert((-1.2 | 0) is -1, '-1.2 should round to -1 in bitwise context')
+end
+
+@Test function BitwiseOverflowWraps()
+   -- 32-bit signed max is 2147483647 (0x7FFFFFFF)
+   max_int32 = 0x7fffffff
+   assert((max_int32 + 1 & 0xffffffff) is bit.tobit(0x80000000),
+      'Incrementing max int32 in bitwise context should wrap to min int32')
+end
+
+@Test function BitwiseNegativeRepresentation()
+   assert((-1 & 0xff) is 0xff, '-1 masked to 8 bits should be 0xFF (255)')
+   assert((-1 & 0xffff) is 0xffff, '-1 masked to 16 bits should be 0xFFFF')
+end
+
+@Test function BitShiftBoundaries()
+   -- Shift counts are masked to 0-31
+   assert((1 << 0) is 1, 'Shift by 0 should be identity')
+   assert((1 << 31) is bit.tobit(0x80000000), 'Shift by 31 should set sign bit')
+   -- Shift by 32 should be equivalent to shift by 0 (masked)
+   assert((1 << 32) is 1, 'Shift by 32 should wrap to shift by 0')
+end
+
+@Test function BitwiseWithLargeDoubles()
+   -- Large doubles outside 32-bit range get truncated via tobit
+   large = 2 ** 33  -- 8589934592
+   result = large & 0xffffffff
+   assert(result is 0, '2^33 should truncate to 0 in 32-bit context')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- num.* explicit type constructors
+
+@Test function NumIntCreation()
+   n = num.int(42)
+   assert(n.value is 42, 'num.int(42) should store value 42')
+end
+
+@Test function NumInt64Creation()
+   n = num.int64(100)
+   assert(n.value is 100, 'num.int64(100) should store value 100')
+end
+
+@Test function NumFloatCreation()
+   n = num.float(3.14)
+   -- Float precision is lower than double
+   assert(math.abs(n.value - 3.14) < 1e-6, 'num.float(3.14) should be approximately 3.14')
+end
+
+@Test function NumDoubleCreation()
+   n = num.double(3.141592653589793)
+   assert(n.value is 3.141592653589793, 'num.double should preserve full double precision')
+end
+
+@Test function NumInt16Creation()
+   n = num.int16(1000)
+   assert(n.value is 1000, 'num.int16(1000) should store value 1000')
+end
+
+@Test function NumByteCreation()
+   n = num.byte(127)
+   assert(n.value is 127, 'num.byte(127) should store value 127')
+end
+
+@Test function NumFloatPrecisionLoss()
+   -- Float (32-bit) has ~7 significant digits; double has ~15
+   precise = 1.23456789012345
+   float_val = num.float(precise)
+   double_val = num.double(precise)
+   -- Float should lose precision compared to double
+   assert(math.abs(double_val.value - precise) < 1e-15, 'Double should preserve full precision')
+   assert(math.abs(float_val.value - precise) > 1e-10, 'Float should show measurable precision loss')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Typed array numeric coercion
+
+@Test function IntArrayTruncatesFloats()
+   arr = array<int> { 1.9, -2.7, 3.5 }
+   assert(arr[0] is 1, '1.9 stored in int array should truncate to 1')
+   assert(arr[1] is -2, '-2.7 stored in int array should truncate to -2')
+   assert(arr[2] is 3, '3.5 stored in int array should truncate to 3')
+end
+
+@Test function FloatArrayPrecision()
+   arr = array<float> { 1.23456789012345 }
+   -- Float array stores 32-bit floats, so precision is reduced
+   assert(math.abs(arr[0] - 1.23456789012345) > 1e-10,
+      'Float array should show precision loss for high-precision values')
+   assert(math.abs(arr[0] - 1.23456789012345) < 1e-5,
+      'Float array should still be approximately correct')
+end
+
+@Test function DoubleArrayPreservesPrecision()
+   precise = 1.23456789012345
+   arr = array<double> { precise }
+   assert(arr[0] is precise, 'Double array should preserve full precision')
+end
+
+@Test function Int64ArrayLargeValues()
+   arr = array<int64, 2>
+   arr[0] = 2 ** 40  -- 1099511627776, beyond 32-bit range
+   arr[1] = -(2 ** 40)
+   assert(arr[0] is 2 ** 40, 'Int64 array should handle values beyond 32-bit range')
+   assert(arr[1] is -(2 ** 40), 'Int64 array should handle large negative values')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Tonumber and type conversion edge cases
+
+@Test function TonumberFromString()
+   assert(tonumber('42') is 42, 'tonumber("42") should produce 42')
+   assert(tonumber('3.14') is 3.14, 'tonumber("3.14") should produce 3.14')
+   assert(tonumber('-1e5') is -100000, 'tonumber("-1e5") should produce -100000')
+   assert(tonumber('0xff') is 255, 'tonumber("0xff") should produce 255')
+end
+
+@Test function TonumberInvalidInput()
+   assert(tonumber('hello') is nil, 'tonumber of non-numeric string should be nil')
+   assert(tonumber('') is nil, 'tonumber of empty string should be nil')
+   assert(tonumber(nil) is nil, 'tonumber of nil should be nil')
+end
+
+@Test function TonumberWithBase()
+   assert(tonumber('ff', 16) is 255, 'tonumber("ff", 16) should produce 255')
+   assert(tonumber('77', 8) is 63, 'tonumber("77", 8) should produce 63')
+   assert(tonumber('1010', 2) is 10, 'tonumber("1010", 2) should produce 10')
+end
+
+@Test function TostringOfSpecialValues()
+   assert(tostring(math.huge) is 'inf', 'tostring(inf) should be "inf"')
+   assert(tostring(-math.huge) is '-inf', 'tostring(-inf) should be "-inf"')
+   nan = 0 / 0
+   assert(tostring(nan) is 'nan' or tostring(nan) is '-nan', 'tostring(NaN) should be "nan" or "-nan"')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Comparison edge cases
+
+@Test function ComparisonWithMixedTypes()
+   -- Number-to-string comparison should not coerce
+   assert(not (42 is '42'), 'Number 42 should not equal string "42"')
+   assert(not (0 is '0'), 'Number 0 should not equal string "0"')
+end
+
+@Test function ComparisonOrdering()
+   assert(-math.huge < -1e308, '-Infinity should be less than -1e308')
+   assert(1e308 < math.huge, '1e308 should be less than infinity')
+   assert(-1 < 0, '-1 should be less than 0')
+   assert(0 < 1, '0 should be less than 1')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Rounding edge cases
+
+@Test function RoundingHalfUp()
+   assert(math.round(0.5) is 1, 'math.round(0.5) should round up to 1')
+   assert(math.round(1.5) is 2, 'math.round(1.5) should round up to 2')
+   assert(math.round(2.5) is 3, 'math.round(2.5) should round up to 3')
+end
+
+@Test function RoundingNegativeHalf()
+   -- Negative halves: round-half-up means towards positive infinity
+   assert(math.round(-0.5) is 0, 'math.round(-0.5) should round toward +inf to 0')
+   assert(math.round(-1.5) is -1, 'math.round(-1.5) should round toward +inf to -1')
+   assert(math.round(-2.5) is -2, 'math.round(-2.5) should round toward +inf to -2')
+end
+
+@Test function RoundingWithPrecision()
+   assert(math.round(1.005, 2) is 1.01 or math.abs(math.round(1.005, 2) - 1.0) < 0.01,
+      'math.round(1.005, 2) demonstrates floating-point representation issues')
+   assert(math.round(1.555, 2) is 1.56 or math.abs(math.round(1.555, 2) - 1.56) < 0.01,
+      'math.round(1.555, 2) should be approximately 1.56')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Power operator edge cases
+
+@Test function PowerEdgeCases()
+   assert(0 ** 0 is 1, '0^0 should be 1 (mathematical convention)')
+   assert(1 ** math.huge is 1, '1^infinity should be 1')
+   assert(2 ** -1 is 0.5, '2^(-1) should be 0.5')
+   assert((-1) ** 0 is 1, '(-1)^0 should be 1')
+end
+
+@Test function PowerOverflow()
+   result = 2 ** 1024
+   assert(result is math.huge, '2^1024 should overflow to infinity')
+end
+
+@Test function PowerUnderflow()
+   result = 2 ** -1075
+   assert(result is 0, '2^(-1075) should underflow to 0')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- String-to-number arithmetic coercion
+
+@Test function StringToNumberCoercionInArithmetic()
+   -- Tiri may or may not coerce strings in arithmetic; test the actual behaviour
+   try
+      result = 3 + '4'
+      -- If we get here, coercion happened
+      assert(result is 7, 'If string coercion occurs, 3 + "4" should be 7')
+   except
+      -- If we get here, coercion is not supported (which is safer)
+      assert(true, 'String-to-number coercion in arithmetic correctly raises error')
+   end
+end

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -194,7 +194,6 @@ end
             return 42
          end
       ]])
-   end
    success
       error("should detect return type mismatch: num returned for str declaration")
    end
@@ -207,7 +206,6 @@ end
             return {}
          end
       ]])
-   end
    success
       error("should detect return type mismatch: table returned for bool declaration")
    end
@@ -220,7 +218,6 @@ end
             return "wrong", 42
          end
       ]])
-   end
    success
       error("should detect return type mismatch in multiple returns")
    end
@@ -296,7 +293,6 @@ end
             return N * factorial(N - 1)
          end
       ]])
-   end
    success
       error("recursive function without explicit return type should error")
    end
@@ -355,7 +351,6 @@ end
       exec([[
          bad = (x => num: "not a number")
       ]])
-   end
    success
       error("arrow function with mismatched return type should error")
    end
@@ -400,7 +395,6 @@ end
             end
          end
       ]])
-   end
    success
       error("inconsistent return types should error (first wins rule)")
    end
@@ -429,7 +423,6 @@ end
             end
          end
       ]])
-   end
    success
       error("inconsistent multiple return types should error")
    end
@@ -521,7 +514,7 @@ end
       return 42
    end
 
-   result: num = getNum()
+   local result: num = getNum()
    assert(result is 42, "typed variable from typed function should work")
 end
 
@@ -533,7 +526,7 @@ end
          function getNum():num
             return 42
          end
-         result: str = getNum()
+         local result: str = getNum()
       ]])
    success
       error("Expected exception to be raised from invalid typed assignment")
@@ -619,7 +612,7 @@ end
       mul = function(A: num, B: num):num return A * B end
    }
    assert(ops.add(3, 4) is 7, "typed function in table should work")
-   assert(ops.substr(10, 3) is 7, "second typed function should work")
+   assert(ops.sub(10, 3) is 7, "second typed function should work")
    assert(ops.mul(3, 4) is 12, "third typed function should work")
 end
 
@@ -667,12 +660,12 @@ end
             return "text"
          end
       ]])
-   success
-      error("should have caught type error")
    except ex
       -- Check that error message is helpful
       msg = ex.message
       assert(string.find(msg, "type") or string.find(msg, "num") or string.find(msg, "str"),
          "error message should mention type information")
+   success
+      error("should have caught type error")
    end
 end

--- a/src/tiri/tests/test_tips.tiri
+++ b/src/tiri/tests/test_tips.tiri
@@ -171,7 +171,7 @@ end
 ]]
 
    msg('--- Testing nested loops with string concatenation ---')
-   script = obj.new('tiri', { statement = glNestedLoopScript, jitOptions = JOF_TIPS })
+   script = obj.new('tiri', { statement = statement, jitOptions = JOF_TIPS })
    err = script.acActivate()
    assert(err is ERR_Okay, 'Script should execute successfully')
 end

--- a/src/tiri/tests/test_url.tiri
+++ b/src/tiri/tests/test_url.tiri
@@ -44,9 +44,9 @@ end
    assert(url.decode(nil) is nil, 'Nil decoding should return nil')
 
    -- Round-trip test
-   local original = 'Hello World! @#$%^&*()'
-   local encoded = url.encode(original)
-   local decoded = url.decode(encoded)
+   original = 'Hello World! @#$%^&*()'
+   encoded = url.encode(original)
+   decoded = url.decode(encoded)
    assert(decoded is original, 'Round-trip encoding/decoding failed')
 end
 
@@ -55,68 +55,68 @@ end
 
 @Test function QueryParsing()
    -- Basic query parsing
-   local params = url.parseQuery('name=John&age=30&city=New%20York')
+   params = url.parseQuery('name=John&age=30&city=New%20York')
    assert(params.name is 'John', 'Basic query param failed')
    assert(params.age is '30', 'Numeric query param failed')
    assert(params.city is 'New York', 'Encoded query param failed')
 
    -- Empty query
-   local empty = url.parseQuery('')
+   empty = url.parseQuery('')
    assert(type(empty) is 'table' and next(empty) is nil, 'Empty query should return empty table')
 
    -- Query with no values
-   local novals = url.parseQuery('flag1&flag2')
+   novals = url.parseQuery('flag1&flag2')
    assert(novals.flag1 is '', 'No-value param should be empty string')
    assert(novals.flag2 is '', 'No-value param should be empty string')
 
    -- Duplicate keys
-   local dups = url.parseQuery('tag=red&tag=blue&tag=green')
+   dups = url.parseQuery('tag=red&tag=blue&tag=green')
    assert(type(dups.tag) is 'table', 'Duplicate keys should create table')
    assert(#dups.tag is 3, 'Should have 3 values for duplicate key')
-   assert(dups.tag[1] is 'red' and dups.tag[2] is 'blue' and dups.tag[3] is 'green', 'Duplicate values incorrect')
+   assert(dups.tag[0] is 'red' and dups.tag[1] is 'blue' and dups.tag[2] is 'green', 'Duplicate values incorrect')
 
    -- Plus encoding in query
-   local plus = url.parseQuery('message=hello+world&name=John+Doe')
+   plus = url.parseQuery('message=hello+world&name=John+Doe')
    assert(plus.message is 'hello world', 'Plus decoding in query failed')
    assert(plus.name is 'John Doe', 'Plus decoding in name failed')
 end
 
 @Test function QueryList()
    -- Parse as list to preserve order
-   local list = url.parseQueryList('first=1&second=2&first=3')
+   list = url.parseQueryList('first=1&second=2&first=3')
    assert(#list is 3, 'Query list should have 3 items')
-   assert(list[1].key is 'first' and list[1].value is '1', 'First item incorrect')
-   assert(list[2].key is 'second' and list[2].value is '2', 'Second item incorrect')
-   assert(list[3].key is 'first' and list[3].value is '3', 'Third item incorrect')
+   assert(list[0].key is 'first' and list[0].value is '1', 'First item incorrect')
+   assert(list[1].key is 'second' and list[1].value is '2', 'Second item incorrect')
+   assert(list[2].key is 'first' and list[2].value is '3', 'Third item incorrect')
 end
 
 @Test function QueryBuilding()
    -- Build from table
-   local params = { name = 'John Doe', age = 30, active = true }
-   local query = url.buildQuery(params)
+   params = { name = 'John Doe', age = 30, active = true }
+   query = url.buildQuery(params)
 
    -- Parse back to verify
-   local parsed = url.parseQuery(query)
+   parsed = url.parseQuery(query)
    assert(parsed.name is 'John Doe', 'Built query name incorrect')
    assert(parsed.age is '30', 'Built query age incorrect')
    assert(parsed.active is 'true', 'Built query boolean incorrect')
 
    -- Build from list
-   local list = {
+   list = array<table> {
       { key = 'first', value = '1' },
       { key = 'second', value = '2' },
       { key = 'first', value = '3' }
    }
-   local listQuery = url.buildQuery(list)
+   listQuery = url.buildQuery(list)
    assert(listQuery is 'first=1&second=2&first=3', 'List query building failed')
 
    -- Build with special characters
-   local special = { }
+   special = { }
    special['hello world'] = 'test&value'
    special['key=name'] = 'John+Doe'
 
-   local specialQuery = url.buildQuery(special)
-   local specialParsed = url.parseQuery(specialQuery)
+   specialQuery = url.buildQuery(special)
+   specialParsed = url.parseQuery(specialQuery)
    assert(specialParsed['hello world'] is 'test&value', 'Special char key failed')
    assert(specialParsed['key=name'] is 'John+Doe', 'Special char value failed')
 end
@@ -126,7 +126,7 @@ end
 
 @Test function BasicParsing()
    -- Simple HTTP URL
-   local parts = url.parse('https://example.com/path?query=value#section')
+   parts = url.parse('https://example.com/path?query=value#section')
    assert(parts.scheme is 'https', 'Scheme parsing failed')
    assert(parts.host is 'example.com', 'Host parsing failed')
    assert(parts.path is '/path', 'Path parsing failed')
@@ -134,14 +134,14 @@ end
    assert(parts.fragment is 'section', 'Fragment parsing failed')
 
    -- URL with port
-   local withPort = url.parse('http://localhost:8080/api/test')
+   withPort = url.parse('http://localhost:8080/api/test')
    assert(withPort.scheme is 'http', 'Port URL scheme failed')
    assert(withPort.host is 'localhost', 'Port URL host failed')
    assert(withPort.port is 8080, 'Port parsing failed')
    assert(withPort.path is '/api/test', 'Port URL path failed')
 
    -- URL with auth
-   local withAuth = url.parse('ftp://user:pass@ftp.example.com/files/')
+   withAuth = url.parse('ftp://user:pass@ftp.example.com/files/')
    assert(withAuth.scheme is 'ftp', 'Auth URL scheme failed')
    assert(withAuth.auth is 'user:pass', 'Auth parsing failed')
    assert(withAuth.host is 'ftp.example.com', 'Auth URL host failed')
@@ -150,44 +150,44 @@ end
 
 @Test function IPv6Parsing()
    -- IPv6 host
-   local ipv6 = url.parse('http://[2001:db8::1]:8080/path')
+   ipv6 = url.parse('http://[2001:db8::1]:8080/path')
    assert(ipv6.host is '2001:db8::1', 'IPv6 host parsing failed')
    assert(ipv6.port is 8080, 'IPv6 port parsing failed')
    assert(ipv6.path is '/path', 'IPv6 path parsing failed')
 
    -- IPv6 without port
-   local ipv6NoPort = url.parse('http://[::1]/test')
+   ipv6NoPort = url.parse('http://[::1]/test')
    assert(ipv6NoPort.host is '::1', 'IPv6 localhost parsing failed')
    assert(ipv6NoPort.port is nil, 'IPv6 no port should be nil')
 end
 
 @Test function RelativeURLs()
    -- Path-only URL
-   local pathOnly = url.parse('/path/to/resource')
+   pathOnly = url.parse('/path/to/resource')
    assert(pathOnly.scheme is nil, 'Path-only should have no scheme')
    assert(pathOnly.host is nil, 'Path-only should have no host')
    assert(pathOnly.path is '/path/to/resource', 'Path-only path failed')
 
    -- Query-only URL
-   local queryOnly = url.parse('?query=value')
+   queryOnly = url.parse('?query=value')
    assert(queryOnly.path is '', 'Query-only path should be empty')
    assert(queryOnly.query is 'query=value', 'Query-only query failed')
 
    -- Fragment-only URL
-   local fragOnly = url.parse('#section')
+   fragOnly = url.parse('#section')
    assert(fragOnly.path is '', 'Fragment-only path should be empty')
    assert(fragOnly.fragment is 'section', 'Fragment-only fragment failed')
 end
 
 @Test function URLUnparsing()
    -- Round-trip test
-   local original = 'https://user:pass@example.com:8080/path/to/resource;param=value?query=test&foo=bar#section'
-   local parsed = url.parse(original)
-   local reconstructed = url.unparse(parsed)
+   original = 'https://user:pass@example.com:8080/path/to/resource;param=value?query=test&foo=bar#section'
+   parsed = url.parse(original)
+   reconstructed = url.unparse(parsed)
 
    -- Parse both to compare components (order might differ in query)
-   local origParts = url.parse(original)
-   local reconParts = url.parse(reconstructed)
+   origParts = url.parse(original)
+   reconParts = url.parse(reconstructed)
 
    assert(origParts.scheme is reconParts.scheme, 'Round-trip scheme failed')
    assert(origParts.host is reconParts.host, 'Round-trip host failed')
@@ -201,26 +201,26 @@ end
 
 @Test function URLJoining()
    -- Basic relative URL joining
-   local joined = url.join('https://example.com/api/', 'users/123')
+   joined = url.join('https://example.com/api/', 'users/123')
    assert(joined is 'https://example.com/api/users/123', 'Basic joining failed')
 
    -- Absolute path joining
-   local absJoined = url.join('https://example.com/api/old', '/new/path')
+   absJoined = url.join('https://example.com/api/old', '/new/path')
    assert(absJoined is 'https://example.com/new/path', 'Absolute path joining failed')
 
    -- Parent directory navigation
-   local parentJoined = url.join('https://example.com/api/v1/', '../v2/users')
+   parentJoined = url.join('https://example.com/api/v1/', '../v2/users')
    assert(parentJoined is 'https://example.com/api/v2/users', 'Parent directory joining failed')
 
    -- Query and fragment handling
-   local queryJoined = url.join('https://example.com/base', '?query=value')
+   queryJoined = url.join('https://example.com/base', '?query=value')
    assert(queryJoined is 'https://example.com/base?query=value', 'Query joining failed')
 
-   local fragJoined = url.join('https://example.com/page', '#section')
+   fragJoined = url.join('https://example.com/page', '#section')
    assert(fragJoined is 'https://example.com/page#section', 'Fragment joining failed')
 
    -- Absolute URL overrides base
-   local absOverride = url.join('https://old.com/path', 'https://new.com/other')
+   absOverride = url.join('https://old.com/path', 'https://new.com/other')
    assert(absOverride is 'https://new.com/other', 'Absolute URL override failed')
 end
 
@@ -274,47 +274,47 @@ end
 
 @Test function EdgeCases()
    -- Empty/nil URLs
-   local nilResult = url.parse(nil)
+   nilResult = url.parse(nil)
    assert(nilResult is nil, 'Nil URL should return nil')
 
-   local emptyResult = url.parse('')
+   emptyResult = url.parse('')
    assert(emptyResult is nil, 'Empty URL should return nil')
 
    -- Malformed URLs
-   local malformed = url.parse('ht!tp://bad-scheme.com')
+   malformed = url.parse('ht!tp://bad-scheme.com')
    assert(malformed.scheme is nil, 'Bad scheme should not be parsed as scheme')
 
    -- URL with only scheme
-   local schemeOnly = url.parse('file:')
+   schemeOnly = url.parse('file:')
    assert(schemeOnly.scheme is 'file', 'Scheme-only parsing failed')
    assert(schemeOnly.path is '', 'Scheme-only should have empty path')
 
    -- URLs with special characters
-   local special = url.parse('https://example.com/path with spaces?query=value with spaces')
+   special = url.parse('https://example.com/path with spaces?query=value with spaces')
    assert(special.path is '/path with spaces', 'Path with spaces should be preserved')
    assert(special.query is 'query=value with spaces', 'Query with spaces should be preserved')
 
    -- Very long URLs
-   local longPath = string.rep('a', 1000)
-   local longURL = 'https://example.com/' .. longPath
-   local longParsed = url.parse(longURL)
+   longPath = string.rep('a', 1000)
+   longURL = 'https://example.com/' .. longPath
+   longParsed = url.parse(longURL)
    assert(longParsed.host is 'example.com', 'Long URL host parsing failed')
    assert(longParsed.path is '/' .. longPath, 'Long URL path parsing failed')
 end
 
 @Test function Defrag()
    -- URL with fragment
-   local base, frag = url.defrag('https://example.com/path#section')
+   base, frag = url.defrag('https://example.com/path#section')
    assert(base is 'https://example.com/path', 'Defrag base incorrect')
    assert(frag is 'section', 'Defrag fragment incorrect')
 
    -- URL without fragment
-   local noFragBase, noFragFragment = url.defrag('https://example.com/path')
+   noFragBase, noFragFragment = url.defrag('https://example.com/path')
    assert(noFragBase is 'https://example.com/path', 'No-frag base should be unchanged')
    assert(noFragFragment is nil, 'No-frag fragment should be nil')
 
    -- Empty fragment
-   local emptyFragBase, emptyFrag = url.defrag('https://example.com/path#')
+   emptyFragBase, emptyFrag = url.defrag('https://example.com/path#')
    assert(emptyFragBase is 'https://example.com/path', 'Empty frag base incorrect')
    assert(emptyFrag is '', 'Empty fragment should be empty string')
 end


### PR DESCRIPTION
Corrected zero-based indexing throughout url.tiri (sub(), find()), fixed off-by-one errors in authority/fragment/query/params extraction, and replaced deprecated ?? shorthand with explicit nil checks.  Registered numeric_limits, return_types, url, and tips tests in CMake, and fixed logic errors in test_return_types.tiri (missing end, swapped success/except blocks, wrong field name), test_tips.tiri (wrong variable reference), and test_url.tiri (zero-based index corrections, removed superfluous local declarations).