### PR TITLE
[Tiri] Structured exception metadata for try/except error tables

### DIFF
--- a/src/tiri/jit/src/debug/lj_debug.cpp
+++ b/src/tiri/jit/src/debug/lj_debug.cpp
@@ -377,6 +377,48 @@ void lj_debug_shortname(char *out, GCstr *str, BCLine line)
 }
 
 //********************************************************************************************************************
+// Resolve current location of a frame without formatting it into the error message.
+// Uses FileSource tracking to display accurate file:line for imported code.
+
+bool lj_debug_getloc(lua_State *L, cTValue *Frame, cTValue *NextFrame, DebugLocation *Location)
+{
+   Location->source = nullptr;
+   Location->line   = 0;
+   Location->valid  = false;
+
+   if (Frame) {
+      GCfunc *fn = frame_func(Frame);
+      if (isluafunc(fn)) {
+         BCLine line = debug_frameline(L, fn, NextFrame);
+         if (line.isValid()) {
+            GCproto *pt = funcproto(fn);
+            GCstr *source = nullptr;
+
+            if (not L->file_sources.empty()) {
+               const FileSource *src = get_file_source(L, line.fileIndex());
+               if (src and not src->filename.empty()) {
+                  source = lj_str_new(L, src->filename.c_str(), src->filename.size());
+               }
+            }
+
+            if (not source) {
+               char buf[LUA_IDSIZE];
+               lj_debug_shortname(buf, proto_chunk_name(pt), pt->firstline);
+               source = lj_str_newz(L, buf);
+            }
+
+            Location->source = source;
+            Location->line   = line.lineNumber();
+            Location->valid  = true;
+            return true;
+         }
+      }
+   }
+
+   return false;
+}
+
+//********************************************************************************************************************
 // Add current location of a frame to error message.
 // Uses FileSource tracking to display accurate file:line for imported code.
 // The BCLine returned by debug_frameline encodes the file index in its upper 8 bits (no separate fileinfo array).

--- a/src/tiri/jit/src/debug/lj_debug.h
+++ b/src/tiri/jit/src/debug/lj_debug.h
@@ -25,6 +25,12 @@ struct lj_Debug {
    int isvararg;
 };
 
+struct DebugLocation {
+   GCstr *source;
+   int line;
+   bool valid;
+};
+
 extern cTValue* lj_debug_frame(lua_State* L, int level, int* size);
 extern BCLine lj_debug_line(GCproto* pt, BCPOS pc);
 extern const char* lj_debug_uvname(GCproto* pt, uint32_t idx);
