### PR TITLE
[Tiri] Skip FileSource registration for synthetic parser chunks

### DIFF
--- a/src/tiri/jit/src/debug/dump_bytecode.cpp
+++ b/src/tiri/jit/src/debug/dump_bytecode.cpp
@@ -302,12 +302,13 @@ void format_bc_line(lua_State *L, BCLine Line, int FileWidth, BytecodeLogger Log
          const FileSource *src = get_file_source(L, Line.fileIndex());
 
          std::string_view sv("<unknown>");
-         if (src) sv = std::string_view(src->filename);
+         if (src) {
+            sv = std::string_view(src->filename);
+            if (src->total_lines > 10000) line_no_width += 2;
+            else if (src->total_lines > 1000) line_no_width++;
+         }
          if (sv.size() > size_t(FileWidth)) sv.remove_suffix(sv.size() - FileWidth);
          file_and_line = std::format("{}:{}", sv, Line.lineNumber());
-
-         if (src->total_lines > 10000) line_no_width += 2;
-         else if (src->total_lines > 1000) line_no_width++;
       }
       else file_and_line = "<unknown>:-";
 

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -236,20 +236,18 @@ extern GCproto * lj_parse(LexState *State)
    State->chunk_name = lj_str_newz(L, State->chunk_arg);
 #endif
 
-   log.branch("Chunk: %.*s", State->chunk_name->len, strdata(State->chunk_name));
-
-   // Register this file with FileSource tracking.
-   // The chunk_arg starts with '@' for file sources, extract the path.
+   // Register real file chunks with FileSource tracking.  Synthetic chunks such as "=validate" have no stable path and
+   // should fall back to their chunk name in diagnostics rather than being added to the persistent file source map.
    // Note: We don't clear existing file_sources to preserve import deduplication across loadFile() calls.
-   {
+
+   if (State->chunk_arg and State->chunk_arg[0] IS '@') {
       std::string path = State->chunk_arg;
-      std::string filename = path;
-      if (not path.empty() and path[0] IS '@') {
-         path = path.substr(1);
-         // Extract just the filename from the path
-         auto pos = path.find_last_of("/\\");
-         filename = (pos != std::string::npos) ? path.substr(pos + 1) : path;
-      }
+      path = path.substr(1);
+
+      // Extract just the filename from the path
+      auto pos = path.find_last_of("/\\");
+      std::string filename = (pos != std::string::npos) ? path.substr(pos + 1) : path;
+
       // Estimate source lines from the source view (count newlines + 1)
       BCLine source_lines = 1;
       for (char c : State->source) {
@@ -257,6 +255,9 @@ extern GCproto * lj_parse(LexState *State)
       }
       State->current_file_index = register_main_file_source(L, path, filename, source_lines);
    }
+   else State->current_file_index = FILESOURCE_OVERFLOW_INDEX;
+
+   log.branch("Chunk: %.*s, Registered: %c", State->chunk_name->len, strdata(State->chunk_name), State->current_file_index IS FILESOURCE_OVERFLOW_INDEX ? 'N' : 'Y');
 
    setstrV(L, L->top, State->chunk_name);  // Anchor chunk_name string.
    incr_top(L);

--- a/tools/tiri_lsp/lsp_lib.tiri
+++ b/tools/tiri_lsp/lsp_lib.tiri
@@ -380,6 +380,7 @@ global function computeErrorRange(Doc:table, Line:num, Column:num)
    return Column, Column + 1
 end
 
+@Doc(text="Compute diagnostics for a document using debug.validate()")
 global function computeDiagnostics(Doc:table)
    result = debug.validate(Doc.content)
 


### PR DESCRIPTION
## Summary

- Only register file chunks beginning with `@` in the persistent file source map; synthetic chunks such as `=validate` now receive `FILESOURCE_OVERFLOW_INDEX` instead of polluting the map with entries that have no stable path
- Improved log output at chunk parse time to indicate whether the chunk was registered with FileSource tracking
- Added `@Doc` annotation to `computeDiagnostics` in `lsp_lib.tiri`

## Test plan

- [ ] Verify `debug.validate()` no longer causes spurious entries in the file source map
- [ ] Confirm that normal `.tiri` file loads still register correctly in FileSource tracking
- [ ] Confirm LSP diagnostics continue to function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)