### PR TITLE
Add Tuku redirect following, include mode, and multipart upload

### DIFF
--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -44,6 +44,38 @@ end
                res.send('hello from tuku')
             end
          },
+         { pattern = '/redirect-once',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/hello', 302)
+            end
+         },
+         { pattern = '/chain-1',
+            method = 'GET',
+            handler = function(req, res)
+               res.status(301)
+                  .header('Location', f'http://127.0.0.1:{SERVER_PORT}/chain-2')
+                  .send('redirect', 'text/plain')
+            end
+         },
+         { pattern = '/chain-2',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/hello', 302)
+            end
+         },
+         { pattern = '/redirect-303',
+            method = 'POST',
+            handler = function(req, res)
+               res.redirect('/hello', 303)
+            end
+         },
+         { pattern = '/redirect-loop',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/redirect-loop', 302)
+            end
+         },
          { pattern = '/headers',
             method = 'GET',
             handler = function(req, res)
@@ -147,7 +179,7 @@ end
 function runTuku(Parameters:array):table
    local output = ''
    local errors = ''
-   local task_params = array<string> { glTukuPath }
+   local task_params = array<string> { quoteTaskParam(glTukuPath:replace('\\', '/')) }
 
    for param in values(Parameters) do
       task_params:push(quoteTaskParam(param))
@@ -184,6 +216,9 @@ end
 
    assert(result.returnCode is 0, 'Help should return 0, got ' .. result.returnCode)
    assert(result.text:find('headers'), 'Help should include response headers option')
+   assert(result.text:find('include'), 'Help should include include response headers option')
+   assert(result.text:find('follow'), 'Help should include redirect follow option')
+   assert(result.text:find('max-redirects'), 'Help should include redirect limit option')
    assert(result.text:find('header=HEADER'), 'Help should include future header option')
    assert(result.text:find('json=JSON'), 'Help should include future JSON option')
    assert(result.text:find('debug-socket'), 'Help should include future socket debug option')
@@ -226,6 +261,76 @@ end
 
    assert(result.returnCode is 0, 'GET should return 0, got ' .. result.returnCode .. ': ' .. result.errors)
    assert(io.readAll(glOutputFile) is 'hello from tuku', 'Output file content mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFollowsSingleRedirect()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Followed redirect should return 0: ' .. result.errors)
+   assert(result.output is 'hello from tuku', 'Followed redirect body mismatch: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFollowsRedirectChain()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/chain-1',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Redirect chain should return 0: ' .. result.errors)
+   assert(result.output is 'hello from tuku', 'Redirect chain body mismatch: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirect303ChangesMethodToGet()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-303',
+      'data=body',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, '303 redirect should return 0: ' .. result.errors)
+   assert(result.output is 'hello from tuku', '303 redirect should re-fetch using GET: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRejectsRedirectLoopLimit()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-loop',
+      'follow',
+      'max-redirects=2',
+      'timeout=5'
+   })
+
+   assert(result.returnCode != 0, 'Redirect loop should fail after the configured redirect limit')
+   assert(result.text:find('tuku: error: type=redirect status=302'),
+      'Redirect loop should emit structured redirect error: ' .. result.text)
+   assert(result.text:find('Maximum redirects exceeded (2).'),
+      'Redirect loop diagnostic mismatch: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineReturnsRedirectStatusWithoutFollow()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Redirect without follow should not fail: ' .. result.errors)
+   assert(result.output is '302\n', 'Redirect without follow should report 302, got: ' .. result.text)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -443,6 +548,49 @@ end
    assert(result.text:find('tuku: header x-tuku-list=yes'),
       'Headers mode should include custom enumerated response header: ' .. result.text)
    assert(result.output is '200\n', 'Headers and status output should keep status on stdout: ' .. result.output)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineIncludePrintsHeadersBeforeBody()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/headers',
+      'with-headers',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Include mode should return 0: ' .. result.errors)
+
+   status_pos = result.output:find('HTTP 200')
+   header_pos = result.output:find('content-length: 11')
+   body_pos = result.output:find('header-body')
+
+   assert(status_pos != nil, 'Include output should start with HTTP status: ' .. result.output)
+   assert(header_pos != nil, 'Include output should contain response headers: ' .. result.output)
+   assert(body_pos != nil, 'Include output should contain response body: ' .. result.output)
+   assert(status_pos < header_pos and header_pos < body_pos, 'Include output order mismatch: ' .. result.output)
+   assert(result.output:find('\n\nheader-body') != nil,
+      'Include output should separate headers from body with a blank line: ' .. result.output)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineIncludeWritesHeadersToStdoutAndBodyToFile()
+   mSys.DeleteFile(glOutputFile)
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/headers',
+      'with-headers',
+      'output=' .. glOutputFile,
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Include output file mode should return 0: ' .. result.errors)
+   assert(result.output:find('HTTP 200') != nil, 'Include output should contain HTTP status: ' .. result.output)
+   assert(result.output:find('content-length: 11') != nil,
+      'Include output should contain response headers: ' .. result.output)
+   assert(result.output:find('header-body') is nil, 'Include output should not duplicate file body on stdout')
+   assert(io.readAll(glOutputFile) is 'header-body', 'Include output file body mismatch')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -93,6 +93,20 @@ end
                res.redirect('/hello', 303)
             end
          },
