### PR TITLE
Fix HTTP redirect socket cleanup, socket naming, and SSL test robustness

### DIFF
--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -41,7 +41,7 @@ http = obj.new('http', {
    method     = 'get',
    outputFile = 'temp:index.html',
    stateChanged = function(HTTP, State)
-      if (State == HGS::COMPLETED) then print(content) end
+      if (State is HGS::COMPLETED) then print(content) end
    end
 })
 
@@ -56,7 +56,7 @@ http = obj.new('http', {
    src        = 'http://www.kotuku.dev/index.html',
    method     = 'get',
    datatype   = 'text',
-   objectMode = 'DATA_FEED',
+   objectMode = 'FEED',
    outputObject = doc
 })
 http.acActivate()
@@ -827,6 +827,7 @@ static ERR HTTP_Activate(extHTTP *Self)
       }
 
       if (!(Self->Socket = objNetSocket::create::local(
+            fl::Name("http_main_sock"),
             fl::ClientData(Self),
             fl::Incoming(C_FUNCTION(socket_incoming)),
             fl::Feedback(C_FUNCTION(socket_feedback)),

--- a/src/http/http_incoming.cpp
+++ b/src/http/http_incoming.cpp
@@ -249,11 +249,10 @@ static ERR read_incoming_header(extHTTP *Self, objNetSocket *Socket)
 
                   log.msg("MovedPermanently to %s", location.c_str());
 
-                  auto active_socket = Self->Socket;
-                  if (active_socket) {
-                     active_socket->set(FID_Feedback, (APTR)nullptr);
+                  if (auto active_socket = Self->Socket) {
+                     Self->Socket->set(FID_Feedback, (APTR)nullptr);
                      Self->Socket = nullptr;
-                     QueueAction(AC::Free, active_socket->UID);
+                     FreeResource(active_socket);
                   }
 
                   if (location.starts_with("http:")) redirect_error = Self->setLocation(location);

--- a/src/network/tests/test_ssl.tiri
+++ b/src/network/tests/test_ssl.tiri
@@ -82,7 +82,7 @@ function BasicSSLCommunication()
          err, read_len = Client.acRead(buffer)
 
          if err is ERR_Okay then
-            assert(read_len > 0, 'Received incoming data notification with no data to read.')
+            if read_len is 0 then return end
 
             emsg = buffer:substr(0, read_len)
             logOutput('[Server] Received encrypted message of ' .. read_len .. ' bytes: "' .. tostring(emsg) .. '"')
@@ -131,7 +131,7 @@ function BasicSSLCommunication()
          err, read_len = Socket.acRead(buffer)
 
          if err is ERR_Okay then
-            assert(read_len > 0, 'Received incoming data notification with no data to read.')
+            if read_len is 0 then return end
 
             emsg = buffer:substr(0, read_len)
             logOutput('[Client] Received encrypted message of ' .. read_len .. ' bytes: "' .. tostring(emsg) .. '"')
@@ -411,8 +411,8 @@ function HTTPSConnection()
                err, read_len = Socket.acRead(buffer)
                if err is ERR_Okay and read_len > 0 then
                   chunk = buffer:substr(0, read_len)
-                  page_content = page_content .. chunk
-                  logOutput('Read ' .. read_len .. ' bytes during disconnect (total: ' .. #page_content .. ')')
+                  page_content ..= chunk
+                  logOutput(f'Read {read_len} bytes during disconnect (total: {#page_content})')
                   data_received = true
                end
             end
@@ -432,12 +432,16 @@ function HTTPSConnection()
             err, read_len = Socket.acRead(buffer)
 
             if err is ERR_Okay then
-               assert(read_len > 0, 'Received incoming data notification with no data to read.')
+               if read_len is 0 then
+                  -- This is a common issue because the SSL protocol can send unfinished encrypted blocks
+                  msg('Received incoming data notification with no data to read.')
+                  return
+               end
 
                chunks_received++
                callback_total += read_len
                chunk = buffer:substr(0, read_len)
-               page_content = page_content .. chunk
+               page_content ..= chunk
 
                logOutput('Chunk ' .. chunks_received .. ' received: ' .. read_len .. ' bytes from ' ..
                      SITE .. ' at ' .. elapsed .. 's (total: ' .. #page_content .. ' bytes)')
@@ -586,7 +590,7 @@ function CustomCertificate()
       incoming = function(Socket, Client)
          buffer = string.alloc(1024)
          err, read_len = Client.acRead(buffer)
-         if err is ERR_Okay then
+         if err is ERR_Okay and read_len > 0 then
             message = buffer:substr(0, read_len)
             logOutput('[Server] Received: ' .. message)
             custom_cert_test_complete = true


### PR DESCRIPTION
## Summary

* Replace `QueueAction(AC::Free)` with `FreeResource()` for immediate socket cleanup when handling `MovedPermanently` redirects in `http_incoming.cpp`
* Add `fl::Name("http_main_sock")` to the outgoing `NetSocket` creation in `HTTP_Activate` for easier debugging
* Fix example code in `http.cpp`: `==` → `is`, and `objectMode = 'DATA_FEED'` → `objectMode = 'FEED'`
* Replace failing `assert(read_len > 0)` calls in `test_ssl.tiri` with graceful early returns to handle SSL protocol partial encrypted block notifications
* Use `..=` string append operator and f-string formatting in SSL test for cleaner code

## Test plan

- [ ] Build the `http` module and verify no compilation errors
- [ ] Run SSL Flute tests: `build/agents-install/origo tools/flute.tiri file=src/network/tests/test_ssl.tiri --log-warning`
- [ ] Verify HTTP redirect behaviour is unchanged (MovedPermanently responses free the socket immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)