### PR TITLE
[Core] Preserve async cancellation callbacks

### DIFF
--- a/src/core/data.cpp
+++ b/src/core/data.cpp
@@ -71,6 +71,7 @@ std::set<std::shared_ptr<std::jthread>> glAsyncThreads;
 std::mutex glmActionQueue;
 std::unordered_map<OBJECTID, std::deque<QueuedAction>> glActionQueues;
 std::unordered_set<OBJECTID> glActiveAsyncObjects;
+std::unordered_set<OBJECTID> glCancelledAsyncObjects;
 std::unordered_map<OBJECTID, int> glAsyncObjectThreads;
 
 std::condition_variable_any cvObjects;

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -174,6 +174,7 @@ struct ThreadActionMessage {
    OBJECTID  ObjectID;  // ID of the target object (for queue dispatch).
    ERR       Error;     // The error code resulting from the action's execution.
    FUNCTION  Callback;  // Callback function to execute on action completion.
+   bool      DispatchNext = true; // False for callbacks emitted while draining a queue.
 };
 
 // Queued async action, waiting for the same-object action to complete.
@@ -206,6 +207,7 @@ extern std::recursive_mutex glmAsyncActions;
 extern std::mutex glmActionQueue;
 extern std::unordered_map<OBJECTID, std::deque<QueuedAction>> glActionQueues;
 extern std::unordered_set<OBJECTID> glActiveAsyncObjects;
+extern std::unordered_set<OBJECTID> glCancelledAsyncObjects;
 extern std::unordered_map<OBJECTID, int> glAsyncObjectThreads;
 
 extern std::condition_variable_any cvResources;

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -999,7 +999,8 @@ int AsyncPending(OBJECTID ObjectID)
 {
    std::lock_guard<std::mutex> lock(glmActionQueue);
    int count = 0;
-   if (glActiveAsyncObjects.contains(ObjectID) or glAsyncObjectThreads.contains(ObjectID)) count++;
+   // Match AsyncWait() state: worker-thread bookkeeping can outlive completion dispatch briefly.
+   if (glActiveAsyncObjects.contains(ObjectID)) count++;
    if (auto it = glActionQueues.find(ObjectID); it != glActionQueues.end()) {
       count += int(it->second.size());
    }

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -551,7 +551,6 @@ static void launch_async_thread(OBJECTPTR Object, ACTIONID ActionID, int ArgsSiz
          {
             std::lock_guard<std::mutex> lock(glmActionQueue);
             glAsyncObjectThreads.erase(object_uid);
-            glCancelledAsyncObjects.erase(object_uid);
          }
          deregister_thread();
          std::lock_guard<std::recursive_mutex> lock(glmAsyncActions);

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -26,7 +26,7 @@ Name: Objects
 
 using namespace kt;
 
-static void drain_action_queue(OBJECTID, bool = false);
+static void drain_action_queue(OBJECTID ObjectID, bool Terminating = false, bool PreserveActive = false);
 static void async_wait_callback(OBJECTID, bool);
 
 // AsyncWait() state — guarded by glmAsyncWait.
@@ -79,6 +79,7 @@ void stop_async_actions(void)
       std::lock_guard<std::mutex> lock(glmActionQueue);
       glActionQueues.clear();
       glActiveAsyncObjects.clear();
+      glCancelledAsyncObjects.clear();
       glAsyncObjectThreads.clear();
    }
 }
@@ -439,7 +440,8 @@ void dispatch_queued_action(OBJECTID ObjectID)
                .ActionID = next.ActionID,
                .ObjectID = ObjectID,
                .Error    = ERR::DoesNotExist,
-               .Callback = next.Callback
+               .Callback = next.Callback,
+               .DispatchNext = false
             };
             SendMessage(MSGID::THREAD_ACTION, MSF::NIL, &msg, sizeof(msg));
          }
@@ -461,7 +463,8 @@ void dispatch_queued_action(OBJECTID ObjectID)
             .ActionID = next.ActionID,
             .ObjectID = ObjectID,
             .Error    = obj.error,
-            .Callback = next.Callback
+            .Callback = next.Callback,
+            .DispatchNext = false
          };
          SendMessage(MSGID::THREAD_ACTION, MSF::NIL, &msg, sizeof(msg));
       }