@@ -32,6 +38,7 @@ extern const char* lj_debug_uvnamev(cTValue* o, uint32_t idx, TValue** tvp, GCob
 extern const char* lj_debug_slotname(GCproto* pt, const BCIns* pc, BCREG slot, const char** name);
 extern const char* lj_debug_funcname(lua_State* L, cTValue* frame, const char** name);
 extern void lj_debug_shortname(char* out, GCstr* str, BCLine line);
+extern bool lj_debug_getloc(lua_State *L, cTValue *Frame, cTValue *NextFrame, DebugLocation *Location);
 extern void lj_debug_addloc(lua_State* L, const char* msg, cTValue* frame, cTValue* nextframe);
 extern void lj_debug_pushloc(lua_State* L, GCproto* pt, BCPOS pc);
 extern int lj_debug_getinfo(lua_State* L, const char* what, lj_Debug* ar, int ext);

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -81,13 +81,50 @@
 // These are defined in tiri_functions.cpp.
 
 extern "C" bool lj_try_find_handler(lua_State *, const TryFrame *, ERR, const BCIns **, BCREG *);
-extern "C" void lj_try_build_exception_table(lua_State *, ERR, CSTRING, int, BCREG, CapturedStackTrace *);
+extern "C" void lj_try_build_exception_table(lua_State *, ERR, GCstr *, GCstr *, int, BCREG, CapturedStackTrace *);
 
 // Error message strings.
 LJ_DATADEF CSTRING lj_err_allmsg =
 #define ERRDEF(name, msg)  msg "\0"
 #include "lj_errmsg.h"
 ;
+
+//********************************************************************************************************************
+// Pending structured exception metadata.
+
+static void err_clear_pending_exception(lua_State *L)
+{
+   L->pending_exception_message = nullptr;
+   L->pending_exception_source  = nullptr;
+   L->pending_exception_line    = 0;
+   L->pending_exception_valid   = false;
+}
+
+static GCstr * err_string_for_pending(lua_State *L, CSTRING Message)
+{
+   if (not Message) return nullptr;
+
+   if (L->top > tvref(L->stack) and tvisstr(L->top - 1) and strVdata(L->top - 1) IS Message) {
+      return strV(L->top - 1);
+   }
+
+   return lj_str_newz(L, Message);
+}
+
+static void err_record_pending_exception(lua_State *L, CSTRING Message, cTValue *Frame, cTValue *NextFrame)
+{
+   err_clear_pending_exception(L);
+
+   L->pending_exception_message = err_string_for_pending(L, Message);
+
+   DebugLocation location;
+   if (lj_debug_getloc(L, Frame, NextFrame, &location)) {
+      L->pending_exception_source = location.source;
+      L->pending_exception_line   = location.line;
+   }
+
+   L->pending_exception_valid = true;
+}
 
 //********************************************************************************************************************
 // Call __close handlers for to-be-closed locals during error unwinding.
@@ -473,23 +510,6 @@ extern "C" void setup_try_handler(lua_State *L)
    // Validate handler PC
    lj_assertL(handler_pc != nullptr, "setup_try_handler: handler found but handler_pc is null");
 
-   // Get error message before restoring stack
-   CSTRING error_msg = nullptr;
-   if (L->top > L->base and tvisstr(L->top - 1)) error_msg = strVdata(L->top - 1);
-
-   // Extract line number from error message (format: "filename:line: message")
-   // On Windows, filenames may contain colons (e.g., "E:\path\file.tiri:10: msg")
-   // so we search for the first colon followed by a digit.
-   int line = 0;
-   if (error_msg) {
-      for (auto p = error_msg; *p; p++) {
-         if (*p IS ':' and p[1] >= '0' and p[1] <= '9') {
-            line = int(strtol(p + 1, nullptr, 10));
-            break;
-         }
-      }
-   }
-
    // Convert offsets back to pointers using restorestack()
    TValue *saved_base = restorestack(L, try_frame->frame_base);
    TValue *saved_top = restorestack(L, try_frame->saved_top);
@@ -530,13 +550,30 @@ extern "C" void setup_try_handler(lua_State *L)
    // or in the try block's frame (unwind_close_try_block).
 
    TValue *current_err = final_err ? final_err : errobj;
-   if (current_err and tvisstr(current_err)) {
-      error_msg = strVdata(current_err);
-      // Re-extract line number from new error message (same Windows-aware logic)
-      line = 0;
-      for (auto p = error_msg; *p; p++) {
+   GCstr *error_msg = nullptr;
+   GCstr *error_source = nullptr;
+   int line = 0;
+
+   if (L->pending_exception_valid) {
+      error_msg    = L->pending_exception_message;
+      error_source = L->pending_exception_source;
+      line         = L->pending_exception_line;
+   }
+   else if (current_err and tvisstr(current_err)) {
+      error_msg = strV(current_err);
+      CSTRING formatted_msg = strVdata(current_err);
+
+      // Fallback for older or unusual paths: extract location metadata from "filename:line: message".
+      // On Windows, filenames may contain colons (e.g., "E:\path\file.tiri:10: msg"), so search for
+      // the first colon followed by a digit.
+
+      for (auto p = formatted_msg; *p; p++) {
          if (*p IS ':' and p[1] >= '0' and p[1] <= '9') {
             line = int(strtol(p + 1, nullptr, 10));
+            if (p > formatted_msg) {
+               error_source = lj_str_new(L, formatted_msg, size_t(p - formatted_msg));
+               L->pending_exception_source = error_source;  // Root until err_clear_pending_exception().
+            }
             break;
          }
       }
@@ -550,8 +587,9 @@ extern "C" void setup_try_handler(lua_State *L)
 
    // Build exception table and place in handler's register (pass pending_trace, which may be null)
 
-   lj_try_build_exception_table(L, err_code, error_msg, line, exception_reg, L->pending_trace);
+   lj_try_build_exception_table(L, err_code, error_msg, error_source, line, exception_reg, L->pending_trace);
    L->pending_trace = nullptr;  // Ownership transferred to exception table builder
+   err_clear_pending_exception(L);
    L->CaughtError = ERR::Okay; // Reset CaughtError so it doesn't leak to subsequent exceptions
    L->try_handler_pc = handler_pc; // Stash handler PC for VM re-entry (already set, but confirm)
 }
@@ -1201,6 +1239,7 @@ LJ_NORET LJ_NOINLINE static void err_msgv(lua_State *L, ErrMsg em, ...)
    if (curr_funcisL(L)) L->top = curr_topL(L);
    msg = lj_strfmt_pushvf(L, err2msg(em), argp);
    va_end(argp);
+   err_record_pending_exception(L, msg, L->base - 1, nullptr);
    lj_debug_addloc(L, msg, L->base - 1, nullptr);
    lj_err_run(L);
 }
@@ -1223,6 +1262,7 @@ LJ_NOINLINE void lj_err_msgv(lua_State *L, ErrMsg em, ...)
    if (curr_funcisL(L)) L->top = curr_topL(L);
    auto msg = lj_strfmt_pushvf(L, err2msg(em), argp);
    va_end(argp);
+   err_record_pending_exception(L, msg, L->base - 1, nullptr);
    lj_debug_addloc(L, msg, L->base - 1, nullptr);
    lj_err_run(L);
 }
@@ -1306,6 +1346,7 @@ LJ_NOINLINE void lj_err_callermsg(lua_State *L, CSTRING msg)
          else pframe = frame_prevd(frame);
       }
    }
