### PR TITLE
Add Tuku HTTP command-line application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -758,6 +758,7 @@ add_subdirectory (src/regex)
 
 add_subdirectory (src/launcher)
 
+add_subdirectory (apps)
 add_subdirectory (tools/tiri_lsp)
 
 # --------------------------------------------------------------------------------------------------------------------
@@ -838,6 +839,7 @@ if (KOTUKU_INSTALL)
       "${PROJECT_SOURCE_DIR}/apps/httpserver.tiri"
       "${PROJECT_SOURCE_DIR}/apps/httpserver_cfg.tiri"
       "${PROJECT_SOURCE_DIR}/apps/paintbox.tiri"
+      "${PROJECT_SOURCE_DIR}/apps/tuku.tiri"
       "${PROJECT_SOURCE_DIR}/apps/vuepoint.tiri"
       DESTINATION "${SHARE_TARGET}/apps")
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Application script tests.
+
+if (NOT DISABLE_HTTP AND NOT DISABLE_NETWORK)
+   flute_test (apps_tuku "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tuku.tiri")
+endif ()

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -1,0 +1,169 @@
+-- Flute tests for the Tuku command-line HTTP client.
+
+   import 'net/httpserver'
+
+SERVER_PORT <const> = 18952
+glOutputFile <const> = 'temp:tuku-test-output.txt'
+
+function resolveFirstPath(Candidates:array):str
+   for candidate in values(Candidates) do
+      err, resolved = mSys.ResolvePath(candidate)
+      if err is ERR_Okay then return resolved end
+   end
+
+   error('Unable to resolve any candidate path')
+end
+
+@BeforeAll function init(State)
+   global glOrigoPath = resolveFirstPath(array<string> {
+      'build/agents-install/origo',
+      'build/agents-install/origo.exe',
+      'origo',
+      'origo.exe',
+      '../agents-install/origo',
+      '../agents-install/origo.exe',
+      '../../build/agents-install/origo',
+      '../../build/agents-install/origo.exe'
+   })
+   global glTukuPath = resolveFirstPath(array<string> {
+      'apps/tuku.tiri',
+      '../agents-install/apps/tuku.tiri',
+      '../../apps/tuku.tiri'
+   })
+
+   global glServer = hslib.start({
+      port    = SERVER_PORT,
+      folder  = State.folder,
+      verbose = true,
+      routes = {
+         { pattern = '/hello',
+            method = 'GET',
+            handler = function(req, res)
+               res.send('hello from tuku')
+            end
+         },
+         { pattern = '/head',
+            method = 'GET',
+            handler = function(req, res)
+               res.send('')
+            end
+         },
+         { pattern = '/options',
+            method = 'OPTIONS',
+            handler = function(req, res)
+               res.status(204).send('')
+            end
+         }
+      }
+   })
+end
+
+@AfterAll function cleanup()
+   glServer.stop()
+   mSys.DeleteFile(glOutputFile)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+function runTuku(Parameters:array):table
+   local output = ''
+   local errors = ''
+   local task_params = array<string> { glTukuPath }
+
+   for param in values(Parameters) do
+      task_params:push(param)
+   end
+   task_params:push('--log-warning')
+
+   local task = obj.new('task', {
+      src = glOrigoPath,
+      args = task_params:join(' '),
+      flags = TSF_WAIT,
+      timeOut = 10,
+      outputCallback = function(Task:obj, Buffer:array)
+         output ..= Buffer:getString()
+      end,
+      errorCallback = function(Task:obj, Buffer:array)
+         errors ..= Buffer:getString()
+      end
+   })
+
+   check task.acActivate()
+
+   return {
+      returnCode = task.returnCode,
+      output     = output,
+      errors     = errors,
+      text       = output .. errors
+   }
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineHelpListsFutureOptions()
+   result = runTuku(array<string> { 'help' })
+
+   assert(result.returnCode is 0, 'Help should return 0, got ' .. result.returnCode)
+   assert(result.text:find('header=HEADER'), 'Help should include future header option')
+   assert(result.text:find('json=JSON'), 'Help should include future JSON option')
+   assert(result.text:find('debug-socket'), 'Help should include future socket debug option')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRejectsFutureBodyOptionsForPhaseOne()
+   result = runTuku(array<string> { f'url=http://127.0.0.1:{SERVER_PORT}/hello', 'json={}' })
+
+   assert(result.returnCode != 0, 'Future body option should fail in phase 1')
+   assert(result.errors:find('Phase 1 supports'), 'Unexpected error output: ' .. result.errors)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineParserErrorsFail()
+   result = runTuku(array<string> { 'timeout=abc' })
+
+   assert(result.returnCode != 0, 'Parser-level argument errors should fail')
+   assert(result.text:find("Parameter 'timeout' requires a number."),
+      'Unexpected parser error output: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFetchWritesOutputFile()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'output=' .. glOutputFile,
+      'timeout=5',
+      'connect-timeout=2',
+      'data-timeout=3'
+   })
+
+   assert(result.returnCode is 0, 'GET should return 0, got ' .. result.returnCode .. ': ' .. result.errors)
+   assert(io.readAll(glOutputFile) is 'hello from tuku', 'Output file content mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineHeadAndOptionsStatus()
+   head_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/head',
+      'method=head',
+      'status',
+      'timeout=5'
+   })
+
+   assert(head_result.returnCode is 0, 'HEAD should return 0: ' .. head_result.errors)
+   assert(head_result.text:trim() is '200', 'HEAD status should be 200, got ' .. head_result.text)
+
+   options_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/options',
+      'method=options',
+      'status',
+      'timeout=5'
+   })
+
+   assert(options_result.returnCode is 0, 'OPTIONS should return 0: ' .. options_result.errors)
+   assert(options_result.text:trim() is '200' or options_result.text:trim() is '204',
+      'OPTIONS status should be successful, got ' .. options_result.text)
+end

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -44,6 +44,20 @@ end
                res.send('hello from tuku')
             end
          },
