### PR TITLE
Improve options library help detection and error handling

### DIFF
--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -1,21 +1,18 @@
 --[[
-Declarative command-line option parsing for Tiri scripts.
+Declarative command-line option parsing for Tiri scripts.  Refer to the Tiri-Options-API.md Wiki for usage information.
 --]]
 
    include 'core'
    import 'json'
    namespace 'options'
 
-local create_parser
+   local create_parser, get_error_instruction, apply_error_instruction, get_help
 
    _LIB[_NS] = function(Config:table):table
       return create_parser(Config)
    end
    options = _LIB[_NS]
 
-local get_error_instruction
-local apply_error_instruction
-local get_help
 
 help_result_marker = {}
 rx_env_camel <const> = <{ regex.new('([a-z0-9])([A-Z])') }>
@@ -1649,7 +1646,7 @@ function is_true_help_value(Value:any):bool
    if Value is nil then return false end
 
    text = tostring(Value):lower()
-   return text is 'true' or text is '1' or text is 'yes' or text is 'on'
+   return text is 'true' or text is '1'
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -1972,6 +1969,20 @@ function reject_param_command_collision(Parser:table, Param:table)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Reject parameter names that collide with automatic help handling.
+
+function reject_param_help_collision(Parser:table, Param:table)
+   if not Parser.autoHelp then return end
+
+   for name in values(Param.names) do
+      if name is Parser.helpArg then
+         message = f"Parameter name or alias '{name}' conflicts with automatic help; set autoHelp to false."
+         raise ERR_DuplicateValue, message
+      end
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Reject command names that cannot be reached by ordered command dispatch.
 
 function reject_command_dispatch_collision(Parser:table, Name:str)
@@ -2002,6 +2013,7 @@ function add_param(Parser:table, Definition:table):table
       end
    end
 
+   reject_param_help_collision(Parser, param)
    reject_param_command_collision(Parser, param)
 
    if param.kind is 'positional' then
@@ -2085,7 +2097,6 @@ create_parser = function(Config:table):table
       defaults    = Config.defaults,
       strict      = Config.strict,
       autoHelp    = Config.autoHelp,
-      helpArg     = Config.helpArg,
       onError     = Config.onError,
       onHelp      = Config.onHelp
    }
@@ -2093,7 +2104,7 @@ create_parser = function(Config:table):table
    parser.name     ?= 'script'
    parser.strict   ?= true
    parser.autoHelp ?= true
-   parser.helpArg  ?= 'help'
+   parser.helpArg  ?= 'help' -- In future, allow translations to user's locale
    validate_name(parser.helpArg)
    assert(parser.onError is nil or type(parser.onError) is 'function', 'onError must be a function.')
    assert(parser.onHelp is nil or type(parser.onHelp) is 'function', 'onHelp must be a function.')
@@ -2289,10 +2300,9 @@ create_parser = function(Config:table):table
    values, or `nil`.  When `Input` is `nil`, parsing reads ordered arguments from the active task parameters after the
    script path.  If ordered task input is unavailable, named script arguments are read from `arg()`.  Explicit arrays
    and tables bypass task input.  Named options use `name=value` syntax unless a default allows a bare option token.
-   Flags accept `name`, `no-name`, or `name=value` syntax.  Automatic help intercepts the configured help token only
-   when it is not declared as a parameter; help requests return a structured help table with `help`, `topic`, and
-   `text` fields instead of printing.  When the parser defines commands, global options are parsed before the command
-   token and the result contains `command`, `globals`, and `args` fields.
+   Flags accept `name`, `no-name`, or `name=value` syntax.  Help requests return a structured help table with `help`,
+   `topic`, and `text` fields instead of printing.  When the parser defines commands, global options are parsed before
+   the command token and the result contains `command`, `globals`, and `args` fields.
 
    `Options.taskParameters` may be an ordered task parameter array used instead of the active task parameters.  Set it
    to `false` to force the `arg()` fallback.
@@ -2324,10 +2334,9 @@ create_parser = function(Config:table):table
    values, or `nil`.  When `Input` is `nil`, parsing reads ordered arguments from the active task parameters after the
    script path.  If ordered task input is unavailable, named script arguments are read from `arg()`.  Explicit arrays
    and tables bypass task input.  Named options use `name=value` syntax unless a default allows a bare option token.
-   Flags accept `name`, `no-name`, or `name=value` syntax.  Automatic help intercepts the configured help token only
-   when it is not declared as a parameter; help requests print generated help or dispatch it through `onHelp`, then
-   return `nil`.  When the parser defines commands, global options are parsed before the command token and the result
-   contains `command`, `globals`, and `args` fields.
+   Flags accept `name`, `no-name`, or `name=value` syntax.  Help requests print generated help or dispatch it through
+   `onHelp`, then return `nil`.  When the parser defines commands, global options are parsed before the command token
+   and the result contains `command`, `globals`, and `args` fields.
 
    Use parser.tryProcess() when parser failures should be returned instead of raised.
 

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -18,16 +18,30 @@ local apply_error_instruction
 local get_help
 
 help_result_marker = {}
