### PR TITLE
[Script] Fix help detection when a declared help parameter overrides built-in help

### DIFF
--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -794,7 +794,7 @@ end
 
 function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array)
    pos_index = 0
-   use_help_param = #Input is 1
+   use_help_param = #Input is 1 or (not Parser.autoHelp and Parser._named_lookup[Parser.helpArg] != nil)
 
    for token in values(Input) do
       assert(type(token) is 'string', 'Command-line input must contain strings')
@@ -1666,7 +1666,14 @@ function declared_help_result(Param:table, Value:any, HasExplicitValue:bool):<bo
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Detect manual help requests through a named help parameter when automatic help is disabled.
+-- Return true when the parser has a caller-declared help parameter that owns the help token.
+
+function has_declared_help_override(Parser:table):bool
+   return not Parser.autoHelp and Parser._named_lookup[Parser.helpArg] != nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Detect help requests through a caller-declared help parameter from older parser configurations.
 
 function find_declared_ordered_help(Parser:table, Input:array):<bool, str>
    if Parser.autoHelp then return false, nil end
@@ -1684,7 +1691,7 @@ function find_declared_ordered_help(Parser:table, Input:array):<bool, str>
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Detect manual help requests in keyed input when automatic help is disabled.
+-- Detect keyed help requests through a caller-declared help parameter from older parser configurations.
 
 function find_declared_table_help(Parser:table, Input:table):<bool, str>
    if Parser.autoHelp then return false, nil end
@@ -1698,10 +1705,10 @@ function find_declared_table_help(Parser:table, Input:table):<bool, str>
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Detect automatic help requests in ordered input.
+-- Detect explicit help requests in ordered input.
 
 function find_ordered_help(Parser:table, Input:array):<bool, str>
-   if not Parser.autoHelp then return false, nil end
+   if has_declared_help_override(Parser) then return false, nil end
    if #Input != 1 then return false, nil end
 
    name, value, has_explicit_value = split_token(Input[0])
@@ -1713,10 +1720,10 @@ function find_ordered_help(Parser:table, Input:array):<bool, str>
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Detect automatic help requests in keyed table input.
+-- Detect explicit help requests in keyed table input.
 
 function find_table_help(Parser:table, Input:table):<bool, str>
-   if not Parser.autoHelp then return false, nil end
+   if has_declared_help_override(Parser) then return false, nil end
 
    for name, value in pairs(Input) do
       if name is Parser.helpArg then
@@ -1729,10 +1736,10 @@ function find_table_help(Parser:table, Input:table):<bool, str>
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Detect automatic help requests through the arg() fallback.
+-- Detect explicit help requests through the arg() fallback.
 
 function find_arg_help(Parser:table):<bool, str>
-   if not Parser.autoHelp then return false, nil end
+   if has_declared_help_override(Parser) then return false, nil end
 
    value = arg(Parser.helpArg, nil)
    if value then
@@ -1994,8 +2001,8 @@ function reject_command_dispatch_collision(Parser:table, Name:str)
       raise ERR_DuplicateValue, f"Command name or alias '{Name}' conflicts with global no- token '{Name}'."
    end
 
-   if Parser.autoHelp and Name is Parser.helpArg then
-      raise ERR_DuplicateValue, f"Command name or alias '{Name}' conflicts with automatic help token '{Name}'."
+   if Name is Parser.helpArg then
+      raise ERR_DuplicateValue, f"Command name or alias '{Name}' conflicts with the reserved help token."
    end
 end
 
@@ -2162,7 +2169,7 @@ create_parser = function(Config:table):table
    Validates and registers a command definition supplied through `commands` or added after construction.  The
    definition may use `name` or `names`; when `names` is supplied, the first name is the canonical command name and
    later names are aliases.  Command aliases must be unique within the parser's command scope and must not collide
-   with global named parameters or the automatic help token.  Command `args` are parsed only after that command is
+   with global named parameters or the reserved help token.  Command `args` are parsed only after that command is
    selected, and command results are returned separately from global parser results.
 
    -INPUT-
