### PR TITLE
Add @FunctionName, @SourceFile, and @SourceLine parser annotation expressions

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -154,6 +154,41 @@ AstBuilder::AstBuilder(ParserContext &Context) : ctx(Context)
 {
 }
 
+AstBuilder::FunctionNameScope::FunctionNameScope(AstBuilder &Builder, GCstr *FunctionName) : builder(Builder)
+{
+   this->builder.function_name_stack.push_back(FunctionName ? FunctionName : this->builder.anonymous_function_name());
+}
+
+AstBuilder::FunctionNameScope::~FunctionNameScope()
+{
+   this->builder.function_name_stack.pop_back();
+}
+
+GCstr *AstBuilder::anonymous_function_name()
+{
+   return this->ctx.lex().keepstr("Anonymous");
+}
+
+GCstr *AstBuilder::current_function_name()
+{
+   if (this->function_name_stack.empty()) return this->ctx.lex().keepstr("Main");
+   return this->function_name_stack.back();
+}
+
+GCstr *AstBuilder::current_source_file()
+{
+   const char *chunk_arg = this->ctx.lex().chunk_arg;
+   if (not chunk_arg) return this->ctx.lex().keepstr("<runtime>");
+
+   std::string source_file(chunk_arg);
+   if (not source_file.empty() and (source_file[0] IS '@' or source_file[0] IS '=')) {
+      source_file.erase(0, 1);
+   }
+
+   if (source_file.empty()) source_file = "<runtime>";
+   return this->ctx.lex().keepstr(source_file);
+}
+
 //********************************************************************************************************************
 // Main entry point for parsing a chunk (entire source file).
 

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -23,13 +23,26 @@ public:
    ParserResult<ExprNodePtr> parse_expression(uint8_t precedence = 0);
    ParserResult<ExprNodeList> parse_expression_list();
 
-   [[nodiscard]] bool at_top_level() const { return function_depth_ == 0; }
+   [[nodiscard]] bool at_top_level() const { return function_depth_ IS 0; }
 
 private:
    ParserContext& ctx;
    bool in_guard_expression = false;  // True when parsing 'when' clause guard expression
    bool in_choose_expression = false; // True when parsing choose expression cases (for tuple pattern detection)
    int function_depth_ = 0;           // Tracks nesting depth inside function bodies