+         { pattern = '/redirect-patch-302',
+            method = 'PATCH',
+            handler = function(req, res)
+               res.redirect('/echo', 302)
+            end
+         },
+         { pattern = '/redirect-put-301',
+            method = 'PUT',
+            handler = function(req, res)
+               res.status(301)
+                  .header('Location', f'http://127.0.0.1:{SERVER_PORT}/echo')
+                  .send('redirect', 'text/plain')
+            end
+         },
          { pattern = '/redirect-loop',
             method = 'GET',
             handler = function(req, res)
@@ -164,6 +178,20 @@ end
          },
          { pattern = '/echo',
             method = 'PATCH',
+            handler = function(req, res)
+               res.json({
+                  method      = req.method,
+                  body        = req.body,
+                  contentType = req.headers['content-type'],
+                  userAgent   = req.headers['user-agent'],
+                  accept      = req.headers['accept'],
+                  custom      = req.headers['x-tuku-test'],
+                  parsedBody  = req.parsedBody
+               })
+            end
+         },
+         { pattern = '/echo',
+            method = 'PUT',
             handler = function(req, res)
                res.json({
                   method      = req.method,
@@ -369,6 +397,46 @@ end
 
    assert(result.returnCode is 0, '303 redirect should return 0: ' .. result.errors)
    assert(result.output is 'hello from tuku', '303 redirect should re-fetch using GET: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirect302PreservesPatchMethodAndBody()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-patch-302',
+      'method=patch',
+      'json=[7,8,9]',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, '302 PATCH redirect should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.method is 'PATCH', '302 redirect should preserve PATCH method')
+   assert(response.contentType is 'application/json', '302 redirect should preserve PATCH content type')
+   assert(response.parsedBody[0] is 7, '302 redirect should preserve PATCH JSON body')
+   assert(response.parsedBody[2] is 9, '302 redirect should preserve PATCH JSON body tail')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirect301PreservesPutMethodAndBody()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-put-301',
+      'method=put',
+      'data=put-body',
+      'contenttype=text/plain',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, '301 PUT redirect should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.method is 'PUT', '301 redirect should preserve PUT method')
+   assert(response.body is 'put-body', '301 redirect should preserve PUT body')
+   assert(response.contentType is 'text/plain', '301 redirect should preserve PUT content type')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -403,6 +403,22 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function CommandLineReturnsPermanentRedirectStatusWithoutFollow()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/chain-1',
+      'headers',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, '301 redirect without follow should not fail: ' .. result.errors)
+   assert(result.output is '301\n', '301 redirect without follow should report 301, got: ' .. result.text)
+   assert(result.text:find(f'tuku: header location=http://127.0.0.1:{SERVER_PORT}/chain-2'),
+      '301 redirect without follow should expose Location header: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function CommandLinePostsDataAndCustomHeaders()
    result = runTuku(array<string> {
       f'url=http://127.0.0.1:{SERVER_PORT}/echo',

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -33,6 +33,8 @@ end
       '../agents-install/apps/tuku.tiri',
       '../../apps/tuku.tiri'
    })
+   global glFollowNoRedirectHits = 0
+   global glFollowRedirectTargetHits = 0
 
    global glServer = hslib.start({
       port    = SERVER_PORT,
@@ -43,6 +45,26 @@ end
             method = 'GET',
             handler = function(req, res)
                res.send('hello from tuku')
+            end
+         },
+         { pattern = '/follow-counted',
+            method = 'GET',
+            handler = function(req, res)
+               glFollowNoRedirectHits++
+               res.send(tostring(glFollowNoRedirectHits))
+            end
+         },
+         { pattern = '/redirect-counted',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/follow-redirect-target-counted', 302)
+            end
+         },
+         { pattern = '/follow-redirect-target-counted',
+            method = 'GET',
+            handler = function(req, res)
+               glFollowRedirectTargetHits++
+               res.send(tostring(glFollowRedirectTargetHits))
             end
          },
          { pattern = '/redirect-once',
@@ -162,6 +184,7 @@ end
    glServer.stop()
    mSys.DeleteFile(glOutputFile)
    mSys.DeleteFile(glOutputFile .. '.tuku-resume')
+   mSys.DeleteFile(glOutputFile .. '.tuku-follow')
    mSys.DeleteFile(glBodyFile)
    mSys.DeleteFile(glUploadFile)
 end
@@ -277,6 +300,48 @@ end
 
    assert(result.returnCode is 0, 'Followed redirect should return 0: ' .. result.errors)
    assert(result.output is 'hello from tuku', 'Followed redirect body mismatch: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFollowDoesNotReplayNonRedirectResponse()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/follow-counted',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Followed non-redirect should return 0: ' .. result.errors)
+   assert(result.output is '1', 'Follow should not replay a non-redirect response: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFollowDoesNotReplayFinalRedirectHop()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-counted',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Followed redirect should return 0: ' .. result.errors)
+   assert(result.output is '1', 'Follow should not replay the terminal redirect hop: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineFollowWritesFinalResponseToOutputFile()
+   mSys.DeleteFile(glOutputFile)
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-once',
+      'follow',
+      'output=' .. glOutputFile,
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Followed output request should return 0: ' .. result.errors)
+   assert(io.readAll(glOutputFile) is 'hello from tuku', 'Followed output file content mismatch')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -6,6 +6,7 @@
 SERVER_PORT <const> = 18952
 glOutputFile <const> = 'temp:tuku-test-output.txt'
 glBodyFile <const> = 'temp:tuku-test-body.txt'
+glUploadFile <const> = 'temp:tuku-test-upload.txt'
 
 function resolveFirstPath(Candidates:array):str
    for candidate in values(Candidates) do
@@ -162,6 +163,7 @@ end
    mSys.DeleteFile(glOutputFile)
    mSys.DeleteFile(glOutputFile .. '.tuku-resume')
    mSys.DeleteFile(glBodyFile)
+   mSys.DeleteFile(glUploadFile)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -221,6 +223,7 @@ end
    assert(result.text:find('max-redirects'), 'Help should include redirect limit option')
    assert(result.text:find('header=HEADER'), 'Help should include future header option')
    assert(result.text:find('json=JSON'), 'Help should include future JSON option')
+   assert(result.text:find('multipart=MULTIPART'), 'Help should include multipart body option')
    assert(result.text:find('debug-socket'), 'Help should include future socket debug option')
 end
 
@@ -404,6 +407,60 @@ end
    assert(response.contentType is 'application/json', 'PATCH JSON should set application/json content type')
    assert(response.parsedBody[0] is 4, 'PATCH JSON array body should be parsed by the server')
    assert(response.parsedBody[2] is 6, 'PATCH JSON array value mismatch')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLinePostsMultipartTextFields()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'multipart={name=Ada,role=Engineer}',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Multipart text POST should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.method is 'POST', 'Multipart body option should imply POST')
+   assert(response.contentType:find('multipart/form-data'), 'Multipart should set multipart/form-data content type')
+   assert(response.parsedBody.name is 'Ada', 'Multipart text field "name" should round-trip')
+   assert(response.parsedBody.role is 'Engineer', 'Multipart text field "role" should round-trip')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLinePostsMultipartFile()
+   io.writeAll(glUploadFile, 'uploaded file body')
+
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'multipart={doc=@' .. glUploadFile .. '}',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Multipart file POST should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.contentType:find('multipart/form-data'), 'File upload should set multipart/form-data content type')
+   assert(response.parsedBody.doc.filename is 'tuku-test-upload.txt',
+      'Multipart file field should preserve filename: ' .. tostring(response.parsedBody.doc.filename))
+   assert(response.parsedBody.doc.value is 'uploaded file body',
+      'Multipart file field should preserve content: ' .. tostring(response.parsedBody.doc.value))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRejectsMultipartWithOtherBodyOptions()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/echo',
+      'data=plain',
+      'multipart={name=Ada}',
+      'timeout=5'
+   })
+
+   assert(result.returnCode != 0, 'Multipart combined with another body option should fail')
+   assert(result.text:find("excludes 'multipart'.") or result.text:find("Parameter 'multipart' excludes"),
+      'Unexpected multipart exclusion error output: ' .. result.text)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -638,7 +638,7 @@ function applyRedirect(Args:table, Result:table)
       raise ERR_Failed, message
    end
 
-   if Result.status is 301 or Result.status is 302 or Result.status is 303 then
+   if Result.status is 303 or ((Result.status is 301 or Result.status is 302) and Args.method is 'post') then
       Args.method = 'get'
       clearBodyOptions(Args)
    end

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -28,6 +28,8 @@ glOptionDefs = array<table> {
      comment = 'Print the numeric HTTP status.' },
    { name = 'headers', kind = 'flag', group = 'Output',
      comment = 'Print all response headers as key=value lines.' },
+   { name = 'include', names = array<string> { 'include', 'with-headers' }, kind = 'flag', group = 'Output',
+     comment = 'Print response headers before the response body.' },
    { name = 'silent', kind = 'flag', group = 'Output',
      comment = 'Suppress non-body output.' },
    { name = 'verbose', kind = 'flag', group = 'Output',
@@ -74,6 +76,10 @@ glOptionDefs = array<table> {
      comment = 'Disable HTTP chunk handling.' },
    { name = 'no-head', kind = 'flag', group = 'Transfer Controls',
      comment = 'Do not send a HEAD probe before upload methods.' },
+   { name = 'follow', kind = 'flag', group = 'Transfer Controls',
+     comment = 'Follow HTTP redirects.' },
+   { name = 'max-redirects', type = 'int', default = 10, group = 'Transfer Controls',
+     comment = 'Maximum redirects to follow.' },
    { name = 'debug-socket', kind = 'flag', group = 'Transfer Controls',
      comment = 'Log request socket headers and data.' }
 }
@@ -199,6 +205,10 @@ function validateArgs(Args:table)
    requirePositive('connect-timeout', Args['connect-timeout'])
    requirePositive('data-timeout', Args['data-timeout'])
 
+   if Args['max-redirects'] < 1 then
+      error("Parameter 'max-redirects' must be at least 1.")
+   end
+
    if Args.url:startsWith('http://') is false and Args.url:startsWith('https://') is false then
       error("Parameter 'url' must start with http:// or https://.")
    end
@@ -294,17 +304,35 @@ function makeRequestFlags(Args:table):num
    if Args.raw then flags = flags | HTF_RAW end
    if Args['debug-socket'] then flags = flags | HTF_DEBUG_SOCKET end
    if Args.insecure then flags = flags | HTF_DISABLE_SERVER_VERIFY end
+   if Args.follow then flags = flags | HTF_NO_AUTO_REDIRECT end
 
    return flags
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Reads a raw boolean argument as a fallback for option names that collide with Tiri command words.
+
+function readRawFlag(Name:str, Current:any):bool
+   raw_no = arg('no-' .. Name)
+   if raw_no != nil then return false end
+
+   raw = arg(Name)
+   if raw is nil then return Current is true end
+
+   text = tostring(raw):lower()
+   return text != 'false' and text != '0' and text != 'no' and text != 'off'
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Builds the HTTP object configuration table from validated command-line arguments.
 
 function makeRequestConfig(Args:table):table
-   output_file = Args.output
-   if Args.resumeTempPath != nil then
-      output_file = Args.resumeTempPath
+   output_file = nil
+   if not Args._suppressBody then
+      output_file = Args.output
+      if Args.resumeTempPath != nil then
+         output_file = Args.resumeTempPath
+      end
    end
 
    request = {
@@ -329,6 +357,13 @@ function makeRequestConfig(Args:table):table
 
    if output_file != nil then
       request.outputFile = output_file
+   elseif Args._suppressBody then
+      -- Redirect probes only need status and headers; final response output is fetched separately.
+   elseif Args['include'] and not Args.status then
+      Args._bodyBuffer = ''
+      request.incoming = function(HTTP:obj, Buffer:array)
+         Args._bodyBuffer ..= Buffer:getString()
+      end
    elseif not Args.status then
       -- Streams response body chunks to standard output when the body is not redirected or suppressed.
       request.incoming = function(HTTP:obj, Buffer:array)
@@ -486,6 +521,52 @@ function readResponseHeaders(HTTP:obj):table
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Returns true when an HTTP status code is a redirect that Tuku can follow.
+
+function isRedirectStatus(Status:num):bool
+   return Status is 301 or Status is 302 or Status is 303 or Status is 307 or Status is 308
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Resolves a redirect Location header against the URL that produced it.
+
+function resolveRedirectUrl(BaseUrl:str, Location:str):str
+   return url.join(BaseUrl, Location)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Removes request body options when redirect semantics require a GET request.
+
+function clearBodyOptions(Args:table)
+   Args.data = nil
+   Args.datafile = nil
+   Args.json = nil
+   Args.form = nil
+   Args.contenttype = nil
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Mutates request arguments for the next hop in a redirect chain.
+
+function applyRedirect(Args:table, Result:table)
+   location = Result.headers.values.location
+   next_url = resolveRedirectUrl(Args.url, location)
+
+   if next_url:startsWith('http://') is false and next_url:startsWith('https://') is false then
+      message = "Redirect location must resolve to an HTTP or HTTPS URL."
+      reportError('redirect', message, Result.status, ERR_Failed)
+      raise ERR_Failed, message
+   end
+
+   if Result.status is 301 or Result.status is 302 or Result.status is 303 then
+      Args.method = 'get'
+      clearBodyOptions(Args)
+   end
+
+   Args.url = next_url
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Prints response header lines in a stable line-oriented format.
 
 function printResponseHeaders(Result:table)
@@ -494,6 +575,24 @@ function printResponseHeaders(Result:table)
       if value != nil then
          print(f"tuku: header {name}={value}")
       end
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Prints response headers followed by a blank line and the buffered response body.
+
+function printIncludedResponse(Result:table)
+   io.write('HTTP ' .. tostring(Result.status) .. '\n')
+   for name in values(Result.headers.names) do
+      value = Result.headers.values[name]
+      if value != nil then
+         io.write(f"{name}: {value}\n")
+      end
+   end
+   io.write('\n')
+
+   if Result.body != nil then
+      io.write(Result.body)
    end
 end
 
@@ -533,13 +632,17 @@ function parseCommandLine():table
       return nil
    end
 
+   if args != nil then
+      args['include'] = readRawFlag('include', args['include'])
+   end
+
    return args
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Starts the HTTP transfer, waits for completion, and returns the response summary used by output handling.
+-- Starts one HTTP transfer, waits for completion, and returns the response summary used by output handling.
 
-function fetch(Args:table):table
+function fetchOnce(Args:table):table
    local http = obj.new('http', makeRequestConfig(Args))
    applyTransferHeaders(http, Args)
    applyRequestHeaders(http, Args)
@@ -560,9 +663,47 @@ function fetch(Args:table):table
       bytes              = http.index,
       output             = Args.output,
       headers            = readResponseHeaders(http),
+      body               = Args._bodyBuffer,
       transportError     = transport_error,
       transportErrorText = (transport_error is ERR_Okay) ? 'Okay' :> mSys.GetErrorMsg(transport_error)
    }
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Starts the HTTP transfer, optionally following redirects before fetching the final response with normal output.
+
+function fetch(Args:table):table
+   if not Args.follow then
+      return fetchOnce(Args)
+   end
+
+   redirect_count = 0
+
+   while true do
+      Args._suppressBody = true
+      result = fetchOnce(Args)
+      Args._suppressBody = false
+
+      if result.transportError != ERR_Okay and result.status <= 0 then
+         return result
+      end
+
+      location = result.headers.values.location
+      if not isRedirectStatus(result.status) or location is nil then
+         break
+      end
+
+      if redirect_count >= Args['max-redirects'] then
+         message = f"Maximum redirects exceeded ({Args['max-redirects']})."
+         reportError('redirect', message, result.status, ERR_Failed)
+         raise ERR_Failed, message
+      end
+
+      redirect_count++
+      applyRedirect(Args, result)
+   end
+
+   return fetchOnce(Args)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -583,6 +724,14 @@ end
 
       result = fetch(args)
       finaliseResumeDownload(args, result)
+
+      if args['include'] then
+         if not args.silent then
+            printIncludedResponse(result)
+         elseif result.body != nil then
+            io.write(result.body)
+         end
+      end
 
       if args.verbose and not args.silent then
          printVerboseSummary(args, result)

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -1,6 +1,6 @@
 #!/usr/bin/env origo
 --[[
-Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.
+Tuku: A small HTTP/HTTPS client for Tiri command-line workflows.  Documented in the Wiki.
 --]]
 
    include 'http'
@@ -38,17 +38,20 @@ glOptionDefs = array<table> {
      comment = 'Treat HTTP 4xx and 5xx statuses as failures.' },
 
    { name = 'data', type = 'str', group = 'Request Body',
-     excludes = array<string> { 'datafile', 'json', 'form' },
+     excludes = array<string> { 'datafile', 'json', 'form', 'multipart' },
      comment = 'Send a string request body.' },
    { name = 'datafile', type = 'file', exists = true, group = 'Request Body',
-     excludes = array<string> { 'data', 'json', 'form' },
+     excludes = array<string> { 'data', 'json', 'form', 'multipart' },
      comment = 'Read the request body from a file.' },
    { name = 'json', type = 'str', group = 'Request Body',
-     excludes = array<string> { 'data', 'datafile', 'form' },
+     excludes = array<string> { 'data', 'datafile', 'form', 'multipart' },
      comment = 'Send a JSON request body.' },
    { name = 'form', type = 'array', group = 'Request Body',
-     excludes = array<string> { 'data', 'datafile', 'json' },
+     excludes = array<string> { 'data', 'datafile', 'json', 'multipart' },
      comment = 'Send form fields as name=value entries.' },
+   { name = 'multipart', type = 'array', group = 'Request Body',
+     excludes = array<string> { 'data', 'datafile', 'json', 'form' },
+     comment = 'Send multipart/form-data fields as name=value or name=@path entries.' },
    { name = 'contenttype', type = 'str', group = 'Request Body',
      comment = 'Request Content-Type header.' },
 
@@ -95,7 +98,7 @@ glParser = options({
 -- Returns true when the command-line options include any supported request body source.
 
 function hasBodyOption(Args:table):bool
-   return Args.data != nil or Args.datafile != nil or Args.json != nil or Args.form != nil
+   return Args.data != nil or Args.datafile != nil or Args.json != nil or Args.form != nil or Args.multipart != nil
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -118,6 +121,61 @@ function encodeFormBody(Form:array):str
    end
 
    return url.buildQuery(params)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Escapes quoted multipart header values.
+
+function escapeMultipartHeaderValue(Value:str):str
+   return Value:replace('\\', '\\\\'):replace('"', '\\"')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Converts an array of name=value or name=@file arguments into multipart/form-data request content.
+
+function buildMultipartBody(Fields:array):<str, str>
+   boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime()))
+   crlf <const> = '\r\n'
+   body = ''
+
+   for field in values(Fields) do
+      text = tostring(field)
+      eq = text:find('=', 0, true)
+      if eq is nil then
+         error("Parameter 'multipart' entries must use name=value syntax.")
+      end
+
+      name = text:substr(0, eq):trim()
+      value = text:substr(eq + 1)
+
+      if name is '' then
+         error("Parameter 'multipart' entries require a field name.")
+      end
+
+      body ..= '--' .. boundary .. crlf
+
+      if value:startsWith('@') then
+         path = value:substr(1)
+         if path is '' then
+            error("Parameter 'multipart' file entries require a path after '@'.")
+         end
+
+         _, filename = io.splitPath(path)
+         filename ??= path
+
+         body ..= 'Content-Disposition: form-data; name="' .. escapeMultipartHeaderValue(name) ..
+            '"; filename="' .. escapeMultipartHeaderValue(filename) .. '"' .. crlf
+         body ..= 'Content-Type: application/octet-stream' .. crlf .. crlf
+         body ..= io.readAll(path) .. crlf
+      else
+         body ..= 'Content-Disposition: form-data; name="' .. escapeMultipartHeaderValue(name) .. '"' .. crlf .. crlf
+         body ..= value .. crlf
+      end
+   end
+
+   body ..= '--' .. boundary .. '--' .. crlf
+
+   return body, 'multipart/form-data; boundary=' .. boundary
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -261,6 +319,11 @@ function normaliseArgs(Args:table):table
       Args.contenttype = 'application/json'
    elseif Args.form != nil and Args.contenttype is nil then
       Args.contenttype = 'application/x-www-form-urlencoded'
+   elseif Args.multipart != nil then
+      Args._multipartBody, multipart_content_type = buildMultipartBody(Args.multipart)
+      if Args.contenttype is nil then
+         Args.contenttype = multipart_content_type
+      end
    end
 
    if Args.user != nil then
@@ -288,6 +351,7 @@ end
 -- Returns the string request body to send for body options that are not file-backed.
 
 function makeRequestBody(Args:table):str
+   if Args._multipartBody != nil then return Args._multipartBody end
    if Args.data != nil then return Args.data end
    if Args.json != nil then return Args.json end
    if Args.form != nil then return encodeFormBody(Args.form) end
@@ -542,6 +606,8 @@ function clearBodyOptions(Args:table)
    Args.datafile = nil
    Args.json = nil
    Args.form = nil
+   Args.multipart = nil
+   Args._multipartBody = nil
    Args.contenttype = nil
 end
 

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -375,7 +375,7 @@ function makeRequestFlags(Args:table):num
    if Args.raw then flags = flags | HTF_RAW end
    if Args['debug-socket'] then flags = flags | HTF_DEBUG_SOCKET end
    if Args.insecure then flags = flags | HTF_DISABLE_SERVER_VERIFY end
-   if Args.follow then flags = flags | HTF_NO_AUTO_REDIRECT end
+   flags = flags | HTF_NO_AUTO_REDIRECT
 
    return flags
 end

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -304,6 +304,13 @@ function makeResumeTempPath(Path:str):str
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Builds the temporary side-file path used while following redirects for output-file requests.
+
+function makeFollowTempPath(Path:str):str
+   return Path .. '.tuku-follow'
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Normalises derived argument values, including method casing and implicit content types, before validation.
 
 function normaliseArgs(Args:table):table
@@ -392,7 +399,9 @@ end
 
 function makeRequestConfig(Args:table):table
    output_file = nil
-   if not Args._suppressBody then
+   if Args._captureOutputPath != nil then
+      output_file = Args._captureOutputPath
+   elseif not Args._suppressBody and not Args._captureBody then
       output_file = Args.output
       if Args.resumeTempPath != nil then
          output_file = Args.resumeTempPath
@@ -419,10 +428,15 @@ function makeRequestConfig(Args:table):table
       request.proxyPort = Args.proxyPort
    end
 
-   if output_file != nil then
+   if Args._captureBody then
+      Args._bodyBuffer = ''
+      request.incoming = function(HTTP:obj, Buffer:array)
+         Args._bodyBuffer ..= Buffer:getString()
+      end
+   elseif output_file != nil then
       request.outputFile = output_file
    elseif Args._suppressBody then
-      -- Redirect probes only need status and headers; final response output is fetched separately.
+      -- Redirect probes only need status and headers.
    elseif Args['include'] and not Args.status then
       Args._bodyBuffer = ''
       request.incoming = function(HTTP:obj, Buffer:array)
@@ -663,6 +677,39 @@ function printIncludedResponse(Result:table)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Emits or stores a captured final response body after redirect handling has confirmed that it should be kept.
+
+function commitCapturedResponseBody(Args:table, Result:table)
+   if Args.output != nil then
+      if Result.capturePath != nil then
+         if Args.resumeTempPath != nil then return end
+
+         err = mSys.MoveFile(Result.capturePath, Args.output)
+         if err != ERR_Okay then
+            mSys.DeleteFile(Args.output)
+            err = mSys.MoveFile(Result.capturePath, Args.output)
+         end
+
+         if err != ERR_Okay then
+            error('Failed to move followed output file: ' .. mSys.GetErrorMsg(err))
+         end
+      elseif Result.body != nil then
+         io.writeAll(Args.resumeTempPath ?? Args.output, Result.body)
+      end
+
+      return
+   end
+
+   if Result.body is nil then return end
+
+   if Args['include'] or Args.status then
+      -- Include and status modes have their own output handling after fetch() returns.
+   else
+      io.write(Result.body)
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Prints the verbose transfer summary in a stable line-oriented format.
 
 function printVerboseSummary(Args:table, Result:table)
@@ -728,6 +775,7 @@ function fetchOnce(Args:table):table
       status             = http.status,
       bytes              = http.index,
       output             = Args.output,
+      capturePath        = Args._captureOutputPath,
       headers            = readResponseHeaders(http),
       body               = Args._bodyBuffer,
       transportError     = transport_error,
@@ -736,7 +784,7 @@ function fetchOnce(Args:table):table
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Starts the HTTP transfer, optionally following redirects before fetching the final response with normal output.
+-- Starts the HTTP transfer, optionally following redirects while keeping only the final response body.
 
 function fetch(Args:table):table
    if not Args.follow then
@@ -746,17 +794,26 @@ function fetch(Args:table):table
    redirect_count = 0
 
    while true do
-      Args._suppressBody = true
+      if Args.output != nil then
+         Args._captureOutputPath = Args.resumeTempPath ?? makeFollowTempPath(Args.output)
+         mSys.DeleteFile(Args._captureOutputPath)
+      else
+         Args._captureBody = true
+      end
+
       result = fetchOnce(Args)
-      Args._suppressBody = false
+      Args._captureBody = false
+      Args._captureOutputPath = nil
 
       if result.transportError != ERR_Okay and result.status <= 0 then
+         if result.capturePath != nil then mSys.DeleteFile(result.capturePath) end
          return result
       end
 
       location = result.headers.values.location
       if not isRedirectStatus(result.status) or location is nil then
-         break
+         commitCapturedResponseBody(Args, result)
+         return result
       end
 
       if redirect_count >= Args['max-redirects'] then
@@ -765,11 +822,11 @@ function fetch(Args:table):table
          raise ERR_Failed, message
       end
 
+      if result.capturePath != nil then mSys.DeleteFile(result.capturePath) end
+
       redirect_count++
       applyRedirect(Args, result)
    end
-
-   return fetchOnce(Args)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -13,27 +13,30 @@
 
 glTime = obj.new('time')
 
-rxControlChars    = <{ regex.new([=[[\x00-\x1f\x7f]]=]) }>
-rxQueryFragment   = <{ regex.new([[^([^?#]*)]]) }>
-rxFileExtension   = <{ regex.new([[\.([^.]+)$]]) }>
-rxCookiePair      = <{ regex.new([[\s*([^=]+)=(.+)]]) }>
-rxTrimWhitespace  = <{ regex.new([[^\s*(.*?)\s*$]]) }>
-rxRequestLine     = <{ regex.new([[(\S+)\s+(\S+)\s+(\S+)]]) }>
-rxPathQuery       = <{ regex.new([[([^?]*)\??(.*)]]) }>
-rxHeaderLine      = <{ regex.new([[([^:]+):\s*(.+)]]) }>
-rxRouteParam      = <{ regex.new([[:(\w+)]]) }>
-rxPercentEncoded  = <{ regex.new([[%([0-9A-Fa-f]{2})]]) }>
-rxRouteParamSub   = <{ regex.new([[:[\w_]+]]) }>
-rxEscapedWildcard = <{ regex.new([[\\\*]]) }>
-rxPathComponent   = <{ regex.new([[([^\/]+)]]) }>
-rxHexChunkSize    = <{ regex.new([[^([0-9a-fA-F]+)]]) }>
-rxQueryPair       = <{ regex.new([[([^&]+)]]) }>
-rxKeyValue        = <{ regex.new([[([^=]+)=(.+)]]) }>
-rxCookieItem      = <{ regex.new([[([^;]+)]]) }>
-rxLineIterator    = <{ regex.new([[([^\r\n]+)]]) }>
-rxParentPath      = <{ regex.new([[(.+)\/.+\/]]) }>
+rxControlChars    <const> = <{ regex.new([=[[\x00-\x1f\x7f]]=]) }>
+rxQueryFragment   <const> = <{ regex.new([[^([^?#]*)]]) }>
+rxFileExtension   <const> = <{ regex.new([[\.([^.]+)$]]) }>
+rxCookiePair      <const> = <{ regex.new([[\s*([^=]+)=(.+)]]) }>
+rxTrimWhitespace  <const> = <{ regex.new([[^\s*(.*?)\s*$]]) }>
+rxRequestLine     <const> = <{ regex.new([[(\S+)\s+(\S+)\s+(\S+)]]) }>
+rxPathQuery       <const> = <{ regex.new([[([^?]*)\??(.*)]]) }>
+rxHeaderLine      <const> = <{ regex.new([[([^:]+):\s*(.+)]]) }>
+rxRouteParam      <const> = <{ regex.new([[:(\w+)]]) }>
+rxPercentEncoded  <const> = <{ regex.new([[%([0-9A-Fa-f]{2})]]) }>
+rxRouteParamSub   <const> = <{ regex.new([[:[\w_]+]]) }>
+rxEscapedWildcard <const> = <{ regex.new([[\\\*]]) }>
+rxPathComponent   <const> = <{ regex.new([[([^\/]+)]]) }>
+rxHexChunkSize    <const> = <{ regex.new([[^([0-9a-fA-F]+)]]) }>
+rxQueryPair       <const> = <{ regex.new([[([^&]+)]]) }>
+rxKeyValue        <const> = <{ regex.new([[([^=]+)=(.+)]]) }>
+rxCookieItem      <const> = <{ regex.new([[([^;]+)]]) }>
+rxLineIterator    <const> = <{ regex.new([[([^\r\n]+)]]) }>
+rxParentPath      <const> = <{ regex.new([[(.+)\/.+\/]]) }>
+rxMultipartBoundary <const> = <{ regex.new([[boundary="?([^";]+)"?]], regex.ICASE) }>
+rxMultipartName     <const> = <{ regex.new([[name="([^"]*)"]], regex.ICASE) }>
+rxMultipartFilename <const> = <{ regex.new([[filename="([^"]*)"]], regex.ICASE) }>
 
-glStatusTexts = {
+glStatusTexts <const> = {
       [200] = 'OK', [201] = 'Created', [204] = 'No Content',
       [301] = 'Moved Permanently', [302] = 'Found', [304] = 'Not Modified',
       [400] = 'Bad Request', [401] = 'Unauthorized', [403] = 'Forbidden',
@@ -41,7 +44,7 @@ glStatusTexts = {
       [500] = 'Internal Server Error', [501] = 'Not Implemented', [502] = 'Bad Gateway'
 }
 
-glMimeTypes = {
+glMimeTypes <const> = {
    -- Text
    html = 'text/html',
    htm  = 'text/html',
@@ -529,9 +532,9 @@ function parseJsonBody(Body:str):table
 
    try
       return json.decode(Body)
-   except e
-      return {}
    end
+
+   return {}
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -539,6 +542,83 @@ end
 
 function parseFormBody(Body:str):table
    return parseQueryString(Body) -- Same parsing logic as query strings
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Remove the CRLF that precedes the next multipart boundary.
+
+function trimMultipartPartValue(Value:str):str
+   if Value:endsWith('\r\n') then
+      return Value:substr(0, #Value - 2)
+   elseif Value:endsWith('\n') then
+      return Value:substr(0, #Value - 1)
+   end
+
+   return Value
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Parse multipart/form-data body fields.  File parts are returned as { filename, value } tables.
+
+function parseMultipartBody(Body:str, ContentType:str):table
+   result = {}
+   Body ?? return result
+
+   boundary = rxMultipartBoundary.extract(ContentType ?? '')
+   if boundary is nil or boundary:trim() is '' then return result end
+
+   marker = '--' .. boundary:trim()
+   for raw_part in values(Body:split(marker)) do
+      if raw_part is '' or raw_part:startsWith('--') then
+         continue
+      end
+
+      part = raw_part
+      if part:startsWith('\r\n') then
+         part = part:substr(2)
+      elseif part:startsWith('\n') then
+         part = part:substr(1)
+      end
+
+      header_end = part:find('\r\n\r\n', 0, true)
+      delimiter_size = 4
+      if header_end is nil then
+         header_end = part:find('\n\n', 0, true)
+         delimiter_size = 2
+      end
+      if header_end is nil then continue end
+
+      header_text = part:substr(0, header_end):replace('\r\n', '\n')
+      value = trimMultipartPartValue(part:substr(header_end + delimiter_size))
+      disposition = nil
+
+      for header_line in values(header_text:split('\n')) do
+         colon = header_line:find(':', 0, true)
+         if colon is nil then continue end
+
+         header_name = header_line:substr(0, colon):trim():lower()
+         header_value = header_line:substr(colon + 1):trim()
+
+         if header_name is 'content-disposition' then
+            disposition = header_value
+         end
+      end
+
+      field_name = rxMultipartName.extract(disposition ?? '')
+      if field_name is nil or field_name is '' then continue end
+
+      filename = rxMultipartFilename.extract(disposition ?? '')
+      if filename != nil then
+         result[field_name] = {
+            filename = filename,
+            value    = value
+         }
+      else
+         result[field_name] = value
+      end
+   end
+
+   return result
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -1602,6 +1682,9 @@ function serverIncoming(self, ClientSocket)
          elseif contentType:find('application/x-www-form-urlencoded') then
             logMessage(self, 'Parsing URL-encoded form data')
             state.request.parsedBody = parseFormBody(state.request.body)
+         elseif contentType:find('multipart/form-data') then
+            logMessage(self, 'Parsing multipart form data')
+            state.request.parsedBody = parseMultipartBody(state.request.body, contentType)
          else
             -- Keep raw body for other content types
             state.request.parsedBody = { _raw = state.request.body }
@@ -1939,7 +2022,7 @@ hslib.start = function(Options)
 
    cfg = {
       port     = self.port,
-      flags    = 'SERVER|MULTI_CONNECT',
+      flags    = NSF_SERVER|NSF_MULTI_CONNECT,
       feedback = function(Server, ClientSocket, State)
          if State is NTC_CONNECTED then
             -- New client connection


### PR DESCRIPTION
## Summary

* **Follow redirects** (`follow`, `max-redirects`): Tuku now follows 3xx redirect chains up to a configurable limit. Redirect semantics are correct per status code — 303 changes the method to GET; 307/308 preserve the original method and body. A `resolveRedirectUrl` helper resolves relative and absolute-path location headers against the current URL.
* **Include response headers** (`include`): Prints a `HTTP {status}` line, all response headers, and a blank separator before the body — equivalent to `curl -i`. Body is buffered when writing to stdout so headers always appear first.
* **Multipart form upload** (`multipart`): Accepts `name=value` and `name=@filepath` entries, constructs a MIME multipart/form-data body with a unique boundary, and sets the Content-Type automatically. Body option exclusion rules are extended to cover the new option.
* **httpserver multipart parsing**: The test fixture now parses `multipart/form-data` request bodies, returning text fields as strings and file parts as `{ filename, value }` tables. Regex globals are promoted to constants and a `parseJsonBody` return-path bug is fixed.

## Test plan

- [ ] Build and install: `cmake --build build/agents --config Debug --parallel && cmake --install build/agents --config Debug`
- [ ] Run Tuku Flute suite: `build/agents-install/origo tools/flute.tiri file=apps/tests/test_tuku.tiri --log-warning`
- [ ] Verify redirect tests: single-hop, chain, 303 method change, max-redirects exceeded, no-follow baseline
- [ ] Verify include tests: headers before body in stdout, headers to stdout with body to file
- [ ] Verify multipart tests: text fields round-trip, file upload with filename, exclusion with other body options

🤖 Generated with [Claude Code](https://claude.com/claude-code)