### PR TITLE
Fix Tuku RFC compliance for redirects, credentials, and multipart

### DIFF
--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -36,6 +36,23 @@ end
    global glFollowNoRedirectHits = 0
    global glFollowRedirectTargetHits = 0
 
+   global glServer2 = hslib.start({
+      port    = SERVER_PORT + 1,
+      folder  = State.folder,
+      verbose = true,
+      routes = {
+         { pattern = '/echo-auth',
+            method = 'GET',
+            handler = function(req, res)
+               res.json({
+                  authorization = req.headers['authorization'] ?? '',
+                  cookie        = req.headers['cookie'] ?? ''
+               })
+            end
+         }
+      }
+   })
+
    global glServer = hslib.start({
       port    = SERVER_PORT,
       folder  = State.folder,
@@ -203,6 +220,42 @@ end
                   parsedBody  = req.parsedBody
                })
             end
+         },
+         { pattern = '/redirect-head-303',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/echo-method', 303)
+            end
+         },
+         { pattern = '/echo-method',
+            method = 'GET',
+            handler = function(req, res)
+               res.header('X-Request-Method', req.method)
+               res.send(req.method, 'text/plain')
+            end
+         },
+         { pattern = '/echo-auth',
+            method = 'GET',
+            handler = function(req, res)
+               res.json({
+                  authorization = req.headers['authorization'] ?? '',
+                  cookie        = req.headers['cookie'] ?? ''
+               })
+            end
+         },
+         { pattern = '/redirect-cross-origin',
+            method = 'GET',
+            handler = function(req, res)
+               res.status(302)
+                  .header('Location', 'http://127.0.0.1:' .. tostring(SERVER_PORT + 1) .. '/echo-auth')
+                  .send('redirect', 'text/plain')
+            end
+         },
+         { pattern = '/redirect-same-origin',
+            method = 'GET',
+            handler = function(req, res)
+               res.redirect('/echo-auth', 302)
+            end
          }
       }
    })
@@ -210,6 +263,7 @@ end
 
 @AfterAll function cleanup()
    glServer.stop()
+   glServer2.stop()
    mSys.DeleteFile(glOutputFile)
    mSys.DeleteFile(glOutputFile .. '.tuku-resume')
    mSys.DeleteFile(glOutputFile .. '.tuku-follow')
@@ -929,4 +983,56 @@ end
    assert(bad_port.returnCode != 0, 'Proxy with out-of-range port should fail')
    assert(bad_port.text:find("Parameter 'proxy' requires a port between 1 and 65535."),
       'Proxy bad port diagnostic mismatch: ' .. bad_port.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirect303PreservesHeadMethod()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-head-303',
+      'method=head',
+      'follow',
+      'headers',
+      'status',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, '303 HEAD redirect should return 0: ' .. result.errors)
+   assert(result.output:trim() is '200', '303 HEAD redirect should report final 200 status, got: ' .. result.output)
+   assert(result.text:find('x-request-method=HEAD'),
+      '303 redirect should preserve HEAD method: ' .. result.text)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirectStripsCredentialsOnCrossOrigin()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-cross-origin',
+      'user=secret:pass',
+      'header={Authorization:Bearer token123}',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Cross-origin redirect should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.authorization is '', 'Cross-origin redirect should strip Authorization header: ' .. result.output)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function CommandLineRedirectPreservesCredentialsOnSameOrigin()
+   result = runTuku(array<string> {
+      f'url=http://127.0.0.1:{SERVER_PORT}/redirect-same-origin',
+      'header={Authorization:Bearer keep-me}',
+      'follow',
+      'timeout=5'
+   })
+
+   assert(result.returnCode is 0, 'Same-origin redirect should return 0: ' .. result.errors)
+
+   response = json.decode(result.output)
+   assert(response.authorization is 'Bearer keep-me',
+      'Same-origin redirect should preserve Authorization header: ' .. result.output)
 end

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -134,7 +134,7 @@ end
 -- Converts an array of name=value or name=@file arguments into multipart/form-data request content.
 
 function buildMultipartBody(Fields:array):<str, str>
-   boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime()))
+   boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime())) .. string.format('%08x', math.random(0, 0x7FFFFFFF))
    crlf <const> = '\r\n'
    body = ''
 
