### PR TITLE
[Tiri] Add bulk TValue operations with AVX2 acceleration for arrays and tables

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -199,6 +199,8 @@ if (MSVC)
    list(FILTER JIT_LIB_SOURCES EXCLUDE REGEX "lib_.*\\.cpp$")
    list(FILTER JIT_CORE_SOURCES EXCLUDE REGEX "lib\\.cpp$|load\\.cpp$|lj_parse\\.cpp$|lj_lex\\.cpp$|parser_unit_tests\\.cpp$")
 
+   set_source_files_properties("${JIT_SRC}/runtime/lj_bulk_avx2.cpp" PROPERTIES COMPILE_OPTIONS "/arch:AVX2")
+
    file(GLOB JIT_DEP_LJ_H
       "${JIT_SRC}/bytecode/lj_*.h"
       "${JIT_SRC}/debug/lj_*.h"
@@ -561,10 +563,15 @@ else ()
       set(OBJECT_FILE "${JIT_BUILD_DIR}/${FILENAME}.o")
       list(APPEND JIT_OBJECT_FILES ${OBJECT_FILE})
 
+      set(JIT_SOURCE_CXXFLAGS ${JIT_COMMON_CXXFLAGS})
+      if (JIT_TARGET_ARCH STREQUAL "x64" AND FILENAME STREQUAL "lj_bulk_avx2")
+         list(APPEND JIT_SOURCE_CXXFLAGS -mavx2)
+      endif ()
+
       # Create custom command to compile each source file with explicit flags
       add_custom_command(
          OUTPUT ${OBJECT_FILE}
-         COMMAND ${CMAKE_CXX_COMPILER} ${JIT_COMMON_CXXFLAGS}
+         COMMAND ${CMAKE_CXX_COMPILER} ${JIT_SOURCE_CXXFLAGS}
             -funwind-tables -DLUAJIT_UNWIND_EXTERNAL
             ${JIT_NON_MSVC_DEFS}
             ${JIT_LIBRARY_DEFS}
@@ -672,6 +679,7 @@ if (ENABLE_UNIT_TESTS)
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_test_vm_asm.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_arrays.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_allocator.cpp")
+   list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_bulk.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/jit/jit_unit_tests.cpp")
 
    # Add MASM assembly file for register capture on MSVC x64

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -19,6 +19,7 @@
 #include "lj_tab.h"
 #include "lj_str.h"
 #include "lj_array.h"
+#include "lj_bulk.h"
 #include "lj_meta.h"
 #include "lib.h"
 #include "lib_range.h"
@@ -725,8 +726,7 @@ LJLIB_CF(array_clear)
       for (MSize i = 0; i < arr->len; i++) setgcrefnull(refs[i]);
    }
    else if (arr->elemtype IS AET::ANY) {
-      auto slots = arr->get<TValue>();
-      for (MSize i = 0; i < arr->len; i++) setnilV(&slots[i]);
+      lj_bulk_nil_tvalue(arr->get<TValue>(), arr->len);
    }
 
    arr->len = 0;
@@ -775,8 +775,7 @@ LJLIB_CF(array_resize)
          }
 
          case AET::ANY: {
-            auto slots = arr->get<TValue>();
-            for (MSize i = old_len; i < target_len; i++) setnilV(&slots[i]);
+            lj_bulk_nil_tvalue(&arr->get<TValue>()[old_len], target_len - old_len);
             break;
          }
 
@@ -802,8 +801,7 @@ LJLIB_CF(array_resize)
          }
 
          case AET::ANY: {
-            auto slots = arr->get<TValue>();
-            for (MSize i = target_len; i < old_len; i++) setnilV(&slots[i]);
+            lj_bulk_nil_tvalue(&arr->get<TValue>()[target_len], old_len - target_len);
             break;
          }
 
@@ -2639,7 +2637,8 @@ LJLIB_CF(array_insert)
    if (shift_count > 0) {
       void *src = lj_array_index(arr, index);
       void *dst = lj_array_index(arr, index + num_values);
-      memmove(dst, src, shift_count * arr->elemsize);
+      if (arr->elemtype IS AET::ANY) lj_bulk_move_tvalue((TValue *)dst, (const TValue *)src, shift_count);
+      else memmove(dst, src, shift_count * arr->elemsize);
    }
 
    // Insert the new values