+         { pattern = '/headers',
+            method = 'GET',
+            handler = function(req, res)
+               res.header('Content-Type', 'text/plain')
+               res.header('Location', '/next')
+               res.send('header-body')
+            end
+         },
+         { pattern = '/missing',
+            method = 'GET',
+            handler = function(req, res)
+               res.status(404).send('missing')
+            end
+         },
          { pattern = '/head',
             method = 'GET',
             handler = function(req, res)
@@ -283,4 +297,70 @@ end
    assert(options_result.returnCode is 0, 'OPTIONS should return 0: ' .. options_result.errors)
    assert(options_result.text:trim() is '200' or options_result.text:trim() is '204',
       'OPTIONS status should be successful, got ' .. options_result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineStatusOnlyUsesStdout()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Status-only GET should return 0: ' .. result.errors)
+   assert(result.output is '200\n', 'Status should be written predictably to stdout, got: ' .. result.output)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFailTreatsHttpErrorStatusAsFailure()
+   normal_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/missing',
+      'status',
+      'timeout=5'
+   })
+
+   assert(normal_result.returnCode is 0, 'HTTP 404 should not fail without fail=true: ' .. normal_result.errors)
+   assert(normal_result.output is '404\n', 'Non-failing 404 should still report status, got: ' .. normal_result.text)
+
+   fail_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/missing',
+      'fail',
+      'status',
+      'timeout=5'
+   })
+
+   assert(fail_result.returnCode != 0, 'HTTP 404 should fail when fail=true')
+   assert(fail_result.output is '404\n', 'Failing HTTP status should still be printed predictably')
+   assert(fail_result.text:find('tuku: error: type=http status=404'),
+      'Structured HTTP error line missing: ' .. fail_result.text)
+   assert(fail_result.text:find('HTTP status 404'), 'HTTP failure message missing: ' .. fail_result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineVerbosePrintsSummaryAndSelectedHeaders()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/headers',
+      'output=' .. glOutputFile,
+      'verbose',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Verbose GET should return 0: ' .. result.errors)
+   assert(io.readAll(glOutputFile) is 'header-body', 'Verbose output file content mismatch')
+   assert(result.text:find('tuku: method=GET'), 'Verbose summary should include method: ' .. result.text)
+   assert(result.text:find(f'tuku: url=http://127.0.0.1:{SERVER_PORT}/headers'),
+      'Verbose summary should include URL: ' .. result.text)
+   assert(result.text:find('tuku: status=200'), 'Verbose summary should include status: ' .. result.text)
+   assert(result.text:find('tuku: bytes=11'), 'Verbose summary should include byte count: ' .. result.text)
+   assert(result.text:find('tuku: output=' .. glOutputFile), 'Verbose summary should include output target')
+   assert(result.text:find('tuku: transport=Okay'), 'Verbose summary should include transport status')
+   assert(result.text:find('tuku: header content-type='),
+      'Verbose summary should include content-type header: ' .. result.text)
+   assert(result.text:find('tuku: header content-length=11'),
+      'Verbose summary should include content-length header: ' .. result.text)
+   assert(result.text:find('tuku: header location=/next'),
+      'Verbose summary should include location header: ' .. result.text)
 end

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -49,7 +49,24 @@ end
             handler = function(req, res)
                res.header('Content-Type', 'text/plain')
                res.header('Location', '/next')
+               res.header('X-Tuku-List', 'yes')
                res.send('header-body')
+            end
+         },
+         { pattern = '/range',
+            method = 'GET',
+            handler = function(req, res)
+               if req.headers['range'] is 'bytes=6-' then
+                  res.status(206).header('Content-Range', 'bytes 6-14/15').send('from tuku', 'text/plain')
+               else
+                  res.send('hello from tuku', 'text/plain')
+               end
+            end
+         },
+         { pattern = f'/http:/127.0.0.1:{SERVER_PORT}/proxy-target',
+            method = 'GET',
+            handler = function(req, res)
+               res.send('proxied tuku', 'text/plain')
             end
          },
          { pattern = '/missing',
@@ -145,6 +162,7 @@ end
    result = runTuku(array<string> { 'help' })
 
    assert(result.returnCode is 0, 'Help should return 0, got ' .. result.returnCode)
+   assert(result.text:find('headers'), 'Help should include response headers option')
    assert(result.text:find('header=HEADER'), 'Help should include future header option')
    assert(result.text:find('json=JSON'), 'Help should include future JSON option')
    assert(result.text:find('debug-socket'), 'Help should include future socket debug option')
@@ -363,4 +381,122 @@ end
       'Verbose summary should include content-length header: ' .. result.text)
    assert(result.text:find('tuku: header location=/next'),
       'Verbose summary should include location header: ' .. result.text)
+   assert(result.text:find('tuku: header x-tuku-list=yes'),
+      'Verbose summary should include enumerated custom response header: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineHeadersPrintsFullResponseHeaderList()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/headers',
+      'headers',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Headers mode should return 0: ' .. result.errors)
+   assert(result.text:find('tuku: header content-length=11'),
+      'Headers mode should include content-length: ' .. result.text)
+   assert(result.text:find('tuku: header location=/next'),
+      'Headers mode should include location: ' .. result.text)
+   assert(result.text:find('tuku: header x-tuku-list=yes'),
+      'Headers mode should include custom enumerated response header: ' .. result.text)
+   assert(result.output is '200\n', 'Headers and status output should keep status on stdout: ' .. result.output)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineResumesOutputDownload()
+   io.writeAll(glOutputFile, 'hello ')
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/range',
+      'output=' .. glOutputFile,
+      'resume',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Resume download should return 0: ' .. result.errors)
+   assert(io.readAll(glOutputFile) is 'hello from tuku', 'Resume download should append ranged content')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineValidatesResumeRequirements()
+   no_output = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/range',
+      'resume',
+      'timeout=5'
+   })
+
+   assert(no_output.returnCode != 0, 'Resume without output should fail')
+   assert(no_output.text:find("Parameter 'resume' requires 'output'."),
+      'Resume without output diagnostic mismatch: ' .. no_output.text)
+
+   post_resume = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'output=' .. glOutputFile,
+      'resume',
+      'data=body',
+      'timeout=5'
+   })
+
+   assert(post_resume.returnCode != 0, 'Resume with POST should fail')
+   assert(post_resume.text:find("Parameter 'resume' can only be used with method=get."),
+      'Resume method diagnostic mismatch: ' .. post_resume.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineAcceptsTransferControlFlags()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'raw',
+      'no-head',
+      'debug-socket',
+      'insecure',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Transfer control flags should be accepted: ' .. result.errors)
+   assert(result.output is '200\n', 'Transfer control flags should not disrupt status output: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineProxyParsesHostPort()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/proxy-target',
+      f'proxy=127.0.0.1:{SERVER_PORT}',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Proxy request should return 0: ' .. result.errors)
+   assert(result.output is 'proxied tuku', 'Proxy request body mismatch: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRejectsInvalidProxy()
+   missing_port = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'proxy=127.0.0.1',
+      'timeout=5'
+   })
+
+   assert(missing_port.returnCode != 0, 'Proxy without port should fail')
+   assert(missing_port.text:find("Parameter 'proxy' must use host:port syntax."),
+      'Proxy missing port diagnostic mismatch: ' .. missing_port.text)
+
+   bad_port = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'proxy=127.0.0.1:70000',
+      'timeout=5'
+   })
+
+   assert(bad_port.returnCode != 0, 'Proxy with out-of-range port should fail')
+   assert(bad_port.text:find("Parameter 'proxy' requires a port between 1 and 65535."),
+      'Proxy bad port diagnostic mismatch: ' .. bad_port.text)
 end

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -1,9 +1,11 @@
 -- Flute tests for the Tuku command-line HTTP client.
 
    import 'net/httpserver'
+   import 'json'
 
 SERVER_PORT <const> = 18952
 glOutputFile <const> = 'temp:tuku-test-output.txt'
+glBodyFile <const> = 'temp:tuku-test-body.txt'
 
 function resolveFirstPath(Candidates:array):str
    for candidate in values(Candidates) do
@@ -53,6 +55,20 @@ end
             handler = function(req, res)
                res.status(204).send('')
             end
+         },
+         { pattern = '/echo',
+            method = 'POST',
+            handler = function(req, res)
+               res.json({
+                  method      = req.method,
+                  body        = req.body,
+                  contentType = req.headers['content-type'],
+                  userAgent   = req.headers['user-agent'],
+                  accept      = req.headers['accept'],
+                  custom      = req.headers['x-tuku-test'],
+                  parsedBody  = req.parsedBody
+               })
+            end
          }
       }
    })
@@ -61,6 +77,17 @@ end
 @AfterAll function cleanup()
    glServer.stop()
    mSys.DeleteFile(glOutputFile)
+   mSys.DeleteFile(glBodyFile)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+function quoteTaskParam(Param:str):str
+   if Param:find(' ') is nil and Param:find('"') is nil then
+      return Param
+   end
+
+   return '"' .. Param:replace('"', '\\"') .. '"'
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -71,7 +98,7 @@ function runTuku(Parameters:array):table
    local task_params = array<string> { glTukuPath }
 
    for param in values(Parameters) do
