### PR TITLE
Fix Windows standard handle duplication for File objects and console attachment

### DIFF
--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -75,6 +75,51 @@ in a file.
 
  #define open64   open
  #define lseek64  lseek
+
+ #define KOTUKU_STD_INPUT_HANDLE   ((unsigned long)-10)
+ #define KOTUKU_STD_OUTPUT_HANDLE  ((unsigned long)-11)
+ #define KOTUKU_STD_ERROR_HANDLE   ((unsigned long)-12)
+ #define KOTUKU_DUPLICATE_ACCESS   2
+
+ #ifdef _MSC_VER
+  #define KOTUKU_WINAPI __stdcall
+  #define KOTUKU_WINIMPORT __declspec(dllimport)
+ #else
+  #define KOTUKU_WINAPI
+  #define KOTUKU_WINIMPORT
+ #endif
+
+extern "C" {
+   KOTUKU_WINIMPORT WINHANDLE KOTUKU_WINAPI GetStdHandle(unsigned long);
+   KOTUKU_WINIMPORT WINHANDLE KOTUKU_WINAPI GetCurrentProcess(void);
+   KOTUKU_WINIMPORT int KOTUKU_WINAPI DuplicateHandle(WINHANDLE, WINHANDLE, WINHANDLE, WINHANDLE *, unsigned long, int, unsigned long);
+   KOTUKU_WINIMPORT int KOTUKU_WINAPI CloseHandle(WINHANDLE);
+}
+
+static int duplicate_std_handle(FILE *Stream, unsigned long StdHandle, int OpenFlags)
+{
+   auto source = GetStdHandle(StdHandle);
+   if ((source) and (source != (WINHANDLE)(intptr_t)-1)) {
+      WINHANDLE duplicate = nullptr;
+      if (DuplicateHandle(GetCurrentProcess(), source, GetCurrentProcess(), &duplicate, 0, false, KOTUKU_DUPLICATE_ACCESS)) {
+         int file = _open_osfhandle((intptr_t)duplicate, OpenFlags);
+         if (file >= 0) return file;
+
+         CloseHandle(duplicate);
+      }
+   }
+
+   int file = _fileno(Stream);
+   if (file >= 0) {
+      auto os_handle = (WINHANDLE)_get_osfhandle(file);
+      if ((os_handle) and (os_handle != (WINHANDLE)(intptr_t)-1)) {
+         auto duplicate = _dup(file);
+         if (duplicate >= 0) return duplicate;
+      }
+   }
+
+   return -1;
+}
 #endif // _WIN32
 
 #ifdef __APPLE__
