### PR TITLE
[Linux] Propagate socket errors to Kotuku error codes

### DIFF
--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -159,8 +159,9 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
          return ERR::Okay;
       }
       else {
-         log.warning("recv() failed: %s", strerror(errno));
-         return ERR::SystemCall;
+         const int system_error = errno;
+         log.warning("recv() failed: %s", strerror(system_error));
+         return convert_socket_error(system_error);
       }
    }
 #elif _WIN32

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -341,8 +341,9 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
                log.trace("IPv6 connect() attempt would block or need to try again.");
             }
             else {
-               log.warning("IPv6 Connect() failed: %s", strerror(errno));
-               Socket->Error = ERR::SystemCall;
+               const int system_error = errno;
+               log.warning("IPv6 Connect() failed: %s", strerror(system_error));
+               Socket->Error = convert_socket_error(system_error);
                Socket->setState(NTC::DISCONNECTED);
                return;
             }
@@ -384,8 +385,9 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
                log.trace("IPv4-mapped IPv6 connect() attempt would block or need to try again.");
             }
             else {
-               log.warning("IPv4-mapped IPv6 Connect() failed: %s", strerror(errno));
-               Socket->Error = ERR::SystemCall;
+               const int system_error = errno;
+               log.warning("IPv4-mapped IPv6 Connect() failed: %s", strerror(system_error));
+               Socket->Error = convert_socket_error(system_error);
                Socket->setState(NTC::DISCONNECTED);
                return;
             }
@@ -412,13 +414,13 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
          server_address6.sin6_addr.s6_addr[11] = 0xff;
          *((uint32_t*)&server_address6.sin6_addr.s6_addr[12]) = htonl(addr->Data[0]);
 
-         if (win_connect(Socket->Handle, (struct sockaddr *)&server_address6, sizeof(server_address6)) IS ERR::Okay) {
+         Socket->Error = win_connect(Socket->Handle, (struct sockaddr *)&server_address6, sizeof(server_address6));
+         if (Socket->Error IS ERR::Okay) {
             log.trace("IPv4-mapped IPv6 connection initiated successfully");
             Socket->setState(NTC::CONNECTING);
          }
          else {
-            log.trace("IPv4-mapped IPv6 connect() failed");
-            Socket->Error = ERR::SystemCall;
+            log.trace("IPv4-mapped IPv6 connect() failed: %s", GetErrorMsg(Socket->Error));
             Socket->setState(NTC::DISCONNECTED);
          }
          return;
@@ -442,8 +444,9 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
          log.trace("connect() attempt would block or need to try again.");
       }
       else {
-         log.warning("Connect() failed: %s", strerror(errno));
-         Socket->Error = ERR::SystemCall;
+         const int system_error = errno;
+         log.warning("Connect() failed: %s", strerror(system_error));
+         Socket->Error = convert_socket_error(system_error);
          Socket->setState(NTC::DISCONNECTED);
          return;
       }
@@ -817,14 +820,17 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
       }
    }
    else {
-      log.warning("Failed to create socket: %s", strerror(errno));
-      return ERR::SystemCall;
+      const int system_error = errno;
+      log.warning("Failed to create socket: %s", strerror(system_error));
+      return convert_socket_error(system_error);
    }
 
    // Put the socket into non-blocking mode, this is required when registering it as an FD and also prevents connect()
    // calls from going to sleep.
 
-   if (fcntl(Self->Handle, F_SETFL, fcntl(Self->Handle, F_GETFL) | O_NONBLOCK)) return log.warning(ERR::SystemCall);
+   if (fcntl(Self->Handle, F_SETFL, fcntl(Self->Handle, F_GETFL) | O_NONBLOCK)) {
+      return log.warning(convert_socket_error());
+   }
 
    // Set the send timeout so that connect() will timeout after a reasonable time
 
@@ -916,8 +922,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
                }
                return ERR::Okay;
             }
-            else if (result IS EADDRINUSE) return log.warning(ERR::InUse);
-            else return log.warning(ERR::SystemCall);
+            else return log.warning(convert_socket_error());
          #elif _WIN32
             // Windows IPv6 dual-stack server binding
             struct sockaddr_in6 addr;
@@ -991,10 +996,10 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
                }
                return ERR::Okay;
             }