+   err_record_pending_exception(L, msg, pframe, frame);
    lj_debug_addloc(L, msg, pframe, frame);
    lj_err_run(L);
 }
@@ -1427,6 +1468,12 @@ extern lua_CFunction lua_atpanic(lua_State *L, lua_CFunction panicf)
 // Forwarders for the public API (C calling convention and no LJ_NORET).
 extern int lua_error(lua_State *L)
 {
+   err_clear_pending_exception(L);
+   if (L->top > L->base and tvisstr(L->top - 1)) {
+      L->pending_exception_message = strV(L->top - 1);
+      // No structured source metadata is available here.  Leave the pending record invalid so setup_try_handler()
+      // can fall back to parsing luaL_where() prefixes from preformatted C API error strings.
+   }
    lj_err_run(L);
    return 0;  //  unreachable
 }

--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -23,21 +23,130 @@
 #include "lauxlib.h"
 #include "lj_tab.h"
 #include "lj_trace.h"
+#include "lj_strfmt.h"
+
+//********************************************************************************************************************
+// Exception table metatable.
+
+static bool is_exception_table(lua_State *L, cTValue *Value)
+{
+   if (not tvistab(Value)) return false;
+
+   GCtab *mt = tabref(tabV(Value)->metatable);
+   if (not mt) return false;
+
+   cTValue *name = lj_tab_getstr(mt, lj_str_newlit(L, "__metatable"));
+   return name and tvisstr(name) and strV(name) IS lj_str_newlit(L, "exception");
+}
+
+static void push_exception_string(lua_State *L, GCtab *exception)
+{
+   cTValue *msg_tv    = lj_tab_getstr(exception, lj_str_newlit(L, "message"));
+   cTValue *source_tv = lj_tab_getstr(exception, lj_str_newlit(L, "source"));
+   cTValue *line_tv   = lj_tab_getstr(exception, lj_str_newlit(L, "line"));
+
+   GCstr *message = (msg_tv and tvisstr(msg_tv)) ? strV(msg_tv) : lj_str_newlit(L, "<No message>");
+   GCstr *source  = (source_tv and tvisstr(source_tv)) ? strV(source_tv) : nullptr;
+   int line       = (line_tv and tvisnum(line_tv)) ? int(numberVint(line_tv)) : 0;
+
+   if (source and line > 0) lj_strfmt_pushf(L, "%s:%d: %s", strdata(source), line, strdata(message));
+   else if (source) lj_strfmt_pushf(L, "%s: %s", strdata(source), strdata(message));
+   else setstrV(L, L->top++, message);
+}
+
+static void push_concat_value_string(lua_State *L, cTValue *Value)
+{
+   if (is_exception_table(L, Value)) {
+      cTValue *msg_tv = lj_tab_getstr(tabV(Value), lj_str_newlit(L, "message"));
+      GCstr *message = (msg_tv and tvisstr(msg_tv)) ? strV(msg_tv) : lj_str_newlit(L, "<No message>");
+      setstrV(L, L->top++, message);
+   }
+   else setstrV(L, L->top++, lj_strfmt_obj(L, Value));
+}
+
+static int exception_tostring(lua_State *L)
+{
+   TValue *value = L->base;
+   if (is_exception_table(L, value)) push_exception_string(L, tabV(value));
+   else setstrV(L, L->top++, lj_str_newlit(L, "exception"));
+
+   return 1;
+}
+
+static int exception_concat(lua_State *L)
+{
+   push_concat_value_string(L, L->base);
+   push_concat_value_string(L, L->base + 1);
+   lua_concat(L, 2);
+   return 1;
+}
+
+static void attach_exception_metatable(lua_State *L, GCtab *Table)
+{
+   GCtab *mt = lj_tab_new(L, 0, 4);
+   lj_assertL(mt != nullptr, "attach_exception_metatable: metatable allocation failed");
+   setgcref(Table->metatable, obj2gco(mt));
+   lj_gc_objbarriert(L, Table, mt);
+
+   TValue *slot = lj_tab_setstr(L, mt, lj_str_newlit(L, "__metatable"));
+   setstrV(L, slot, lj_str_newlit(L, "exception"));
+
+   slot = lj_tab_setstr(L, mt, lj_str_newlit(L, "__name"));
+   setstrV(L, slot, lj_str_newlit(L, "exception"));
+
+   GCfunc *tostring_func = lj_func_newC(L, 0, tabref(L->env));
+   tostring_func->c.f = exception_tostring;
+   slot = lj_tab_setstr(L, mt, lj_str_newlit(L, "__tostring"));
+   setfuncV(L, slot, tostring_func);
+
+   GCfunc *concat_func = lj_func_newC(L, 0, tabref(L->env));
+   concat_func->c.f = exception_concat;
+   slot = lj_tab_setstr(L, mt, lj_str_newlit(L, "__concat"));
+   setfuncV(L, slot, concat_func);
+
+   lj_gc_anybarriert(L, mt);
+}
 
 //********************************************************************************************************************
 // Native bytecode helpers for BC_CHECK and BC_RAISE opcodes.
 // These are called from VM assembly after type checking and L->CaughtError is already set.
 // Both functions are noreturn - they always throw an exception.
 