-      task_params:push(param)
+      task_params:push(quoteTaskParam(param))
    end
    task_params:push('--log-warning')
 
@@ -111,11 +138,16 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-@Test function CommandLineRejectsFutureBodyOptionsForPhaseOne()
-   result = runTuku(array<string> { f'url=http://127.0.0.1:{SERVER_PORT}/hello', 'json={}' })
+@Test function CommandLineRejectsIncompatibleBodyOptions()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'data=plain',
+      'json={}'
+   })
 
-   assert(result.returnCode != 0, 'Future body option should fail in phase 1')
-   assert(result.errors:find('Phase 1 supports'), 'Unexpected error output: ' .. result.errors)
+   assert(result.returnCode != 0, 'Incompatible body options should fail')
+   assert(result.text:find("Parameter 'data' excludes 'json'."),
+      'Unexpected body option error output: ' .. result.text)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -141,6 +173,91 @@ end
 
    assert(result.returnCode is 0, 'GET should return 0, got ' .. result.returnCode .. ': ' .. result.errors)
    assert(io.readAll(glOutputFile) is 'hello from tuku', 'Output file content mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLinePostsDataAndCustomHeaders()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'data=plain-body',
+      'contenttype=text/plain',
+      'header={X-Tuku-Test:phase2,Accept:application/json}',
+      'useragent=Tuku-Test/2.0',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'POST data should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.method is 'POST', 'Body option should imply POST')
+   assert(response.body is 'plain-body', 'POST body mismatch: ' .. tostring(response.body))
+   assert(response.contentType is 'text/plain', 'Content-Type header mismatch')
+   assert(response.custom is 'phase2', 'Custom header mismatch')
+   assert(response.accept is 'application/json', 'Accept header mismatch')
+   assert(response.userAgent is 'Tuku-Test/2.0', 'User-Agent header mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLinePostsJsonAndFormBodies()
+   json_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'json=[1,2,3]',
+      'timeout=5'
+   })
+
+   assert(json_result.returnCode is 0, 'JSON POST should return 0: ' .. json_result.errors)
+   json_response = json.decode(json_result.output)
+   assert(json_response.contentType is 'application/json', 'JSON should set application/json content type')
+   assert(json_response.parsedBody[0] is 1, 'JSON array body should be parsed by the server')
+   assert(json_response.parsedBody[2] is 3, 'JSON array body value mismatch')
+
+   form_result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'form={name=Ada,email=ada@example.com}',
+      'timeout=5'
+   })
+
+   assert(form_result.returnCode is 0, 'Form POST should return 0: ' .. form_result.errors)
+   form_response = json.decode(form_result.output)
+   assert(form_response.contentType is 'application/x-www-form-urlencoded',
+      'Form should set application/x-www-form-urlencoded content type')
+   assert(form_response.body is 'name=Ada&email=ada%40example.com',
+      'Form body was not URL encoded as expected: ' .. tostring(form_response.body))
+   assert(form_response.parsedBody.name is 'Ada', 'Form name should round-trip')
+   assert(form_response.parsedBody.email is 'ada@example.com', 'Form email should round-trip')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLinePostsDataFile()
+   io.writeAll(glBodyFile, 'file-body')
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'datafile=' .. glBodyFile,
+      'contenttype=text/plain',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Data file POST should return 0: ' .. result.errors)
+   response = json.decode(result.output)
+   assert(response.body is 'file-body', 'Data file body mismatch')
+   assert(response.contentType is 'text/plain', 'Data file content type mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineAcceptsUserCredentials()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/hello',
+      'user=tuku:pass',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'GET with user credentials should return 0: ' .. result.errors)
+   assert(result.output is 'hello from tuku', 'User credentials should not disrupt normal GET output')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -63,6 +63,12 @@ end
                end
             end
          },