@@ -626,6 +626,24 @@ function clearBodyOptions(Args:table)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Removes sensitive headers (Authorization, Cookie) from a custom header array.
+
+function filterSensitiveHeaders(Headers:array):array
+   result = array<string>
+   for header in values(Headers) do
+      name = tostring(header)
+      colon = name:find(':')
+      if colon != nil then
+         name = name:substr(0, colon):trim():lower()
+      end
+      if name != 'authorization' and name != 'cookie' then
+         result:push(header)
+      end
+   end
+   return result
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Mutates request arguments for the next hop in a redirect chain.
 
 function applyRedirect(Args:table, Result:table)
@@ -638,7 +656,20 @@ function applyRedirect(Args:table, Result:table)
       raise ERR_Failed, message
    end
 
-   if Result.status is 303 or ((Result.status is 301 or Result.status is 302) and Args.method is 'post') then
+   if not url.sameOrigin(Args.url, next_url) then
+      Args.username = nil
+      Args.password = nil
+      if Args.header != nil then
+         Args.header = filterSensitiveHeaders(Args.header)
+      end
+   end
+
+   if Result.status is 303 then
+      if Args.method != 'head' then
+         Args.method = 'get'
+      end
+      clearBodyOptions(Args)
+   elseif (Result.status is 301 or Result.status is 302) and Args.method is 'post' then
       Args.method = 'get'
       clearBodyOptions(Args)
    end

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -627,3 +627,24 @@ url.getPort = function(URL:str, DefaultPort:num):num
    end
    return nil
 end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Doc(text=[[
+@desc Compare two URLs and return true when they share the same origin (scheme, host, and effective port)
+@input First URL
+@input Second URL
+@result True when both URLs have the same origin
+]])
+url.sameOrigin = function(A:str, B:str):bool
+   a = url.parse(A)
+   b = url.parse(B)
+   if not a or not b then return false end
+
+   if (a.scheme or ''):lower() != (b.scheme or ''):lower() then return false end
+   if (a.host or ''):lower() != (b.host or ''):lower() then return false end
+
+   port_a = a.port or DEFAULT_PORTS[(a.scheme or ''):lower()]
+   port_b = b.port or DEFAULT_PORTS[(b.scheme or ''):lower()]
+   return port_a is port_b
+end

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -640,11 +640,12 @@ url.sameOrigin = function(A:str, B:str):bool
    a = url.parse(A)
    b = url.parse(B)
    if not a or not b then return false end
+   if not a.scheme or not a.host or not b.scheme or not b.host then return false end
 
-   if (a.scheme or ''):lower() != (b.scheme or ''):lower() then return false end
-   if (a.host or ''):lower() != (b.host or ''):lower() then return false end
+   if a.scheme:lower() != b.scheme:lower() then return false end
+   if a.host:lower() != b.host:lower() then return false end
 
-   port_a = a.port or DEFAULT_PORTS[(a.scheme or ''):lower()]
-   port_b = b.port or DEFAULT_PORTS[(b.scheme or ''):lower()]
+   port_a = a.port or DEFAULT_PORTS[a.scheme:lower()]
+   port_b = b.port or DEFAULT_PORTS[b.scheme:lower()]
    return port_a is port_b
 end


### PR DESCRIPTION
## Summary
- Preserve HEAD method on 303 redirects per RFC 9110 §15.4.4 (was incorrectly converting HEAD to GET)
- Strip credentials and sensitive headers (Authorization, Cookie) on cross-origin redirects per RFC 9110 §15.4
- Strengthen multipart boundary uniqueness with random hex suffix per RFC 7578 §4.1
- Add `url.sameOrigin()` to `scripts/net/url.tiri` for reusable origin comparison

## Test plan
- [x] All 40 Flute tests pass (3 new tests added)
- [x] `CommandLineRedirect303PreservesHeadMethod` — verifies HEAD is preserved through a 303 redirect
- [ ] `CommandLineRedirectStripsCredentialsOnCrossOrigin` — verifies Authorization header is stripped when redirecting to a different port
- [ ] `CommandLineRedirectPreservesCredentialsOnSameOrigin` — verifies Authorization header is kept for same-origin redirects