+LJ_NORET static void lj_raise_recorded(lua_State *L, ERR ErrorCode, GCstr *Message)
+{
+   L->CaughtError = ErrorCode;
+
+   L->pending_exception_message = Message;
+   L->pending_exception_source  = nullptr;
+   L->pending_exception_line    = 0;
+   L->pending_exception_valid   = true;
+
+   DebugLocation location;
+   if (lj_debug_getloc(L, L->base - 1, nullptr, &location)) {
+      L->pending_exception_source = location.source;
+      L->pending_exception_line   = location.line;
+   }
+
+   lj_debug_addloc(L, strdata(Message), L->base - 1, nullptr);
+   lj_err_run(L);
+}
+
 extern "C" LJ_NORET void lj_raise(lua_State *L, int32_t ErrorCode)
 {
-   luaL_error(L, ERR(ErrorCode));
+   ERR error = ERR(ErrorCode);
+   GCstr *message = lj_str_newz(L, GetErrorMsg(error));
+   lj_raise_recorded(L, error, message);
 }
 
 extern "C" LJ_NORET void lj_raise_with_msg(lua_State *L, int32_t ErrorCode, TValue *Msg)
 {
-   if (tvisstr(Msg)) luaL_error(L, ERR(ErrorCode), "%s", strdata(strV(Msg)));
-   else luaL_error(L, ERR(ErrorCode));
+   ERR error = ERR(ErrorCode);
+   GCstr *message;
+
+   if (tvisstr(Msg)) message = strV(Msg);
+   else message = lj_str_newz(L, GetErrorMsg(error));
+
+   lj_raise_recorded(L, error, message);
 }
 
 //********************************************************************************************************************