+         { pattern = '/range-ignore',
+            method = 'GET',
+            handler = function(req, res)
+               res.send('hello from tuku', 'text/plain')
+            end
+         },
          { pattern = f'/http:/127.0.0.1:{SERVER_PORT}/proxy-target',
             method = 'GET',
             handler = function(req, res)
@@ -108,6 +114,7 @@ end
 @AfterAll function cleanup()
    glServer.stop()
    mSys.DeleteFile(glOutputFile)
+   mSys.DeleteFile(glOutputFile .. '.tuku-resume')
    mSys.DeleteFile(glBodyFile)
 end
 
@@ -407,6 +414,24 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function CommandLineSilentSuppressesNonBodyOutput()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/headers',
+      'output=' .. glOutputFile,
+      'silent',
+      'verbose',
+      'headers',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Silent diagnostic suppression should return 0: ' .. result.errors)
+   assert(io.readAll(glOutputFile) is 'header-body', 'Silent request should still write the response body')
+   assert(result.text is '', 'Silent should suppress verbose, header and status output: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function CommandLineResumesOutputDownload()
    io.writeAll(glOutputFile, 'hello ')
 
@@ -419,6 +444,24 @@ end
 
    assert(result.returnCode is 0, 'Resume download should return 0: ' .. result.errors)
    assert(io.readAll(glOutputFile) is 'hello from tuku', 'Resume download should append ranged content')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineResumeRejectsFullResponse()
+   io.writeAll(glOutputFile, 'hello ')
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/range-ignore',
+      'output=' .. glOutputFile,
+      'resume',
+      'timeout=5'
+   })
+
+   assert(result.returnCode != 0, 'Resume should fail when the server ignores Range')
+   assert(io.readAll(glOutputFile) is 'hello ', 'Resume should leave the partial output file unchanged')
+   assert(result.text:find('Resume request returned HTTP 200 instead of 206 Partial Content.'),
+      'Resume non-206 diagnostic mismatch: ' .. result.text)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -1,0 +1,232 @@
+#!/usr/bin/env origo
+--[[
+Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.
+--]]
+
+   include 'http'
+   import 'options'
+
+TUKU_VERSION <const> = '1.0'
+TUKU_USER_AGENT <const> = 'Tuku/1.0 Kotuku'
+
+glOptionDefs = array<table> {
+   { name = 'url', type = 'str', group = 'Core',
+     comment = 'Target HTTP or HTTPS URL.' },
+   { name = 'method', type = 'enum', choices = array<string> { 'get', 'head', 'delete', 'options', 'post', 'put' },
+     default = 'get', group = 'Core', comment = 'HTTP method to use.' },
+   { name = 'version', kind = 'flag', group = 'Core',
+     comment = 'Print the Tuku version.' },
+
+   { name = 'output', type = 'file', group = 'Output',
+     comment = 'Save the response body to a file.' },
+   { name = 'status', kind = 'flag', group = 'Output',
+     comment = 'Print the numeric HTTP status.' },
+   { name = 'silent', kind = 'flag', group = 'Output',
+     comment = 'Suppress non-body output.' },
+   { name = 'verbose', kind = 'flag', group = 'Output',
+     comment = 'Print transfer summary information.' },
+   { name = 'fail', kind = 'flag', group = 'Output',
+     comment = 'Treat HTTP 4xx and 5xx statuses as failures.' },
+
+   { name = 'data', type = 'str', group = 'Request Body',
+     excludes = array<string> { 'datafile', 'json', 'form' },
+     comment = 'Send a string request body.' },
+   { name = 'datafile', type = 'file', exists = true, group = 'Request Body',
+     excludes = array<string> { 'data', 'json', 'form' },
+     comment = 'Read the request body from a file.' },
+   { name = 'json', type = 'str', group = 'Request Body',
+     excludes = array<string> { 'data', 'datafile', 'form' },
+     comment = 'Send a JSON request body.' },
+   { name = 'form', type = 'array', group = 'Request Body',
+     excludes = array<string> { 'data', 'datafile', 'json' },
+     comment = 'Send form fields as name=value entries.' },
+   { name = 'contenttype', type = 'str', group = 'Request Body',
+     comment = 'Request Content-Type header.' },
+
+   { name = 'header', type = 'array', group = 'Request Headers',
+     comment = 'Custom request header entries in Name: Value form.' },
+   { name = 'useragent', type = 'str', default = TUKU_USER_AGENT, group = 'Request Headers',
+     comment = 'User-Agent request header.' },
+   { name = 'user', type = 'str', group = 'Request Headers',
+     comment = 'Authentication credentials as username:password.' },
+
+   { name = 'timeout', type = 'num', default = 30, group = 'Connection',
+     comment = 'Overall transfer timeout in seconds.' },
+   { name = 'connect-timeout', type = 'num', default = 10, group = 'Connection',
+     comment = 'Initial connection timeout in seconds.' },
+   { name = 'data-timeout', type = 'num', default = 30, group = 'Connection',
+     comment = 'Send/receive data timeout in seconds.' },
+   { name = 'proxy', type = 'str', group = 'Connection',
+     comment = 'Proxy server as host:port.' },
+   { name = 'insecure', kind = 'flag', group = 'Connection',
+     comment = 'Disable SSL server certificate verification.' },
+
+   { name = 'resume', kind = 'flag', group = 'Transfer Controls',
+     comment = 'Resume a partial download.' },
+   { name = 'raw', kind = 'flag', group = 'Transfer Controls',
+     comment = 'Disable HTTP chunk handling.' },
+   { name = 'no-head', kind = 'flag', group = 'Transfer Controls',
+     comment = 'Do not send a HEAD probe before upload methods.' },
+   { name = 'debug-socket', kind = 'flag', group = 'Transfer Controls',
+     comment = 'Log request socket headers and data.' }
+}
+
+glParser = options({
+   name        = 'Tuku',
+   description = 'Transfer data from an HTTP or HTTPS URL.',
+   epilog      = 'Examples: origo apps/tuku.tiri url=https://example.com output=page.html',
+   args        = glOptionDefs
+})
+
+----------------------------------------------------------------------------------------------------------------------
+-- Returns true when the command-line options include any supported request body source.
+
+function hasBodyOption(Args:table):bool
+   return Args.data != nil or Args.datafile != nil or Args.json != nil or Args.form != nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Ensures that numeric timeout values are valid before the request is started.
+
+function requirePositive(Name:str, Value:num)
+   if Value <= 0 then
+      error(f"Parameter '{Name}' must be greater than zero.")
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Rejects command-line options that are declared now but intentionally deferred to a later implementation phase.
+
+function rejectPhaseFuture(Name:str)
+   error(f"Parameter '{Name}' is reserved for a later Tuku phase.")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Validates the Phase 1 option set and reports unsupported methods or deferred parameters as argument errors.
+
+function validatePhaseOneArgs(Args:table)
+   if Args.version then return end
+
+   if Args.url is nil then
+      error("Required parameter 'url' is missing.")
+   end
+
+   requirePositive('timeout', Args.timeout)
+   requirePositive('connect-timeout', Args['connect-timeout'])
+   requirePositive('data-timeout', Args['data-timeout'])
+
+   if Args.url:startsWith('http://') is false and Args.url:startsWith('https://') is false then
+      error("Parameter 'url' must start with http:// or https://.")
+   end
+
+   if Args.method != 'get' and Args.method != 'head' and Args.method != 'delete' and Args.method != 'options' then
+      error("Phase 1 supports method=get, method=head, method=delete, and method=options.")
+   end
+
+   if Args.fail then rejectPhaseFuture('fail') end
+   if Args.verbose then rejectPhaseFuture('verbose') end
+   if Args.data != nil then rejectPhaseFuture('data') end
+   if Args.datafile != nil then rejectPhaseFuture('datafile') end
+   if Args.json != nil then rejectPhaseFuture('json') end
+   if Args.form != nil then rejectPhaseFuture('form') end
+   if Args.contenttype != nil then rejectPhaseFuture('contenttype') end
+   if Args.header != nil then rejectPhaseFuture('header') end
+   if Args.user != nil then rejectPhaseFuture('user') end
+   if Args.proxy != nil then rejectPhaseFuture('proxy') end
+   if Args.insecure then rejectPhaseFuture('insecure') end
+   if Args.resume then rejectPhaseFuture('resume') end
+   if Args.raw then rejectPhaseFuture('raw') end
+   if Args['no-head'] then rejectPhaseFuture('no-head') end
+   if Args['debug-socket'] then rejectPhaseFuture('debug-socket') end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Normalises derived argument values, including method casing and implicit content types, before validation.
+
+function normaliseArgs(Args:table):table
+   Args.method = Args.method:lower()
+
+   if hasBodyOption(Args) and Args.method is 'get' then
+      Args.method = 'post'
+   end
+
+   if Args.json != nil and Args.contenttype is nil then
+      Args.contenttype = 'application/json'
+   elseif Args.form != nil and Args.contenttype is nil then
+      Args.contenttype = 'application/x-www-form-urlencoded'
+   end
+
+   validatePhaseOneArgs(Args)
+   return Args
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Builds the HTTP object configuration table from validated command-line arguments.
+
+function makeRequestConfig(Args:table):table
+   request = {
+      src            = Args.url,
+      method         = Args.method,
+      connectTimeout = Args['connect-timeout'],
+      dataTimeout    = Args['data-timeout'],
+      userAgent      = Args.useragent,
+      -- Wakes the waiting processing context when the HTTP transfer reaches a terminal state.
+      stateChanged   = function(HTTP:obj, State:num)
+         if State is HGS_COMPLETED or State is HGS_TERMINATED then
+            HTTP.acSignal()
+         end
+      end
+   }
+
+   if Args.output != nil then
+      request.outputFile = Args.output
+   elseif not Args.status then
+      -- Streams response body chunks to standard output when the body is not redirected or suppressed.
+      request.incoming = function(HTTP:obj, Buffer:array)
+         io.write(Buffer:getString())
+      end
+   end
+
+   return request
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Starts the HTTP transfer, waits for completion, and returns the response summary used by output handling.
+
+function fetch(Args:table):table
+   local http = obj.new('http', makeRequestConfig(Args))
+   proc = processing.new({ timeout = Args.timeout, signals = array<object> { http } })
+
+   err = http.acActivate() -- Send asynchronous request
+   assert(err is ERR_Okay, 'Failed to start HTTP request: ' .. mSys.GetErrorMsg(err))
+
+   err = proc.sleep()
+   assert(err is ERR_Okay, 'HTTP request did not complete: ' .. mSys.GetErrorMsg(err))
+
+   if (http.currentState is HGS_TERMINATED or http.error != ERR_Okay) and http.status <= 0 then
+      error('HTTP request failed: ' .. mSys.GetErrorMsg(http.error))
+   end
+
+   return {
+      status = http.status,
+      bytes  = http.index,
+      output = Args.output
+   }
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+   args = glParser.process()
+   if args is nil then return end
+
+   args = normaliseArgs(args)
+
+   if args.version then
+      print('Tuku ' .. TUKU_VERSION)
+      return
+   end
+
+   result = fetch(args)
+   if args.status then
+      print(result.status)
+   end

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -9,6 +9,8 @@ Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.
 
 TUKU_VERSION <const> = '2026.5.7'
 TUKU_USER_AGENT <const> = 'Tuku/1.0 Kotuku'