@@ -2757,7 +2756,8 @@ LJLIB_CF(array_remove)
    if (shift_count > 0) {
       void *src = lj_array_index(arr, shift_start);
       void *dst = lj_array_index(arr, index);
-      memmove(dst, src, shift_count * arr->elemsize);
+      if (arr->elemtype IS AET::ANY) lj_bulk_move_tvalue((TValue *)dst, (const TValue *)src, shift_count);
+      else memmove(dst, src, shift_count * arr->elemsize);
    }
 
    // Clear trailing elements for GC-tracked types
@@ -2768,10 +2768,7 @@ LJLIB_CF(array_remove)
       }
    }
    else if (arr->elemtype IS AET::ANY) {
-      auto slots = arr->get<TValue>();
-      for (MSize i = arr->len - MSize(count); i < arr->len; i++) {
-         setnilV(&slots[i]);
-      }
+      lj_bulk_nil_tvalue(&arr->get<TValue>()[arr->len - MSize(count)], MSize(count));
    }
 
    arr->len -= MSize(count);
@@ -2822,8 +2819,8 @@ LJLIB_CF(array_clone)
          // For any-type arrays, copy TValues and set up barriers for GC values
          auto src_slots = arr->get<TValue>();
          auto dst_slots = result->get<TValue>();
+         lj_bulk_copy_tvalue(dst_slots, src_slots, arr->len);
          for (MSize i = 0; i < arr->len; i++) {
-            copyTV(L, &dst_slots[i], &src_slots[i]);
             if (tvisgcv(&src_slots[i])) lj_gc_objbarrier(L, result, gcV(&src_slots[i]));
          }
          break;

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -8,6 +8,7 @@
 #include "lj_gc.h"
 #include "lj_err.h"
 #include "lj_array.h"
+#include "lj_bulk.h"
 #include "lj_object.h"
 #include "lj_tab.h"
 
@@ -170,7 +171,10 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
             arr->init(storage, Type, elem_size, Length, Length, Flags, sdef);
-            if (byte_size > 0) std::memcpy(storage, Data, byte_size);
+            if (byte_size > 0) {
+               if (Type IS AET::ANY) lj_bulk_copy_tvalue((TValue *)storage, (const TValue *)Data, Length);
+               else std::memcpy(storage, Data, byte_size);
+            }
             return arr;
          }
       }
@@ -185,8 +189,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       if (storage) {
          if (Type IS AET::ANY) {
             // _ANY arrays require explicit nil initialization (nil TValue = -1, not 0)
-            TValue *slots = (TValue*)storage;
-            for (MSize i = 0; i < Length; i++) setnilV(&slots[i]);
+            lj_bulk_nil_tvalue((TValue *)storage, Length);
          }
          else std::memset(storage, 0, byte_size);
       }
@@ -221,8 +224,11 @@ bool lj_array_grow(lua_State *L, GCarray *Array, MSize MinCapacity)
    // Reallocate storage
    void *new_storage = lj_mem_realloc(L, Array->storage, old_size, new_size);
 
-   // Zero-initialise new elements for vulnerable types (pointers, strings, tables)
-   if (int(Array->elemtype) >= int(AET::VULNERABLE)) {
+   // Initialise new elements for vulnerable types (pointers, strings, tables)
+   if (Array->elemtype IS AET::ANY) {
+      lj_bulk_nil_tvalue((TValue *)((char *)new_storage + old_size), new_capacity - Array->capacity);
+   }
+   else if (int(Array->elemtype) >= int(AET::VULNERABLE)) {
       size_t zerolen = new_size - old_size;
       std::memset((char *)new_storage + old_size, 0, zerolen);
    }
@@ -256,8 +262,13 @@ void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, u
 
    void *dst_ptr = lj_array_index(Dest, DstIdx);
    void *src_ptr = lj_array_index(Src, SrcIdx);
-   size_t byte_count = Count * Dest->elemsize;
-   memmove(dst_ptr, src_ptr, byte_count); // Use memmove to handle overlapping regions
+   if (Dest->elemtype IS AET::ANY) {
+      lj_bulk_move_tvalue((TValue *)dst_ptr, (const TValue *)src_ptr, Count);
+   }
+   else {
+      size_t byte_count = Count * Dest->elemsize;
+      memmove(dst_ptr, src_ptr, byte_count); // Use memmove to handle overlapping regions
+   }
 }
 
 //********************************************************************************************************************