+   std::vector<GCstr *> function_name_stack;
+
+   class FunctionNameScope {
+   public:
+      FunctionNameScope(AstBuilder &Builder, GCstr *FunctionName);
+      ~FunctionNameScope();
+
+      FunctionNameScope(const FunctionNameScope &) = delete;
+      FunctionNameScope& operator=(const FunctionNameScope &) = delete;
+
+   private:
+      AstBuilder &builder;
+   };
 
    struct BinaryOpInfo {
       AstBinaryOperator op = AstBinaryOperator::Add;
@@ -69,7 +82,8 @@ private:
    ParserResult<ExprNodePtr> parse_primary();
    ParserResult<ExprNodePtr> parse_suffixed(ExprNodePtr);
    ParserResult<ExprNodePtr> parse_arrow_function(ExprNodeList parameters);
-   ParserResult<ExprNodePtr> parse_function_literal(const Token &, bool is_thunk = false);
+   ParserResult<ExprNodePtr> parse_function_literal(
+      const Token &, bool IsThunk = false, GCstr *FunctionName = nullptr);
    ParserResult<ExprNodePtr> parse_table_literal();
    ParserResult<ReturnStmtPayload> parse_return_payload(const Token &, bool same_line_only);
    ParserResult<FunctionReturnTypes> parse_return_type_annotation();
@@ -108,6 +122,9 @@ private:
    [[nodiscard]] size_t skip_to_synchronisation_point(std::span<const TokenKind> terminators);
    [[nodiscard]] static Identifier make_identifier(const Token &);
    [[nodiscard]] static LiteralValue make_literal(const Token &);
+   [[nodiscard]] GCstr *anonymous_function_name();
+   [[nodiscard]] GCstr *current_function_name();
+   [[nodiscard]] GCstr *current_source_file();
    [[nodiscard]] inline SourceSpan span_from(const Token &Token) { return Token.span(); }
    [[nodiscard]] inline SourceSpan span_from(const Token &Start, const Token &End) const { return combine_spans(Start.span(), End.span()); }
    [[nodiscard]] std::optional<BinaryOpInfo> match_binary_operator(const Token &) const;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -405,6 +405,40 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
+      case TokenKind::Annotate: {
+         Token at_token = this->ctx.tokens().current();
+         this->ctx.tokens().advance();
+
+         auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
+         if (not name_token.ok()) return ParserResult<ExprNodePtr>::failure(name_token.error_ref());
+
+         GCstr *name = name_token.value_ref().identifier();
+         std::string_view annotation_name = name ? std::string_view(strdata(name), name->len) : std::string_view();
+
+         if (annotation_name IS "FunctionName") {
+            node = make_literal_expr(span_from(at_token, name_token.value_ref()),
+               LiteralValue::string(this->current_function_name()));
+            break;
+         }
+
+         if (annotation_name IS "SourceFile") {
+            node = make_literal_expr(span_from(at_token, name_token.value_ref()),
+               LiteralValue::string(this->current_source_file()));
+            break;
+         }
+
+         if (annotation_name IS "SourceLine") {
+            node = make_literal_expr(span_from(at_token, name_token.value_ref()),
+               LiteralValue::number(double(at_token.span().line)));
+            break;
+         }
+
+         {
+            return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
+               "unknown parser annotation expression '@" + std::string(annotation_name) + "'");
+         }
+      }
+
       case TokenKind::Choose: {
          auto choose_result = this->parse_choose_expr();
          if (not choose_result.ok()) return choose_result;
@@ -772,6 +806,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
 
    std::unique_ptr<BlockStmt> body;
    FunctionReturnTypes return_types;
+   FunctionNameScope function_name_scope(*this, nullptr);
 
    if (this->ctx.check(TokenKind::DoToken)) {
       this->ctx.tokens().advance();

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -16,12 +16,13 @@
 // Parses optional return type annotation after parameters for all functions.
 // If is_thunk is true, validates thunk-specific constraints.
 
-ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(const Token &function_token, bool is_thunk)
+ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
+   const Token &FunctionToken, bool IsThunk, GCstr *FunctionName)
 {
    auto params = this->parse_parameter_list(false);
    if (not params.ok()) return ParserResult<ExprNodePtr>::failure(params.error_ref());
 
-   if (is_thunk and params.value_ref().is_vararg) {
+   if (IsThunk and params.value_ref().is_vararg) {
       return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
          "thunk functions do not support varargs");
    }
@@ -33,19 +34,20 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(const Token &functi
 
    // For thunk compatibility: extract single return type for thunk_return_type field
    TiriType thunk_return_type = TiriType::Any;
-   if (is_thunk and return_types.count > 0) {
+   if (IsThunk and return_types.count > 0) {
       thunk_return_type = return_types.types[0];
    }
 
    const TokenKind terms[] = { TokenKind::EndToken };
+   FunctionNameScope function_name_scope(*this, FunctionName);
    ++this->function_depth_;
    auto body = this->parse_block(terms);
    --this->function_depth_;
    if (not body.ok()) return ParserResult<ExprNodePtr>::failure(body.error_ref());
 
    this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
-   ExprNodePtr node = make_function_expr(function_token.span(), std::move(params.value_ref().parameters),
-      params.value_ref().is_vararg, std::move(body.value_ref()), is_thunk, thunk_return_type, return_types);
+   ExprNodePtr node = make_function_expr(FunctionToken.span(), std::move(params.value_ref().parameters),
+      params.value_ref().is_vararg, std::move(body.value_ref()), IsThunk, thunk_return_type, return_types);
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -34,7 +34,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
          Token function_token = local_token;  // Use local_token as span start
          auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
          if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
-         auto fn = this->parse_function_literal(function_token, is_thunk);
+         GCstr *funcname = name_token.value_ref().identifier();
+         auto fn = this->parse_function_literal(function_token, is_thunk, funcname);
          if (not fn.ok()) return ParserResult<StmtNodePtr>::failure(fn.error_ref());
          ExprNodePtr function_expr = std::move(fn.value_ref());
          auto stmt = std::make_unique<StmtNode>(AstNodeKind::LocalFunctionStmt, this->span_from(local_token, name_token.value_ref()));
@@ -121,7 +122,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
       Token function_token = global_token;
       auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
       if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
-      auto fn = this->parse_function_literal(function_token, is_thunk);
+      GCstr *funcname = name_token.value_ref().identifier();
+      auto fn = this->parse_function_literal(function_token, is_thunk, funcname);
       if (not fn.ok()) return ParserResult<StmtNodePtr>::failure(fn.error_ref());
       ExprNodePtr function_expr = std::move(fn.value_ref());
 
@@ -225,7 +227,15 @@ ParserResult<StmtNodePtr> AstBuilder::parse_function_stmt()
       path.method = make_identifier(seg.value_ref());
    }
 
-   auto fn = this->parse_function_literal(func_token, is_thunk);
+   GCstr *funcname = nullptr;
+   if (path.method.has_value() and path.method->symbol) {
+      funcname = path.method->symbol;
+   }
+   else if (not path.segments.empty()) {
+      funcname = path.segments.back().symbol;
+   }
+
+   auto fn = this->parse_function_literal(func_token, is_thunk, funcname);
    if (not fn.ok()) return ParserResult<StmtNodePtr>::failure(fn.error_ref());
    ExprNodePtr function_expr = std::move(fn.value_ref());
 

--- a/src/tiri/tests/test_annotations.tiri
+++ b/src/tiri/tests/test_annotations.tiri
@@ -2,6 +2,55 @@
 
 ----------------------------------------------------------------------------------------------------------------------
 
+top_level_function_name = @FunctionName
+top_level_source_file = @SourceFile
+top_level_source_line = @SourceLine
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function SourceAnnotationsResolveParserLocation()
+   function sourceLineHelper()
+      return @SourceLine
+   end
+
+   assert(top_level_source_file:endsWith('test_annotations.tiri'),
+      "Top level @SourceFile should resolve to this test file, got " .. tostring(top_level_source_file))
+   assert(top_level_source_line > 0, "Top level @SourceLine should resolve to a positive line number")
+   assert(sourceLineHelper() > top_level_source_line, "Function @SourceLine should resolve inside the function body")
+   assert(@SourceFile:endsWith('test_annotations.tiri'),
+      "Function @SourceFile should resolve to this test file, got " .. tostring(@SourceFile))
+   assert(@SourceLine > sourceLineHelper(), "Inline @SourceLine should resolve at the current statement")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function FunctionNameAnnotationResolvesScopes()
+   function namedHelper()
+      return @FunctionName
+   end
+
+   helper_table = {}
+
+   function helper_table:methodHelper()
+      return @FunctionName
+   end
+
+   anonymous_helper = function()
+      return @FunctionName
+   end
+
+   arrow_helper = () => @FunctionName
+
+   assert(top_level_function_name is "Main", "Top level @FunctionName should resolve to Main")
+   assert(@FunctionName is "FunctionNameAnnotationResolvesScopes", "Current test function name should be resolved")
+   assert(namedHelper() is "namedHelper", "Named function should resolve its own name")
+   assert(helper_table:methodHelper() is "methodHelper", "Method function should resolve the method name")
+   assert(anonymous_helper() is "Anonymous", "Anonymous function should resolve to Anonymous")
+   assert(arrow_helper() is "Anonymous", "Arrow function should resolve to Anonymous")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function AnnoSetTableInput()
    function sampleFunc()
       return "test"

--- a/tools/tiri_lsp/CMakeLists.txt
+++ b/tools/tiri_lsp/CMakeLists.txt
@@ -53,4 +53,5 @@ endif ()
 
 flute_test(tiri_lsp_definition "${TIRI_LSP_DIR}/tests/test_definition.tiri")
 flute_test(tiri_lsp_document_symbols "${TIRI_LSP_DIR}/tests/test_document_symbols.tiri")
+flute_test(tiri_lsp_semantic_tokens "${TIRI_LSP_DIR}/tests/test_semantic_tokens.tiri")
 flute_test(tiri_lsp_signature_help "${TIRI_LSP_DIR}/tests/test_signature_help.tiri")

--- a/tools/tiri_lsp/lsp_defs.tiri
+++ b/tools/tiri_lsp/lsp_defs.tiri
@@ -238,6 +238,25 @@ glKeywords = {
 }
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Parser Intrinsic Annotations
+
+glParserAnnotations = {
+   ['FunctionName'] = {
+      comment = 'Expands at parse time to the current function name as a string.  Top-level code resolves to ' ..
+         '"Main"; anonymous functions resolve to "Anonymous".',
+      prototype = '@FunctionName'
+   },
+   ['SourceFile'] = {
+      comment = 'Expands at parse time to the current source file path as a string.',
+      prototype = '@SourceFile'
+   },
+   ['SourceLine'] = {
+      comment = 'Expands at parse time to the current 1-based source line number.',
+      prototype = '@SourceLine'
+   }
+}
+
+----------------------------------------------------------------------------------------------------------------------
 -- Module prefixes mapping
 
 glModulePrefixes = {
@@ -257,5 +276,6 @@ glModulePrefixes = {
    return {
       builtins = glBuiltins,
       keywords = glKeywords,
+      parserAnnotations = glParserAnnotations,
       modulePrefixes = glModulePrefixes
    }

--- a/tools/tiri_lsp/lsp_hover.tiri
+++ b/tools/tiri_lsp/lsp_hover.tiri
@@ -176,6 +176,15 @@ function formatKeywordHover(Keyword, KeywordDoc)
    return md
 end
 
+function formatParserAnnotationHover(AnnotationName, AnnotationDoc)
+   md = f'**@{AnnotationName}** _(Parser annotation)_\n\n'
+   if AnnotationDoc.prototype?? then
+      md ..= '```lua\n' .. AnnotationDoc.prototype .. '\n```\n\n'
+   end
+   md ..= AnnotationDoc.comment
+   return md
+end
+
 @Doc(text="Resolve hover content for a token")
 global function resolveHoverContent(TokenInfo, Doc)
    -- Priority: keywords, builtins, class names, module functions, object methods/fields
@@ -188,6 +197,11 @@ global function resolveHoverContent(TokenInfo, Doc)
    -- Check for keywords
    if glDefs?.keywords?[token] then
       return formatKeywordHover(token, glDefs.keywords[token])
+   end
+
+   -- Check parser intrinsic annotations
+   if glDefs?.parserAnnotations?[token] then
+      return formatParserAnnotationHover(token, glDefs.parserAnnotations[token])
    end
 
    -- Check for built-in functions

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -210,6 +210,13 @@ global FLUID_CONSTANTS = {
    ['true'] = true, ['false'] = true, ['nil'] = true
 }
 
+-- Parser intrinsic annotations that can be used as expressions.
+global FLUID_PARSER_ANNOTATIONS = {
+   ['FunctionName'] = true,
+   ['SourceFile'] = true,
+   ['SourceLine'] = true
+}
+
 -- Built-in functions (default library)
 global FLUID_BUILTINS = {
    -- Output

--- a/tools/tiri_lsp/lsp_parsing.tiri
+++ b/tools/tiri_lsp/lsp_parsing.tiri
@@ -275,6 +275,34 @@ global function tokenizeTiri(Source:str):array
             col = save_col
             line = save_line
          end
+      elseif c is '@' then
+         anno_start = col
+         pos++
+         col++
+
+         if pos < len and isIdentStart(Source:sub(pos, pos + 1)) then
+            name_start = col
+            name_pos = pos
+            while pos < len and isIdentChar(Source:sub(pos, pos + 1)) do
+               pos++
+               col++
+            end
+
+            anno_name = Source:sub(name_pos, pos)
+            token_type = 3
+            token_mod = 0
+            if FLUID_PARSER_ANNOTATIONS[anno_name] then
+               token_type = 12
+               token_mod = 4
+            elseif FLUID_KEYWORDS[anno_name] then
+               token_type = 0
+               token_mod = 0
+            end
+            addToken(line, anno_start, 1, 12, 4) -- @ marker
+            addToken(line, name_start, col - name_start, token_type, token_mod)
+         else
+            addToken(line, anno_start, 1, 12, 4)
+         end
       elseif c is '?' then -- Symbolic operators (multi-character first, then single-character)
          op_start = col
          if pos + 2 < len and Source:sub(pos + 1, pos + 3) is '?=' then

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -1,0 +1,70 @@
+global glSemanticTokensTestUri = nil
+
+@BeforeAll function SetupSemanticTokenTests(State)
+   local err, sdk_path = mSys.ResolvePath(State.folder .. '../../../')
+   assert(err is ERR_Okay, 'Failed to resolve SDK path for LSP semantic token tests.')
+   mSys.SetVolume('sdk', sdk_path)
+
+   loadFile('sdk:tools/tiri_lsp/lsp_lib.tiri')
+   assert(lspInitDocs('sdk:docs/xml/'), 'Failed to initialise LSP documentation cache.')
+   glSemanticTokensTestUri = lspPathToUri('sdk:tools/tiri_lsp/tests/test_semantic_tokens.tiri')
+   assert(glSemanticTokensTestUri, 'Failed to create test document URI.')
+end
+
+function makeDoc(Content:str):table
+   return {
+      uri = glSemanticTokensTestUri,
+      languageId = 'tiri',
+      version = 1,
+      content = Content,
+      lineIndex = nil
+   }
+end
+
+function findToken(Tokens:array, Line:num, Char:num, Text:str):table
+   for token in values(Tokens) do
+      if token.line is Line and token.char is Char and token.length is #Text then
+         return token
+      end
+   end
+end
+
+@Test function ParserAnnotationsReceiveSemanticTokens()
+   source = 'value = @SourceFile\n' ..
+      'line = @SourceLine\n' ..
+      'name = @FunctionName\n' ..
+      '@Test function sample()\n' ..
+      '@if(debug=true)\n' ..
+      '@end\n' ..
+      'end\n'
+
+   tokens = tokenizeTiri(source)
+
+   source_file = findToken(tokens, 0, 9, 'SourceFile')
+   source_line = findToken(tokens, 1, 8, 'SourceLine')
+   function_name = findToken(tokens, 2, 8, 'FunctionName')
+   test_annotation = findToken(tokens, 3, 1, 'Test')
+   compile_if = findToken(tokens, 4, 1, 'if')
+   compile_end = findToken(tokens, 5, 1, 'end')
+
+   assert(source_file and source_file.type is 12, '@SourceFile should be highlighted as a macro token.')
+   assert(source_line and source_line.type is 12, '@SourceLine should be highlighted as a macro token.')
+   assert(function_name and function_name.type is 12, '@FunctionName should be highlighted as a macro token.')
+   assert(test_annotation and test_annotation.type is 3, 'Declaration annotations should remain function tokens.')
+   assert(compile_if and compile_if.type is 0, '@if should retain keyword highlighting.')
+   assert(compile_end and compile_end.type is 0, '@end should retain keyword highlighting.')
+
+   assert((source_file.modifiers & 4) != 0, '@SourceFile should be marked readonly.')
+   assert((source_line.modifiers & 4) != 0, '@SourceLine should be marked readonly.')
+   assert((function_name.modifiers & 4) != 0, '@FunctionName should be marked readonly.')
+end
+
+@Test function ParserAnnotationHoverDocumentation()
+   doc = makeDoc('value = @SourceFile\n')
+   token = getTokenAtPosition(doc, 0, 10)
+   hover = resolveHoverContent(token, doc)
+
+   assert(token and token.text is 'SourceFile', 'Hover token extraction should identify SourceFile.')
+   assert(hover and hover:find('@SourceFile', 0, true), 'Hover should document @SourceFile.')
+   assert(hover:find('Parser annotation', 0, true), 'Hover should identify parser annotations.')
+end

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -5,6 +5,7 @@
    "patterns": [
       { "include": "#comments" },
       { "include": "#strings" },
+      { "include": "#annotations" },
       { "include": "#functions" },
       { "include": "#keywords" },
       { "include": "#operators" },
@@ -23,6 +24,18 @@
             {
                "name": "comment.line.double-dash.tiri",
                "match": "--.*$"
+            }
+         ]
+      },
+      "annotations": {
+         "patterns": [
+            {
+               "name": "support.constant.parser-annotation.tiri",
+               "match": "@(FunctionName|SourceFile|SourceLine)\\b"
+            },
+            {
+               "name": "entity.name.function.annotation.tiri",
+               "match": "@[A-Za-z_][A-Za-z0-9_]*"
             }
          ]
       },
@@ -129,6 +142,7 @@
                "patterns": [
                   { "include": "#comments" },
                   { "include": "#strings" },
+                  { "include": "#annotations" },
                   { "include": "#functions" },
                   { "include": "#keywords" },
                   { "include": "#operators" },


### PR DESCRIPTION
## Summary

- Adds three compile-time parser annotation expressions (`@FunctionName`, `@SourceFile`, `@SourceLine`) to the Tiri JIT parser, resolved at parse time to string/number literals
- Extends the Tiri LSP with hover documentation and semantic token highlighting for the new annotations, and updates the VS Code tmLanguage grammar to distinguish parser annotations from declaration annotations
- Adds a new `test_semantic_tokens.tiri` Flute test suite covering semantic token classification and hover documentation

## Test plan

- [ ] Build `tiri` target and confirm compilation succeeds
- [ ] Run `test_annotations` Flute test to verify `@FunctionName`, `@SourceFile`, and `@SourceLine` resolve correctly at top level, inside named/anonymous/arrow functions, and method contexts
- [ ] Run `tiri_lsp_semantic_tokens` Flute test to verify parser annotations receive correct semantic token type (macro, readonly) and hover content identifies them as parser annotations
- [ ] Confirm `@FunctionName` resolves to `"Main"` at top level, the function name for named functions, and `"Anonymous"` for lambdas and arrow functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)