### PR TITLE
[Network] Prevent TLS WANT_READ from driving write-spin queueing

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -961,6 +961,7 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
 
          if (Self->HandshakeStatus != SHS::NIL) {
             *Length = 0;
+            if (Self->HandshakeStatus IS SHS::READ) return ERR::Busy;
             return ERR::BufferOverflow;
          }
 
@@ -981,7 +982,7 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
                   auto read_callback = std::is_same<T, extNetSocket>::value ?
                      ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
                   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, read_callback, Self);
-                  return ERR::BufferOverflow;
+                  return ERR::Busy;
                }
 
                case SSL_ERROR_SYSCALL:


### PR DESCRIPTION
### Motivation

- Prevent a CPU spin / tight write-callback loop caused when `SSL_write()` returns `SSL_ERROR_WANT_READ` and callers treat that as outbound buffer pressure. 
- Avoid enqueuing writes and keeping level-triggered write subscriptions active while a read-driven TLS handshake is pending.

### Description

- When a socket `HandshakeStatus` is already `SHS::READ`, `send_data` now returns `ERR::Busy` instead of `ERR::BufferOverflow` to signal a read-blocked handshake rather than write backpressure. 
- When `SSL_write()` yields `SSL_ERROR_WANT_READ`, the code still registers the read callback but now returns `ERR::Busy` (not `ERR::BufferOverflow`) to prevent callers from queueing more data and re-arm write readiness.

### Testing

- Built the `network` target in Debug successfully using `cmake --build build/agents --config Debug --target network --parallel`. 
- No other automated tests (e.g. `ctest`) were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9082fe908832ebd52ee00dffa8bc3)