### PR TITLE
[LSP] Fix stdio transport framing and refine stdio mode detection

### DIFF
--- a/tools/tiri_lsp/README.md
+++ b/tools/tiri_lsp/README.md
@@ -140,7 +140,7 @@ Configure in VSCode settings:
 |-|-|-|
 |`tiri.lsp.enable`|true|Enable LSP server connection|
 |`tiri.lsp.host`|"127.0.0.1"|LSP server host address|
-|`tiri.lsp.port`|5007|LSP server TCP port|
+|`tiri.lsp.port`|5007|LSP server port. `0` runs the server over stdio; non-zero values use TCP.|
 
 ## Architecture
 

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -530,16 +530,16 @@ end
 global function lspStart(Options)
    Options ?= {}
 
-   self.port       = Options.port or 5007
-   self.verbose    = Options.verbose or false
-   self.logMessage = Options.logMessage or function(msg) print(msg) end
-   self.requestLog = Options.requestLog  -- Optional request/response logging callback
-   self.stdioInput  = Options.stdioInput
-   self.stdioOutput = Options.stdioOutput
+   self.port            = Options.port or 5007
+   self.verbose         = Options.verbose or false
+   self.logMessage      = Options.logMessage or function(msg) print(msg) end
+   self.requestLog      = Options.requestLog  -- Optional request/response logging callback
+   self.stdioInput      = Options.stdioInput
+   self.stdioOutput     = Options.stdioOutput
    self.stdioTextOutput = false
-   self._socket    = nil
-   self._stdioClient = nil
-   self._handlers  = {}
+   self._socket         = nil
+   self._stdioClient    = nil
+   self._handlers       = {}
 
    registerCoreHandlers(self)
 

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -536,6 +536,7 @@ global function lspStart(Options)
    self.requestLog = Options.requestLog  -- Optional request/response logging callback
    self.stdioInput  = Options.stdioInput
    self.stdioOutput = Options.stdioOutput
+   self.stdioTextOutput = false
    self._socket    = nil
    self._stdioClient = nil
    self._handlers  = {}
@@ -562,6 +563,7 @@ global function lspStart(Options)
    end
 
    if self.port is 0 then
+      self.stdioTextOutput = true
       runStdioServer(self)
       return self
    end

--- a/tools/tiri_lsp/lsp_protocol.tiri
+++ b/tools/tiri_lsp/lsp_protocol.tiri
@@ -1,6 +1,6 @@
 
-local rx_split_header_lines = <{ regex.new([[([^\r\n]+)]]) }>
-local rx_header_value = <{ regex.new([[([^:]+):\s*(.+)]]) }>
+rx_split_header_lines = <{ regex.new([[([^\r\n]+)]]) }>
+rx_header_value = <{ regex.new([[([^:]+):\s*(.+)]]) }>
 
 function makeErrorResponse(Id:num, Code:num, Message:str):table
    return {
@@ -69,7 +69,7 @@ end
 
 function formatResponse(ResponseTable:table, TextOutput:bool):str
    body = json.encode(ResponseTable)
-   separator = TextOutput and '\n\n' or '\r\n\r\n'
+   separator = TextOutput ? '\n\n' :> '\r\n\r\n'
    return 'Content-Length: ' .. #body .. separator .. body
 end
 

--- a/tools/tiri_lsp/lsp_protocol.tiri
+++ b/tools/tiri_lsp/lsp_protocol.tiri
@@ -67,15 +67,16 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Response Formatting
 
-function formatResponse(ResponseTable:table):str
+function formatResponse(ResponseTable:table, TextOutput:bool):str
    body = json.encode(ResponseTable)
-   return 'Content-Length: ' .. #body .. '\r\n\r\n' .. body
+   separator = TextOutput and '\n\n' or '\r\n\r\n'
+   return 'Content-Length: ' .. #body .. separator .. body
 end
 
 global function sendResponse(Self, ClientSocket, ResponseTable, RequestLog)
    ResponseTable ?? return -- Notifications don't get responses
 
-   formatted = formatResponse(ResponseTable)
+   formatted = formatResponse(ResponseTable, Self.stdioTextOutput)
    err = ClientSocket.acWrite(formatted)
    if err != ERR_Okay then
       logMessage(Self, 'Failed to send response: ' .. mSys.GetErrorMsg(err))
@@ -98,7 +99,7 @@ global function sendNotification(Self, ClientSocket, Method, Params)
       method = Method,
       params = Params
    }
