### PR TITLE
Add Go to Definition support to Tiri LSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,6 +750,8 @@ add_subdirectory (src/regex)
 
 add_subdirectory (src/launcher)
 
+add_subdirectory (tools/tiri_lsp)
+
 # --------------------------------------------------------------------------------------------------------------------
 # Create a combined static library that links all modules together
 # This breaks the circular dependencies by having a separate target own all the inter-module linkage

--- a/tools/tiri_lsp/CMakeLists.txt
+++ b/tools/tiri_lsp/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Tiri LSP tooling
+
+set(TIRI_LSP_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(TIRI_LSP_VSCODE_PLUGIN_DIR "${TIRI_LSP_DIR}/vscode_plugin")
+set(TIRI_LSP_VSCODE_BUNDLE "${TIRI_LSP_VSCODE_PLUGIN_DIR}/dist/extension.js")
+set(TIRI_LSP_VSCODE_VSIX "${TIRI_LSP_VSCODE_PLUGIN_DIR}/tiri-language-0.1.0.vsix")
+
+find_program(NPM_EXECUTABLE NAMES npm.cmd npm)
+
+if (NPM_EXECUTABLE)
+   set(TIRI_LSP_NPM_INSTALL_COMMAND install)
+   set(TIRI_LSP_NPM_INSTALL_DEPENDS)
+   if (EXISTS "${TIRI_LSP_VSCODE_PLUGIN_DIR}/package-lock.json")
+      set(TIRI_LSP_NPM_INSTALL_COMMAND ci)
+      list(APPEND TIRI_LSP_NPM_INSTALL_DEPENDS "${TIRI_LSP_VSCODE_PLUGIN_DIR}/package-lock.json")
+   endif ()
+
+   add_custom_command(
+      OUTPUT "${TIRI_LSP_VSCODE_BUNDLE}"
+      COMMAND "${NPM_EXECUTABLE}" ${TIRI_LSP_NPM_INSTALL_COMMAND}
+      COMMAND "${NPM_EXECUTABLE}" run bundle
+      WORKING_DIRECTORY "${TIRI_LSP_VSCODE_PLUGIN_DIR}"
+      DEPENDS
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/extension.js"
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/language-configuration.json"
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/package.json"
+         ${TIRI_LSP_NPM_INSTALL_DEPENDS}
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/syntaxes/tiri.tmLanguage.json"
+      COMMENT "Building the Tiri VS Code plugin bundle with npm"
+      VERBATIM)
+
+   add_custom_target(tiri_lsp_vscode_plugin
+      DEPENDS "${TIRI_LSP_VSCODE_BUNDLE}")
+
+   add_custom_command(
+      OUTPUT "${TIRI_LSP_VSCODE_VSIX}"
+      COMMAND "${NPM_EXECUTABLE}" exec --yes -- vsce package
+      WORKING_DIRECTORY "${TIRI_LSP_VSCODE_PLUGIN_DIR}"
+      DEPENDS
+         tiri_lsp_vscode_plugin
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/.vscodeignore"
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/README.md"
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/images/tiri.png"
+         "${TIRI_LSP_VSCODE_PLUGIN_DIR}/package.json"
+      COMMENT "Packaging the Tiri VS Code plugin VSIX with npm"
+      VERBATIM)
+
+   add_custom_target(tiri_lsp_vscode_plugin_vsix
+      DEPENDS "${TIRI_LSP_VSCODE_VSIX}")
+else ()
+   message(STATUS "npm was not found; Tiri VS Code plugin build targets will be unavailable.")
+endif ()
+
+flute_test(tiri_lsp_definition "${TIRI_LSP_DIR}/tests/test_definition.tiri")

--- a/tools/tiri_lsp/README.md
+++ b/tools/tiri_lsp/README.md
@@ -108,7 +108,7 @@ origo tools/tiri_lsp/server.tiri port=0
 |---------------|------------------------------------|------------------------------------- |
 | `port`        | 5007                               | TCP port to listen on, or `0` for stdio |
 | `verbose`     | false                              | Enable debug logging                 |
-| `config`      | `user:config/lsp_server_cfg.tiri` | Path to configuration file           |
+| `config`      | `user:config/lsp_server_cfg.tiri`  | Path to configuration file           |
 | `request-log` | (none)                             | Path for request/response logging    |
 
 Example with options:

--- a/tools/tiri_lsp/lsp_cache.tiri
+++ b/tools/tiri_lsp/lsp_cache.tiri
@@ -13,6 +13,8 @@
    import 'io/filesearch'
 
 rx_pos_pair = <{ regex.new([[(\d+),(\d+)]]) }>
+rx_source_file_path = <{ regex.new([[<file\s+path="([^"]*)">([^<]+)<\/file>]]) }>
+rx_source_file_plain = <{ regex.new([[<file>([^<]+)<\/file>]]) }>
 
 -- Encode a field entry to compact string format
 function encodeField(Access, Type, ByteStart, ByteEnd, Comment)
@@ -125,6 +127,28 @@ function extractChildAttr(Content:str, TagName:str, AttrName:str):str
    return content
 end
 
+function extractSources(Content:str):array
+   sources = array<table>
+   sourceMatch = extractXMLElement(Content, 'source', 0)
+   sourceMatch ?? return sources
+
+   for start, stop, cap in rx_source_file_path.findAll(sourceMatch.content) do
+      sources:push({
+         path = cap[0] or '',
+         file = cap[1] or ''
+      })
+   end
+
+   for start, stop, cap in rx_source_file_plain.findAll(sourceMatch.content) do
+      sources:push({
+         path = '',
+         file = cap[0] or ''
+      })
+   end
+
+   return sources
+end
+
 function processModuleXML(FilePath:str, DocPath:str):<str,table>
    -- Process a module XML file and extract function information
    content = io.readAll(FilePath)
@@ -141,7 +165,10 @@ function processModuleXML(FilePath:str, DocPath:str):<str,table>
 
    modEntry = {
       file = relativePath,
+      byteStart = infoMatch.byteStart,
+      byteEnd = infoMatch.byteEnd,
       comment = extractChildText(infoMatch.content, 'comment') or '',
+      sources = extractSources(infoMatch.content),
       functions = {}
    }
 
@@ -185,8 +212,11 @@ function processClassXML(FilePath, DocPath)
 
    classEntry = {
       file = relativePath,
+      byteStart = infoMatch.byteStart,
+      byteEnd = infoMatch.byteEnd,
       module = extractChildText(infoMatch.content, 'module') or '',
       comment = extractChildText(infoMatch.content, 'comment') or '',
+      sources = extractSources(infoMatch.content),
       methods = {},
       actions = {},
       fields = {}
@@ -262,7 +292,7 @@ global function buildDocCache(DocPath)
    -- Build the documentation cache from XML files
 
    cache = {
-      version = 1,
+      version = 2,
       built = mSys.PreciseTime() / 1000000,
       sdkPath = DocPath,
       modules = {},
@@ -277,8 +307,7 @@ global function buildDocCache(DocPath)
    print('Scanning modules for documentation cache; ', modulesPath)
 
    err = io.search(modulesPath, {
-      nameFilter = [[\.xml$]],
-      nameWild = true,
+      nameFilter = regex.new([[\.xml$]]),
       maxDepth = 0,
       matchFeedback = function(Path, FileName, File)
          -- Skip if it's a directory entry for 'classes'
@@ -300,8 +329,7 @@ global function buildDocCache(DocPath)
    print('Scanning classes for documentation cache; ', classesPath)
 
    err = io.search(classesPath, {
-      nameFilter = [[\.xml$]],
-      nameWild = true,
+      nameFilter = regex.new([[\.xml$]]),
       maxDepth = 1,
       matchFeedback = function(Path, FileName, File)
          fullPath = Path .. FileName
@@ -381,8 +409,17 @@ global function loadDocCache(DocPath)
       return nil
    end
 
-   if cache.version != 1 then msg('Unsupported version'); return nil end
+   if cache.version != 2 then msg('Unsupported version'); return nil end
    if cache.sdkPath != DocPath then msg('Path mismatch: ' .. cache.sdkPath .. ' != ' .. DocPath); return nil end
+
+   module_count = 0
+   class_count = 0
+   for k, v in pairs(cache.modules or {}) do module_count++ end
+   for k, v in pairs(cache.classes or {}) do class_count++ end
+   if module_count is 0 or class_count is 0 then
+      msg('Documentation cache is empty; rebuilding.')
+      return nil
+   end
 
    return cache
 end

--- a/tools/tiri_lsp/lsp_definition.tiri
+++ b/tools/tiri_lsp/lsp_definition.tiri
@@ -5,7 +5,6 @@ rx_def_func = <{ regex.new([[\bfunction\s+([A-Za-z_][A-Za-z0-9_:.]*)\s*\(([^\)]*
 rx_def_decl = <{ regex.new([[\b(local|global)\s+([A-Za-z_][A-Za-z0-9_]*)]]) }>
 rx_def_assign_func = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^\)]*)\)]]) }>
 rx_def_assign          = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
-rx_def_trailing_comma  = <{ regex.new([[,\s*$]]) }>
 rx_def_param = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
 rx_def_loader_before = <{ regex.new([[\b(import|require|include)\s*(?:\(\s*)?$]]) }>
 rx_def_obj_new_before = <{ regex.new([[obj\.new\s*\(\s*$]]) }>
@@ -264,14 +263,31 @@ function addFunctionParameters(Symbols:array, Params:str, LineText:str, Line:num
    end
 end
 
+function updateTableDepth(LineCode:str, TableDepth:num):num
+   depth = TableDepth or 0
+
+   for i = 0, #LineCode - 1 do
+      c = LineCode:sub(i, i + 1)
+      if c is '{' then
+         depth++
+      elseif c is '}' and depth > 0 then
+         depth--
+      end
+   end
+
+   return depth
+end
+
 global function extractDefinitionSymbols(Doc:table):array
    symbols = array<table>
    total_lines = getTotalLines(Doc)
    in_block_comment = false
+   table_depth = 0
 
    for line_num = 0, total_lines - 1 do
       line_text = getLine(Doc, line_num)
       line_code, in_block_comment = maskNonCode(line_text, in_block_comment)
+      in_table_literal = table_depth > 0
 
       for start, stop, cap in rx_def_func.findAll(line_code) do
          name = cap[0]
@@ -307,7 +323,7 @@ global function extractDefinitionSymbols(Doc:table):array
 
       for start, stop, cap in rx_def_assign.findAll(line_code) do
          name = cap[0]
-         if name and name != 'local' and name != 'global' and not rx_def_trailing_comma.test(line_code) then
+         if name and name != 'local' and name != 'global' and not in_table_literal then
             name_start = line_text:find(name, start, true) or start
             eq_pos = line_text:find('=', name_start + #name, true)
             next_char = eq_pos and line_text:sub(eq_pos + 1, eq_pos + 2) or ''
@@ -317,6 +333,8 @@ global function extractDefinitionSymbols(Doc:table):array
             end
          end
       end
+
+      table_depth = updateTableDepth(line_code, table_depth)
    end
 
    return symbols

--- a/tools/tiri_lsp/lsp_definition.tiri
+++ b/tools/tiri_lsp/lsp_definition.tiri
@@ -1,0 +1,598 @@
+----------------------------------------------------------------------------------------------------------------------
+-- Go to Definition Support
+
+rx_def_func = <{ regex.new([[\bfunction\s+([A-Za-z_][A-Za-z0-9_:.]*)\s*\(([^\)]*)\)]]) }>
+rx_def_decl = <{ regex.new([[\b(local|global)\s+([A-Za-z_][A-Za-z0-9_]*)]]) }>
+rx_def_assign_func = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^\)]*)\)]]) }>
+rx_def_assign          = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
+rx_def_trailing_comma  = <{ regex.new([[,\s*$]]) }>
+rx_def_param = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
+rx_def_loader_before = <{ regex.new([[\b(import|require|include)\s*(?:\(\s*)?$]]) }>
+rx_def_obj_new_before = <{ regex.new([[obj\.new\s*\(\s*$]]) }>
+rx_def_obj_new = <{ regex.new([=[([A-Za-z_][A-Za-z0-9_]*)\s*=\s*obj\.new\s*\(\s*['"]([^'"]+)['"]]=], regex.DOT_ALL) }>
+rx_def_action_prefix = <{ regex.new([=[^ac[A-Z]]=]) }>
+rx_def_method_prefix = <{ regex.new([=[^mt[A-Z]]=]) }>
+
+----------------------------------------------------------------------------------------------------------------------
+-- URI and Path Helpers
+
+global function lspPercentDecode(Text:str):str
+   result = ''
+   pos = 0
+
+   while pos < #Text do
+      c = Text:sub(pos, pos + 1)
+      if c is '%' and pos + 2 < #Text then
+         hex = Text:sub(pos + 1, pos + 3)
+         value = tonumber(hex, 16)
+         if value then
+            result ..= string.char(value)
+            pos += 3
+         else
+            result ..= c
+            pos++
+         end
+      else
+         result ..= c
+         pos++
+      end
+   end
+
+   return result
+end
+
+function lspPercentEncode(Text:str):str
+   return Text:replace('%', '%25'):replace(' ', '%20'):replace('#', '%23'):replace('?', '%3F')
+end
+
+global function lspUriToPath(Uri:str):str
+   Uri ?? return nil
+   path = Uri
+
+   if path:startsWith('file://') then
+      path = path:sub(7)
+   end
+
+   path = lspPercentDecode(path):replace('\\', '/')
+
+   -- VS Code sends Windows file URIs as file:///e:/path.
+   if #path >= 3 and path:sub(0, 1) is '/' and path:sub(2, 3) is ':' then
+      path = path:sub(1)
+   end
+
+   return path
+end
+
+global function lspPathToUri(Path:str):str
+   Path ?? return nil
+
+   local resolved
+   err, resolved = mSys.ResolvePath(Path)
+   if err != ERR_Okay then
+      err, resolved = mSys.ResolvePath(Path, RSF_NO_FILE_CHECK)
+   end
+   if err != ERR_Okay then return nil end
+
+   resolved = resolved:replace('\\', '/')
+   if #resolved >= 2 and resolved:sub(1, 2) is ':' then
+      resolved = '/' .. resolved
+   elseif not resolved:startsWith('/') then
+      resolved = '/' .. resolved
+   end
+
+   return 'file://' .. lspPercentEncode(resolved)
+end
+
+function getParentPath(Path:str):str
+   Path ?? return ''
+   path = Path:replace('\\', '/')
+   last_slash = -1
+
+   for i = 0, #path - 1 do
+      if path:sub(i, i + 1) is '/' then last_slash = i end
+   end
+
+   if last_slash < 0 then return '' end
+   return path:sub(0, last_slash + 1)
+end
+
+function resolveExistingPath(Path:str):str
+   Path ?? return nil
+   local resolved
+   err, resolved = mSys.ResolvePath(Path)
+   if err is ERR_Okay then return resolved end
+   return nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Location Helpers
+
+function offsetToPosition(Content:str, Offset:num):table
+   line = 0
+   character = 0
+   pos = 0
+   limit = Offset
+   if limit > #Content then limit = #Content end
+
+   while pos < limit do
+      c = Content:sub(pos, pos + 1)
+      if c is '\n' then
+         line++
+         character = 0
+      else
+         character++
+      end
+      pos++
+   end
+
+   return { line = line, character = character }
+end
+
+function makeLocation(Path:str, StartLine:num, StartChar:num, EndLine:num, EndChar:num):table
+   uri = lspPathToUri(Path)
+   uri ?? return nil
+
+   return {
+      uri = uri,
+      range = {
+         start = { line = StartLine or 0, character = StartChar or 0 },
+         ['end'] = { line = EndLine or StartLine or 0, character = EndChar or StartChar or 0 }
+      }
+   }
+end
+
+function makeDocLocation(Doc:table, StartLine:num, StartChar:num, EndLine:num, EndChar:num):table
+   return {
+      uri = Doc.uri,
+      range = {
+         start = { line = StartLine or 0, character = StartChar or 0 },
+         ['end'] = { line = EndLine or StartLine or 0, character = EndChar or StartChar or 0 }
+      }
+   }
+end
+
+function makeOffsetLocation(Path:str, ByteStart:num, ByteEnd:num):table
+   ByteStart ?= 0
+   ByteEnd ?= ByteStart
+
+   content = io.readAll(Path)
+   if not content then return makeLocation(Path, 0, 0, 0, 0) end
+
+   start_pos = offsetToPosition(content, ByteStart)
+   end_pos = offsetToPosition(content, ByteEnd)
+   return makeLocation(Path, start_pos.line, start_pos.character, end_pos.line, end_pos.character)
+end
+
+function makeXmlLocation(Entry:table, ByteStart:num, ByteEnd:num):table
+   if not Entry or not Entry.file or not glDocCache then return nil end
+   return makeOffsetLocation(glDocCache.sdkPath .. Entry.file, ByteStart or Entry.byteStart or 0, ByteEnd or Entry.byteEnd or 0)
+end
+
+function pushLocation(Locations:array, Location:table)
+   if Location then Locations:push(Location) end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- String Context
+
+function getStringAtPosition(Doc:table, Line:num, Character:num):table
+   line_text = getLine(Doc, Line)
+   if not line_text or Character >= #line_text then return nil end
+
+   pos = 0
+   while pos < #line_text do
+      c = line_text:sub(pos, pos + 1)
+      if c is '"' or c is "'" then
+         quote = c
+         start_pos = pos
+         pos++
+
+         while pos < #line_text do
+            sc = line_text:sub(pos, pos + 1)
+            if sc is '\\' and pos + 1 < #line_text then
+               pos += 2
+            elseif sc is quote then
+               if Character > start_pos and Character < pos then
+                  return {
+                     text = line_text:sub(start_pos + 1, pos),
+                     quoteStart = start_pos,
+                     quoteEnd = pos,
+                     before = line_text:sub(0, start_pos)
+                  }
+               end
+               break
+            else
+               pos++
+            end
+         end
+      end
+      pos++
+   end
+
+   return nil
+end
+
+function getLoaderStringAtPosition(Doc:table, Position:table):table
+   string_info = getStringAtPosition(Doc, Position.line, Position.character)
+   string_info ?? return nil
+
+   keyword = rx_def_loader_before.extract(string_info.before)
+   keyword ?? return nil
+
+   string_info.keyword = keyword
+   return string_info
+end
+
+function getObjNewStringAtPosition(Doc:table, Position:table):table
+   string_info = getStringAtPosition(Doc, Position.line, Position.character)
+   string_info ?? return nil
+   if rx_def_obj_new_before.test(string_info.before) then return string_info end
+   return nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Current Document Symbols
+
+function addSymbol(Symbols:array, Name:str, Kind:str, Line:num, StartChar:num, EndChar:num)
+   if not Name or Name is '' then return end
+   Symbols:push({
+      name = Name,
+      kind = Kind,
+      line = Line,
+      startChar = StartChar,
+      endChar = EndChar,
+      range = {
+         start = { line = Line, character = StartChar },
+         ['end'] = { line = Line, character = EndChar }
+      }
+   })
+end
+
+function addFunctionParameters(Symbols:array, Params:str, LineText:str, Line:num, SearchFrom:num)
+   Params ?? return
+   scan_from = SearchFrom or 0
+
+   for start, stop, cap in rx_def_param.findAll(Params) do
+      name = cap[0]
+      if name and name != '' then
+         name_start = LineText:find(name, scan_from, true)
+         if name_start then
+            addSymbol(Symbols, name, 'parameter', Line, name_start, name_start + #name)
+            scan_from = name_start + #name
+         end
+      end
+   end
+end
+
+global function extractDefinitionSymbols(Doc:table):array
+   symbols = array<table>
+   total_lines = getTotalLines(Doc)
+   in_block_comment = false
+
+   for line_num = 0, total_lines - 1 do
+      line_text = getLine(Doc, line_num)
+      line_code, in_block_comment = maskNonCode(line_text, in_block_comment)
+
+      for start, stop, cap in rx_def_func.findAll(line_code) do
+         name = cap[0]
+         params = cap[1]
+         name_start = line_text:find(name, start, true) or start
+         addSymbol(symbols, name, 'function', line_num, name_start, name_start + #name)
+
+         paren_start = line_text:find('(', name_start + #name, true)
+         if paren_start then
+            addFunctionParameters(symbols, params, line_text, line_num, paren_start + 1)
+         end
+      end
+
+      for start, stop, cap in rx_def_assign_func.findAll(line_code) do
+         name = cap[0]
+         params = cap[1]
+         name_start = line_text:find(name, start, true) or start
+         addSymbol(symbols, name, 'function', line_num, name_start, name_start + #name)
+
+         paren_start = line_text:find('(', name_start + #name, true)
+         if paren_start then
+            addFunctionParameters(symbols, params, line_text, line_num, paren_start + 1)
+         end
+      end
+
+      for start, stop, cap in rx_def_decl.findAll(line_code) do
+         name = cap[1]
+         if name and name != 'function' then
+            name_start = line_text:find(name, start, true) or start
+            addSymbol(symbols, name, 'variable', line_num, name_start, name_start + #name)
+         end
+      end
+
+      for start, stop, cap in rx_def_assign.findAll(line_code) do
+         name = cap[0]
+         if name and name != 'local' and name != 'global' and not rx_def_trailing_comma.test(line_code) then
+            name_start = line_text:find(name, start, true) or start
+            eq_pos = line_text:find('=', name_start + #name, true)
+            next_char = eq_pos and line_text:sub(eq_pos + 1, eq_pos + 2) or ''
+
+            if eq_pos and next_char != '=' and next_char != '>' then
+               addSymbol(symbols, name, 'variable', line_num, name_start, name_start + #name)
+            end
+         end
+      end
+   end
+
+   return symbols
+end
+
+function isSymbolBefore(Symbol:table, Position:table):bool
+   if Symbol.line < Position.line then return true end
+   if Symbol.line is Position.line and Symbol.startChar <= Position.character then return true end
+   return false
+end
+
+function symbolNameMatches(SymbolName:str, TokenInfo:table):bool
+   token = TokenInfo.text
+   if SymbolName is token then return true end
+
+   if TokenInfo.object then
+      if SymbolName is TokenInfo.object .. '.' .. token then return true end
+      if SymbolName is TokenInfo.object .. ':' .. token then return true end
+   end
+
+   if SymbolName:endsWith('.' .. token) or SymbolName:endsWith(':' .. token) then return true end
+   return false
+end
+
+function resolveDocumentSymbolDefinition(Doc:table, TokenInfo:table, Position:table):array
+   TokenInfo ?? return nil
+
+   symbols = extractDefinitionSymbols(Doc)
+   best = nil
+   fallback_function = nil
+
+   for symbol in values(symbols) do
+      if symbolNameMatches(symbol.name, TokenInfo) then
+         if symbol.kind is 'function' and not fallback_function then
+            fallback_function = symbol
+         end
+
+         if isSymbolBefore(symbol, Position) then
+            if not best or symbol.line > best.line or
+                  (symbol.line is best.line and symbol.startChar > best.startChar) then
+               best = symbol
+            end
+         end
+      end
+   end
+
+   best ?= fallback_function
+   best ?? return nil
+
+   locations = array<table>
+   pushLocation(locations, makeDocLocation(Doc, best.line, best.startChar, best.line, best.endChar))
+   return locations
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Import, Require and Include Targets
+
+function normaliseModuleName(Name:str):str
+   if not Name or not glDocCache or not glDocCache.modules then return nil end
+   for module_name, entry in pairs(glDocCache.modules) do
+      if module_name:lower() is Name:lower() then return module_name end
+   end
+   return nil
+end
+
+function resolveScriptImport(Doc:table, Name:str):table
+   candidates = array<string>
+   doc_path = lspUriToPath(Doc.uri)
+   base_path = getParentPath(doc_path)
+   script_name = Name:endsWith('.tiri') and Name or (Name .. '.tiri')
+
+   if Name:startsWith('./') or Name:startsWith('../') then
+      candidates:push(base_path .. script_name)
+   end
+
+   candidates:push('sdk:scripts/' .. script_name)
+   candidates:push('scripts:' .. script_name)
+
+   for candidate in values(candidates) do
+      resolved = resolveExistingPath(candidate)
+      if resolved then return makeLocation(resolved, 0, 0, 0, 0) end
+   end
+
+   return nil
+end
+
+function resolveLoaderDefinition(Doc:table, Position:table):array
+   string_info = getLoaderStringAtPosition(Doc, Position)
+   string_info ?? return nil
+
+   locations = array<table>
+
+   if string_info.keyword is 'include' then
+      module_name = normaliseModuleName(string_info.text)
+      if module_name then
+         module_doc = glDocCache.modules[module_name]
+         pushLocation(locations, makeXmlLocation(module_doc, module_doc.byteStart, module_doc.byteEnd))
+      end
+   else
+      pushLocation(locations, resolveScriptImport(Doc, string_info.text))
+   end
+
+   if #locations > 0 then return locations end
+   return nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Kotuku API Targets
+
+function normaliseClassName(Name:str):str
+   if not Name or not glDocCache or not glDocCache.classes then return nil end
+   if glDocCache.classes[Name] then return Name end
+
+   for class_name, entry in pairs(glDocCache.classes) do
+      if class_name:lower() is Name:lower() then return class_name end
+   end
+
+   capitalised = Name:sub(0, 1):upper() .. Name:sub(1)
+   if glDocCache.classes[capitalised] then return capitalised end
+
+   return nil
+end
+
+function buildDefinitionTypeMap(Doc:table):table
+   type_map = {}
+
+   for start, stop, cap in rx_def_obj_new.findAll(Doc.content) do
+      local var_name, class_name = cap[0], cap[1]
+      normalised = normaliseClassName(class_name)
+      if var_name and normalised then type_map[var_name] = normalised end
+   end
+
+   return type_map
+end
+
+function addSourceFallback(Locations:array, ApiEntry:table)
+   if not ApiEntry or not ApiEntry.sources or not ApiEntry.module then return end
+
+   module_folder = ApiEntry.module:lower()
+   for source in values(ApiEntry.sources) do
+      if source.file and source.file != '' then
+         candidate = 'sdk:src/' .. module_folder .. '/' .. (source.path or '') .. source.file
+         resolved = resolveExistingPath(candidate)
+         if resolved then
+            pushLocation(Locations, makeLocation(resolved, 0, 0, 0, 0))
+            return
+         end
+      end
+   end
+end
+
+function resolveClassDefinition(ClassName:str):array
+   class_name = normaliseClassName(ClassName)
+   class_name ?? return nil
+
+   class_doc = glDocCache.classes[class_name]
+   locations = array<table>
+   pushLocation(locations, makeXmlLocation(class_doc, class_doc.byteStart, class_doc.byteEnd))
+   addSourceFallback(locations, class_doc)
+   return #locations > 0 and locations or nil
+end
+
+function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
+   if not TokenInfo or not TokenInfo.object or not glDocCache then return nil end
+
+   token = TokenInfo.text
+   object_name = TokenInfo.object
+   type_map = buildDefinitionTypeMap(Doc)
+   class_name = type_map[object_name] ?? normaliseClassName(object_name)
+
+   if class_name then
+      class_doc = glDocCache.classes[class_name]
+      if class_doc then
+         locations = array<table>
+
+         if rx_def_action_prefix.test(token) then
+            action_name = token:sub(2)
+            if class_doc.actions and class_doc.actions[action_name] then
+               action_doc = decodeMethod(class_doc.actions[action_name])
+               pushLocation(locations, makeXmlLocation(class_doc, action_doc.byteStart, action_doc.byteEnd))
+            end
+         end
+
+         if #locations is 0 and rx_def_method_prefix.test(token) then
+            method_name = token:sub(2)
+            if class_doc.methods and class_doc.methods[method_name] then
+               method_doc = decodeMethod(class_doc.methods[method_name])
+               pushLocation(locations, makeXmlLocation(class_doc, method_doc.byteStart, method_doc.byteEnd))
+            end
+         end
+
+         if #locations is 0 and class_doc.methods and class_doc.methods[token] then
+            method_doc = decodeMethod(class_doc.methods[token])
+            pushLocation(locations, makeXmlLocation(class_doc, method_doc.byteStart, method_doc.byteEnd))
+         end
+
+         if #locations is 0 and class_doc.actions and class_doc.actions[token] then
+            action_doc = decodeMethod(class_doc.actions[token])
+            pushLocation(locations, makeXmlLocation(class_doc, action_doc.byteStart, action_doc.byteEnd))
+         end
+
+         if #locations is 0 and class_doc.fields then
+            field_doc = class_doc.fields[token]
+            if not field_doc then
+               field_name = token:sub(0, 1):upper() .. token:sub(1)
+               field_doc = class_doc.fields[field_name]
+            end
+
+            if field_doc then
+               decoded_field = decodeField(field_doc)
+               pushLocation(locations, makeXmlLocation(class_doc, decoded_field.byteStart, decoded_field.byteEnd))
+            end
+         end
+
+         if #locations > 0 then
+            addSourceFallback(locations, class_doc)
+            return locations
+         end
+      end
+   end
+
+   if glDefs?.modulePrefixes?[object_name] then
+      module_name = glDefs.modulePrefixes[object_name]
+      module_doc = glDocCache?.modules?[module_name]
+      func_doc = module_doc?.functions?[token]
+      if module_doc and func_doc then
+         decoded_func = decodeMethod(func_doc)
+         locations = array<table>
+         pushLocation(locations, makeXmlLocation(module_doc, decoded_func.byteStart, decoded_func.byteEnd))
+         return #locations > 0 and locations or nil
+      end
+   end
+
+   return nil
+end
+
+function resolveApiDefinition(Doc:table, Position:table, TokenInfo:table):array
+   obj_new_string = getObjNewStringAtPosition(Doc, Position)
+   if obj_new_string then
+      class_locations = resolveClassDefinition(obj_new_string.text)
+      if class_locations then return class_locations end
+   end
+
+   if TokenInfo then
+      if TokenInfo.context is 'identifier' then
+         class_locations = resolveClassDefinition(TokenInfo.text)
+         if class_locations then return class_locations end
+      end
+
+      member_locations = resolveApiMemberDefinition(Doc, TokenInfo)
+      if member_locations then return member_locations end
+   end
+
+   return nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Public Resolver
+
+global function resolveDefinition(Doc:table, Position:table):array
+   Doc ?? return nil
+   Position ?? return nil
+
+   loader_locations = resolveLoaderDefinition(Doc, Position)
+   if loader_locations then return loader_locations end
+
+   api_string_locations = resolveApiDefinition(Doc, Position, nil)
+   if api_string_locations then return api_string_locations end
+
+   token_info = getTokenAtPosition(Doc, Position.line, Position.character)
+
+   document_locations = resolveDocumentSymbolDefinition(Doc, token_info, Position)
+   if document_locations then return document_locations end
+
+   api_locations = resolveApiDefinition(Doc, Position, token_info)
+   if api_locations then return api_locations end
+
+   return nil
+end

--- a/tools/tiri_lsp/lsp_defs.tiri
+++ b/tools/tiri_lsp/lsp_defs.tiri
@@ -206,14 +206,20 @@ glKeywords = {
    -- Variables
    ['local'] = { comment = 'Declares a local variable (block-scoped).' },
    ['global'] = { comment = 'Declares a global variable.' },
+   ['import'] = { comment = 'Loads a Tiri module into the current scope.' },
 
    -- Pattern matching
    ['choose'] = { comment = 'Pattern matching expression (switch-like).' },
    ['from'] = { comment = 'Specifies the value to match in choose.' },
-   ['when'] = { comment = 'A case in a choose expression.' },
+   ['when'] = { comment = 'A case in a `choose` expression, or a condition filter in an `except` ' ..
+      'clause.' },
 
    -- Special
    ['defer'] = { comment = 'Deferred execution - code runs when scope exits.' },
+   ['try'] = { comment = 'Opens an exception-handling block. Pair with `except`.' },
+   ['except'] = { comment = 'Catches an exception raised by the preceding `try` block. Use `when` ' ..
+      'to filter by condition.' },
+   ['throw'] = { comment = 'Raises an exception. Can be caught by an enclosing `try/except`.' },
    ['catch'] = { comment = 'Error handling block.' },
    ['raise'] = { comment = 'Raises an error or exception.' },
    ['check'] = { comment = 'Error checking statement - raises on failure.' },

--- a/tools/tiri_lsp/lsp_handlers.tiri
+++ b/tools/tiri_lsp/lsp_handlers.tiri
@@ -1,26 +1,11 @@
 
-   -- Deferred regex patterns for keyword matching
+   -- Deferred regex patterns for symbol matching
 
-   rx_kw_function = <{ regex.new([[\bfunction\b]]) }>
-   rx_kw_if       = <{ regex.new([[\bif\b]]) }>
-   rx_kw_then     = <{ regex.new([[\bthen\b]]) }>
-   rx_kw_for      = <{ regex.new([[\bfor\b]]) }>
-   rx_kw_do       = <{ regex.new([[\bdo\b]]) }>
-   rx_kw_while    = <{ regex.new([[\bwhile\b]]) }>
-   rx_kw_repeat   = <{ regex.new([[\brepeat\b]]) }>
-   rx_kw_defer    = <{ regex.new([[\bdefer\b]]) }>
-   rx_kw_end      = <{ regex.new([[\bend\b]]) }>
-   rx_kw_until    = <{ regex.new([[\buntil\b]]) }>
-   rx_block_close = <{ regex.new("\\]\\]") }>
-   rx_block_open  = <{ regex.new("--\\[\\[") }>
    rx_trim_start  = <{ regex.new([[^\s*(.*)]], regex.DOT_ALL) }>
    rx_func_sig    = <{ regex.new([=[function\s+[\w]]=]) }>
    rx_func_name   = <{ regex.new([[^function\s+([\w:.]+)]]) }>
    rx_local_end   = <{ regex.new([[local\s*$]]) }>
    rx_global_end  = <{ regex.new([[global\s*$]]) }>
-   rx_if_then     = <{ regex.new([[\bif\b.*\bthen\b]]) }>
-   rx_for_do      = <{ regex.new([[\bfor\b.*\bdo\b]]) }>
-   rx_while_do    = <{ regex.new([[\bwhile\b.*\bdo\b]]) }>
 
    glNextResultId = 1
 
@@ -64,39 +49,138 @@ function applyTextEdit(Content, Range, NewText)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Replace strings and comments with spaces while preserving byte offsets for range calculations.
+
+function maskNonCode(LineText:str, InBlockComment:bool):<str, bool>
+   result = ''
+   pos = 0
+   len = #LineText
+
+   if InBlockComment then
+      close_pos = LineText:find(']]')
+      if close_pos then
+         result ..= string.rep(' ', close_pos + 2)
+         pos = close_pos + 2
+         InBlockComment = false
+      else
+         return string.rep(' ', len), true
+      end
+   end
+
+   while pos < len do
+      c = LineText:sub(pos, pos + 1)
+      next_two = LineText:sub(pos, pos + 2)
+
+      if c is '"' or c is "'" then
+         quote = c
+         result ..= ' '
+         pos++
+
+         while pos < len do
+            sc = LineText:sub(pos, pos + 1)
+            if sc is '\\' and pos + 1 < len then
+               result ..= '  '
+               pos += 2
+            elseif sc is quote then
+               result ..= ' '
+               pos++
+               break
+            else
+               result ..= ' '
+               pos++
+            end
+         end
+      elseif next_two is '--' then
+         if LineText:sub(pos, pos + 4) is '--[[' then
+            close_pos = LineText:find(']]', pos + 4)
+            if close_pos then
+               result ..= string.rep(' ', close_pos + 2 - pos)
+               pos = close_pos + 2
+            else
+               result ..= string.rep(' ', len - pos)
+               return result, true
+            end
+         else
+            result ..= string.rep(' ', len - pos)
+            return result, false
+         end
+      elseif next_two is '[[' then
+         close_pos = LineText:find(']]', pos + 2)
+         if close_pos then
+            result ..= string.rep(' ', close_pos + 2 - pos)
+            pos = close_pos + 2
+         else
+            result ..= string.rep(' ', len - pos)
+            return result, true
+         end
+      else
+         result ..= c
+         pos++
+      end
+   end
+
+   return result, InBlockComment
+end
+
+function isBlockTokenChar(Char:str):bool
+   return (Char >= 'a' and Char <= 'z') or (Char >= 'A' and Char <= 'Z') or
+      (Char >= '0' and Char <= '9') or Char is '_'
+end
+
+function countBlockKeyword(LineCode:str, Keyword:str):num
+   count = 0
+   pos = 0
+   len = #LineCode
+
+   while pos < len do
+      c = LineCode:sub(pos, pos + 1)
+      if isBlockTokenChar(c) then
+         token_start = pos
+         pos++
+
+         while pos < len and isBlockTokenChar(LineCode:sub(pos, pos + 1)) do
+            pos++
+         end
+
+         if LineCode:sub(token_start, pos) is Keyword then
+            count++
+         end
+      else
+         pos++
+      end
+   end
+
+   return count
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Find the line number of the matching 'end' for a block starting at StartLine
 
 function findMatchingEnd(Doc:table, StartLine:num):num
    depth = 1
    line_num = StartLine + 1
    total_lines = getTotalLines(Doc)
+   in_block_comment = false
 
    while line_num < total_lines do
       line_text = getLine(Doc, line_num)
+      line_code, in_block_comment = maskNonCode(line_text, in_block_comment)
 
-      -- Count block openers (simplified - doesn't handle strings/comments perfectly)
-      for start, stop, cap in rx_kw_function.findAll(line_text) do depth++ end
-      for start, stop, cap in rx_kw_if.findAll(line_text) do
-         if rx_if_then.test(line_text) then
-            depth++
-         end
+      -- Count block openers
+      depth += countBlockKeyword(line_code, 'function')
+      if countBlockKeyword(line_code, 'then') > 0 then
+         depth += countBlockKeyword(line_code, 'if')
       end
-      for start, stop, cap in rx_kw_for.findAll(line_text) do
-         if rx_for_do.test(line_text) then
-            depth++
-         end
+      if countBlockKeyword(line_code, 'do') > 0 then
+         depth += countBlockKeyword(line_code, 'for')
+         depth += countBlockKeyword(line_code, 'while')
       end
-      for start, stop, cap in rx_kw_while.findAll(line_text) do
-         if rx_while_do.test(line_text) then
-            depth++
-         end
-      end
-      for start, stop, cap in rx_kw_repeat.findAll(line_text) do depth++ end
-      for start, stop, cap in rx_kw_defer.findAll(line_text) do depth++ end
+      depth += countBlockKeyword(line_code, 'repeat')
+      depth += countBlockKeyword(line_code, 'defer')
 
       -- Count block closers
-      for start, stop, cap in rx_kw_end.findAll(line_text) do depth -= 1 end
-      for start, stop, cap in rx_kw_until.findAll(line_text) do depth -= 1 end
+      depth -= countBlockKeyword(line_code, 'end')
+      depth -= countBlockKeyword(line_code, 'until')
 
       if depth <= 0 then
          return line_num
@@ -120,44 +204,25 @@ function extractDocumentSymbols(Doc:table):array
 
    for line_num = 0, total_lines - 1 do
       line_text = getLine(Doc, line_num)
-
-      -- Track block comments --[[ ... ]]
-      if in_block_comment then
-         if rx_block_close.test(line_text) then
-            in_block_comment = false
-         end
-         continue
-      end
-
-      -- Check for block comment start
-      if rx_block_open.test(line_text) then
-         in_block_comment = true
-         continue
-      end
+      line_code, in_block_comment = maskNonCode(line_text, in_block_comment)
 
       -- Skip line comments (lines starting with --)
-      trimmed = rx_trim_start.extract(line_text)
-      if trimmed:sub(0, 2) is '--' then
+      trimmed = rx_trim_start.extract(line_code)
+      if trimmed is '' then
          continue
       end
 
       -- Check if 'function' appears before any line comment
-      comment_pos = line_text:find('--')
-      func_start, func_stop = rx_func_sig.findFirst(line_text)
-
-      -- Skip if function keyword is inside a line comment
-      if func_start and comment_pos and comment_pos < func_start then
-         continue
-      end
+      func_start, func_stop = rx_func_sig.findFirst(line_code)
 
       if func_start then
          -- Extract everything after 'function '
-         after_func = line_text:sub(func_start)
+         after_func = line_code:sub(func_start)
          name = rx_func_name.extract(after_func)
 
          if name then
             -- Determine scope by looking before 'function'
-            before_func = line_text:sub(0, func_start)
+            before_func = line_code:sub(0, func_start)
             scope = nil
             if rx_local_end.test(before_func) then
                scope = 'local'
@@ -166,8 +231,8 @@ function extractDocumentSymbols(Doc:table):array
             end
 
             -- Find the column where the name starts (0-based)
-            name_start = line_text:find(name, func_pos, true)
-            name_start = name_start and (name_start - 1) or 0
+            name_start = line_text:find(name, func_start, true)
+            name_start ?= 0
 
             -- Determine symbol kind based on name pattern
             kind = SYMBOL_KIND.FUNCTION
@@ -471,7 +536,8 @@ global function registerCoreHandlers(Self)
          edit_size += (edit.data and #edit.data or 0)
       end
 
-      logVerbose(Self, 'Returning ' .. #edits .. ' edits (' .. edit_size .. ' integers vs ' .. #new_encoded .. ' full), resultId=' .. result_id)
+      logVerbose(Self, 'Returning ' .. #edits .. ' edits (' .. edit_size .. ' integers vs ' .. #new_encoded ..
+         ' full), resultId=' .. result_id)
 
       return {
          jsonrpc = '2.0',

--- a/tools/tiri_lsp/lsp_handlers.tiri
+++ b/tools/tiri_lsp/lsp_handlers.tiri
@@ -51,7 +51,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Replace strings and comments with spaces while preserving byte offsets for range calculations.
 
-function maskNonCode(LineText:str, InBlockComment:bool):<str, bool>
+global function maskNonCode(LineText:str, InBlockComment:bool):<str, bool>
    result = ''
    pos = 0
    len = #LineText
@@ -303,7 +303,9 @@ global function registerCoreHandlers(Self)
                -- Folding ranges for code folding
                foldingRangeProvider = true,
                -- Hover information
-               hoverProvider = true
+               hoverProvider = true,
+               -- Go to Definition
+               definitionProvider = true
             },
             serverInfo = {
                name = 'Tiri LSP Server',
@@ -666,6 +668,44 @@ global function registerCoreHandlers(Self)
                ['end'] = { line = position.line, character = tokenInfo.endCol }
             }
          }
+      }
+   end
+
+   -------------------------------------------------------------------------------------------------------------------
+   -- Go to Definition
+
+   -- textDocument/definition: Return definition locations for the symbol at cursor
+
+   Self._handlers['textDocument/definition'] = function(Msg, State)
+      uri = Msg.params.textDocument.uri
+      position = Msg.params.position
+      doc = glDocuments[uri]
+
+      if not doc then
+         logMessage(Self, 'Definition requested for unknown document: ' .. uri)
+         return {
+            jsonrpc = '2.0',
+            id = Msg.id,
+            result = json.null
+         }
+      end
+
+      locations = resolveDefinition(doc, position)
+
+      if not locations or #locations is 0 then
+         return {
+            jsonrpc = '2.0',
+            id = Msg.id,
+            result = json.null
+         }
+      end
+
+      logVerbose(Self, 'Returning ' .. #locations .. ' definition location(s)')
+
+      return {
+         jsonrpc = '2.0',
+         id = Msg.id,
+         result = locations
       }
    end
 end

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -90,7 +90,7 @@ global function getLine(Doc:table, LineNo:num):str
    if LineNo < 0 or LineNo >= total_lines then return '' end
 
    idx = LineNo * 2
-   return Doc.content:substr(Doc.lineIndex[idx], Doc.lineIndex[idx + 1])
+   return Doc.content:substr(Doc.lineIndex[idx], Doc.lineIndex[idx + 1] + 1)
 end
 
 -- Mark line N and subsequent lines for recomputation.  Currently we are very lazy about this...

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -433,10 +433,11 @@ global function computeDiagnostics(Doc:table)
    return { uri = Doc.uri, version = Doc.version, diagnostics = lsp_diags }
 end
 
-   import './lsp_parsing'
-   import './lsp_handlers'
    import './lsp_cache'
    import './lsp_hover'
+   import './lsp_definition'
+   import './lsp_parsing'
+   import './lsp_handlers'
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Public API
@@ -453,7 +454,20 @@ global function lspInitDocs(DocPath)
    end
 
    -- Load static definitions (builtins, keywords)
-   defsPath = glSelf.workingPath .. 'lsp_defs.tiri'
+   defsPath = nil
+   try
+      defsPath = glSelf.workingPath .. 'lsp_defs.tiri'
+   end
+   if not defsPath or mSys.AnalysePath(defsPath) != ERR_Okay then
+      try
+         defsPath = glSelf.workingPath .. '../lsp_defs.tiri'
+      except ex
+         defsPath = nil
+      end
+   end
+   if not defsPath or mSys.AnalysePath(defsPath) != ERR_Okay then
+      defsPath = 'sdk:tools/tiri_lsp/lsp_defs.tiri'
+   end
    local result
    try
       result = loadFile(defsPath)

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -1,0 +1,136 @@
+global glDefinitionTestUri = nil
+
+@BeforeAll function SetupDefinitionTests(State)
+   local err, sdk_path = mSys.ResolvePath(State.folder .. '../../../')
+   assert(err is ERR_Okay, 'Failed to resolve SDK path for LSP definition tests.')
+   mSys.SetVolume('sdk', sdk_path)
+
+   loadFile('sdk:tools/tiri_lsp/lsp_lib.tiri')
+   assert(lspInitDocs('sdk:docs/xml/'), 'Failed to initialise LSP documentation cache.')
+   glDefinitionTestUri = lspPathToUri('sdk:tools/tiri_lsp/tests/test_definition.tiri')
+   assert(glDefinitionTestUri, 'Failed to create test document URI.')
+end
+
+function makeDoc(Content:str):table
+   return {
+      uri = glDefinitionTestUri,
+      languageId = 'tiri',
+      version = 1,
+      content = Content,
+      lineIndex = nil
+   }
+end
+
+function assertLocationLine(Locations:array, Line:num, Message:str)
+   assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
+   assert(Locations[0].range.start.line is Line,
+      f'{Message}: expected line {Line}, got {Locations[0].range.start.line}')
+end
+
+function assertUriContains(Locations:array, Needle:str, Message:str)
+   assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
+   uri = Locations[0].uri:replace('\\', '/'):lower()
+   assert(uri:find(Needle:lower(), 0, true), f'{Message}: expected URI to contain {Needle}, got {Locations[0].uri}')
+end
+
+@Test function CurrentDocumentFunction()
+   doc = makeDoc('local function alpha(Value)\n   return Value\nend\n\nresult = alpha(5)\n')
+   locations = resolveDefinition(doc, { line = 4, character = 10 })
+   assertLocationLine(locations, 0, 'Function call should resolve to local function definition')
+end
+
+@Test function CurrentDocumentVariable()
+   doc = makeDoc('local answer = 42\nprint(answer)\n')
+   locations = resolveDefinition(doc, { line = 1, character = 7 })
+   assertLocationLine(locations, 0, 'Variable use should resolve to local declaration')
+end
+
+@Test function CurrentDocumentImplicitVariable()
+   doc = makeDoc('win = gui.window({ title = "Test" })\nprint(win)\n')
+   locations = resolveDefinition(doc, { line = 1, character = 7 })
+   assertLocationLine(locations, 0, 'Implicit variable use should resolve to assignment declaration')
+end
+
+@Test function TableKeyNotTreatedAsDeclaration()
+   doc = makeDoc('y = 10\ntbl = {\n   y = y,\n}\nprint(y)\n')
+   locations = resolveDefinition(doc, { line = 4, character = 7 })
+   assertLocationLine(locations, 0, 'Variable use should resolve to the top-level assignment, not the table key')
+end
+
+@Test function CurrentDocumentParameter()
+   doc = makeDoc('function sample(Input)\n   print(Input)\nend\n')
+   locations = resolveDefinition(doc, { line = 1, character = 10 })
+   assertLocationLine(locations, 0, 'Parameter use should resolve to function parameter')
+end
+
+@Test function UnknownIdentifier()
+   doc = makeDoc('print(missing_symbol)\n')
+   locations = resolveDefinition(doc, { line = 0, character = 8 })
+   assert(not locations, 'Unknown identifiers should not resolve.')
+end
+
+@Test function ImportScriptResolution()
+   doc = makeDoc("import 'json'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 9 })
+   assertUriContains(locations, '/scripts/json.tiri', 'Import should resolve to SDK script')
+end
+
+@Test function ImportNestedScriptResolution()
+   doc = makeDoc("import 'gui/window'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 12 })
+   assertUriContains(locations, '/scripts/gui/window.tiri', 'Nested import should resolve to SDK script')
+end
+
+@Test function IncludeModuleResolution()
+   doc = makeDoc("include 'network'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 10 })
+   assertUriContains(locations, '/docs/xml/modules/network.xml', 'Include should resolve to module documentation')
+end
+
+@Test function ObjectClassResolution()
+   doc = makeDoc("xml = obj.new('xml')\n")
+   locations = resolveDefinition(doc, { line = 0, character = 16 })
+   assertUriContains(locations, '/docs/xml/modules/classes/xml.xml', 'obj.new class literal should resolve to class docs')
+end
+
+@Test function ObjectActionResolution()
+   doc = makeDoc("xml = obj.new('xml')\nxml.acClear()\n")
+   locations = resolveDefinition(doc, { line = 1, character = 6 })
+   assertUriContains(locations, '/docs/xml/modules/classes/xml.xml', 'Object action should resolve to class docs')
+   assert(locations[0].range.start.line > 30, 'Object action should resolve below the XML class info section.')
+end
+
+@Test function ModuleFunctionResolution()
+   doc = makeDoc('mSys.WaitTime(0.1)\n')
+   locations = resolveDefinition(doc, { line = 0, character = 7 })
+   assertUriContains(locations, '/docs/xml/modules/core.xml', 'Module function should resolve to module docs')
+end
+
+@Test function HandlerAdvertisesAndResolvesDefinition()
+   server = {
+      _handlers = {},
+      verbose = false,
+      logMessage = function(Message) end
+   }
+   registerCoreHandlers(server)
+
+   init = server._handlers['initialize']({ jsonrpc = '2.0', id = 1, params = {} }, {})
+   assert(init.result.capabilities.definitionProvider is true, 'Server must advertise definitionProvider.')
+
+   doc = makeDoc('local function beta()\nend\n\nbeta()\n')
+   glDocuments[doc.uri] = doc
+
+   response = server._handlers['textDocument/definition']({
+      jsonrpc = '2.0',
+      id = 2,
+      params = {
+         textDocument = { uri = doc.uri },
+         position = { line = 3, character = 1 }
+      }
+   }, {})
+
+   glDocuments[doc.uri] = nil
+
+   assert(response.result and #response.result > 0, 'Definition handler should return a location array.')
+   assert(response.result[0].range.start.line is 0, 'Definition handler should resolve through resolver.')
+end

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -57,6 +57,12 @@ end
    assertLocationLine(locations, 0, 'Variable use should resolve to the top-level assignment, not the table key')
 end
 
+@Test function LastTableKeyNotTreatedAsDeclaration()
+   doc = makeDoc('y = 10\ntbl = {\n   x = 1,\n   y = y\n}\nprint(y)\n')
+   locations = resolveDefinition(doc, { line = 5, character = 7 })
+   assertLocationLine(locations, 0, 'Variable use should ignore the final table key without a trailing comma')
+end
+
 @Test function CurrentDocumentParameter()
    doc = makeDoc('function sample(Input)\n   print(Input)\nend\n')
    locations = resolveDefinition(doc, { line = 1, character = 10 })

--- a/tools/tiri_lsp/vscode_plugin/README.md
+++ b/tools/tiri_lsp/vscode_plugin/README.md
@@ -13,6 +13,8 @@ npm install
 
 ### 2. LSP Server Startup
 
+Ensure that the release version of `origo` is available for execution in your terminal.  If not, check that Kōtuku is installed correctly and that the `origo` folder is referenced in the `PATH` environment variable.
+
 By default, the extension looks for an existing Tiri LSP server on port 5007.  This commandline starts the server manually with the default port:
 
 ```bash


### PR DESCRIPTION
## Summary

* Implements `textDocument/definition` (Go to Definition) for the Tiri LSP server, covering local symbols, function parameters, `import`/`require`/`include` targets, `obj.new` class literals, and Kōtuku API members (actions, methods, fields, module functions)
* Extends the documentation cache (version bump to 2) to store `byteStart`/`byteEnd` byte offsets and `<source>` file paths for modules and classes, enabling precise location links into XML docs and C++ source files
* Adds `tools/tiri_lsp/CMakeLists.txt` to integrate VS Code plugin build targets (`tiri_lsp_vscode_plugin`, `tiri_lsp_vscode_plugin_vsix`) and register the definition Flute test suite
* Bug fixes to `lsp_defs.tiri` and `lsp_handlers.tiri` from prior session

## Test plan

- [ ] Build the project and run the Flute test suite: `build/agents-install/origo tools/flute.tiri file=tools/tiri_lsp/tests/test_definition.tiri --log-warning`
- [ ] Verify all 13 definition tests pass (local function, variable, parameter, import, include, obj.new class, action, module function, handler advertisement)
- [ ] Open a `.tiri` file in VS Code with the plugin active and confirm F12 / Go to Definition navigates correctly for local symbols and SDK imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)