@@ -266,6 +277,11 @@ GCtab * lj_array_to_table(lua_State *L, GCarray *Array)
 {
    GCtab *t = lj_tab_new(L, Array->len, 0);  // 0-based: indices 0..len-1
    auto array_part = tvref(t->array);
+
+   if (Array->elemtype IS AET::ANY) {
+      lj_bulk_copy_tvalue(array_part, (const TValue *)Array->arraydata(), Array->len);
+      return t;
+   }
 
    auto data = (uint8_t *)Array->arraydata();
    for (MSize i = 0; i < Array->len; i++) {

--- a/src/tiri/jit/src/runtime/lj_bulk.cpp
+++ b/src/tiri/jit/src/runtime/lj_bulk.cpp
@@ -1,0 +1,145 @@
+// Bulk TValue operations.
+// Copyright (C) 2026 Paul Manias
+
+#define lj_bulk_c
+#define LUA_CORE
+
+#include "lj_bulk.h"
+
+#include <cstring>
+
+#if LJ_TARGET_X64
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+#endif
+
+using BulkNilFunc = void (*)(TValue *, MSize);
+using BulkCopyFunc = void (*)(TValue *, const TValue *, MSize);
+
+extern "C" void lj_bulk_avx2_nil_tvalue(TValue *, MSize);
+extern "C" void lj_bulk_avx2_copy_tvalue(TValue *, const TValue *, MSize);
+extern "C" void lj_bulk_avx2_move_tvalue(TValue *, const TValue *, MSize);
+
+static constexpr MSize LJ_BULK_AVX2_THRESHOLD = 64;
+
+static void bulk_scalar_nil_tvalue(TValue *Dst, MSize Count)
+{
+   for (MSize i = 0; i < Count; i++) setnilV(&Dst[i]);
+}
+
+static void bulk_scalar_copy_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   if (Count > 0) std::memcpy(Dst, Src, Count * sizeof(TValue));
+}
+
+static void bulk_scalar_move_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   if (Count > 0) std::memmove(Dst, Src, Count * sizeof(TValue));
+}
+
+#if LJ_TARGET_X64
+
+static void bulk_cpuid(uint32_t Leaf, uint32_t Subleaf, uint32_t Regs[4])
+{
+#if defined(_MSC_VER)
+   int cpu_info[4];
+   __cpuidex(cpu_info, int(Leaf), int(Subleaf));
+   Regs[0] = uint32_t(cpu_info[0]);
+   Regs[1] = uint32_t(cpu_info[1]);
+   Regs[2] = uint32_t(cpu_info[2]);
+   Regs[3] = uint32_t(cpu_info[3]);
+#elif defined(__GNUC__)
+   uint32_t eax = Leaf;
+   uint32_t ebx = 0;
+   uint32_t ecx = Subleaf;
+   uint32_t edx = 0;
+   __asm__ volatile("cpuid"
+      : "+a"(eax), "=b"(ebx), "+c"(ecx), "=d"(edx)
+      :
+      :);
+   Regs[0] = eax;
+   Regs[1] = ebx;
+   Regs[2] = ecx;
+   Regs[3] = edx;
+#else
+   Regs[0] = Regs[1] = Regs[2] = Regs[3] = 0;
+#endif
+}
+
+static uint64_t bulk_xgetbv(uint32_t Index)
+{
+#if defined(_MSC_VER)
+   return _xgetbv(Index);
+#elif defined(__GNUC__)
+   uint32_t eax = 0;
+   uint32_t edx = 0;
+   __asm__ volatile("xgetbv" : "=a"(eax), "=d"(edx) : "c"(Index));
+   return (uint64_t(edx) << 32) | eax;
+#else
+   return 0;
+#endif
+}
+
+static bool bulk_cpu_has_avx2()
+{
+   uint32_t regs[4];
+   bulk_cpuid(0, 0, regs);
+   if (regs[0] < 7) return false;
+
+   bulk_cpuid(1, 0, regs);
+   bool has_osxsave = not ((regs[2] & (1u << 27)) IS 0);
+   bool has_avx = not ((regs[2] & (1u << 28)) IS 0);
+   if (not has_osxsave or not has_avx) return false;
+
+   uint64_t xcr0 = bulk_xgetbv(0);
+   if (not ((xcr0 & 0x6) IS 0x6)) return false;
+
+   bulk_cpuid(7, 0, regs);
+   return not ((regs[1] & (1u << 5)) IS 0);
+}
+
+#else
+
+static bool bulk_cpu_has_avx2()
+{
+   return false;
+}
+
+#endif
+
+static BulkNilFunc bulk_nil_impl()
+{
+   static BulkNilFunc impl = bulk_cpu_has_avx2() ? lj_bulk_avx2_nil_tvalue : bulk_scalar_nil_tvalue;
+   return impl;
+}
+
+static BulkCopyFunc bulk_copy_impl()
+{
+   static BulkCopyFunc impl = bulk_cpu_has_avx2() ? lj_bulk_avx2_copy_tvalue : bulk_scalar_copy_tvalue;
+   return impl;
+}
+
+static BulkCopyFunc bulk_move_impl()
+{
+   static BulkCopyFunc impl = bulk_cpu_has_avx2() ? lj_bulk_avx2_move_tvalue : bulk_scalar_move_tvalue;
+   return impl;
+}
+
+void lj_bulk_nil_tvalue(TValue *Dst, MSize Count)
+{
+   if (Count >= LJ_BULK_AVX2_THRESHOLD) bulk_nil_impl()(Dst, Count);
+   else bulk_scalar_nil_tvalue(Dst, Count);
+}
+
+void lj_bulk_copy_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   if (Count >= LJ_BULK_AVX2_THRESHOLD) bulk_copy_impl()(Dst, Src, Count);
+   else bulk_scalar_copy_tvalue(Dst, Src, Count);
+}
+
+void lj_bulk_move_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   if (Count >= LJ_BULK_AVX2_THRESHOLD) bulk_move_impl()(Dst, Src, Count);
+   else bulk_scalar_move_tvalue(Dst, Src, Count);
+}

