### PR TITLE
[Tiri] Use cached API prototypes for LSP signature help

### DIFF
--- a/src/http/tests/test_validate_header.tiri
+++ b/src/http/tests/test_validate_header.tiri
@@ -1,23 +1,123 @@
 --[[
-Header Validation Testing
-
-Tests the new validateHeader callback feature for routes, which allows
-early header validation before the full request body is processed.
+Test the validateHeader callback feature for routes, which allows early header validation before the full
+request body is processed.
 --]]
 
    import 'net/httpserver'
    import 'json'
    include 'http'
 
-   SERVER_PORT = 18940
+SERVER_PORT <const> = 18940
+
+@BeforeAll function init(Path)
+   global glPath = Path
+
+   global glServer = hslib.start({
+      port    = SERVER_PORT,
+      folder  = glPath,
+      verbose = false,
+      logMessage = function(Message)
+         print(Message)
+      end,
+      routes = {
+         -- Route with authentication validation
+         { pattern = '/auth/protected',
+            method = 'GET',
+            validateHeader = function(headers):any
+               local auth = headers['authorization']
+               if not auth then
+                  return { status = 401, statusText = 'Unauthorized',
+                           message = 'Authentication required',
+                           details = 'Missing Authorization header' }
+               end
+
+               local token = regex.new('Bearer\\s+(.+)').extract(auth)
+               if token != 'valid-token-123' then
+                  return false -- Simple 400 Bad Request
+               end
+
+               return true -- Valid, continue processing
+            end,
+            handler = function(req, res)
+               res.json({ message = 'Access granted', user = 'authenticated' })
+            end
+         },
+
+         -- Route with admin-level validation
+         { pattern = '/api/admin-only',
+            method = 'POST',
+            validateHeader = function(headers):any
+               local auth = headers['authorization']
+               if not auth then
+                  return { status = 401, statusText = 'Unauthorized',
+                           message = 'Authentication required',
+                           details = 'Missing Authorization header' }
+               end
+
+               local token = regex.new('Bearer\\s+(.+)').extract(auth)
+               if not token or not token:find('admin') then
+                  return { status = 403, statusText = 'Forbidden',
+                           message = 'Admin access required',
+                           details = 'This endpoint requires admin privileges' }
+               end
+
+               return true
+            end,
+            handler = function(req, res)
+               res.json({ message = 'Admin endpoint accessed', privileges = 'admin' })
+            end
+         },
+
+         -- Route with content-type validation
+         { pattern = '/api/json-only',
+            method = 'POST',
+            validateHeader = function(headers):any
+               local contentType = headers['content-type']
+               if not contentType or not contentType:find('application/json') then
+                  return { status = 415, statusText = 'Unsupported Media Type',
+                           message = 'JSON content type required',
+                           details = 'This endpoint only accepts application/json' }
+               end
+               return true
+            end,
+            handler = function(req, res)
+               res.json({ message = 'JSON data received', data = req.parsedBody })
+            end
+         },
+
+         -- Route with validation that throws an exception
+         { pattern = '/error/validation-crash',
+            method = 'GET',
+            validateHeader = function(headers):any
+               error('Intentional validation error')
+            end,
+            handler = function(req, res)
+               res.json({ message = 'This should never be reached' })
+            end
+         },
+
+         -- Route without validateHeader callback
+         { pattern = '/public/no-validation',
+            method = 'GET',
+            handler = function(req, res)
+               res.json({ message = 'Public endpoint', access = 'unrestricted' })
+            end
+         }
+      }
+   })
+end
+
+@AfterAll function cleanup()
+   glServer.stop()
+end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderSuccess()
-   local proc = processing.new({ timeout = 5.0 })
-   local content = ''
+@Test function ValidateHeaderSuccess()
+   proc = processing.new({ timeout = 5.0 })
+   content = ''
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src = 'http://127.0.0.1:' .. SERVER_PORT .. '/auth/protected',
       method = 'GET',
       flags = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -34,12 +134,12 @@ function ValidateHeaderSuccess()
 
    assert(http.acActivate() is ERR_Okay, "Valid header test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'Valid header processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 200, 'Valid header should return 200, got: ' .. http.status)
 
-   local response = json.decode(content)
+   response = json.decode(content)
    assert(response.message is 'Access granted', 'Should receive success message')
 
    print('validateHeader success test passed; HTTP Error: ' .. mSys.GetErrorMsg(http.error))
@@ -47,10 +147,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderFailure()
-   local proc = processing.new({ timeout = 5.0 })
+@Test function ValidateHeaderFailure()
+   proc = processing.new({ timeout = 5.0 })
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src = 'http://127.0.0.1:' .. SERVER_PORT .. '/auth/protected',
       method = 'GET',
       flags = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -64,7 +164,7 @@ function ValidateHeaderFailure()
 
    assert(http.acActivate() is ERR_Okay, "Invalid header test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'Invalid header processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 400, 'Invalid header should return 400, got: ' .. http.status)
@@ -74,10 +174,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderCustomError()
-   local proc = processing.new({ timeout = 5.0 })
+@Test function ValidateHeaderCustomError()
+   proc = processing.new({ timeout = 5.0 })
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src = 'http://127.0.0.1:' .. SERVER_PORT .. '/api/admin-only',
       method = 'POST',
       flags = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -93,7 +193,7 @@ function ValidateHeaderCustomError()
 
    assert(http.acActivate() is ERR_Okay, "Custom error test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'Custom error processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 403, 'Custom error should return 403 (Forbidden), got: ' .. http.status)
@@ -103,10 +203,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderMissingAuth()
-   local proc = processing.new({ timeout = 5.0 })
+@Test function ValidateHeaderMissingAuth()
+   proc = processing.new({ timeout = 5.0 })
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src = 'http://127.0.0.1:' .. SERVER_PORT .. '/auth/protected',
       method = 'GET',
       flags = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -120,7 +220,7 @@ function ValidateHeaderMissingAuth()
 
    check http.acActivate()
 
-   local err = proc.sleep()
+   err = proc.sleep()
    assert(err is ERR_Okay, 'Missing auth processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 401, 'Missing auth should return 401, got: ' .. http.status)
 
@@ -129,13 +229,13 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderContentType()
-   local proc = processing.new({ timeout = 5.0 })
+@Test function ValidateHeaderContentType()
+   proc = processing.new({ timeout = 5.0 })
 
    -- Send XML to an endpoint that only accepts JSON
-   local xml_data = '<?xml version="1.0"?><test>data</test>'
+   xml_data = '<?xml version="1.0"?><test>data</test>'
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src         = 'http://127.0.0.1:' .. SERVER_PORT .. '/api/json-only',
       method      = 'POST',
       flags       = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -151,7 +251,7 @@ function ValidateHeaderContentType()
 
    assert(http.acActivate() is ERR_Okay, "Content type validation test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'Content type validation processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 415, 'Content type validation should return 415, got: ' .. http.status)
@@ -161,10 +261,10 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function ValidateHeaderException()
-   local proc = processing.new({ timeout = 5.0 })
+@Test function ValidateHeaderException()
+   proc = processing.new({ timeout = 5.0 })
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src    = 'http://127.0.0.1:' .. SERVER_PORT .. '/error/validation-crash',
       method = 'GET',
       flags  = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -177,7 +277,7 @@ function ValidateHeaderException()
 
    assert(http.acActivate() is ERR_Okay, "Validation exception test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'Validation exception processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 500, 'Validation exception should return 500, got: ' .. http.status)
@@ -187,11 +287,11 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function NoValidateHeaderCallback()
-   local proc = processing.new({ timeout = 5.0 })
-   local content = ''
+@Test function NoValidateHeaderCallback()
+   proc = processing.new({ timeout = 5.0 })
+   content = ''
 
-   local http = obj.new('http', {
+   http = obj.new('http', {
       src      = 'http://127.0.0.1:' .. SERVER_PORT .. '/public/no-validation',
       method   = 'GET',
       flags    = HTF_NO_HEAD | HTF_NO_DIALOG,
@@ -207,127 +307,13 @@ function NoValidateHeaderCallback()
 
    assert(http.acActivate() is ERR_Okay, "No validation test failed to activate")
 
-   local err = proc.sleep()
+   err = proc.sleep()
    msg('Test woke up; HTTP error: ' .. mSys.GetErrorMsg(http.error))
    assert(err is ERR_Okay, 'No validation processing failed: ' .. mSys.GetErrorMsg(err))
    assert(http.status is 200, 'No validation should return 200, got: ' .. http.status)
 
-   local response = json.decode(content)
+   response = json.decode(content)
    assert(response.message is 'Public endpoint', 'Should receive public endpoint message')
 
    print('No validateHeader callback test passed; HTTP Error: ' .. mSys.GetErrorMsg(http.error))
 end
-
-----------------------------------------------------------------------------------------------------------------------
-
-   return {
-      tests = {
-         testValidateHeaderSuccess,
-         testValidateHeaderFailure,
-         testValidateHeaderCustomError,
-         testValidateHeaderMissingAuth,
-         testValidateHeaderContentType,
-         testValidateHeaderException,
-         testNoValidateHeaderCallback
-      },
-      init = function(Path)
-         global glPath = Path
-
-         global glServer = hslib.start({
-            port = SERVER_PORT,
-            folder = glPath,
-            verbose = false,
-            logMessage = function(Message)
-               print(Message)
-            end,
-            routes = {
-               -- Route with authentication validation
-               { pattern = '/auth/protected',
-                 method = 'GET',
-                 validateHeader = function(headers):any
-                    local auth = headers['authorization']
-                    if not auth then
-                       return { status = 401, statusText = 'Unauthorized',
-                               message = 'Authentication required',
-                               details = 'Missing Authorization header' }
-                    end
-
-                    local token = regex.new('Bearer\\s+(.+)').extract(auth)
-                    if token != 'valid-token-123' then
-                       return false -- Simple 400 Bad Request
-                    end
-
-                    return true -- Valid, continue processing
-                 end,
-                 handler = function(req, res)
-                    res.json({ message = 'Access granted', user = 'authenticated' })
-                 end
-               },
-
-               -- Route with admin-level validation
-               { pattern = '/api/admin-only',
-                 method = 'POST',
-                 validateHeader = function(headers):any
-                    local auth = headers['authorization']
-                    if not auth then
-                       return { status = 401, statusText = 'Unauthorized',
-                               message = 'Authentication required',
-                               details = 'Missing Authorization header' }
-                    end
-
-                    local token = regex.new('Bearer\\s+(.+)').extract(auth)
-                    if not token or not token:find('admin') then
-                       return { status = 403, statusText = 'Forbidden',
-                               message = 'Admin access required',
-                               details = 'This endpoint requires admin privileges' }
-                    end
-
-                    return true
-                 end,
-                 handler = function(req, res)
-                    res.json({ message = 'Admin endpoint accessed', privileges = 'admin' })
-                 end
-               },
-
-               -- Route with content-type validation
-               { pattern = '/api/json-only',
-                 method = 'POST',
-                 validateHeader = function(headers):any
-                    local contentType = headers['content-type']
-                    if not contentType or not contentType:find('application/json') then
-                       return { status = 415, statusText = 'Unsupported Media Type',
-                               message = 'JSON content type required',
-                               details = 'This endpoint only accepts application/json' }
-                    end
-                    return true
-                 end,
-                 handler = function(req, res)
-                    res.json({ message = 'JSON data received', data = req.parsedBody })
-                 end
-               },
-
-               -- Route with validation that throws an exception
-               { pattern = '/error/validation-crash',
-                 method = 'GET',
-                 validateHeader = function(headers):any
-                    error('Intentional validation error')
-                 end,
-                 handler = function(req, res)
-                    res.json({ message = 'This should never be reached' })
-                 end
-               },
-
-               -- Route without validateHeader callback
-               { pattern = '/public/no-validation',
-                 method = 'GET',
-                 handler = function(req, res)
-                    res.json({ message = 'Public endpoint', access = 'unrestricted' })
-                 end
-               }
-            }
-         })
-      end,
-      cleanup = function()
-         glServer.stop()
-      end
-   }

--- a/tools/tiri_lsp/lsp_cache.tiri
+++ b/tools/tiri_lsp/lsp_cache.tiri
@@ -21,17 +21,6 @@ function encodeField(Access, Type, ByteStart, ByteEnd, Comment)
    return f'A:{Access or "R"}\tL:{ByteStart},{ByteEnd}\tT:{Type or ""}\tC:{Comment or ""}'
 end
 
-@Doc(text='Encode a method/action/function entry.')
-function encodeMethod(Prototype, TiriPrototype, ByteStart, ByteEnd, Comment, Params)
-   return {
-      byteStart = ByteStart,
-      byteEnd = ByteEnd,
-      prototype = (TiriPrototype or Prototype) or '',
-      comment = Comment or '',
-      params = Params or array<table>
-   }
-end
-
 @Doc(text='Decode a field from compact string format')
 global function decodeField(Str:any):table
    if type(Str) != 'string' then return Str end  -- Already decoded or nil
@@ -57,31 +46,15 @@ global function decodeField(Str:any):table
    return result
 end
 
--- Decode a method/action/function from compact string format
-
-global function decodeMethod(Str:any):table
-   if type(Str) is 'table' then return Str end  -- Already decoded or nil
-
-   result = {}
-   for field in values(Str:split('\t')) do
-      key = field:sub(0, 1)
-      value = field:sub(2)
-      if key is 'L' then
-         start_pos, end_pos = rx_pos_pair.extract(value)
-         result.byteStart = tonumber(start_pos)
-         result.byteEnd = tonumber(end_pos)
-      elseif key is 'P' then
-         result.prototype = value
-      elseif key is 'T' then
-         result.tiriPrototype = value
-      elseif key is 'C' then
-         result.comment = value
-      else
-         print(f'Unrecognised key: {key}')
-      end
-   end
-
-   return result
+@Doc(text='Encode a method/action/function entry into a table record.')
+function createMethodRecord(Prototype, TiriPrototype, ByteStart, ByteEnd, Comment, Params)
+   return {
+      byteStart = ByteStart,
+      byteEnd = ByteEnd,
+      prototype = (TiriPrototype or Prototype) or '',
+      comment = Comment or '',
+      params = Params or array<table>
+   }
 end
 
 function extractAttrFromText(Text:str, AttrName:str):str
@@ -217,7 +190,7 @@ function processModuleXML(FilePath:str, DocPath:str):<str,table>
 
       funcName = extractChildText(funcMatch.content, 'name')
       if funcName then
-         modEntry.functions[funcName] = encodeMethod(
+         modEntry.functions[funcName] = createMethodRecord(
             extractChildText(funcMatch.content, 'prototype') or '',
             extractChildText(funcMatch.content, 'tiriPrototype') or '',
             funcMatch.byteStart,
@@ -269,7 +242,7 @@ function processClassXML(FilePath, DocPath)
 
       methodName = extractChildText(methodMatch.content, 'name')
       if methodName then
-         classEntry.methods[methodName] = encodeMethod(
+         classEntry.methods[methodName] = createMethodRecord(
             extractChildText(methodMatch.content, 'prototype') or '',
             extractChildText(methodMatch.content, 'tiriPrototype') or '',
             methodMatch.byteStart,
@@ -290,7 +263,7 @@ function processClassXML(FilePath, DocPath)
 
       actionName = extractChildText(actionMatch.content, 'name')
       if actionName then
-         classEntry.actions[actionName] = encodeMethod(
+         classEntry.actions[actionName] = createMethodRecord(
             extractChildText(actionMatch.content, 'prototype') or '',
             extractChildText(actionMatch.content, 'tiriPrototype') or '',
             actionMatch.byteStart,

--- a/tools/tiri_lsp/lsp_definition.tiri
+++ b/tools/tiri_lsp/lsp_definition.tiri
@@ -513,7 +513,7 @@ function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
          if rx_def_action_prefix.test(token) then
             action_name = token:sub(2)
             if class_doc.actions and class_doc.actions[action_name] then
-               action_doc = decodeMethod(class_doc.actions[action_name])
+               action_doc = class_doc.actions[action_name]
                pushLocation(locations, makeXmlLocation(class_doc, action_doc.byteStart, action_doc.byteEnd))
             end
          end
@@ -521,18 +521,18 @@ function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
          if #locations is 0 and rx_def_method_prefix.test(token) then
             method_name = token:sub(2)
             if class_doc.methods and class_doc.methods[method_name] then
-               method_doc = decodeMethod(class_doc.methods[method_name])
+               method_doc = class_doc.methods[method_name]
                pushLocation(locations, makeXmlLocation(class_doc, method_doc.byteStart, method_doc.byteEnd))
             end
          end
 
          if #locations is 0 and class_doc.methods and class_doc.methods[token] then
-            method_doc = decodeMethod(class_doc.methods[token])
+            method_doc = class_doc.methods[token]
             pushLocation(locations, makeXmlLocation(class_doc, method_doc.byteStart, method_doc.byteEnd))
          end
 
          if #locations is 0 and class_doc.actions and class_doc.actions[token] then
-            action_doc = decodeMethod(class_doc.actions[token])
+            action_doc = class_doc.actions[token]
             pushLocation(locations, makeXmlLocation(class_doc, action_doc.byteStart, action_doc.byteEnd))
          end
 
@@ -561,7 +561,7 @@ function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
       module_doc = glDocCache?.modules?[module_name]
       func_doc = module_doc?.functions?[token]
       if module_doc and func_doc then
-         decoded_func = decodeMethod(func_doc)
+         decoded_func = func_doc
          locations = array<table>
          pushLocation(locations, makeXmlLocation(module_doc, decoded_func.byteStart, decoded_func.byteEnd))
          return #locations > 0 and locations or nil

--- a/tools/tiri_lsp/lsp_hover.tiri
+++ b/tools/tiri_lsp/lsp_hover.tiri
@@ -121,20 +121,20 @@ function formatClassHover(ClassName, ClassDoc)
 end
 
 function formatMethodHover(ClassName, MethodName, MethodDoc)
-   doc = decodeMethod(MethodDoc)  -- Decode compact string if needed
+   doc = MethodDoc
    md = f'**{ClassName}.{MethodName}**\n\n'
    if doc.prototype?? then
-      md ..= '```c\n' .. doc.prototype .. '\n```\n\n'
+      md ..= '```lua\n' .. doc.prototype .. '\n```\n\n'
    end
    md ..= doc.comment or ''
    return md
 end
 
 function formatActionHover(ClassName, ActionName, ActionDoc)
-   doc = decodeMethod(ActionDoc)  -- Decode compact string if needed
+   doc = ActionDoc
    md = f'**{ClassName}.ac{ActionName}** _(Action)_\n\n'
    if doc.prototype?? then
-      md ..= '```c\n' .. doc.prototype .. '\n```\n\n'
+      md ..= '```lua\n' .. doc.prototype .. '\n```\n\n'
    end
    md ..= doc.comment or ''
    return md
@@ -152,10 +152,10 @@ function formatFieldHover(ClassName, FieldName, FieldDoc)
 end
 
 function formatModuleFunctionHover(ModuleName, FuncName, FuncDoc)
-   doc = decodeMethod(FuncDoc)  -- Decode compact string if needed
+   doc = FuncDoc
    md = f'**{ModuleName}.{FuncName}**\n\n'
    if doc.prototype?? then
-      md ..= '```c\n' .. doc.prototype .. '\n```\n\n'
+      md ..= '```lua\n' .. doc.prototype .. '\n```\n\n'
    end
    md ..= doc.comment or ''
    md ..= f'\n\n[Documentation]({HTML_URI}{ModuleName:lower()}.html?page={FuncName})'

--- a/tools/tiri_lsp/lsp_signature.tiri
+++ b/tools/tiri_lsp/lsp_signature.tiri
@@ -9,6 +9,8 @@ global glSignatureSymbolCache = {}
 ----------------------------------------------------------------------------------------------------------------------
 -- Source Scanning
 
+-- Convert an LSP line/character position to the matching byte offset in the document content.
+
 function signaturePositionToOffset(Doc:table, Position:table):num
    offset = 0
    current_line = 0
@@ -25,13 +27,19 @@ function signaturePositionToOffset(Doc:table, Position:table):num
    return offset
 end
 
+-- Return true when a character can start a Tiri identifier.
+
 function signatureIsIdentStart(Char:str):bool
    return (Char >= 'a' and Char <= 'z') or (Char >= 'A' and Char <= 'Z') or Char is '_'
 end
 
+-- Return true when a character can appear after the first character of a Tiri identifier.
+
 function signatureIsIdentChar(Char:str):bool
    return signatureIsIdentStart(Char) or (Char >= '0' and Char <= '9')
 end
+
+-- Move backwards over whitespace and return the first non-space byte offset.
 
 function signatureSkipBackSpaces(Content:str, Pos:num):num
    while Pos >= 0 do
@@ -41,6 +49,8 @@ function signatureSkipBackSpaces(Content:str, Pos:num):num
    end
    return Pos
 end
+
+-- Read the identifier that ends before or at the supplied byte offset.
 
 function signatureReadIdentifierBefore(Content:str, Pos:num):table
    end_pos = signatureSkipBackSpaces(Content, Pos)
@@ -57,6 +67,8 @@ function signatureReadIdentifierBefore(Content:str, Pos:num):table
       endPos = end_pos + 1
    }
 end
+
+-- Resolve the function or method name attached to an opening parenthesis.
 
 function signatureReadCallName(Content:str, ParenPos:num):table
    name_info = signatureReadIdentifierBefore(Content, ParenPos - 1)
@@ -90,6 +102,8 @@ function signatureReadCallName(Content:str, ParenPos:num):table
    }
 end
 
+-- Add a call frame to the parser stack for an opening parenthesis.
+
 function signaturePushFrame(Stack:array, Content:str, Pos:num)
    call = signatureReadCallName(Content, Pos)
    Stack:push({
@@ -101,6 +115,8 @@ function signaturePushFrame(Stack:array, Content:str, Pos:num)
       bracketDepth = 0
    })
 end
+
+-- Find the innermost call expression and active argument index at the requested document position.
 
 global function signatureFindCallContext(Doc:table, Position:table):table
    content = Doc.content or ''
@@ -189,6 +205,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Signature Formatting
 
+-- Wrap text as LSP markdown documentation when meaningful content is available.
+
 function signatureMarkup(Text:str):table
    Text ?? return nil
    if Text is '' then return nil end
@@ -197,6 +215,8 @@ function signatureMarkup(Text:str):table
       value = Text
    }
 end
+
+-- Build the visible label for a single parameter.
 
 function signatureParamLabel(Param:table):str
    name = Param.name or ''
@@ -207,6 +227,8 @@ function signatureParamLabel(Param:table):str
    if param_type != '' then return param_type end
    return Param.label or ''
 end
+
+-- Convert internal parameter records to LSP ParameterInformation records.
 
 function signatureBuildParameterInfo(Params:array):array
    result = array<table>
@@ -219,6 +241,8 @@ function signatureBuildParameterInfo(Params:array):array
    return result
 end
 
+-- Build an LSP SignatureInformation record from a label, documentation and parameter list.
+
 function signatureBuildInfo(Label:str, Documentation:str, Params:array):table
    info = {
       label = Label or '',
@@ -229,12 +253,16 @@ function signatureBuildInfo(Label:str, Documentation:str, Params:array):table
    return info
 end
 
+-- Keep the active parameter index inside the bounds of the signature parameter list.
+
 function signatureClampActiveParameter(Active:num, Params:array):num
    if not Params or #Params is 0 then return 0 end
    if Active < 0 then return 0 end
    if Active >= #Params then return #Params - 1 end
    return Active
 end
+
+-- Split a prototype parameter string while ignoring commas inside nested expressions.
 
 function signatureSplitParams(ParamText:str):array
    params = array<table>
@@ -268,6 +296,8 @@ function signatureSplitParams(ParamText:str):array
    return params
 end
 
+-- Extract raw parameter labels from the first parenthesised parameter list in a prototype.
+
 function signatureParamsFromPrototype(Prototype:str):array
    Prototype ?? return array<table>
    open_pos = Prototype:find('(', 0, true)
@@ -275,6 +305,8 @@ function signatureParamsFromPrototype(Prototype:str):array
    if not open_pos or not close_pos or close_pos <= open_pos then return array<table> end
    return signatureSplitParams(Prototype:sub(open_pos + 1, close_pos))
 end
+
+-- Extract the display name from a prototype, falling back when no callable name is present.
 
 function signatureDisplayNameFromPrototype(Prototype:str, Fallback:str):str
    open_pos = Prototype and Prototype:find('(', 0, true) or nil
@@ -304,6 +336,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Current Document Symbols
 
+-- Get cached parser symbols for the document, refreshing them when the document content has changed.
+
 function signatureGetDocumentSymbols(Doc:table):array
    if Doc.signatureSymbolsContent is Doc.content and Doc.signatureSymbols then return Doc.signatureSymbols end
 
@@ -324,6 +358,8 @@ function signatureGetDocumentSymbols(Doc:table):array
    return Doc.signatureSymbols or glSignatureSymbolCache[Doc.uri]
 end
 
+-- Return true when a parsed document symbol can satisfy the current call context.
+
 function signatureSymbolMatches(Symbol:table, Context:table):bool
    if Symbol.name is Context.name or Symbol.name is Context.fullName then return true end
    if Context.object then
@@ -332,6 +368,8 @@ function signatureSymbolMatches(Symbol:table, Context:table):bool
    end
    return false
 end
+
+-- Convert a parser symbol into LSP signature information.
 
 function signatureFromDocumentSymbol(Symbol:table):table
    params = array<table>
@@ -347,6 +385,8 @@ function signatureFromDocumentSymbol(Symbol:table):table
    return signatureBuildInfo(Symbol.signature or Symbol.name, doc_text, params)
 end
 
+-- Resolve signature help from functions declared in the current document.
+
 function resolveDocumentSignature(Doc:table, Context:table):table
    symbols = signatureGetDocumentSymbols(Doc)
    symbols ?? return nil
@@ -361,6 +401,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Built-ins and Kotuku API
 
+-- Resolve signature help from the built-in Tiri definition table.
+
 function signatureFromBuiltin(Context:table):table
    key = Context.object and (Context.object .. '.' .. Context.name) or Context.name
    builtin = glDefs?.builtins?[key]
@@ -368,6 +410,8 @@ function signatureFromBuiltin(Context:table):table
 
    return signatureBuildInfo(builtin.prototype or key, builtin.comment, signatureParamsFromPrototype(builtin.prototype))
 end
+
+-- Match a class name from source text to the canonical class name in the documentation cache.
 
 function signatureNormaliseClassName(Name:str):str
    if not Name or not glDocCache or not glDocCache.classes then return nil end
@@ -381,6 +425,8 @@ function signatureNormaliseClassName(Name:str):str
    if glDocCache.classes[capitalised] then return capitalised end
 end
 
+-- Scan the document for obj.new() assignments and map variable names to class names.
+
 function signatureBuildTypeMap(Doc:table):table
    type_map = {}
    for start, stop, cap in rx_sig_obj_new.findAll(Doc.content) do
@@ -390,6 +436,8 @@ function signatureBuildTypeMap(Doc:table):table
    end
    return type_map
 end
+
+-- Convert a C-style prototype parameter label to the signature-help parameter shape.
 
 function signatureParamFromPrototypeLabel(Label:str):table
    label = Label:trim()
@@ -416,6 +464,8 @@ function signatureParamFromPrototypeLabel(Label:str):table
    }
 end
 
+-- Convert a Tiri-style prototype parameter label to the signature-help parameter shape.
+
 function signatureParamFromTiriLabel(Label:str):table
    label = Label:trim()
    if label is '' then return { label = '' } end
@@ -435,6 +485,8 @@ function signatureParamFromTiriLabel(Label:str):table
    return { name = label, label = label }
 end
 
+-- Extract API parameters from a generated XML prototype.
+
 function signatureXmlParamsFromPrototype(Prototype:str):array
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
@@ -443,6 +495,8 @@ function signatureXmlParamsFromPrototype(Prototype:str):array
    return params
 end
 
+-- Extract Tiri parameters from a generated Tiri prototype.
+
 function signatureTiriParamsFromPrototype(Prototype:str):array
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
@@ -450,6 +504,26 @@ function signatureTiriParamsFromPrototype(Prototype:str):array
    end
    return params
 end
+
+-- Return true when the cached prototype has the Tiri-facing signature shape.
+
+function signaturePrototypeIsTiri(Prototype:str):bool
+   if not Prototype or Prototype is '' then return false end
+   if Prototype:find('=', 0, true) then return true end
+
+   open_pos = Prototype:find('(', 0, true)
+   open_pos ?? return false
+   close_pos = Prototype:find(')', open_pos, true)
+   close_pos ?? return false
+
+   param_text = Prototype:sub(open_pos + 1, close_pos)
+   if param_text:find(':', 0, true) then return true end
+
+   suffix = Prototype:sub(close_pos + 1):trim()
+   return suffix:startsWith(':')
+end
+
+-- Copy parameter documentation from generated API metadata onto parsed prototype parameters.
 
 function signatureCopyParamDocs(Params:array, SourceParams:array):array
    if not SourceParams then return Params end
@@ -468,12 +542,16 @@ function signatureCopyParamDocs(Params:array, SourceParams:array):array
    return Params
 end
 
+-- Identify the implicit receiver parameter used by generated object method and action prototypes.
+
 function signatureIsImplicitObjectParam(Param:table, Index:num):bool
    if Index != 0 then return false end
    label = Param.label or ''
    param_type = Param.type or ''
    return label:startsWith('*Object') or param_type:startsWith('OBJECTPTR') or param_type:startsWith('*')
 end
+
+-- Build visible API parameters, optionally hiding the generated receiver argument.
 
 function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array
    source_params = MethodDoc.params
@@ -497,6 +575,8 @@ function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array
    return params
 end
 
+-- Build the display label for a signature sourced from XML API metadata.
+
 function signatureXmlLabel(DisplayName:str, Params:array):str
    labels = array<string>
    for param in values(Params or array<table>) do
@@ -505,33 +585,43 @@ function signatureXmlLabel(DisplayName:str, Params:array):str
    return DisplayName .. '(' .. labels:join(', ') .. ')'
 end
 
+-- Build the display label for a signature that has an explicit Tiri prototype.
+
 function signatureTiriLabel(DisplayName:str, Prototype:str):str
    open_pos = Prototype and Prototype:find('(', 0, true) or nil
    if not open_pos then return DisplayName end
-   return DisplayName .. Prototype:sub(open_pos)
+
+   prefix = ''
+   equals_pos = Prototype:find('=', 0, true)
+   if equals_pos and equals_pos < open_pos then prefix = Prototype:sub(0, equals_pos + 1):rtrim() .. ' ' end
+
+   return prefix .. DisplayName .. Prototype:sub(open_pos)
 end
 
-function signatureFromXmlEntry(DisplayName:str, Entry:any, HideReceiver:bool):table
-   doc = decodeMethod(Entry)
-   doc ?? return nil
+-- Convert a generated API entry into LSP signature information.
+
+function signatureFromXmlEntry(DisplayName:str, Doc:table, HideReceiver:bool):table
+   Doc ?? return nil
 
    local params
    local label
 
-   if doc.tiriPrototype?? then
-      params = signatureTiriParamsFromPrototype(doc.tiriPrototype)
-      params = signatureCopyParamDocs(params, doc.params)
-      label = signatureTiriLabel(DisplayName, doc.tiriPrototype)
+   if signaturePrototypeIsTiri(Doc.prototype) then
+      params = signatureTiriParamsFromPrototype(Doc.prototype)
+      params = signatureCopyParamDocs(params, Doc.params)
+      label = signatureTiriLabel(DisplayName, Doc.prototype)
    else
-      params = signatureXmlParams(doc, HideReceiver)
+      params = signatureXmlParams(Doc, HideReceiver)
       label = signatureXmlLabel(DisplayName, params)
-      if #params is 0 and doc.prototype and doc.prototype != '' then
+      if #params is 0 and Doc.prototype and Doc.prototype != '' then
          label = DisplayName .. '()'
       end
    end
 
-   return signatureBuildInfo(label, doc.comment, params)
+   return signatureBuildInfo(label, Doc.comment, params)
 end
+
+-- Resolve signature help from generated module, class, method and action documentation.
 
 function resolveApiSignature(Doc:table, Context:table):table
    if not Context.object or not glDocCache then return nil end
@@ -575,6 +665,13 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Public Resolver
 
+@Doc(text=[[
+Public resolver for signatureHelp calls
+
+-INPUT-
+Doc: Document record from glDocuments[URI]
+Position: Document position being queried
+]])
 global function resolveSignatureHelp(Doc:table, Position:table):table
    Doc ?? return nil
    Position ?? return nil

--- a/tools/tiri_lsp/tests/test_signature_help.tiri
+++ b/tools/tiri_lsp/tests/test_signature_help.tiri
@@ -10,14 +10,11 @@ global glSignatureHelpTestUri = nil
    glSignatureHelpTestUri = lspPathToUri('sdk:tools/tiri_lsp/tests/test_signature_help.tiri')
    assert(glSignatureHelpTestUri, 'Failed to create test document URI.')
 
-   glDocCache.modules.Core.functions.WaitTime.tiriPrototype = 'WaitTime(Seconds: num):num'
-   glDocCache.classes.XML.methods.GetAttrib.tiriPrototype = 'GetAttrib(Index: num, Attrib: str, Value: str):num'
    glDefs.modulePrefixes.mTest = 'Test'
    glDocCache.modules.Test = {
       functions = {
          Mixed = {
-            prototype = 'APTR Mixed(APTR Value)',
-            tiriPrototype = 'Mixed(Value: any):any',
+            prototype = 'Mixed(Value: any):any',
             comment = 'Mixed pointer fallback.',
             params = array<table> {
                { name = 'Value', type = 'APTR', doc = 'Pointer-like value.' }
@@ -153,14 +150,16 @@ end
 end
 
 @Test function ModuleApiSignature()
-   help = signatureAt('mSys.WaitTime(|)\n')
+   help = signatureAt("mSys.ResolvePath('test:', |)\n")
    signature = firstSignature(help)
 
-   assert(signature.label is 'mSys.WaitTime(Seconds: num):num', 'Module API signature should prefer Tiri prototypes.')
-   assert(signature.parameters[0].label is 'Seconds: num', 'Module API parameter should include the Tiri type.')
-   assertContains(signature.parameters[0].documentation.value, 'seconds',
+   assert(signature.label is 'err, Result:str = mSys.ResolvePath(Path:str, Flags:num)',
+      'Module API signature should use the cached Tiri prototype.')
+   assert(signature.parameters[0].label is 'Path:str', 'Module API parameter should include the Tiri type.')
+   assert(signature.parameters[1].label is 'Flags:num', 'Module API parameter should include the Tiri type.')
+   assertContains(signature.parameters[0].documentation.value, 'path',
       'Module API parameter should include XML docs.')
-   assert(help.activeParameter is 0, 'First module parameter should be active.')
+   assert(help.activeParameter is 1, 'Second module parameter should be active.')
 end
 
 @Test function ObjectMethodSignatureHidesReceiver()
@@ -170,9 +169,10 @@ xml.mtGetAttrib(1, |)
 ]=])
    signature = firstSignature(help)
 
-   assert(signature.label is 'xml.mtGetAttrib(Index: num, Attrib: str, Value: str):num',
-      'Object method signature should prefer Tiri prototypes.')
-   assert(signature.parameters[0].label is 'Index: num', 'First visible method parameter should be Index.')
+   assert(signature.label is 'err, Value:str = xml.mtGetAttrib(Index:num, Attrib:str)',
+      'Object method signature should use the cached Tiri prototype.')
+   assert(signature.parameters[0].label is 'Index:num', 'First visible method parameter should be Index.')
+   assert(signature.parameters[1].label is 'Attrib:str', 'Second visible method parameter should be Attrib.')
    assert(help.activeParameter is 1, 'Second method argument should be active.')
 end
 
@@ -193,7 +193,7 @@ xml.acClear(|)
 ]=])
    signature = firstSignature(help)
 
-   assert(signature.label is 'xml.acClear()', 'Object action should hide implicit receiver-only parameters.')
+   assert(signature.label is 'err = xml.acClear()', 'Object action should use the cached Tiri prototype.')
    assert(#signature.parameters is 0, 'Receiver-only action should expose no parameters.')
    assert(help.activeParameter is 0, 'Active parameter should clamp to zero for empty signatures.')
 end


### PR DESCRIPTION
* Store generated API method records directly with the preferred Tiri prototype
* Update signature, hover and definition lookups to consume cached method records without decode shims
* Refresh signature help and HTTP header validation tests for Flute registration