@@ -618,7 +663,7 @@ static ERR FILE_Init(extFile *Self)
       if (iequals("std:in", Self->Path)) {
          Self->Flags |= FL::READ;
          #ifdef _WIN32
-            Self->Handle = _fileno(stdin);
+            Self->Handle = duplicate_std_handle(stdin, KOTUKU_STD_INPUT_HANDLE, O_RDONLY|WIN32OPEN);
          #else
             Self->Handle = STDIN_FILENO;
          #endif
@@ -626,7 +671,7 @@ static ERR FILE_Init(extFile *Self)
       else if (iequals("std:out", Self->Path)) {
          Self->Flags |= FL::WRITE;
          #ifdef _WIN32
-            Self->Handle = _fileno(stdout);
+            Self->Handle = duplicate_std_handle(stdout, KOTUKU_STD_OUTPUT_HANDLE, O_WRONLY|WIN32OPEN);
          #else
             Self->Handle = STDOUT_FILENO;
          #endif
@@ -634,7 +679,7 @@ static ERR FILE_Init(extFile *Self)
       else if (iequals("std:err", Self->Path)) {
          Self->Flags |= FL::WRITE;
          #ifdef _WIN32
-            Self->Handle = _fileno(stderr);
+            Self->Handle = duplicate_std_handle(stderr, KOTUKU_STD_ERROR_HANDLE, O_WRONLY|WIN32OPEN);
          #else
             Self->Handle = STDERR_FILENO;
          #endif

--- a/src/core/microsoft/windows.cpp
+++ b/src/core/microsoft/windows.cpp
@@ -303,12 +303,28 @@ extern "C" void activate_console(int8_t AllowOpenConsole)
    static bool activated = false;
 
    if (!activated) {
+      HANDLE current_out = GetStdHandle(STD_OUTPUT_HANDLE);
+      HANDLE current_err = GetStdHandle(STD_ERROR_HANDLE);
+
+      if (((current_out) and (current_out != INVALID_HANDLE_VALUE)) or
+          ((current_err) and (current_err != INVALID_HANDLE_VALUE))) {
+         activated = true;
+         return;
+      }
+
       char value[8];
       if (GetEnvironmentVariable("TERM", value, sizeof(value)) or
           GetEnvironmentVariable("PROMPT", value, sizeof(value))) { // TERM defined by Cygwin, Mingw, PROMPT defined by cmd.exe
 
-         HANDLE current_out = GetStdHandle(STD_OUTPUT_HANDLE);
-         HANDLE current_err = GetStdHandle(STD_ERROR_HANDLE);
+         auto stdout_fd = _fileno(stdout);
+         auto stderr_fd = _fileno(stderr);
+
+         if (((stdout_fd >= 0) and (not _isatty(stdout_fd))) or ((stderr_fd >= 0) and (not _isatty(stderr_fd))) or
+             ((current_out) and (current_out != INVALID_HANDLE_VALUE) and (not is_console(current_out))) or
+             ((current_err) and (current_err != INVALID_HANDLE_VALUE) and (not is_console(current_err)))) {
+            activated = true;
+            return;
+         }
 
          AttachConsole(ATTACH_PARENT_PROCESS);
 

--- a/src/core/microsoft/windows.cpp
+++ b/src/core/microsoft/windows.cpp
@@ -305,42 +305,54 @@ extern "C" void activate_console(int8_t AllowOpenConsole)
    if (!activated) {
       HANDLE current_out = GetStdHandle(STD_OUTPUT_HANDLE);
       HANDLE current_err = GetStdHandle(STD_ERROR_HANDLE);
+      const bool out_valid = (current_out) and (current_out != INVALID_HANDLE_VALUE);
+      const bool err_valid = (current_err) and (current_err != INVALID_HANDLE_VALUE);
+      const bool out_console = out_valid and is_console(current_out);
+      const bool err_console = err_valid and is_console(current_err);
 
-      if (((current_out) and (current_out != INVALID_HANDLE_VALUE)) or
-          ((current_err) and (current_err != INVALID_HANDLE_VALUE))) {
+      if ((out_valid and not out_console) or (err_valid and not err_console)) {
+         if (out_console or err_console) {
+            SetConsoleOutputCP(CP_UTF8);
+            SetConsoleCP(CP_UTF8);
+         }
+
          activated = true;
          return;
       }
 
-      char value[8];
-      if (GetEnvironmentVariable("TERM", value, sizeof(value)) or
-          GetEnvironmentVariable("PROMPT", value, sizeof(value))) { // TERM defined by Cygwin, Mingw, PROMPT defined by cmd.exe
+      if (out_console or err_console) {
+         // Already attached to a console; keep the inherited handles and update the code page below.
+      }
+      else {
+         char value[8];
+         if (GetEnvironmentVariable("TERM", value, sizeof(value)) or
+             GetEnvironmentVariable("PROMPT", value, sizeof(value))) { // TERM defined by Cygwin, Mingw, PROMPT defined by cmd.exe
 
-         auto stdout_fd = _fileno(stdout);
-         auto stderr_fd = _fileno(stderr);
+            auto stdout_fd = _fileno(stdout);
+            auto stderr_fd = _fileno(stderr);
 
-         if (((stdout_fd >= 0) and (not _isatty(stdout_fd))) or ((stderr_fd >= 0) and (not _isatty(stderr_fd))) or
-             ((current_out) and (current_out != INVALID_HANDLE_VALUE) and (not is_console(current_out))) or
-             ((current_err) and (current_err != INVALID_HANDLE_VALUE) and (not is_console(current_err)))) {
-            activated = true;
-            return;
+            if (((stdout_fd >= 0) and (not _isatty(stdout_fd))) or ((stderr_fd >= 0) and (not _isatty(stderr_fd))) or
+                (out_valid and not out_console) or (err_valid and not err_console)) {
+               activated = true;
+               return;
+            }
+
+            AttachConsole(ATTACH_PARENT_PROCESS);
+
+            // Double-check if we're attached to the console with is_console() because the parent process may have
+            // redirected the std* descriptors to a file for instance.  If we freopen() blindly then we otherwise
+            // revert output back to the console.
+
+            if (is_console(current_out)) freopen("CON", "w", stdout);  // Redirect stdout and stderr descriptors to the attached console.
+            if (is_console(current_err)) freopen("CON", "w", stderr);
          }
-
-         AttachConsole(ATTACH_PARENT_PROCESS);
-
-         // Double-check if we're attached to the console with is_console() because the parent process may have
-         // redirected the std* descriptors to a file for instance.  If we freopen() blindly then we otherwise
-         // revert output back to the console.
-
-         if (is_console(current_out)) freopen("CON", "w", stdout);  // Redirect stdout and stderr descriptors to the attached console.
-         if (is_console(current_err)) freopen("CON", "w", stderr);
+         else if (AllowOpenConsole) { // Assume that executable was launched from desktop without a console
+            AllocConsole();
+            freopen("CON", "w", stdout);  // Redirect stdout and stderr descriptors to the attached console.
+            freopen("CON", "w", stderr);
+         }
+         else return;
       }
-      else if (AllowOpenConsole) { // Assume that executable was launched from desktop without a console
-         AllocConsole();
-         freopen("CON", "w", stdout);  // Redirect stdout and stderr descriptors to the attached console.
-         freopen("CON", "w", stderr);
-      }
-      else return;
 
       // Set console mode to handle UTF-8 properly
 


### PR DESCRIPTION
## Summary

* Use `DuplicateHandle()` for `std:in`, `std:out`, and `std:err` File paths on Windows so the duplicated descriptor can be safely closed without affecting the underlying process stream; fall back to `_dup()` if `DuplicateHandle()` fails
* Fix `activate_console()` in `windows.cpp` to return early when stdout or stderr handles are already valid, preventing unnecessary `AttachConsole()` calls
* Skip console attachment when stdout or stderr are already redirected to a non-terminal (e.g. piped output)

## Test plan

- [ ] Build the Core module on Windows and verify compilation succeeds
- [ ] Open `std:out` as a File object, write to it, free it, and confirm the process stdout stream remains functional afterwards
- [ ] Run origo with output redirected to a file (`origo script.tiri > out.txt`) and verify `activate_console()` does not interfere
- [ ] Run origo from a terminal and confirm console output still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)