### PR TITLE
[Tiri] Improve compact doc parameter/result handling and extend annotation support

### DIFF
--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -1,8 +1,8 @@
 -- URL parsing and handling module for Kōtuku
 --
 -- Usage:
---   urllib = import 'net/url' -- Choose a name that avoids namespace conflicts
---   parts = urllib.parse('https://example.com/path?query=value')
+--   import 'net/url'
+--   parts = url.parse('https://example.com/path?query=value')
 
    namespace 'url'
 

--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -251,8 +251,8 @@ Compact form is intended for terse one-line documentation.  Tags are exact and l
 |Tag|Target metadata|Line parser|
 |-|-|-|
 |`@desc`|`doc.summary`, `doc.body`|First `@desc` sets `summary`; each non-empty payload is appended to `body`.|
-|`@input`|`params[].doc`|Payload is parsed as `Name: Description`.|
-|`@result`|`results[].doc`|Payload is parsed as `type: Description`.|
+|`@input`|`params[].doc`|Payload is used as documentation for the next non-`self` parameter.|
+|`@result`|`results[].doc`|Payload is used as documentation for the next result value.|
 |`@error`|`errors[]`|Payload is parsed as `Code: Description`.|
 
 Compact entries do not support continuation lines.  Unknown lines are ignored by the compact parser.
