### PR TITLE
[Tiri] Extend parser symbol collection to cover global function declarations

### DIFF
--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -510,7 +510,8 @@ static void collect_assignment_functions(ParserSymbolCollection &Collection, con
    }
 }
 
-static void collect_local_decl_functions(ParserSymbolCollection &Collection, const LocalDeclStmtPayload &Payload,
+template <typename DeclPayload>
+static void collect_decl_functions(ParserSymbolCollection &Collection, const DeclPayload &Payload,
    SourceSpan Span)
 {
    size_t count = Payload.names.size() < Payload.values.size() ? Payload.names.size() : Payload.values.size();
@@ -550,7 +551,12 @@ static void collect_from_statement(ParserSymbolCollection &Collection, const Stm
       }
       case AstNodeKind::LocalDeclStmt: {
          const auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
-         collect_local_decl_functions(Collection, payload, Statement.span);
+         collect_decl_functions(Collection, payload, Statement.span);
+         break;
+      }
+      case AstNodeKind::GlobalDeclStmt: {
+         const auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
+         collect_decl_functions(Collection, payload, Statement.span);
          break;
       }
       case AstNodeKind::AssignmentStmt: {

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -493,3 +493,23 @@ end
    assert(symbol.errors[1].code is "Failed", "Expected second compact error code")
    assert(symbol.errors[1].doc is "Random failure", "Expected second compact error doc")
 end
+
+@Test function ValidateSymbolsWithGlobalFunctionExpression()
+   code = [=[
+      global greetGlobal = function(Name: str):str
+         return "Hello " .. Name
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Valid global function expression should succeed")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.name is "greetGlobal", "Expected global function expression symbol, got " .. tostring(symbol.name))
+   assert(symbol.signature is "greetGlobal(Name: str):str", "Unexpected signature: " .. tostring(symbol.signature))
+   assert(symbol.params[0].name is "Name", "Expected first param to be Name")
+   assert(symbol.params[0].type is "str", "Expected Name type to be str")
+   assert(symbol.results[0].type is "str", "Expected return type to be str")
+end


### PR DESCRIPTION
## Summary

* Templatises `collect_local_decl_functions` into `collect_decl_functions` so it handles both `LocalDeclStmtPayload` and `GlobalDeclStmtPayload` without duplication
* Adds a `GlobalDeclStmt` case to `collect_from_statement` so global function expressions are included in symbol results returned by `debug.validate`
* Adds Flute test `ValidateSymbolsWithGlobalFunctionExpression` covering name, signature, parameters, and return type for a global function expression

## Test plan

- [ ] Run `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_debug.tiri --log-warning` and confirm `ValidateSymbolsWithGlobalFunctionExpression` passes
- [ ] Confirm existing symbol collection tests continue to pass
- [ ] Verify LSP symbol listing reflects global function declarations correctly in an editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)