### PR TITLE
Raise JIT allocator alignment to 16 bytes and add GC list prefetching

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -671,6 +671,7 @@ if (ENABLE_UNIT_TESTS)
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_test_indexing.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_test_vm_asm.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_arrays.cpp")
+   list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_allocator.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/jit/jit_unit_tests.cpp")
 
    # Add MASM assembly file for register capture on MSVC x64

--- a/src/tiri/jit/src/runtime/lj_alloc.cpp
+++ b/src/tiri/jit/src/runtime/lj_alloc.cpp
@@ -36,7 +36,7 @@
 #ifndef LUAJIT_USE_SYSMALLOC
 
 #define MAX_SIZE_T      (~(size_t)0)
-#define MALLOC_ALIGNMENT   ((size_t)8U)
+#define MALLOC_ALIGNMENT   ((size_t)16U)
 
 #define DEFAULT_GRANULARITY   ((size_t)128U * (size_t)1024U)
 #define DEFAULT_TRIM_THRESHOLD   ((size_t)2U * (size_t)1024U * (size_t)1024U)

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -51,6 +51,10 @@
 #include <array>
 #include <span>
 
+#if defined(_MSC_VER)
+#include <xmmintrin.h>
+#endif
+
 // -- GC Configuration Constants -----------------------------------------------
 // These control the incremental GC stepping behaviour.
 
@@ -66,6 +70,20 @@ static GCRef* gc_sweep(global_State *, GCRef *, uint32_t);
 // The current trace is a GC root while not anchored in the prototype (yet).
 
 #define gc_traverse_curtrace(g)   gc_traverse_trace(g, &G2J(g)->cur)
+
+//********************************************************************************************************************
+// Prefetch helper for pointer-chasing through GC list links.
+
+static inline void gc_prefetch(const void *Address) noexcept
+{
+#if defined(__GNUC__)
+   __builtin_prefetch(Address, 0, 1);
+#elif defined(_MSC_VER)
+   _mm_prefetch((const char *)Address, _MM_HINT_T0);
+#else
+   (void)Address;
+#endif
+}
 
 //********************************************************************************************************************
 // RAII guard for GC finaliser state preservation.
