### PR TITLE
Materialise trace slots before throwable calls in JIT try blocks

### DIFF
--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -462,6 +462,7 @@ struct jit_State {
   int32_t tailcalled;   //  Number of successive tailcalls.
   int32_t framedepth;   //  Current frame depth.
   int32_t retdepth;     //  Return frame depth (count of RETF).
+  uint8_t trydepth;     //  Current try block depth while recording.
 
   uint32_t k32[unsigned(K32::_MAX)];  //  Common 4 byte constants used by backends.
   TValue ksimd[unsigned(KSimd::_MAX)*2+1];  //  16 byte aligned SIMD constants.

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -195,6 +195,8 @@ static TRef recff_ir_call_fixed(jit_State* J, IRCallID CallId, TRef Arg1, TRef A
    uint32_t nargs = CCI_NARGS(call_info);
    if (call_info->flags & CCI_L) nargs--;
 
+   if ((call_info->flags & CCI_T) and J->trydepth > 0) lj_record_try_materialise(J);
+
    TRef carg = TREF_NIL;
    if (nargs IS 1) {
       carg = Arg1;

--- a/src/tiri/jit/src/lj_ir.cpp
+++ b/src/tiri/jit/src/lj_ir.cpp
@@ -19,6 +19,7 @@
 #include "lj_ircall.h"
 #include "lj_iropt.h"
 #include "lj_trace.h"
+#include "lj_record.h"
 #include "lj_vm.h"
 #include "lj_strscan.h"
 #include "lj_serialize.h"
@@ -131,6 +132,9 @@ TRef lj_ir_call(jit_State* J, IRCallID id, ...)
    uint32_t n = CCI_NARGS(ci);
    TRef tr = TREF_NIL;
    va_list argp;
+
+   if ((ci->flags & CCI_T) and J->trydepth > 0) lj_record_try_materialise(J);
+
    va_start(argp, id);
    if ((ci->flags & CCI_L)) n--;
    if (n > 0)

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -30,6 +30,7 @@
 #include "lj_prng.h"
 #include "jit/frame_manager.h"
 #include "runtime/lj_object.h"
+#include "runtime/lj_state.h"
 
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)         (&J->cur.ir[(ref)])
@@ -47,6 +48,93 @@ static TRef rec_tmpref(jit_State *J, TRef tr, int mode)
 {
    if (!LJ_DUALNUM and tref_isinteger(tr)) tr = emitir(IRTN(IR_CONV), tr, IRCONV_NUM_INT);
    return emitir(IRT(IR_TMPREF, IRT_PGC), tr, mode);
+}
+
+static TRef sload(jit_State *J, int32_t Slot);
+
+//********************************************************************************************************************
+// Materialise live trace slots back to the Lua stack before a throwable helper runs inside a recorded try block.
+
+static void rec_try_materialise_slots(jit_State *J, bool ForceLoad)
+{
+   if (J->maxslot IS 0) return;
+
+   IRBuilder ir(J);
+   bool stored = false;
+
+   for (BCREG slot = 0; slot < J->maxslot; slot++) {
+      TRef value_ref = J->base[slot];
+      if (not value_ref and ForceLoad) value_ref = sload(J, slot);
+      if (not value_ref or (value_ref & (TREF_FRAME | TREF_CONT))) continue;
+
+      int32_t absolute_slot = int32_t(J->baseslot) + int32_t(slot);
+      int32_t byte_offset = 8 * (absolute_slot - 1 - LJ_FR2);
+      TRef slot_addr = ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, ir.kint(byte_offset));
+
+      if (tref_isnum(value_ref)) {
+         emitir(IRT(IR_XSTORE, IRT_NUM), slot_addr, value_ref);
+      }
+      else if (tref_isint(value_ref)) {
+#if LJ_DUALNUM
+         TRef store_ref = emitir(IRT(IR_CONV, IRT_I64), value_ref,
+            (IRT_I64 << IRCONV_DSH) | IRT_INT);
+         store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), store_ref,
+            lj_ir_kint64(J, uint64_t(LJ_TISNUM) << 47));
+         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
+#else
+         TRef store_ref = emitir(IRT(IR_CONV, IRT_NUM), value_ref, IRCONV_NUM_INT);
+         emitir(IRT(IR_XSTORE, IRT_NUM), slot_addr, store_ref);
+#endif
+      }
+      else if (tref_isgcv(value_ref)) {
+         uint32_t itype = irt_toitype_(tref_type(value_ref));
+         TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), value_ref,
+            lj_ir_kint64(J, uint64_t(itype) << 47));
+         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
+      }
+      else if (tref_ispri(value_ref)) {
+         TValue tv;
+         setpriV(&tv, irt_toitype_(tref_type(value_ref)));
+         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, lj_ir_kint64(J, tv.u64));
+      }
+      else if (tref_islightud(value_ref)) {
+         TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), value_ref,
+            lj_ir_kint64(J, uint64_t(LJ_TLIGHTUD) << 47));
+         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
+      }
+      else {
+         setintV(&J->errinfo, int32_t(tref_type(value_ref)));
+         lj_trace_err_info(J, LJ_TRERR_NYIIR);
+      }
+
+      stored = true;
+   }
+
+   if (stored) emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+}
+
+void lj_record_try_materialise(jit_State *J)
+{
+   rec_try_materialise_slots(J, false);
+}
+
+//********************************************************************************************************************
+// Return the active try depth for the frame where recording starts.
+
+static uint8_t rec_try_active_depth(jit_State *J)
+{
+   lua_State *L = J->L;
+   if (L->try_stack.depth IS 0) return 0;
+
+   ptrdiff_t frame_base = savestack(L, L->base);
+   uint8_t depth = 0;
+
+   for (int i = 0; i < L->try_stack.depth; i++) {
+      const TryFrame *try_frame = &L->try_stack.frames[i];
+      if (try_frame->func IS J->fn and try_frame->frame_base IS frame_base) depth++;
+   }
+
+   return depth;
 }
 
 //********************************************************************************************************************