@@ -2348,7 +2355,7 @@ create_parser = function(Config:table):table
    Options: Optional parser controls, currently `taskParameters`.
 
    -RESULT-
-   table: Parsed argument table, command result table, or `nil` when automatic help is handled.
+   table: Parsed argument table, command result table, or `nil` when help is handled.
    ]])
    parser.process = function(Input:any, Options:table):table
       local result, err = parser.tryProcess(Input, Options)

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -934,7 +934,55 @@ end
    error('addParam() should reject help parameters when automatic help is enabled')
 end
 
-@Test function ManualHelpParameterBypassesRequiredValidation()
+@Test function ExplicitHelpBypassesRequiredValidationWhenAutoHelpDisabled()
+   seen_text = nil
+   seen_topic = nil
+   parser = options({
+      name = 'convert',
+      autoHelp = false,
+      onHelp = function(Parser:table, Text:str, Topic:any)
+         seen_text = Text
+         seen_topic = Topic
+      end,
+      args = array<table> {
+         { name = 'input', kind = 'positional', type = 'file', required = true },
+         { name = 'output', kind = 'option', type = 'file', required = true }
+      }
+   })
+
+   returned = parser.process(array<string> { 'help' })
+   assert(returned is nil, 'Explicit help should be handled before required validation')
+   assert(seen_topic is nil, 'Bare help should request normal help')
+   assert(seen_text:find('Usage: convert'), 'Explicit help should generate normal help text')
+
+   result, err = parser.tryProcess(nil, {
+      taskParameters = array<string> { '--log-warning', 'test.tiri', 'help' }
+   })
+   assert(err is nil, 'Task-parameter help should not validate required arguments')
+   assert(result.help is true, 'Task-parameter help should return a structured help result')
+   assert(result.text:find('Usage: convert'), 'Task-parameter help should include normal help text')
+
+   result, err = parser.tryProcess(array<string> { 'help=output' })
+   assert(err is nil, 'Help topics should not validate required arguments')
+   assert(result.topic is 'output', 'Help should preserve explicit topics')
+   assert(result.text:find('output:'), 'Help topics should generate detailed help text')
+
+   positioned = options({
+      autoHelp = false,
+      args = array<table> {
+         { name = 'input', kind = 'positional', required = true },
+         { name = 'output', kind = 'positional', required = true }
+      }
+   })
+
+   args = positioned.process(array<string> { 'abc', 'help' })
+   assert(args.input is 'abc' and args.output is 'help', 'Manual help after another argument should parse normally')
+
+   args = positioned.process(array<string> { 'help', 'abc' })
+   assert(args.input is 'help' and args.output is 'abc', 'Manual help before another argument should parse normally')
+end
+
+@Test function DeclaredHelpParameterOverridesBuiltInHelpWhenAutoHelpDisabled()
    seen_text = nil
    seen_topic = nil
    parser = options({
@@ -952,38 +1000,27 @@ end
    })
 
    returned = parser.process(array<string> { 'help' })
-   assert(returned is nil, 'Manual help should be handled before required validation')
-   assert(seen_topic is nil, 'Manual bare help should request normal help')
-   assert(seen_text:find('Usage: convert'), 'Manual help should generate normal help text')
-
-   result, err = parser.tryProcess(nil, {
-      taskParameters = array<string> { '--log-warning', 'test.tiri', 'help' }
-   })
-   assert(err is nil, 'Manual task-parameter help should not validate required arguments')
-   assert(result.help is true, 'Manual task-parameter help should return a structured help result')
-   assert(result.text:find('Usage: convert'), 'Manual task-parameter help should include normal help text')
+   assert(returned is nil, 'Declared help should be handled before required validation')
+   assert(seen_topic is nil, 'Declared bare help should request normal help')
+   assert(seen_text:find('Usage: convert'), 'Declared help should generate normal help text')
 
    result, err = parser.tryProcess(array<string> { 'help=output' })