-            else if (result IS EADDRINUSE) return log.warning(ERR::InUse);
             else {
-               log.warning("bind() failed with error: %s", strerror(errno));
-               return ERR::SystemCall;
+               const int system_error = errno;
+               log.warning("bind() failed with error: %s", strerror(system_error));
+               return convert_socket_error(system_error);
             }
          #elif _WIN32
             if ((error = win_bind(Self->Handle, (struct sockaddr *)&addr, sizeof(addr))) IS ERR::Okay) {
@@ -1328,8 +1333,9 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
    }
    else if ((errno IS EAGAIN) or (errno IS EINTR)) return ERR::Okay;
    else {
-      log.warning("recv() failed: %s", strerror(errno));
-      return ERR::SystemCall;
+      const int system_error = errno;
+      log.warning("recv() failed: %s", strerror(system_error));
+      return convert_socket_error(system_error);
    }
 #elif _WIN32
    size_t result;
@@ -1480,8 +1486,9 @@ static ERR NETSOCKET_RecvFrom(extNetSocket *Self, struct ns::RecvFrom *Args)
          case EMSGSIZE:
             return ERR::BufferOverflow;
          default:
-            log.warning("recvfrom() failed: %s", strerror(errno));
-            return ERR::SystemCall;
+            const int system_error = errno;
+            log.warning("recvfrom() failed: %s", strerror(system_error));
+            return convert_socket_error(system_error);
       }
    }
 #elif _WIN32
@@ -1612,8 +1619,9 @@ static ERR NETSOCKET_SendTo(extNetSocket *Self, struct ns::SendTo *Args)
       case ENETUNREACH: return ERR::NetworkUnreachable;
       case EINVAL:      return ERR::Args;
       default:
-         log.warning("sendto() failed: %s", strerror(errno));
-         return ERR::SystemCall;
+         const int system_error = errno;
+         log.warning("sendto() failed: %s", strerror(system_error));
+         return convert_socket_error(system_error);
    }
 #elif defined(_WIN32)
    auto error = WIN_SENDTO(Self->Handle, Args->Data, &bytes_to_send, (sockaddr *)&dest_addr, addr_len);

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -528,11 +528,7 @@ static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
       if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
 
-      if (result IS ECONNREFUSED)      Self->Error = ERR::ConnectionRefused;
-      else if (result IS ENETUNREACH)  Self->Error = ERR::NetworkUnreachable;
-      else if (result IS EHOSTUNREACH) Self->Error = ERR::HostUnreachable;
-      else if (result IS ETIMEDOUT)    Self->Error = ERR::TimeOut;
-      else Self->Error = ERR::SystemCall;
+      Self->Error = convert_socket_error(result);
 
       log.error(Self->Error);
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -266,6 +266,10 @@ public:
    }
 #endif
 
+#ifdef __linux__
+   #include "socket_errors.h"
+#endif
+
 class extClientSocket : public objClientSocket {
    public:
    SocketHandle Handle;
@@ -1007,8 +1011,9 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
       if (errno IS EAGAIN) return ERR::BufferOverflow;
       else if (errno IS EMSGSIZE) return ERR::DataSize;
       else {
-         log.warning("send() failed: %s", strerror(errno));
-         return ERR::Failed;
+         const int system_error = errno;
+         log.warning("send() failed: %s", strerror(system_error));
+         return convert_socket_error(system_error, ERR::Failed);
       }
    }
 #elif _WIN32