+glResponseHeaderNames = array<string> { 'content-type', 'content-length', 'location' }
+glReportedError = false
 
 glOptionDefs = array<table> {
    { name = 'url', type = 'str', group = 'Core',
@@ -173,8 +175,6 @@ function validateArgs(Args:table)
       error("Parameter 'url' must start with http:// or https://.")
    end
 
-   if Args.fail then rejectPhaseFuture('fail') end
-   if Args.verbose then rejectPhaseFuture('verbose') end
    if Args.proxy != nil then rejectPhaseFuture('proxy') end
    if Args.insecure then rejectPhaseFuture('insecure') end
    if Args.resume then rejectPhaseFuture('resume') end
@@ -285,6 +285,82 @@ function applyRequestHeaders(HTTP:obj, Args:table)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Prints a stable, machine-friendly error line before raising a command failure.
+
+function reportError(Type:str, Message:str, Status:num, Code:num)
+   text = f"tuku: error: type={Type}"
+   if Status != nil then text ..= f" status={Status}" end
+   if Code != nil then text ..= f" code={Code}" end
+   text ..= " message=" .. Message
+
+   glReportedError = true
+   print(text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Looks up a response header through HTTP.GetKey(), returning nil when the class does not expose it.
+
+function getResponseHeader(HTTP:obj, Name:str):str
+   value = HTTP.getKey(Name)
+   if value is nil or value is '' then return nil end
+   return value
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Returns the selected response headers that are useful for command-line automation.
+
+function readResponseHeaders(HTTP:obj):table
+   headers = {}
+
+   for name in values(glResponseHeaderNames) do
+      value = getResponseHeader(HTTP, name)
+      if value != nil then
+         headers[name] = value
+      end
+   end
+
+   return headers
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Prints the verbose transfer summary in a stable line-oriented format.
+
+function printVerboseSummary(Args:table, Result:table)
+   print('tuku: method=' .. Args.method:upper())
+   print('tuku: url=' .. Args.url)
+   print('tuku: status=' .. tostring(Result.status))
+   print('tuku: bytes=' .. tostring(Result.bytes))
+   print('tuku: output=' .. (Result.output ?? 'stdout'))
+   print('tuku: transport=' .. Result.transportErrorText)
+
+   for name in values(glResponseHeaderNames) do
+      value = Result.headers[name]
+      if value != nil then
+         print(f"tuku: header {name}={value}")
+      end
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Parses command-line options while keeping help and parser errors under Tuku's output policy.
+
+function parseCommandLine():table
+   args, err = glParser.tryProcess()
+
+   if err != nil then
+      reportError('argument', err.message, nil, err.code)
+      raise err.code, err.message
+   end
+
+   if args != nil and args.text != nil and args._helpMarker != nil then
+      print(args.text)
+      return nil
+   end
+
+   return args
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Starts the HTTP transfer, waits for completion, and returns the response summary used by output handling.
 
 function fetch(Args:table):table
@@ -293,35 +369,61 @@ function fetch(Args:table):table
    proc = processing.new({ timeout = Args.timeout, signals = array<object> { http } })
 
    err = http.acActivate() -- Send asynchronous request
-   assert(err is ERR_Okay, 'Failed to start HTTP request: ' .. mSys.GetErrorMsg(err))
+   if err is ERR_Okay then
+      err = proc.sleep()
+   end
 
-   err = proc.sleep()
-   assert(err is ERR_Okay, 'HTTP request did not complete: ' .. mSys.GetErrorMsg(err))
-
-   if (http.currentState is HGS_TERMINATED or http.error != ERR_Okay) and http.status <= 0 then
-      error('HTTP request failed: ' .. mSys.GetErrorMsg(http.error))
+   transport_error = http.error
+   if err != ERR_Okay and transport_error is ERR_Okay then
+      transport_error = err
    end
 
    return {
-      status = http.status,
-      bytes  = http.index,
-      output = Args.output
+      status             = http.status,
+      bytes              = http.index,
+      output             = Args.output,
+      headers            = readResponseHeaders(http),
+      transportError     = transport_error,
+      transportErrorText = (transport_error is ERR_Okay) ? 'Okay' :> mSys.GetErrorMsg(transport_error)
    }
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-   args = glParser.process()
-   if args is nil then return end
+   try
+      args = parseCommandLine()
+      if args is nil then return end
 
-   args = normaliseArgs(args)
+      args = normaliseArgs(args)
 
-   if args.version then
-      print('Tuku ' .. TUKU_VERSION)
-      return
-   end
+      if args.version then
+         print('Tuku ' .. TUKU_VERSION)
+         return
+      end
 
-   result = fetch(args)
-   if args.status then
-      print(result.status)
+      result = fetch(args)
+
+      if args.verbose then
+         printVerboseSummary(args, result)
+      end
+
+      if args.status then
+         io.write(tostring(result.status) .. '\n')
+      end
+
+      if result.transportError != ERR_Okay and result.status <= 0 then
+         reportError('transport', result.transportErrorText, result.status, result.transportError)
+         raise ERR_Failed, result.transportErrorText
+      end
+
+      if args.fail and result.status >= 400 then
+         message = f"HTTP status {result.status}"
+         reportError('http', message, result.status, ERR_Failed)
+         raise ERR_Failed, message
+      end
+   except ex
+      if not glReportedError then
+         reportError('runtime', ex.message, nil, ex.code)
+      end
+      raise ex.code, ex.message
    end

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -24,6 +24,8 @@ glOptionDefs = array<table> {
      comment = 'Save the response body to a file.' },
    { name = 'status', kind = 'flag', group = 'Output',
      comment = 'Print the numeric HTTP status.' },
+   { name = 'headers', kind = 'flag', group = 'Output',
+     comment = 'Print all response headers as key=value lines.' },
    { name = 'silent', kind = 'flag', group = 'Output',
      comment = 'Suppress non-body output.' },
    { name = 'verbose', kind = 'flag', group = 'Output',
@@ -142,6 +144,30 @@ function splitUser(User:str):<str, str>
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Splits host:port proxy arguments into the HTTP fields used by the client object.
+
+function splitProxy(Proxy:str):<str, num>
+   colon = Proxy:find(':')
+   if colon is nil then
+      error("Parameter 'proxy' must use host:port syntax.")
+   end
+
+   host = Proxy:substr(0, colon):trim()
+   port_text = Proxy:substr(colon + 1):trim()
+   port = tonumber(port_text)
+
+   if host is '' then
+      error("Parameter 'proxy' requires a proxy host.")
+   end
+
+   if port is nil or math.floor(port) != port or port < 1 or port > 65535 then
+      error("Parameter 'proxy' requires a port between 1 and 65535.")
+   end
+
+   return host, port
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Ensures that numeric timeout values are valid before the request is started.
 
 function requirePositive(Name:str, Value:num)
@@ -175,12 +201,29 @@ function validateArgs(Args:table)
       error("Parameter 'url' must start with http:// or https://.")
    end
 
-   if Args.proxy != nil then rejectPhaseFuture('proxy') end
-   if Args.insecure then rejectPhaseFuture('insecure') end
-   if Args.resume then rejectPhaseFuture('resume') end
-   if Args.raw then rejectPhaseFuture('raw') end
-   if Args['no-head'] then rejectPhaseFuture('no-head') end
-   if Args['debug-socket'] then rejectPhaseFuture('debug-socket') end
+   if Args.resume then
+      if Args.output is nil then
+         error("Parameter 'resume' requires 'output'.")
+      end
+
+      if Args.method != 'get' then
+         error("Parameter 'resume' can only be used with method=get.")
+      end
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Returns the size of an existing file, or zero if the file is absent or inaccessible.
+
+function getFileSize(Path:str):num
+   try
+      file = obj.new('file', { path = Path, flags = 'READ' })
+      size = file.size
+      file.free()
+      return size
+   except
+      return 0
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -205,7 +248,16 @@ function normaliseArgs(Args:table):table
       Args.username, Args.password = splitUser(Args.user)
    end
 
+   if Args.proxy != nil then
+      Args.proxyHost, Args.proxyPort = splitProxy(Args.proxy)
+   end
+
    validateArgs(Args)
+
+   if Args.resume and Args.output != nil then
+      Args.resumeOffset = getFileSize(Args.output)
+   end
+
    return Args
 end
 
@@ -220,6 +272,21 @@ function makeRequestBody(Args:table):str
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Builds the HTTP flag mask from transfer-control arguments.
+
+function makeRequestFlags(Args:table):num
+   flags = HTF_NO_DIALOG
+
+   if hasBodyOption(Args) or Args['no-head'] then flags = flags | HTF_NO_HEAD end
+   if Args.resume then flags = flags | HTF_RESUME end
+   if Args.raw then flags = flags | HTF_RAW end
+   if Args['debug-socket'] then flags = flags | HTF_DEBUG_SOCKET end
+   if Args.insecure then flags = flags | HTF_DISABLE_SERVER_VERIFY end
+
+   return flags
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Builds the HTTP object configuration table from validated command-line arguments.
 
 function makeRequestConfig(Args:table):table
@@ -229,7 +296,7 @@ function makeRequestConfig(Args:table):table
       connectTimeout = Args['connect-timeout'],
       dataTimeout    = Args['data-timeout'],
       userAgent      = Args.useragent,
-      flags          = HTF_NO_DIALOG | (hasBodyOption(Args) ? HTF_NO_HEAD :> 0),
+      flags          = makeRequestFlags(Args),
       -- Wakes the waiting processing context when the HTTP transfer reaches a terminal state.
       stateChanged   = function(HTTP:obj, State:num)
          if State is HGS_COMPLETED or State is HGS_TERMINATED then
@@ -237,6 +304,11 @@ function makeRequestConfig(Args:table):table
          end
       end
    }
+
+   if Args.proxyHost != nil then
+      request.proxyServer = Args.proxyHost
+      request.proxyPort = Args.proxyPort
+   end
 
    if Args.output != nil then
       request.outputFile = Args.output
@@ -267,6 +339,18 @@ function makeRequestConfig(Args:table):table
    end
 
    return request
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Applies transfer-control headers that are derived from validated command-line options.
+
+function applyTransferHeaders(HTTP:obj, Args:table)
+   if Args.resume and Args.resumeOffset != nil and Args.resumeOffset > 0 then
+      err = HTTP.acSetKey('Range', f"bytes={Args.resumeOffset}-")
+      if err != ERR_Okay then
+         error('Failed to set resume range header: ' .. mSys.GetErrorMsg(err))
+      end
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -307,19 +391,61 @@ function getResponseHeader(HTTP:obj, Name:str):str
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Returns the selected response headers that are useful for command-line automation.
+-- Returns available response header names, falling back to the phase 3 common keys on older HTTP builds.
+
+function readResponseHeaderNames(HTTP:obj):array
+   names = array<string>
+   seen = {}
+
+   if HTTP.responseKeys != nil then
+      for key in values(HTTP.responseKeys) do
+         if not seen[key] then
+            names:push(key)
+            seen[key] = true
+         end
+      end
+   end
+
+   if #names is 0 then
+      for name in values(glResponseHeaderNames) do
+         names:push(name)
+      end
+   end
+
+   names:sort()
+   return names
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Returns response headers that are useful for command-line automation.
 
 function readResponseHeaders(HTTP:obj):table
    headers = {}
+   names = readResponseHeaderNames(HTTP)
 
-   for name in values(glResponseHeaderNames) do
+   for name in values(names) do
       value = getResponseHeader(HTTP, name)
       if value != nil then
          headers[name] = value
       end
    end
 
-   return headers
+   return {
+      names  = names,
+      values = headers
+   }
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Prints response header lines in a stable line-oriented format.
+
+function printResponseHeaders(Result:table)
+   for name in values(Result.headers.names) do
+      value = Result.headers.values[name]
+      if value != nil then
+         print(f"tuku: header {name}={value}")
+      end
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -333,12 +459,7 @@ function printVerboseSummary(Args:table, Result:table)
    print('tuku: output=' .. (Result.output ?? 'stdout'))
    print('tuku: transport=' .. Result.transportErrorText)
 
-   for name in values(glResponseHeaderNames) do
-      value = Result.headers[name]
-      if value != nil then
-         print(f"tuku: header {name}={value}")
-      end
-   end
+   printResponseHeaders(Result)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -365,6 +486,7 @@ end
 
 function fetch(Args:table):table
    local http = obj.new('http', makeRequestConfig(Args))
+   applyTransferHeaders(http, Args)
    applyRequestHeaders(http, Args)
    proc = processing.new({ timeout = Args.timeout, signals = array<object> { http } })
 
@@ -405,6 +527,10 @@ end
 
       if args.verbose then
          printVerboseSummary(args, result)
+      end
+
+      if args.headers and not args.verbose then
+         printResponseHeaders(result)
       end
 
       if args.status then

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -5,15 +5,16 @@ Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.
 
    include 'http'
    import 'options'
+   import 'net/url'
 
-TUKU_VERSION <const> = '1.0'
+TUKU_VERSION <const> = '2026.5.7'
 TUKU_USER_AGENT <const> = 'Tuku/1.0 Kotuku'
 
 glOptionDefs = array<table> {
    { name = 'url', type = 'str', group = 'Core',
      comment = 'Target HTTP or HTTPS URL.' },
    { name = 'method', type = 'enum', choices = array<string> { 'get', 'head', 'delete', 'options', 'post', 'put' },
-     default = 'get', group = 'Core', comment = 'HTTP method to use.' },
+     group = 'Core', comment = 'HTTP method to use.' },
    { name = 'version', kind = 'flag', group = 'Core',
      comment = 'Print the Tuku version.' },
 
@@ -86,6 +87,59 @@ function hasBodyOption(Args:table):bool
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Converts an array of name=value form arguments into application/x-www-form-urlencoded request content.
+
+function encodeFormBody(Form:array):str
+   params = array<table>
+
+   for field in values(Form) do
+      text = tostring(field)
+      eq = text:find('=')
+      if eq is nil then
+         error("Parameter 'form' entries must use name=value syntax.")
+      end
+
+      params:push({
+         key   = text:substr(0, eq),
+         value = text:substr(eq + 1)
+      })
+   end
+
+   return url.buildQuery(params)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Splits a Name: Value header argument into its key and value components.
+
+function splitHeader(Header:str):<str, str>
+   colon = Header:find(':')
+   if colon is nil then
+      error("Parameter 'header' entries must use Name: Value syntax.")
+   end
+
+   name = Header:substr(0, colon):trim()
+   value = Header:substr(colon + 1):trim()
+
+   if name is '' then
+      error("Parameter 'header' entries require a header name.")
+   end
+
+   return name, value
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Splits username:password into the HTTP fields used by the client object.
+
+function splitUser(User:str):<str, str>
+   colon = User:find(':')
+   if colon is nil then
+      error("Parameter 'user' must use username:password syntax.")
+   end
+
+   return User:substr(0, colon), User:substr(colon + 1)
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Ensures that numeric timeout values are valid before the request is started.
 
 function requirePositive(Name:str, Value:num)
@@ -102,9 +156,9 @@ function rejectPhaseFuture(Name:str)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Validates the Phase 1 option set and reports unsupported methods or deferred parameters as argument errors.
+-- Validates currently supported options and reports deferred parameters as argument errors.
 
-function validatePhaseOneArgs(Args:table)
+function validateArgs(Args:table)
    if Args.version then return end
 
    if Args.url is nil then
@@ -119,19 +173,8 @@ function validatePhaseOneArgs(Args:table)
       error("Parameter 'url' must start with http:// or https://.")
    end
 
-   if Args.method != 'get' and Args.method != 'head' and Args.method != 'delete' and Args.method != 'options' then
-      error("Phase 1 supports method=get, method=head, method=delete, and method=options.")
-   end
-
    if Args.fail then rejectPhaseFuture('fail') end
    if Args.verbose then rejectPhaseFuture('verbose') end
-   if Args.data != nil then rejectPhaseFuture('data') end
-   if Args.datafile != nil then rejectPhaseFuture('datafile') end
-   if Args.json != nil then rejectPhaseFuture('json') end
-   if Args.form != nil then rejectPhaseFuture('form') end
-   if Args.contenttype != nil then rejectPhaseFuture('contenttype') end
-   if Args.header != nil then rejectPhaseFuture('header') end
-   if Args.user != nil then rejectPhaseFuture('user') end
    if Args.proxy != nil then rejectPhaseFuture('proxy') end
    if Args.insecure then rejectPhaseFuture('insecure') end
    if Args.resume then rejectPhaseFuture('resume') end
@@ -144,10 +187,12 @@ end
 -- Normalises derived argument values, including method casing and implicit content types, before validation.
 
 function normaliseArgs(Args:table):table
-   Args.method = Args.method:lower()
-
-   if hasBodyOption(Args) and Args.method is 'get' then
+   if Args.method != nil then
+      Args.method = Args.method:lower()
+   elseif hasBodyOption(Args) then
       Args.method = 'post'
+   else
+      Args.method = 'get'
    end
 
    if Args.json != nil and Args.contenttype is nil then
@@ -156,8 +201,22 @@ function normaliseArgs(Args:table):table
       Args.contenttype = 'application/x-www-form-urlencoded'
    end
 
-   validatePhaseOneArgs(Args)
+   if Args.user != nil then
+      Args.username, Args.password = splitUser(Args.user)
+   end
+
+   validateArgs(Args)
    return Args
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Returns the string request body to send for body options that are not file-backed.
+
+function makeRequestBody(Args:table):str
+   if Args.data != nil then return Args.data end
+   if Args.json != nil then return Args.json end
+   if Args.form != nil then return encodeFormBody(Args.form) end
+   return nil
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -170,6 +229,7 @@ function makeRequestConfig(Args:table):table
       connectTimeout = Args['connect-timeout'],
       dataTimeout    = Args['data-timeout'],
       userAgent      = Args.useragent,
+      flags          = HTF_NO_DIALOG | (hasBodyOption(Args) ? HTF_NO_HEAD :> 0),
       -- Wakes the waiting processing context when the HTTP transfer reaches a terminal state.
       stateChanged   = function(HTTP:obj, State:num)
          if State is HGS_COMPLETED or State is HGS_TERMINATED then
@@ -187,7 +247,41 @@ function makeRequestConfig(Args:table):table
       end
    end
 
+   if Args.contenttype != nil then
+      request.contentType = Args.contenttype
+   end
+
+   if Args.username != nil then
+      request.username = Args.username
+      request.password = Args.password
+   end
+
+   if Args.datafile != nil then
+      request.inputFile = Args.datafile
+   else
+      body = makeRequestBody(Args)
+      if body != nil then
+         request.inputFile = 'string:' .. body
+         request.size = #body
+      end
+   end
+
    return request
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Applies request headers after object construction because custom headers are stored through acSetKey().
+
+function applyRequestHeaders(HTTP:obj, Args:table)
+   if Args.header is nil then return end
+
+   for header in values(Args.header) do
+      name, value = splitHeader(header)
+      err = HTTP.acSetKey(name, value)
+      if err != ERR_Okay then
+         error("Invalid request header '" .. name .. "': " .. mSys.GetErrorMsg(err))
+      end
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -195,6 +289,7 @@ end
 
 function fetch(Args:table):table
    local http = obj.new('http', makeRequestConfig(Args))
+   applyRequestHeaders(http, Args)
    proc = processing.new({ timeout = Args.timeout, signals = array<object> { http } })
 
    err = http.acActivate() -- Send asynchronous request

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -11,6 +11,7 @@ TUKU_VERSION <const> = '2026.5.7'
 TUKU_USER_AGENT <const> = 'Tuku/1.0 Kotuku'
 glResponseHeaderNames = array<string> { 'content-type', 'content-length', 'location' }
 glReportedError = false
+glSilent = false
 
 glOptionDefs = array<table> {
    { name = 'url', type = 'str', group = 'Core',
@@ -227,6 +228,13 @@ function getFileSize(Path:str):num
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Builds the temporary side-file path used while validating resumed responses.
+
+function makeResumeTempPath(Path:str):str
+   return Path .. '.tuku-resume'
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Normalises derived argument values, including method casing and implicit content types, before validation.
 
 function normaliseArgs(Args:table):table
@@ -256,6 +264,10 @@ function normaliseArgs(Args:table):table
 
    if Args.resume and Args.output != nil then
       Args.resumeOffset = getFileSize(Args.output)
+      if Args.resumeOffset > 0 then
+         Args.resumeTempPath = makeResumeTempPath(Args.output)
+         mSys.DeleteFile(Args.resumeTempPath)
+      end
    end
 
    return Args
@@ -278,7 +290,6 @@ function makeRequestFlags(Args:table):num
    flags = HTF_NO_DIALOG
 
    if hasBodyOption(Args) or Args['no-head'] then flags = flags | HTF_NO_HEAD end
-   if Args.resume then flags = flags | HTF_RESUME end
    if Args.raw then flags = flags | HTF_RAW end
    if Args['debug-socket'] then flags = flags | HTF_DEBUG_SOCKET end
    if Args.insecure then flags = flags | HTF_DISABLE_SERVER_VERIFY end
@@ -290,6 +301,11 @@ end
 -- Builds the HTTP object configuration table from validated command-line arguments.
 
 function makeRequestConfig(Args:table):table
+   output_file = Args.output
+   if Args.resumeTempPath != nil then
+      output_file = Args.resumeTempPath
+   end
+
    request = {
       src            = Args.url,
       method         = Args.method,
@@ -310,8 +326,8 @@ function makeRequestConfig(Args:table):table
       request.proxyPort = Args.proxyPort
    end
 
-   if Args.output != nil then
-      request.outputFile = Args.output
+   if output_file != nil then
+      request.outputFile = output_file
    elseif not Args.status then
       -- Streams response body chunks to standard output when the body is not redirected or suppressed.
       request.incoming = function(HTTP:obj, Buffer:array)
@@ -339,6 +355,36 @@ function makeRequestConfig(Args:table):table
    end
 
    return request
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Appends a completed temporary response body to the requested output file.
+
+function appendFile(Source:str, Destination:str)
+   data = io.readAll(Source)
+   file = io.open(Destination, 'a')
+   file:write(data)
+   file:close()
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Completes a resumed download only after confirming that the server honoured the Range request.
+
+function finaliseResumeDownload(Args:table, Result:table)
+   if Args.resumeTempPath is nil then return end
+
+   if Result.transportError != ERR_Okay then
+      mSys.DeleteFile(Args.resumeTempPath)
+      return
+   end
+
+   if Result.status is 206 then
+      appendFile(Args.resumeTempPath, Args.output)
+      mSys.DeleteFile(Args.resumeTempPath)
+   else
+      mSys.DeleteFile(Args.resumeTempPath)
+      Result.resumeError = f"Resume request returned HTTP {Result.status} instead of 206 Partial Content."
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -372,12 +418,14 @@ end
 -- Prints a stable, machine-friendly error line before raising a command failure.
 
 function reportError(Type:str, Message:str, Status:num, Code:num)
+   glReportedError = true
+   if glSilent then return end
+
    text = f"tuku: error: type={Type}"
    if Status != nil then text ..= f" status={Status}" end
    if Code != nil then text ..= f" code={Code}" end
    text ..= " message=" .. Message
 
-   glReportedError = true
    print(text)
 end
 
@@ -469,6 +517,12 @@ function parseCommandLine():table
    args, err = glParser.tryProcess()
 
    if err != nil then
+      raw_silent = arg('silent')
+      if raw_silent != nil then
+         raw_silent = tostring(raw_silent):lower()
+         glSilent = raw_silent != 'false' and raw_silent != '0' and raw_silent != 'no' and raw_silent != 'off'
+      end
+
       reportError('argument', err.message, nil, err.code)
       raise err.code, err.message
    end
@@ -516,25 +570,34 @@ end
       args = parseCommandLine()
       if args is nil then return end
 
+      glSilent = args.silent
       args = normaliseArgs(args)
 
       if args.version then
-         print('Tuku ' .. TUKU_VERSION)
+         if not args.silent then
+            print('Tuku ' .. TUKU_VERSION)
+         end
          return
       end
 
       result = fetch(args)
+      finaliseResumeDownload(args, result)
 
-      if args.verbose then
+      if args.verbose and not args.silent then
          printVerboseSummary(args, result)
       end
 
-      if args.headers and not args.verbose then
+      if args.headers and not args.verbose and not args.silent then
          printResponseHeaders(result)
       end
 
-      if args.status then
+      if args.status and not args.silent then
          io.write(tostring(result.status) .. '\n')
+      end
+
+      if result.resumeError != nil then
+         reportError('http', result.resumeError, result.status, ERR_Failed)
+         raise ERR_Failed, result.resumeError
       end
 
       if result.transportError != ERR_Okay and result.status <= 0 then

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -1109,6 +1109,7 @@ static const FieldArray clFields[] = {
    { "Outgoing",       FDF_FUNCTIONPTR|FDF_RW,   GET_Outgoing, SET_Outgoing },
    { "Realm",          FDF_STRING|FDF_RW,        GET_Realm, SET_Realm },
    { "RecvBuffer",     FDF_ARRAY|FDF_BYTE|FDF_R, GET_RecvBuffer },
+   { "ResponseKeys",   FDF_ARRAY|FDF_STRING|FDF_ALLOC|FDF_R, GET_ResponseKeys },
    { "Src",            FDF_STRING|FDF_SYNONYM|FD_PRIVATE|FDF_RW, GET_Location, SET_Location }, // Deprecated by URL
    { "URL",            FDF_STRING|FDF_SYNONYM|FDF_RW, GET_Location, SET_Location },
    { "StateChanged",   FDF_FUNCTIONPTR|FDF_RW,   GET_StateChanged, SET_StateChanged },

--- a/src/http/http_fields.cpp
+++ b/src/http/http_fields.cpp
@@ -643,6 +643,45 @@ static ERR GET_RecvBuffer(extHTTP *Self, uint8_t **Value, int *Elements)
 /*********************************************************************************************************************
 
 -FIELD-
+ResponseKeys: Returns a string list of received response keys.
+
+This field returns a string list of all the keys found in the HTTP response header.  An empty list will be returned
+if no keys are found.
+
+*********************************************************************************************************************/
+
+static ERR GET_ResponseKeys(extHTTP *Self, STRING **Value, int *Elements)
+{
+   if (Self->ResponseKeys.empty()) {
+      *Value = nullptr;
+      *Elements = 0;
+      return ERR::Okay;
+   }
+
+   const int total_keys = int(Self->ResponseKeys.size());
+   int buffer_size = sizeof(CSTRING) * (total_keys + 1);
+   for (const auto &response_key : Self->ResponseKeys) buffer_size += int(response_key.first.length()) + 1;
+
+   STRING *array;
+   if (AllocMemory(buffer_size, MEM::STRING|MEM::NO_CLEAR, (APTR *)&array, nullptr) IS ERR::Okay) {
+      STRING buffer = (STRING)(array + total_keys + 1);
+      int i = 0;
+      for (const auto &response_key : Self->ResponseKeys) {
+         array[i++] = buffer;
+         buffer += kt::strcopy(response_key.first, buffer, int(response_key.first.length()) + 1) + 1;
+      }
+      array[i] = nullptr;
+   }
+   else return ERR::AllocMemory;
+
+   *Value = array;
+   *Elements = total_keys;
+   return ERR::Okay;
+}
+
+/*********************************************************************************************************************
+
+-FIELD-
 Size: Set this field to define the length of a data transfer when issuing a `POST` command.
 
 Prior to the execution of a `POST` command, it is recommended that the Size field is set to the length of the data

--- a/src/http/tests/test_response_features.tiri
+++ b/src/http/tests/test_response_features.tiri
@@ -254,6 +254,48 @@ end
    assert(response.customHeaders, 'Custom response headers should be set')
    assert(raw_response:find('content-type: application/json'), 'Content-Type header not set correctly')
    assert(raw_response:find('x-custom-response: CustomValue'), 'Custom response header missing')
+
+   content = ''
+   http = obj.new('http', {
+      src      = 'http://127.0.0.1:' .. SERVER_PORT .. '/headers/response',
+      method   = 'GET',
+      incoming = function(HTTP, Buffer)
+         content ..= Buffer:getString()
+      end,
+      stateChanged = function(HTTP, State)
+         if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
+            HTTP.acSignal()
+         end
+      end
+   })
+
+   proc = processing.new({ timeout = 5.0, signals = array<object> { http } })
+   check http.acActivate()
+   check proc.sleep()
+
+   assert(http.error is ERR_Okay, 'Response keys HTTP error: ' .. mSys.GetErrorMsg(http.error))
+   assert(http.status is 200, 'Response keys unexpected status: ' .. http.status)
+
+   response_keys = http.responseKeys
+   assert(response_keys, 'ResponseKeys field should return received header names')
+   assert(#response_keys >= 3, 'ResponseKeys should include custom response headers')
+
+   found_content_type = false
+   found_custom_response = false
+   found_server_version = false
+   found_request_id = false
+   for key in values(response_keys) do
+      if key is 'content-type' then found_content_type = true
+      elseif key is 'x-custom-response' then found_custom_response = true
+      elseif key is 'x-server-version' then found_server_version = true
+      elseif key is 'x-request-id' then found_request_id = true
+      end
+   end
+
+   assert(found_content_type, 'ResponseKeys should include content-type')
+   assert(found_custom_response, 'ResponseKeys should include x-custom-response')
+   assert(found_server_version, 'ResponseKeys should include x-server-version')
+   assert(found_request_id, 'ResponseKeys should include x-request-id')
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
* Add the Tuku HTTP command-line application and register it in the app build.
* Support request bodies, automation-friendly output, full response header listing, resume downloads, proxy parsing and transfer-control flags.
* Expose HTTP response header keys through `ResponseKeys` and cover the HTTP/Tuku behaviours with Flute tests.

## Testing
* Not run in this PR creation step.