@@ -474,11 +477,12 @@ void dispatch_queued_action(OBJECTID ObjectID)
 // Drain all queued actions for an object, sending error callbacks for each.  Called when the object
 // is being freed or is otherwise no longer valid.
 
-static void drain_action_queue(OBJECTID ObjectID, bool Terminating)
+static void drain_action_queue(OBJECTID ObjectID, bool Terminating, bool PreserveActive)
 {
    kt::Log log(__FUNCTION__);
 
    std::deque<QueuedAction> drained;
+   bool clear_active = not PreserveActive;
    {
       std::lock_guard<std::mutex> lock(glmActionQueue);
       auto it = glActionQueues.find(ObjectID);
@@ -486,12 +490,15 @@ static void drain_action_queue(OBJECTID ObjectID, bool Terminating)
          drained = std::move(it->second);
          glActionQueues.erase(it);
       }
-      glActiveAsyncObjects.erase(ObjectID);
+      if (clear_active) {
+         glActiveAsyncObjects.erase(ObjectID);
+         glCancelledAsyncObjects.erase(ObjectID);
+      }
    }
 
    // Clear the async flag.  The object may already be freed in the Terminating case, so tolerate lock failure.
 
-   if (not Terminating) {
+   if ((not Terminating) and clear_active) {
       ScopedObjectLock obj(ObjectID);
       if (obj.granted()) {
          if (obj->defined(NF::ASYNC_ACTIVE)) {
@@ -511,7 +518,8 @@ static void drain_action_queue(OBJECTID ObjectID, bool Terminating)
             .ActionID = action.ActionID,
             .ObjectID = ObjectID,
             .Error    = ERR::DoesNotExist,
-            .Callback = action.Callback
+            .Callback = action.Callback,
+            .DispatchNext = false
          };
          SendMessage(MSGID::THREAD_ACTION, MSF::NIL, &msg, sizeof(msg));
       }
@@ -541,6 +549,7 @@ static void launch_async_thread(OBJECTPTR Object, ACTIONID ActionID, int ArgsSiz
          {
             std::lock_guard<std::mutex> lock(glmActionQueue);
             glAsyncObjectThreads.erase(object_uid);
+            glCancelledAsyncObjects.erase(object_uid);
          }
          deregister_thread();
          std::lock_guard<std::recursive_mutex> lock(glmAsyncActions);
@@ -556,12 +565,18 @@ static void launch_async_thread(OBJECTPTR Object, ACTIONID ActionID, int ArgsSiz
          std::lock_guard<std::mutex> lock(glmActionQueue);
          glAsyncObjectThreads[object_uid] = int(get_thread_id());
       }
+
       auto is_stopping = [&stop_token, &thread_rec]() {
          return stop_token.stop_requested()
             or (thread_rec and thread_rec->state.load(std::memory_order_acquire) IS TSTATE::STOPPING);
       };
 
-      if (is_stopping()) {
+      auto is_cancelled = [object_uid]() {
+         std::lock_guard<std::mutex> lock(glmActionQueue);
+         return glCancelledAsyncObjects.contains(object_uid);
+      };
+
+      if (is_stopping() or is_cancelled()) {
          ThreadActionMessage msg = {
             .ActionID = ActionID,
             .ObjectID = object_uid,
@@ -576,7 +591,7 @@ static void launch_async_thread(OBJECTPTR Object, ACTIONID ActionID, int ArgsSiz
       ERR error;
       if (error = LockObject(Object, 5000); error IS ERR::Okay) { // Access the object and process the action.
          // Check for stop request before executing action
-         if (not is_stopping()) {
+         if ((not is_stopping()) and (not is_cancelled())) {
             error = Action(ActionID, Object, ArgsSize ? (APTR)Parameters.data() : nullptr);
          }
 
@@ -591,7 +606,7 @@ static void launch_async_thread(OBJECTPTR Object, ACTIONID ActionID, int ArgsSiz
       // Preserve the callback on cancellation so script-side cleanup still runs.
 
       auto completion_error = error;
-      if (is_stopping()) completion_error = ERR::Cancelled;
+      if (is_stopping() or is_cancelled()) completion_error = ERR::Cancelled;
 
       ThreadActionMessage msg = {
          .ActionID = ActionID,
@@ -945,6 +960,7 @@ ERR AsyncCancel(OBJECTID *Objects, int Size)
       int thread_id;
       {
          std::lock_guard<std::mutex> lock(glmActionQueue);
+         if (glActiveAsyncObjects.contains(object_id)) glCancelledAsyncObjects.insert(object_id);
          auto it = glAsyncObjectThreads.find(object_id);
          if (it != glAsyncObjectThreads.end()) thread_id = it->second;
          else thread_id = 0;
@@ -952,7 +968,7 @@ ERR AsyncCancel(OBJECTID *Objects, int Size)
 
       if (thread_id) WakeThread(thread_id, true);
 
-      drain_action_queue(object_id);
+      drain_action_queue(object_id, false, true);
    }
 
    return ERR::Okay;
@@ -1107,7 +1123,7 @@ ERR msg_threadaction(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgS
    }
 
    // Dispatch the next queued action for this object (if any).
-   dispatch_queued_action(msg->ObjectID);
+   if (msg->DispatchNext) dispatch_queued_action(msg->ObjectID);
 
    return ERR::Okay;
 }

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -403,6 +403,8 @@ void dispatch_queued_action(OBJECTID ObjectID)
    bool queue_empty = false;
    {
       std::lock_guard<std::mutex> lock(glmActionQueue);
+      // Cancellation state applies only to the action whose completion is being processed.
+      glCancelledAsyncObjects.erase(ObjectID);
       auto it = glActionQueues.find(ObjectID);
       if ((it IS glActionQueues.end()) or it->second.empty()) {
          glActiveAsyncObjects.erase(ObjectID);

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -1,4 +1,7 @@
 
+@BeforeEach(hotpath=3)
+function enforce_hotpath() end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Create two dummy objects and use them to confirm that the signalling of multiple objects works.
 -- Also ensures that the garbage collector doesn't collect the script while it's running.

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -560,9 +560,39 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- async.cancel() must not leave stale cancellation state after the worker finishes but before its message is processed.
+
+@Test(priority=26) function CancelCompletedWorkerAllowsNextAction()
+   async.pool.clear()
+   async.pool.completed_cancel_race = 0
+
+   script = obj.new('script', {
+      statement=[[ async.pool.completed_cancel_race = async.pool.completed_cancel_race + 1 ]]
+   })
+
+   async.script(script)
+
+   -- Negative WaitTime sleeps without processing the worker completion message.
+   mSys.WaitTime(-0.25)
+
+   check async.cancel(script)
+
+   async.script(script)
+   check async.wait(script, 3.0)
+
+   count = async.pool.completed_cancel_race
+   pending = async.pending(script)
+
+   assert(count is 2, f'Expected second action to run after stale cancellation window, got {count}')
+   assert(pending is 0, f'Expected 0 pending after stale cancellation window, got {pending}')
+
+   async.pool.clear()
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- async.pending() must reject non-object arguments.
 
-@Test(priority=26) function PendingRejectsBadArgs()
+@Test(priority=27) function PendingRejectsBadArgs()
    for arg in values({ 'hello', 42, true, { } }) do
       rejected = false
       try
@@ -577,7 +607,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- async.cancel() must reject non-object/non-array arguments.
 
-@Test(priority=27) function CancelRejectsBadArgs()
+@Test(priority=28) function CancelRejectsBadArgs()
    for arg in values({ 'hello', 42, true }) do
       rejected = false
       try
@@ -592,7 +622,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify that async.action() passes user arguments after the fixed Object, Action, Callback and Key parameters.
 
-@Test(priority=28) function ActionArgumentOffset()
+@Test(priority=29) function ActionArgumentOffset()
    script = obj.new('script', { statement=[[ ]] })
 
    async.action(script, 'SetKey', function(ActionID, Object, Error, Key)


### PR DESCRIPTION
* Track cancelled async objects so running actions finish with cancellation while queued work is drained
* Prevent drained callbacks from dispatching follow-up queued actions
* Add async test hotpath setup for cancellation coverage