-   formatted = formatResponse(notification)
+   formatted = formatResponse(notification, Self.stdioTextOutput)
    err = ClientSocket.acWrite(formatted)
    if err != ERR_Okay then
       logMessage(Self, 'Failed to send notification: ' .. mSys.GetErrorMsg(err))

--- a/tools/tiri_lsp/server.tiri
+++ b/tools/tiri_lsp/server.tiri
@@ -152,8 +152,9 @@ end
       tm = obj.new('time')
       tm.acQuery()
       glOptions.requestLog = function(Direction, Content)
-         timestamp = string.format('%04d-%02d-%02d %02d:%02d:%02d', tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second)
-         header = '\n=== ' .. Direction .. ' [' .. timestamp .. '] ===\n'
+         log_timestamp = string.format('%04d-%02d-%02d %02d:%02d:%02d',
+            tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second)
+         header = '\n=== ' .. Direction .. ' [' .. log_timestamp .. '] ===\n'
          glReqLog.acWrite(header)
          glReqLog.acWrite(Content)
          glReqLog.acWrite('\n')

--- a/tools/tiri_lsp/vscode_plugin/README.md
+++ b/tools/tiri_lsp/vscode_plugin/README.md
@@ -11,13 +11,15 @@ cd tools/tiri_lsp/vscode_plugin
 npm install
 ```
 
-### 2. Start the LSP Server
+### 2. LSP Server Startup
 
-By default, the extension starts the Tiri LSP server automatically for local connections. To start it manually instead, set `tiri.lsp.autoStart` to `false` and run:
+By default, the extension looks for an existing Tiri LSP server on port 5007.  This commandline starts the server manually with the default port:
 
 ```bash
 origo tools/tiri_lsp/server.tiri port=5007
 ```
+
+If `tiri.lsp.autoStart` is enabled, the plugin will start the server on the defined `port`.  If `port=0`, the server runs in stdio mode.
 
 ### 3. Install the Extension
 
@@ -48,12 +50,12 @@ code --install-extension tiri-language-0.1.0.vsix
 
 ### LSP Server Auto-Start
 
-The extension auto-starts the server with `origo tools/tiri_lsp/server.tiri port=5007`. Configure `tiri.lsp.origoPath` if `origo` is not in PATH, or `tiri.lsp.serverScript` if the server script is in another location.
+If `port=0` or `tiri.lsp.autoStart` is enabled, the server script is started automatically.  Configure `tiri.lsp.origoPath` if `origo` is not in PATH, or `tiri.lsp.serverScript` if the server script is in another location.
 
 ### "Could not connect to server"
 
-1. Ensure the LSP server is running.
-2. Check the port matches your VS Code settings
+1. For TCP mode, ensure the LSP server is running.
+2. Check the port matches your VS Code settings.
 3. View the Tiri LSP output channel for connection details:
    - View > Output > Select "Tiri LSP" from dropdown
 

--- a/tools/tiri_lsp/vscode_plugin/extension.js
+++ b/tools/tiri_lsp/vscode_plugin/extension.js
@@ -1,5 +1,5 @@
 // Tiri Language Support for VS Code
-// Connects to the Tiri LSP server over TCP
+// Connects to the Tiri LSP server over stdio or TCP
 
 const vscode = require('vscode');
 const { LanguageClient } = require('vscode-languageclient/node');
@@ -16,7 +16,7 @@ function getSettings() {
    return {
       enabled: config.get('enable', true),
       host: config.get('host', '127.0.0.1'),
-      port: config.get('port', 5007),
+      port: config.get('port', 0),
       autoStart: config.get('autoStart', false),
       origoPath: config.get('origoPath', 'origo'),
       serverScript: config.get('serverScript', 'tools/tiri_lsp/server.tiri')
@@ -152,6 +152,28 @@ async function connectToServer(settings) {
    throw lastError;
 }
 
+function createStdioServerOptions(settings) {
+   const serverScript = resolveServerScript(settings.serverScript);
+   if (!serverScript) {
+      outputChannel.appendLine('Cannot start Tiri LSP server: server script is relative and no workspace is open');
+      vscode.window.showWarningMessage(
+         'Tiri LSP: Set tiri.lsp.serverScript to an absolute path, or open the Kōtuku workspace.'
+      );
+      throw new Error('Unable to resolve Tiri LSP server script');
+   }
+
+   outputChannel.appendLine(`Starting LSP server in stdio mode: ${settings.origoPath} ${serverScript} port=0`);
+
+   return {
+      command: settings.origoPath,
+      args: [serverScript, 'port=0'],
+      options: {
+         cwd: getWorkspacePath(),
+         windowsHide: true
+      }
+   };
+}
+
 async function stopLanguageClient() {
    if (client) {
       const oldClient = client;
@@ -161,7 +183,9 @@ async function stopLanguageClient() {
 }
 
 function createLanguageClient(settings) {
-   const serverOptions = () => connectToServer(settings);
+   const serverOptions = settings.port === 0
+      ? createStdioServerOptions(settings)
+      : () => connectToServer(settings);
 
    const clientOptions = {
       documentSelector: [
@@ -189,9 +213,23 @@ async function startLanguageClient() {
       return;
    }
 
-   outputChannel.appendLine(`Connecting to LSP server at ${settings.host}:${settings.port}`);
+   if (settings.port === 0) {
+      outputChannel.appendLine('Using stdio mode for LSP server');
+   }
+   else {
+      outputChannel.appendLine(`Connecting to LSP server at ${settings.host}:${settings.port}`);
+   }
 
-   const newClient = createLanguageClient(settings);
+   let newClient;
+
+   try {
+      newClient = createLanguageClient(settings);
+   }
+   catch (err) {
+      outputChannel.appendLine(`Failed to create LSP client: ${err.message}`);
+      return;
+   }
+
    client = newClient;
 
    try {

--- a/tools/tiri_lsp/vscode_plugin/package.json
+++ b/tools/tiri_lsp/vscode_plugin/package.json
@@ -63,12 +63,12 @@
             "tiri.lsp.port": {
                "type": "number",
                "default": 5007,
-               "description": "LSP server TCP port"
+               "description": "LSP server port. Set to 0 to run the server over stdio."
             },
             "tiri.lsp.autoStart": {
                "type": "boolean",
                "default": false,
-               "description": "Automatically start the Tiri LSP server when connecting to a local host"
+               "description": "Automatically start the Tiri LSP server when connecting over TCP to a local host"
             },
             "tiri.lsp.origoPath": {
                "type": "string",


### PR DESCRIPTION
## Summary

* Fixes Content-Length header separator to use `\n\n` for stdio transport vs `\r\n\r\n` for TCP, ensuring spec-compliant LSP framing in stdio mode
* Adds `stdioTextOutput` flag to the server object so response and notification formatters correctly select the separator based on transport
* Defaults the VS Code plugin port setting to `0` (stdio mode) and adds `createStdioServerOptions()` to launch the server process automatically over stdio
* Wraps language client creation in try/catch to surface configuration errors (e.g. unresolvable server script path) gracefully in the output channel

## Test plan

- [ ] Open a `.tiri` file in VS Code with `tiri.lsp.port` set to `0` — confirm the LSP server starts automatically in stdio mode and language features work
- [ ] Set `tiri.lsp.port` to `5007`, start `origo tools/tiri_lsp/server.tiri port=5007` manually, and confirm TCP mode still works
- [ ] Confirm that an invalid `tiri.lsp.serverScript` path shows a warning message rather than crashing the extension
- [ ] Check the "Tiri LSP" output channel for correct mode messages (`Using stdio mode` vs `Connecting to LSP server at ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)