--- a/src/network/socket_errors.h
+++ b/src/network/socket_errors.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <kotuku/system/errors.h>
+
+#ifdef __linux__
+   #include <errno.h>
+#endif
+
+struct SocketErrorEntry {
+   int SystemError;
+   ERR KotukuError;
+};
+
+static const SocketErrorEntry glSocketErrors[] = {
+#ifdef _WIN32
+   { WSAEINTR,              ERR::Cancelled },
+   { WSAEACCES,             ERR::PermissionDenied },
+   { WSAEFAULT,             ERR::InvalidData },
+   { WSAEINVAL,             ERR::Args },
+   { WSAEMFILE,             ERR::OutOfSpace },
+   { WSAEWOULDBLOCK,        ERR::InvalidState },
+   { WSAEINPROGRESS,        ERR::Busy },
+   { WSAEALREADY,           ERR::Busy },
+   { WSAENOTSOCK,           ERR::Args },
+   { WSAEDESTADDRREQ,       ERR::Args },
+   { WSAEMSGSIZE,           ERR::DataSize },
+   { WSAEPROTOTYPE,         ERR::Args },
+   { WSAENOPROTOOPT,        ERR::Args },
+   { WSAEPROTONOSUPPORT,    ERR::NoSupport },
+   { WSAESOCKTNOSUPPORT,    ERR::NoSupport },
+   { WSAEOPNOTSUPP,         ERR::NoSupport },
+   { WSAEPFNOSUPPORT,       ERR::NoSupport },
+   { WSAEAFNOSUPPORT,       ERR::NoSupport },
+   { WSAEADDRINUSE,         ERR::InUse },
+   { WSAEADDRNOTAVAIL,      ERR::HostUnreachable },
+   { WSAENETDOWN,           ERR::NetworkUnreachable },
+   { WSAENETUNREACH,        ERR::NetworkUnreachable },
+   { WSAENETRESET,          ERR::Disconnected },
+   { WSAECONNABORTED,       ERR::ConnectionAborted },
+   { WSAECONNRESET,         ERR::Disconnected },
+   { WSAENOBUFS,            ERR::BufferOverflow },
+   { WSAEISCONN,            ERR::DoubleInit },
+   { WSAENOTCONN,           ERR::Disconnected },
+   { WSAESHUTDOWN,          ERR::Disconnected },
+   { WSAETIMEDOUT,          ERR::TimeOut },
+   { WSAECONNREFUSED,       ERR::ConnectionRefused },
+   { WSAEHOSTDOWN,          ERR::HostUnreachable },
+   { WSAEHOSTUNREACH,       ERR::HostUnreachable },
+   { WSAHOST_NOT_FOUND,     ERR::HostNotFound },
+   { WSASYSCALLFAILURE,     ERR::SystemCall },
+#elif defined(__linux__)
+   { EINTR,                 ERR::Cancelled },
+   { EACCES,                ERR::PermissionDenied },
+   { EPERM,                 ERR::PermissionDenied },
+   { EFAULT,                ERR::InvalidData },
+   { EINVAL,                ERR::Args },
+   { EMFILE,                ERR::OutOfSpace },
+   { ENFILE,                ERR::OutOfSpace },
+   { EAGAIN,                ERR::InvalidState },
+   { EWOULDBLOCK,           ERR::InvalidState },
+   { EINPROGRESS,           ERR::Busy },
+   { EALREADY,              ERR::Busy },
+   { ENOTSOCK,              ERR::Args },
+   { EDESTADDRREQ,          ERR::Args },
+   { EMSGSIZE,              ERR::DataSize },
+   { EPROTOTYPE,            ERR::Args },
+   { ENOPROTOOPT,           ERR::Args },
+   { EPROTONOSUPPORT,       ERR::NoSupport },
+   { ESOCKTNOSUPPORT,       ERR::NoSupport },
+   { EOPNOTSUPP,            ERR::NoSupport },
+   { EPFNOSUPPORT,          ERR::NoSupport },
+   { EAFNOSUPPORT,          ERR::NoSupport },
+   { EADDRINUSE,            ERR::InUse },
+   { EADDRNOTAVAIL,         ERR::HostUnreachable },
+   { ENETDOWN,              ERR::NetworkUnreachable },
+   { ENETUNREACH,           ERR::NetworkUnreachable },
+   { ENETRESET,             ERR::Disconnected },
+   { ECONNABORTED,          ERR::ConnectionAborted },
+   { ECONNRESET,            ERR::Disconnected },
+   { ENOBUFS,               ERR::BufferOverflow },
+   { ENOMEM,                ERR::NoMemory },
+   { EISCONN,               ERR::DoubleInit },
+   { ENOTCONN,              ERR::Disconnected },
+   { ESHUTDOWN,             ERR::Disconnected },
+   { ETIMEDOUT,             ERR::TimeOut },
+   { ECONNREFUSED,          ERR::ConnectionRefused },
+   { EHOSTDOWN,             ERR::HostUnreachable },
+   { EHOSTUNREACH,          ERR::HostUnreachable },
+   { EPIPE,                 ERR::Disconnected },
+#endif
+   { 0, ERR::NIL }
+};
+
+static ERR convert_socket_error(int Error = 0, ERR Default = ERR::SystemCall)
+{
+#ifdef _WIN32
+   if (Error IS 0) Error = WSAGetLastError();
+#elif defined(__linux__)
+   if (Error IS 0) Error = errno;
+#endif
+
+   for (int i=0; glSocketErrors[i].SystemError; i++) {
+      if (glSocketErrors[i].SystemError IS Error) return glSocketErrors[i].KotukuError;
+   }
+
+   return Default;
+}