-rx_env_camel = <{ regex.new('([a-z0-9])([A-Z])') }>
-rx_env_chars = <{ regex.new('[^A-Za-z0-9]+') }>
-iso_date_pattern =
+rx_env_camel <const> = <{ regex.new('([a-z0-9])([A-Z])') }>
+rx_env_chars <const> = <{ regex.new('[^A-Za-z0-9]+') }>
+duration_multipliers <const> = {
+   ms = 0.001,
+   s  = 1,
+   m  = 60,
+   h  = 3600,
+   d  = 86400
+}
+size_multipliers <const> = {
+   b  = 1,
+   kb = 1024,
+   mb = 1024 * 1024,
+   gb = 1024 * 1024 * 1024,
+   tb = 1024 * 1024 * 1024 * 1024
+}
+iso_date_pattern <const> =
    [[((([0-9]{2}([02468][48]|[13579][26]|[2468]0))|(([02468][048]|[13579][26])00))-02-29|]] ..
    [[[0-9]{4}-((01|03|05|07|08|10|12)-(0[1-9]|[12][0-9]|3[01])|]] ..
    [[(04|06|09|11)-(0[1-9]|[12][0-9]|30)|02-(0[1-9]|1[0-9]|2[0-8])))]]
-iso_time_pattern = [[([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\.[0-9]+)?)?]]
-iso_timezone_pattern = [[(Z|[+\-]([01][0-9]|2[0-3]):[0-5][0-9])?]]
-rx_iso_date = regex.new('^' .. iso_date_pattern .. '$')
-rx_iso_time = regex.new('^' .. iso_time_pattern .. '$')
+iso_time_pattern <const> = [[([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\.[0-9]+)?)?]]
+iso_timezone_pattern <const> = [[(Z|[+\-]([01][0-9]|2[0-3]):[0-5][0-9])?]]
+rx_iso_date <const> = regex.new('^' .. iso_date_pattern .. '$')
+rx_iso_time <const> = regex.new('^' .. iso_time_pattern .. '$')
 rx_iso_datetime = regex.new('^' .. iso_date_pattern .. 'T' .. iso_time_pattern .. iso_timezone_pattern .. '$')
 css_number_pattern = [[([0-9]+(\.[0-9]+)?|\.[0-9]+)]]
 css_signed_number_pattern = [[([+\-]?([0-9]+(\.[0-9]+)?|\.[0-9]+))]]
@@ -58,7 +72,7 @@ oklch_colour_pattern =
    [[oklch\(\s*]] .. css_lightness_pattern .. [[\s+]] .. css_chroma_pattern .. [[\s+]] ..
    css_hue_pattern .. css_slash_alpha_pattern .. [[\s*\)]]
 
