### PR TITLE
[Tiri] Add parser symbol metadata extraction for LSP and documentation tooling

### DIFF
--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -104,6 +104,189 @@ local script = obj.new('tiri', {
 script.acActivate()
 ```
 
+## Annotation System Internals
+
+Function annotations are parsed in the C++ parser and can follow two different paths:
+
+- AST annotation parsing: `src/parser/ast/annotations.cpp` and `src/parser/ast/nodes.h` parse `@Name(...)`
+  syntax into `AnnotationEntry` values and attach them to `FunctionExprPayload::annotations`.
+- Runtime registration: `src/parser/ir_emitter/emit_function.cpp` and `src/lib/lib_debug.cpp` emit
+  `debug.anno.set(func, "...", source, name)` for annotated functions so runtime code can inspect annotations.
+- Parser metadata extraction: `src/parser/parser_symbols.cpp`, `src/parser/parser_symbols.h` and
+  `src/lib/lib_debug.cpp` build the `debug.validate(Source, "symbols").symbols` table for LSP and documentation
+  tooling.
+
+### Runtime Annotation Registration
+
+`IrEmitter::emit_annotation_registration()` serialises parsed `AnnotationEntry` values back to annotation syntax and
+emits bytecode that calls `debug.anno.set()`.  String annotation values are escaped by
+`append_annotation_string_literal()` before being embedded in the generated annotation string; keep this escaping path
+in mind when adding new annotation value types.
+
+`@Doc` is special because documentation text can be large.  The emitter checks:
+
+```cpp
+L->script and ((L->script->Flags & SCF::PROCESS_DOC) != SCF::NIL)
+```
+
+If `SCF::PROCESS_DOC` is not set, a `@Doc` annotation is still registered as an annotation marker, but its arguments are
+omitted from the runtime annotation string.  This prevents normal script execution from retaining large documentation
+payloads in `debug.anno`.  Tooling paths that need the payload must enable `SCF::PROCESS_DOC`.
+
+### Parser Symbol Extraction
+
+`debug.validate(Source, "symbols")` is the public extraction path for parser-provided symbol and documentation metadata.
+In `LJLIB_CF(debug_validate)`:
+
+1. The `"symbols"` flag temporarily sets `L->script->Flags |= SCF::PROCESS_DOC`.
+2. `lua_load()` parses the source in diagnose mode.
+3. `collect_parser_symbols()` is called after AST construction from `parser.cpp`.
+4. `push_symbol_metadata()` converts `L->parser_symbols` into a Tiri table named `symbols`.
+5. The original script flags are restored and `L->parser_symbols` is deleted after the table has been pushed.
+
+`collect_parser_symbols()` is deliberately gated on `SCF::PROCESS_DOC`; without the flag it deletes any stale
+`Lua.parser_symbols` value and returns without walking the AST.
+
+The collector walks function declarations and function expressions assigned to variables or members.  For every function
+it builds a `ParserSymbolMetadata` record:
+
+```cpp
+struct ParserSymbolMetadata {
+   std::string name;
+   std::string kind;       // "function" or "thunk"
+   std::string signature;  // e.g. "greet(Name: str):str"
+   SourceSpan span;
+   SourceSpan end_span;
+   std::vector<ParserAnnotationMetadata> annotations;
+   ParserDocBlockMetadata doc;
+   std::vector<ParserDocParamMetadata> params;
+   std::vector<ParserDocReturnMetadata> results;
+   std::vector<ParserDocErrorMetadata> errors;
+};
+```
+
+The table exposed to Tiri is zero-indexed and has this shape:
+
+```lua
+{
+   symbols = {
+      [0] = {
+         name = "greet",
+         kind = "function",
+         signature = "greet(Name: str):str",
+         line = 0,
+         column = 0,
+         endLine = 6,
+         endColumn = 1,
+         annotations = {
+            [0] = { name = "Doc", args = { text = "..." } }
+         },
+         doc = {
+            summary = "Returns a greeting.",
+            body = "Returns a greeting.",
+            raw = "...original annotation text...",
+            examples = {}
+         },
+         params = {
+            [0] = { name = "Name", type = "str", doc = "Person to greet", inferred = false }
+         },
+         results = {
+            [0] = { type = "str", doc = "Greeting text", inferred = false }
+         },
+         errors = {
+            [0] = { code = "Args", doc = "If the name is invalid", inferred = false }
+         }
+      }
+   }
+}
+```
+
+The parser exposes result values as `results`, not `returns`.  This matches the field name used by
+`ParserSymbolMetadata` and by the Tiri tests.
+
+### `@Doc(text=...)` Parsing
+
+`parser_symbols.cpp` looks for an annotation named exactly `Doc` and an argument named exactly `text`.  The text
+argument must be a string; other argument types are ignored for documentation parsing.
+
+`parse_doc_text()` first calls `normalise_doc_lines()`:
+
+- Split on `\n`.
+- Drop a trailing `\r` from each line.
+- Drop leading whitespace from every line.
+
+This means indented documentation blocks are valid and marker recognition is independent of indentation:
+
+```lua
+@Doc(text=[[
+   Returns a greeting.
+
+   -INPUT-
+   Name: Person to greet
+]])
+```
+
+After normalisation, the parser chooses between long form and compact form.  If the first non-empty, trimmed line starts
+with `@`, compact form is used; otherwise marker form is used.
+
+### Marker Form
+
+Marker form uses exact marker names:
+
+|Marker|Target metadata|Line parser|
+|-|-|-|
+|Description text|`doc.summary`, `doc.body`|First non-empty line is `summary`; joined block is `body`.|
+|`-INPUT-`|`params[].doc`|Parsed as `Name: Description`, then matched to signature parameters by name.|
+|`-RESULTS-`|`results[].doc`|Each non-empty line is parsed as `type: Description` and matched to result positions.|
+|`-ERRORS-`|`errors[]`|Each non-empty line is parsed as `Code: Description`.|
+|`-EXAMPLE-`|`doc.examples[]`|All lines until the next marker or end of block are joined and appended as one example.|
+
+`parse_name_doc_line()` is used for input, result and error lines.  If no colon is present, the whole line becomes the
+name/type/code and the doc string is empty.
+
+### Compact Form
+
+Compact form is intended for terse one-line documentation.  Tags are exact and lower-case:
+
+|Tag|Target metadata|Line parser|
+|-|-|-|
+|`@desc`|`doc.summary`, `doc.body`|First `@desc` sets `summary`; each non-empty payload is appended to `body`.|
+|`@input`|`params[].doc`|Payload is parsed as `Name: Description`.|
+|`@result`|`results[].doc`|Payload is parsed as `type: Description`.|
+|`@error`|`errors[]`|Payload is parsed as `Code: Description`.|
+
+Compact entries do not support continuation lines.  Unknown lines are ignored by the compact parser.
+
+Example:
+
+```lua
+@Doc(text=[[
+   @desc Returns a greeting.
+   @input Name: Person to greet
+   @result str: Greeting text
+   @result str: Additional argument
+   @error Args: If the name is invalid
+   @error Failed: Random failure
+]])
+function greetCompact(Name: str):<str, str>
+   return "Hello " .. Name, "extra"
+end
+```
+
+### Signature Merging Rules
+
+Documentation text augments parser-derived signature metadata; it does not replace it.
+
+- Parameters always come from the function signature, excluding implicit `self`.
+- Parameter documentation is matched by parameter name.  `params[].inferred` is `true` when no matching doc line was
+  found.
+- Result entries use the larger of the declared result count and documented result count.
+- Declared result types take precedence over documented result types.  A documented result type is used only when no
+  declared type exists at that position.
+- `results[].inferred` is `true` only for documented result entries beyond the declared result count.
+- Error entries currently come only from explicit documentation.  Error-code inference is not implemented in the
+  collector yet, so `errors[].inferred` is currently `false`.
+
 ### Unit Tests
 - Unit tests are managed by `MODTests()` in `src/tiri/tiri.cpp`
 - Run compiled-in unit tests: `src/tiri/tests/test_unit_tests.tiri` with `--log-api`

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -57,6 +57,7 @@
 #include "debug/error_guard.h"
 #include "debug/filesource.h"
 #include "parser/parser_diagnostics.h"
+#include "parser/parser_symbols.h"
 #include "parser/parser_tips.h"
 #include "../../defs.h"
 
@@ -1051,11 +1052,144 @@ static CSTRING diagnostic_code_name(ParserErrorCode Code)
    }
 }
 
+static void set_table_string(lua_State *L, CSTRING Key, const std::string &Value)
+{
+   lua_pushlstring(L, Value.data(), Value.size());
+   lua_setfield(L, -2, Key);
+}
+
+static void set_table_bool(lua_State *L, CSTRING Key, bool Value)
+{
+   lua_pushboolean(L, Value);
+   lua_setfield(L, -2, Key);
+}
+
+static void set_table_int(lua_State *L, CSTRING Key, int Value)
+{
+   lua_pushinteger(L, Value);
+   lua_setfield(L, -2, Key);
+}
+
+static void push_annotation_metadata(lua_State *L, const std::vector<ParserAnnotationMetadata> &Annotations)
+{
+   lua_newtable(L);
+   int idx = 0;
+
+   for (const auto &annotation : Annotations) {
+      lua_newtable(L);
+      set_table_string(L, "name", annotation.name);
+
+      lua_newtable(L);
+      for (const auto &[key, value] : annotation.args) {
+         lua_pushlstring(L, value.data(), value.size());
+         lua_setfield(L, -2, key.c_str());
+      }
+      lua_setfield(L, -2, "args");
+
+      lua_rawseti(L, -2, idx++);
+   }
+}
+
+static void push_doc_metadata(lua_State *L, const ParserDocBlockMetadata &Doc)
+{
+   lua_newtable(L);
+   set_table_string(L, "summary", Doc.summary);
+   set_table_string(L, "body", Doc.body);
+   set_table_string(L, "raw", Doc.raw);
+
+   lua_newtable(L);
+   int idx = 0;
+   for (const std::string &example : Doc.examples) {
+      lua_pushlstring(L, example.data(), example.size());
+      lua_rawseti(L, -2, idx++);
+   }
+   lua_setfield(L, -2, "examples");
+}
+
+static void push_params_metadata(lua_State *L, const std::vector<ParserDocParamMetadata> &Params)
+{
+   lua_newtable(L);
+   int idx = 0;
+
+   for (const auto &param : Params) {
+      lua_newtable(L);
+      set_table_string(L, "name", param.name);
+      set_table_string(L, "type", param.type);
+      set_table_string(L, "doc", param.doc);
+      set_table_bool(L, "inferred", param.inferred);
+      lua_rawseti(L, -2, idx++);
+   }
+}
+
+static void push_results_metadata(lua_State *L, const std::vector<ParserDocReturnMetadata> &Results)
+{
+   lua_newtable(L);
+   int idx = 0;
+
+   for (const auto &ret : Results) {
+      lua_newtable(L);
+      set_table_string(L, "type", ret.type);
+      set_table_string(L, "doc", ret.doc);
+      set_table_bool(L, "inferred", ret.inferred);
+      lua_rawseti(L, -2, idx++);
+   }
+}
+
+static void push_errors_metadata(lua_State *L, const std::vector<ParserDocErrorMetadata> &Errors)
+{
+   lua_newtable(L);
+   int idx = 0;
+
+   for (const auto &err : Errors) {
+      lua_newtable(L);
+      set_table_string(L, "code", err.code);
+      set_table_string(L, "doc", err.doc);
+      set_table_bool(L, "inferred", err.inferred);
+      lua_rawseti(L, -2, idx++);
+   }
+}
+
+static void push_symbol_metadata(lua_State *L, const ParserSymbolCollection *Symbols)
+{
+   lua_newtable(L);
+   if (Symbols IS nullptr) return;
+
+   int idx = 0;
+   for (const auto &symbol : Symbols->symbols) {
+      lua_newtable(L);
+
+      set_table_string(L, "name", symbol.name);
+      set_table_string(L, "kind", symbol.kind);
+      set_table_string(L, "signature", symbol.signature);
+      set_table_int(L, "line", symbol.span.line > 0 ? int(symbol.span.line) - 1 : 0);
+      set_table_int(L, "column", symbol.span.column > 0 ? int(symbol.span.column) - 1 : 0);
+      set_table_int(L, "endLine", symbol.end_span.line > 0 ? int(symbol.end_span.line) - 1 : 0);
+      set_table_int(L, "endColumn", symbol.end_span.column > 0 ? int(symbol.end_span.column) - 1 : 0);
+
+      push_params_metadata(L, symbol.params);
+      lua_setfield(L, -2, "params");
+
+      push_results_metadata(L, symbol.results);
+      lua_setfield(L, -2, "results");
+
+      push_errors_metadata(L, symbol.errors);
+      lua_setfield(L, -2, "errors");
+
+      push_doc_metadata(L, symbol.doc);
+      lua_setfield(L, -2, "doc");
+
+      push_annotation_metadata(L, symbol.annotations);
+      lua_setfield(L, -2, "annotations");
+
+      lua_rawseti(L, -2, idx++);
+   }
+}
+
 LJLIB_CF(debug_validate)
 {
    CSTRING statement = luaL_checkstring(L, 1);
-   // flags parameter reserved for future use (type checking, etc.)
-   // CSTRING flags = luaL_optstring(L, 2, "s");
+   CSTRING flags = luaL_optstring(L, 2, "");
+   bool include_symbols = flags and std::string_view(flags).find("symbols") != std::string_view::npos;
 
    // Create result table
    lua_newtable(L);
@@ -1072,11 +1206,15 @@ LJLIB_CF(debug_validate)
    // This requires temporarily enabling JOF::DIAGNOSE
    auto *prv = (prvTiri *)L->script->ChildPrivate;
    JOF old_options = prv ? prv->JitOptions : JOF::NIL;
+   SCF old_flags = L->script->Flags;
    if (prv) prv->JitOptions |= JOF::DIAGNOSE|JOF::ALL_TIPS;
+   if (include_symbols) L->script->Flags |= SCF::PROCESS_DOC;
+   if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
 
    int parse_result = lua_load(L, std::string_view(statement, strlen(statement)), "=validate");
 
    if (prv) prv->JitOptions = old_options;  // Restore options
+   L->script->Flags = old_flags;
 
    // Pop the compiled chunk or error message
    lua_pop(L, 1);
@@ -1137,6 +1275,16 @@ LJLIB_CF(debug_validate)
    }
 
    lua_setfield(L, -2, "tips");
+
+   if (include_symbols) {
+      push_symbol_metadata(L, L->parser_symbols);
+      lua_setfield(L, -2, "symbols");
+
+      if (L->parser_symbols) {
+         delete L->parser_symbols;
+         L->parser_symbols = nullptr;
+      }
+   }
 
    // Set success field
    settabsb(L, "success", parse_result IS 0);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -692,12 +692,19 @@ static void append_annotation_value(std::string &Out, const AnnotationArgValue &
    }
 }
 
+static bool annotation_entry_name_is(const AnnotationEntry &Annotation, std::string_view Name)
+{
+   if (Annotation.name IS nullptr) return false;
+   return std::string_view(strdata(Annotation.name), Annotation.name->len) IS Name;
+}
+
 ParserResult<IrEmitUnit> IrEmitter::emit_annotation_registration(BCReg FuncReg, const std::vector<AnnotationEntry>& Annotations, GCstr* Funcname)
 {
    if (Annotations.empty()) return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 
    FuncState* fs = &this->func_state;
    lua_State* L = fs->L;
+   bool process_doc = L->script and ((L->script->Flags & SCF::PROCESS_DOC) != SCF::NIL);
 
    // Build annotation string from parsed annotation entries
    // Format: @Name(key=value, ...); @Name2; ...
@@ -707,7 +714,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_annotation_registration(BCReg FuncReg, 
       anno_str += "@";
       if (anno.name) anno_str.append(strdata(anno.name), anno.name->len);
 
-      if (not anno.args.empty()) {
+      bool include_args = not anno.args.empty();
+      if (annotation_entry_name_is(anno, "Doc") and not process_doc) include_args = false;
+
+      if (include_args) {
          anno_str += "(";
          bool first_arg = true;
          for (const auto& [key, value] : anno.args) {

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <span>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <kotuku/main.h>

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -46,6 +46,7 @@ static const struct {
 #include "token_types.h"
 #include "parse_types.h"
 #include "parse_internal.h"
+#include "parser_symbols.h"
 #include "parser_profiler.h"
 #include "value_categories.h"
 #include "../../../defs.h"
@@ -56,6 +57,7 @@ static const struct {
 #include "parser_context.cpp"
 #include "ast/nodes.cpp"
 #include "ast/builder.cpp"
+#include "parser_symbols.cpp"
 #include "parse_control_flow.cpp"
 #include "ir_emitter/ir_emitter.cpp"
 #include "parse_constants.cpp"
@@ -170,6 +172,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    std::unique_ptr<BlockStmt> chunk = std::move(chunk_result.value_ref());
    parse_timer.stop();
    trace_ast_boundary(Context, *chunk, "parse");
+   collect_parser_symbols(Context.lua(), *chunk);
 
    if (Context.config().enable_type_analysis) {
       ParserProfiler::StageTimer type_timer = Profiler.stage("type_analysis");

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -1,0 +1,635 @@
+// Parser symbol metadata collection for validation and LSP tooling.
+// Copyright © 2025-2026 Paul Manias
+
+#include "parser_symbols.h"
+
+#include <cctype>
+#include <string_view>
+
+#include "ast/nodes.h"
+#include "runtime/lj_obj.h"
+#include "../../../defs.h"
+
+enum class DocSection : uint8_t {
+   Description,
+   Input,
+   Results,
+   Errors,
+   Example
+};
+
+struct ParsedDocText {
+   ParserDocBlockMetadata block;
+   std::vector<std::pair<std::string, std::string>> inputs;
+   std::vector<ParserDocReturnMetadata> results;
+   std::vector<ParserDocErrorMetadata> errors;
+};
+
+static std::string gcstr_to_string(GCstr *Value)
+{
+   if (Value IS nullptr) return {};
+   return std::string(strdata(Value), Value->len);
+}
+
+static std::string type_to_string(TiriType Type)
+{
+   if (Type IS TiriType::Unknown) return {};
+   return std::string(type_name(Type));
+}
+
+static std::string trim_left(std::string_view Text)
+{
+   size_t pos = 0;
+   while (pos < Text.size() and std::isspace((unsigned char)Text[pos])) pos++;
+   return std::string(Text.substr(pos));
+}
+
+static std::string trim_right(std::string_view Text)
+{
+   size_t end = Text.size();
+   while (end > 0 and std::isspace((unsigned char)Text[end - 1])) end--;
+   return std::string(Text.substr(0, end));
+}
+
+static std::string trim(std::string_view Text)
+{
+   return trim_right(trim_left(Text));
+}
+
+static std::vector<std::string> normalise_doc_lines(std::string_view Text)
+{
+   std::vector<std::string> lines;
+   size_t start = 0;
+
+   while (start <= Text.size()) {
+      size_t end = Text.find('\n', start);
+      if (end IS std::string_view::npos) end = Text.size();
+
+      std::string_view line = Text.substr(start, end - start);
+      if (not line.empty() and line.back() IS '\r') line.remove_suffix(1);
+      lines.push_back(trim_left(line));
+
+      if (end >= Text.size()) break;
+      start = end + 1;
+   }
+
+   return lines;
+}
+
+static std::string join_lines(const std::vector<std::string> &Lines)
+{
+   size_t first = 0;
+   size_t last = Lines.size();
+
+   while (first < last and trim(Lines[first]).empty()) first++;
+   while (last > first and trim(Lines[last - 1]).empty()) last--;
+
+   std::string result;
+   for (size_t i = first; i < last; ++i) {
+      if (i > first) result += "\n";
+      result += Lines[i];
+   }
+   return result;
+}
+
+static void parse_name_doc_line(std::string_view Line, std::string &Name, std::string &Doc)
+{
+   size_t colon = Line.find(':');
+   if (colon IS std::string_view::npos) {
+      Name = trim(Line);
+      Doc.clear();
+      return;
+   }
+
+   Name = trim(Line.substr(0, colon));
+   Doc = trim(Line.substr(colon + 1));
+}
+
+static bool doc_uses_compact_form(const std::vector<std::string> &Lines)
+{
+   for (const std::string &line : Lines) {
+      std::string trimmed = trim(line);
+      if (trimmed.empty()) continue;
+      return trimmed.front() IS '@';
+   }
+
+   return false;
+}
+
+static std::string compact_doc_payload(std::string_view Line, std::string_view Tag)
+{
+   if (Line.size() < Tag.size()) return {};
+   if (Line.substr(0, Tag.size()) != Tag) return {};
+   if (Line.size() > Tag.size() and not std::isspace((unsigned char)Line[Tag.size()])) return {};
+   return trim(Line.substr(Tag.size()));
+}
+
+static ParsedDocText parse_compact_doc_text(std::string_view Text, const std::vector<std::string> &Lines)
+{
+   ParsedDocText parsed;
+   parsed.block.raw = std::string(Text);
+
+   for (const std::string &line : Lines) {
+      std::string trimmed = trim(line);
+      if (trimmed.empty()) continue;
+
+      std::string payload = compact_doc_payload(trimmed, "@desc");
+      if (not payload.empty()) {
+         if (parsed.block.summary.empty()) parsed.block.summary = payload;
+         if (parsed.block.body.empty()) parsed.block.body = payload;
+         else parsed.block.body += "\n" + payload;
+         continue;
+      }
+
+      payload = compact_doc_payload(trimmed, "@input");
+      if (not payload.empty()) {
+         std::string name;
+         std::string doc;
+         parse_name_doc_line(payload, name, doc);
+         if (not name.empty()) parsed.inputs.emplace_back(std::move(name), std::move(doc));
+         continue;
+      }
+
+      payload = compact_doc_payload(trimmed, "@result");
+      if (not payload.empty()) {
+         ParserDocReturnMetadata ret;
+         parse_name_doc_line(payload, ret.type, ret.doc);
+         parsed.results.push_back(std::move(ret));
+         continue;
+      }
+
+      payload = compact_doc_payload(trimmed, "@error");
+      if (not payload.empty()) {
+         ParserDocErrorMetadata err;
+         parse_name_doc_line(payload, err.code, err.doc);
+         if (not err.code.empty()) parsed.errors.push_back(std::move(err));
+      }
+   }
+
+   return parsed;
+}
+
+static ParsedDocText parse_marker_doc_text(std::string_view Text, const std::vector<std::string> &Lines)
+{
+   ParsedDocText parsed;
+   parsed.block.raw = std::string(Text);
+
+   std::vector<std::string> description_lines;
+   std::vector<std::string> example_lines;
+   DocSection section = DocSection::Description;
+
+   auto flush_example = [&]() {
+      if (not example_lines.empty()) {
+         parsed.block.examples.push_back(join_lines(example_lines));
+         example_lines.clear();
+      }
+   };
+
+   for (const std::string &line : Lines) {
+      std::string marker = trim(line);
+
+      if (marker IS "-INPUT-" or marker IS "-RESULTS-" or marker IS "-ERRORS-" or marker IS "-EXAMPLE-") {
+         if (section IS DocSection::Example) flush_example();
+
+         if (marker IS "-INPUT-") section = DocSection::Input;
+         else if (marker IS "-RESULTS-") section = DocSection::Results;
+         else if (marker IS "-ERRORS-") section = DocSection::Errors;
+         else section = DocSection::Example;
+
+         continue;
+      }
+
+      switch (section) {
+         case DocSection::Description:
+            description_lines.push_back(line);
+            break;
+         case DocSection::Input: {
+            if (marker.empty()) break;
+            std::string name;
+            std::string doc;
+            parse_name_doc_line(line, name, doc);
+            if (not name.empty()) parsed.inputs.emplace_back(std::move(name), std::move(doc));
+            break;
+         }
+         case DocSection::Results: {
+            if (marker.empty()) break;
+            ParserDocReturnMetadata ret;
+            parse_name_doc_line(line, ret.type, ret.doc);
+            parsed.results.push_back(std::move(ret));
+            break;
+         }
+         case DocSection::Errors: {
+            if (marker.empty()) break;
+            ParserDocErrorMetadata err;
+            parse_name_doc_line(line, err.code, err.doc);
+            if (not err.code.empty()) parsed.errors.push_back(std::move(err));
+            break;
+         }
+         case DocSection::Example:
+            example_lines.push_back(line);
+            break;
+      }
+   }
+
+   if (section IS DocSection::Example) flush_example();
+
+   parsed.block.body = join_lines(description_lines);
+   for (const std::string &line : description_lines) {
+      std::string summary = trim(line);
+      if (not summary.empty()) {
+         parsed.block.summary = std::move(summary);
+         break;
+      }
+   }
+
+   return parsed;
+}
+
+static ParsedDocText parse_doc_text(std::string_view Text)
+{
+   std::vector<std::string> lines = normalise_doc_lines(Text);
+   if (doc_uses_compact_form(lines)) return parse_compact_doc_text(Text, lines);
+   return parse_marker_doc_text(Text, lines);
+}
+
+static bool annotation_name_is(const AnnotationEntry &Annotation, std::string_view Name)
+{
+   if (Annotation.name IS nullptr) return false;
+   return std::string_view(strdata(Annotation.name), Annotation.name->len) IS Name;
+}
+
+static std::string annotation_value_to_string(const AnnotationArgValue &Value)
+{
+   switch (Value.type) {
+      case AnnotationArgValue::Type::Bool:
+         return Value.bool_value ? "true" : "false";
+      case AnnotationArgValue::Type::Number:
+         return std::to_string(Value.number_value);
+      case AnnotationArgValue::Type::String:
+         return gcstr_to_string(Value.string_value);
+      case AnnotationArgValue::Type::Array: {
+         std::string result;
+         for (size_t i = 0; i < Value.array_value.size(); ++i) {
+            if (i > 0) result += ", ";
+            result += annotation_value_to_string(Value.array_value[i]);
+         }
+         return result;
+      }
+      default:
+         return {};
+   }
+}
+
+static const AnnotationArgValue * find_annotation_arg(const AnnotationEntry &Annotation, std::string_view Name)
+{
+   for (const auto &[key, value] : Annotation.args) {
+      if (key and std::string_view(strdata(key), key->len) IS Name) return &value;
+   }
+
+   return nullptr;
+}
+
+static std::string find_doc_text(const std::vector<AnnotationEntry> &Annotations)
+{
+   for (const AnnotationEntry &annotation : Annotations) {
+      if (not annotation_name_is(annotation, "Doc")) continue;
+
+      const AnnotationArgValue *text = find_annotation_arg(annotation, "text");
+      if (text and text->type IS AnnotationArgValue::Type::String) return gcstr_to_string(text->string_value);
+   }
+
+   return {};
+}
+
+static std::vector<ParserAnnotationMetadata> collect_annotations(const std::vector<AnnotationEntry> &Annotations)
+{
+   std::vector<ParserAnnotationMetadata> result;
+
+   for (const AnnotationEntry &annotation : Annotations) {
+      ParserAnnotationMetadata meta;
+      meta.name = gcstr_to_string(annotation.name);
+
+      for (const auto &[key, value] : annotation.args) {
+         if (key) meta.args.emplace_back(gcstr_to_string(key), annotation_value_to_string(value));
+      }
+
+      result.push_back(std::move(meta));
+   }
+
+   return result;
+}
+
+static std::string identifier_to_string(const Identifier &Identifier)
+{
+   return gcstr_to_string(Identifier.symbol);
+}
+
+static std::string function_name_to_string(const FunctionNamePath &Path)
+{
+   std::string name;
+
+   for (size_t i = 0; i < Path.segments.size(); ++i) {
+      if (i > 0) name += ".";
+      name += identifier_to_string(Path.segments[i]);
+   }
+
+   if (Path.method.has_value()) {
+      name += ":";
+      name += identifier_to_string(Path.method.value());
+   }
+
+   return name;
+}
+
+static std::string expression_name_to_string(const ExprNode &Expression)
+{
+   if (Expression.kind IS AstNodeKind::IdentifierExpr) {
+      if (const auto *name = std::get_if<NameRef>(&Expression.data)) return identifier_to_string(name->identifier);
+   }
+
+   if (Expression.kind IS AstNodeKind::MemberExpr) {
+      if (const auto *member = std::get_if<MemberExprPayload>(&Expression.data)) {
+         if (member->table) {
+            std::string table_name = expression_name_to_string(*member->table);
+            if (not table_name.empty()) return table_name + "." + identifier_to_string(member->member);
+         }
+      }
+   }
+
+   return {};
+}
+
+static std::string build_signature(const std::string &Name, const FunctionExprPayload &Function)
+{
+   std::string signature = Name + "(";
+   bool first = true;
+
+   for (const FunctionParameter &param : Function.parameters) {
+      if (param.is_self) continue;
+
+      if (not first) signature += ", ";
+      first = false;
+
+      signature += identifier_to_string(param.name);
+      if (param.type != TiriType::Any and param.type != TiriType::Unknown) {
+         signature += ": ";
+         signature += type_to_string(param.type);
+      }
+   }
+
+   if (Function.is_vararg) {
+      if (not first) signature += ", ";
+      signature += "...";
+   }
+
+   signature += ")";
+
+   if (Function.return_types.count IS 1) {
+      signature += ":";
+      signature += type_to_string(Function.return_types.types[0]);
+   }
+   else if (Function.return_types.count > 1) {
+      signature += ":<";
+      for (uint8_t i = 0; i < Function.return_types.count; ++i) {
+         if (i > 0) signature += ", ";
+         signature += type_to_string(Function.return_types.types[i]);
+      }
+      if (Function.return_types.is_variadic) signature += ", ...";
+      signature += ">";
+   }
+
+   return signature;
+}
+
+static std::string find_param_doc(const ParsedDocText &Doc, const std::string &Name, bool &Found)
+{
+   for (const auto &[doc_name, doc_text] : Doc.inputs) {
+      if (doc_name IS Name) {
+         Found = true;
+         return doc_text;
+      }
+   }
+
+   Found = false;
+   return {};
+}
+
+static void add_params(ParserSymbolMetadata &Symbol, const FunctionExprPayload &Function, const ParsedDocText *Doc)
+{
+   for (const FunctionParameter &param : Function.parameters) {
+      if (param.is_self) continue;
+
+      ParserDocParamMetadata meta;
+      meta.name = identifier_to_string(param.name);
+      meta.type = type_to_string(param.type);
+
+      bool found = false;
+      if (Doc) meta.doc = find_param_doc(*Doc, meta.name, found);
+      meta.inferred = not found;
+
+      Symbol.params.push_back(std::move(meta));
+   }
+}
+
+static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload &Function, const ParsedDocText *Doc)
+{
+   size_t declared_count = Function.return_types.count;
+   size_t doc_count = Doc ? Doc->results.size() : 0;
+   size_t count = declared_count > doc_count ? declared_count : doc_count;
+
+   for (size_t i = 0; i < count; ++i) {
+      ParserDocReturnMetadata meta;
+
+      if (i < declared_count) meta.type = type_to_string(Function.return_types.types[i]);
+      if (Doc and i < Doc->results.size()) {
+         meta.doc = Doc->results[i].doc;
+         if (meta.type.empty()) meta.type = Doc->results[i].type;
+      }
+
+      meta.inferred = i >= declared_count;
+      Symbol.results.push_back(std::move(meta));
+   }
+}
+
+static SourceSpan end_span_for(const FunctionExprPayload &Function)
+{
+   if (Function.body) return Function.body->span;
+   return {};
+}
+
+static ParserSymbolMetadata make_function_symbol(const std::string &Name, const FunctionExprPayload &Function,
+   SourceSpan Span)
+{
+   ParserSymbolMetadata symbol;
+   symbol.name = Name;
+   symbol.kind = Function.is_thunk ? "thunk" : "function";
+   symbol.span = Span;
+   symbol.end_span = end_span_for(Function);
+   symbol.signature = build_signature(Name, Function);
+   symbol.annotations = collect_annotations(Function.annotations);
+
+   std::string doc_text = find_doc_text(Function.annotations);
+   if (not doc_text.empty()) {
+      ParsedDocText parsed = parse_doc_text(doc_text);
+      symbol.doc = parsed.block;
+      symbol.errors = std::move(parsed.errors);
+      add_params(symbol, Function, &parsed);
+      add_results(symbol, Function, &parsed);
+   }
+   else {
+      add_params(symbol, Function, nullptr);
+      add_results(symbol, Function, nullptr);
+   }
+
+   return symbol;
+}
+
+static void collect_from_block(ParserSymbolCollection &Collection, const BlockStmt &Block);
+
+static void collect_nested_function_body(ParserSymbolCollection &Collection, const FunctionExprPayload &Function)
+{
+   if (Function.body) collect_from_block(Collection, *Function.body);
+}
+
+static void collect_assignment_functions(ParserSymbolCollection &Collection, const ExprNodeList &Targets,
+   const ExprNodeList &Values, SourceSpan Span)
+{
+   size_t count = Targets.size() < Values.size() ? Targets.size() : Values.size();
+
+   for (size_t i = 0; i < count; ++i) {
+      const ExprNodePtr &target = Targets[i];
+      const ExprNodePtr &value = Values[i];
+      if (not target or not value or value->kind != AstNodeKind::FunctionExpr) continue;
+
+      const auto *function = std::get_if<FunctionExprPayload>(&value->data);
+      if (not function) continue;
+
+      std::string name = expression_name_to_string(*target);
+      if (not name.empty()) Collection.symbols.push_back(make_function_symbol(name, *function, Span));
+      collect_nested_function_body(Collection, *function);
+   }
+}
+
+static void collect_local_decl_functions(ParserSymbolCollection &Collection, const LocalDeclStmtPayload &Payload,
+   SourceSpan Span)
+{
+   size_t count = Payload.names.size() < Payload.values.size() ? Payload.names.size() : Payload.values.size();
+
+   for (size_t i = 0; i < count; ++i) {
+      const ExprNodePtr &value = Payload.values[i];
+      if (not value or value->kind != AstNodeKind::FunctionExpr) continue;
+
+      const auto *function = std::get_if<FunctionExprPayload>(&value->data);
+      if (not function) continue;
+
+      Collection.symbols.push_back(make_function_symbol(identifier_to_string(Payload.names[i]), *function, Span));
+      collect_nested_function_body(Collection, *function);
+   }
+}
+
+static void collect_from_statement(ParserSymbolCollection &Collection, const StmtNode &Statement)
+{
+   switch (Statement.kind) {
+      case AstNodeKind::LocalFunctionStmt: {
+         const auto &payload = std::get<LocalFunctionStmtPayload>(Statement.data);
+         if (payload.function) {
+            Collection.symbols.push_back(make_function_symbol(identifier_to_string(payload.name),
+               *payload.function, Statement.span));
+            collect_nested_function_body(Collection, *payload.function);
+         }
+         break;
+      }
+      case AstNodeKind::FunctionStmt: {
+         const auto &payload = std::get<FunctionStmtPayload>(Statement.data);
+         if (payload.function) {
+            Collection.symbols.push_back(make_function_symbol(function_name_to_string(payload.name),
+               *payload.function, Statement.span));
+            collect_nested_function_body(Collection, *payload.function);
+         }
+         break;
+      }
+      case AstNodeKind::LocalDeclStmt: {
+         const auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
+         collect_local_decl_functions(Collection, payload, Statement.span);
+         break;
+      }
+      case AstNodeKind::AssignmentStmt: {
+         const auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
+         collect_assignment_functions(Collection, payload.targets, payload.values, Statement.span);
+         break;
+      }
+      case AstNodeKind::IfStmt: {
+         const auto &payload = std::get<IfStmtPayload>(Statement.data);
+         for (const IfClause &clause : payload.clauses) {
+            if (clause.block) collect_from_block(Collection, *clause.block);
+         }
+         break;
+      }
+      case AstNodeKind::WhileStmt:
+      case AstNodeKind::RepeatStmt: {
+         const auto &payload = std::get<LoopStmtPayload>(Statement.data);
+         if (payload.body) collect_from_block(Collection, *payload.body);
+         break;
+      }
+      case AstNodeKind::NumericForStmt: {
+         const auto &payload = std::get<NumericForStmtPayload>(Statement.data);
+         if (payload.body) collect_from_block(Collection, *payload.body);
+         break;
+      }
+      case AstNodeKind::GenericForStmt: {
+         const auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+         if (payload.body) collect_from_block(Collection, *payload.body);
+         break;
+      }
+      case AstNodeKind::DoStmt: {
+         const auto &payload = std::get<DoStmtPayload>(Statement.data);
+         if (payload.block) collect_from_block(Collection, *payload.block);
+         break;
+      }
+      case AstNodeKind::ConditionalShorthandStmt: {
+         const auto &payload = std::get<ConditionalShorthandStmtPayload>(Statement.data);
+         if (payload.body) collect_from_statement(Collection, *payload.body);
+         break;
+      }
+      case AstNodeKind::DeferStmt: {
+         const auto &payload = std::get<DeferStmtPayload>(Statement.data);
+         if (payload.callable) collect_nested_function_body(Collection, *payload.callable);
+         break;
+      }
+      case AstNodeKind::TryExceptStmt: {
+         const auto &payload = std::get<TryExceptPayload>(Statement.data);
+         if (payload.try_block) collect_from_block(Collection, *payload.try_block);
+         for (const ExceptClause &clause : payload.except_clauses) {
+            if (clause.block) collect_from_block(Collection, *clause.block);
+         }
+         if (payload.success_block) collect_from_block(Collection, *payload.success_block);
+         break;
+      }
+      case AstNodeKind::WithStmt: {
+         const auto &payload = std::get<WithStmtPayload>(Statement.data);
+         if (payload.block) collect_from_block(Collection, *payload.block);
+         break;
+      }
+      default:
+         break;
+   }
+}
+
+static void collect_from_block(ParserSymbolCollection &Collection, const BlockStmt &Block)
+{
+   for (const StmtNode &statement : Block.view()) collect_from_statement(Collection, statement);
+}
+
+void collect_parser_symbols(lua_State &Lua, const BlockStmt &Chunk)
+{
+   if (Lua.parser_symbols) {
+      delete Lua.parser_symbols;
+      Lua.parser_symbols = nullptr;
+   }
+
+   if (Lua.script IS nullptr or (Lua.script->Flags & SCF::PROCESS_DOC) IS SCF::NIL) return;
+
+   auto *collection = new ParserSymbolCollection();
+   collect_from_block(*collection, Chunk);
+   Lua.parser_symbols = collection;
+}

--- a/src/tiri/jit/src/parser/parser_symbols.h
+++ b/src/tiri/jit/src/parser/parser_symbols.h
@@ -1,0 +1,63 @@
+// Parser symbol metadata for validation and LSP tooling.
+// Copyright © 2025-2026 Paul Manias
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lexer.h"
+
+struct BlockStmt;
+struct lua_State;
+
+struct ParserAnnotationMetadata {
+   std::string name;
+   std::vector<std::pair<std::string, std::string>> args;
+};
+
+struct ParserDocBlockMetadata {
+   std::string summary;
+   std::string body;
+   std::string raw;
+   std::vector<std::string> examples;
+};
+
+struct ParserDocParamMetadata {
+   std::string name;
+   std::string type;
+   std::string doc;
+   bool inferred = false;
+};
+
+struct ParserDocReturnMetadata {
+   std::string type;
+   std::string doc;
+   bool inferred = false;
+};
+
+struct ParserDocErrorMetadata {
+   std::string code;
+   std::string doc;
+   bool inferred = false;
+};
+
+struct ParserSymbolMetadata {
+   std::string name;
+   std::string kind;
+   std::string signature;
+   SourceSpan span{};
+   SourceSpan end_span{};
+   std::vector<ParserAnnotationMetadata> annotations;
+   ParserDocBlockMetadata doc;
+   std::vector<ParserDocParamMetadata> params;
+   std::vector<ParserDocReturnMetadata> results;
+   std::vector<ParserDocErrorMetadata> errors;
+};
+
+struct ParserSymbolCollection {
+   std::vector<ParserSymbolMetadata> symbols;
+};
+
+void collect_parser_symbols(lua_State &, const BlockStmt &);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -48,6 +48,7 @@ struct StrInternState;
 // Parser objects
 
 class TipEmitter;
+struct ParserSymbolCollection;
 
 // Debug objects
 
@@ -1169,6 +1170,7 @@ struct lua_State {
    uint8_t resolving_thunk;  // Flag to prevent recursive thunk resolution
    ParserDiagnostics *parser_diagnostics; // Stores ParserDiagnostics* during parsing errors
    TipEmitter *parser_tips;               // Stores TipEmitter* during parsing for code hints
+   ParserSymbolCollection *parser_symbols; // Stores parser symbol metadata for LSP/documentation tooling
    TValue close_err;  // Current error for __close handlers (nil if no error)
    // Try-except exception handling runtime state (lazily allocated)
    TryFrameStack try_stack;      // Exception frame stack (nullptr until first BC_TRYENTER)

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -23,6 +23,7 @@
 #include "lj_prng.h"
 #include "../parser/lexer.h"
 #include "../parser/parser_diagnostics.h"
+#include "../parser/parser_symbols.h"
 #include "../parser/parser_tips.h"
 #include "lj_alloc.h"
 #include "luajit.h"
@@ -217,6 +218,7 @@ static void close_state(lua_State *L)
    global_State *g = G(L);
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }
+   if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
    funcnames_free(g);
    lj_func_closeuv(L, tvref(L->stack));
 
@@ -377,6 +379,7 @@ void lj_state_free(global_State* g, lua_State *L)
 
    if (L->parser_diagnostics) { delete (ParserDiagnostics*)L->parser_diagnostics; L->parser_diagnostics = nullptr; }
    if (L->parser_tips) { delete L->parser_tips; L->parser_tips = nullptr; }
+   if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
 
    lj_func_closeuv(L, tvref(L->stack));
    lj_assertG(gcref(L->openupval) IS nullptr, "stale open upvalues");

--- a/src/tiri/tests/test_annotations.tiri
+++ b/src/tiri/tests/test_annotations.tiri
@@ -170,7 +170,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function AnnoCompiledStringEscaping()
-   @Doc(text=[[said "hello" and used C:\Temp\docs]])
+   @Note(text=[[said "hello" and used C:\Temp\docs]])
    @Test(labels=["plain", [[quoted "label"]], [[C:\Temp\label]]])
    function documentedFunc()
    end
@@ -179,15 +179,28 @@ end
    assert(entry != nil, "Compiled annotations should register successfully")
    assert(#entry.annotations is 2, "Expected 2 compiled annotations, got " .. #entry.annotations)
 
-   doc = entry.annotations[0]
-   assert(doc.name is "Doc", "Expected first annotation to be Doc, got " .. tostring(doc.name))
-   assert(doc.args.text is [[said "hello" and used C:\Temp\docs]],
-      "Doc text should preserve quotes and backslashes, got " .. tostring(doc.args.text))
+   note = entry.annotations[0]
+   assert(note.name is "Note", "Expected first annotation to be Note, got " .. tostring(note.name))
+   assert(note.args.text is [[said "hello" and used C:\Temp\docs]],
+      "Annotation text should preserve quotes and backslashes, got " .. tostring(note.args.text))
 
    labels = entry.annotations[1].args.labels
    assert(labels[0] is "plain", "Expected first label to be plain")
    assert(labels[1] is [[quoted "label"]], "Expected quoted array label to be preserved, got " .. tostring(labels[1]))
    assert(labels[2] is [[C:\Temp\label]], "Expected backslash array label to be preserved, got " .. tostring(labels[2]))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function AnnoDocPayloadSkippedWithoutProcessDoc()
+   @Doc(text=[[large documentation payload]])
+   function docPayloadSkipped()
+   end
+
+   entry = debug.anno.get(docPayloadSkipped)
+   assert(entry != nil, "@Doc identity should still be registered")
+   assert(entry.annotations[0].name is "Doc", "Expected Doc annotation identity")
+   assert(entry.annotations[0].args.text is nil, "@Doc text should not be registered without SCF_PROCESS_DOC")
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -422,3 +422,74 @@ end
    result = debug.validate(code)
    assert(result.success is true, "Valid function definition should succeed")
 end
+
+@Test function ValidateSymbolsWithDocAnnotation()
+   code = [=[
+      @Doc(text=[[
+         Returns a greeting.
+
+         -INPUT-
+         Name: Person to greet
+
+         -RESULTS-
+         str: Greeting text
+
+         -ERRORS-
+         Args: If the name is invalid
+      ]])
+      function greet(Name: str):str
+         return "Hello " .. Name
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Valid documented function should succeed")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.name is "greet", "Expected function name greet, got " .. tostring(symbol.name))
+   assert(symbol.signature is "greet(Name: str):str", "Unexpected signature: " .. tostring(symbol.signature))
+   assert(symbol.doc.summary is "Returns a greeting.", "Doc summary should be parsed")
+   assert(symbol.params[0].name is "Name", "Expected first param to be Name")
+   assert(symbol.params[0].type is "str", "Expected Name type to be str")
+   assert(symbol.params[0].doc is "Person to greet", "Expected Name doc to be merged")
+   assert(symbol.results[0].type is "str", "Expected return type to be str")
+   assert(symbol.results[0].doc is "Greeting text", "Expected return doc to be merged")
+   assert(symbol.errors[0].code is "Args", "Expected Args error documentation")
+end
+
+@Test function ValidateSymbolsWithCompactDocAnnotation()
+   code = [=[
+      @Doc(text=[[
+         @desc Returns a greeting.
+         @input Name: Person to greet
+         @result str: Greeting text
+         @result str: Additional argument
+         @error Args: If the name is invalid
+         @error Failed: Random failure
+      ]])
+      function greetCompact(Name: str):<str, str>
+         return "Hello " .. Name, "extra"
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Valid compact documented function should succeed")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.name is "greetCompact", "Expected function name greetCompact, got " .. tostring(symbol.name))
+   assert(symbol.doc.summary is "Returns a greeting.", "Compact @desc should define doc summary")
+   assert(symbol.params[0].name is "Name", "Expected first compact param to be Name")
+   assert(symbol.params[0].doc is "Person to greet", "Expected compact @input doc to be merged")
+   assert(symbol.results[0].type is "str", "Expected first compact return type to be str")
+   assert(symbol.results[0].doc is "Greeting text", "Expected first compact @result doc")
+   assert(symbol.results[1].type is "str", "Expected second compact return type to be str")
+   assert(symbol.results[1].doc is "Additional argument", "Expected second compact @result doc")
+   assert(symbol.errors[0].code is "Args", "Expected first compact error code")
+   assert(symbol.errors[0].doc is "If the name is invalid", "Expected first compact error doc")
+   assert(symbol.errors[1].code is "Failed", "Expected second compact error code")
+   assert(symbol.errors[1].doc is "Random failure", "Expected second compact error doc")
+end


### PR DESCRIPTION
## Summary

* Introduces `parser_symbols.cpp/.h` — a new module that walks the AST after parsing and collects structured metadata (name, kind, signature, source span, annotations, `@Doc`-derived params/results/errors) for every function declaration in a script.
* Extends `debug.validate(source, "symbols")` to return a zero-indexed `symbols` table exposing this metadata to Tiri tooling consumers (LSP, documentation generators).
* Gates `@Doc` annotation argument emission on `SCF::PROCESS_DOC` so that large documentation payloads are not retained in `debug.anno` during normal script execution; the `"symbols"` flag sets this automatically.
* Adds `parser_symbols` field to `lua_State` with matching lifecycle cleanup in `lj_state.cpp`.
* Updates `AGENTS.md` with detailed documentation of the annotation system internals, the symbol extraction pipeline, and both marker-form and compact-form `@Doc` parsing rules.

## Test plan

- [ ] Run `test_debug.tiri` — new `ValidateSymbolsWithDocAnnotation` and `ValidateSymbolsWithCompactDocAnnotation` tests validate marker-form and compact-form `@Doc` parsing including param, result, and error metadata merging.
- [ ] Run `test_annotations.tiri` — updated `AnnoCompiledStringEscaping` (renamed to use `@Note`) and new `AnnoDocPayloadSkippedWithoutProcessDoc` verify `@Doc` gating behaviour.
- [ ] Confirm `debug.validate(code)` (no flags) still works and does not expose a `symbols` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)