### PR TITLE
[Fix] Improve module expunge sub-class tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,10 +310,14 @@ function (idl_gen)
          list (APPEND IDLC_ARGS "files={" ${IDLC_FILES} "}")
       endif ()
 
+      list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo
+         "[idl_gen] ${ORIGO_CMD} ${IDL_C_SCRIPT} --log-warning src=${ARGV0} output=${IDLC_OUTPUT} sdk=${PROJECT_SOURCE_DIR} ${IDLC_ARGS}")
       list (APPEND COMMAND_LIST COMMAND ${ORIGO_CMD} ${IDL_C_SCRIPT} "--log-warning" "src=${ARGV0}"
          "output=${IDLC_OUTPUT}" "sdk=${PROJECT_SOURCE_DIR}" ${IDLC_ARGS})
 
       if (DEFINED IDLC_APPEND_IDL)
+         list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo
+            "[idl_gen] ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} --log-warning src=${ARGV0} output=${IDLC_APPEND_IDL} sdk=${PROJECT_SOURCE_DIR} format=c append")
          list (APPEND COMMAND_LIST COMMAND ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} "--log-warning" "src=${ARGV0}"
             "output=${IDLC_APPEND_IDL}" "sdk=${PROJECT_SOURCE_DIR}" "format=c" "append")
       endif ()