-rx_css_colour = regex.new(
+rx_css_colour <const> = regex.new(
    '^(' .. rgb_colour_pattern .. '|' .. hsl_colour_pattern .. '|' .. hsv_colour_pattern .. '|' ..
    oklch_colour_pattern .. ')$',
    regex.ICASE
@@ -101,7 +115,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Verify that a parameter name is usable as a command-line token name.
 
-function validate_name(Name:any, Field:str)
+function validate_name(Name:any)
    if type(Name) != 'string' or Name is '' then
       raise ERR_EmptyString, 'Parameter names must be non-empty strings.'
    end
@@ -118,7 +132,7 @@ function clone_definition(Definition:table):table
    names = normalise_names(Definition)
    canonical = names[0]
 
-   validate_name(canonical, 'name')
+   validate_name(canonical)
 
    param = {}
    for key, value in pairs(Definition) do
@@ -140,7 +154,7 @@ function clone_definition(Definition:table):table
    end
 
    for name in values(names) do
-      validate_name(name, 'names')
+      validate_name(name)
    end
 
    if param.type is 'enum' and param.choices is nil then
@@ -157,7 +171,7 @@ function clone_command_definition(Parser:table, Definition:table):table
    names = normalise_names(Definition)
    canonical = names[0]
 
-   validate_name(canonical, 'name')
+   validate_name(canonical)
 
    command = {}
    for key, value in pairs(Definition) do
@@ -182,7 +196,7 @@ function clone_command_definition(Parser:table, Definition:table):table
    command._set_defaults = nil
 
    for name in values(names) do
-      validate_name(name, 'names')
+      validate_name(name)
    end
 
    return command
@@ -192,12 +206,12 @@ end
 -- Split a command-line token into its name, value, and explicit-value marker.
 
 function split_token(Token:str):<str, any, bool>
-   parts = Token:split('=')
-   if #parts is 1 then
+   eq = Token:find('=')
+   if eq is nil then
       return Token, nil, false
    end
 
-   return parts[0], Token:substr(#parts[0] + 1), true
+   return Token:substr(0, eq), Token:substr(eq + 1), true
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -299,13 +313,7 @@ function convert_duration(Value:any, Param:table):num
    if type(Value) is 'number' then return Value end
 
    number, unit = split_number_unit(Value, Param, "a duration with an ms, s, m, h, or d suffix")
-   multiplier = ({
-      ms = 0.001,
-      s  = 1,
-      m  = 60,
-      h  = 3600,
-      d  = 86400
-   })[unit]
+   multiplier = duration_multipliers[unit]
 
    if multiplier is nil then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a duration with an ms, s, m, h, or d suffix."
@@ -321,13 +329,7 @@ function convert_size(Value:any, Param:table):num
    if type(Value) is 'number' then return Value end
 
    number, unit = split_number_unit(Value, Param, "a size with a b, kb, mb, gb, or tb suffix")
-   multiplier = ({
-      b  = 1,
-      kb = 1024,
-      mb = 1024 * 1024,
-      gb = 1024 * 1024 * 1024,
-      tb = 1024 * 1024 * 1024 * 1024
-   })[unit]
+   multiplier = size_multipliers[unit]
 
    if multiplier is nil then
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a size with a b, kb, mb, gb, or tb suffix."
@@ -470,7 +472,9 @@ function convert_builtin(TypeName:str, Value:any, Param:table):any
       if type(Value) is 'number' then return Value end
 
       number = tonumber(Value)
-      assert(number, f"Parameter '{Param.name}' requires a number.")
+      if number is nil then
+         raise ERR_WrongType, f"Parameter '{Param.name}' requires a number."
+      end
       return number
    elseif TypeName is 'int' then
       local number:any
@@ -646,10 +650,14 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply a false value to a recognised no- flag token.
 
-function parse_flag_negation(Parser:table, Result:table, ArgNames:table, Presence:table, Name:str):bool
+function parse_flag_negation(Parser:table, Result:table, ArgNames:table, Presence:table, Name:str,
+   UseHelpParam:bool):bool
+
    if not Name:startsWith('no-') then return false end
 
    suffix = Name:substr(3)
+   if suffix is Parser.helpArg and not UseHelpParam then return false end
+
    param = Parser._named_lookup[suffix]
 
    if param then
@@ -669,7 +677,9 @@ end
 
 function parse_positional_value(Parser:table, Result:table, ArgNames:table, Presence:table, Token:str, PosIndex:num):num
    if PosIndex >= #Parser._positionals then
-      assert(not Parser.strict, f"Unknown parameter '{Token}'.")
+      if Parser.strict then
+         raise ERR_ParameterUnknown, f"Unknown parameter '{Token}'."
+      end
       return PosIndex
    end
 
@@ -687,21 +697,28 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse one ordered command-line token and apply it to the result table.
 
-function parse_ordered_token(Parser:table, Result:table, ArgNames:table, Presence:table, Token:str, PosIndex:num):num
+function parse_ordered_token(Parser:table, Result:table, ArgNames:table, Presence:table, Token:str, PosIndex:num,
+   UseHelpParam:bool):num
+
    name, value, has_explicit_value = split_token(Token)
    param = Parser._named_lookup[name]
+   if name is Parser.helpArg and not UseHelpParam then
+      param = nil
+   end
 
    if param then
       parse_observed_value(Parser, Result, ArgNames, Presence, param, name, value, has_explicit_value)
       return PosIndex
    end
 
-   if parse_flag_negation(Parser, Result, ArgNames, Presence, name) then
+   if parse_flag_negation(Parser, Result, ArgNames, Presence, name, UseHelpParam) then
       return PosIndex
    end
 
    if has_explicit_value then
-      assert(not Parser.strict, f"Unknown parameter '{name}'.")
+      if Parser.strict then
+         raise ERR_ParameterUnknown, f"Unknown parameter '{name}'."
+      end
       return PosIndex
    end
 
@@ -780,10 +797,11 @@ end
 
 function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array)
    pos_index = 0
+   use_help_param = #Input is 1
 
    for token in values(Input) do
       assert(type(token) is 'string', 'Command-line input must contain strings')
-      pos_index = parse_ordered_token(Parser, Result, ArgNames, Presence, token, pos_index)
+      pos_index = parse_ordered_token(Parser, Result, ArgNames, Presence, token, pos_index, use_help_param)
    end
 end
 
@@ -843,7 +861,8 @@ function get_environment_value(Parser:table, Param:table):<str, any>
       return nil, nil
    end
 
-   env_name = Parser.envPrefix .. '_' .. env_suffix(Param.name)
+   Param._envSuffix ?= env_suffix(Param.name)
+   env_name = Parser.envPrefix .. '_' .. Param._envSuffix
 
    try
       task = processing.task()
@@ -1422,7 +1441,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Validate one converted scalar value against per-parameter validation fields.
 
-function validate_scalar_value(Parser:table, Param:table, ArgName:str, Value:any)
+function validate_scalar_value(Param:table, Value:any)
    if Param.choices then
       assert(type(Param.choices) is 'array' or type(Param.choices) is 'table',
          f"Parameter '{Param.name}' choices must be an array or table.")
@@ -1433,9 +1452,15 @@ function validate_scalar_value(Parser:table, Param:table, ArgName:str, Value:any
    end
 
    if Param.pattern then
-      local pattern = Param.pattern
-      if type(pattern) is 'string' then
-         pattern = regex.new(pattern)
+      local pattern = Param._pattern
+      if pattern is nil or Param._pattern_source != Param.pattern then
+         pattern = Param.pattern
+         if type(pattern) is 'string' then
+            pattern = regex.new(pattern)
+         end
+
+         Param._pattern = pattern
+         Param._pattern_source = Param.pattern
       end
 
       assert(type(pattern) is 'userdata', f"Parameter '{Param.name}' pattern must be a regex or string.")
@@ -1454,10 +1479,10 @@ function validate_param_value(Parser:table, Param:table, ArgName:str, Value:any)
    if Param.multiple then
       assert(type(Value) is 'array', f"Parameter '{Param.name}' should contain an array of values.")
       for item in values(Value) do
-         validate_scalar_value(Parser, Param, ArgName, item)
+         validate_scalar_value(Param, item)
       end
    else
-      validate_scalar_value(Parser, Param, ArgName, Value)
+      validate_scalar_value(Param, Value)
    end
 
    if Param.exec then
@@ -1606,34 +1631,85 @@ function parse_arg_fallback(Parser:table, Result:table, ArgNames:table, Presence
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Return true when a declared help parameter value means that help was deliberately disabled.
+
+function is_false_help_value(Value:any):bool
+   if Value is false then return true end
+   if Value is nil then return false end
+
+   text = tostring(Value):lower()
+   return text is 'false' or text is '0' or text is 'no' or text is 'off'
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Return true when a declared help parameter value requests normal help rather than a detailed topic.
+
+function is_true_help_value(Value:any):bool
+   if Value is true then return true end
+   if Value is nil then return false end
+
+   text = tostring(Value):lower()
+   return text is 'true' or text is '1' or text is 'yes' or text is 'on'
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Interpret a caller-declared help parameter value.
+
+function declared_help_result(Param:table, Value:any, HasExplicitValue:bool):<bool, str>
+   if Param.kind is 'flag' then
+      if HasExplicitValue and is_false_help_value(Value) then return false, nil end
+      if not HasExplicitValue or is_true_help_value(Value) then return true, nil end
+      return true, tostring(Value)
+   end
+
+   if not HasExplicitValue then return false, nil end
+   if is_false_help_value(Value) then return false, nil end
+   if is_true_help_value(Value) then return true, nil end
+   return true, tostring(Value)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Detect manual help requests through a named help parameter when automatic help is disabled.
+
+function find_declared_ordered_help(Parser:table, Input:array):<bool, str>
+   if Parser.autoHelp then return false, nil end
+   if #Input != 1 then return false, nil end
+
+   param = Parser._named_lookup[Parser.helpArg]
+   if param is nil then return false, nil end
+
+   name, value, has_explicit_value = split_token(Input[0])
+   if name is Parser.helpArg then
+      return declared_help_result(param, value, has_explicit_value)
+   end
+
+   return false, nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Detect manual help requests in keyed input when automatic help is disabled.
+
+function find_declared_table_help(Parser:table, Input:table):<bool, str>
+   if Parser.autoHelp then return false, nil end
+
+   param = Parser._lookup[Parser.helpArg]
+   if param is nil then return false, nil end
+
+   value = Input[Parser.helpArg]
+   if value is nil then return false, nil end
+   return declared_help_result(param, value, true)
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Detect automatic help requests in ordered input.
 
 function find_ordered_help(Parser:table, Input:array):<bool, str>
    if not Parser.autoHelp then return false, nil end
+   if #Input != 1 then return false, nil end
 
-   pos_index = 0
-
-   for token in values(Input) do
-      name, value, has_explicit_value = split_token(token)
-      if Parser._named_lookup[name] then
-         continue
-      end
-
-      if not has_explicit_value and name:startsWith('no-') and Parser._named_lookup[name:substr(3)] then
-         continue
-      end
-
-      if not has_explicit_value and pos_index < #Parser._positionals then
-         param = Parser._positionals[pos_index]
-         if not param.multiple then
-            pos_index++
-         end
-         continue
-      end
-
-      if name is Parser.helpArg then
-         return true, has_explicit_value ? value :> nil
-      end
+   name, value, has_explicit_value = split_token(Input[0])
+   if name is Parser.helpArg then
+      return true, has_explicit_value ? value :> nil
    end
 
    return false, nil
@@ -1644,7 +1720,6 @@ end
 
 function find_table_help(Parser:table, Input:table):<bool, str>
    if not Parser.autoHelp then return false, nil end
-   if Parser._lookup[Parser.helpArg] then return false, nil end
 
    for name, value in pairs(Input) do
       if name is Parser.helpArg then
@@ -1661,7 +1736,6 @@ end
 
 function find_arg_help(Parser:table):<bool, str>
    if not Parser.autoHelp then return false, nil end
-   if Parser._lookup[Parser.helpArg] then return false, nil end
 
    value = arg(Parser.helpArg, nil)
    if value then
@@ -1729,14 +1803,12 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Determine whether an ordered token belongs to the global parser before a command token.
 
-function is_global_ordered_token(Parser:table, Token:str):bool
-   name, _, has_explicit_value = split_token(Token)
-
-   if Parser._named_lookup[name] then
+function is_global_ordered_token(Parser:table, Name:str, HasExplicitValue:bool):bool
+   if Parser._named_lookup[Name] then
       return true
    end
 
-   if not has_explicit_value and name:startsWith('no-') and Parser._named_lookup[name:substr(3)] then
+   if not HasExplicitValue and Name:startsWith('no-') and Parser._named_lookup[Name:substr(3)] then
       return true
    end
 
@@ -1757,7 +1829,9 @@ function parse_command_ordered_input(Parser:table, Input:array):table
       assert(type(token) is 'string', 'Command-line input must contain strings')
       name, _, has_explicit_value = split_token(token)
 
-      if not is_global_ordered_token(Parser, token) and not has_explicit_value and Parser._command_lookup[name] then
+      if not is_global_ordered_token(Parser, name, has_explicit_value) and not has_explicit_value and
+         Parser._command_lookup[name] then
+
          command = Parser._command_lookup[name]
          index++
          break
@@ -1829,6 +1903,13 @@ function parse_input(Parser:table, Input:any, Options:table):table
       task_parameters = get_task_parameters(Options)
       if task_parameters then
          script_arguments = get_script_arguments(task_parameters)
+         wants_help, help_topic = find_declared_ordered_help(Parser, script_arguments)
+         if wants_help then return make_help_result(Parser, help_topic) end
+
+         if #script_arguments is 0 and Parser.autoHelp then
+            return make_help_result(Parser, nil)
+         end
+
          wants_help, help_topic = find_ordered_help(Parser, script_arguments)
          if wants_help then return make_help_result(Parser, help_topic) end
 
@@ -1845,12 +1926,18 @@ function parse_input(Parser:table, Input:any, Options:table):table
          parse_arg_fallback(Parser, input_result, input_arg_names, input_presence)
       end
    elseif type(Input) is 'array' then
+      wants_help, help_topic = find_declared_ordered_help(Parser, Input)
+      if wants_help then return make_help_result(Parser, help_topic) end
+
       wants_help, help_topic = find_ordered_help(Parser, Input)
       if wants_help then return make_help_result(Parser, help_topic) end
 
       if has_commands then return parse_command_ordered_input(Parser, Input) end
       parse_ordered_input(Parser, input_result, input_arg_names, input_presence, Input)
    elseif type(Input) is 'table' then
+      wants_help, help_topic = find_declared_table_help(Parser, Input)
+      if wants_help then return make_help_result(Parser, help_topic) end
+
       wants_help, help_topic = find_table_help(Parser, Input)
       if wants_help then return make_help_result(Parser, help_topic) end
 
@@ -2003,21 +2090,21 @@ create_parser = function(Config:table):table
       onHelp      = Config.onHelp
    }
 
-   parser.name    ?= 'script'
-   if parser.strict is nil then parser.strict = true end
-   if parser.autoHelp is nil then parser.autoHelp = true end
-   parser.helpArg ?= 'help'
-   validate_name(parser.helpArg, 'helpArg')
+   parser.name     ?= 'script'
+   parser.strict   ?= true
+   parser.autoHelp ?= true
+   parser.helpArg  ?= 'help'
+   validate_name(parser.helpArg)
    assert(parser.onError is nil or type(parser.onError) is 'function', 'onError must be a function.')
    assert(parser.onHelp is nil or type(parser.onHelp) is 'function', 'onHelp must be a function.')
 
-   parser._params       = array<table>
-   parser._positionals  = array<table>
-   parser._lookup       = {}
-   parser._named_lookup = {}
-   parser._commands     = array<table>
+   parser._params         = array<table>
+   parser._positionals    = array<table>
+   parser._lookup         = {}
+   parser._named_lookup   = {}
+   parser._commands       = array<table>
    parser._command_lookup = {}
-   parser._set_defaults = nil
+   parser._set_defaults   = nil
 
    @Doc(text=[[
    Add a parameter definition to the parser

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -205,7 +205,9 @@ end
 
 @Test function UnknownParametersRespectStrictMode()
    strict_parser = options({ args = array<table> { { name = 'file' } } })
-   expect_error(strict_parser, array<string> { 'extra=value' }, ERR_Exception, "Unknown parameter 'extra'.")
+   err = expect_error(strict_parser, array<string> { 'extra=value' }, ERR_ParameterUnknown,
+      "Unknown parameter 'extra'.")
+   assert(err.message:find('stack traceback') is nil, 'Unknown named parameters should not include a stack trace')
 
    loose_parser = options({ strict = false, args = array<table> { { name = 'file', default = 'fallback.txt' } } })
    args = loose_parser.process(array<string> { 'extra=value' })
@@ -285,7 +287,7 @@ end
 
    args, err = parser.tryProcess(array<string> { 'unknown=value' })
    assert(args is nil, 'tryProcess() should return nil on parse failure')
-   assert(err.code is ERR_Exception, 'tryProcess() should return the parse error')
+   assert(err.code is ERR_ParameterUnknown, 'tryProcess() should return the parse error')
    assert(called is false, 'tryProcess() must not invoke parser.error()')
 end
 
@@ -477,8 +479,9 @@ end
       }
    })
 
-   expect_error(strict_parser, array<string> { 'scene.svg', 'extra.svg' }, ERR_Exception,
+   err = expect_error(strict_parser, array<string> { 'scene.svg', 'extra.svg' }, ERR_ParameterUnknown,
       "Unknown parameter 'extra.svg'.")
+   assert(err.message:find('stack traceback') is nil, 'Unknown positional parameters should not include a stack trace')
 
    loose_parser = options({
       strict = false,
@@ -851,6 +854,29 @@ end
    assert(result.topic is 'file', 'Detailed help result should report the requested topic')
    assert(result.text:find('File to read'), 'Detailed help should be generated for help=argname')
 
+   cli_parser = options({
+      name = 'convert',
+      args = array<table> {
+         { name = 'input', kind = 'positional', type = 'file', required = true },
+         { name = 'output', kind = 'option', type = 'file', required = true },
+         { name = 'help', kind = 'flag', type = 'bool', comment = 'Show help.' }
+      }
+   })
+
+   result, err = cli_parser.tryProcess(nil, {
+      taskParameters = array<string> { '--log-warning', 'test.tiri', 'help' }
+   })
+   assert(err is nil, 'Default task-parameter help should not validate required arguments')
+   assert(result.help is true, 'Default task-parameter help should return a structured help result')
+   assert(result.text:find('Usage: convert'), 'Default task-parameter help should include normal help text')
+
+   result, err = cli_parser.tryProcess(nil, {
+      taskParameters = array<string> { '--log-warning', 'test.tiri' }
+   })
+   assert(err is nil, 'Empty default task parameters should print help instead of validating required arguments')
+   assert(result.help is true, 'Empty default task parameters should return a structured help result')
+   assert(result.text:find('Usage: convert'), 'Empty default task parameter help should include normal help text')
+
    seen_text = nil
    seen_topic = nil
    help_parser = options({
@@ -871,15 +897,16 @@ end
    assert(seen_text:find('File to read'), 'process() should pass generated help text to onHelp')
 end
 
-@Test function AutomaticHelpDoesNotClaimDeclaredOrderedArguments()
+@Test function AutomaticHelpClaimsDeclaredHelpToken()
    positional = options({
       args = array<table> {
-         { name = 'file', kind = 'positional', type = 'file', required = true }
+         { name = 'help', kind = 'positional', type = 'file', required = true }
       }
    })
 
-   args = positional.process(array<string> { 'help' })
-   assert(args.file is 'help', 'Bare help should remain a valid positional value')
+   result, err = positional.tryProcess(array<string> { 'help' })
+   assert(err is nil, 'Automatic help should not fail when help is also a declared positional')
+   assert(result.help is true, 'Automatic help should take precedence over a declared positional')
 
    named = options({
       args = array<table> {
@@ -887,8 +914,10 @@ end
       }
    })
 
-   args = named.process(array<string> { 'help=topic' })
-   assert(args.help is 'topic', 'Declared help option should parse as normal input')
+   result, err = named.tryProcess(array<string> { 'help=help' })
+   assert(err is nil, 'Automatic help should not fail when help is also a declared option')
+   assert(result.topic is 'help', 'Automatic help should treat help=value as a detailed help topic')
+   assert(result.text:find('help:'), 'Automatic help should generate detailed help for the declared parameter')
 
    flag = options({
       args = array<table> {
@@ -896,8 +925,85 @@ end
       }
    })
 
-   args = flag.process(array<string> { 'help' })
-   assert(args.help is true, 'Declared help flag should parse as normal input')
+   result, err = flag.tryProcess(array<string> { 'help' })
+   assert(err is nil, 'Automatic help should not fail when help is also a declared flag')
+   assert(result.help is true, 'Automatic help should take precedence over a declared flag')
+
+   positioned = options({
+      args = array<table> {
+         { name = 'input', kind = 'positional', type = 'file', required = true },
+         { name = 'output', kind = 'positional', type = 'file', required = true },
+         { name = 'help', kind = 'flag', type = 'bool' }
+      }
+   })
+
+   args = positioned.process(array<string> { 'abc', 'help' })
+   assert(args.input is 'abc', 'Help after another argument should not trigger automatic help')
+   assert(args.output is 'help', 'Help after another argument should remain positional input')
+   assert(args.help is nil, 'Help after another argument should not parse as the declared help flag')
+
+   args = positioned.process(array<string> { 'help', 'abc' })
+   assert(args.input is 'help', 'Help before another argument should not trigger automatic help')
+   assert(args.output is 'abc', 'A following argument should make help remain positional input')
+   assert(args.help is nil, 'Help before another argument should not parse as the declared help flag')
+
+   result, err = positioned.tryProcess(nil, {
+      taskParameters = array<string> { '--log-warning', 'test.tiri', 'abc', 'help' }
+   })
+   assert(err is nil, 'Task-parameter help after another argument should parse normally')
+   assert(result.input is 'abc' and result.output is 'help', 'Task-parameter help should remain positional input')
+end
+
+@Test function ManualHelpParameterBypassesRequiredValidation()
+   seen_text = nil
+   seen_topic = nil
+   parser = options({
+      name = 'convert',
+      autoHelp = false,
+      onHelp = function(Parser:table, Text:str, Topic:any)
+         seen_text = Text
+         seen_topic = Topic
+      end,
+      args = array<table> {
+         { name = 'input', kind = 'positional', type = 'file', required = true },
+         { name = 'output', kind = 'option', type = 'file', required = true },
+         { name = 'help', kind = 'flag', type = 'bool', comment = 'Show help.' }
+      }
+   })
+
+   returned = parser.process(array<string> { 'help' })
+   assert(returned is nil, 'Manual help should be handled before required validation')
+   assert(seen_topic is nil, 'Manual bare help should request normal help')
+   assert(seen_text:find('Usage: convert'), 'Manual help should generate normal help text')
+
+   result, err = parser.tryProcess(nil, {
+      taskParameters = array<string> { '--log-warning', 'test.tiri', 'help' }
+   })
+   assert(err is nil, 'Manual task-parameter help should not validate required arguments')
+   assert(result.help is true, 'Manual task-parameter help should return a structured help result')
+   assert(result.text:find('Usage: convert'), 'Manual task-parameter help should include normal help text')
+
+   result, err = parser.tryProcess(array<string> { 'help=output' })
+   assert(err is nil, 'Manual help topics should not validate required arguments')
+   assert(result.topic is 'output', 'Manual help should preserve explicit topics')
+   assert(result.text:find('output:'), 'Manual help topics should generate detailed help text')
+
+   positioned = options({
+      autoHelp = false,
+      args = array<table> {
+         { name = 'input', kind = 'positional', required = true },
+         { name = 'output', kind = 'positional', required = true },
+         { name = 'help', kind = 'flag', type = 'bool' }
+      }
+   })
+
+   args = positioned.process(array<string> { 'abc', 'help' })
+   assert(args.input is 'abc' and args.output is 'help', 'Manual help after another argument should parse normally')
+   assert(args.help is nil, 'Manual help after another argument should not parse as the declared help flag')
+
+   args = positioned.process(array<string> { 'help', 'abc' })
+   assert(args.input is 'help' and args.output is 'abc', 'Manual help before another argument should parse normally')
+   assert(args.help is nil, 'Manual help before another argument should not parse as the declared help flag')
 end
 
 @Test function UnsupportedHelpFormatsFail()
@@ -930,7 +1036,7 @@ end
       }
    })
 
-   expect_error(disabled, array<string> { 'help' }, ERR_Exception, "Unknown parameter 'help'.")
+   expect_error(disabled, array<string> { 'help' }, ERR_ParameterUnknown, "Unknown parameter 'help'.")
 
    renamed = options({
       helpArg = 'usage',
@@ -1179,8 +1285,8 @@ end
    assert(result.args.filter is 'svg', 'Selected command arguments should parse')
    assert(result.args.input is nil, 'Arguments from other commands should not leak into the selected command')
 
-   expect_error(parser, array<string> { 'build', 'filter=svg' }, ERR_Exception, "Unknown parameter 'filter'.")
-   expect_error(parser, array<string> { 'input=src', 'build' }, ERR_Exception, "Unknown parameter 'input'.")
+   expect_error(parser, array<string> { 'build', 'filter=svg' }, ERR_ParameterUnknown, "Unknown parameter 'filter'.")
+   expect_error(parser, array<string> { 'input=src', 'build' }, ERR_ParameterUnknown, "Unknown parameter 'input'.")
 end
 
 @Test function MissingAndUnknownCommandsFail()
@@ -1191,7 +1297,7 @@ end
    })
 
    expect_error(parser, array<string> { }, ERR_ParameterRequired, 'Command is required.')
-   expect_error(parser, array<string> { 'unknown' }, ERR_Exception, "Unknown parameter 'unknown'.")
+   expect_error(parser, array<string> { 'unknown' }, ERR_ParameterUnknown, "Unknown parameter 'unknown'.")
    expect_error(parser, { command = 'unknown' }, ERR_ParameterUnknown, "Unknown command 'unknown'.")
 end
 

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -858,8 +858,7 @@ end
       name = 'convert',
       args = array<table> {
          { name = 'input', kind = 'positional', type = 'file', required = true },
-         { name = 'output', kind = 'option', type = 'file', required = true },
-         { name = 'help', kind = 'flag', type = 'bool', comment = 'Show help.' }
+         { name = 'output', kind = 'option', type = 'file', required = true }
       }
    })
 
@@ -897,61 +896,42 @@ end
    assert(seen_text:find('File to read'), 'process() should pass generated help text to onHelp')
 end
 
-@Test function AutomaticHelpClaimsDeclaredHelpToken()
-   positional = options({
+@Test function AutomaticHelpRejectsDeclaredHelpToken()
+   expect_options_error({
       args = array<table> {
          { name = 'help', kind = 'positional', type = 'file', required = true }
       }
-   })
+   }, ERR_DuplicateValue, "Parameter name or alias 'help' conflicts with automatic help; set autoHelp to false.")
 
-   result, err = positional.tryProcess(array<string> { 'help' })
-   assert(err is nil, 'Automatic help should not fail when help is also a declared positional')
-   assert(result.help is true, 'Automatic help should take precedence over a declared positional')
-
-   named = options({
+   expect_options_error({
       args = array<table> {
          { name = 'help', type = 'str', required = true }
       }
-   })
+   }, ERR_DuplicateValue, "Parameter name or alias 'help' conflicts with automatic help; set autoHelp to false.")
 
-   result, err = named.tryProcess(array<string> { 'help=help' })
-   assert(err is nil, 'Automatic help should not fail when help is also a declared option')
-   assert(result.topic is 'help', 'Automatic help should treat help=value as a detailed help topic')
-   assert(result.text:find('help:'), 'Automatic help should generate detailed help for the declared parameter')
-
-   flag = options({
+   expect_options_error({
       args = array<table> {
          { name = 'help', kind = 'flag', type = 'bool' }
       }
-   })
+   }, ERR_DuplicateValue, "Parameter name or alias 'help' conflicts with automatic help; set autoHelp to false.")
 
-   result, err = flag.tryProcess(array<string> { 'help' })
-   assert(err is nil, 'Automatic help should not fail when help is also a declared flag')
-   assert(result.help is true, 'Automatic help should take precedence over a declared flag')
-
-   positioned = options({
+   expect_options_error({
       args = array<table> {
-         { name = 'input', kind = 'positional', type = 'file', required = true },
-         { name = 'output', kind = 'positional', type = 'file', required = true },
-         { name = 'help', kind = 'flag', type = 'bool' }
+         { names = array<string> { 'show-help', 'help' }, kind = 'flag', type = 'bool' }
       }
-   })
+   }, ERR_DuplicateValue, "Parameter name or alias 'help' conflicts with automatic help; set autoHelp to false.")
 
-   args = positioned.process(array<string> { 'abc', 'help' })
-   assert(args.input is 'abc', 'Help after another argument should not trigger automatic help')
-   assert(args.output is 'help', 'Help after another argument should remain positional input')
-   assert(args.help is nil, 'Help after another argument should not parse as the declared help flag')
+   parser = options({})
+   try
+      parser.addParam({ name = 'help', kind = 'flag', type = 'bool' })
+   except e
+      assert(e.code is ERR_DuplicateValue, 'addParam() help collision should report a duplicate value')
+      assert(e.message:find("Parameter name or alias 'help' conflicts with automatic help; set autoHelp to false."),
+         'addParam() help collision diagnostic should explain the autoHelp requirement')
+      return
+   end
 
-   args = positioned.process(array<string> { 'help', 'abc' })
-   assert(args.input is 'help', 'Help before another argument should not trigger automatic help')
-   assert(args.output is 'abc', 'A following argument should make help remain positional input')
-   assert(args.help is nil, 'Help before another argument should not parse as the declared help flag')
-
-   result, err = positioned.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'test.tiri', 'abc', 'help' }
-   })
-   assert(err is nil, 'Task-parameter help after another argument should parse normally')
-   assert(result.input is 'abc' and result.output is 'help', 'Task-parameter help should remain positional input')
+   error('addParam() should reject help parameters when automatic help is enabled')
 end
 
 @Test function ManualHelpParameterBypassesRequiredValidation()