@@ -186,9 +295,9 @@ extern "C" bool lj_try_find_handler(lua_State *L, const TryFrame *Frame, ERR Err
 
 //********************************************************************************************************************
 // Build an exception table and place it in the specified register.
-// The exception table has fields: code, message, line, trace, stackTrace
+// The exception table has fields: code, message, source, line, trace, stackTrace
 
-extern "C" void lj_try_build_exception_table(lua_State *L, ERR ErrorCode, CSTRING Message, int Line, BCREG ExceptionReg, CapturedStackTrace *Trace)
+extern "C" void lj_try_build_exception_table(lua_State *L, ERR ErrorCode, GCstr *Message, GCstr *Source, int Line, BCREG ExceptionReg, CapturedStackTrace *Trace)
 {
    if (ExceptionReg IS 0xff) { // No exception variable - just free the trace and return
       if (Trace) lj_debug_free_trace(L, Trace);
@@ -205,9 +314,10 @@ extern "C" void lj_try_build_exception_table(lua_State *L, ERR ErrorCode, CSTRIN
    // Create exception table and store immediately at target_slot to root it.
    // This protects it from GC during subsequent allocations without modifying L->top.
 
-   GCtab *t = lj_tab_new(L, 0, 5);
+   GCtab *t = lj_tab_new(L, 0, 6);
    lj_assertL(t != nullptr, "lj_try_build_exception_table: table allocation failed");
    settabV(L, target_slot, t);  // Root immediately - don't modify L->top
+   attach_exception_metatable(L, t);
 
    TValue *slot;
 
@@ -220,9 +330,15 @@ extern "C" void lj_try_build_exception_table(lua_State *L, ERR ErrorCode, CSTRIN
    // Set e.message
 
    slot = lj_tab_setstr(L, t, lj_str_newlit(L, "message"));
-   if (Message) setstrV(L, slot, lj_str_newz(L, Message));
+   if (Message) setstrV(L, slot, Message);
    else if (ErrorCode != ERR::Okay) setstrV(L, slot, lj_str_newz(L, GetErrorMsg(ErrorCode)));
    else setstrV(L, slot, lj_str_newlit(L, "<No message>"));
+
+   // Set e.source
+
+   slot = lj_tab_setstr(L, t, lj_str_newlit(L, "source"));
+   if (Source) setstrV(L, slot, Source);
+   else setnilV(slot);
 
    // Set e.line
 

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -586,6 +586,8 @@ LJLIB_CF(error)
       GCstr *message = nullptr;
       GCstr *source = nullptr;
       int line = 0;
+      ERR error_code = ERR::Okay;
+      bool has_error_code = false;
 
       lua_getfield(L, 1, "message");
       if (tvisstr(L->top - 1)) message = strV(L->top - 1);
@@ -598,11 +600,19 @@ LJLIB_CF(error)
       if (tvisnum(L->top - 1)) line = int(numV(L->top - 1));
       lua_pop(L, 1);
 
+      lua_getfield(L, 1, "code");
+      if (tvisnum(L->top - 1)) {
+         error_code = ERR(numberVint(L->top - 1));
+         has_error_code = true;
+      }
+      lua_pop(L, 1);
+
       if (message) {
          L->pending_exception_message = message;
          L->pending_exception_source  = source;
          L->pending_exception_line    = line;
          L->pending_exception_valid   = true;
+         if (has_error_code) L->CaughtError = error_code;
          rethrow_metadata = true;
          lua_replace(L, 1);  // Replace the table with the message string
       }

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -571,22 +571,70 @@ LJLIB_CF(error)
    int32_t level = lj_lib_optint(L, 2, 1);
    lua_settop(L, 1);
 
+   L->pending_exception_message = nullptr;
+   L->pending_exception_source  = nullptr;
+   L->pending_exception_line    = 0;
+   L->pending_exception_valid   = false;
+
    // Handle exception tables (as received by 'except' keyword) by extracting the message field
    // The error code will remain in the lua_State, so does not require management.
    // TODO: There is room for improvement (e.g. retaining stack traces if a stack trace is present) but this will do for
    // now - a rewrite of exception management is probably in order later.
 
+   bool rethrow_metadata = false;
    if (lua_istable(L, 1)) {
+      GCstr *message = nullptr;
+      GCstr *source = nullptr;
+      int line = 0;
+
       lua_getfield(L, 1, "message");
-      if (lua_isstring(L, -1)) lua_replace(L, 1);  // Replace the table with the message string
-      else lua_pop(L, 1);  // Pop the nil/non-string value, keep original table
+      if (tvisstr(L->top - 1)) message = strV(L->top - 1);
+
+      lua_getfield(L, 1, "source");
+      if (tvisstr(L->top - 1)) source = strV(L->top - 1);
+      lua_pop(L, 1);
+
+      lua_getfield(L, 1, "line");
+      if (tvisnum(L->top - 1)) line = int(numV(L->top - 1));
+      lua_pop(L, 1);
+
+      if (message) {
+         L->pending_exception_message = message;
+         L->pending_exception_source  = source;
+         L->pending_exception_line    = line;
+         L->pending_exception_valid   = true;
+         rethrow_metadata = true;
+         lua_replace(L, 1);  // Replace the table with the message string
+      }
+      else lua_pop(L, 1);  // Pop the nil/non-string message value, keep original table
    }
 
    // Handle regular string errors.
-   if (lua_isstring(L, 1) and level > 0) {
-      luaL_where(L, level);  // Inject source and line number
-      lua_pushvalue(L, 1);
-      lua_concat(L, 2);
+   if (lua_isstring(L, 1)) {
+      if (not rethrow_metadata and tvisstr(L->base)) {
+         L->pending_exception_message = strV(L->base);
+         L->pending_exception_source  = nullptr;
+         L->pending_exception_line    = 0;
+         L->pending_exception_valid   = true;
+      }
+
+      if (level > 0) {
+         if (not L->pending_exception_source and L->pending_exception_line IS 0) {
+            int size;
+            cTValue *frame = lj_debug_frame(L, level, &size);
+            cTValue *nextframe = (frame and size) ? frame + size : nullptr;
+            DebugLocation location;
+
+            if (lj_debug_getloc(L, frame, nextframe, &location)) {
+               L->pending_exception_source = location.source;
+               L->pending_exception_line   = location.line;
+            }
+         }
+
+         luaL_where(L, level);  // Keep unhandled error output compatible.
+         lua_pushvalue(L, 1);
+         lua_concat(L, 2);
+      }
    }
    lj_err_run(L); // Does not return
    return 0;

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -555,6 +555,8 @@ static void gc_traverse_thread(global_State *g, lua_State* th)
          if (cf->funcname) gc_markobj(g, cf->funcname);
       }
    }
+   if (th->pending_exception_message) gc_markobj(g, th->pending_exception_message);
+   if (th->pending_exception_source) gc_markobj(g, th->pending_exception_source);
    lj_state_shrinkstack(th, gc_traverse_frames(g, th));
 }
 

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1176,6 +1176,10 @@ struct lua_State {
    TryFrameStack try_stack;      // Exception frame stack (nullptr until first BC_TRYENTER)
    const BCIns   *try_handler_pc; // Handler PC for error re-entry (set during unwind)
    CapturedStackTrace *pending_trace; // Trace captured during exception handling (for try<trace>)
+   GCstr  *pending_exception_message = nullptr; // Raw exception message for try/except tables
+   GCstr  *pending_exception_source = nullptr;  // Display source filename for try/except tables
+   int    pending_exception_line = 0;           // Source line for try/except tables
+   bool   pending_exception_valid = false;      // True if pending exception metadata is current
    ERR    CaughtError = ERR::Okay; // Catches ERR results from module functions.
 
    // FileSource tracking for accurate error reporting in imported files

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -156,6 +156,27 @@ end
    assert(outer_handled, "Rethrown exception should be caught by outer handler")
 end
 
+@Test(priority=5) function RethrowPreservesErrorCodeForFilters()
+   local matched_args = false
+
+   try
+      try
+         raise ERR_Args, "Rethrown args"
+      except e
+         assert(e.code is ERR_Args, "Inner handler should receive ERR_Args")
+         error(e)
+      end
+   except e when ERR_Args
+      matched_args = true
+      assert(e.code is ERR_Args, "Outer filtered handler should receive ERR_Args")
+      assert(e.message is "Rethrown args", "Rethrow should preserve raw message")
+   except e
+      assert(false, "Rethrown ERR_Args should not fall through to catch-all with code " .. tostring(e.code))
+   end
+
+   assert(matched_args, "Rethrown ERR_Args should match outer ERR_Args filter")
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Exception table fields
 

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -131,6 +131,8 @@ end
 
 @Test(priority=5,hotpath=3) function Rethrow()
    outer_handled = false
+   inner_source = nil
+   inner_line = 0
 
    try
       msg("Entered outer try")
@@ -139,12 +141,16 @@ end
          error("Raising error")
       except e
          msg("Captured inner error: " .. e.message)
+         inner_source = e.source
+         inner_line = e.line
          error(e)
       end
    except e
       outer_handled = true
       msg("Captured rethrown error in outer try: " .. e.message)
-      assert(e.message:find("Raising error"), "Outer should catch rethrown error, got: " .. e.message)
+      assert(e.message is "Raising error", "Outer should catch raw rethrown error, got: " .. e.message)
+      assert(e.source is inner_source, "Rethrow should preserve source")
+      assert(e.line is inner_line, "Rethrow should preserve line")
    end
 
    assert(outer_handled, "Rethrown exception should be caught by outer handler")
@@ -158,10 +164,34 @@ end
       error("Test message")
    except e
       assert(e.code is ERR_Exception, "Lua errors should have ERR_Exception code")
-      assert(e.message:find("Test message"), "Message should match, got " .. e.message)
+      assert(e.message is "Test message", "Message should be raw, got " .. e.message)
+      assert(e.source:find("test_try_except.tiri"), "Should have source filename, got " .. tostring(e.source))
       assert(e.line > 0, "Should have line number, got " .. tostring(e.line))
+      assert(getmetatable(e) is "exception", "Exception metatable should be protected with name 'exception'")
+      local exception_text = tostring(e)
+      assert(exception_text:find("test_try_except.tiri"), "Printable exception should include source")
+      assert(exception_text:find("Test message"), "Printable exception should include message")
+      assert(exception_text:find(tostring(e.line)), "Printable exception should include line")
+      local prefixed_text = "caught: " .. e
+      assert(prefixed_text:find("caught: "), "Prefixed concat should include prefix")
+      assert(prefixed_text:find("Test message"), "Prefixed concat should include message")
+      local suffixed_text = e .. " [handled]"
+      assert(suffixed_text:find(" [handled]"), "Suffixed concat should include suffix")
+      assert(suffixed_text:find("Test message"), "Suffixed concat should include message")
       -- TODO: trace capture not yet implemented (requires saving before stack restoration)
       -- assert(e.trace != nil, "Should have stack trace")
+   end
+end
+
+@Test(priority=7) function ExceptionMessageLocationTextIsNotParsed()
+   local message = "fake.tiri:99999: payload"
+
+   try
+      error(message)
+   except e
+      assert(e.message is message, "Message should remain raw, got " .. e.message)
+      assert(e.line != 99999, "Line should come from debug metadata, got " .. tostring(e.line))
+      assert(e.source:find("test_try_except.tiri"), "Should have real source filename, got " .. tostring(e.source))
    end
 end
 
@@ -1337,7 +1367,9 @@ end
       raise ERR_Args, "Custom error message"
    except e
       assert(e.code is ERR_Args, "raise should set error code")
-      assert(e.message:find("Custom error message"), "raise should use custom message")
+      assert(e.message is "Custom error message", "raise should use raw custom message")
+      assert(e.source:find("test_try_except.tiri"), "raise should set source, got " .. tostring(e.source))
+      assert(e.line > 0, "raise should set line, got " .. tostring(e.line))
       return
    end
    error("raise with message did not throw an exception")


### PR DESCRIPTION
## Summary

- Exception tables now carry separate, structured `source` (GCstr filename) and `line` (int) fields resolved directly from debug frame metadata — `e.message` is the raw message with no location prefix prepended.
- A protected exception metatable is attached to every exception table, providing `__tostring` (`source:line: message`) and `__concat` (raw message) so exceptions can be used directly in string operations.
- Pending exception metadata (`pending_exception_message`, `pending_exception_source`, `pending_exception_line`, `pending_exception_valid`) is threaded through `lua_State` across the unwind path and marked during GC traversal.

### Key changes

- `lj_debug.h/cpp` — new `DebugLocation` struct and `lj_debug_getloc()` to resolve a frame's file/line without formatting it into the error string.
- `lj_obj.h` — four new `pending_exception_*` fields on `lua_State`.
- `lj_gc.cpp` — GC marking for both pending GCstr fields.
- `lj_err.cpp` — `err_record_pending_exception()` called from `err_msgv`, `lj_err_callermsg`; `lua_error` path sets `pending_exception_message`; metadata consumed and cleared in `setup_try_handler`.
- `try_except.cpp` — `lj_try_build_exception_table` now accepts `GCstr *Message` and `GCstr *Source`; adds `source` field; attaches exception metatable. New `lj_raise_recorded` helper records metadata before throwing.
- `lib_base.cpp` — `error()` built-in captures structured metadata for rethrows and new string errors, then calls `lj_debug_getloc` for the caller frame instead of parsing `luaL_where` prefixes.
- `test_try_except.tiri` — extended tests assert raw `e.message`, `e.source`, `e.line`, metatable `__name`, `tostring(e)`, and `..` concat behaviour; new `ExceptionMessageLocationTextIsNotParsed` test.

## Test plan

- [ ] Build `tiri` module: `cmake --build build/agents --config Debug --target tiri --parallel && cmake --install build/agents --config Debug`
- [ ] Run the try/except Flute test: `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_try_except.tiri --log-warning`
- [ ] Verify all existing try/except tests pass (no regressions in error-code, rethrow, nested, and ERR-raise paths)
- [ ] Verify new `ExceptionMessageLocationTextIsNotParsed` test passes and `e.source` contains `test_try_except.tiri`
- [ ] Verify `tostring(e)` and `e .. " suffix"` produce formatted strings containing source, line, and message

🤖 Generated with [Claude Code](https://claude.com/claude-code)