-   assert(err is nil, 'Manual help topics should not validate required arguments')
-   assert(result.topic is 'output', 'Manual help should preserve explicit topics')
-   assert(result.text:find('output:'), 'Manual help topics should generate detailed help text')
+   assert(err is nil, 'Declared help topics should not validate required arguments')
+   assert(result.topic is 'output', 'Declared help should preserve explicit topics')
+   assert(result.text:find('output:'), 'Declared help topics should generate detailed help text')
 
-   positioned = options({
+   args = parser.process(array<string> { 'input.svg', 'output=preview.png', 'help' })
+   assert(args.input is 'input.svg', 'Declared help after another argument should parse normally')
+   assert(args.output is 'preview.png', 'Declared help should not consume neighbouring arguments')
+   assert(args.help is true, 'Declared help after another argument should parse as the declared help flag')
+
+   args = options({
       autoHelp = false,
       args = array<table> {
-         { name = 'input', kind = 'positional', required = true },
-         { name = 'output', kind = 'positional', required = true },
          { name = 'help', kind = 'flag', type = 'bool' }
       }
-   })
-
-   args = positioned.process(array<string> { 'abc', 'help' })
-   assert(args.input is 'abc' and args.output is 'help', 'Manual help after another argument should parse normally')
-   assert(args.help is nil, 'Manual help after another argument should not parse as the declared help flag')
-
-   args = positioned.process(array<string> { 'help', 'abc' })
-   assert(args.input is 'help' and args.output is 'abc', 'Manual help before another argument should parse normally')
-   assert(args.help is nil, 'Manual help before another argument should not parse as the declared help flag')
+   }).process(array<string> { 'help=false' })
+   assert(args.help is false, 'Declared help=false should parse instead of falling through to built-in help')
 end
 
 @Test function UnsupportedHelpFormatsFail()
@@ -1010,13 +1047,19 @@ end
 
 @Test function AutoHelpCanBeDisabled()
    disabled = options({
+      name = 'viewer',
       autoHelp = false,
       args = array<table> {
-         { name = 'file' }
+         { name = 'file', required = true }
       }
    })
 
-   expect_error(disabled, array<string> { 'help' }, ERR_ParameterUnknown, "Unknown parameter 'help'.")
+   result, err = disabled.tryProcess(array<string> { 'help' })
+   assert(err is nil, 'Explicit help should still work when autoHelp is disabled')
+   assert(result.help is true, 'Explicit help should return a structured help result')
+   assert(result.text:find('Usage: viewer'), 'Explicit help should include normal help text')
+
+   expect_error(disabled, array<string> { }, ERR_ParameterRequired, "Required parameter 'file' is missing.")
 end
 
 @Test function OnErrorInstructions()
@@ -1168,17 +1211,14 @@ end
       commands = array<table> {
          { name = 'help' }
       }
-   }, ERR_DuplicateValue, "Command name or alias 'help' conflicts with automatic help token 'help'.")
+   }, ERR_DuplicateValue, "Command name or alias 'help' conflicts with the reserved help token.")
 
-   help_command = options({
+   expect_options_error({
       autoHelp = false,
       commands = array<table> {
          { name = 'help' }
       }
-   })
-
-   result = help_command.process(array<string> { 'help' })
-   assert(result.command is 'help', 'Disabling automatic help should allow a help command')
+   }, ERR_DuplicateValue, "Command name or alias 'help' conflicts with the reserved help token.")
 end
 
 @Test function LaterGlobalParamCannotHideCommand()


### PR DESCRIPTION
* Add has_declared_help_override() helper to identify when a caller-declared help parameter should take precedence
* Update find_ordered_help(), find_table_help(), and find_arg_help() to defer to declared help parameters rather than checking autoHelp directly
* Ensure the explicit 'help' token still triggers built-in help when autoHelp is disabled and no declared parameter exists
* Reserve the help token for conflict detection regardless of autoHelp setting
* Add DeclaredHelpParameterOverridesBuiltInHelpWhenAutoHelpDisabled test covering declared help flag behaviour
* Rename ManualHelpParameterBypassesRequiredValidation to ExplicitHelpBypassesRequiredValidationWhenAutoHelpDisabled
* Update AutoHelpCanBeDisabled test to verify built-in help remains accessible when autoHelp is false