@@ -262,9 +262,9 @@ Example:
 ```lua
 @Doc(text=[[
    @desc Returns a greeting.
-   @input Name: Person to greet
-   @result str: Greeting text
-   @result str: Additional argument
+   @input Person to greet
+   @result Greeting text
+   @result Additional argument
    @error Args: If the name is invalid
    @error Failed: Random failure
 ]])
@@ -278,12 +278,12 @@ end
 Documentation text augments parser-derived signature metadata; it does not replace it.
 
 - Parameters always come from the function signature, excluding implicit `self`.
-- Parameter documentation is matched by parameter name.  `params[].inferred` is `true` when no matching doc line was
-  found.
+- Compact parameter documentation is matched by declaration order.  Marker-form parameter documentation is matched by
+  parameter name.  `params[].inferred` is `true` when no matching doc line was found.
 - Result entries use the larger of the declared result count and documented result count.
-- Declared result types take precedence over documented result types.  A documented result type is used only when no
-  declared type exists at that position.
-- `results[].inferred` is `true` only for documented result entries beyond the declared result count.
+- Declared result types take precedence.  Compact result docs do not carry types; if no declared type exists, the
+  collector infers obvious return expression types and otherwise exposes `any`.
+- `results[].inferred` is `false` for declared result types and `true` for inferred or `any` fallback compact types.
 - Error entries currently come only from explicit documentation.  Error-code inference is not implemented in the
   collector yet, so `errors[].inferred` is currently `false`.
 

--- a/src/tiri/jit/src/parser/ast/annotations.cpp
+++ b/src/tiri/jit/src/parser/ast/annotations.cpp
@@ -146,8 +146,64 @@ ParserResult<std::vector<AnnotationEntry>> AstBuilder::parse_annotations()
 }
 
 //********************************************************************************************************************
+// Attaches parsed annotations to a function expression value.
+
+static bool attach_annotations_to_function_value(ExprNodePtr &Value, std::vector<AnnotationEntry> &Annotations)
+{
+   if (not Value or Value->kind != AstNodeKind::FunctionExpr) return false;
+
+   if (auto *function = std::get_if<FunctionExprPayload>(&Value->data)) {
+      function->annotations = std::move(Annotations);
+      return true;
+   }
+
+   return false;
+}
+
+//********************************************************************************************************************
+// Attaches parsed annotations to a statement containing a single function expression.
+
+static bool attach_annotations_to_statement(StmtNode &Statement, std::vector<AnnotationEntry> &Annotations)
+{
+   if (Statement.kind IS AstNodeKind::FunctionStmt) {
+      auto *payload = std::get_if<FunctionStmtPayload>(&Statement.data);
+      if (payload and payload->function) {
+         payload->function->annotations = std::move(Annotations);
+         return true;
+      }
+   }
+   else if (Statement.kind IS AstNodeKind::LocalFunctionStmt) {
+      auto *payload = std::get_if<LocalFunctionStmtPayload>(&Statement.data);
+      if (payload and payload->function) {
+         payload->function->annotations = std::move(Annotations);
+         return true;
+      }
+   }
+   else if (Statement.kind IS AstNodeKind::AssignmentStmt) {
+      auto *payload = std::get_if<AssignmentStmtPayload>(&Statement.data);
+      if (payload and payload->values.size() IS 1) {
+         return attach_annotations_to_function_value(payload->values[0], Annotations);
+      }
+   }
+   else if (Statement.kind IS AstNodeKind::LocalDeclStmt) {
+      auto *payload = std::get_if<LocalDeclStmtPayload>(&Statement.data);
+      if (payload and payload->values.size() IS 1) {
+         return attach_annotations_to_function_value(payload->values[0], Annotations);
+      }
+   }
+   else if (Statement.kind IS AstNodeKind::GlobalDeclStmt) {
+      auto *payload = std::get_if<GlobalDeclStmtPayload>(&Statement.data);
+      if (payload and payload->values.size() IS 1) {
+         return attach_annotations_to_function_value(payload->values[0], Annotations);
+      }
+   }
+
+   return false;
+}
+
+//********************************************************************************************************************
 // Parses a statement preceded by one or more annotations.
-// Annotations can only precede function declarations (function, local function, global function, thunk).
+// Annotations can precede function declarations or single function-valued assignments.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_annotated_statement()
 {
@@ -163,7 +219,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_annotated_statement()
 
    Token current = this->ctx.tokens().current();
 
-   // Parse the following statement - must be a function declaration
+   // Parse the following statement - must contain a single function value.
    StmtNodePtr stmt;
 
    if (current.kind() IS TokenKind::Function or current.kind() IS TokenKind::ThunkToken) {
@@ -175,39 +231,25 @@ ParserResult<StmtNodePtr> AstBuilder::parse_annotated_statement()
       auto result = this->parse_local();
       if (not result.ok()) return result;
       stmt = std::move(result.value_ref());
-      // Verify it's a local function, not a variable declaration
-      if (stmt->kind != AstNodeKind::LocalFunctionStmt) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, current,
-            "annotations can only precede function declarations");
-      }
    }
    else if (current.kind() IS TokenKind::Global) {
       auto result = this->parse_global();
       if (not result.ok()) return result;
       stmt = std::move(result.value_ref());
-      // Verify it's a global function, not a variable declaration
-      if (stmt->kind != AstNodeKind::FunctionStmt) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, current,
-            "annotations can only precede function declarations");
-      }
+   }
+   else if (current.kind() IS TokenKind::Identifier) {
+      auto result = this->parse_expression_stmt();
+      if (not result.ok()) return result;
+      stmt = std::move(result.value_ref());
    }
    else {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, current,
-         "annotations must precede a function declaration");
+         "annotations must precede a function declaration or function assignment");
    }
 
-   // Attach annotations to the function payload
-   if (stmt->kind IS AstNodeKind::FunctionStmt) {
-      auto* payload = std::get_if<FunctionStmtPayload>(&stmt->data);
-      if (payload and payload->function) {
-         payload->function->annotations = std::move(annotations);
-      }
-   }
-   else if (stmt->kind IS AstNodeKind::LocalFunctionStmt) {
-      auto* payload = std::get_if<LocalFunctionStmtPayload>(&stmt->data);
-      if (payload and payload->function) {
-         payload->function->annotations = std::move(annotations);
-      }
+   if (not stmt or not attach_annotations_to_statement(*stmt, annotations)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, current,
+         "annotations must precede a function declaration or function assignment");
    }
 
    return ParserResult<StmtNodePtr>::success(std::move(stmt));

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -23,6 +23,7 @@ struct ParsedDocText {
    std::vector<std::pair<std::string, std::string>> inputs;
    std::vector<ParserDocReturnMetadata> results;
    std::vector<ParserDocErrorMetadata> errors;
+   bool compact = false;
 };
 
 inline std::string gcstr_to_string(GCstr *Value)
@@ -128,6 +129,7 @@ static ParsedDocText parse_compact_doc_text(std::string_view Text, const std::ve
 {
    ParsedDocText parsed;
    parsed.block.raw = std::string(Text);
+   parsed.compact = true;
 
    for (const std::string &line : Lines) {
       std::string trimmed = trim(line);
@@ -143,17 +145,14 @@ static ParsedDocText parse_compact_doc_text(std::string_view Text, const std::ve
 
       payload = compact_doc_payload(trimmed, "@input");
       if (not payload.empty()) {
-         std::string name;
-         std::string doc;
-         parse_name_doc_line(payload, name, doc);
-         if (not name.empty()) parsed.inputs.emplace_back(std::move(name), std::move(doc));
+         parsed.inputs.emplace_back(std::string(), std::move(payload));
          continue;
       }
 
       payload = compact_doc_payload(trimmed, "@result");
       if (not payload.empty()) {
          ParserDocReturnMetadata ret;
-         parse_name_doc_line(payload, ret.type, ret.doc);
+         ret.doc = std::move(payload);
          parsed.results.push_back(std::move(ret));
          continue;
       }
@@ -401,8 +400,18 @@ static std::string build_signature(const std::string &Name, const FunctionExprPa
    return signature;
 }
 
-static std::string find_param_doc(const ParsedDocText &Doc, const std::string &Name, bool &Found)
+static std::string find_param_doc(const ParsedDocText &Doc, const std::string &Name, size_t Index, bool &Found)
 {
+   if (Doc.compact) {
+      if (Index < Doc.inputs.size()) {
+         Found = true;
+         return Doc.inputs[Index].second;
+      }
+
+      Found = false;
+      return {};
+   }
+
    for (const auto &[doc_name, doc_text] : Doc.inputs) {
       if (doc_name IS Name) {
          Found = true;
@@ -416,6 +425,8 @@ static std::string find_param_doc(const ParsedDocText &Doc, const std::string &N
 
 static void add_params(ParserSymbolMetadata &Symbol, const FunctionExprPayload &Function, const ParsedDocText *Doc)
 {
+   size_t param_index = 0;
+
    for (const FunctionParameter &param : Function.parameters) {
       if (param.is_self) continue;
 
@@ -424,11 +435,139 @@ static void add_params(ParserSymbolMetadata &Symbol, const FunctionExprPayload &
       meta.type = type_to_string(param.type);
 
       bool found = false;
-      if (Doc) meta.doc = find_param_doc(*Doc, meta.name, found);
+      if (Doc) meta.doc = find_param_doc(*Doc, meta.name, param_index, found);
       meta.inferred = not found;
 
       Symbol.params.push_back(std::move(meta));
+      param_index++;
    }
+}
+
+static TiriType infer_result_expression_type(const ExprNode &Expression, const FunctionExprPayload &Function)
+{
+   if (Expression.kind IS AstNodeKind::IdentifierExpr) {
+      if (const auto *name = std::get_if<NameRef>(&Expression.data)) {
+         std::string expr_name = identifier_to_string(name->identifier);
+
+         for (const FunctionParameter &param : Function.parameters) {
+            if (param.is_self) continue;
+            if (identifier_to_string(param.name) IS expr_name and param.type != TiriType::Unknown) return param.type;
+         }
+      }
+   }
+
+   return infer_expression_type(Expression);
+}
+
+static FunctionReturnTypes infer_results_from_return(const ReturnStmtPayload &Return,
+   const FunctionExprPayload &Function)
+{
+   FunctionReturnTypes result;
+   size_t count = Return.values.size() < MAX_RETURN_TYPES ? Return.values.size() : MAX_RETURN_TYPES;
+   result.count = uint8_t(count);
+
+   for (size_t i = 0; i < count; ++i) {
+      result.types[i] = infer_result_expression_type(*Return.values[i], Function);
+   }
+
+   return result;
+}
+
+static bool infer_results_from_block(FunctionReturnTypes &Result, const BlockStmt &Block,
+   const FunctionExprPayload &Function);
+
+static bool infer_results_from_statement(FunctionReturnTypes &Result, const StmtNode &Statement,
+   const FunctionExprPayload &Function)
+{
+   switch (Statement.kind) {
+      case AstNodeKind::ReturnStmt: {
+         const auto &payload = std::get<ReturnStmtPayload>(Statement.data);
+         Result = infer_results_from_return(payload, Function);
+         return Result.count > 0;
+      }
+      case AstNodeKind::IfStmt: {
+         const auto &payload = std::get<IfStmtPayload>(Statement.data);
+         for (const IfClause &clause : payload.clauses) {
+            if (clause.block and infer_results_from_block(Result, *clause.block, Function)) return true;
+         }
+         break;
+      }
+      case AstNodeKind::WhileStmt:
+      case AstNodeKind::RepeatStmt: {
+         const auto &payload = std::get<LoopStmtPayload>(Statement.data);
+         if (payload.body and infer_results_from_block(Result, *payload.body, Function)) return true;
+         break;
+      }
+      case AstNodeKind::NumericForStmt: {
+         const auto &payload = std::get<NumericForStmtPayload>(Statement.data);
+         if (payload.body and infer_results_from_block(Result, *payload.body, Function)) return true;
+         break;
+      }
+      case AstNodeKind::GenericForStmt: {
+         const auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+         if (payload.body and infer_results_from_block(Result, *payload.body, Function)) return true;
+         break;
+      }
+      case AstNodeKind::DoStmt: {
+         const auto &payload = std::get<DoStmtPayload>(Statement.data);
+         if (payload.block and infer_results_from_block(Result, *payload.block, Function)) return true;
+         break;
+      }
+      case AstNodeKind::ConditionalShorthandStmt: {
+         const auto &payload = std::get<ConditionalShorthandStmtPayload>(Statement.data);
+         if (payload.body and infer_results_from_statement(Result, *payload.body, Function)) return true;
+         break;
+      }
+      case AstNodeKind::TryExceptStmt: {
+         const auto &payload = std::get<TryExceptPayload>(Statement.data);
+         if (payload.try_block and infer_results_from_block(Result, *payload.try_block, Function)) return true;
+         for (const ExceptClause &clause : payload.except_clauses) {
+            if (clause.block and infer_results_from_block(Result, *clause.block, Function)) return true;
+         }
+         if (payload.success_block and infer_results_from_block(Result, *payload.success_block, Function)) return true;
+         break;
+      }
+      case AstNodeKind::WithStmt: {
+         const auto &payload = std::get<WithStmtPayload>(Statement.data);
+         if (payload.block and infer_results_from_block(Result, *payload.block, Function)) return true;
+         break;
+      }
+      default:
+         break;
+   }
+
+   return false;
+}
+
+static bool infer_results_from_block(FunctionReturnTypes &Result, const BlockStmt &Block,
+   const FunctionExprPayload &Function)
+{
+   for (const StmtNode &statement : Block.view()) {
+      if (infer_results_from_statement(Result, statement, Function)) return true;
+   }
+
+   return false;
+}
+
+static FunctionReturnTypes infer_function_results(const FunctionExprPayload &Function)
+{
+   FunctionReturnTypes result;
+   if (Function.body) infer_results_from_block(result, *Function.body, Function);
+   return result;
+}
+
+static TiriType compact_result_type_at(const FunctionExprPayload &Function, const FunctionReturnTypes &Inferred,
+   size_t Index, bool &InferredType)
+{
+   if (Function.return_types.is_explicit and (Index < Function.return_types.count or
+       (Function.return_types.is_variadic and Function.return_types.count > 0))) {
+      InferredType = false;
+      return Function.return_types.type_at(Index);
+   }
+
+   InferredType = true;
+   if (Index < Inferred.count and Inferred.types[Index] != TiriType::Unknown) return Inferred.types[Index];
+   return TiriType::Any;
 }
 
 static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload &Function, const ParsedDocText *Doc)
@@ -436,17 +575,31 @@ static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload 
    size_t declared_count = Function.return_types.count;
    size_t doc_count = Doc ? Doc->results.size() : 0;
    size_t count = declared_count > doc_count ? declared_count : doc_count;
+   FunctionReturnTypes inferred_results;
+
+   if (Doc and Doc->compact and doc_count > declared_count) {
+      inferred_results = infer_function_results(Function);
+   }
 
    for (size_t i = 0; i < count; ++i) {
       ParserDocReturnMetadata meta;
 
-      if (i < declared_count) meta.type = type_to_string(Function.return_types.types[i]);
-      if (Doc and i < Doc->results.size()) {
-         meta.doc = Doc->results[i].doc;
-         if (meta.type.empty()) meta.type = Doc->results[i].type;
+      if (Doc and Doc->compact) {
+         bool inferred_type = true;
+         meta.type = type_to_string(compact_result_type_at(Function, inferred_results, i, inferred_type));
+         meta.inferred = inferred_type;
+      }
+      else if (i < declared_count) {
+         meta.type = type_to_string(Function.return_types.types[i]);
+         meta.inferred = false;
       }
 
-      meta.inferred = i >= declared_count;
+      if (Doc and i < Doc->results.size()) {
+         meta.doc = Doc->results[i].doc;
+         if ((not Doc->compact) and meta.type.empty()) meta.type = Doc->results[i].type;
+      }
+
+      if (not (Doc and Doc->compact)) meta.inferred = i >= declared_count;
       Symbol.results.push_back(std::move(meta));
    }
 }

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -463,14 +463,15 @@ end
    code = [=[
       @Doc(text=[[
          @desc Returns a greeting.
-         @input Name: Person to greet
-         @result str: Greeting text
-         @result str: Additional argument
+         @input First name to greet
+         @input Last name to greet
+         @result Greeting text
+         @result Additional argument
          @error Args: If the name is invalid
          @error Failed: Random failure
       ]])
-      function greetCompact(Name: str):<str, str>
-         return "Hello " .. Name, "extra"
+      function greetCompact(First: str, Last: str):<str, str>
+         return "Hello " .. First .. " " .. Last, "extra"
       end
    ]=]
 
@@ -482,16 +483,104 @@ end
    symbol = result.symbols[0]
    assert(symbol.name is "greetCompact", "Expected function name greetCompact, got " .. tostring(symbol.name))
    assert(symbol.doc.summary is "Returns a greeting.", "Compact @desc should define doc summary")
-   assert(symbol.params[0].name is "Name", "Expected first compact param to be Name")
-   assert(symbol.params[0].doc is "Person to greet", "Expected compact @input doc to be merged")
+   assert(symbol.params[0].name is "First", "Expected first compact param to be First")
+   assert(symbol.params[0].doc is "First name to greet", "Expected first compact @input doc to be merged")
+   assert(symbol.params[1].name is "Last", "Expected second compact param to be Last")
+   assert(symbol.params[1].doc is "Last name to greet", "Expected second compact @input doc to be merged")
    assert(symbol.results[0].type is "str", "Expected first compact return type to be str")
    assert(symbol.results[0].doc is "Greeting text", "Expected first compact @result doc")
+   assert(symbol.results[0].inferred is false, "Explicit compact result type should not be inferred")
    assert(symbol.results[1].type is "str", "Expected second compact return type to be str")
    assert(symbol.results[1].doc is "Additional argument", "Expected second compact @result doc")
+   assert(symbol.results[1].inferred is false, "Explicit compact result type should not be inferred")
    assert(symbol.errors[0].code is "Args", "Expected first compact error code")
    assert(symbol.errors[0].doc is "If the name is invalid", "Expected first compact error doc")
    assert(symbol.errors[1].code is "Failed", "Expected second compact error code")
    assert(symbol.errors[1].doc is "Random failure", "Expected second compact error doc")
+end
+
+@Test function ValidateSymbolsWithCompactDocInferredResults()
+   code = [=[
+      @Doc(text=[[
+         @desc Infers result types from return expressions.
+         @input Value to format
+         @result Incremented value
+         @result Status text
+         @result Success flag
+      ]])
+      function inferCompact(Value: num)
+         return Value + 1, "ready", true
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Valid compact inferred result docs should succeed")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.params[0].doc is "Value to format", "Expected compact @input doc to be positional")
+   assert(symbol.results[0].type is "num", "Expected first compact result type to be inferred as num")
+   assert(symbol.results[0].doc is "Incremented value", "Expected first inferred compact @result doc")
+   assert(symbol.results[0].inferred is true, "Inferred compact result type should be marked inferred")
+   assert(symbol.results[1].type is "str", "Expected second compact result type to be inferred as str")
+   assert(symbol.results[1].doc is "Status text", "Expected second inferred compact @result doc")
+   assert(symbol.results[1].inferred is true, "Inferred compact result type should be marked inferred")
+   assert(symbol.results[2].type is "bool", "Expected third compact result type to be inferred as bool")
+   assert(symbol.results[2].doc is "Success flag", "Expected third inferred compact @result doc")
+   assert(symbol.results[2].inferred is true, "Inferred compact result type should be marked inferred")
+end
+
+@Test function ValidateSymbolsWithCompactDocUnknownResultFallback()
+   code = [=[
+      @Doc(text=[[
+         @desc Falls back when a result type is unknown.
+         @input Callback that produces a value
+         @result Callback result
+      ]])
+      function compactFallback(Callback)
+         return Callback()
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Valid compact unknown result docs should succeed")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.params[0].doc is "Callback that produces a value", "Expected fallback compact @input doc")
+   assert(symbol.results[0].type is "any", "Unknown compact result type should fall back to any")
+   assert(symbol.results[0].doc is "Callback result", "Expected fallback compact @result doc")
+   assert(symbol.results[0].inferred is true, "Fallback compact result type should be marked inferred")
+end
+
+@Test function ValidateSymbolsWithAnnotatedFunctionAssignment()
+   code = [=[
+      docs = {}
+
+      @Doc(text=[[
+         @desc Documents an assigned function expression.
+         @input Text to return
+         @result Returned text
+      ]])
+      docs.echo = function(Text: str):str
+         return Text
+      end
+   ]=]
+
+   result = debug.validate(code, "symbols")
+   assert(result.success is true, "Annotated function assignment should parse")
+   assert(result.symbols != nil, "symbols option should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
+
+   symbol = result.symbols[0]
+   assert(symbol.name is "docs.echo", "Expected assigned function symbol, got " .. tostring(symbol.name))
+   assert(symbol.doc.summary is "Documents an assigned function expression.", "Expected assignment doc summary")
+   assert(symbol.params[0].name is "Text", "Expected assignment parameter name")
+   assert(symbol.params[0].doc is "Text to return", "Expected assignment parameter doc")
+   assert(symbol.results[0].type is "str", "Expected assignment result type")
+   assert(symbol.results[0].doc is "Returned text", "Expected assignment result doc")
 end
 
 @Test function ValidateSymbolsWithGlobalFunctionExpression()


### PR DESCRIPTION
## Summary

* Compact `@input` parameters are now matched **positionally** (by declaration order) rather than by name, making compact doc blocks simpler to write
* Compact `@result` types are **inferred from return expressions** (e.g. `num`, `str`, `bool`) and fall back to `any` when the type cannot be determined; explicit declared return types still take precedence
* **Annotations can now precede function-valued assignments** (e.g. `docs.echo = function(...)`) in addition to named function declarations
* Updated `AGENTS.md` to document the revised compact doc semantics
* Extended Flute test suite with cases for inferred results, unknown-type fallback, and annotated function assignments
* Minor fix to `url.tiri` usage comment (corrects import style example)

## Test plan

- [ ] Run `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri` to verify all Tiri tests pass
- [ ] Confirm `ValidateSymbolsWithCompactDoc` passes with the updated two-parameter `greetCompact` function
- [ ] Confirm `ValidateSymbolsWithCompactDocInferredResults` passes (inferred `num`, `str`, `bool` result types)
- [ ] Confirm `ValidateSymbolsWithCompactDocUnknownResultFallback` passes (`any` fallback)
- [ ] Confirm `ValidateSymbolsWithAnnotatedFunctionAssignment` passes (annotation on `docs.echo = function(...)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)