@@ -348,6 +352,8 @@ function (idl_compile)
       endif ()
 
       add_custom_command (OUTPUT ${IDLC_OUTPUT}
+         COMMAND ${CMAKE_COMMAND} -E echo
+            "[idl_compile] ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} --log-warning src=${ARGV0} output=${IDLC_OUTPUT} sdk=${PROJECT_SOURCE_DIR} format=c ${IDLC_ARGS}"
          COMMAND "${ORIGO_CMD}" "${IDL_COMPILE_SCRIPT}" "--log-warning" "src=${ARGV0}" "output=${IDLC_OUTPUT}" "sdk=${PROJECT_SOURCE_DIR}" "format=c" ${IDLC_ARGS}
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
          DEPENDS ${ARGV0}

--- a/docs/xml/modules/classes/compression.xml
+++ b/docs/xml/modules/classes/compression.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Core</module>
     <comment>Compresses data into archives, supporting a variety of compression formats.</comment>
-    <fileExtension>*.zip</fileExtension>
+    <fileExtension>zip</fileExtension>
     <fileDescription>ZIP File</fileDescription>
     <version>1</version>
     <id>2aebea46</id>

--- a/docs/xml/modules/classes/config.xml
+++ b/docs/xml/modules/classes/config.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Core</module>
     <comment>Manages the reading and writing of configuration files.</comment>
-    <fileExtension>*.cfg|*.cnf|*.config</fileExtension>
+    <fileExtension>cfg|cnf|config</fileExtension>
     <fileDescription>Config File</fileDescription>
     <version>1</version>
     <id>abba1e78</id>

--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Document</module>
     <comment>Provides document display and editing facilities.</comment>
-    <fileExtension>*.rpl|*.ripple|*.ripl</fileExtension>
+    <fileExtension>rpl|ripple|ripl</fileExtension>
     <version>1</version>
     <id>9989342d</id>
     <idstring>DOCUMENT</idstring>

--- a/docs/xml/modules/classes/font.xml
+++ b/docs/xml/modules/classes/font.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Font</module>
     <comment>Draws bitmap fonts and manages font meta information.</comment>
-    <fileExtension>*.font|*.fnt|*.ttf|*.fon</fileExtension>
+    <fileExtension>font|fnt|ttf|fon</fileExtension>
     <fileDescription>Font</fileDescription>
     <version>1</version>
     <id>58644726</id>

--- a/docs/xml/modules/classes/module.xml
+++ b/docs/xml/modules/classes/module.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Core</module>
     <comment>Manages the loading of system libraries.</comment>
-    <fileExtension>*.mod|*.so|*.dll</fileExtension>
+    <fileExtension>mod|so|dll</fileExtension>
     <fileDescription>System Module</fileDescription>
     <version>1</version>
     <id>cd79e511</id>

--- a/docs/xml/modules/classes/picture.xml
+++ b/docs/xml/modules/classes/picture.xml
@@ -7,8 +7,8 @@
     <type>class</type>
     <module>Picture</module>
     <comment>Loads and saves picture files in a variety of different data formats.</comment>
-    <fileExtension>*.png</fileExtension>
-    <fileDescription>PNG Picture</fileDescription>
+    <fileExtension>png</fileExtension>
+    <fileDescription>PNG Image</fileDescription>
     <version>1</version>
     <id>4f77ddf7</id>
     <idstring>PICTURE</idstring>

--- a/docs/xml/modules/classes/sound.xml
+++ b/docs/xml/modules/classes/sound.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Audio</module>
     <comment>High-level audio sample playback interface with intelligent resource management and format detection.</comment>
-    <fileExtension>*.wav|*.wave|*.snd</fileExtension>
+    <fileExtension>wav|wave|snd</fileExtension>
     <fileDescription>Sound Sample</fileDescription>
     <version>1</version>
     <id>825a6b79</id>

--- a/docs/xml/modules/classes/svg.xml
+++ b/docs/xml/modules/classes/svg.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>SVG</module>
     <comment>Provides comprehensive support for parsing, rendering and animating SVG documents.</comment>
-    <fileExtension>*.svg</fileExtension>
+    <fileExtension>svg</fileExtension>
     <fileDescription>Scalable Vector Graphics (SVG)</fileDescription>
     <version>1</version>
     <id>bf531772</id>

--- a/docs/xml/modules/classes/task.xml
+++ b/docs/xml/modules/classes/task.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>Core</module>
     <comment>System processes are managed by the Task class.</comment>
-    <fileExtension>*.exe|*.bat|*.com</fileExtension>
+    <fileExtension>exe|bat|com</fileExtension>
     <fileDescription>Executable File</fileDescription>
     <version>1</version>
     <id>56332d91</id>

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>XML</module>
     <comment>Provides an interface for the management of structured data.</comment>
-    <fileExtension>*.xml</fileExtension>
+    <fileExtension>xml</fileExtension>
     <fileDescription>Extendable Markup Language (XML)</fileDescription>
     <version>1</version>
     <id>6293d85f</id>

--- a/docs/xml/modules/classes/xquery.xml
+++ b/docs/xml/modules/classes/xquery.xml
@@ -7,7 +7,7 @@
     <type>class</type>
     <module>XQuery</module>
     <comment>Provides an interface for XQuery evaluation and execution.</comment>
-    <fileExtension>*.xqm|*.xq</fileExtension>
+    <fileExtension>xqm|xq</fileExtension>
     <fileDescription>XQuery Module</fileDescription>
     <version>1</version>
     <id>58128f50</id>

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -242,18 +242,15 @@ ERR CLASS_Free(extMetaClass *Self)
    if (Self->ClassID != CLASSID::NIL) glClassMap.erase(Self->ClassID);
    if (Self->Location) { FreeResource(Self->Location); Self->Location = nullptr; }
 
-#ifndef KOTUKU_STATIC
    if (not Self->SubClasses.empty()) {
       // Sanity check - if a base has sub-classes present then there is an issue that requires resolution.
       // Note that for static builds there is no way to control termination order, so these controls are disabled.
-      kt::Log log;
-      log.warning("Out-of-order termination: Base-class %s has %d active sub-classes.", Self->ClassName, int(Self->SubClasses.size()));
+      kt::Log().warning("Out-of-order termination: Base-class %s has %d active sub-classes.", Self->ClassName, int(Self->SubClasses.size()));
    }
 
    if (Self->Base) {
       std::erase_if(Self->Base->SubClasses, [Self](extMetaClass *Cmp) { return Cmp IS Self; });
    }
-#endif
 
    Self->~extMetaClass();
    return ERR::Okay;

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -243,7 +243,7 @@ ERR CLASS_Free(extMetaClass *Self)
    if (Self->Location) { FreeResource(Self->Location); Self->Location = nullptr; }
 
 #ifndef KOTUKU_STATIC
-   if (!Self->SubClasses.empty()) {
+   if (not Self->SubClasses.empty()) {
       // Sanity check - if a base has sub-classes present then there is an issue that requires resolution.
       // Note that for static builds there is no way to control termination order, so these controls are disabled.
       kt::Log log;

--- a/src/core/core_close.cpp
+++ b/src/core/core_close.cpp
@@ -334,8 +334,7 @@ __export void Expunge(int16_t Force)
                auto mem = glPrivateMemory.find(id);
                if (mem IS glPrivateMemory.end()) continue;
 
-               auto mc = (extMetaClass *)mem->second.Address;
-               if ((mc) and (mc->classID() IS CLASSID::METACLASS)) {
+               if (auto mc = (extMetaClass *)mem->second.Address; (mc) and (mc->classID() IS CLASSID::METACLASS)) {
                   if (mc->OpenCount > 0) {
                      log.msg("Module %s manages a class that is in use - Class: %s, Count: %d.", mod_master->Name.c_str(), mc->ClassName, mc->OpenCount);
                      class_in_use = true;

--- a/src/core/core_close.cpp
+++ b/src/core/core_close.cpp
@@ -8,17 +8,17 @@ static void free_classes(void)
    #ifdef __ANDROID__
    if (glAssetClass) { FreeResource(glAssetClass); glAssetClass = 0; }
    #endif
-   if (glCompressedStreamClass) { FreeResource(glCompressedStreamClass); glCompressedStreamClass  = 0; }
-   if (glArchiveClass)      { FreeResource(glArchiveClass);      glArchiveClass      = 0; }
-   if (glCompressionClass)  { FreeResource(glCompressionClass);  glCompressionClass  = 0; }
-   if (glScriptClass)       { FreeResource(glScriptClass);       glScriptClass       = 0; }
-   if (glFileClass)         { FreeResource(glFileClass);         glFileClass         = 0; }
-   if (glStorageClass)      { FreeResource(glStorageClass);      glStorageClass      = 0; }
-   if (glConfigClass)       { FreeResource(glConfigClass);       glConfigClass       = 0; }
-   if (glTimeClass)         { FreeResource(glTimeClass);         glTimeClass         = 0; }
-   if (glModuleClass)       { FreeResource(glModuleClass);       glModuleClass       = 0; }
-   if (glThreadClass)       { FreeResource(glThreadClass);       glThreadClass       = 0; }
-   if (glRootModuleClass)   { FreeResource(glRootModuleClass);   glRootModuleClass   = 0; }
+   if (glCompressedStreamClass) { FreeResource(glCompressedStreamClass); glCompressedStreamClass  = nullptr; }
+   if (glArchiveClass)      { FreeResource(glArchiveClass);      glArchiveClass      = nullptr; }
+   if (glCompressionClass)  { FreeResource(glCompressionClass);  glCompressionClass  = nullptr; }
+   if (glScriptClass)       { FreeResource(glScriptClass);       glScriptClass       = nullptr; }
+   if (glFileClass)         { FreeResource(glFileClass);         glFileClass         = nullptr; }
+   if (glStorageClass)      { FreeResource(glStorageClass);      glStorageClass      = nullptr; }
+   if (glConfigClass)       { FreeResource(glConfigClass);       glConfigClass       = nullptr; }
+   if (glTimeClass)         { FreeResource(glTimeClass);         glTimeClass         = nullptr; }
+   if (glModuleClass)       { FreeResource(glModuleClass);       glModuleClass       = nullptr; }
+   if (glThreadClass)       { FreeResource(glThreadClass);       glThreadClass       = nullptr; }
+   if (glRootModuleClass)   { FreeResource(glRootModuleClass);   glRootModuleClass   = nullptr; }
 }
 
 //********************************************************************************************************************
@@ -335,9 +335,22 @@ __export void Expunge(int16_t Force)
                if (mem IS glPrivateMemory.end()) continue;
 
                auto mc = (extMetaClass *)mem->second.Address;
-               if ((mc) and (mc->classID() IS CLASSID::METACLASS) and (mc->OpenCount > 0)) {
-                  log.msg("Module %s manages a class that is in use - Class: %s, Count: %d.", mod_master->Name.c_str(), mc->ClassName, mc->OpenCount);
-                  class_in_use = true;
+               if ((mc) and (mc->classID() IS CLASSID::METACLASS)) {
+                  if (mc->OpenCount > 0) {
+                     log.msg("Module %s manages a class that is in use - Class: %s, Count: %d.", mod_master->Name.c_str(), mc->ClassName, mc->OpenCount);
+                     class_in_use = true;
+                  }
+                  else if (not mc->SubClasses.empty()) {
+                     int ext_count = 0;
+                     for (auto & sc : mc->SubClasses) {
+                        if (sc->ownerID() != mod_master->UID) ext_count++;
+                     }
+
+                     if (ext_count > 0) {
+                        log.msg("Module %s manages a class with active sub-classes - Class: %s, Count: %d.", mod_master->Name.c_str(), mc->ClassName, ext_count);
+                        class_in_use = true;
+                     }
+                  }
                }
             }
 

--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -38,6 +38,7 @@ if (BUILD_DEFS) # Customised idl_c() equivalent, this is for defining the output
       "${DOCS}/modules/classes/display.xml"
       "${DOCS}/modules/classes/pointer.xml"
       "${DOCS}/modules/classes/surface.xml"
+      ${COMMAND_LIST}
       COMMAND ${ORIGO_CMD} ${IDL_C_SCRIPT} "--log-warning" "src=${MOD}.tdl" "sdk=${PROJECT_SOURCE_DIR}"
               "output-proto=prototypes.h" "output-defs=module_def.c" "files={" ${FUNCTIONS} "lib_surfaces.cpp" "}"
       COMMAND ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} "--log-warning" "src=${MOD}.tdl" "output=${CMAKE_CURRENT_SOURCE_DIR}/idl.h"

--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -27,6 +27,9 @@ set (DISPLAY_DEFS # Full paths are required for add_custom_command() dependencie
    "${CMAKE_CURRENT_SOURCE_DIR}/class_surface/surface_def.c")
 
 if (BUILD_DEFS) # Customised idl_c() equivalent, this is for defining the output from the TDL file
+   list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo "[idl_c] ${ORIGO_CMD} ${IDL_C_SCRIPT} --log-warning src=${MOD}.tdl sdk=${PROJECT_SOURCE_DIR} output-proto=prototypes.h output-defs=module_def.c files={ ${FUNCTIONS} lib_surfaces.cpp }")
+   list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo "[idl_comp] ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} --log-warning src=${MOD}.tdl output=${CMAKE_CURRENT_SOURCE_DIR}/idl.h sdk=${PROJECT_SOURCE_DIR} format=c")
+
    add_custom_command (OUTPUT
       ${DISPLAY_DEFS}
       "${DOCS}/modules/classes/bitmap.xml"


### PR DESCRIPTION
* src/core/core_close.cpp: Replace integer 0 with nullptr when nullifying global class pointers
* src/core/core_close.cpp: Extend Expunge() to detect classes with active sub-classes owned by other modules, preventing premature unloading
* src/core/classes/class_metaclass.cpp: Replace ! operator with not keyword per coding standards
* CMakeLists.txt: Add echo commands before idl_gen and idl_compile custom commands to improve build-time diagnostics
* src/display/CMakeLists.txt: Add echo commands for display module IDL build steps
* docs/xml/modules/classes/*.xml: Remove glob wildcard prefix from fileExtension values (e.g. *.zip -> zip)