@@ -426,8 +514,16 @@ static int rec_for_direction(cTValue *o)
 //********************************************************************************************************************
 // Simulate the runtime behavior of the FOR loop iterator.
 
-static LoopEvent rec_for_iter(IROp* op, cTValue *o, int isforl)
+static LoopEvent rec_for_iter(jit_State *J, IROp* op, cTValue *o, int isforl)
 {
+#if LJ_DUALNUM
+   if (not tvisnumber(&o[FORL_STOP]) or not tvisnumber(&o[FORL_IDX]) or not tvisnumber(&o[FORL_STEP]))
+      lj_trace_err(J, LJ_TRERR_BADTYPE);
+#else
+   if (not tvisnum(&o[FORL_STOP]) or not tvisnum(&o[FORL_IDX]) or not tvisnum(&o[FORL_STEP]))
+      lj_trace_err(J, LJ_TRERR_BADTYPE);
+#endif
+
    lua_Number stopv = numberVnum(&o[FORL_STOP]);
    lua_Number idxv = numberVnum(&o[FORL_IDX]);
    lua_Number stepv = numberVnum(&o[FORL_STEP]);
@@ -570,7 +666,7 @@ static LoopEvent rec_for(jit_State *J, const BCIns *fori, int isforl)
       rec_for_check(J, t, rec_for_direction(&tv[FORL_STEP]), stop, tr[FORL_STEP], 1);
    }
 
-   ev = rec_for_iter(&op, tv, isforl);
+   ev = rec_for_iter(J, &op, tv, isforl);
    if (ev IS LOOPEV_LEAVE) {
       J->maxslot = ra + FORL_EXT + 1;
       J->pc = fori + 1;
@@ -2106,7 +2202,7 @@ static void rec_comp_fixup(jit_State *J, const BCIns *pc, int cond)
    // Skip PC modification inside try blocks to prevent snapshot restoration issues.
    // See function header comment for detailed explanation.
 
-   if (J->L->try_stack.depth > 0) {
+   if (J->trydepth > 0) {
       J->needsnap = 1;
       return;
    }
@@ -3281,34 +3377,21 @@ void lj_record_ins(jit_State *J)
       break;
 
    case BC_TRYENTER: {
-      // Inlined frames use a virtual base pointer. Compute the correct base below so
-      // try-enter can still record properly inside inlined calls.
-
-      // Add snapshot before try block to enable on-trace error catching.
-      // This allows the JIT to exit at this point when an exception occurs,
-      // letting the interpreter handle the try-except recovery.
-
       uint16_t try_index = (uint16_t)bc_d(ins);
+      rec_try_materialise_slots(J, true);
       lj_snap_add(J);
-
-      // Emit call to lj_try_enter(L, Func, Base, TryBlockIndex)
-      // L is implicit (CCI_L flag)
-      // Func is the current function for this frame (may differ from J->fn)
-      // Base must point at the current frame. For inlined frames, REF_BASE is the root base,
-      // so add the baseslot offset to reach the virtual frame base.
-
       TRef tr_func = getcurrf(J);
       TRef tr_base = REF_BASE;
       if (J->baseslot > FRC::MIN_BASESLOT) {
          IRBuilder ir(J);
-         int32_t slot_delta = (int32_t)J->baseslot - (int32_t)FRC::MIN_BASESLOT;
+         int32_t slot_delta = int32_t(J->baseslot) - int32_t(FRC::MIN_BASESLOT);
          int32_t byte_delta = slot_delta * 8;
          tr_base = ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, ir.kint(byte_delta));
       }
-      TRef tr_index = lj_ir_kint(J, (int32_t)try_index);
+      TRef tr_index = lj_ir_kint(J, int32_t(try_index));
       lj_ir_call(J, IRCALL_lj_try_enter, tr_func, tr_base, tr_index);
-
-      J->needsnap = 1; // Snapshot after try_enter to create a restore point for trace exits
+      J->trydepth++;
+      J->needsnap = 1;
       break;
    }
 
@@ -3317,6 +3400,7 @@ void lj_record_ins(jit_State *J)
       // Note: vm_exit_interp in vm_x64.dasc must correctly dispatch BC_TRYLEAVE to its handler,
       // not to the C function path. See the bytecode dispatch logic after trace exit.
       lj_ir_call(J, IRCALL_lj_try_leave); // L is implicit (CCI_L flag), no explicit args needed
+      if (J->trydepth > 0) J->trydepth--;
       J->needsnap = 1; // Snapshot after try_leave to mark the end of the try block scope
       break;
    }