@@ -547,6 +565,10 @@ static size_t propagatemark(global_State *g)
 {
    GCobj* o = gcref(g->gc.gray);
    int gct = o->gch.gct;
+   GCobj* next_gray = gcref(o->gch.gclist);
+
+   if (next_gray) gc_prefetch(next_gray);
+
    lj_assertG(isgray(o), "propagation of non-gray object");
    gray2black(o);
    setgcrefr(g->gc.gray, o->gch.gclist);  //  Remove from gray list.

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -51,7 +51,7 @@
 #include <array>
 #include <span>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) and LJ_TARGET_X86ORX64
 #include <xmmintrin.h>
 #endif
 
@@ -78,7 +78,7 @@ static inline void gc_prefetch(const void *Address) noexcept
 {
 #if defined(__GNUC__)
    __builtin_prefetch(Address, 0, 1);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) and LJ_TARGET_X86ORX64
    _mm_prefetch((const char *)Address, _MM_HINT_T0);
 #else
    (void)Address;

--- a/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_allocator.cpp
@@ -1,0 +1,153 @@
+// Unit tests for the bundled LuaJIT allocator.
+
+#include <kotuku/main.h>
+
+#ifdef ENABLE_UNIT_TESTS
+
+#include "lj_alloc.h"
+#include "lj_prng.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+struct TestCase {
+   const char* name;
+   bool (*fn)(kt::Log &Log);
+};
+
+#ifndef LUAJIT_USE_SYSMALLOC
+
+static void free_blocks(void *AllocState, std::array<void *, 12> &Blocks)
+{
+   for (void *block : Blocks) {
+      if (block) lj_alloc_f(AllocState, block, 0, 0);
+   }
+}
+
+static bool is_16_byte_aligned(const void *Block)
+{
+   return ((((uintptr_t)Block) & (uintptr_t)15) IS 0);
+}
+
+#endif
+
+static bool test_allocator_returns_16_byte_aligned_blocks(kt::Log &Log)
+{
+#ifdef LUAJIT_USE_SYSMALLOC
+   (void)Log;
+   return true;
+#else
+   PRNGState prng;
+   lj_prng_seed_fixed(&prng);
+
+   void *alloc_state = lj_alloc_create(&prng);
+   if (not alloc_state) {
+      Log.error("allocator state creation failed");
+      return false;
+   }
+
+   constexpr std::array<size_t, 12> sizes = { {
+      1, 8, 15, 16, 24, 31, 32, 64, 255, 4096, 128 * 1024, 256 * 1024
+   } };
+   std::array<void *, 12> blocks = { };
+   bool ok = true;
+
+   for (size_t i = 0; i < sizes.size(); i++) {
+      blocks[i] = lj_alloc_f(alloc_state, nullptr, 0, sizes[i]);
+      if (not blocks[i]) {
+         Log.error("allocation of %zu bytes failed", sizes[i]);
+         ok = false;
+         break;
+      }
+      if (not is_16_byte_aligned(blocks[i])) {
+         Log.error("allocation of %zu bytes returned unaligned block %p", sizes[i], blocks[i]);
+         ok = false;
+         break;
+      }
+   }
+
+   free_blocks(alloc_state, blocks);
+   lj_alloc_destroy(alloc_state);
+   return ok;
+#endif
+}
+
+static bool test_allocator_realloc_preserves_16_byte_alignment(kt::Log &Log)
+{
+#ifdef LUAJIT_USE_SYSMALLOC
+   (void)Log;
+   return true;
+#else
+   PRNGState prng;
+   lj_prng_seed_fixed(&prng);
+
+   void *alloc_state = lj_alloc_create(&prng);
+   if (not alloc_state) {
+      Log.error("allocator state creation failed");
+      return false;
+   }
+
+   void *block = lj_alloc_f(alloc_state, nullptr, 0, 7);
+   if (not block) {
+      Log.error("initial allocation failed");
+      lj_alloc_destroy(alloc_state);
+      return false;
+   }
+
+   bool ok = is_16_byte_aligned(block);
+   if (not ok) Log.error("initial allocation returned unaligned block %p", block);
+
+   constexpr std::array<size_t, 5> sizes = { { 33, 257, 4097, 128 * 1024, 17 } };
+   size_t old_size = 7;
+
+   for (size_t new_size : sizes) {
+      void *new_block = lj_alloc_f(alloc_state, block, old_size, new_size);
+      if (not new_block) {
+         Log.error("reallocation to %zu bytes failed", new_size);
+         ok = false;
+         break;
+      }
+
+      block = new_block;
+      old_size = new_size;
+
+      if (not is_16_byte_aligned(block)) {
+         Log.error("reallocation to %zu bytes returned unaligned block %p", new_size, block);
+         ok = false;
+         break;
+      }
+   }
+
+   lj_alloc_f(alloc_state, block, old_size, 0);
+   lj_alloc_destroy(alloc_state);
+   return ok;
+#endif
+}
+
+} // namespace
+
+extern void allocator_unit_tests(int &Passed, int &Total)
+{
+   constexpr std::array<TestCase, 2> Tests = { {
+      { "allocator_returns_16_byte_aligned_blocks", test_allocator_returns_16_byte_aligned_blocks },
+      { "allocator_realloc_preserves_16_byte_alignment", test_allocator_realloc_preserves_16_byte_alignment }
+   } };
+
+   for (const TestCase& Test : Tests) {
+      kt::Log Log("AllocatorTests");
+      Log.branch("Running %s", Test.name);
+      ++Total;
+      if (Test.fn(Log)) {
+         ++Passed;
+         Log.msg("%s passed", Test.name);
+      }
+      else {
+         Log.error("%s failed", Test.name);
+      }
+   }
+}
+
+#endif // ENABLE_UNIT_TESTS

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -307,6 +307,7 @@ extern void vm_asm_unit_tests(int &, int &);
 extern void jit_frame_unit_tests(int &, int &);
 extern void parser_unit_tests(int &, int &);
 extern void array_unit_tests(int &, int &);
+extern void allocator_unit_tests(int &, int &);
 #endif
 
 static void MODTest(CSTRING Options, int *Passed, int *Total)
@@ -336,6 +337,11 @@ static void MODTest(CSTRING Options, int *Passed, int *Total)
       kt::Log log("TiriTests");
       log.branch("Running array unit tests...");
       array_unit_tests(*Passed, *Total);
+   }
+   {
+      kt::Log log("TiriTests");
+      log.branch("Running allocator unit tests...");
+      allocator_unit_tests(*Passed, *Total);
    }
 #else
    kt::Log("TiriTests").warning("Unit tests are disabled in this build.");


### PR DESCRIPTION
## Summary

* Bump `MALLOC_ALIGNMENT` from 8 to 16 in `lj_alloc.cpp` so all heap allocations are guaranteed SIMD-safe without manual alignment fixups
* Add `gc_prefetch()` helper in `lj_gc.cpp` (uses `__builtin_prefetch` on GCC/Clang, `_mm_prefetch` on MSVC) and call it at the top of `propagatemark()` to overlap memory latency with grey-list traversal
* Add `unit_tests_allocator.cpp` with two unit tests: fresh allocations of various sizes return 16-byte-aligned pointers, and realloc preserves 16-byte alignment across a series of size changes
* Register the new test file in `CMakeLists.txt` and wire `allocator_unit_tests()` into `MODTest()` in `tiri.cpp`

## Test plan

- [ ] Build Tiri module with `ENABLE_UNIT_TESTS=ON` and verify compilation succeeds on both MSVC and GCC
- [ ] Run `ctest` and confirm the two new allocator unit tests pass
- [ ] Confirm no regressions in the existing Tiri unit test suite (indexing, VM asm, arrays)
- [ ] Verify the `_mm_prefetch` include guard compiles cleanly on MSVC (`<xmmintrin.h>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)