### PR TITLE
Add --log-file option to redirect log output to a file

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -23,6 +23,7 @@ This documentation is intended for technical reference and is not suitable as an
 #include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <string.h>
 
 #ifdef _MSC_VER
  #include <io.h>
@@ -76,13 +77,18 @@ This documentation is intended for technical reference and is not suitable as an
 #include "defs.h"
 #include <kotuku/modules/core.h>
 
+static FILE *log_output(void)
+{
+   return glLogFile ? glLogFile : stderr;
+}
+
 #ifndef NDEBUG // KMSG() prints straight to stderr without going through the log.
 #define KMSG(...) //fprintf(stderr, __VA_ARGS__)
 #else
 #define KMSG(...)
 #endif
 
-#define KERR(...) fprintf(stderr, __VA_ARGS__)
+#define KERR(...) fprintf(log_output(), __VA_ARGS__)
 
 #ifdef __unix__
 [[maybe_unused]] static void CrashHandler(int, siginfo_t *, APTR);
@@ -113,6 +119,7 @@ int InitCore(void);
 __export void CloseCore(void);
 __export ERR OpenCore(OpenInfo *, struct CoreBase **);
 static ERR init_volumes(const std::forward_list<std::string> &);
+static ERR set_log_file(CSTRING);
 
 #ifdef _WIN32
 #define DLLCALL // __declspec(dllimport)
@@ -139,6 +146,26 @@ static void print_class_list(void)
       out << v.Name << " ";
    }
    log.msg("Total: %d, %s", (int)glClassDB.size(), out.str().c_str());
+}
+
+//********************************************************************************************************************
+
+static ERR set_log_file(CSTRING Path)
+{
+   if ((!Path) or (!Path[0])) {
+      fprintf(stderr, "No path specified for --log-file.\n");
+      return ERR::Args;
+   }
+
+   FILE *file = fopen(Path, "w");
+   if (!file) {
+      fprintf(stderr, "Failed to open log file '%s': %s\n", Path, strerror(errno));
+      return ERR::OpenFile;
+   }
+
+   if (glLogFile) fclose(glLogFile);
+   glLogFile = file;
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -169,7 +196,7 @@ ERR OpenCore(OpenInfo *Info, struct CoreBase **JumpTable)
    tlMainThread = true;
    glCodeIndex  = 0; // Reset the code index so that CloseCore() will work.
 
-   if (glProcessID) fprintf(stderr, "Core module has already been initialised (OpenCore() called more than once.)\n");
+   if (glProcessID) fprintf(log_output(), "Core module has already been initialised (OpenCore() called more than once.)\n");
 
 #ifdef __unix__
    // Record the 'original' user id and group id, which we need to know in case the binary has been run with the suid
@@ -248,7 +275,7 @@ ERR OpenCore(OpenInfo *Info, struct CoreBase **JumpTable)
          if (winGetExeDirectory(sizeof(buffer), buffer)) glRootPath = buffer;
          else if (winGetCurrentDirectory(sizeof(buffer), buffer)) glRootPath = buffer;
          else {
-            fprintf(stderr, "Failed to determine root folder.\n");
+            fprintf(log_output(), "Failed to determine root folder.\n");
             return ERR::SystemCall;
          }
          if (glRootPath.back() != '\\') glRootPath += '\\';
@@ -322,6 +349,19 @@ ERR OpenCore(OpenInfo *Info, struct CoreBase **JumpTable)
          }
          else if ((iequals(arg, "set-volume")) and (i+1 < Info->ArgCount)) { // --set-volume scripts=my:location/
             volumes.emplace_front(Info->Args[++i]);
+         }
+         else if (iequals(arg, "log-file")) {
+            if (i+1 >= Info->ArgCount) {
+               fprintf(stderr, "No path specified for --log-file.\n");
+               return ERR::Args;
+            }
+
+            if (auto error = set_log_file(Info->Args[++i]); error != ERR::Okay) return error;
+            if (glLogLevel < 5) glLogLevel = 5;
+         }
+         else if (startswith("log-file=", arg)) {
+            if (auto error = set_log_file(arg + 9); error != ERR::Okay) return error;
+            if (glLogLevel < 5) glLogLevel = 5;
          }
          else if (iequals(arg, "no-crash-handler")) glEnableCrashHandler = false;
          else if (iequals(arg, "sync"))        glSync = true;