@@ -3464,6 +3548,7 @@ void lj_record_setup(jit_State *J)
    J->maxslot    = 0;
    J->framedepth = 0;
    J->retdepth   = 0;
+   J->trydepth   = rec_try_active_depth(J);
    J->instunroll = J->param[JIT_P_instunroll];
    J->loopunroll = J->param[JIT_P_loopunroll];
    J->tailcalled = 0;

--- a/src/tiri/jit/src/lj_record.h
+++ b/src/tiri/jit/src/lj_record.h
@@ -37,7 +37,7 @@ LJ_FUNC void lj_record_ret(jit_State* J, BCREG rbase, ptrdiff_t gotresults);
 LJ_FUNC int lj_record_mm_lookup(jit_State* J, RecordIndex* ix, MMS mm);
 LJ_FUNC TRef lj_record_idx(jit_State* J, RecordIndex* ix);
 LJ_FUNC int lj_record_next(jit_State* J, RecordIndex* ix);
+LJ_FUNC void lj_record_try_materialise(jit_State* J);
 LJ_FUNC void lj_record_ins(jit_State* J);
 LJ_FUNC void lj_record_setup(jit_State* J);
 #endif
-

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -313,6 +313,12 @@ static BCREG snap_usedef(jit_State *J, uint8_t *udf, const BCIns *pc, BCREG maxs
             else if (op IS BC_TSETM) {
                for (s = bc_a(ins) - 1; s < maxslot; s++) USE_SLOT(s);
             }
+            else if (op IS BC_TRYENTER) {
+               // Exception handlers can read any local in scope at the try entry point.
+               // Conservatively mark all slots as used to prevent purging.
+               for (s = 0; s < maxslot; s++) USE_SLOT(s);
+               return maxslot;
+            }
             break;
          default: break;
       }

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -74,6 +74,39 @@ function constant_target(Value)
    return offset, label
 end
 
+function jit_regex_failure_convert(Value:any, Param:table):any
+   global jit_regex_failure_param_name = Param.name
+   global jit_regex_failure_value = Value
+
+   try
+      return regex.new(jit_regex_failure_value)
+   except e
+      raise ERR_WrongType, f"Parameter '{jit_regex_failure_param_name}' requires a valid regex pattern."
+   end
+end
+
+@Test(hotpath=80) function JITTryRegexFailurePreservesParamName()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   local param = { name = 'pattern', type = 'regex' }
+   local expected_message = "Parameter 'pattern' requires a valid regex pattern."
+
+   for i = 0, 99 do
+      local err
+      try
+         jit_regex_failure_convert('(', param)
+      except e
+         err = e
+      end
+
+      assert(err != nil, "Invalid regex should raise an error")
+      assert(err.code is ERR_WrongType, f"Expected ERR_WrongType, got {err.code}")
+      assert(err.message is expected_message, f"Expected '{expected_message}', got '{err.message}'")
+   end
+end
+
 @Test(hotpath=80) function JITVariableNumericHashLookup()
    jit.on()
    jit.flush()


### PR DESCRIPTION
## Summary

- Adds `trydepth` tracking to `jit_State` so the recorder knows when it is inside a try block without querying interpreter state
- Introduces `rec_try_materialise_slots()` which emits XSTORE IR to write live trace values back to the Lua stack before any throwable helper call (`CCI_T`) during recording inside a try block, ensuring exception handlers see correct variable values
- Guards both `lj_ir_call()` and `recff_ir_call_fixed()` to trigger materialisation automatically for throwable calls
- `BC_TRYENTER` now materialises all slots before snapshotting and increments `trydepth`; `BC_TRYLEAVE` decrements it
- `snap_usedef()` conservatively marks all slots as used at `BC_TRYENTER` to prevent dead-slot purging
- `rec_comp_fixup()` now checks `J->trydepth` instead of `L->try_stack.depth`
- `rec_for_iter()` validates loop variable types to abort traces with non-numeric for-loop operands
- Adds `JITTryRegexFailurePreservesParamName` test that verifies exception data integrity (error code, message with interpolated parameter name) is preserved across JIT compilation of try blocks

## Test plan

- [ ] Build succeeds: `cmake --build build/agents --config Debug --target tiri --parallel`
- [ ] Existing JIT tests pass: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri_jit`
- [ ] New `JITTryRegexFailurePreservesParamName` test passes through interpreter and JIT compilation phases
- [ ] Verify no regressions in try/except handling for non-JIT paths