--- a/src/tiri/jit/src/runtime/lj_bulk.h
+++ b/src/tiri/jit/src/runtime/lj_bulk.h
@@ -1,0 +1,11 @@
+// Bulk TValue operations.
+// Copyright (C) 2026 Paul Manias
+
+#pragma once
+
+#include "lj_obj.h"
+
+extern void lj_bulk_nil_tvalue(TValue *Dst, MSize Count);
+extern void lj_bulk_copy_tvalue(TValue *Dst, const TValue *Src, MSize Count);
+extern void lj_bulk_move_tvalue(TValue *Dst, const TValue *Src, MSize Count);
+

--- a/src/tiri/jit/src/runtime/lj_bulk_avx2.cpp
+++ b/src/tiri/jit/src/runtime/lj_bulk_avx2.cpp
@@ -1,0 +1,83 @@
+// AVX2 bulk TValue operations.
+// Copyright (C) 2026 Paul Manias
+
+#define lj_bulk_avx2_c
+#define LUA_CORE
+
+#include "lj_bulk.h"
+
+#if LJ_TARGET_X64
+
+#include <immintrin.h>
+
+extern "C" void lj_bulk_avx2_nil_tvalue(TValue *Dst, MSize Count)
+{
+   __m256i nils = _mm256_set1_epi64x(-1);
+   MSize i = 0;
+   for (; i + 4 <= Count; i += 4) {
+      _mm256_storeu_si256((__m256i *)(Dst + i), nils);
+   }
+   _mm256_zeroupper();
+   for (; i < Count; i++) setnilV(&Dst[i]);
+}
+
+extern "C" void lj_bulk_avx2_copy_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   MSize i = 0;
+   for (; i + 4 <= Count; i += 4) {
+      __m256i values = _mm256_loadu_si256((const __m256i *)(Src + i));
+      _mm256_storeu_si256((__m256i *)(Dst + i), values);
+   }
+   _mm256_zeroupper();
+   for (; i < Count; i++) Dst[i] = Src[i];
+}
+
+extern "C" void lj_bulk_avx2_move_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   uintptr_t dst_addr = uintptr_t(Dst);
+   uintptr_t src_addr = uintptr_t(Src);
+   uintptr_t byte_count = uintptr_t(Count) * sizeof(TValue);
+   if (dst_addr > src_addr and dst_addr < src_addr + byte_count) {
+      MSize i = Count;
+      while (i >= 4) {
+         i -= 4;
+         __m256i values = _mm256_loadu_si256((const __m256i *)(Src + i));
+         _mm256_storeu_si256((__m256i *)(Dst + i), values);
+      }
+      _mm256_zeroupper();
+      while (i > 0) {
+         i--;
+         Dst[i] = Src[i];
+      }
+   }
+   else {
+      lj_bulk_avx2_copy_tvalue(Dst, Src, Count);
+   }
+}
+
+#else
+
+extern "C" void lj_bulk_avx2_nil_tvalue(TValue *Dst, MSize Count)
+{
+   for (MSize i = 0; i < Count; i++) setnilV(&Dst[i]);
+}
+
+extern "C" void lj_bulk_avx2_copy_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   for (MSize i = 0; i < Count; i++) Dst[i] = Src[i];
+}
+
+extern "C" void lj_bulk_avx2_move_tvalue(TValue *Dst, const TValue *Src, MSize Count)
+{
+   uintptr_t dst_addr = uintptr_t(Dst);
+   uintptr_t src_addr = uintptr_t(Src);
+   uintptr_t byte_count = uintptr_t(Count) * sizeof(TValue);
+   if (dst_addr > src_addr and dst_addr < src_addr + byte_count) {
+      for (MSize i = Count; i > 0; i--) Dst[i - 1] = Src[i - 1];
+   }
+   else {
+      for (MSize i = 0; i < Count; i++) Dst[i] = Src[i];
+   }
+}
+
+#endif

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -11,6 +11,7 @@
 #include "lj_gc.h"
 #include "lj_err.h"
 #include "lj_tab.h"