@@ -695,7 +735,7 @@ void print_diagnosis(int Signal)
 
    //if (glLogLevel <= 1) return;
 
-   fd = stderr;
+   fd = log_output();
    fprintf(fd, "Diagnostic Information:\n\n");
 
    // Print details of the object context at the time of the crash.  If this code fails, it indicates that the object context is corrupt.
@@ -762,15 +802,16 @@ void print_diagnosis(int Signal)
 #ifndef _WIN32
    // If the output was to a file, now print that file to stderr
 
-   if (fd != stderr) {
+   if ((not (fd IS stderr)) and (not (fd IS glLogFile))) {
       char buffer[4096];
 
       rewind(fd);
       if (auto len = fread(buffer, 1, sizeof(buffer)-1, fd); len > 0) {
          buffer[len] = 0;
+         auto out = log_output();
          fflush(nullptr);
-         fsync(STDERR_FILENO);
-         fprintf(stderr, "%s", buffer);
+         if (out IS stderr) fsync(STDERR_FILENO);
+         fprintf(out, "%s", buffer);
 
          // Copy process status to the output file
 
@@ -809,7 +850,7 @@ static void CrashHandler(int SignalNumber, siginfo_t *Info, APTR Context)
 
    if (glCrashStatus > 1) {
       if ((glCodeIndex) and (glCodeIndex IS glLastCodeIndex)) {
-         fprintf(stderr, "Unable to recover - exiting immediately.\n");
+         fprintf(log_output(), "Unable to recover - exiting immediately.\n");
          exit(255);
       }
 
@@ -832,9 +873,9 @@ static void CrashHandler(int SignalNumber, siginfo_t *Info, APTR Context)
          log.msg("Process terminated.\n");
       }
       else if ((SignalNumber > 0) and (SignalNumber < std::ssize(signals))) {
-         fprintf(stderr, "\nProcess terminated, signal %s.\n\n", signals[SignalNumber]);
+         fprintf(log_output(), "\nProcess terminated, signal %s.\n\n", signals[SignalNumber]);
       }
-      else fprintf(stderr, "\nProcess terminated, signal %d.\n\n", SignalNumber);
+      else fprintf(log_output(), "\nProcess terminated, signal %d.\n\n", SignalNumber);
 
       if ((SignalNumber IS SIGILL) or (SignalNumber IS SIGFPE) or
           (SignalNumber IS SIGSEGV) or (SignalNumber IS SIGBUS)) {
@@ -843,7 +884,7 @@ static void CrashHandler(int SignalNumber, siginfo_t *Info, APTR Context)
       else glPageFault = 0;
    }
    else {
-      fprintf(stderr, "Secondary crash or hangup request at code index %d (last %d).\n", glCodeIndex, glLastCodeIndex);
+      fprintf(log_output(), "Secondary crash or hangup request at code index %d (last %d).\n", glCodeIndex, glLastCodeIndex);
       kill(getpid(), SIGKILL);
       exit(255);
    }
@@ -937,7 +978,7 @@ static int CrashHandler(int Code, APTR Address, int Continuable, int *Info)
 
    if (glCrashStatus > 1) {
       if ((glCodeIndex) and (glCodeIndex IS glLastCodeIndex)) {
-         fprintf(stderr, "Unable to recover - exiting immediately.\n");
+         fprintf(log_output(), "Unable to recover - exiting immediately.\n");
          fflush(nullptr);
          return 1;
       }
@@ -949,25 +990,25 @@ static int CrashHandler(int Code, APTR Address, int Continuable, int *Info)
          if (glLogLevel >= 5) {
             log.warning("CRASH!"); // Using LogF is helpful because branched output can indicate where the crash occurred.
          }
-         else fprintf(stderr, "\n\nCRASH!");
+         else fprintf(log_output(), "\n\nCRASH!");
 
-         fprintf(stderr, "\n%s (%s), at address: %p\n", ExceptionTable[Code], (Continuable) ? "Continuable" : "Fatal", Address);
+         fprintf(log_output(), "\n%s (%s), at address: %p\n", ExceptionTable[Code], (Continuable) ? "Continuable" : "Fatal", Address);
          if ((Code IS EXP_ACCESS_VIOLATION) and (Info)) {
             CSTRING type;
             if (Info[0] IS 1) type = "write";
             else if (Info[0] IS 0) type = "read";
             else if (Info[0] IS 8) type = "execution";
             else type = "access";
-            fprintf(stderr, "Attempted %s on address %p\n", type, ((void **)(Info+1))[0]);
+            fprintf(log_output(), "Attempted %s on address %p\n", type, ((void **)(Info+1))[0]);
          }
-         fprintf(stderr, "\n");
+         fprintf(log_output(), "\n");
       }
       else {
-         fprintf(stderr, "Recovering from secondary crash (%s) at code index %d.\n", ExceptionTable[Code], glCodeIndex);
+         fprintf(log_output(), "Recovering from secondary crash (%s) at code index %d.\n", ExceptionTable[Code], glCodeIndex);
          return 1;
       }
    }
-   else fprintf(stderr, "\n\nCRASH!  Exception code of %d is unrecognised.\n\n", Code);
+   else fprintf(log_output(), "\n\nCRASH!  Exception code of %d is unrecognised.\n\n", Code);
 
    glCrashStatus = 2;
 
@@ -1018,7 +1059,7 @@ static void BreakHandler(void)
    if (glLogLevel >= 5) {
       log.warning("USER BREAK"); // Using log is helpful for branched output to indicate where the crash occurred
    }
-   else fprintf(stderr, "\nUSER BREAK");
+   else fprintf(log_output(), "\nUSER BREAK");
 
    glCrashStatus = 1;
 

--- a/src/core/core_close.cpp
+++ b/src/core/core_close.cpp
@@ -287,7 +287,12 @@ void CloseCore(void)
    if (glCodeIndex < CP_FINISHED) glCodeIndex = CP_FINISHED;
 
    fflush(stdout);
-   fflush(stderr);
+   if (glLogFile) {
+      fflush(glLogFile);
+      fclose(glLogFile);
+      glLogFile = nullptr;
+   }
+   else fflush(stderr);
 
    // NOTE: LeakSanitizer can sometimes report segfault errors on closure.  These can go away on their own and may
    // not be easily duplicated.  One possible explanation is tom-foolery from LuaJIT resulting in false positives that

--- a/src/core/data.cpp
+++ b/src/core/data.cpp
@@ -148,6 +148,7 @@ size_t glPageSize = 4096; // Overwritten on opening the Core
 #endif
 
 HOSTHANDLE glConsoleFD = (HOSTHANDLE)-1; // Managed by GetResource()
+FILE *glLogFile = nullptr;
 
 int64_t glTimeLog    = 0;
 int16_t glCrashStatus   = 0;

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -87,6 +87,7 @@ constexpr int DRIVETYPE_USB       = 5;
 #include <kotuku/system/registry.h>
 
 #include <stdarg.h>
+#include <stdio.h>
 
 struct ChildEntry;
 struct ObjectInfo;
@@ -741,6 +742,7 @@ extern const CSTRING glMessages[int(ERR::END)+1];       // Read-only table of er
 extern const int glTotalMessages;
 extern "C" int glProcessID;   // Read only
 extern HOSTHANDLE glConsoleFD;
+extern FILE *glLogFile;
 extern int glStdErrFlags; // Read only
 extern int glValidateProcessID; // Used by core thread only.
 extern size_t glPageSize;

--- a/src/core/lib_log.cpp
+++ b/src/core/lib_log.cpp
@@ -41,6 +41,8 @@ Log levels are:
 #include "defs.h"
 
 static void fmsg(CSTRING, STRING, int8_t, int8_t);
+static FILE *log_output(void);
+static bool log_output_is_file(void);
 
 #ifdef __ANDROID__
 static const int COLUMN1 = 40;
@@ -56,6 +58,16 @@ enum { MS_NONE, MS_FUNCTION, MS_MSG };
 enum { EL_NONE=0, EL_MINOR, EL_MAJOR, EL_MAJORBOLD };
 
 static thread_local int tlBaseLine = 0;
+
+static FILE *log_output(void)
+{
+   return glLogFile ? glLogFile : stderr;
+}
+
+static bool log_output_is_file(void)
+{
+   return glLogFile;
+}
 
 /*********************************************************************************************************************
 
@@ -125,6 +137,8 @@ va_list Args: A `va_list` corresponding to the arguments referenced in `Message`
 void VLogF(VLF Flags, CSTRING Header, CSTRING Message, va_list Args)
 {
    if (tlLogStatus <= 0) { if ((Flags & VLF::BRANCH) != VLF::NIL) tlDepth++; return; }
+   FILE *fd = log_output();
+   const bool file_output = log_output_is_file();
 
    static const VLF log_levels[10] = {
       VLF::CRITICAL,
@@ -144,25 +158,30 @@ void VLogF(VLF Flags, CSTRING Header, CSTRING Message, va_list Args)
          __android_log_vprint(ANDROID_LOG_ERROR, Header ? Header : "Kotuku", Message, Args);
       #else
          #ifdef ESC_OUTPUT
-            if (!Header) Header = "";
-            #ifdef _WIN32
-               fprintf(stderr, "!%s ", Header);
-            #else
-               fprintf(stderr, "\033[1m%s ", Header);
-            #endif
+            if (file_output) {
+               if (Header) fprintf(fd, "%s ", Header);
+            }
+            else {
+               if (!Header) Header = "";
+               #ifdef _WIN32
+                  fprintf(fd, "!%s ", Header);
+               #else
+                  fprintf(fd, "\033[1m%s ", Header);
+               #endif
+            }
          #else
-            if (Header) fprintf(stderr, "%s ", Header);
+            if (Header) fprintf(fd, "%s ", Header);
          #endif
 
-         vfprintf(stderr, Message, Args);
+         vfprintf(fd, Message, Args);
 
          #ifdef ESC_OUTPUT
             #ifndef _WIN32
-               fprintf(stderr, "\033[0m");
+               if (!file_output) fprintf(fd, "\033[0m");
             #endif
          #endif
 
-         fprintf(stderr, "\n");
+         fprintf(fd, "\n");
       #endif
 
       if ((Flags & VLF::BRANCH) != VLF::NIL) tlDepth++;
@@ -186,11 +205,11 @@ void VLogF(VLF Flags, CSTRING Header, CSTRING Message, va_list Args)
       if ((Flags & (VLF::BRANCH|VLF::FUNCTION)) != VLF::NIL) msgstate = MS_FUNCTION;
       else msgstate = MS_MSG;
 
-      if (glLogThreads) fprintf(stderr, "%.4d ", int(get_thread_id()));
+      if (glLogThreads) fprintf(fd, "%.4d ", int(get_thread_id()));
 
       #if defined(__unix__) and !defined(__ANDROID__)
          bool flushdbg;
-         if (glLogLevel >= 3) {
+         if ((fd IS stderr) and (glLogLevel >= 3)) {
             flushdbg = true;
             if (tlPublicLockCount) flushdbg = false;
             if (flushdbg) fcntl(STDERR_FILENO, F_SETFL, glStdErrFlags & (~O_NONBLOCK));
@@ -199,12 +218,12 @@ void VLogF(VLF Flags, CSTRING Header, CSTRING Message, va_list Args)
       #endif
 
       #ifdef ESC_OUTPUT // Highlight errors if the log output is crowded
-         if ((glLogLevel > 2) and ((Flags & (VLF::ERROR|VLF::WARNING)) != VLF::NIL)) {
+         if ((not file_output) and (glLogLevel > 2) and ((Flags & (VLF::ERROR|VLF::WARNING)) != VLF::NIL)) {
             #ifdef _WIN32
-               fprintf(stderr, "!");
+               fprintf(fd, "!");
                adjust = 1;
             #else
-               fprintf(stderr, "\033[1m");
+               fprintf(fd, "\033[1m");
             #endif
          }
       #endif
@@ -268,31 +287,37 @@ void VLogF(VLF Flags, CSTRING Header, CSTRING Message, va_list Args)
 
             if (glLogLevel > 5) {
                if (ctx.field) {
-                  fprintf(stderr, "%s[%s%s%s:%d:%s] ", msgheader, (action) ? action : (STRING)"", (action) ? ":" : "", name, obj->UID, ctx.field->Name);
+                  fprintf(fd, "%s[%s%s%s:%d:%s] ", msgheader, (action) ? action : (STRING)"", (action) ? ":" : "", name, obj->UID, ctx.field->Name);
                }
-               else fprintf(stderr, "%s[%s%s%s:%d] ", msgheader, (action) ? action : (STRING)"", (action) ? ":" : "", name, obj->UID);
+               else fprintf(fd, "%s[%s%s%s:%d] ", msgheader, (action) ? action : (STRING)"", (action) ? ":" : "", name, obj->UID);
             }
             else if (ctx.field) {
-               fprintf(stderr, "%s[%s:%d:%s] ", msgheader, name, obj->UID, ctx.field->Name);
+               fprintf(fd, "%s[%s:%d:%s] ", msgheader, name, obj->UID, ctx.field->Name);
             }
-            else fprintf(stderr, "%s[%s:%d] ", msgheader, name, obj->UID);
+            else fprintf(fd, "%s[%s:%d] ", msgheader, name, obj->UID);
          }
-         else fprintf(stderr, "%s", msgheader);
+         else fprintf(fd, "%s", msgheader);
 
-         vfprintf(stderr, Message, Args);
+         vfprintf(fd, Message, Args);
 
          #if defined(ESC_OUTPUT) and !defined(_WIN32)
-            if ((glLogLevel > 2) and ((Flags & (VLF::ERROR|VLF::WARNING)) != VLF::NIL)) fprintf(stderr, "\033[0m");
+            if ((not file_output) and (glLogLevel > 2) and ((Flags & (VLF::ERROR|VLF::WARNING)) != VLF::NIL)) fprintf(fd, "\033[0m");
          #endif
 
-         fprintf(stderr, "\n");
+         fprintf(fd, "\n");
 
          #if defined(__unix__) and !defined(__ANDROID__)
             if (flushdbg) {
-               fflush(0); // A fflush() appears to be enough - using fsync() will synchronise to disk, which we don't want by default (slow)
+               fflush(nullptr); // A fflush() appears to be enough - using fsync() will synchronise to disk, which we don't want by default (slow)
                if (glSync) fsync(STDERR_FILENO);
                fcntl(STDERR_FILENO, F_SETFL, glStdErrFlags);
             }
+            else if (glSync) {
+               fflush(fd);
+               if (fd IS stderr) fsync(STDERR_FILENO);
+            }
+         #else
+            if (glSync) fflush(fd);
          #endif
       #endif
    }
@@ -350,11 +375,13 @@ ERR FuncError(CSTRING Header, ERR Code)
       }
       else __android_log_print(ANDROID_LOG_ERROR, Header, "%s", glMessages[Code]);
    #else
+      FILE *fd = log_output();
+      const bool file_output = log_output_is_file();
       char msgheader[COLUMN1+1];
       CSTRING histart = "", hiend = "";
 
       #ifdef ESC_OUTPUT
-         if (glLogLevel > 2) {
+         if ((not file_output) and (glLogLevel > 2)) {
             #ifdef _WIN32
                histart = "!";
             #else
@@ -370,14 +397,19 @@ ERR FuncError(CSTRING Header, ERR Code)
          CSTRING name = obj->Name[0] ? obj->Name : obj->Class->ClassName;
 
          if (ctx.field) {
-            fprintf(stderr, "%s%s[%s:%d:%s] %s%s\n", histart, msgheader, name, obj->UID, ctx.field->Name, glMessages[int(Code)], hiend);
+            fprintf(fd, "%s%s[%s:%d:%s] %s%s\n", histart, msgheader, name, obj->UID, ctx.field->Name, glMessages[int(Code)], hiend);
          }
-         else fprintf(stderr, "%s%s[%s:%d] %s%s\n", histart, msgheader, name, obj->UID, glMessages[int(Code)], hiend);
+         else fprintf(fd, "%s%s[%s:%d] %s%s\n", histart, msgheader, name, obj->UID, glMessages[int(Code)], hiend);
       }
-      else fprintf(stderr, "%s%s%s%s\n", histart, msgheader, glMessages[int(Code)], hiend);
+      else fprintf(fd, "%s%s%s%s\n", histart, msgheader, glMessages[int(Code)], hiend);
 
       #if defined(__unix__) && !defined(__ANDROID__)
-         if (glSync) { fflush(0); fsync(STDERR_FILENO); }
+         if (glSync) {
+            fflush(fd);
+            if (fd IS stderr) fsync(STDERR_FILENO);
+         }
+      #else
+         if (glSync) fflush(fd);
       #endif
    #endif
 

--- a/src/launcher/origo.cpp
+++ b/src/launcher/origo.cpp
@@ -56,6 +56,7 @@ The following options can be used when executing script files:
  --log-api       Activates run-time log messages at API level.
  --log-info      Activates run-time log messages at INFO level.
  --log-error     Activates run-time log messages at ERROR level.
+ --log-file      Write log output to the given file path.
  --jit-options   Development options that control the behaviour of the compiler.
  --version       Prints the version number on line 1 and git commit on line 2.
 )";
@@ -136,8 +137,8 @@ static ERR process_args(void)
                i++;
             }
          }
-         else if (kt::iequals(args[i], "--jit-options")) {
-            // Handled by the Tiri module, we just need to skip the next argument.
+         else if ((kt::iequals(args[i], "--jit-options")) or (kt::iequals(args[i], "--log-file"))) {
+            // For some system parameters we need to skip the next argument.
             if (i + 1 < args.size()) i++;
          }
          else if (kt::startswith("--", args[i])) {


### PR DESCRIPTION
## Summary

* Introduces a `glLogFile` global and `set_log_file()` helper that opens a file for writing log output, falling back to `stderr` when none is set
* Adds `--log-file <path>` and `--log-file=<path>` argument forms to `OpenCore()`; automatically raises the log level to 5 when active
* Redirects all `KERR`, `VLogF`, `FuncError`, and crash-handler `fprintf` calls through `log_output()` so every diagnostic goes to the configured destination
* Suppresses ANSI escape codes in log output when writing to a file to keep the file clean
* Flushes and closes `glLogFile` cleanly in `CloseCore()`
* Documents `--log-file` in the origo usage string and skips its path argument correctly in `process_args()`

## Test plan

- [ ] Build Core and origo and verify compilation succeeds
- [ ] Run `origo --log-file=/tmp/test.log --log-warning <script>` and confirm output appears in the file rather than stderr
- [ ] Confirm `--log-file=path` (equals form) also works
- [ ] Confirm that omitting `--log-file` produces normal stderr output with ANSI colouring intact
- [ ] Verify `CloseCore()` flushes and closes the file without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)