### PR TITLE
[Tiri] Add processing.halt() and simplify processing.sleep() API

### DIFF
--- a/scripts/gui/dialog.tiri
+++ b/scripts/gui/dialog.tiri
@@ -53,7 +53,7 @@ gui.dialog.message = function(Options)
 
    self.wait = function()
       self.waiting = true
-      processing.sleep(-1, true)
+      processing.sleep(-1)
       self.waiting = nil
    end
 

--- a/src/audio/tests/test-audio.tiri
+++ b/src/audio/tests/test-audio.tiri
@@ -3,25 +3,37 @@
 -- These are audible tests that require human verification to confirm a full pass.
 -- NB: Latency differs between platforms.  Do not expect playback gaps to match between Windows and Linux.
 
+@BeforeAll function init(State)
+   global glFolder = State.folder
+   global glAudio = obj.new('audio', { name='SystemAudio' })
+
+   check glAudio.acActivate()
+   global glLag = glAudio.mixerLag
+   logOutput('Audio mixer lag time measured as ' .. string.format('%.2fs', glLag))
+end
+
+@AfterAll function cleanup()
+   mSys.DeleteFile('temp:low-tone.wav')
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- This test must result in playback of a low-tone, then followed by a high tone.
 
-@Test(requires='audio')
+@Test(requires='audio', priority=10)
 function SequentialPlayback()
-   local proc = processing.new()
-
-   local snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', volume=0.25 })
+   snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', volume=0.25 })
    assert(snd, 'Failed to process low-tone wav file.')
 
    local time, time_taken
-   snd.onStop = function(SoundID)
+   snd.onStop = function(Sound:obj)
       time_taken = (mSys.preciseTime() - time) / 1000000
-      proc.signal()
+      Sound.acSignal()
    end
 
-   local duration = snd.duration
+   duration = snd.duration
    processing.collect()
 
+   proc = processing.new({ signals = array<object> { snd } })
    assert(snd.acActivate() is ERR_Okay, 'Failed to playback low-tone sound sample.')
    time = mSys.preciseTime()
 
@@ -32,13 +44,15 @@ function SequentialPlayback()
 
    -- Second sample
 
-   local snd = obj.new('sound', { path=glFolder .. 'high-tone.wav', volume=0.25 })
+   snd = obj.new('sound', { path=glFolder .. 'high-tone.wav', volume=0.25 })
    assert(snd, 'Failed to process high-tone wav file.')
 
-   snd.onStop = function(SoundID)
+   snd.onStop = function(Sound:obj)
       time_taken = (mSys.preciseTime() - time) / 1000000
-      proc.signal()
+      Sound.acSignal()
    end
+
+   proc = processing.new({ signals = array<object> { snd } })
 
    duration = snd.duration
    assert(snd.acActivate() is ERR_Okay, 'Failed to playback high-tone sound sample.')
@@ -49,24 +63,24 @@ function SequentialPlayback()
    assert(time_taken >= duration, 'End-of-sample occurred earlier than duration of ' .. duration .. ': ' .. time_taken)
    assert(time_taken <  duration+glLag+0.02, 'End-of-sample exceeded duration of ' .. duration .. ': ' .. time_taken)
 
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Test left and right speaker panning
 
-@Test(requires='audio')
+@Test(requires='audio', priority=20)
 function Pan()
-   local proc = processing.new()
+   proc = processing.new()
 
-   local snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', pan=-1.0, volume=0.25 })
+   snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', pan=-1.0, volume=0.25 })
    assert(snd, 'Failed to process low-tone wav file.')
 
    snd.onStop = function(SoundID)
       proc.signal()
    end
 
-   print('Play left speaker.')
+   logOutput('Play left speaker.')
 
    assert(snd.acActivate() is ERR_Okay, 'Failed to playback low-tone sound sample.')
 
@@ -74,33 +88,32 @@ function Pan()
 
    -- Right speaker
 
-   print('Play right speaker.')
+   logOutput('Play right speaker.')
    snd.pan = 1.0
    assert(snd.acActivate() is ERR_Okay, 'Failed to playback low-tone sound sample.')
 
    proc.sleep()
 
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Test volume adjustment and OnStop trigger rates.
 
-@Test(requires='audio')
+@Test(requires='audio', priority=30)
 function Volume()
-   local proc = processing.new()
+   snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
 
-   local snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
-   assert(snd, 'Failed to process low-tone wav file.')
+   logOutput('Sample duration is ' .. string.format('%.2fs', snd.duration))
 
-   print('Sample duration is ' .. string.format('%.2fs', snd.duration))
-
-   local active_time = 0
-   local elapsed = 0
-   snd.onStop = function(SoundID)
+   active_time = 0
+   elapsed = 0
+   snd.onStop = function(Sound)
       elapsed = (mSys.PreciseTime() - active_time) / 1000000
-      proc.signal()
+      Sound.acSignal()
    end
+
+   proc = processing.new({ signals = array<object> { snd } })
 
    for i=1,4 do
       snd.volume = 1.0 * (i / 4)
@@ -108,24 +121,23 @@ function Volume()
       snd.acActivate()
       proc.sleep()
       assert(elapsed >= snd.duration-0.02, 'OnStop triggered ' .. string.format('%.2fs', snd.duration - elapsed) .. ' earlier than the sample\'s duration.')
-      print('Playback latency measured as ' .. string.format('%.2fs', elapsed - snd.duration))
+      logOutput('Playback latency measured as ' .. string.format('%.2fs', elapsed - snd.duration))
    end
 
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Increase the pitch repeatedly
 
-@Test(requires='audio')
+@Test(requires='audio', priority=40)
 function Tones()
-   local proc = processing.new()
+   proc = processing.new()
 
-   local snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', volume=0.25 })
-   assert(snd, 'Failed to process low-tone wav file.')
+   snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', volume=0.25 })
 
-   local active_time = 0
-   local elapsed = 0
+   active_time = 0
+   elapsed = 0
    snd.onStop = function(SoundID)
       elapsed = (mSys.PreciseTime() - active_time) / 1000000
       proc.signal()
@@ -138,12 +150,12 @@ function Tones()
       proc.sleep()
    end
 
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test(requires='audio')
+@Test(requires='audio', priority=50)
 function Beep()
    glAudio.mtBeep(3000, 100, 5)
 end
@@ -152,13 +164,13 @@ end
 -- Test WAVE file saving by loading a file and saving it to a temp location, then comparing the binary content of
 -- both files.
 
-@Test(requires='audio')
+@Test(requires='audio', priority=60)
 function WaveSave()
-   local snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
-   local output_file = obj.new('file', { path='temp:low-tone.wav', flags='!NEW|WRITE' })
+   snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
+   output_file = obj.new('file', { path='temp:low-tone.wav', flags='!NEW|WRITE' })
 
    -- Save the sound as WAVE format to the temporary file
-   local result = snd.acSaveToObject(output_file)
+   result = snd.acSaveToObject(output_file)
    assert(result is ERR_Okay, 'Failed to save sound to temporary file: ' .. mSys.GetErrorMsg(result))
 
    -- Close the output file to ensure data is flushed
@@ -166,39 +178,39 @@ function WaveSave()
    processing.collect()
 
    -- Now read both files as binary and compare their content
-   local original_file = obj.new('file', { path=glFolder .. 'low-tone.wav', flags='READ' })
+   original_file = obj.new('file', { path=glFolder .. 'low-tone.wav', flags='READ' })
    assert(original_file, 'Failed to open original low-tone.wav for reading.')
 
-   local saved_file = obj.new('file', { path='temp:low-tone.wav', flags='READ' })
+   saved_file = obj.new('file', { path='temp:low-tone.wav', flags='READ' })
    assert(saved_file, 'Failed to open saved low-tone.wav for reading.')
 
    -- Get file sizes
-   local original_size = original_file.size
-   local saved_size = saved_file.size
+   original_size = original_file.size
+   saved_size = saved_file.size
 
    assert(original_size is saved_size, 'File sizes do not match: original=' .. original_size .. ', saved=' .. saved_size)
 
    -- Compare file content in chunks
-   local chunk_size = 4096
-   local bytes_compared = 0
+   chunk_size = 4096
+   bytes_compared = 0
 
    while bytes_compared < original_size do
-      local remaining = original_size - bytes_compared
-      local read_size = math.min(chunk_size, remaining)
+      remaining = original_size - bytes_compared
+      read_size = math.min(chunk_size, remaining)
 
-      local original_data = string.alloc(read_size)
-      local saved_data = string.alloc(read_size)
-      local err, size_a = original_file.acRead(original_data, read_size)
-      local err, size_b = saved_file.acRead(saved_data, read_size)
+      original_data = string.alloc(read_size)
+      saved_data = string.alloc(read_size)
+      err, size_a = original_file.acRead(original_data, read_size)
+      err, size_b = saved_file.acRead(saved_data, read_size)
 
       assert(original_data, 'Failed to read from original file at offset ' .. bytes_compared)
       assert(saved_data, 'Failed to read from saved file at offset ' .. bytes_compared)
       assert(size_a is size_b, 'Read size mismatch at offset ' .. bytes_compared)
 
       -- Compare byte by byte
-      for i = 1, read_size do
-         local orig_byte = string.byte(original_data, i)
-         local saved_byte = string.byte(saved_data, i)
+      for i = 0, read_size-1 do
+         orig_byte = string.byte(original_data, i)
+         saved_byte = string.byte(saved_data, i)
          if orig_byte != saved_byte then
             error('Byte mismatch at offset ' .. (bytes_compared + i - 1) .. ': original=' .. orig_byte .. ', saved=' .. saved_byte)
          end
@@ -211,21 +223,3 @@ function WaveSave()
    saved_file = nil
    processing.collect()
 end
-
------------------------------------------------------------------------------------------------------------------------
-
-   return {
-      init = function(Folder)
-         glFolder = Folder
-         glAudio = obj.new('audio', { name='SystemAudio' })
-         if not glAudio then error('Failed to create audio object.') end
-         if glAudio.acActivate() != ERR_Okay then
-            error('Failed to initialise audio server.')
-         end
-         glLag = glAudio.mixerLag
-         print('Audio mixer lag time measured as ' .. string.format('%.2fs', glLag))
-      end,
-      cleanup = function()
-         mSys.DeleteFile('temp:low-tone.wav')
-      end
-   }

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -638,7 +638,7 @@ ERR WaitForObjects(PMF Flags, int TimeOut, ObjectSignal *ObjectSignals)
    log.branch("Flags: $%.8x, Timeout: %d, Signals: %p", int(Flags), TimeOut, ObjectSignals);
 
    // Set the current task as the context to ensure predictable behaviour.  Note: Don't use SwitchContext here as
-   // it retains a lock on the task when we definitely don't actually want to.
+   // it retains a lock on the task and we don't want that.
 
    SetObjectContext(glCurrentTask, nullptr, AC::NIL);
 

--- a/src/http/tests/test_edge_cases.tiri
+++ b/src/http/tests/test_edge_cases.tiri
@@ -26,7 +26,7 @@ SERVER_PORT <const> = 18945
             method = 'GET',
             handler = function(req, res)
                -- Simulate slow response (but not too slow to break tests)
-               processing.sleep(0.5) -- 0.5 second delay
+               processing.halt(0.5) -- 0.5 second delay
                res.json({ message = 'Delayed response' })
             end
          },

--- a/src/http/tests/test_validate_header.tiri
+++ b/src/http/tests/test_validate_header.tiri
@@ -106,7 +106,7 @@ SERVER_PORT <const> = 18940
       }
    })
 
-   processing.sleep(0.1)
+   processing.halt(0.1)
 end
 
 @AfterAll function cleanup()

--- a/src/mp3/tests/test-mp3.tiri
+++ b/src/mp3/tests/test-mp3.tiri
@@ -60,7 +60,7 @@ end
    assert(time_taken > duration-0.05, 'End-of-sample occurred earlier than duration of ' .. duration .. ': ' .. time_taken)
    assert(time_taken < duration+glLag+0.1, 'End-of-sample exceeded duration of ' .. duration .. ': ' .. time_taken)
 
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -79,5 +79,5 @@ end
 
    snd.acActivate()
    proc.sleep()
-   proc.sleep(0.25)
+   processing.halt(0.25)
 end

--- a/src/network/tests/test_bind_address.tiri
+++ b/src/network/tests/test_bind_address.tiri
@@ -15,7 +15,8 @@
 
 @Test function BindLocalhost()
    port = glBasePort + 1
-   proc = processing.new({ timeout = 3.0 })
+   signal = obj.new('time', { })
+   proc = processing.new({ timeout = 3.0, signals = array<object> { signal } })
 
    server = obj.new('netsocket', {
       port = port,
@@ -29,12 +30,12 @@
       feedback = function(Socket, State)
          assert(Socket, 'Socket parameter not defined.')
          if (State is NTC_CONNECTED) then
-            proc.signal()
+            signal.acSignal()
          end
       end,
    })
 
-   proc.sleep()
+   check proc.sleep()
 
    assert(client.state is NTC_CONNECTED, 'Client failed to connect from localhost')
 end

--- a/src/network/tests/test_client_server.tiri
+++ b/src/network/tests/test_client_server.tiri
@@ -5,14 +5,15 @@ Client-Server Network Communications test.  Creates a server socket and then sta
    include 'network'
    mNet ?= mod.load('network')
 
-   glTestSteps = 0
-   glExpectedSteps = 6
-   glServerData = nil
-   glClientData = nil
-   glPort = 8206
-   glTestCompleted = false
+glTestSteps     = 0
+glExpectedSteps = 6
+glServerData    = nil
+glClientData    = nil
+glPort          = 8206
+glTestCompleted = false
+rxMessage <const> = regex.new('\\w+:(.+)')
 
-function printableState(State)
+function logOutputableState(State)
    return choose State from
       NTC_CONNECTED -> 'CONNECTED'
       NTC_CONNECTING -> 'CONNECTING'
@@ -23,25 +24,23 @@ function printableState(State)
    end
 end
 
-rxMessage = regex.new('\\w+:(.+)')
-
 ------------------------------------------------------------------------------------------------------------------------
 -- Test address validation and error handling
 
 @Test function StrToAddress()
