### PR TITLE
[Script] Add log-api/log-file support to Tiri LSP

### DIFF
--- a/tools/tiri_lsp/lsp_definition.tiri
+++ b/tools/tiri_lsp/lsp_definition.tiri
@@ -1,16 +1,16 @@
 ----------------------------------------------------------------------------------------------------------------------
 -- Go to Definition Support
 
-rx_def_func = <{ regex.new([[\bfunction\s+([A-Za-z_][A-Za-z0-9_:.]*)\s*\(([^\)]*)\)]]) }>
-rx_def_decl = <{ regex.new([[\b(local|global)\s+([A-Za-z_][A-Za-z0-9_]*)]]) }>
-rx_def_assign_func = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^\)]*)\)]]) }>
-rx_def_assign = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
-rx_def_param = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
-rx_def_loader_before = <{ regex.new([[\b(import|require|include)\s*(?:\(\s*)?$]]) }>
+rx_def_func           = <{ regex.new([[\bfunction\s+([A-Za-z_][A-Za-z0-9_:.]*)\s*\(([^\)]*)\)]]) }>
+rx_def_decl           = <{ regex.new([[\b(local|global)\s+([A-Za-z_][A-Za-z0-9_]*)]]) }>
+rx_def_assign_func    = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^\)]*)\)]]) }>
+rx_def_assign         = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
+rx_def_param          = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
+rx_def_loader_before  = <{ regex.new([[\b(import|require|include)\s*(?:\(\s*)?$]]) }>
 rx_def_obj_new_before = <{ regex.new([[obj\.new\s*\(\s*$]]) }>
-rx_def_obj_new = <{ regex.new([=[([A-Za-z_][A-Za-z0-9_]*)\s*=\s*obj\.new\s*\(\s*['"]([^'"]+)['"]]=], regex.DOT_ALL) }>
-rx_def_action_prefix = <{ regex.new([=[^ac[A-Z]]=]) }>
-rx_def_method_prefix = <{ regex.new([=[^mt[A-Z]]=]) }>
+rx_def_obj_new        = <{ regex.new([=[([A-Za-z_][A-Za-z0-9_]*)\s*=\s*obj\.new\s*\(\s*['"]([^'"]+)['"]]=], regex.DOT_ALL) }>
+rx_def_action_prefix  = <{ regex.new([=[^ac[A-Z]]=]) }>
+rx_def_method_prefix  = <{ regex.new([=[^mt[A-Z]]=]) }>
 
 ----------------------------------------------------------------------------------------------------------------------
 -- URI and Path Helpers

--- a/tools/tiri_lsp/lsp_protocol.tiri
+++ b/tools/tiri_lsp/lsp_protocol.tiri
@@ -69,8 +69,7 @@ end
 
 function formatResponse(ResponseTable:table, TextOutput:bool):str
    body = json.encode(ResponseTable)
-   separator = TextOutput ? '\n\n' :> '\r\n\r\n'
-   return 'Content-Length: ' .. #body .. separator .. body
+   return 'Content-Length: ' .. #body .. '\r\n\r\n' .. body
 end
 
 global function sendResponse(Self, ClientSocket, ResponseTable, RequestLog)

--- a/tools/tiri_lsp/lsp_protocol.tiri
+++ b/tools/tiri_lsp/lsp_protocol.tiri
@@ -65,7 +65,9 @@ function parseMessage(JsonBody)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Response Formatting
+-- Response Formatting: LSP framing is not platform-specific.  The spec requires headers terminated with \r\n, with
+-- the header/body separator effectively \r\n\r\n, regardless of Windows/Linux/macOS. Source: Microsoft LSP 3.17
+-- base protocol, https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.17/specification.md
 
 function formatResponse(ResponseTable:table, TextOutput:bool):str
    body = json.encode(ResponseTable)

--- a/tools/tiri_lsp/server.tiri
+++ b/tools/tiri_lsp/server.tiri
@@ -100,6 +100,7 @@ end
    glConfigFile = arg('config', 'user:config/lsp_server_cfg.tiri')
    glDocPath = 'sdk:docs/xml/'
    glOptions = { }
+   glSysState = mSys.GetSystemState()
 
    if arg('help') then
       print(glHelp)

--- a/tools/tiri_lsp/vscode_plugin/extension.js
+++ b/tools/tiri_lsp/vscode_plugin/extension.js
@@ -19,7 +19,9 @@ function getSettings() {
       port: config.get('port', 0),
       autoStart: config.get('autoStart', false),
       origoPath: config.get('origoPath', 'origo'),
-      serverScript: config.get('serverScript', 'tools/tiri_lsp/server.tiri')
+      serverScript: config.get('serverScript', 'tools/tiri_lsp/server.tiri'),
+      logApi: config.get('logApi', false),
+      logFile: config.get('logFile', '')
    };
 }
 
@@ -50,6 +52,36 @@ function resolveServerScript(serverScript) {
 
 function wait(ms) {
    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getLogFilePath(settings, port) {
+   const configuredPath = settings.logFile && settings.logFile.trim();
+   if (configuredPath) {
+      return configuredPath;
+   }
+
+   if (port === 0 && settings.logApi) {
+      const workspacePath = getWorkspacePath();
+      return path.join(workspacePath || process.cwd(), 'tiri-lsp-core.log');
+   }
+
+   return '';
+}
+
+function getServerArgs(settings, serverScript, port) {
+   const args = [];
+   const logFile = getLogFilePath(settings, port);
+
+   if (settings.logApi) {
+      args.push('--log-api');
+   }
+
+   if (logFile) {
+      args.push('--log-file', logFile);
+   }
+
+   args.push(serverScript, `port=${port}`);
+   return args;
 }
 
 function openSocket(settings) {
@@ -87,9 +119,10 @@ function startServerProcess(settings) {
 
    const cwd = getWorkspacePath();
 
-   outputChannel.appendLine(`Starting Tiri LSP server: ${settings.origoPath} ${serverScript} port=${settings.port}`);
+   const args = getServerArgs(settings, serverScript, settings.port);
+   outputChannel.appendLine(`Starting Tiri LSP server: ${settings.origoPath} ${args.join(' ')}`);
 
-   serverProcess = spawn(settings.origoPath, [serverScript, `port=${settings.port}`], {
+   serverProcess = spawn(settings.origoPath, args, {
       cwd: cwd,
       windowsHide: true
    });
@@ -162,11 +195,12 @@ function createStdioServerOptions(settings) {
       throw new Error('Unable to resolve Tiri LSP server script');
    }
 
-   outputChannel.appendLine(`Starting LSP server in stdio mode: ${settings.origoPath} ${serverScript} port=0`);
+   const args = getServerArgs(settings, serverScript, 0);
+   outputChannel.appendLine(`Starting LSP server in stdio mode: ${settings.origoPath} ${args.join(' ')}`);
 
    return {
       command: settings.origoPath,
-      args: [serverScript, 'port=0'],
+      args: args,
       options: {
          cwd: getWorkspacePath(),
          windowsHide: true

--- a/tools/tiri_lsp/vscode_plugin/package.json
+++ b/tools/tiri_lsp/vscode_plugin/package.json
@@ -79,6 +79,16 @@
                "type": "string",
                "default": "tools/tiri_lsp/server.tiri",
                "description": "Path to the Tiri LSP server script used when auto-starting the server. Relative paths are resolved from the first workspace folder."
+            },
+            "tiri.lsp.logApi": {
+               "type": "boolean",
+               "default": false,
+               "description": "Enable Origo/Core API logging for the Tiri LSP server. In stdio mode, logs are written to tiri.lsp.logFile or tiri-lsp-core.log in the workspace."
+            },
+            "tiri.lsp.logFile": {
+               "type": "string",
+               "default": "",
+               "description": "Optional host file path for Origo/Core log output from the Tiri LSP server."
             }
          }
       },


### PR DESCRIPTION
* Add tiri.lsp.logApi and tiri.lsp.logFile VS Code settings to pass --log-api and --log-file to the origo server process
* Introduce getLogFilePath() and getServerArgs() helpers in extension.js to construct origo launch arguments cleanly
* In stdio mode, auto-generate a tiri-lsp-core.log path in the workspace when logApi is enabled but no logFile is set
* Fix formatResponse() in lsp_protocol.tiri to always use CRLF separators instead of conditionally switching to LF for text output
* Align regex variable declarations in lsp_definition.tiri for readability