--- a/src/network/win32/winsockwrappers.cpp
+++ b/src/network/win32/winsockwrappers.cpp
@@ -63,58 +63,13 @@ static char glWinsockInitialised = false;
 
 //********************************************************************************************************************
 
-static const struct {
-   int WinError;
-   ERR PanError;
-} glErrors[] = {
-   { WSAEINTR,              ERR::Cancelled },
-   { WSAEACCES,             ERR::PermissionDenied },
-   { WSAEFAULT,             ERR::InvalidData },
-   { WSAEINVAL,             ERR::Args },
-   { WSAEMFILE,             ERR::OutOfSpace },
-   { WSAEWOULDBLOCK,        ERR::InvalidState },
-   { WSAEINPROGRESS,        ERR::Busy },
-   { WSAEALREADY,           ERR::Busy },
-   { WSAENOTSOCK,           ERR::Args },
-   { WSAEDESTADDRREQ,       ERR::Args },
-   { WSAEMSGSIZE,           ERR::DataSize },
-   { WSAEPROTOTYPE,         ERR::Args },
-   { WSAENOPROTOOPT,        ERR::Args },
-   { WSAEPROTONOSUPPORT,    ERR::NoSupport },
-   { WSAESOCKTNOSUPPORT,    ERR::NoSupport },
-   { WSAEOPNOTSUPP,         ERR::NoSupport },
-   { WSAEPFNOSUPPORT,       ERR::NoSupport },
-   { WSAEAFNOSUPPORT,       ERR::NoSupport },
-   { WSAEADDRINUSE,         ERR::InUse },
-   { WSAEADDRNOTAVAIL,      ERR::HostUnreachable },
-   { WSAENETDOWN,           ERR::NetworkUnreachable },
-   { WSAENETUNREACH,        ERR::NetworkUnreachable },
-   { WSAENETRESET,          ERR::Disconnected },
-   { WSAECONNABORTED,       ERR::ConnectionAborted },
-   { WSAECONNRESET,         ERR::Disconnected },
-   { WSAENOBUFS,            ERR::BufferOverflow },
-   { WSAEISCONN,            ERR::DoubleInit },
-   { WSAENOTCONN,           ERR::Disconnected },
-   { WSAESHUTDOWN,          ERR::Disconnected },
-   { WSAETIMEDOUT,          ERR::TimeOut },
-   { WSAECONNREFUSED,       ERR::ConnectionRefused },
-   { WSAEHOSTDOWN,          ERR::HostUnreachable },
-   { WSAEHOSTUNREACH,       ERR::HostUnreachable },
-   { WSAHOST_NOT_FOUND,     ERR::HostNotFound },
-   { WSASYSCALLFAILURE,     ERR::SystemCall },
-   { 0, ERR::NIL }
-};
+#include "../socket_errors.h"
 
 //********************************************************************************************************************
 
 static ERR convert_error(int error = 0)
 {
-   if (!error) error = WSAGetLastError();
-
-   for (int i=0; glErrors[i].WinError; i++) {
-      if (glErrors[i].WinError IS error) return glErrors[i].PanError;
-   }
-   return ERR::SystemCall;
+   return convert_socket_error(error);
 }
 
 //********************************************************************************************************************


### PR DESCRIPTION
* Introduce socket_errors.h with a cross-platform convert_socket_error() function replacing the duplicate Win32 error table in winsockwrappers.cpp
* Replace ERR::SystemCall fallbacks in NetSocket, ClientSocket, and network.cpp with convert_socket_error() for accurate error propagation
* Include socket_errors.h on Linux via network.cpp and on Win32 via winsockwrappers.cpp