### PR TITLE
[Build] Fix Windows SFX package staging to use a versioned subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1067,6 +1067,9 @@ if(WIN32 AND NOT DISABLE_CPACK)
 
    # Add custom SFX generation target if 7-Zip is available
    if(SEVENZIP_EXECUTABLE)
+      set(SFX_STAGING_DIR "${CMAKE_BINARY_DIR}/sfx_temp")
+      set(SFX_PACKAGE_DIR "Kotuku-${PROJECT_VERSION}")
+
       # Create SFX configuration file
       set(SFX_CONFIG_FILE "${CMAKE_BINARY_DIR}/sfx_config.txt")
       file(WRITE ${SFX_CONFIG_FILE}
@@ -1077,20 +1080,23 @@ ExtractTitle=\"Extracting Kotuku...\"
 ExtractDialogText=\"Please wait while Kotuku is extracted.\"
 InstallPath=\"%ProgramFiles%\\\\Kotuku\"
 OverwriteMode=2
-ExecuteFile=\"origo.exe\"
+ExecuteFile=\"${SFX_PACKAGE_DIR}\\\\origo.exe\"
 ExecuteParameters=\"\"
 ;!@InstallEnd@!
 ")
 
       add_custom_target(package_sfx
          COMMAND ${CMAKE_COMMAND} -E echo "Creating Self-Extracting Archive..."
-         COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_BINARY_DIR}/sfx_temp"
-         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/sfx_temp"
-         COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_INSTALL_PREFIX}" "${CMAKE_BINARY_DIR}/sfx_temp"
-         COMMAND ${SEVENZIP_EXECUTABLE} a -t7z -mx9 "${CMAKE_BINARY_DIR}/${CPACK_PACKAGE_FILE_NAME}-sfx.exe" "${CMAKE_BINARY_DIR}/sfx_temp/*" -sfx
-         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+         COMMAND ${CMAKE_COMMAND} -E remove_directory "${SFX_STAGING_DIR}"
+         COMMAND ${CMAKE_COMMAND} -E make_directory "${SFX_STAGING_DIR}/${SFX_PACKAGE_DIR}"
+         COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_INSTALL_PREFIX}" "${SFX_STAGING_DIR}/${SFX_PACKAGE_DIR}"
+         COMMAND ${CMAKE_COMMAND} -E chdir "${SFX_STAGING_DIR}"
+            ${SEVENZIP_EXECUTABLE} a -t7z -mx9 "${CMAKE_BINARY_DIR}/${CPACK_PACKAGE_FILE_NAME}-sfx.exe"
+            "${SFX_PACKAGE_DIR}" -sfx
+         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
          COMMENT "Creating Self-Extracting Archive: ${CPACK_PACKAGE_FILE_NAME}-sfx.exe"
          DEPENDS install
+         VERBATIM
       )
 
       message(STATUS "SFX target 'package_sfx' created - use 'cmake --build . --target package_sfx' to generate SFX")


### PR DESCRIPTION
## Summary

* Stages the install tree into a versioned subdirectory (`Kotuku-<version>`) so the `ExecuteFile` path in the SFX config correctly references the executable after extraction
* Fixes the `ExecuteFile` entry in the 7-Zip SFX configuration to include the package subdirectory prefix
* Uses `cmake -E chdir` to set the correct working directory when invoking 7-Zip, ensuring the archive root matches the expected layout
* Adds `VERBATIM` to the `package_sfx` custom target to prevent CMake from mangling command arguments
* Extracts `SFX_STAGING_DIR` and `SFX_PACKAGE_DIR` into named variables to reduce repetition

## Test plan

- [ ] Configure a Windows build with CPack/7-Zip available and run `cmake --build . --target package_sfx`
- [ ] Verify the generated SFX archive extracts into a `Kotuku-<version>` subdirectory
- [ ] Confirm the extracted `origo.exe` launches correctly from the SFX installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)