@@ -1028,7 +1008,7 @@ end
    assert(err.code is ERR_ParameterUnknown, 'Unknown help topics should report parameter-unknown')
 end
 
-@Test function AutoHelpCanBeDisabledOrRenamed()
+@Test function AutoHelpCanBeDisabled()
    disabled = options({
       autoHelp = false,
       args = array<table> {
@@ -1037,17 +1017,6 @@ end
    })
 
    expect_error(disabled, array<string> { 'help' }, ERR_ParameterUnknown, "Unknown parameter 'help'.")
-
-   renamed = options({
-      helpArg = 'usage',
-      args = array<table> {
-         { name = 'file' }
-      }
-   })
-
-   result, err = renamed.tryProcess(array<string> { 'usage' })
-   assert(err is nil, 'Renamed help argument should be recognised')
-   assert(result.help is true, 'Renamed help argument should return a help result')
 end
 
 @Test function OnErrorInstructions()


### PR DESCRIPTION
## Summary

- Tighten help token detection: `is_true_help_value` now accepts only `'true'` and `'1'`, dropping `'yes'` and `'on'`
- Replace silent help-claiming behaviour with a hard `ERR_DuplicateValue` error via `reject_param_help_collision()` — declaring a parameter whose name or alias matches the auto-help argument (default `'help'`) is now rejected at parser construction time
- Remove `helpArg` config key; the help argument name defaults to `'help'` only (locale translation noted as a future concern)
- Update tests: `AutomaticHelpClaimsDeclaredHelpToken` → `AutomaticHelpRejectsDeclaredHelpToken` with assertions covering positional, option, flag, and alias collisions; `AutoHelpCanBeDisabledOrRenamed` → `AutoHelpCanBeDisabled` removing the renamed-help-arg cases

## Test plan

- [ ] Run `ctest` Flute test suite targeting `test_options.tiri` and confirm all tests pass
- [ ] Verify that a parser declaring `{ name = 'help', ... }` with `autoHelp = true` raises `ERR_DuplicateValue` with the expected message
- [ ] Verify that setting `autoHelp = false` still allows a `'help'` parameter to be declared without error
- [ ] Confirm that `is_true_help_value` no longer treats `'yes'` or `'on'` as truthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)