### PR TITLE
[Tiri] Replace hashrot() with 64-bit splitmix hash for x64 table lookups

### DIFF
--- a/src/tiri/jit/src/lj_asm.cpp
+++ b/src/tiri/jit/src/lj_asm.cpp
@@ -1074,7 +1074,7 @@ static uint32_t ir_khash(ASMState* as, IRIns* ir)
       lo = u32ptr(ir_kgc(ir));
       hi = (uint32_t)(u64ptr(ir_kgc(ir)) >> 32) | (irt_toitype(ir->t) << 15);
    }
-   return hashrot(lo, hi);
+   return hashlohi_bits(lo, hi);
 }
 
 // -- Allocations ---------------------------------------------------------

--- a/src/tiri/jit/src/lj_asm_x86.h
+++ b/src/tiri/jit/src/lj_asm_x86.h
@@ -852,6 +852,25 @@ static void asm_aref(ASMState* as, IRIns* ir)
    else if (as->mrm.base != dest) emit_rr(as, XO_MOV, dest | REX_GC64, as->mrm.base);
 }
 
+static void asm_href_mix64(ASMState* as, Reg Hash, Reg Scratch)
+{
+   emit_rr(as, XO_ARITH(XOg_XOR), Hash | REX_64, Scratch);
+   emit_shifti(as, XOg_SHR | REX_64, Scratch, 31);
+   emit_rr(as, XO_MOV, Scratch | REX_64, Hash | REX_64);
+   emit_mrm(as, XO_IMUL, Hash | REX_64, Scratch);
+   emit_loadu64(as, Scratch, HASH_MIX64_MUL2);
+   checkmclim(as);
+   emit_rr(as, XO_ARITH(XOg_XOR), Hash | REX_64, Scratch);
+   emit_shifti(as, XOg_SHR | REX_64, Scratch, 27);
+   emit_rr(as, XO_MOV, Scratch | REX_64, Hash | REX_64);
+   emit_mrm(as, XO_IMUL, Hash | REX_64, Scratch);
+   emit_loadu64(as, Scratch, HASH_MIX64_MUL1);
+   checkmclim(as);
+   emit_rr(as, XO_ARITH(XOg_XOR), Hash | REX_64, Scratch);
+   emit_shifti(as, XOg_SHR | REX_64, Scratch, 30);
+   emit_rr(as, XO_MOV, Scratch | REX_64, Hash | REX_64);
+}
+
 /* Inlined hash lookup. Specialized for key type and for const keys.
 ** The equivalent C code is:
 **   Node *n = hashkey(t, key);
@@ -952,34 +971,26 @@ static void asm_href(ASMState* as, IRIns* ir, IROp merge)
          emit_rmro(as, XO_ARITH(XOg_AND), dest, key, offsetof(GCstr, sid));
          emit_rmro(as, XO_MOV, dest, tab, offsetof(GCtab, hmask));
       }
-      else {  // Must match with hashrot() in lj_tab.c.
+      else {  // Must match with hashlohi_bits() in lj_tab.h.
          emit_rmro(as, XO_ARITH(XOg_AND), dest, tab, offsetof(GCtab, hmask));
-         emit_rr(as, XO_ARITH(XOg_SUB), dest, tmp);
-         emit_shifti(as, XOg_ROL, tmp, HASH_ROT3);
-         emit_rr(as, XO_ARITH(XOg_XOR), dest, tmp);
-         emit_shifti(as, XOg_ROL, dest, HASH_ROT2);
-         emit_rr(as, XO_ARITH(XOg_SUB), tmp, dest);
-         emit_shifti(as, XOg_ROL, dest, HASH_ROT1);
-         emit_rr(as, XO_ARITH(XOg_XOR), tmp, dest);
+         asm_href_mix64(as, dest, tmp);
+         checkmclim(as);
          if (irt_isnum(kt)) {
-            emit_rr(as, XO_ARITH(XOg_ADD), dest, dest);
-            emit_shifti(as, XOg_SHR | REX_64, dest, 32);
-            emit_rr(as, XO_MOV, tmp, dest);
+            emit_rr(as, XO_ARITH(XOg_OR), dest | REX_64, tmp);
+            emit_rr(as, XO_MOV, dest, dest);
+            emit_shifti(as, XOg_SHL | REX_64, tmp, 32);
+            emit_rr(as, XO_ARITH(XOg_ADD), tmp, tmp);
+            emit_shifti(as, XOg_SHR | REX_64, tmp, 32);
+            emit_rr(as, XO_MOV, tmp | REX_64, dest | REX_64);
             emit_rr(as, XO_MOVDto, key | REX_64, dest);
          }
          else {
-            emit_rr(as, XO_MOV, tmp, key);
             checkmclim(as);
-            emit_gri(as, XG_ARITHi(XOg_XOR), dest, irt_toitype(kt) << 15);
-            if ((as->flags & JIT_F_BMI2)) {
-               emit_i8(as, 32);
-               emit_mrm(as, (x86Op)(XV_RORX | VEX_64), dest, key);
-            }
-            else {
-               emit_shifti(as, XOg_SHR | REX_64, dest, 32);
-               emit_rr(as, XO_MOV, dest | REX_64, key | REX_64);
-            }
+            emit_rr(as, XO_ARITH(XOg_OR), dest | REX_64, tmp);
+            emit_loadu64(as, tmp, uint64_t(irt_toitype(kt)) << 47);
+            emit_rr(as, XO_MOV, dest | REX_64, key | REX_64);
          }
+         checkmclim(as);
       }
    }
 }

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -12,6 +12,8 @@ inline constexpr int32_t HASH_BIAS = (-0x04c11db7);
 inline constexpr int HASH_ROT1 = 14;
 inline constexpr int HASH_ROT2 = 5;
 inline constexpr int HASH_ROT3 = 13;
+inline constexpr uint64_t HASH_MIX64_MUL1 = 0xbf58476d1ce4e5b9ull;
+inline constexpr uint64_t HASH_MIX64_MUL2 = 0x94d049bb133111ebull;
 
 // Scramble the bits of numbers and pointers.
 [[nodiscard]] inline constexpr uint32_t hashrot(uint32_t lo, uint32_t hi) noexcept
@@ -30,6 +32,20 @@ inline constexpr int HASH_ROT3 = 13;
    return hi;
 }
 
+// Scramble table hash bits. x64 can use full-width multiply cheaply; other targets keep the legacy JIT-matched mix.
+[[nodiscard]] inline constexpr uint32_t hashlohi_bits(uint32_t Lo, uint32_t Hi) noexcept
+{
+#if LJ_TARGET_X64
+   uint64_t hash = (uint64_t(Hi) << 32) | uint64_t(Lo);
+   hash = (hash ^ (hash >> 30)) * HASH_MIX64_MUL1;
+   hash = (hash ^ (hash >> 27)) * HASH_MIX64_MUL2;
+   hash ^= hash >> 31;
+   return uint32_t(hash);
+#else
+   return hashrot(Lo, Hi);
+#endif
+}
+
 // Hash values are masked with the table hash mask and used as an index.
 [[nodiscard]] inline constexpr Node* hashmask(const GCtab* t, uint32_t hash) noexcept
 {
@@ -45,7 +61,7 @@ inline constexpr int HASH_ROT3 = 13;
 
 [[nodiscard]] inline constexpr Node* hashlohi(const GCtab* t, uint32_t lo, uint32_t hi) noexcept
 {
-   return hashmask(t, hashrot(lo, hi));
+   return hashmask(t, hashlohi_bits(lo, hi));
 }
 
 [[nodiscard]] inline constexpr Node* hashnum(const GCtab* t, const TValue* o) noexcept

--- a/src/tiri/jit/src/runtime/unit_test_indexing.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_indexing.cpp
@@ -50,6 +50,19 @@ struct TestCase {
    bool (*fn)(kt::Log& Log);
 };
 
+static uint32_t expected_table_hash(uint32_t Lo, uint32_t Hi)
+{
+#if LJ_TARGET_X64
+   uint64_t hash = (uint64_t(Hi) << 32) | uint64_t(Lo);
+   hash = (hash ^ (hash >> 30)) * HASH_MIX64_MUL1;
+   hash = (hash ^ (hash >> 27)) * HASH_MIX64_MUL2;
+   hash ^= hash >> 31;
+   return uint32_t(hash);
+#else
+   return hashrot(Lo, Hi);
+#endif
+}
+
 // Execute Lua code and check result
 static bool run_lua_test(lua_State* L, std::string_view Code, std::string& Error)
 {
@@ -424,11 +437,130 @@ static bool test_lj_tab_len_returns_element_count(kt::Log& Log)
    return false;
 }
 
+static bool test_table_hash_mixer_matches_expected(kt::Log& Log)
+{
+   constexpr std::array<uint32_t, 4> LoValues = { 0x00000000u, 0x89abcdefu, 0xffffffffu, 0x13579bdfu };
+   constexpr std::array<uint32_t, 4> HiValues = { 0x00000000u, 0x01234567u, 0x80000000u, 0xfedcba98u };
+
+   for (size_t index = 0; index < LoValues.size(); index++) {
+      const uint32_t hash = hashlohi_bits(LoValues[index], HiValues[index]);
+      const uint32_t expected = expected_table_hash(LoValues[index], HiValues[index]);
+      if (not (hash IS expected)) {
+         Log.error("hashlohi_bits mismatch at %u: got 0x%08x expected 0x%08x",
+            (unsigned)index, hash, expected);
+         return false;
+      }
+   }
+
+   return true;
+}
+
+static bool test_table_numeric_hash_keys_roundtrip(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 0, 5);
+   constexpr std::array<lua_Number, 4> Keys = { 0.5, 1.5, 65536.5, 131072.5 };
+
+   for (size_t index = 0; index < Keys.size(); index++) {
+      TValue key;
+      TValue value;
+      setnumV(&key, Keys[index]);
+      setnumV(&value, lua_Number(index) + 10.0);
+      copyTV(L, lj_tab_set(L, table, &key), &value);
+   }
+
+   for (size_t index = 0; index < Keys.size(); index++) {
+      TValue key;
+      setnumV(&key, Keys[index]);
+      cTValue* found = lj_tab_get(L, table, &key);
+      const lua_Number expected = lua_Number(index) + 10.0;
+      if ((not found) or (not tvisnum(found)) or not (numV(found) IS expected)) {
+         Log.error("numeric hash key %u did not roundtrip", (unsigned)index);
+         return false;
+      }
+   }
+
+   return true;
+}
+
+static bool test_table_gc_hash_keys_roundtrip(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 0, 5);
+   GCtab* key_one = lj_tab_new(L, 0, 0);
+   GCtab* key_two = lj_tab_new(L, 0, 0);
+   std::array<GCtab*, 2> Keys = { key_one, key_two };
+
+   for (size_t index = 0; index < Keys.size(); index++) {
+      TValue key;
+      TValue value;
+      settabV(L, &key, Keys[index]);
+      setnumV(&value, lua_Number(index) + 20.0);
+      copyTV(L, lj_tab_set(L, table, &key), &value);
+   }
+
+   for (size_t index = 0; index < Keys.size(); index++) {
+      TValue key;
+      settabV(L, &key, Keys[index]);
+      cTValue* found = lj_tab_get(L, table, &key);
+      const lua_Number expected = lua_Number(index) + 20.0;
+      if ((not found) or (not tvisnum(found)) or not (numV(found) IS expected)) {
+         Log.error("GC hash key %u did not roundtrip", (unsigned)index);
+         return false;
+      }
+   }
+
+   return true;
+}
+
+static bool test_table_string_hash_keys_unchanged(kt::Log& Log)
+{
+   LuaStateHolder Holder;
+   lua_State* L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   GCtab* table = lj_tab_new(L, 0, 5);
+   GCstr* key = lj_str_newlit(L, "hash_string_key");
+   TValue value;
+   setnumV(&value, 42.0);
+   copyTV(L, lj_tab_setstr(L, table, key), &value);
+
+   cTValue* found = lj_tab_getstr(table, key);
+   if ((not found) or (not tvisnum(found)) or not (numV(found) IS 42.0)) {
+      Log.error("string hash key did not roundtrip");
+      return false;
+   }
+
+   Node* expected_node = hashmask(table, key->sid);
+   Node* actual_node = hashstr(table, key);
+   if (not (actual_node IS expected_node)) {
+      Log.error("string hash key no longer uses interned sid");
+      return false;
+   }
+
+   return true;
+}
+
 }  // namespace
 
 extern void indexing_unit_tests(int& Passed, int& Total)
 {
-   constexpr std::array<TestCase, 12> Tests = { {
+   constexpr std::array<TestCase, 16> Tests = { {
       { "array_first_element_access", test_array_first_element_access },
       { "table_length_operator", test_table_length_operator },
       { "ipairs_starting_index", test_ipairs_starting_index },
@@ -440,7 +572,11 @@ extern void indexing_unit_tests(int& Passed, int& Total)
       { "empty_table_length", test_empty_table_length },
       { "negative_string_indices_unchanged", test_negative_string_indices_unchanged },
       { "lj_tab_getint_semantic_index", test_lj_tab_getint_semantic_index },
-      { "lj_tab_len_returns_element_count", test_lj_tab_len_returns_element_count }
+      { "lj_tab_len_returns_element_count", test_lj_tab_len_returns_element_count },
+      { "table_hash_mixer_matches_expected", test_table_hash_mixer_matches_expected },
+      { "table_numeric_hash_keys_roundtrip", test_table_numeric_hash_keys_roundtrip },
+      { "table_gc_hash_keys_roundtrip", test_table_gc_hash_keys_roundtrip },
+      { "table_string_hash_keys_unchanged", test_table_string_hash_keys_unchanged }
    } };
 
    if (NewObject(CLASSID::TIRI, &glTestScript) != ERR::Okay) return;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -74,6 +74,48 @@ function constant_target(Value)
    return offset, label
 end
 
+@Test(hotpath=80) function JITVariableNumericHashLookup()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   lookup = {}
+   lookup[0.5] = 11
+   lookup[1.5] = 17
+   lookup[65536.5] = 23
+   lookup[131072.5] = 31
+   keys = { 0.5, 1.5, 65536.5, 131072.5 }
+
+   total = 0
+   for i = 0, 199 do
+      key = keys[i % 4]
+      total += lookup[key]
+   end
+
+   assert(total is 4100, "JIT variable numeric hash lookup returned " .. tostring(total))
+end
+
+@Test(hotpath=80) function JITVariableTableHashLookup()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   key_one = {}
+   key_two = {}
+   lookup = {}
+   lookup[key_one] = 7
+   lookup[key_two] = 13
+   keys = { key_one, key_two }
+
+   total = 0
+   for i = 0, 199 do
+      key = keys[i % 2]
+      total += lookup[key]
+   end
+
+   assert(total is 2000, "JIT variable table hash lookup returned " .. tostring(total))
+end
+
 @Test function EngineModeToggles()
    jit.on()
    enabled_on = jit.status()


### PR DESCRIPTION
* Introduce hashlohi_bits() using a splitmix64-style mixer on x64 targets, falling back to legacy hashrot() on other architectures
* Update asm_href() x86/x64 code generation to emit the new 64-bit multiply-based hash sequence via asm_href_mix64()
* Update ir_khash() in lj_asm.cpp to use hashlohi_bits()
* Update hashlohi() to delegate to hashlohi_bits()
* Add four C++ unit tests covering the hash mixer, numeric key roundtrip, GC key roundtrip, and string key unchanged behaviour
* Add two Flute JIT tests for variable numeric and table hash lookups under hot-path compilation