-   invalidAddresses = {
+   invalidAddresses = array<string> {
       'gggg::1',           -- Invalid hex digits
       '1::2::3',           -- Double double-colon
       '1:2:3:4:5:6:7:8:9', -- Too many groups
       'not.an.ipv6.address' -- Not an IP address at all
    }
 
-   for i, addr in ipairs(invalidAddresses) do
+   for addr in values(invalidAddresses) do
       dest = struct.new('IPAddress')
       assert(mNet.StrToAddress(addr, dest) != ERR_Okay, 'StrToAddress should fail for invalid IPv6 address: ' .. addr)
    end
 
-   validAddresses = {
+   validAddresses = array<string> {
       '::1',                   -- Loopback
       '::',                    -- Any address
       '2001:db8::1',           -- Documentation prefix
@@ -49,48 +48,46 @@ rxMessage = regex.new('\\w+:(.+)')
       '::ffff:127.0.0.1',      -- IPv4-mapped IPv6
    }
 
-   for i, addr in ipairs(validAddresses) do
+   for addr in values(validAddresses) do
       dest = struct.new('IPAddress')
-      assert(mNet.StrToAddress(addr, dest) is ERR_Okay, 'StrToAddress should succeed for IPv6 address: ' .. addr)
+      check mNet.StrToAddress(addr, dest)
    end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ClientServer()
-   proc = processing.new({ timeout = 5.0 })
-
    server_buffer = string.alloc(1024)
 
    sockServer = obj.new('netsocket', {
-      name = 'Server',
+      name    = 'Server',
       address = '127.0.0.1',
-      feedback = function(Socket, Client, State)
+      feedback = function(Socket:obj, Client:obj, State)
          assert(Socket and Client, '[Server] Socket or Client parameter not defined.')
 
-         if (State is NTC_CONNECTED) then
-            print('[Server] Connection established to new client.')
+         if State is NTC_CONNECTED then
+            logOutput('[Server] Connection established to new client.')
             err, len = Client.acWrite('Hello from the server')
             assert(err is ERR_Okay, '[Server] Failed to send message to the client: ' .. mSys.GetErrorMsg(err))
          else
-            print('[Server] Ignoring state ' .. printableState(State))
+            logOutput('[Server] Ignoring state ' .. logOutputableState(State))
          end
       end,
-      incoming = function(Socket, Client)
+      incoming = function(Socket:obj, Client:obj)
          assert(Socket and Client, '[Server] Socket or Client parameter not defined.')
 
          err, read_len = Client.acRead(server_buffer)
          assert(err is ERR_Okay, 'Failed to read data from client, error: ' .. mSys.GetErrorMsg(err))
 
          msg = server_buffer:sub(0, read_len)
-         print(f'[Server] Received "{msg}"')
+         logOutput(f'[Server] Received "{msg}"')
          if (msg:find('Reply')) then
             glTestCompleted = true
-            proc.signal()
+            Socket.acSignal()
          end
       end,
       port  = glPort,
-      flags = 'SERVER'
+      flags = NSF_SERVER
    } )
 
    clientSocket = obj.new('netsocket', {
@@ -98,7 +95,7 @@ end
       feedback = function(Socket, State)
          assert(Socket, 'Socket parameter not defined.')
          if (State is NTC_CONNECTED) then
-            print('[Client] Writing hello message to the server...')
+            logOutput('[Client] Writing hello message to the server...')
             err, len = Socket.acWrite('Hello from the client.')
             assert(err is ERR_Okay, '[Client] Failed to write chars, error: ' .. mSys.GetErrorMsg(err))
          end
@@ -107,18 +104,17 @@ end
          buffer = string.alloc(1024)
          err, read_len = Socket.acRead(buffer)
          assert(err is ERR_Okay, '[Client] Failed to read data from the socket.')
-         print('[Client] Received: ' .. buffer:sub(0,read_len))
-         print('[Client] Sending reply to server...')
+         logOutput('[Client] Received: ' .. buffer:sub(0,read_len))
+         logOutput('[Client] Sending reply to server...')
          err, len = Socket.acWrite('Reply from the client.')
          assert(err is ERR_Okay, '[Client] Failed to send reply, error: ' .. mSys.GetErrorMsg(err))
       end
    } )
 
-   print('Connecting client to the server...')
+   proc = processing.new({ timeout = 5.0, signals = array<object> { sockServer } })
 
-   assert(clientSocket.mtConnect('127.0.0.1', glPort) is ERR_Okay, 'Failed to connect to server.')
-   err = proc.sleep()
-   assert(err is ERR_Okay, 'Failed to complete the test: ' .. mSys.GetErrorMsg(err))
+   check clientSocket.mtConnect('127.0.0.1', glPort)
+   check proc.sleep()
    assert(glTestCompleted, 'The test did not complete the steps as expected.')
 end
 
@@ -126,25 +122,23 @@ end
 -- One-on-one basic communication test between client and server.
 
 @Test function BasicCommunication()
-   proc = processing.new({ timeout = 10.0 })
-
    glPort++
 
    -- Create server socket with comprehensive message handling
    sockServer = obj.new('netsocket', {
       name = 'BasicTestServer',
       feedback = function(Socket, Client, State)
-         print('[Server] Client state change: ' .. printableState(State))
-         if (State is NTC_CONNECTED) then
-            print('[Server] Client connected, sending welcome message...')
+         logOutput('[Server] Client state change: ' .. logOutputableState(State))
+         if State is NTC_CONNECTED then
+            logOutput('[Server] Client connected, sending welcome message...')
             err, len = Client.acWrite('WELCOME:Server ready for communication')
             assert(err is ERR_Okay, '[Server] Failed to send welcome message: ' .. mSys.GetErrorMsg(err))
-            glTestSteps = glTestSteps + 1
-         elseif (State is NTC_DISCONNECTED) then
-            glTestSteps = glTestSteps + 1
-            print('[Server] Client disconnected.  Step ' .. glTestSteps .. ' of ' .. glExpectedSteps)
-            if (glTestSteps >= glExpectedSteps) then
-               proc.signal()
+            glTestSteps++
+         elseif State is NTC_DISCONNECTED then
+            glTestSteps++
+            logOutput('[Server] Client disconnected.  Step ' .. glTestSteps .. ' of ' .. glExpectedSteps)
+            if glTestSteps >= glExpectedSteps then
+               Socket.acSignal()
             end
          end
       end,
@@ -153,31 +147,31 @@ end
          err, read_len = Client.acRead(buffer)
          if (err != ERR_Okay) then
             if (err is ERR_Disconnected) then
-               if not read_msg_sent then print('[Server] Client disconnected on Read()') end
+               if not read_msg_sent then logOutput('[Server] Client disconnected on Read()') end
                read_msg_sent = true
                return
             end
-            proc.signal()
+            Socket.acSignal()
             error('[Server] Failed to read data from client: ' .. mSys.GetErrorMsg(err))
          end
 
          msg = buffer:sub(0, read_len)
-         print('[Server] Received: ' .. msg)
+         logOutput('[Server] Received: ' .. msg)
 
          if (msg:startsWith('ACK:WELCOME')) then
-            print('[Server] Client acknowledged welcome, requesting data...')
+            logOutput('[Server] Client acknowledged welcome, requesting data...')
             err, len = Client.acWrite('REQUEST:Send your test data')
             assert(err is ERR_Okay, '[Server] Failed to send data request: ' .. mSys.GetErrorMsg(err))
             glTestSteps++
          elseif (msg:startsWith('DATA:')) then
             data = rxMessage.extract(msg)
             glServerData = data
-            print('[Server] Received data: ' .. data)
+            logOutput('[Server] Received data: ' .. data)
             err, len = Client.acWrite('CONFIRM:Data received successfully')
             assert(err is ERR_Okay, '[Server] Failed to send confirmation: ' .. mSys.GetErrorMsg(err))
             glTestSteps++
          elseif (msg:startsWith('COMPLETE:')) then
-            print('[Server] Client signalled completion')
+            logOutput('[Server] Client signalled completion')
             glTestSteps++
          end
       end,
@@ -188,12 +182,12 @@ end
    -- Create client socket with state-aware message handling
    clientSocket = obj.new('netsocket', {
       name = 'BasicTestClient',
-      feedback = function(Socket, State)
-         print('[Client] Connection state: ' .. printableState(State))
-         if (State is NTC_CONNECTED) then
-            print('[Client] Connected to server, waiting for welcome...')
-         elseif (State is NTC_DISCONNECTED) then
-            print('[Client] Disconnected from server')
+      feedback = function(Socket:obj, State:num)
+         logOutput('[Client] Connection state: ' .. logOutputableState(State))
+         if State is NTC_CONNECTED then
+            logOutput('[Client] Connected to server, waiting for welcome...')
+         elseif State is NTC_DISCONNECTED then
+            logOutput('[Client] Disconnected from server')
          end
       end,
       incoming = function(Socket)
@@ -202,20 +196,20 @@ end
          assert(err is ERR_Okay, '[Client] Failed to read data from server: ' .. mSys.GetErrorMsg(err))
 
          msg = buffer:sub(0, read_len)
-         print('[Client] Received: ' .. msg)
+         logOutput('[Client] Received: ' .. msg)
 
-         if (msg:startsWith('WELCOME:')) then
-            print('[Client] Received welcome, sending acknowledgment...')
+         if msg:startsWith('WELCOME:') then
+            logOutput('[Client] Received welcome, sending acknowledgment...')
             err, len = Socket.acWrite('ACK:WELCOME received, client ready')
             assert(err is ERR_Okay, '[Client] Failed to send acknowledgment: ' .. mSys.GetErrorMsg(err))
-            glTestSteps = glTestSteps + 1
-         elseif (msg:startsWith('REQUEST:')) then
-            print('[Client] Received data request, sending test data...')
+            glTestSteps++
+         elseif msg:startsWith('REQUEST:') then
+            logOutput('[Client] Received data request, sending test data...')
             glClientData = 'TestPayload123'
             err, len = Socket.acWrite('DATA:' .. glClientData)
             assert(err is ERR_Okay, '[Client] Failed to send data: ' .. mSys.GetErrorMsg(err))
-         elseif (msg:startsWith('CONFIRM:')) then
-            print('[Client] Server confirmed data receipt, completing test...')
+         elseif msg:startsWith('CONFIRM:') then
+            logOutput('[Client] Server confirmed data receipt, completing test...')
             err, len = Socket.acWrite('COMPLETE:Test finished')
             assert(err is ERR_Okay, '[Client] Failed to send completion: ' .. mSys.GetErrorMsg(err))
             raise ERR_Terminate
@@ -223,76 +217,60 @@ end
       end
    })
 
-   print('[Client] Attempting connection to server...')
-   err = clientSocket.mtConnect('127.0.0.1', glPort)
-   assert(err is ERR_Okay, '[Client] Failed to connect to server: ' .. mSys.GetErrorMsg(err))
+   proc = processing.new({ timeout = 10.0, signals = array<object> { sockServer } })
+   check clientSocket.mtConnect('127.0.0.1', glPort)
+   check proc.sleep()
 
-   -- Wait for test completion with timeout
-
-   err = proc.sleep(5)
-   assert(err is ERR_Okay, 'Test failed to complete: ' .. mSys.GetErrorMsg(err))
-
-   -- Verify test completion and data integrity
    assert(glTestSteps >= glExpectedSteps,
       'Test did not complete all steps. Expected: ' .. glExpectedSteps .. ', Actual: ' .. glTestSteps)
 
    assert(glServerData is glClientData and glServerData != nil,
       'Data integrity check failed. Expected: ' .. tostring(glClientData) .. ', Received: ' .. tostring(glServerData))
-
-   print('Basic communication test completed successfully!')
-   print('Steps completed: ' .. glTestSteps .. '/' .. glExpectedSteps)
-   print('Data verified: ' .. glServerData)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConnectionStates()
-   proc = processing.new({ timeout = 5.0 })
-   stateChanges = {}
+   stateChanges = array<string> {}
 
    glPort++
-
-   print('Testing connection state transitions...')
 
    server = obj.new('netsocket', {
       name = 'StateTestServer',
       feedback = function(Socket, Client, State)
-         print('Server received state change.')
-         table.insert(stateChanges, 'SERVER_CLIENT_' .. printableState(State))
+         logOutput('Server received state change.')
+         stateChanges:push('SERVER_CLIENT_' .. logOutputableState(State))
       end,
       port = glPort,
-      flags = 'SERVER'
+      flags = NSF_SERVER
    })
 
    client = obj.new('netsocket', {
       name = 'StateTestClient',
       feedback = function(Socket, State)
-         print('Client received state change.')
-         table.insert(stateChanges, 'CLIENT_' .. printableState(State))
-         if (State is NTC_CONNECTED) then
-            proc.signal()
+         logOutput('Client received state change.')
+         stateChanges:push('CLIENT_' .. logOutputableState(State))
+         if State is NTC_CONNECTED then
+            server.acSignal()
          end
       end
    })
 
+   proc = processing.new({ timeout = 5.0, signals = array<object> { server } })
    client.mtConnect('127.0.0.1', glPort)
-   proc.sleep()
+   check proc.sleep()
 
-   -- Verify expected state transitions occurred
    assert(#stateChanges >= 2, 'Expected at least 2 state changes, got: ' .. #stateChanges)
 
    foundClientConnected = false
    foundServerConnected = false
-   for i, state in ipairs(stateChanges) do
-      print('State change ' .. i .. ': ' .. state)
+   for state in values(stateChanges) do
       if (state is 'CLIENT_CONNECTED') then foundClientConnected = true end
       if (state is 'SERVER_CLIENT_CONNECTED') then foundServerConnected = true end
    end
 
    assert(foundClientConnected, 'Client connection state change not detected')
    assert(foundServerConnected, 'Server client connection state change not detected')
-
-   print('Connection state test completed successfully!')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -301,7 +279,6 @@ end
    timeoutDuration = 0.5
    startTime = mSys.PreciseTime()
    connectionTimedOut = false
-   proc = processing.new({ timeout = timeoutDuration + 2.0 })
 
    -- Try connecting to an IP address that should not respond (RFC 5737 test address)
    -- 192.0.2.1 is reserved for documentation and should not be routable
@@ -313,23 +290,23 @@ end
       feedback = function(Socket, State)
          currentTime = mSys.PreciseTime()
          elapsed = (currentTime - startTime) / 1000000.0  -- Convert to seconds
-         print(string.format('[Client] State: %s after %.2fs', printableState(State), elapsed))
+         logOutput(string.format('[Client] State: %s after %.2fs', logOutputableState(State), elapsed))
 
-         if (State is NTC_DISCONNECTED) then
-            if (Socket.error is ERR_TimeOut) then
+         if State is NTC_DISCONNECTED then
+            if Socket.error is ERR_TimeOut then
                connectionTimedOut = true
-               proc.signal()
+               Socket.acSignal()
             end
          end
       end
    })
 
-   print(string.format('[Client] Attempting connection to %s:%d with %.1fs timeout...', testAddress, testPort, timeoutDuration))
+   logOutput(string.format('[Client] Attempting connection to %s:%d with %.1fs timeout...', testAddress, testPort, timeoutDuration))
 
-   err = clientSocket.mtConnect(testAddress, testPort, timeoutDuration)
-   assert(err is ERR_Okay, '[Client] Connect() call failed: ' .. mSys.GetErrorMsg(err))
+   proc = processing.new({ timeout = timeoutDuration + 2.0, signals = array<object> { clientSocket } })
+   check clientSocket.mtConnect(testAddress, testPort, timeoutDuration)
+   check proc.sleep()
 
-   proc.sleep()
    endTime = mSys.PreciseTime()
    totalElapsed = (endTime - startTime) / 1000000.0
 
@@ -338,6 +315,4 @@ end
    assert(clientSocket.error is ERR_TimeOut, 'Socket error should be ERR_TimeOut, got: ' .. mSys.GetErrorMsg(clientSocket.error))
    assert(totalElapsed >= timeoutDuration, string.format('Timeout occurred too early: %.2fs < %.2fs', totalElapsed, timeoutDuration))
    assert(totalElapsed <= (timeoutDuration + 1.0), string.format('Timeout occurred too late: %.2fs > %.2fs', totalElapsed, timeoutDuration + 1.0))
-
-   print(string.format('Connection timeout test completed successfully! (%.2fs elapsed)', totalElapsed))
 end

--- a/src/network/tests/test_concurrency.tiri
+++ b/src/network/tests/test_concurrency.tiri
@@ -33,8 +33,6 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function MultipleConnections()
-   proc = processing.new({ timeout = 3.0 })
-
    glPort++
    glClientsCreated = 0
 
@@ -56,7 +54,7 @@ end
 
             if (glClientsCreated is glMaxSockets) and (glActiveClients is 0) then
                print('[Server] All clients disconnected, test complete')
-               proc.signal()
+               Socket.acSignal()
             end
          end
       end,
@@ -81,6 +79,8 @@ end
       flags = 'SERVER|MULTI_CONNECT',
       socketLimit = glMaxSockets
    })
+
+   proc = processing.new({ timeout = 3.0, signals = array<object> { server } })
 
    assert(server, 'Failed to create server socket')
 
@@ -202,10 +202,10 @@ end
          rejectedConnections++
          print('[Client ' .. i .. '] Connection rejected: ' .. mSys.GetErrorMsg(err))
       end
-      processing.sleep(0.05, false) -- Small delay
+      processing.halt(0.05) -- Small delay
    end
 
-   processing.sleep(0.5)
+   processing.halt(0.5)
 
    assert(successfulConnections <= limit,
       'Too many connections accepted. Limit: ' .. limit .. ', Accepted: ' .. successfulConnections)
@@ -216,7 +216,6 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConnectionIsolation()
-   proc = processing.new({ timeout = 3.0 })
    clientCount = 3
    clientMessages = array<array<string>>
    messagesPerClient = 2
@@ -261,6 +260,8 @@ end
 
    clients = {}
    completedClients = 0
+   signal = obj.new('time', { })
+   proc = processing.new({ timeout = 3.0, signals = array<object> { signal } })
 
    for i = 0, clientCount-1 do
       clients[i] = { }
@@ -293,7 +294,7 @@ end
                   print(f'[Client {clientId}] All messages completed')
                   completedClients++
                   if (completedClients is clientCount) then
-                     proc.signal()
+                     signal.acSignal()
                   end
                end
             end

--- a/src/network/tests/test_dns_parallel.tiri
+++ b/src/network/tests/test_dns_parallel.tiri
@@ -6,16 +6,16 @@ Tests for resolving server names in parallel.
 
 glDomains = array<string> { 'google.com', 'kotuku.dev', 'amazon.co.uk', 'stackoverflow.com', 'theguardian.com', 'www.bbc.co.uk' }
 glTotalResolved = 0
-local proc
+local proc, signal
 
 @BeforeAll function init()
    global mNet ?= mod.load('network')
-   proc = processing.new({ timeout = 5.0 })
 end
 
 @AfterAll function cleanup()
    glDomains = nil
    glTotalResolved = nil
+   signal = nil
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -36,14 +36,14 @@ function name_resolved(NetLookup, Error)
 
    total_ips = 0
 
-   print('Resolved host name "' .. host .. '" (' .. (glTotalResolved+1) .. '/' .. #glDomains .. ')')
+   logOutput('Resolved host name "' .. host .. '" (' .. (glTotalResolved+1) .. '/' .. #glDomains .. ')')
 
    ip_list = nil
    addresses = NetLookup.addresses -- array type
    if addresses then
       total_ips = #addresses
       for ip in values(addresses) do
-          assert((ip.type is IPADDR_V4) or (ip.type is IPADDR_V6), 'Unrecognised TCP/IP address type ' .. ip.type)
+         assert((ip.type is IPADDR_V4) or (ip.type is IPADDR_V6), 'Unrecognised TCP/IP address type ' .. ip.type)
          if not ip_list then
             ip_list = netAddressToString(ip)
          else
@@ -54,12 +54,12 @@ function name_resolved(NetLookup, Error)
 
    msg = 'Resolved ' .. host .. ' with ' .. total_ips .. ' IP addresses.'
    if ip_list then msg ..= '  IPs: ' .. ip_list end
-   print(msg)
+   logOutput(msg)
 
    glTotalResolved++
 
    if glTotalResolved is #glDomains then
-      proc.signal() -- Breaks the proc.sleep() loop
+      NetLookup.acSignal()
    end
 end
 
@@ -71,31 +71,29 @@ end
 @Test(requires='network') function Duplication()
    resolved = 0
 
-   domains = { 'google.com', 'reddit.com' }
+   domains = array<string> { 'google.com', 'reddit.com' }
    function duplicate_resolved(NetLookup, Error)
       assert(Error is ERR_Okay, 'Failed to resolve ' .. NetLookup.hostName .. ', error ' ..mSys.GetErrorMsg(Error))
-      print('Resolved: ' .. NetLookup.hostName)
+      logOutput('Resolved: ' .. NetLookup.hostName)
       resolved++
-      if resolved is #domains * 2 then print('All domains resolved.') end
-      proc.signal()
+      if resolved is #domains * 2 then logOutput('All domains resolved.') end
+      NetLookup.acSignal()
    end
 
-   for k,v in pairs(domains) do
+   for domain in values(domains) do
       nlA = obj.new('NetLookup', { callback = duplicate_resolved, flags=NLF_NO_CACHE })
       nlB = obj.new('NetLookup', { callback = duplicate_resolved })
 
-      err = nlA.mtResolveName(v)
-      err = proc.sleep()
-      assert(err is ERR_Okay, 'Name resolution failed: ' .. mSys.GetErrorMsg(err))
-      print('First lookup processed successfully.')
+      proc = processing.new({ timeout = 5.0, signals = array<object> { nlA } })
+      check nlA.mtResolveName(domain)
+      check proc.sleep()
 
+      proc = processing.new({ timeout = 5.0, signals = array<object> { nlB } })
       save = resolved
-      err = nlB.mtResolveName(v)
+      check nlB.mtResolveName(domain)
       if save is resolved then
-         err = proc.sleep()
-         assert(err is ERR_Okay, 'Name resolution failed: ' .. mSys.GetErrorMsg(err))
+         check proc.sleep()
       end
-      print('Second lookup processed successfully.')
    end
 end
 
@@ -105,13 +103,14 @@ end
 @Test(requires='network') function NameResolutionAsync()
    nl = obj.new('NetLookup', { callback=name_resolved, flags=NLF_NO_CACHE })
 
+   proc = processing.new({ timeout = 2.0, signals = array<object> { nl } })
+
    glTotalResolved = 0
-   for i=0,#glDomains-1 do
-      nl.mtResolveName(glDomains[i])
+   for domain in values(glDomains) do
+      nl.mtResolveName(domain)
    end
 
-   err = proc.sleep(5.0)
-   if (err is ERR_TimeOut) then error('Name resolution timed-out.') end
+   check proc.sleep()
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -121,9 +120,9 @@ end
    nl = obj.new('NetLookup', { callback = name_resolved, flags=NLF_NO_CACHE })
 
    glTotalResolved = 0
-   for i=0,#glDomains-1 do
+   for domain in values(glDomains) do
       expected_total = glTotalResolved + 1
-      nl.mtBlockingResolveName(glDomains[i])
+      nl.mtBlockingResolveName(domain)
       assert(expected_total is glTotalResolved, 'Name was not resolved when ResolveName() had returned, got ' .. glTotalResolved .. '/' .. expected_total)
    end
 end

--- a/src/network/tests/test_error_handling.tiri
+++ b/src/network/tests/test_error_handling.tiri
@@ -18,9 +18,8 @@ meaningful error reporting while maintaining system stability.
 
    include 'network'
 
-   glPort = 18304
-   glErrorScenarios = {}
-   glTestResults = {}
+glPort = 18304
+glErrorScenarios = {}
 
 function printableState(State)
    return choose State from
@@ -35,47 +34,47 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConnectionFailures()
-   proc = processing.new({ timeout = 2.0 })
+   results = array<string> {}
    glPort++
 
    -- Test 1: Invalid IP address
-   print('[Test 1] Testing connection to invalid IP address...')
+   logOutput('[Test 1] Testing connection to invalid IP address...')
    client1 = obj.new('netsocket', {
       name = 'InvalidIPClient',
       feedback = function(Socket, State)
-         print('[Client1] State: ' .. State)
+         logOutput('[Client1] State: ' .. State)
          if (State is NTC_DISCONNECTED) then
-            table.insert(glTestResults, 'invalid_ip_handled')
+            results:push('invalid_ip_handled')
          end
       end
    })
 
    err = client1.mtConnect('999.999.999.999', 80)
    if (err != ERR_Okay) then
-      print('[Client1] Connection correctly failed: ' .. mSys.GetErrorMsg(err))
-      table.insert(glTestResults, 'invalid_ip_rejected')
+      logOutput('[Client1] Connection correctly failed: ' .. mSys.GetErrorMsg(err))
+      results:push('invalid_ip_rejected')
    end
 
    -- Test 2: Connection to non-existent port
-   print('[Test 2] Testing connection to closed port...')
+   logOutput('[Test 2] Testing connection to closed port...')
    client2 = obj.new('netsocket', {
       name = 'ClosedPortClient',
       feedback = function(Socket, State)
-         print('[Client2] State: ' .. State)
+         logOutput('[Client2] State: ' .. State)
          if (State is NTC_DISCONNECTED) then
-            table.insert(glTestResults, 'closed_port_handled')
+            results:push('closed_port_handled')
          end
       end
    })
 
    err = client2.mtConnect('127.0.0.1', 65432) -- Unlikely to be in use
    if err != ERR_Okay then
-      print('[Client2] Connection to closed port correctly failed: ' .. mSys.GetErrorMsg(err))
-      table.insert(glTestResults, 'closed_port_rejected')
+      logOutput('[Client2] Connection to closed port correctly failed: ' .. mSys.GetErrorMsg(err))
+      results:push('closed_port_rejected')
    end
 
    -- Test 3: Port conflict (two servers on same port)
-   print('[Test 3] Testing port binding conflicts...')
+   logOutput('[Test 3] Testing port binding conflicts...')
    server1 = obj.new('netsocket', {
       name = 'FirstServer',
       port = glPort,
@@ -94,114 +93,109 @@ end
    end
 
    if (server2 and server2.error != ERR_Okay) then
-      print('[Test3] Port conflict correctly detected: ' .. mSys.GetErrorMsg(server2.error))
-      table.insert(glTestResults, 'port_conflict_detected')
+      logOutput('[Test3] Port conflict correctly detected: ' .. mSys.GetErrorMsg(server2.error))
+      results:push('port_conflict_detected')
    elseif (not server2) then
-      print('[Test3] Second server creation failed as expected')
-      table.insert(glTestResults, 'port_conflict_prevented')
+      logOutput('[Test3] Second server creation failed as expected')
+      results:push('port_conflict_prevented')
    end
 
-   processing.sleep(1.0) -- Allow time for async operations
+   processing.halt(1.0) -- Allow time for async operations
 
    -- Verify error handling results
-   expected_results = { 'invalid_ip_rejected', 'closed_port_rejected', 'port_conflict_detected' }
-   for i, expected in ipairs(expected_results) do
+   expected_results = array<string> { 'invalid_ip_rejected', 'closed_port_rejected', 'port_conflict_detected' }
+   for expected in values(expected_results) do
       found = false
-      for result in values(glTestResults) do
+      for result in values(results) do
          if (result is expected or result:find(expected)) then
             found = true
             break
          end
       end
       if not found then
-         print('Warning: Expected result "' .. expected .. '" not found')
+         logOutput('Warning: Expected result "' .. expected .. '" not found')
       end
    end
-
-   print('Connection failure tests completed with ' .. #glTestResults .. ' results recorded')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function BufferOverflowHandling()
-   proc = processing.new({ timeout = 4.0 })
    overflow_handled = false
    glPort++
 
-   print('Testing buffer overflow scenarios...')
-
-   local large_msg = string.rep('OVERFLOW_TEST_DATA_', 1000) -- ~18KB per message
+   large_msg = string.rep('OVERFLOW_TEST_DATA_', 1000) -- ~18KB per message
 
    server = obj.new('netsocket', {
       name = 'OverflowTestServer',
       feedback = function(Socket, Client, State)
          if State is NTC_CONNECTED then
-            print('[Server] Client connected, sending large data burst...')
+            logOutput('[Server] Client connected, sending large data burst...')
 
             -- Send multiple large messages rapidly to test buffer limits
             for i = 1, 10 do
                local err, len = Client.acWrite(large_msg)
                if err != ERR_Okay then
-                  print('[Server] Write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
+                  logOutput('[Server] Write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
                   if (err is ERR_BufferOverflow or err is ERR_ResourceUnavailable) then
-                     print('[Server] Buffer overflow correctly detected and handled')
+                     logOutput('[Server] Buffer overflow correctly detected and handled')
                      overflow_handled = true
-                     proc.signal()
+                     Socket.acSignal()
                      return
                   end
                end
             end
 
-            print('[Server] All large messages sent (may indicate good buffer management)')
+            logOutput('[Server] All large messages sent (may indicate good buffer management)')
          end
       end,
       incoming = function(Socket, Client)
          -- Don't read data to force buffer buildup
-         print('[Server] Data available but not reading (simulating slow consumer)')
+         logOutput('[Server] Data available but not reading (simulating slow consumer)')
       end,
       port = glPort,
-      flags = 'SERVER'
+      flags = NSF_SERVER
    })
 
    client = obj.new('netsocket', {
       name = 'OverflowTestClient',
       feedback = function(Socket, State)
          if (State is NTC_CONNECTED) then
-            print('[Client] Connected, waiting for server data...')
+            logOutput('[Client] Connected, waiting for server data...')
          elseif (State is NTC_DISCONNECTED) then
-            print('[Client] Disconnected - may indicate buffer overflow handling')
+            logOutput('[Client] Disconnected - may indicate buffer overflow handling')
             overflow_handled = true
-            proc.signal()
+            server.acSignal()
          end
       end,
       incoming = function(Socket)
          -- Simulate slow reading to cause server buffer buildup
-         processing.sleep(0.1, false)
+         processing.halt(0.1)
          buffer = string.alloc(1024)
          err, read_len = Socket.acRead(buffer)
          if err != ERR_Okay then
-            print('[Client] Read error: ' .. mSys.GetErrorMsg(err))
+            logOutput('[Client] Read error: ' .. mSys.GetErrorMsg(err))
             if err is ERR_BufferOverflow then
                overflow_handled = true
-               proc.signal()
+               server.acSignal()
             end
          else
-            print('[Client] Read ' .. read_len .. ' bytes')
+            logOutput('[Client] Read ' .. read_len .. ' bytes')
          end
       end
    })
 
-   client.mtConnect('127.0.0.1', glPort)
+   proc = processing.new({ timeout = 4.0, signals = array<object> { server } })
+   check client.mtConnect('127.0.0.1', glPort)
 
    err = proc.sleep()
+
    -- Note: This test may timeout if buffers are very large, which is also acceptable
    if (err is ERR_TimeOut) then
-      print('[Test] Timeout occurred - may indicate good buffer capacity')
+      logOutput('[Test] Timeout occurred - may indicate good buffer capacity')
    else
       assert(err is ERR_Okay, 'Buffer overflow test failed: ' .. mSys.GetErrorMsg(err))
    end
-
-   print('Buffer overflow handling test completed')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -212,36 +206,34 @@ end
    timeout_handled = false
    glPort++
 
-   print('Testing network timeout scenarios...')
-
    -- Create client with very short timeout expectation
    client = obj.new('netsocket', {
       name = 'TimeoutTestClient',
       feedback = function(Socket, State)
-         print('[Client] State: ' .. State)
+         logOutput('[Client] State: ' .. State)
          if State is NTC_DISCONNECTED then
-            print('[Client] Disconnection detected')
+            logOutput('[Client] Disconnection detected')
             timeout_handled = true
          end
       end
    })
 
    -- Try to connect to an RFC 5737 documentation address that should not respond.
-   print('[Client] Attempting connection to timeout address...')
+   logOutput('[Client] Attempting connection to timeout address...')
    start = mSys.PreciseTime()
    err = client.mtConnect('192.0.2.1', 12345, timeout_duration)
 
    if err != ERR_Okay then
-      print('[Client] Connection immediately failed: ' .. mSys.GetErrorMsg(err))
+      logOutput('[Client] Connection immediately failed: ' .. mSys.GetErrorMsg(err))
       timeout_handled = true
    else
-      print('[Client] Connection attempt started, waiting for timeout...')
+      logOutput('[Client] Connection attempt started, waiting for timeout...')
 
       while not timeout_handled do
          elapsed = (mSys.PreciseTime() - start) / 1000000
          if elapsed > wait_limit then break end
 
-         processing.sleep(0.05, false)
+         processing.halt(0.05)
          if client.state is NTC_DISCONNECTED then
             timeout_handled = true
          end
@@ -254,88 +246,80 @@ end
    if client.error is ERR_TimeOut then
       assert(elapsed >= timeout_duration, f'Timeout occurred too early: {elapsed}s < {timeout_duration}s')
    end
-   print('Network timeout test completed successfully!')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function NTECloseHandling()
-   proc = processing.new({ timeout = 8.0 })
    close_handled = false
    glPort++
-
-   print('Testing NTE_CLOSE message handling...')
 
    server = obj.new('netsocket', {
       name = 'CloseTestServer',
       feedback = function(Socket, Client, State)
          if State is NTC_CONNECTED then
-            print('[Server] Client connected')
+            logOutput('[Server] Client connected')
             -- Send a message then immediately close
             err, len = Client.acWrite('CLOSE_TEST_MESSAGE')
             assert(err is ERR_Okay, 'Failed to send close test message')
 
             -- Force close to trigger NTE_CLOSE handling
-            print('[Server] Forcibly closing client connection...')
+            logOutput('[Server] Forcibly closing client connection...')
             Socket.mtDisconnectSocket(Client)
 
          elseif State is NTC_DISCONNECTED then
-            print('[Server] Client disconnect confirmed')
+            logOutput('[Server] Client disconnect confirmed')
             close_handled = true
-            proc.signal()
+            Socket.acSignal()
          end
       end,
       incoming = function(Socket, Client)
          buffer = string.alloc(1024)
          err, read_len = Client.acRead(buffer)
          if err is ERR_Okay then
-            print('[Server] Received: ' .. buffer:sub(0, read_len))
+            logOutput('[Server] Received: ' .. buffer:sub(0, read_len))
          else
-            print('[Server] Read error during close: ' .. mSys.GetErrorMsg(err))
+            logOutput('[Server] Read error during close: ' .. mSys.GetErrorMsg(err))
          end
       end,
       port = glPort,
-      flags = 'SERVER'
+      flags = NSF_SERVER
    })
 
    client = obj.new('netsocket', {
       name = 'CloseTestClient',
       feedback = function(Socket, State)
-         print('[Client] State: ' .. State)
+         logOutput('[Client] State: ' .. State)
          if (State is NTC_DISCONNECTED) then
-            print('[Client] Received close notification')
+            logOutput('[Client] Received close notification')
             close_handled = true
-            proc.signal()
+            server.acSignal()
          end
       end,
       incoming = function(Socket)
          buffer = string.alloc(1024)
          err, read_len = Socket.acRead(buffer)
          if err is ERR_Okay then
-            print('[Client] Received: ' .. buffer:sub(0, read_len))
+            logOutput('[Client] Received: ' .. buffer:sub(0, read_len))
          else
-            print('[Client] Read error (expected during close): ' .. mSys.GetErrorMsg(err))
+            logOutput('[Client] Read error (expected during close): ' .. mSys.GetErrorMsg(err))
             if err is ERR_Disconnected or err is ERR_Failed then
                close_handled = true
-               proc.signal()
+               server.acSignal()
             end
          end
       end
    })
 
+   proc = processing.new({ timeout = 2.0, signals = array<object> { server } })
    client.mtConnect('127.0.0.1', glPort)
-
-   err = proc.sleep()
-   assert(err is ERR_Okay, 'NTE_CLOSE handling test failed: ' .. mSys.GetErrorMsg(err))
+   check proc.sleep()
    assert(close_handled, 'Close handling was not properly detected')
-
-   print('NTE_CLOSE handling test completed successfully!')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function InvalidParameters()
-   print('Testing invalid parameter handling...')
    glPort++
 
    -- Test invalid socket creation parameters
@@ -344,36 +328,31 @@ end
       flags = 'INVALID_FLAG' -- Invalid flag
    })
 
-   if (invalid_socket and invalid_socket.error != ERR_Okay) then
-      print('[Test] Invalid socket parameters correctly rejected: ' .. mSys.GetErrorMsg(invalid_socket.error))
-   elseif (not invalid_socket) then
-      print('[Test] Invalid socket creation correctly failed')
+   if invalid_socket and invalid_socket.error != ERR_Okay then
+      logOutput('[Test] Invalid socket parameters correctly rejected: ' .. mSys.GetErrorMsg(invalid_socket.error))
+   elseif not invalid_socket then
+      logOutput('[Test] Invalid socket creation correctly failed')
    end
 
    -- Test invalid connection parameters
    client = obj.new('netsocket', { name = 'InvalidParamClient' })
    if client then
       err = client.mtConnect('', 0) -- Empty address, invalid port
-      if (err != ERR_Okay) then
-         print('[Test] Invalid connection parameters correctly rejected: ' .. mSys.GetErrorMsg(err))
+      if err != ERR_Okay then
+         logOutput('[Test] Invalid connection parameters correctly rejected: ' .. mSys.GetErrorMsg(err))
       end
 
       err = client.mtConnect(nil, 80) -- Nil address
       if err != ERR_Okay then
-         print('[Test] Nil address correctly rejected: ' .. mSys.GetErrorMsg(err))
+         logOutput('[Test] Nil address correctly rejected: ' .. mSys.GetErrorMsg(err))
       end
    end
-
-   print('Invalid parameter tests completed')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ResourceCleanup()
-   proc = processing.new({ timeout = 5.0 })
    glPort++
-
-   print('Testing resource cleanup under error conditions...')
 
    -- Create and destroy multiple sockets rapidly to test cleanup
    -- (puts pressure on threaded socket closures)
@@ -389,12 +368,10 @@ end
          name = 'CleanupTestClient' .. i
       })
 
-      if (server and client) then
+      if server and client then
          client.mtConnect('127.0.0.1', glPort + 20 + i)
       end
    end
 
    processing.collect()
-
-   print('Resource cleanup test completed')
 end

--- a/src/network/tests/test_ipv6.tiri
+++ b/src/network/tests/test_ipv6.tiri
@@ -16,8 +16,6 @@ glPort = 8089
 -- Test IPv6 address parsing and conversion
 
 @Test function IPv6AddressParsing()
-   print('Testing IPv6 address parsing and conversion...')
-
    addresses = {
       '::1',                                  -- IPv6 loopback
       '2001:db8::1',                          -- Standard IPv6
@@ -27,7 +25,7 @@ glPort = 8089
    }
 
    for i, addr_str in ipairs(addresses) do
-      print('Testing address: ' .. addr_str)
+      logOutput('Testing address: ' .. addr_str)
 
       -- Skip link-local with interface identifier for now
       if not string.find(addr_str, '%') then
@@ -35,12 +33,12 @@ glPort = 8089
          err = mNet.StrToAddress(addr_str, addr)
 
          if err is ERR_Okay then
-            print('Parsed successfully as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
+            logOutput('Parsed successfully as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
 
             -- Test conversion back to string
             result_str = mNet.AddressToStr(addr)
             if result_str then
-               print('Converted back to: ' .. result_str)
+               logOutput('Converted back to: ' .. result_str)
             else
                error('Failed to convert back to string')
             end
@@ -48,7 +46,7 @@ glPort = 8089
             error('Failed to parse ' .. addr_str .. ': ' .. mSys.GetErrorMsg(err))
          end
       else
-         print('Skipping link-local with interface identifier')
+         logOutput('Skipping link-local with interface identifier')
       end
    end
 end
@@ -57,7 +55,6 @@ end
 -- Test IPv6 server binding and dual-stack support
 
 @Test function IPv6ServerBinding()
-   proc = processing.new({ timeout = 10.0 })
    server_ready = false
    client_connected = false
 
@@ -67,11 +64,11 @@ end
       port = glPort,
       flags = NSF_SERVER,
       feedback = function(Socket, Client, State)
-         print('[Server] State change: ' .. State)
+         logOutput('[Server] State change: ' .. State)
          if State is NTC_CONNECTED and Client then
-            print('[Server] Client connected from IPv6 server')
+            logOutput('[Server] Client connected from IPv6 server')
             client_connected = true
-            proc.signal()
+            Socket.acSignal()
          end
       end,
       incoming = function(Socket, Client)
@@ -80,7 +77,7 @@ end
             local err, bytes = Client.acRead(buffer, string.len(buffer))
             if err is ERR_Okay and bytes > 0 then
                message = string.substr(buffer, 0, bytes)
-               print('[Server] Received from client: ' .. message)
+               logOutput('[Server] Received from client: ' .. message)
 
                -- Echo back
                Client.acWrite('IPv6 Server Echo: ' .. message, string.len('IPv6 Server Echo: ' .. message))
@@ -93,14 +90,14 @@ end
    server_ready = true
 
    -- Test connecting with IPv6 loopback
-   processing.sleep(1, false) -- Small delay for server to be ready
+   processing.halt(1) -- Small delay for server to be ready
 
    client = obj.new('netsocket', {
       name = 'IPv6TestClient',
       feedback = function(Socket, State)
-         print('[Client] State: ' .. State)
+         logOutput('[Client] State: ' .. State)
          if State is NTC_CONNECTED then
-            print('[Client] Connected to IPv6 server')
+            logOutput('[Client] Connected to IPv6 server')
             Socket.acWrite('Hello IPv6 World!', string.len('Hello IPv6 World!'))
          end
       end,
@@ -109,24 +106,23 @@ end
          local err, bytes = Socket.acRead(buffer, string.len(buffer))
          if err is ERR_Okay and bytes > 0 then
             local response = string.substr(buffer, 0, bytes)
-            print('[Client] Received response: ' .. response)
-            proc.signal()
+            logOutput('[Client] Received response: ' .. response)
+            server.acSignal()
          end
          return ERR_Okay
       end
    })
 
    -- Try IPv6 loopback connection
+
+   proc = processing.new({ timeout = 10.0, signals = array<object> { server } })
    err = client.mtConnect('::1', glPort)
    if err != ERR_Okay then
-      print('[Client] IPv6 loopback connection failed, trying IPv4: ' .. mSys.GetErrorMsg(err))
-      -- Fallback to IPv4 to test dual-stack
-      err = client.mtConnect('127.0.0.1', glPort)
-      assert(err is ERR_Okay, '[Client] IPv4 fallback connection failed: ' .. mSys.GetErrorMsg(err))
+      logOutput('[Client] IPv6 loopback connection failed, trying IPv4: ' .. mSys.GetErrorMsg(err))
+      check client.mtConnect('127.0.0.1', glPort) -- Fallback to IPv4 to test dual-stack
    end
 
-   err = proc.sleep()
-   assert(err is ERR_Okay, 'IPv6 server test failed: ' .. mSys.GetErrorMsg(err))
+   check proc.sleep()
    assert(server_ready, 'Server was not ready')
 end
 
@@ -134,37 +130,33 @@ end
 -- Test IPv6 DNS resolution
 
 @Test function IPv6DNSResolution()
-   proc = processing.new({ timeout = 8.0 })
    resolution_complete = false
 
    lookup = obj.new('netlookup', {
       callback = function(Lookup, Error)
          addresses = Lookup.addresses
          if (Error is ERR_Okay) and addresses then
-            print('[DNS] Resolved ' .. tostring(Lookup.hostName) .. ' to ' .. #addresses .. ' addresses:')
+            logOutput('[DNS] Resolved ' .. tostring(Lookup.hostName) .. ' to ' .. #addresses .. ' addresses:')
             for i, addr in ipairs(addresses) do
                addr_str = mNet.AddressToStr(addr)
                type_str = (addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'
-               print(i .. '. ' .. (addr_str or 'unknown') .. ' (' .. type_str .. ')')
+               logOutput(i .. '. ' .. (addr_str or 'unknown') .. ' (' .. type_str .. ')')
             end
          else
-            print('[DNS] Resolution failed: ' .. mSys.GetErrorMsg(Error))
+            logOutput('[DNS] Resolution failed: ' .. mSys.GetErrorMsg(Error))
          end
 
          resolution_complete = true
-         proc.signal()
+         Lookup.acSignal()
       end
    })
 
    -- Test resolving a hostname that should have both IPv4 and IPv6 addresses
-   err = lookup.mtResolveName('dns.google')
-   if err is ERR_Okay then
-      err = proc.sleep()
-      assert(err is ERR_Okay, 'DNS resolution test failed: ' .. mSys.GetErrorMsg(err))
-      assert(resolution_complete, 'DNS resolution did not complete')
-   else
-      error('[DNS] Failed to start resolution: ' .. mSys.GetErrorMsg(err))
-   end
+
+   proc = processing.new({ timeout = 8.0, signals = array<object> { lookup } })
+   check lookup.mtResolveName('dns.google')
+   check proc.sleep()
+   assert(resolution_complete, 'DNS resolution did not complete')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -172,33 +164,29 @@ end
 
 @Test function IPv6Utilities()
    -- Test various IPv6 address formats
-   test_cases = {
+   test_cases = array<table> {
       { addr = '::1', expected_type = IPADDR_V6, desc = 'loopback' },
       { addr = '127.0.0.1', expected_type = IPADDR_V4, desc = 'IPv4 loopback' },
       { addr = '2001:db8::1', expected_type = IPADDR_V6, desc = 'standard IPv6' },
       { addr = '::ffff:192.0.2.1', expected_type = IPADDR_V6, desc = 'IPv4-mapped IPv6' }
    }
 
-   for i, test in ipairs(test_cases) do
-      print('Testing ' .. test.desc .. ': ' .. test.addr)
+   for test in values(test_cases) do
+      logOutput('Testing ' .. test.desc .. ': ' .. test.addr)
 
       addr = struct.new('IPAddress')
-      err = mNet.StrToAddress(test.addr, addr)
+      check mNet.StrToAddress(test.addr, addr)
 
-      if err is ERR_Okay then
-         if addr.type is test.expected_type then
-            print('    Correctly identified as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
+      if addr.type is test.expected_type then
+         logOutput('    Correctly identified as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
 
-            -- Test round-trip conversion
-            converted = mNet.AddressToStr(addr)
-            if not converted then
-               error('Round-trip conversion failed')
-            end
-         else
-            error('Incorrect type identification')
+         -- Test round-trip conversion
+         converted = mNet.AddressToStr(addr)
+         if not converted then
+            error('Round-trip conversion failed')
          end
       else
-         error('Failed to parse: ' .. mSys.GetErrorMsg(err))
+         error('Incorrect type identification')
       end
    end
 end

--- a/src/network/tests/test_performance.tiri
+++ b/src/network/tests/test_performance.tiri
@@ -33,58 +33,60 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function MessageThroughput()
-   local proc = processing.new({ timeout = 5.0 })
-   local start_time = mSys.PreciseTime()
-   local messages_sent = 0
-   local messages_received = 0
-   local target_messages = 1000
-   local throughput_complete = false
+@Test(priority=10) function MessageThroughput()
+   start_time = mSys.PreciseTime()
+   messages_sent = 0
+   messages_received = 0
+   bytes_sent = 0
+   bytes_received = 0
+   target_messages = 1000
+   throughput_complete = false
 
-   print('Testing message throughput with ' .. target_messages .. ' messages...')
-
-   local server = obj.new('netsocket', {
+   server = obj.new('netsocket', {
       name = 'ThroughputServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            print('[Server] Client connected, starting throughput test...')
+            logOutput('[Server] Client connected, starting throughput test...')
             -- Start sending messages rapidly
             for i = 1, target_messages do
                local msg = 'THROUGHPUT_MSG_' .. i
                local err, len = Client.acWrite(msg)
                if (err is ERR_Okay) then
                   messages_sent = messages_sent + 1
+                  bytes_sent += string.len(msg)
                else
-                  print('[Server] Send failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
+                  logOutput('[Server] Send failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
                   break
                end
             end
-            print('[Server] Finished sending ' .. messages_sent .. ' messages')
+            logOutput('[Server] Finished sending ' .. messages_sent .. ' messages')
          end
       end,
       incoming = function(Socket, Client)
          local buffer = string.alloc(1024)
          local err, read_len = Client.acRead(buffer)
-         if (err is ERR_Okay) then
+         if (err is ERR_Okay and read_len > 0) then
             messages_received = messages_received + 1
-            print('Processed: ' .. messages_received)
+            bytes_received += read_len
+            logOutput('Processed: ' .. messages_received)
 
-            if (messages_received >= target_messages) then
+            if (bytes_received >= bytes_sent and messages_sent >= target_messages) then
                local end_time = mSys.PreciseTime()
-               local duration = end_time - start_time
-               local throughput = messages_received / duration
+               local duration = (end_time - start_time) / 1000000
+               local throughput = messages_sent / duration
 
-               print('[Server] Throughput test completed:')
-               print('  Messages: ' .. messages_received)
-               print('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
-               print('  Throughput: ' .. string.format('%.1f', throughput) .. ' messages/second')
+               logOutput('[Server] Throughput test completed:')
+               logOutput('  Messages: ' .. messages_sent)
+               logOutput('  Echo reads: ' .. messages_received)
+               logOutput('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
+               logOutput('  Throughput: ' .. string.format('%.1f', throughput) .. ' messages/second')
 
-               glThroughputStats.messages = messages_received
+               glThroughputStats.messages = messages_sent
                glThroughputStats.duration = duration
                glThroughputStats.throughput = throughput
 
                throughput_complete = true
-               proc.signal()
+               Socket.acSignal()
             end
          end
       end,
@@ -92,7 +94,9 @@ function MessageThroughput()
       flags = 'SERVER'
    })
 
-   local client = obj.new('netsocket', {
+   proc = processing.new({ timeout = 5.0, signals = array<object> { server } })
+
+   client = obj.new('netsocket', {
       name = 'ThroughputClient',
       incoming = function(Socket, Script)
          -- Echo back all received messages as quickly as possible
@@ -105,45 +109,40 @@ function MessageThroughput()
       end
    })
 
-   client.mtConnect('127.0.0.1', glPort)
+   check client.mtConnect('127.0.0.1', glPort)
+   check proc.sleep()
 
-   local err = proc.sleep()
-   print('Received ' .. messages_received .. ' messages of ' .. target_messages)
-   assert(err is ERR_Okay, 'Throughput test failed: ' .. mSys.GetErrorMsg(err))
+   logOutput('Received ' .. messages_received .. ' messages of ' .. target_messages)
    assert(throughput_complete, 'Throughput test did not complete')
 
    -- Verify minimum acceptable performance
    assert(glThroughputStats.throughput > 100,
       'Throughput too low: ' .. glThroughputStats.throughput .. ' msg/sec (expected > 100)')
 
-   print('Message throughput test completed successfully!')
    return glThroughputStats.throughput
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function LargeMessagePerformance()
-   local proc = processing.new({ timeout = 15.0 })
-   local message_sizes = { 1024, 8192, 65536, 262144 } -- 1KB, 8KB, 64KB, 256KB
-   local transfer_results = {}
-   local current_size_index = 1
+@Test(priority=20) function LargeMessagePerformance()
+   message_sizes = array<int> { 1024, 8192, 65536, 262144 } -- 1KB, 8KB, 64KB, 256KB
+   transfer_results = array<table>
+   current_size_index = 0
 
-   print('Testing large message transfer performance...')
-
-   local server = obj.new('netsocket', {
+   server = obj.new('netsocket', {
       name = 'LargeMessageServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            print('[Server] Starting large message test...')
+            logOutput('[Server] Starting large message test...')
             -- Send first large message
             local size = message_sizes[current_size_index]
             local large_msg = string.rep('X', size)
             local start_time = mSys.PreciseTime()
 
-            print('[Server] Sending ' .. size .. ' byte message...')
+            logOutput('[Server] Sending ' .. size .. ' byte message...')
             local err, len = Client.acWrite(large_msg)
             if (err is ERR_Okay) then
-               transfer_results[current_size_index] = { size = size, start_time = start_time }
+               transfer_results:push({ size = size, start_time = start_time })
             else
                error('[Server] Failed to send large message: ' .. mSys.GetErrorMsg(err))
             end
@@ -162,44 +161,46 @@ function LargeMessagePerformance()
             if (err is ERR_Okay and read_len > 0) then
                total_read = total_read + read_len
             elseif (err is ERR_NoData) then
-               processing.sleep(0.001, false) -- Brief wait for more data
+               processing.halt(0.001) -- Brief wait for more data
             else
                break
             end
          end
 
          local end_time = mSys.PreciseTime()
-         local duration = end_time - transfer_results[current_size_index].start_time
+         local duration = (end_time - transfer_results[current_size_index].start_time) / 1000000
          local throughput_mbps = (expected_size * 2 / 1024 / 1024) / duration -- *2 for round trip
 
-         print('[Server] Large message ' .. expected_size .. ' bytes:')
-         print('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
-         print('  Throughput: ' .. string.format('%.2f', throughput_mbps) .. ' MB/s')
+         logOutput('[Server] Large message ' .. expected_size .. ' bytes:')
+         logOutput('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
+         logOutput('  Throughput: ' .. string.format('%.2f', throughput_mbps) .. ' MB/s')
 
          transfer_results[current_size_index].duration = duration
          transfer_results[current_size_index].throughput = throughput_mbps
 
          current_size_index = current_size_index + 1
-         if (current_size_index <= #message_sizes) then
+         if (current_size_index < #message_sizes) then
             -- Send next size
             local size = message_sizes[current_size_index]
             local large_msg = string.rep('Y', size)
             local start_time = mSys.PreciseTime()
 
-            print('[Server] Sending ' .. size .. ' byte message...')
+            logOutput('[Server] Sending ' .. size .. ' byte message...')
             local err, len = Client.acWrite(large_msg)
             if (err is ERR_Okay) then
-               transfer_results[current_size_index] = { size = size, start_time = start_time }
+               transfer_results:push({ size = size, start_time = start_time })
             end
          else
-            print('[Server] All large message tests completed')
-            proc.signal()
+            logOutput('[Server] All large message tests completed')
+            Socket.acSignal()
          end
       end,
       port = glPort + 1,
       flags = 'SERVER',
       msgLimit = 512 * 1024 -- Allow large messages
    })
+
+   proc = processing.new({ timeout = 15.0, signals = array<object> { server } })
 
    local client = obj.new('netsocket', {
       name = 'LargeMessageClient',
@@ -214,43 +215,36 @@ function LargeMessagePerformance()
       end
    })
 
-   client.mtConnect('127.0.0.1', glPort + 1)
+   check client.mtConnect('127.0.0.1', glPort + 1)
+   check proc.sleep()
 
-   local err = proc.sleep()
-   assert(err is ERR_Okay, 'Large message performance test failed: ' .. mSys.GetErrorMsg(err))
-
-   -- Verify all sizes were tested
    assert(#transfer_results is #message_sizes,
       'Not all message sizes tested. Expected: ' .. #message_sizes .. ', Got: ' .. #transfer_results)
 
-   -- Store results for analysis
    glPerformanceResults.large_messages = transfer_results
-
-   print('Large message performance test completed successfully!')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function ConnectionScaling()
-   local proc = processing.new({ timeout = 20.0 })
-   local max_clients = 20
-   local connected_clients = 0
-   local scaling_complete = false
-   local connection_times = {}
+@Test(priority=30) function ConnectionScaling()
+   max_clients = 20
+   connected_clients = 0
+   scaling_complete = false
+   connection_times = {}
 
-   print('Testing connection scaling with ' .. max_clients .. ' concurrent clients...')
+   logOutput('Testing connection scaling with ' .. max_clients .. ' concurrent clients...')
 
-   local server = obj.new('netsocket', {
+   server = obj.new('netsocket', {
       name = 'ScalingTestServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
             connected_clients = connected_clients + 1
-            print('[Server] Client ' .. connected_clients .. ' connected')
+            logOutput('[Server] Client ' .. connected_clients .. ' connected')
 
             if (connected_clients >= max_clients) then
-               print('[Server] All ' .. max_clients .. ' clients connected successfully')
+               logOutput('[Server] All ' .. max_clients .. ' clients connected successfully')
                scaling_complete = true
-               proc.signal()
+               Socket.acSignal()
             end
          elseif (State is NTC_DISCONNECTED) then
             connected_clients = connected_clients - 1
@@ -262,9 +256,11 @@ function ConnectionScaling()
       backlog = max_clients
    })
 
+   proc = processing.new({ timeout = 20.0, signals = array<object> { server } })
+
    -- Create and connect clients rapidly
-   local clients = {}
-   local start_time = mSys.PreciseTime()
+   clients = {}
+   start_time = mSys.PreciseTime()
 
    for i = 1, max_clients do
       clients[i] = obj.new('netsocket', {
@@ -278,18 +274,18 @@ function ConnectionScaling()
       })
 
       local err = clients[i].mtConnect('127.0.0.1', glPort + 2)
-      if (err != ERR_Okay) then
-         print('[Client ' .. i .. '] Connection failed: ' .. mSys.GetErrorMsg(err))
+      if err != ERR_Okay then
+         logOutput('[Client ' .. i .. '] Connection failed: ' .. mSys.GetErrorMsg(err))
       end
 
       -- Small delay to prevent overwhelming
       if (i % 5 is 0) then
-         processing.sleep(0.01, false)
+         processing.halt(0.01)
       end
    end
 
-   local err = proc.sleep()
-   assert(err is ERR_Okay, 'Connection scaling test failed: ' .. mSys.GetErrorMsg(err))
+   check proc.sleep()
+
    assert(scaling_complete, 'Not all clients connected within timeout')
 
    -- Analyze connection timing
@@ -302,10 +298,10 @@ function ConnectionScaling()
       end
       local avg_time = total_time / #connection_times
 
-      print('Connection Scaling Results:')
-      print('  Successful connections: ' .. #connection_times .. '/' .. max_clients)
-      print('  Average connect time: ' .. string.format('%.3f', avg_time) .. ' seconds')
-      print('  Maximum connect time: ' .. string.format('%.3f', max_time) .. ' seconds')
+      logOutput('Connection Scaling Results:')
+      logOutput('  Successful connections: ' .. #connection_times .. '/' .. max_clients)
+      logOutput('  Average connect time: ' .. string.format('%.3f', avg_time) .. ' seconds')
+      logOutput('  Maximum connect time: ' .. string.format('%.3f', max_time) .. ' seconds')
 
       glPerformanceResults.scaling = {
          clients = #connection_times,
@@ -313,26 +309,25 @@ function ConnectionScaling()
          max_connect_time = max_time
       }
    end
-
-   print('Connection scaling test completed successfully!')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function WriteQueuePerformance()
-   local proc = processing.new({ timeout = 15.0 })
+@Test(priority=40) function WriteQueuePerformance()
    local queue_messages = 500
    local messages_queued = 0
    local messages_processed = 0
+   local bytes_queued = 0
+   local bytes_processed = 0
    local queue_test_complete = false
 
-   print('Testing write queue performance with ' .. queue_messages .. ' queued messages...')
+   logOutput('Testing write queue performance with ' .. queue_messages .. ' queued messages...')
 
    local server = obj.new('netsocket', {
       name = 'QueueTestServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            print('[Server] Client connected, flooding write queue...')
+            logOutput('[Server] Client connected, flooding write queue...')
             local start_time = mSys.PreciseTime()
 
             -- Rapidly queue many messages without waiting
@@ -341,32 +336,34 @@ function WriteQueuePerformance()
                local err, len = Client.acWrite(msg)
                if (err is ERR_Okay) then
                   messages_queued = messages_queued + 1
+                  bytes_queued += string.len(msg)
                else
-                  print('[Server] Queue write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
+                  logOutput('[Server] Queue write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
                   break
                end
             end
 
             local queue_time = mSys.PreciseTime() - start_time
-            print('[Server] Queued ' .. messages_queued .. ' messages in ' ..
-                  string.format('%.3f', queue_time) .. ' seconds')
+            logOutput('[Server] Queued ' .. messages_queued .. ' messages in ' ..
+                  string.format('%.3f', queue_time / 1000000) .. ' seconds')
 
-            glPerformanceResults.queue_time = queue_time
-            glPerformanceResults.queue_rate = messages_queued / queue_time
+            glPerformanceResults.queue_time = queue_time / 1000000
+            glPerformanceResults.queue_rate = messages_queued / glPerformanceResults.queue_time
          end
       end,
       incoming = function(Socket, Client)
          local buffer = string.alloc(1024)
          local err, read_len = Client.acRead(buffer)
-         if (err is ERR_Okay) then
+         if (err is ERR_Okay and read_len > 0) then
             messages_processed = messages_processed + 1
+            bytes_processed += read_len
 
-            if (messages_processed >= messages_queued) then
-               print('[Server] All queued messages processed: ' .. messages_processed)
+            if (bytes_processed >= bytes_queued and messages_queued >= queue_messages) then
+               logOutput('[Server] All queued messages processed: ' .. messages_processed)
                queue_test_complete = true
-               proc.signal()
+               Socket.acSignal()
             elseif (messages_processed % 100 is 0) then
-               print('[Server] Processed ' .. messages_processed .. '/' .. messages_queued .. ' messages')
+               logOutput('[Server] Processed ' .. messages_processed .. '/' .. messages_queued .. ' messages')
             end
          end
       end,
@@ -374,7 +371,9 @@ function WriteQueuePerformance()
       flags = 'SERVER'
    })
 
-   local client = obj.new('netsocket', {
+   proc = processing.new({ timeout = 15.0, signals = array<object> { server } })
+
+   client = obj.new('netsocket', {
       name = 'QueueTestClient',
       incoming = function(Socket, Script)
          -- Read and echo back messages to test queue drainage
@@ -382,29 +381,25 @@ function WriteQueuePerformance()
          local err, read_len = Socket.acRead(buffer)
          if (err is ERR_Okay) then
             local msg = buffer:sub(0, read_len)
-            Socket.acWrite('ACK') -- Simple acknowledgment
+            Socket.acWrite(msg) -- Echo data to test queue drainage
          end
       end
    })
 
-   client.mtConnect('127.0.0.1', glPort + 3)
+   check client.mtConnect('127.0.0.1', glPort + 3)
+   check proc.sleep()
 
-   local err = proc.sleep()
-   assert(err is ERR_Okay, 'Write queue performance test failed: ' .. mSys.GetErrorMsg(err))
    assert(queue_test_complete, 'Queue test did not complete')
 
-   assert(messages_processed >= messages_queued * 0.95, -- Allow 5% tolerance
-      'Too many messages lost. Queued: ' .. messages_queued .. ', Processed: ' .. messages_processed)
+   assert(bytes_processed >= bytes_queued,
+      'Too much queued data was lost. Queued: ' .. bytes_queued .. ', Processed: ' .. bytes_processed)
 
-   print('Write queue performance test completed successfully!')
-   print('Queue rate: ' .. string.format('%.1f', glPerformanceResults.queue_rate) .. ' messages/second')
+   logOutput('Queue rate: ' .. string.format('%.1f', glPerformanceResults.queue_rate) .. ' messages/second')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function MemoryUsageUnderLoad()
-   print('Testing memory usage patterns under network load...')
-
+@Test(priority=50) function MemoryUsageUnderLoad()
    -- This test creates and destroys many network objects to check for leaks
    local iterations = 50
    local objects_per_iteration = 5
@@ -414,16 +409,15 @@ function MemoryUsageUnderLoad()
 
       -- Create multiple network objects
       for i = 1, objects_per_iteration do
-         local port = glPort + 100 + i
          temp_objects[i] = obj.new('netsocket', {
             name = 'MemTestSocket' .. iter .. '_' .. i,
-            port = port,
+            port = glPort + 100 + (iter * objects_per_iteration) + i,
             flags = 'SERVER'
          })
       end
 
       -- Brief usage
-      processing.sleep(0.01, false)
+      processing.halt(0.01)
 
       -- Destroy objects
       for i = 1, objects_per_iteration do
@@ -431,61 +425,40 @@ function MemoryUsageUnderLoad()
       end
 
       -- Periodic status
-      if (iter % 10 is 0) then
-         print('[Memory Test] Completed ' .. iter .. '/' .. iterations .. ' iterations')
+      if iter % 10 is 0 then
+         logOutput('[Memory Test] Completed ' .. iter .. '/' .. iterations .. ' iterations')
       end
    end
 
-   print('Memory usage test completed - no crashes detected')
-   print('Created and destroyed ' .. (iterations * objects_per_iteration) .. ' network objects')
+   logOutput('Memory usage test completed - no crashes detected')
+   logOutput('Created and destroyed ' .. (iterations * objects_per_iteration) .. ' network objects')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function generatePerformanceReport()
-   print('')
-   print('=== NETWORK PERFORMANCE TEST RESULTS ===')
+@Test(priority=100) function generatePerformanceReport()
+   logOutput('=== NETWORK PERFORMANCE TEST RESULTS ===')
 
    if (glThroughputStats.throughput) then
-      print('Message Throughput: ' .. string.format('%.1f', glThroughputStats.throughput) .. ' msg/sec')
+      logOutput('Message Throughput: ' .. string.format('%.1f', glThroughputStats.throughput) .. ' msg/sec')
    end
 
    if (glPerformanceResults.large_messages) then
-      print('Large Message Performance:')
+      logOutput('Large Message Performance:')
       for i, result in ipairs(glPerformanceResults.large_messages) do
          if (result.throughput) then
-            print('  ' .. result.size .. ' bytes: ' .. string.format('%.2f', result.throughput) .. ' MB/s')
+            logOutput('  ' .. result.size .. ' bytes: ' .. string.format('%.2f', result.throughput) .. ' MB/s')
          end
       end
    end
 
    if (glPerformanceResults.scaling) then
-      print('Connection Scaling:')
-      print('  ' .. glPerformanceResults.scaling.clients .. ' concurrent connections')
-      print('  Avg connect time: ' .. string.format('%.3f', glPerformanceResults.scaling.avg_connect_time) .. 's')
+      logOutput('Connection Scaling:')
+      logOutput('  ' .. glPerformanceResults.scaling.clients .. ' concurrent connections')
+      logOutput('  Avg connect time: ' .. string.format('%.3f', glPerformanceResults.scaling.avg_connect_time) .. 's')
    end
 
    if (glPerformanceResults.queue_rate) then
-      print('Write Queue Rate: ' .. string.format('%.1f', glPerformanceResults.queue_rate) .. ' msg/sec')
+      logOutput('Write Queue Rate: ' .. string.format('%.1f', glPerformanceResults.queue_rate) .. ' msg/sec')
    end
-
-   print('==========================================')
 end
-
------------------------------------------------------------------------------------------------------------------------
-
-   return {
-      tests = {
-         testMessageThroughput,
-         testLargeMessagePerformance,
-         testConnectionScaling,
-         testWriteQueuePerformance,
-         testMemoryUsageUnderLoad,
-         generatePerformanceReport
-      },
-      cleanup = function()
-         glThroughputStats = {}
-         glPerformanceResults = {}
-         glLoadTestActive = false
-      end
-   }

--- a/src/network/tests/test_server_io.tiri
+++ b/src/network/tests/test_server_io.tiri
@@ -18,7 +18,6 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test(requires='network') function RawHTTP()
-   proc = processing.new({ timeout = 5.0 })
    netsocket = obj.new('netsocket', {
       feedback = function(Socket, State)
          state = printableState(State)
@@ -29,7 +28,7 @@ end
             Socket.acWrite('GET /index.html HTTP/1.1\r\nHost: kotuku.dev\r\nConnection: close\r\nUser-Agent: Kotuku Client\r\n\r\n')
          elseif state is 'DISCONNECTED' then
             print('Disconnected from server.')
-            proc.signal()
+            Socket.acSignal()
          else
             print('Unknown netsocket state: ' .. state)
          end
@@ -41,15 +40,14 @@ end
          if err is ERR_Okay then
             print(buffer:sub(0,80))
          elseif err is ERR_Disconnected then
-            proc.signal()
+            Socket.acSignal()
          else
             error('Read() failed on NetSocket.')
          end
       end
    } )
 
-   netsocket.mtConnect('kotuku.dev', 80)
-
-   err = proc.sleep()
-   assert(err is ERR_Okay, 'Failed to complete the test: ' .. mSys.GetErrorMsg(err))
+   proc = processing.new({ timeout = 5.0, signals = array<object> { netsocket } })
+   check netsocket.mtConnect('kotuku.dev', 80)
+   check proc.sleep()
 end

--- a/src/network/tests/test_udp_basic.tiri
+++ b/src/network/tests/test_udp_basic.tiri
@@ -11,12 +11,11 @@ glTestTimeout = 3.0
 ------------------------------------------------------------------------------------------------------------------------
 -- Test basic UDP communication (IPv4)
 
-function UDPBasicIPv4()
-   glBasePort = glBasePort + 1
-   serverPort = glBasePort
-   proc = processing.new({ timeout = glTestTimeout })
-   serverReceived = false
-   clientReceived = false
+@Test function UDPBasicIPv4()
+   glBasePort++
+   server_port = glBasePort
+   server_received = false
+   client_received = false
    -- Acquire resources in advance for best performance
    sv_buffer = string.alloc(1024)
    sv_source = struct.new('IPAddress')
@@ -25,114 +24,115 @@ function UDPBasicIPv4()
 
    server = obj.new('netsocket', {
       name    = 'UDPServer',
-      port    = serverPort,
+      port    = server_port,
       address = '127.0.0.1',
-      flags   = 'SERVER|UDP',
+      flags   = NSF_SERVER|NSF_UDP,
       incoming = function(Socket)
          local err, bytesRead = Socket.mtRecvFrom(sv_source, sv_buffer)
          assert(err is ERR_Okay, 'Server failed to receive UDP data: ' .. mSys.GetErrorMsg(err))
 
          if (bytesRead > 0) then
             local msg = sv_buffer:sub(0, bytesRead)
-            print('[UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
+            logOutput('[UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
             assert(msg:startsWith('Hello UDP Server'), 'Unexpected message received')
 
             -- Echo back a response
             local response = 'Hello UDP Client'
             local err, bytesSent = Socket.mtSendTo(sv_source, response)
             assert(err is ERR_Okay, 'Server failed to send UDP response: ' .. mSys.GetErrorMsg(err))
-            print('[UDP Server] Sent response: "' .. response .. '"')
-            serverReceived = true
+            logOutput('[UDP Server] Sent response: "' .. response .. '"')
+            server_received = true
          end
       end
    })
 
-   local client = obj.new('netsocket', {
+   client = obj.new('netsocket', {
       name  = 'UDPClient',
-      flags = 'UDP',
+      flags = NSF_UDP,
       incoming = function(Socket)
          local err, bytesRead = Socket.mtRecvFrom(cl_source, cl_buffer)
          assert(err is ERR_Okay, 'Client failed to receive UDP data: ' .. mSys.GetErrorMsg(err))
 
          if (bytesRead > 0) then
             local msg = cl_buffer:sub(0, bytesRead)
-            print('[UDP Client] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(cl_source) .. ':' .. cl_source.port)
+            logOutput('[UDP Client] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(cl_source) .. ':' .. cl_source.port)
             assert(msg:startsWith('Hello UDP Client'), 'Unexpected response received')
-            clientReceived = true
-            proc.signal()
+            client_received = true
+            Socket.acSignal()
          end
       end
    })
 
-   -- Client sends initial message
-   local message = 'Hello UDP Server'
-   print('[UDP Client] Sending: "' .. message .. '"')
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { client } })
 
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('127.0.0.1', dest))
+   -- Client sends initial message
+   message = 'Hello UDP Server'
+   logOutput('[UDP Client] Sending: "' .. message .. '"')
+
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
    dest.port = server.port
 
-   local err, bytesSent = client.mtSendTo(dest, message)
+   err, bytesSent = client.mtSendTo(dest, message)
    assert(err is ERR_Okay, 'Client failed to send UDP data: ' .. mSys.GetErrorMsg(err))
    assert(bytesSent is string.len(message), 'Not all bytes were sent')
 
-   proc.sleep()
+   check proc.sleep()
 
-   assert(serverReceived, 'Server did not receive expected message')
-   assert(clientReceived, 'Client did not receive expected response')
+   assert(server_received, 'Server did not receive expected message')
+   assert(client_received, 'Client did not receive expected response')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP socket configuration and properties
 
-function UDPConfiguration()
-   local udpSocket = obj.new('netsocket', { flags = 'UDP|BROADCAST', maxPacketSize = 8192, multicastTTL = 10 })
+@Test function UDPConfiguration()
+   udp_socket = obj.new('netsocket', { flags = NSF_UDP|NSF_BROADCAST, maxPacketSize = 8192, multicastTTL = 10 })
 
-   assert(bit.band(udpSocket.flags, NSF_UDP) != 0, 'UDP flag not set')
-   assert(udpSocket.maxPacketSize is 8192, 'MaxPacketSize not set correctly')
-   assert(udpSocket.multicastTTL is 10, 'MulticastTTL not set')
-   assert(udpSocket.state is NTC_CONNECTED, 'UDP socket should be in CONNECTED state')
+   assert(bit.band(udp_socket.flags, NSF_UDP) != 0, 'UDP flag not set')
+   assert(udp_socket.maxPacketSize is 8192, 'MaxPacketSize not set correctly')
+   assert(udp_socket.multicastTTL is 10, 'MulticastTTL not set')
+   assert(udp_socket.state is NTC_CONNECTED, 'UDP socket should be in CONNECTED state')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP error conditions
 
-function UDPErrorHandling()
-   local udpSocket = obj.new('netsocket', { flags = 'UDP' })
+@Test function UDPErrorHandling()
+   udp_socket = obj.new('netsocket', { flags = NSF_UDP })
 
    -- Test invalid address
-   local err, bytesSent = udpSocket.mtSendTo('invalid.address', 'test')
+   err, bytesSent = udp_socket.mtSendTo('invalid.address', 'test')
    assert(err != ERR_Okay, 'SendTo should fail with invalid address')
 
    -- Test Connect method on UDP socket (should fail)
-   local err = udpSocket.mtConnect('127.0.0.1')
+   err = udp_socket.mtConnect('127.0.0.1')
    assert(err != ERR_Okay, 'Connect should not work on UDP sockets')
 
    -- Test TCP-only operations on UDP socket
-   local tcpSocket = obj.new('netsocket', {
-      flags = 'SERVER', port = 28390  -- TCP server
+   tcp_socket = obj.new('netsocket', {
+      flags = NSF_SERVER, port = 28390  -- TCP server
    })
 
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('127.0.0.1', dest))
-   dest.port = tcpSocket.port
-   local err = tcpSocket.mtSendTo(dest, 'test')
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
+   dest.port = tcp_socket.port
+   err = tcp_socket.mtSendTo(dest, 'test')
    assert(err != ERR_Okay, 'SendTo should not work on TCP sockets')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP with different packet sizes
 
-function UDPPacketSizes()
-   glBasePort = glBasePort + 1
-   local serverPort = glBasePort
-   local proc = processing.new({ timeout = glTestTimeout })
-   local testCompleted = false
+@Test function UDPPacketSizes()
+   glBasePort++
+   server_port = glBasePort
+   test_completed = false
 
-   local server = obj.new('netsocket', {
-      port    = serverPort,
+   server = obj.new('netsocket', {
+      port    = server_port,
       address = '127.0.0.1',
-      flags   = 'SERVER|UDP',
+      flags   = NSF_SERVER|NSF_UDP,
       maxPacketSize = 65507,  -- Maximum UDP packet size
       incoming = function(Socket)
          local buffer = string.alloc(65600)  -- Larger than max packet
@@ -142,44 +142,36 @@ function UDPPacketSizes()
          assert(err is ERR_Okay, 'Server failed to receive UDP data: ' .. mSys.GetErrorMsg(err))
 
          if (bytesRead > 0) then
-            print('[UDP Server] Received packet of size: ' .. bytesRead)
-            testCompleted = true
-            proc.signal()
+            logOutput('[UDP Server] Received packet of size: ' .. bytesRead)
+            test_completed = true
+            Socket.acSignal()
          end
       end
    })
 
-   local client = obj.new('netsocket', { flags = 'UDP' })
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
+   client = obj.new('netsocket', { flags = NSF_UDP })
 
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('127.0.0.1', dest))
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
    dest.port = server.port
 
    -- Test small packet
-   local smallMessage = 'Small'
-   local err, bytesSent = client.mtSendTo(dest, smallMessage)
+   small_message = 'Small'
+   err, bytesSent = client.mtSendTo(dest, small_message)
    assert(err is ERR_Okay, 'Failed to send small packet: ' .. mSys.GetErrorMsg(err))
 
-   proc.sleep(0.1)  -- Brief pause
+   processing.halt(0.1)  -- Brief pause
 
    -- Test medium packet (1024 bytes)
-   local mediumMessage = string.rep('M', 1024)
-   err, bytesSent = client.mtSendTo(dest, mediumMessage)
+   medium_message = string.rep('M', 1024)
+   err, bytesSent = client.mtSendTo(dest, medium_message)
    assert(err is ERR_Okay, 'Failed to send medium packet')
    assert(bytesSent is 1024, 'Medium packet not fully sent')
 
-   proc.sleep()
+   check proc.sleep()
 
-   assert(testCompleted, 'Packet size test did not complete')
+   assert(test_completed, 'Packet size test did not complete')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
-
-   return {
-      tests = {
-         testUDPConfiguration,
-         testUDPErrorHandling,
-         testUDPBasicIPv4,
-         testUDPPacketSizes
-      }
-   }

--- a/src/network/tests/test_udp_broadcast_multicast.tiri
+++ b/src/network/tests/test_udp_broadcast_multicast.tiri
@@ -11,45 +11,43 @@ UDP Broadcast and Multicast Test
 ------------------------------------------------------------------------------------------------------------------------
 -- Test multicast group operations
 
-function MulticastGroups()
+@Test function MulticastGroups()
    multicastSocket = obj.new('netsocket', { flags = 'UDP', multicastTTL = 2 })
 
    assert(multicastSocket.multicastTTL is 2, 'MulticastTTL not set correctly')
 
    -- Test joining IPv4 multicast group
    ipv4Group = '224.1.1.1'  -- Test multicast address
-   print('Testing join IPv4 multicast group: ' .. ipv4Group)
+   logOutput('Testing join IPv4 multicast group: ' .. ipv4Group)
    err = multicastSocket.mtJoinMulticastGroup(ipv4Group)
-   if (err is ERR_Okay) then
-      print('Successfully joined IPv4 multicast group')
+   if err is ERR_Okay then
+      logOutput('Successfully joined IPv4 multicast group')
 
       -- Test leaving the group
-      err = multicastSocket.mtLeaveMulticastGroup(ipv4Group)
-      assert(err is ERR_Okay, 'Failed to leave IPv4 multicast group: ' .. mSys.GetErrorMsg(err))
+      check multicastSocket.mtLeaveMulticastGroup(ipv4Group)
    else
-      print('IPv4 multicast join failed (may be expected in some environments): ' .. mSys.GetErrorMsg(err))
+      logOutput('IPv4 multicast join failed (may be expected in some environments): ' .. mSys.GetErrorMsg(err))
    end
 
    -- Test joining IPv6 multicast group
    ipv6Group = 'ff02::1'  -- All-nodes multicast
    err = multicastSocket.mtJoinMulticastGroup(ipv6Group)
-   if (err is ERR_Okay) then
+   if err is ERR_Okay then
       -- Test leaving the group
-      err = multicastSocket.mtLeaveMulticastGroup(ipv6Group)
-      assert(err is ERR_Okay, 'Failed to leave IPv6 multicast group: ' .. mSys.GetErrorMsg(err))
+      check multicastSocket.mtLeaveMulticastGroup(ipv6Group)
    else
-      print('IPv6 multicast join failed (may be expected in some environments): ' .. mSys.GetErrorMsg(err))
+      logOutput('IPv6 multicast join failed (may be expected in some environments): ' .. mSys.GetErrorMsg(err))
    end
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test multicast error handling
 
-function MulticastErrorHandling()
-   local udpSocket = obj.new('netsocket', { flags = 'UDP' })
+@Test function MulticastErrorHandling()
+   udpSocket = obj.new('netsocket', { flags = 'UDP' })
 
    -- Test invalid multicast addresses
-   local invalidGroups = {
+   invalidGroups = {
       '127.0.0.1',      -- Unicast, not multicast
       '192.168.1.1',    -- Private unicast
       '300.1.1.1',      -- Invalid IPv4 address
@@ -63,83 +61,72 @@ function MulticastErrorHandling()
    end
 
    -- Test TCP socket (should not support multicast)
-   local tcpSocket = obj.new('netsocket', {
+   tcpSocket = obj.new('netsocket', {
       flags = 'SERVER', port = 38134  -- TCP socket
    })
 
-   local err = tcpSocket.mtJoinMulticastGroup('224.1.1.1')
+   err = tcpSocket.mtJoinMulticastGroup('224.1.1.1')
    assert(err is ERR_NoSupport, 'Multicast should not be supported on TCP sockets')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test multicast TTL/Hop limit configuration
 
-function MulticastTTL()
+@Test function MulticastTTL()
    -- Test different TTL values
-   local ttlValues = { 1, 5, 10, 32, 255 }
+   ttlValues = { 1, 5, 10, 32, 255 }
 
    for i, ttl in ipairs(ttlValues) do
       local socket = obj.new('netsocket', { flags = 'UDP', multicastTTL = ttl })
 
       assert(socket.multicastTTL is ttl, 'MulticastTTL not set correctly for value: ' .. ttl)
-      print('MulticastTTL set correctly to: ' .. ttl)
+      logOutput('MulticastTTL set correctly to: ' .. ttl)
    end
 
    -- Test TTL = 0 (should not be set, use default)
-   local defaultSocket = obj.new('netsocket', { flags = 'UDP', multicastTTL = 0 })
+   defaultSocket = obj.new('netsocket', { flags = 'UDP', multicastTTL = 0 })
    assert(defaultSocket.multicastTTL is 0, 'MulticastTTL should remain 0 when not specified')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test broadcast with loopback (safe test that doesn't require network broadcast permission)
 
-function BroadcastLoopback()
-   local serverPort = glBasePort + 3
-   local proc = processing.new({ timeout = glTestTimeout })
-   local broadcastReceived = false
+@Test function BroadcastLoopback()
+   server_port = glBasePort + 3
+   bcast_recv = false
 
    -- Create server to listen for broadcast messages
-   local server = obj.new('netsocket', {
-      port = serverPort,
-      address = '0.0.0.0',  -- Listen on all interfaces
-      flags = 'SERVER|UDP',
-      incoming = function(Socket)
-         local buffer = string.alloc(1024)
-         local source = struct.new('IPAddress')
-         local err, bytesRead = Socket.mtRecvFrom(source, buffer)
-         if (err is ERR_Okay and bytesRead > 0) then
-            local msg = buffer:sub(0, bytesRead)
-            print('[Broadcast Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
+   server = obj.new('netsocket', {
+      port     = server_port,
+      address  = '0.0.0.0',  -- Listen on all interfaces
+      flags    = NSF_SERVER|NSF_UDP,
+      incoming = function(Socket:obj)
+         buffer = string.alloc(1024)
+         source = struct.new('IPAddress')
+         err, read_len = Socket.mtRecvFrom(source, buffer)
+         if err is ERR_Okay and read_len > 0 then
+            msg = buffer:sub(0, read_len)
+            logOutput('[Broadcast Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
             if (msg:startsWith('Broadcast Test')) then
-               broadcastReceived = true
-               proc.signal()
+               bcast_recv = true
+               Socket.acSignal()
             end
          end
       end
    })
 
-   local client = obj.new('netsocket', { flags = 'UDP|BROADCAST' })
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
+   client = obj.new('netsocket', { flags = NSF_UDP|NSF_BROADCAST })
 
    -- Send to loopback (not true broadcast, but tests the broadcast socket option)
-   print('[Broadcast Client] Sending message to 127.0.0.1:' .. serverPort)
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('127.0.0.1', dest))
+   logOutput('[Broadcast Client] Sending message to 127.0.0.1:' .. server_port)
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
    dest.port = server.port
-   local err, bytesSent = client.mtSendTo(dest, 'Broadcast Test Message')
+   err, bytesSent = client.mtSendTo(dest, 'Broadcast Test Message')
    assert(err is ERR_Okay, 'Failed to send broadcast message: ' .. mSys.GetErrorMsg(err))
 
-   proc.sleep()
+   check proc.sleep()
 
-   assert(broadcastReceived, 'Broadcast message was not received')
+   assert(bcast_recv, 'Broadcast message was not received')
 end
-
-------------------------------------------------------------------------------------------------------------------------
-
-   return {
-      tests = {
-         testBroadcastLoopback,
-         testMulticastTTL,
-         testMulticastErrorHandling,
-         testMulticastGroups
-      }
-   }

--- a/src/network/tests/test_udp_ipv6.tiri
+++ b/src/network/tests/test_udp_ipv6.tiri
@@ -5,117 +5,119 @@ UDP IPv6 Communication Test
    include 'network'
    mNet ?= mod.load('network')
 
-local glBasePort = 19810  -- Base port for IPv6 UDP tests
-local glTestTimeout = 3.0
+glBasePort = 19810  -- Base port for IPv6 UDP tests
+glTestTimeout = 3.0
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test basic UDP communication with IPv6
 
-function UDPIPv6Basic()
+@Test function UDPIPv6Basic()
    glBasePort++
-   local serverPort = glBasePort
-   local proc = processing.new({ timeout = glTestTimeout })
-   local messageReceived = false
-   local sv_source = struct.new('IPAddress')
+   server_port = glBasePort
+   msg_recv    = false
+   sv_source   = struct.new('IPAddress')
 
-   local server = obj.new('netsocket', {
+   server = obj.new('netsocket', {
       name    = 'UDPServer',
-      port    = serverPort,
+      port    = server_port,
       address = '::1',  -- IPv6 loopback
       flags   = 'SERVER|UDP',
       incoming = function(Socket)
-         local buffer = string.alloc(1024)
-         local err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
+         buffer = string.alloc(1024)
+         err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          assert(err is ERR_Okay, 'Server failed to receive IPv6 UDP data: ' .. mSys.GetErrorMsg(err))
 
-         if (bytesRead > 0) then
-            local msg = buffer:sub(0, bytesRead)
-            print('[IPv6 UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
+         if bytesRead > 0 then
+            msg = buffer:sub(0, bytesRead)
+            logOutput('[IPv6 UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
             assert(msg:startsWith('Hello IPv6'), 'Unexpected message received')
-            messageReceived = true
-            proc.signal()
+            msg_recv = true
+            Socket.acSignal()
          end
       end
    })
 
-   local client = obj.new('netsocket', { flags = 'UDP' })
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
+
+   client = obj.new('netsocket', { flags = 'UDP' })
 
    -- Client sends message to IPv6 loopback
-   local message = 'Hello IPv6 UDP Server'
+   message = 'Hello IPv6 UDP Server'
 
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('::1', dest))
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('::1', dest)
    dest.port = server.port
 
-   print('[IPv6 UDP Client] Sending: "' .. message .. '" to ::1:' .. dest.port)
-   local err, bytesSent = client.mtSendTo(dest, message)
+   logOutput('[IPv6 UDP Client] Sending: "' .. message .. '" to ::1:' .. dest.port)
+   err, bytesSent = client.mtSendTo(dest, message)
    assert(err is ERR_Okay, 'Client failed to send IPv6 UDP data: ' .. mSys.GetErrorMsg(err))
    assert(bytesSent is string.len(message), 'Not all bytes were sent')
 
-   proc.sleep()
+   check proc.sleep()
 
-   assert(messageReceived, 'Server did not receive IPv6 message')
+   assert(msg_recv, 'Server did not receive IPv6 message')
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Test dual-stack IPv4/IPv6 UDP communication
 
-function UDPDualStack()
+@Test function UDPDualStack()
    glBasePort++
-   local serverPort = glBasePort
-   local proc = processing.new({ timeout = glTestTimeout })
-   local ipv4Received = false
-   local ipv6Received = false
+   server_port = glBasePort
+   ipv4Received = false
+   ipv6Received = false
 
-   local server = obj.new('netsocket', {
-      port = serverPort,
+   server = obj.new('netsocket', {
+      port    = server_port,
       address = '::',  -- Bind to all interfaces (dual-stack)
-      flags = 'SERVER|UDP',
+      flags   = NSF_SERVER|NSF_UDP,
       incoming = function(Socket)
-         local buffer = string.alloc(1024)
-         local source = struct.new('IPAddress')
-         local err, bytesRead = Socket.mtRecvFrom(source, buffer)
+         buffer = string.alloc(1024)
+         source = struct.new('IPAddress')
+         err, bytesRead = Socket.mtRecvFrom(source, buffer)
          assert(err is ERR_Okay, 'Server failed to receive dual-stack UDP data: ' .. mSys.GetErrorMsg(err))
 
-         if (bytesRead > 0) then
-            local msg = buffer:sub(0, bytesRead)
-            print('[Dual-Stack UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
+         if bytesRead > 0 then
+            msg = buffer:sub(0, bytesRead)
+            logOutput('[Dual-Stack UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
 
-            if (msg:startsWith('IPv4')) then
+            if msg:endsWith('IPv4') then
                ipv4Received = true
-            elseif (msg:startsWith('IPv6')) then
+            elseif msg:endsWith('IPv6') then
                ipv6Received = true
             end
 
-            if (ipv4Received and ipv6Received) then
-               proc.signal()
+            if ipv4Received and ipv6Received then
+               Socket.acSignal()
             end
          end
       end
    })
 
-   local client = obj.new('netsocket', { flags = 'UDP' })
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
+
+   client = obj.new('netsocket', { flags = 'UDP' })
 
    -- Send IPv4 message
-   local ipv4Message = 'Hello from IPv4'
+   ipv4Message = 'Hello from IPv4'
 
-   local dest = struct.new('IPAddress')
-   check(mNet.StrToAddress('127.0.0.1', dest))
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
    dest.port = server.port
 
-   print('[Dual-Stack Client] Sending IPv4 message to 127.0.0.1:' .. dest.port)
-   local err, bytesSent = client.mtSendTo(dest, ipv4Message)
+   logOutput('[Dual-Stack Client] Sending IPv4 message to 127.0.0.1:' .. dest.port)
+   err, bytesSent = client.mtSendTo(dest, ipv4Message)
    assert(err is ERR_Okay, 'Failed to send IPv4 message: ' .. mSys.GetErrorMsg(err))
 
-   proc.sleep(0.1)  -- Brief pause between messages
+   processing.halt(0.1)  -- Brief pause between messages
 
    -- Send IPv6 message
-   print('[Dual-Stack Client] Sending IPv6 message to ::1:' .. server.port)
-   check(mNet.StrToAddress('::1', dest))
+   logOutput('[Dual-Stack Client] Sending IPv6 message to ::1:' .. server.port)
+   check mNet.StrToAddress('::1', dest)
    err, bytesSent = client.mtSendTo(dest, 'Hello from IPv6')
    assert(err is ERR_Okay, 'Failed to send IPv6 message: ' .. mSys.GetErrorMsg(err))
 
-   proc.sleep()
+   check proc.sleep()
 
    assert(ipv4Received, 'Server did not receive IPv4 message')
    assert(ipv6Received, 'Server did not receive IPv6 message')
@@ -124,20 +126,10 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test IPv6 specific socket properties
 
-function UDPIPv6Properties()
-   local ipv6Socket = obj.new('netsocket', { address = '::1', flags = 'UDP', multicastTTL = 5 })
+@Test function UDPIPv6Properties()
+   ipv6Socket = obj.new('netsocket', { address = '::1', flags = 'UDP', multicastTTL = 5 })
 
    assert(bit.band(ipv6Socket.flags, NSF_UDP) != 0, 'UDP flag not set on IPv6 socket')
    assert(ipv6Socket.state is NTC_CONNECTED, 'IPv6 UDP socket should be in CONNECTED state')
    assert(ipv6Socket.multicastTTL is 5, 'IPv6 multicast TTL (hops) not set correctly')
 end
-
-------------------------------------------------------------------------------------------------------------------------
-
-   return {
-      tests = {
-         testUDPIPv6Properties,
-         testUDPIPv6Basic,
-         testUDPDualStack
-      }
-   }

--- a/src/network/tests/test_udp_performance.tiri
+++ b/src/network/tests/test_udp_performance.tiri
@@ -3,7 +3,7 @@ UDP Performance and Stress Test
 --]]
 
    include 'network'
-   if not mNet then mNet = mod.load('network') end
+   mNet ?= mod.load('network')
 
    glBasePort = 19830  -- Base port for performance tests
    glTestTimeout = 5.0
@@ -14,7 +14,6 @@ UDP Performance and Stress Test
 @Test(requires='network') function UDPHighFrequency()
    glBasePort++
    serverPort = glBasePort
-   proc = processing.new({ timeout = glTestTimeout })
    messagesReceived = 0
    targetMessages = 100
    sv_source = struct.new('IPAddress')
@@ -31,7 +30,7 @@ UDP Performance and Stress Test
          if (err is ERR_Okay) and (bytesRead > 0) then
             messagesReceived = messagesReceived + 1
             if messagesReceived >= targetMessages then
-               proc.signal()
+               Socket.acSignal()
             elseif messagesReceived % 20 is 0 then
                print('[High-Freq Server] Received ' .. messagesReceived .. ' messages so far')
             end
@@ -39,6 +38,7 @@ UDP Performance and Stress Test
       end
    })
 
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
    client = obj.new('netsocket', { flags = 'UDP' })
 
    dest = struct.new('IPAddress')
@@ -54,14 +54,14 @@ UDP Performance and Stress Test
 
       -- Small delay to prevent overwhelming the system
       if (i % 10 is 0) then
-         proc.sleep(0.001)  -- 1ms pause every 10 messages
+         processing.halt(0.001)  -- 1ms pause every 10 messages
       end
    end
 
    sendTime = mSys.PreciseTime() - startTime
    print('Sent ' .. targetMessages .. ' messages in ' .. sendTime .. ' seconds')
 
-   proc.sleep()
+   check proc.sleep()
 
    print('Received ' .. messagesReceived .. ' out of ' .. targetMessages .. ' messages')
    -- Allow some packet loss in high-frequency testing
@@ -77,7 +77,6 @@ end
 @Test(requires='network') function UDPLargePackets()
    glBasePort++
    serverPort = glBasePort
-   proc = processing.new({ timeout = glTestTimeout })
    largePacketReceived = false
    receivedSize = 0
    sv_source = struct.new('IPAddress')
@@ -94,11 +93,12 @@ end
             print('[Large Packet Server] Received packet of size: ' .. bytesRead)
             receivedSize = bytesRead
             largePacketReceived = true
-            proc.signal()
+            Socket.acSignal()
          end
       end
    })
 
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
    client = obj.new('netsocket', { flags = 'UDP' })
 
    -- Test different large packet sizes
@@ -124,10 +124,10 @@ end
          end
       end
 
-      processing.sleep(0.1)  -- Brief pause between packets
+      processing.halt(0.1)  -- Brief pause between packets
    end
 
-   proc.sleep()
+   check proc.sleep()
 
    assert(largePacketReceived, 'No large packets were received')
    print('Large packet test completed (largest received: ' .. receivedSize .. ' bytes)')
@@ -139,7 +139,6 @@ end
 @Test(requires='network') function UDPConcurrency()
    glBasePort++
    serverPort = glBasePort
-   proc = processing.new({ timeout = glTestTimeout })
    clientsConnected = 0
    targetClients = 5
    messagesPerClient = 10
@@ -164,11 +163,13 @@ end
             end
 
             if totalReceived >= targetClients * messagesPerClient then
-               proc.signal()
+               Socket.acSignal()
             end
          end
       end
    })
+
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { server } })
 
    -- Create multiple client sockets
    clients = {}
@@ -192,7 +193,7 @@ end
       print('Client ' .. clientId .. ' sent all ' .. messagesPerClient .. ' messages')
    end
 
-   proc.sleep()
+   check proc.sleep()
 
    print('Received ' .. totalReceived .. ' out of ' .. (targetClients * messagesPerClient) .. ' messages')
    successRate = (totalReceived / (targetClients * messagesPerClient)) * 100
@@ -286,12 +287,12 @@ end
 
       -- Brief processing break every 100 messages
       if messagesSent % 100 is 0 then
-         proc.sleep(0.1)
+         processing.halt(0.1)
       end
    end
 
    benchmarkActive = false
-   proc.sleep(0.5)  -- Allow final messages to be received
+   processing.halt(0.5)  -- Allow final messages to be received
 
    actualDuration = mSys.PreciseTime() - startTime
    sendRate       = messagesSent / actualDuration

--- a/src/network/tests/test_udp_tcp_coexistence.tiri
+++ b/src/network/tests/test_udp_tcp_coexistence.tiri
@@ -20,7 +20,6 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
 @Test(requires='network') function UDPTCPCoexistence()
    udpPort = glBasePort + 1
    tcpPort = glBasePort + 2
-   proc = processing.new({ timeout = glTestTimeout })
    udpReceived = false
    tcpConnected = false
    tcpReceived = false
@@ -36,7 +35,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          err, bytesRead = Socket.mtRecvFrom(source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
             msg = buffer:sub(0, bytesRead)
-            print('[UDP Server] Received: "' .. msg .. '"')
+            logOutput('[UDP Server] Received: "' .. msg .. '"')
             if (msg:startsWith('UDP Test')) then
                udpReceived = true
                -- Send UDP response
@@ -53,7 +52,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
       flags = 'SERVER',  -- TCP only
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            print('[TCP Server] Client connected')
+            logOutput('[TCP Server] Client connected')
             tcpConnected = true
             err, len = Client.acWrite('TCP Hello')
             assert(err is ERR_Okay, 'TCP server failed to send greeting')
@@ -64,18 +63,19 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          err, readLen = Client.acRead(buffer)
          if (err is ERR_Okay and readLen > 0) then
             msg = buffer:sub(0, readLen)
-            print('[TCP Server] Received: "' .. msg .. '"')
+            logOutput('[TCP Server] Received: "' .. msg .. '"')
             if (msg:startsWith('TCP Test')) then
                tcpReceived = true
                if (udpReceived and tcpReceived) then
-                  proc.signal()
+                  Socket.acSignal()
                end
             end
          end
       end
    })
 
-   proc.sleep(0.2)  -- Let servers initialize
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { tcpServer } })
+   processing.halt(0.2)  -- Let servers initialize
 
    -- Create UDP client
    udpClient = obj.new('netsocket', {
@@ -86,7 +86,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          err, bytesRead = Socket.mtRecvFrom(source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
             msg = buffer:sub(0, bytesRead)
-            print('[UDP Client] Received response: "' .. msg .. '"')
+            logOutput('[UDP Client] Received response: "' .. msg .. '"')
          end
       end
    })
@@ -97,7 +97,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
       port = tcpPort,
       feedback = function(Socket, State)
          if (State is NTC_CONNECTED) then
-            print('[TCP Client] Connected to server')
+            logOutput('[TCP Client] Connected to server')
             message = 'TCP Test Message'
             err, len = Socket.acWrite(message)
             assert(err is ERR_Okay, 'TCP client failed to send message')
@@ -108,7 +108,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          err, readLen = Socket.acRead(buffer)
          if (err is ERR_Okay and readLen > 0) then
             msg = buffer:sub(0, readLen)
-            print('[TCP Client] Received: "' .. msg .. '"')
+            logOutput('[TCP Client] Received: "' .. msg .. '"')
          end
       end
    })
@@ -120,11 +120,11 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
    dest.port = udpServer.port
 
    udpMessage = 'UDP Test Message'
-   print('[UDP Client] Sending: "' .. udpMessage .. '"')
+   logOutput('[UDP Client] Sending: "' .. udpMessage .. '"')
    err, bytesSent = udpClient.mtSendTo(dest, udpMessage)
    assert(err is ERR_Okay, 'UDP client failed to send message')
 
-   proc.sleep()
+   check proc.sleep()
 
    assert(udpReceived, 'UDP message was not received')
    assert(tcpConnected, 'TCP connection was not established')
@@ -136,7 +136,6 @@ end
 
 @Test(requires='network') function MixedProtocolPatterns()
    basePort = glBasePort + 10
-   proc = processing.new({ timeout = glTestTimeout })
    results = {}
 
    -- Create multiple servers of different types
@@ -151,7 +150,8 @@ end
             err, bytesRead = Socket.mtRecvFrom(source, buffer)
             if (err is ERR_Okay and bytesRead > 0) then
                results.udp1 = true
-               print('UDP Server 1 received message')
+               logOutput('UDP Server 1 received message')
+               Socket.acSignal()
             end
          end
       }),
@@ -163,7 +163,8 @@ end
          feedback = function(Socket, Client, State)
             if (State is NTC_CONNECTED) then
                results.tcp1 = true
-               print('TCP Server 1 got connection')
+               logOutput('TCP Server 1 got connection')
+               Socket.acSignal()
             end
          end
       }),
@@ -179,13 +180,15 @@ end
             err, bytesRead = Socket.mtRecvFrom(source, buffer)
             if (err is ERR_Okay and bytesRead > 0) then
                results.udp2 = true
-               print('UDP Server 2 (with broadcast) received message')
+               logOutput('UDP Server 2 (with broadcast) received message')
+               Socket.acSignal()
             end
          end
       })
    }
 
-   proc.sleep(0.2)  -- Let servers initialize
+   proc = processing.new({ timeout = glTestTimeout, signals = array<object> { servers.udp1, servers.tcp1, servers.udp2 } })
+   processing.halt(0.2)  -- Let servers initialize
 
    -- Create clients and send messages
    clients = {
@@ -205,7 +208,7 @@ end
    dest.port = servers.udp2.port
    clients.udp2.mtSendTo(dest, 'test2')
 
-   proc.sleep(1.0)  -- Allow time for all operations
+   check proc.sleep()
 
    -- Check results
    assert(results.udp1, 'UDP Server 1 did not receive message')
@@ -222,10 +225,10 @@ end
    -- Create and destroy UDP socket
    do
       udpSocket = obj.new('netsocket', { port = testPort, address = '127.0.0.1', flags = 'SERVER|UDP' })
-      print('UDP socket created and bound to port ' .. testPort)
+      logOutput('UDP socket created and bound to port ' .. testPort)
    end  -- Socket goes out of scope and should be cleaned up
 
    -- Create TCP socket on same port (should work after UDP cleanup)
    tcpSocket = obj.new('netsocket', { port = testPort, address = '127.0.0.1', flags = 'SERVER' })
-   print('TCP socket successfully bound to same port after UDP cleanup')
+   logOutput('TCP socket successfully bound to same port after UDP cleanup')
 end

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -511,7 +511,7 @@ end
    end
 
    -- Give the first action a moment to start executing.
-   processing.sleep(0.1)
+   processing.halt(0.1)
 
    -- Cancel remaining queued actions.
    check async.cancel(script)
@@ -540,7 +540,7 @@ end
    print('Started script_b at ', elapsed(), ' seconds')
 
    -- Allow threads to register before cancelling.
-   processing.sleep(0.25)
+   processing.halt(0.25)
 
    print('Cancelling both scripts at ', elapsed(), ' seconds')
    check async.cancel(array<object> { script_a, script_b })

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -100,12 +100,45 @@ static int processing_new(lua_State *Lua)
 }
 
 //********************************************************************************************************************
-// Usage: err = proc.sleep([Seconds], [WakeOnSignal=true])
+// Usage: proc.halt(Seconds)
+//
+// Puts a process to sleep with message processing in the background.  Cannot be woken early.
+//
+// Setting seconds to zero will process outstanding messages and return immediately.
+
+static int processing_halt(lua_State *Lua)
+{
+   double seconds;
+   if (lua_type(Lua, 1) IS LUA_TNUMBER) seconds = lua_tonumber(Lua, 1);
+   else luaL_argerror(Lua, 1, "Seconds must be a number.");
+
+   if (seconds < 0) luaL_error(Lua, ERR::Args, "Seconds must be a positive number.");
+
+   kt::Log log;
+   log.branch("Timeout: %.2f", seconds);
+
+   // Always collect your garbage before going to sleep.  Can be prevented with processing.stopCollector() if
+   // absolutely necessary.
+
+   if ((seconds != 0) and (lua_gc(Lua, LUA_GCISRUNNING, 0))) {
+      kt::Log log;
+      log.traceBranch("Collecting garbage.");
+      lua_gc(Lua, LUA_GCCOLLECT, 0);
+   }
+
+   WaitTime(seconds);
+   return 0;
+}
+
+//********************************************************************************************************************
+// Usage: err = proc.sleep([Seconds])
 //
 // Puts a process to sleep with message processing in the background.  Can be woken early with a signal to a monitored
 // object.  If no objects are monitored, proc.signal() can be used to wake the process.
 //
 // Setting seconds to zero will process outstanding messages and return immediately.
+// Negative seconds will wait indefinitely for a signal.
+// Returns ERR_Timeout if the timeout expires.
 //
 // NOTE: Can be called directly as an interface function or as a member of a processing object.
 //       Errors are promoted to exceptions if used in a try statement.
@@ -116,23 +149,18 @@ static int processing_sleep(lua_State *Lua)
    static std::recursive_mutex recursion; // Intentionally accessible to all threads
 
    ERR error;
-   int timeout;
+   double seconds;
 
    auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing");
-   if (fp) timeout = int(fp->Timeout * 1000.0);
-   else timeout = -1;
+   if (fp) seconds = fp->Timeout;
+   else seconds = -1;
 
-   if (lua_type(Lua, 1) IS LUA_TNUMBER) timeout = int(lua_tonumber(Lua, 1) * 1000.0);
-   if (timeout < 0) timeout = -1; // Wait indefinitely
+   if (lua_type(Lua, 1) IS LUA_TNUMBER) seconds = lua_tonumber(Lua, 1);
+   if (seconds < 0) seconds = -1; // Wait indefinitely
 
-   bool wake_on_signal;
-   if (lua_type(Lua, 2) IS LUA_TBOOLEAN) wake_on_signal = lua_toboolean(Lua, 2);
-   else if (!timeout) wake_on_signal = false; // We don't want to intercept signals if just processing messages
-   else wake_on_signal = true;
+   log.branch("Timeout: %d, WakeOnSignal: %c", seconds);
 
-   log.branch("Timeout: %d, WakeOnSignal: %c", timeout, wake_on_signal ? 'Y' : 'N');
-
-   if (!timeout) {
+   if (!seconds) {
       // Always collect your garbage before going to sleep.  Can be prevented with processing.stopCollector() if
       // absolutely necessary.
       if (lua_gc(Lua, LUA_GCISRUNNING, 0)) {
@@ -142,34 +170,29 @@ static int processing_sleep(lua_State *Lua)
       }
    }
 
-   if (wake_on_signal) {
-      if ((fp) and (fp->Signals) and (not fp->Signals->empty())) {
-         // Use custom signals provided by the client (or Tiri if no objects were specified).
-         auto signal_list_c = std::make_unique<ObjectSignal[]>(fp->Signals->size() + 1);
-         int i = 0;
-         for (auto &entry : *fp->Signals) signal_list_c[i++] = entry;
-         signal_list_c[i].Object = nullptr;
+   if ((fp) and (fp->Signals) and (not fp->Signals->empty())) {
+      // Use custom signals provided by the client
+      auto signal_list_c = std::make_unique<ObjectSignal[]>(fp->Signals->size() + 1);
+      int i = 0;
+      for (auto &entry : *fp->Signals) signal_list_c[i++] = entry;
+      signal_list_c[i].Object = nullptr;
 
-         std::scoped_lock lock(recursion);
-         error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
-      }
-      else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
-         if (Lua->script->defined(NF::SIGNALLED)) {
-            log.detail("Tiri script already in signalled state.");
-            Lua->script->clearFlag(NF::SIGNALLED);
-            error = ERR::Okay;
-         }
-         else {
-            ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
-            std::scoped_lock lock(recursion);
-            error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
-         }
-      }
-   }
-   else { // Ignore signals, just process messages for the specified time
       std::scoped_lock lock(recursion);
-      WaitTime(timeout / 1000.0); // Convert milliseconds to seconds
-      error = ERR::Okay;
+      int timeout = int(seconds * 1000.0);
+      error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
+   }
+   else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
+      if (Lua->script->defined(NF::SIGNALLED)) {
+         log.detail("Tiri script already in signalled state.");
+         Lua->script->clearFlag(NF::SIGNALLED);
+         error = ERR::Okay;
+      }
+      else {
+         ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
+         std::scoped_lock lock(recursion);
+         int timeout = int(seconds * 1000.0);
+         error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
+      }
    }
 
    // Promote errors to exceptions
@@ -428,6 +451,7 @@ static const luaL_Reg processinglib_functions[] = {
    { "stopCollector",  processing_stop_collector },
    { "startCollector", processing_start_collector },
    { "gcStats",        processing_gcStats },
+   { "halt",           processing_halt },
    { "sleep",          processing_sleep },
    { "signal",         processing_signal },
    { "task",           processing_task },
@@ -465,7 +489,8 @@ void register_processing_class(lua_State *Lua)
    reg_iface_prototype("processing", "stopCollector", {}, {});
    reg_iface_prototype("processing", "startCollector", {}, {});
    reg_iface_prototype("processing", "gcStats", { TiriType::Table }, {});
-   reg_iface_prototype("processing", "sleep", { TiriType::Num }, { TiriType::Num, TiriType::Bool });
+   reg_iface_prototype("processing", "halt", { TiriType::Num }, { TiriType::Num });
+   reg_iface_prototype("processing", "sleep", { TiriType::Num }, { TiriType::Num });
    reg_iface_prototype("processing", "signal", {}, {});
    reg_iface_prototype("processing", "task", { TiriType::Any }, {});
    reg_iface_prototype("processing", "flush", {}, {});

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -114,7 +114,7 @@ static int processing_halt(lua_State *Lua)
 
    if (seconds < 0) luaL_error(Lua, ERR::Args, "Seconds must be a positive number.");
 
-   kt::Log log;
+   kt::Log log("processing.halt");
    log.branch("Timeout: %.2f", seconds);
 
    // Always collect your garbage before going to sleep.  Can be prevented with processing.stopCollector() if
@@ -134,10 +134,11 @@ static int processing_halt(lua_State *Lua)
 // Usage: err = proc.sleep([Seconds])
 //
 // Puts a process to sleep with message processing in the background.  Can be woken early with a signal to a monitored
-// object.  If no objects are monitored, proc.signal() can be used to wake the process.
+// object (or all objects if multiple are listed).  If no objects are monitored, proc.signal() can be used to wake
+// the process.
 //
 // Setting seconds to zero will process outstanding messages and return immediately.
-// Negative seconds will wait indefinitely for a signal.
+// A negative or nil Seconds value will wait indefinitely for a signal.
 // Returns ERR_Timeout if the timeout expires.
 //
 // NOTE: Can be called directly as an interface function or as a member of a processing object.
@@ -145,22 +146,18 @@ static int processing_halt(lua_State *Lua)
 
 static int processing_sleep(lua_State *Lua)
 {
-   kt::Log log;
+   kt::Log log("processing.sleep");
    static std::recursive_mutex recursion; // Intentionally accessible to all threads
 
-   ERR error;
-   double seconds;
-
    auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing");
-   if (fp) seconds = fp->Timeout;
-   else seconds = -1;
+   double seconds = fp ? fp->Timeout : -1;
 
    if (lua_type(Lua, 1) IS LUA_TNUMBER) seconds = lua_tonumber(Lua, 1);
    if (seconds < 0) seconds = -1; // Wait indefinitely
 
-   log.branch("Timeout: %d, WakeOnSignal: %c", seconds);
+   log.branch("Timeout: %g", seconds);
 
-   if (!seconds) {
+   if (seconds != 0) {
       // Always collect your garbage before going to sleep.  Can be prevented with processing.stopCollector() if
       // absolutely necessary.
       if (lua_gc(Lua, LUA_GCISRUNNING, 0)) {
@@ -170,6 +167,7 @@ static int processing_sleep(lua_State *Lua)
       }
    }
 
+   ERR error;
    if ((fp) and (fp->Signals) and (not fp->Signals->empty())) {
       // Use custom signals provided by the client
       auto signal_list_c = std::make_unique<ObjectSignal[]>(fp->Signals->size() + 1);
@@ -178,7 +176,7 @@ static int processing_sleep(lua_State *Lua)
       signal_list_c[i].Object = nullptr;
 
       std::scoped_lock lock(recursion);
-      int timeout = int(seconds * 1000.0);
+      auto timeout = int(seconds * 1000.0);
       error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
    }
    else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
@@ -190,7 +188,7 @@ static int processing_sleep(lua_State *Lua)
       else {
          ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
          std::scoped_lock lock(recursion);
-         int timeout = int(seconds * 1000.0);
+         auto timeout = int(seconds * 1000.0);
          error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
       }
    }
@@ -291,7 +289,7 @@ static int processing_collect(lua_State *Lua)
       lua_pop(Lua, 1);
    }
 
-   int result = lua_gc(Lua, gc_mode, step_size);
+   auto result = lua_gc(Lua, gc_mode, step_size);
    lua_pushinteger(Lua, result);
    return 1;
 }

--- a/tools/svg_mark.tiri
+++ b/tools/svg_mark.tiri
@@ -171,6 +171,8 @@ end
 
       selectedFile = nil
 
+      processing.flush()
+
       gui.dialog.file({
          title      = 'Select SVG File for Benchmark',
          okText     = 'Select',
@@ -188,7 +190,7 @@ end
          end
       })
 
-      processing.sleep(nil, true)
+      processing.sleep(-1)
 
       selectedFile ?? return
       svgFile = selectedFile


### PR DESCRIPTION
## Summary

- Add `processing.halt(Seconds)` — a new sleep function that blocks for a fixed duration without processing signals or allowing early waking; useful for timed delays where interruption is undesirable
- Simplify `processing.sleep()` by removing the `WakeOnSignal` boolean parameter; the function now always wakes on signal, with negative seconds meaning indefinite wait
- Update all callers (`scripts/gui/dialog.tiri`, `tools/svg_mark.tiri`, `src/tiri/tests/test_async.tiri`) and modernise Flute tests across Network, Audio, HTTP, and MP3 modules to current Tiri idioms (`array<string>`, `values()`, `const`, aligned declarations)

## Test plan

- [ ] Build `tiri` module and verify it compiles cleanly
- [ ] Run `test_async.tiri` to confirm `processing.halt()` and `processing.sleep()` behave correctly
- [ ] Run network Flute tests to confirm modernised tests still pass
- [ ] Verify `gui.dialog.message().wait()` still blocks until the dialog is dismissed
- [ ] Verify `tools/svg_mark.tiri` file picker still waits correctly for user selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)