+#include "lj_bulk.h"
 
 //********************************************************************************************************************
 // Hash an arbitrary key and return its anchor position in the hash table.
@@ -172,11 +173,11 @@ GCtab * lj_tab_dup(lua_State *L, const GCtab *kt)
    if (asize > 0) {
       TValue *array = tvref(t->array);
       TValue *karray = tvref(kt->array);
-      if (asize < 64) {  // An inlined loop beats memcpy for < 512 bytes.
+      if (asize < 64) {
          uint32_t i;
          for (i = 0; i < asize; i++) copyTV(L, &array[i], &karray[i]);
       }
-      else memcpy(array, karray, asize * sizeof(TValue));
+      else lj_bulk_copy_tvalue(array, karray, asize);
    }
 
    hmask = kt->hmask;
@@ -234,21 +235,19 @@ void lj_tab_resize(lua_State *L, GCtab *t, uint32_t asize, uint32_t hbits)
    uint32_t oldhmask = t->hmask;
    if (asize > oldasize) {  // Array part grows?
       TValue *array;
-      uint32_t i;
       if (asize > LJ_MAX_ASIZE) lj_err_msg(L, ErrMsg::TABOV);
       if (LJ_MAX_COLOSIZE != 0 and t->colo > 0) {
          // A colocated array must be separated and copied.
          TValue *oarray = tvref(t->array);
          array = lj_mem_newvec(L, asize, TValue);
          t->colo = (int8_t)(t->colo | 0x80);  //  Mark as separated (colo < 0).
-         for (i = 0; i < oldasize; i++) copyTV(L, &array[i], &oarray[i]);
+         lj_bulk_copy_tvalue(array, oarray, oldasize);
       }
       else array = (TValue*)lj_mem_realloc(L, tvref(t->array), oldasize * sizeof(TValue), asize * sizeof(TValue));
 
       setmref(t->array, array);
       t->asize = asize;
-      for (i = oldasize; i < asize; i++)  //  Clear newly allocated slots.
-         setnilV(&array[i]);
+      lj_bulk_nil_tvalue(&array[oldasize], asize - oldasize); // Clear newly allocated slots.
    }
 
    // Create new (empty) hash part.

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -12,6 +12,7 @@
 #include "lj_obj.h"
 #include "lj_gc.h"
 #include "lj_array.h"
+#include "lj_str.h"
 #include "lj_tab.h"
 #include "lj_vmarray.h"
 
@@ -451,6 +452,129 @@ static bool tv_is_integer(cTValue* o, int32_t expected)
    if (tvisint(o)) return intV(o) IS expected;
    if (tvisnum(o)) return numberVint(o) IS expected;
    return false;
+}
+
+static bool test_any_array_nil_initialisation(kt::Log &Log)
+{
+   LuaStateHolder Holder;
+   lua_State *L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(L);
+
+   GCarray* arr = lj_array_new(L, 129, AET::ANY);
+   TValue *slots = arr->get<TValue>();
+
+   for (MSize i = 0; i < arr->len; i++) {
+      if (not tvisnil(&slots[i])) {
+         Log.error("ANY array slot %d is not nil after creation", int(i));
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_any_array_grow_nil_initialisation(kt::Log &Log)
+{
+   LuaStateHolder Holder;
+   lua_State *L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(L);
+
+   GCarray* arr = lj_array_new(L, 2, AET::ANY);
+   TValue *slots = arr->get<TValue>();
+   setintV(&slots[0], 17);
+   setnumV(&slots[1], 25.0);
+
+   if (not lj_array_grow(L, arr, 129)) {
+      Log.error("ANY array grow failed");
+      return false;
+   }
+
+   slots = arr->get<TValue>();
+   if (not tv_is_integer(&slots[0], 17) or not tvisnum(&slots[1])) {
+      Log.error("ANY array grow damaged existing values");
+      return false;
+   }
+
+   for (MSize i = 2; i < arr->capacity; i++) {
+      if (not tvisnil(&slots[i])) {
+         Log.error("ANY array grown slot %d is not nil", int(i));
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_any_array_bulk_copy_overlap(kt::Log &Log)
+{
+   LuaStateHolder Holder;
+   lua_State *L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(L);
+
+   GCarray* arr = lj_array_new(L, 140, AET::ANY);
+   TValue *slots = arr->get<TValue>();
+   for (int32_t i = 0; i < 140; i++) setintV(&slots[i], i);
+
+   lj_array_copy(L, arr, 2, arr, 0, 129);
+   slots = arr->get<TValue>();
+   for (int32_t i = 0; i < 129; i++) {
+      if (not tv_is_integer(&slots[i + 2], i)) {
+         Log.error("ANY array overlapping copy failed at slot %d", int(i + 2));
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_any_array_to_table_mixed_values(kt::Log &Log)
+{
+   LuaStateHolder Holder;
+   lua_State *L = Holder.get();
+   if (not L) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+   luaL_openlibs(L);
+
+   GCarray* arr = lj_array_new(L, 4, AET::ANY);
+   TValue *slots = arr->get<TValue>();
+   setnilV(&slots[0]);
+   setintV(&slots[1], 42);
+   setnumV(&slots[2], 3.5);
+   GCstr *str = lj_str_newz(L, "bulk");
+   setstrV(L, &slots[3], str);
+   lj_gc_objbarrier(L, arr, str);
+
+   GCtab *table = lj_array_to_table(L, arr);
+   TValue *array_part = tvref(table->array);
+
+   if (not tvisnil(&array_part[0])) {
+      Log.error("ANY table slot 0 is not nil");
+      return false;
+   }
+   if (not tv_is_integer(&array_part[1], 42)) {
+      Log.error("ANY table slot 1 is not 42");
+      return false;
+   }
+   if (not tvisnum(&array_part[2]) or not (numV(&array_part[2]) IS 3.5)) {
+      Log.error("ANY table slot 2 is not 3.5");
+      return false;
+   }
+   if (not tvisstr(&array_part[3]) or not (strV(&array_part[3]) IS str)) {
+      Log.error("ANY table slot 3 is not the source string");
+      return false;
+   }
+   return true;
 }
 
 static bool test_arr_getidx_int32(kt::Log &Log)
@@ -934,7 +1058,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 25> Tests = { {
+   constexpr std::array<TestCase, 29> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
@@ -955,6 +1079,10 @@ void array_unit_tests(int &Passed, int &Total)
       { "arr_setidx_double", test_arr_setidx_double },
       { "arr_roundtrip", test_arr_roundtrip },
       { "arr_byte_type", test_arr_byte_type },
+      { "any_array_nil_initialisation", test_any_array_nil_initialisation },
+      { "any_array_grow_nil_initialisation", test_any_array_grow_nil_initialisation },
+      { "any_array_bulk_copy_overlap", test_any_array_bulk_copy_overlap },
+      { "any_array_to_table_mixed_values", test_any_array_to_table_mixed_values },
       // Library Functions (basic integration - detailed tests in test_array.tiri)
       { "lib_array_new", test_lib_array_new },
       { "lib_array_index", test_lib_array_index },

--- a/src/tiri/jit/src/runtime/unit_tests_bulk.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_bulk.cpp
@@ -1,0 +1,146 @@
+// Unit tests for bulk TValue operations.
+// Copyright (C) 2026 Paul Manias
+
+#include <kotuku/main.h>
+
+#ifdef ENABLE_UNIT_TESTS
+
+#include "lj_obj.h"
+#include "lj_bulk.h"
+
+#include <array>
+#include <vector>
+
+namespace {
+
+struct TestCase {
+   const char* name;
+   bool (*fn)(kt::Log &Log);
+};
+
+constexpr std::array<MSize, 13> glBulkCounts = { {
+   0, 1, 2, 3, 4, 15, 16, 31, 32, 63, 64, 65, 129
+} };
+
+static void fill_slots(std::vector<TValue> &Slots)
+{
+   for (MSize i = 0; i < MSize(Slots.size()); i++) {
+      Slots[i].u64 = U64x(5a5a0000, 00000000) + uint64_t(i);
+   }
+}
+
+static bool check_range(const TValue *Actual, const std::vector<uint64_t> &Expected, kt::Log &Log, CSTRING Label)
+{
+   for (MSize i = 0; i < MSize(Expected.size()); i++) {
+      if (not (Actual[i].u64 IS Expected[i])) {
+         Log.error("%s mismatch at slot %d: got %.16llx expected %.16llx",
+            Label, int(i), (unsigned long long)Actual[i].u64, (unsigned long long)Expected[i]);
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_bulk_nil(kt::Log &Log)
+{
+   for (MSize Count : glBulkCounts) {
+      std::vector<TValue> slots(Count + 8);
+      fill_slots(slots);
+      TValue *dst = slots.data() + 1;
+
+      lj_bulk_nil_tvalue(dst, Count);
+
+      for (MSize i = 0; i < Count; i++) {
+         if (not (dst[i].it64 IS -1)) {
+            Log.error("nil fill failed for count %d at slot %d", int(Count), int(i));
+            return false;
+         }
+      }
+      if (not (slots[0].u64 IS U64x(5a5a0000, 00000000))) {
+         Log.error("nil fill overwrote prefix guard for count %d", int(Count));
+         return false;
+      }
+   }
+   return true;
+}
+
+static bool test_bulk_copy(kt::Log &Log)
+{
+   for (MSize Count : glBulkCounts) {
+      std::vector<TValue> src_slots(Count + 8);
+      std::vector<TValue> dst_slots(Count + 8);
+      fill_slots(src_slots);
+      fill_slots(dst_slots);
+
+      TValue *src = src_slots.data() + 1;
+      TValue *dst = dst_slots.data() + 3;
+      std::vector<uint64_t> expected(Count);
+      for (MSize i = 0; i < Count; i++) expected[i] = src[i].u64;
+
+      lj_bulk_copy_tvalue(dst, src, Count);
+      if (not check_range(dst, expected, Log, "copy")) return false;
+   }
+   return true;
+}
+
+static bool test_bulk_move_overlap_forward(kt::Log &Log)
+{
+   for (MSize Count : glBulkCounts) {
+      std::vector<TValue> slots(Count + 12);
+      fill_slots(slots);
+
+      TValue *src = slots.data() + 1;
+      TValue *dst = slots.data() + 3;
+      std::vector<uint64_t> expected(Count);
+      for (MSize i = 0; i < Count; i++) expected[i] = src[i].u64;
+
+      lj_bulk_move_tvalue(dst, src, Count);
+      if (not check_range(dst, expected, Log, "forward overlap move")) return false;
+   }
+   return true;
+}
+
+static bool test_bulk_move_overlap_backward(kt::Log &Log)
+{
+   for (MSize Count : glBulkCounts) {
+      std::vector<TValue> slots(Count + 12);
+      fill_slots(slots);
+
+      TValue *src = slots.data() + 3;
+      TValue *dst = slots.data() + 1;
+      std::vector<uint64_t> expected(Count);
+      for (MSize i = 0; i < Count; i++) expected[i] = src[i].u64;
+
+      lj_bulk_move_tvalue(dst, src, Count);
+      if (not check_range(dst, expected, Log, "backward overlap move")) return false;
+   }
+   return true;
+}
+
+} // namespace
+
+void bulk_unit_tests(int &Passed, int &Total)
+{
+   constexpr std::array<TestCase, 4> Tests = { {
+      { "bulk_nil", test_bulk_nil },
+      { "bulk_copy", test_bulk_copy },
+      { "bulk_move_overlap_forward", test_bulk_move_overlap_forward },
+      { "bulk_move_overlap_backward", test_bulk_move_overlap_backward }
+   } };
+
+   for (const TestCase& Test : Tests) {
+      kt::Log Log("BulkTests");
+      Log.branch("Running %s", Test.name);
+      ++Total;
+      if (Test.fn(Log)) {
+         ++Passed;
+         Log.msg("%s passed", Test.name);
+      }
+      else {
+         Log.error("%s failed", Test.name);
+      }
+   }
+}
+
+#endif // ENABLE_UNIT_TESTS
+

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -308,6 +308,7 @@ extern void jit_frame_unit_tests(int &, int &);
 extern void parser_unit_tests(int &, int &);
 extern void array_unit_tests(int &, int &);
 extern void allocator_unit_tests(int &, int &);
+extern void bulk_unit_tests(int &, int &);
 #endif
 
 static void MODTest(CSTRING Options, int *Passed, int *Total)
@@ -342,6 +343,11 @@ static void MODTest(CSTRING Options, int *Passed, int *Total)
       kt::Log log("TiriTests");
       log.branch("Running allocator unit tests...");
       allocator_unit_tests(*Passed, *Total);
+   }
+   {
+      kt::Log log("TiriTests");
+      log.branch("Running bulk TValue unit tests...");
+      bulk_unit_tests(*Passed, *Total);
    }
 #else
    kt::Log("TiriTests").warning("Unit tests are disabled in this build.");


### PR DESCRIPTION
## Summary

* Introduces a new `lj_bulk` module providing vectorised nil-fill, copy and memmove operations for `TValue` arrays, with runtime CPUID dispatch to AVX2 on capable hardware and a scalar fallback otherwise
* Replaces ad-hoc `setnilV` loops and bare `memcpy`/`memmove` calls in `lj_array`, `lj_tab` and `lib_array` with the unified `lj_bulk_*` wrappers, ensuring correct GC-safe semantics throughout
* `lj_bulk_avx2.cpp` is compiled with `/arch:AVX2` (MSVC) or `-mavx2` (GCC/Clang) via per-file CMake flags so the rest of the build is unaffected

## Test plan

- [ ] Build with `ENABLE_UNIT_TESTS=ON` and confirm `unit_tests_bulk` runs without failures (covers nil, copy and both overlap-move directions across 13 count values including AVX2 boundary sizes 63/64/65/129)
- [ ] Confirm four new ANY-array integration tests pass in `unit_tests_arrays`: nil initialisation, grow nil-init, overlap copy and to-table conversion
- [ ] Run full test suite (`ctest`) on both x64 AVX2 hardware and a non-AVX2 target (or with AVX2 path disabled) to verify scalar fallback correctness
- [ ] Verify no regressions in existing array and table tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)