### PR TITLE
[Script] Add userConfig JSON support to options parser and update HTTPServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,7 +837,7 @@ if (KOTUKU_INSTALL)
    install (FILES
       "${PROJECT_SOURCE_DIR}/apps/find.tiri"
       "${PROJECT_SOURCE_DIR}/apps/httpserver.tiri"
-      "${PROJECT_SOURCE_DIR}/apps/httpserver_cfg.tiri"
+      "${PROJECT_SOURCE_DIR}/apps/httpserver_cfg.json"
       "${PROJECT_SOURCE_DIR}/apps/paintbox.tiri"
       "${PROJECT_SOURCE_DIR}/apps/tuku.tiri"
       "${PROJECT_SOURCE_DIR}/apps/vuepoint.tiri"

--- a/apps/httpserver.tiri
+++ b/apps/httpserver.tiri
@@ -24,7 +24,7 @@ Examples:
   origo apps/httpserver folder=docs/html port=8080
   origo apps/httpserver config=apps/httpserver_cfg.json verbose
 ]],
-      userConfig  = 'user:config/httpserver_cfg.json'
+      userConfig  = 'user:config/httpserver_cfg.json',
       autoHelp    = false,
       args        = array<table> {
          { name = 'folder', type = 'folder', exists = true, required = true, group = 'Server',

--- a/apps/httpserver.tiri
+++ b/apps/httpserver.tiri
@@ -4,60 +4,10 @@
    import 'net/httpserver'
    import 'options'
 
-function validatePortOption(Parser:table, ArgName:str, Value:any, Param:table)
-   if Value < 1 or Value > 65535 then
-      error("Parameter 'port' must be between 1 and 65535.")
-   end
-end
+----------------------------------------------------------------------------------------------------------------------
 
-function validateTimeoutOption(Parser:table, ArgName:str, Value:any, Param:table)
-   if Value < 1 or Value > 300 then
-      error("Parameter 'timeout' must be between 1 and 300 seconds.")
-   end
-end
-
-function validateRateLimitOption(Parser:table, ArgName:str, Value:any, Param:table)
-   if Value < 0 or Value > 1000 then
-      error("Parameter 'ratelimit' must be between 0 and 1000.")
-   end
-end
-
-function makeParserDefaults(Parser:table, Defaults:table):table
-   parser_defaults = {}
-
-   for name, value in pairs(Defaults) do
-      if Parser.getParam(name) then
-         parser_defaults[name] = value
-      end
-   end
-
-   return parser_defaults
-end
-
-function applyParserOptions(Target:table, Values:table)
-   for name, value in pairs(Values) do
-      Target[name] = value
-   end
-end
-
-   glConfigParser = options({
-      name     = 'HTTPServer',
-      strict   = false,
-      autoHelp = false,
-      args     = array<table> {
-         { name = 'config', type = 'path', default = 'user:config/http_server_cfg.tiri' }
-      }
-   })
-
-   glConfigArgs = glConfigParser.process()
-   glConfigFile = glConfigArgs.config
-   global glOptions = {}
    global glSelf = obj.find('self')
    global glPath = glSelf.workingPath
-
-   if mSys.AnalysePath(glConfigFile) is ERR_Okay then
-      loadFile(glConfigFile, glOptions)
-   end
 
    glParser = options({
       name        = 'HTTPServer',
@@ -65,40 +15,51 @@ end
 HTTPServer serves static files from a local folder, with config-file defaults and command-line overrides.
 ]],
       epilog      = [[
-If a config file is stored at user:config/http_server_cfg.tiri then it will be loaded automatically.  Options can be
+If a config file is stored at user:config/httpserver_cfg.json then it will be loaded automatically.  Options can be
 overridden via the command-line, or you can refer to a different file via the config parameter.
 
 Index files are checked in this order: index.html, index.htm, default.html, default.htm
 
 Examples:
   origo apps/httpserver folder=docs/html port=8080
-  origo apps/httpserver config=apps/httpserver_cfg.tiri verbose
+  origo apps/httpserver config=apps/httpserver_cfg.json verbose
 ]],
+      userConfig  = 'user:config/httpserver_cfg.json'
       autoHelp    = false,
       args        = array<table> {
-         { name = 'config', type = 'path', default = 'user:config/http_server_cfg.tiri', group = 'Configuration',
-           comment = 'Tiri config file with options assigned to a glOptions table.' },
-
-         { name = 'folder', type = 'folder', exists = true, group = 'Server',
+         { name = 'folder', type = 'folder', exists = true, required = true, group = 'Server',
            comment = 'Required. Folder containing HTML pages and static files to serve.',
            description = 'Folder containing HTML pages and static files to serve; can also come from config.' },
-         { name = 'port', type = 'int', default = 8080, group = 'Server', exec = validatePortOption,
-           comment = 'Port number to listen on.' },
+         { name = 'port', type = 'int', default = 8080, group = 'Server', comment = 'Port number to listen on.',
+           exec = function(Parser:table, ArgName:str, Value:any, Param:table)
+              if Value < 1 or Value > 65535 then
+                 error("Parameter 'port' must be between 1 and 65535.")
+              end
+           end
+         },
          { name = 'bind', type = 'str', group = 'Server',
            comment = "Bind to a specific IP address, for example '127.0.0.1' for localhost only." },
-
          { name = 'verbose', kind = 'flag', default = false, group = 'Behaviour',
            comment = 'Enable verbose logging.' },
-         { name = 'timeout', type = 'int', default = 30, group = 'Behaviour', exec = validateTimeoutOption,
-           comment = 'Request timeout in seconds.' },
+         { name = 'timeout', type = 'int', default = 30, group = 'Behaviour', comment = 'Request timeout in seconds.',
+           exec = function(Parser:table, ArgName:str, Value:any, Param:table)
+              if Value < 1 or Value > 300 then
+                 error("Parameter 'timeout' must be between 1 and 300 seconds.")
+              end
+           end
+         },
          { names = array<string> { 'autoIndex', 'autoindex' }, kind = 'flag', default = true, group = 'Behaviour',
            comment = 'Enable automatic directory listing.' },
          { names = array<string> { 'rateLimit', 'ratelimit' }, type = 'int', group = 'Behaviour',
-           exec = validateRateLimitOption,
-           comment = 'Maximum requests per rate-limit window; 0 disables rate limiting.' },
+           comment = 'Maximum requests per rate-limit window; 0 disables rate limiting.',
+           exec = function(Parser:table, ArgName:str, Value:any, Param:table)
+              if Value < 0 or Value > 1000 then
+                 error("Parameter 'ratelimit' must be between 0 and 1000.")
+              end
+           end
+         },
          { names = array<string> { 'rateLimitWindow', 'ratelimitwindow' }, type = 'int', group = 'Behaviour',
            comment = 'Rate-limit window in seconds.' },
-
          { name = 'help', type = 'str', hidden = true, implicit = true,
            exec = function(Parser:table, ArgName:str, Value:any, Param:table)
               topic = (Value is true or Value is 'true') ? nil :> Value
@@ -108,10 +69,8 @@ Examples:
       }
    })
 
-   glParser.setDefaults(makeParserDefaults(glParser, glOptions))
-   parsed_options = glParser.process()
-   if parsed_options is nil then return end
-   applyParserOptions(glOptions, parsed_options)
+   glOptions = glParser.process()
+   if glOptions is nil then return end
 
    err, resolved_path = mSys.ResolvePath(glOptions.folder)
    if err is ERR_Okay and resolved_path then

--- a/apps/httpserver_cfg.json
+++ b/apps/httpserver_cfg.json
@@ -1,0 +1,5 @@
+{
+   "_comment": "HTTP server config file.  Copy to user:config/httpserver_cfg.json for httpserver to automatically use it.",
+   "port": 8080,
+   "folder": "docs/html/"
+}

--- a/apps/httpserver_cfg.tiri
+++ b/apps/httpserver_cfg.tiri
@@ -1,5 +1,0 @@
--- HTTP server config file.
--- Copy this to user:config/http_server_cfg.tiri for http_server to automatically  use it.
-
-glOptions.port = 8080
-glOptions.folder = glPath .. '../docs/html/'

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -1729,6 +1729,54 @@ function make_help_result(Parser:table, Topic:any):table
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Load JSON defaults from a configured user config file when the selected file exists.
+
+function load_user_config_defaults(Parser:table, RawResult:table):table
+   Parser._user_config_defaults = nil
+
+   Parser.userConfig ?? return
+
+   config_param = Parser._lookup.config
+   config_param ?? return
+
+   raw_path = RawResult.config
+   raw_path ?? return
+
+   config_path = convert_value(Parser, config_param, raw_path)
+   config_path = tostring(config_path)
+   config_path ?? return
+
+   err, location = mSys.AnalysePath(config_path)
+   if err != ERR_Okay then return end
+
+   if location != LOC_FILE then
+      raise ERR_ExpectedFile, f"User config path '{config_path}' is not a file."
+   end
+
+   file = io.open(config_path, 'r')
+   content = file:read('*a')
+   file:close()
+
+   local defaults:any
+   local pos:num
+   try
+      defaults, pos = json.decode(content)
+      if pos < #content and content:substr(pos):trim() != '' then
+         raise ERR_Syntax, 'Trailing content after JSON value.'
+      end
+   except e
+      raise ERR_WrongType, f"User config '{config_path}' requires valid JSON."
+   end
+
+   if type(defaults) != 'table' then
+      raise ERR_WrongType, f"User config '{config_path}' requires a JSON object."
+   end
+
+   Parser._user_config_defaults = defaults
+   return defaults
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Apply precedence, conversion, and validation to an already parsed input layer.
 
 function resolve_input_result(Parser:table, InputResult:table, InputArgNames:table, InputPresence:table):table
@@ -1746,6 +1794,7 @@ function resolve_input_result(Parser:table, InputResult:table, InputArgNames:tab
       for name, value in pairs(Defaults) do
          param = Parser._lookup[name]
          if param is nil then
+            if name:startsWith('_') then continue end -- Ignore private keys
             raise ERR_ParameterUnknown, f"Unknown default parameter '{name}'."
          end
 
@@ -1800,6 +1849,22 @@ function resolve_input_result(Parser:table, InputResult:table, InputArgNames:tab
 
    apply_param_defaults(Parser, raw_result, arg_names)
    apply_default_table(Parser, raw_result, arg_names, Parser.defaults)
+
+   if not (Parser.autoHelp and InputResult[Parser.helpArg] != nil) then
+      apply_default_table(Parser, raw_result, arg_names, Parser._set_defaults)
+      apply_environment(Parser, raw_result, arg_names, presence)
+      merge_input_result(Parser, raw_result, arg_names, presence, InputResult, InputArgNames, InputPresence)
+      load_user_config_defaults(Parser, raw_result)
+
+      raw_result = {}
+      arg_names = {}
+      presence = {}
+
+      apply_param_defaults(Parser, raw_result, arg_names)
+      apply_default_table(Parser, raw_result, arg_names, Parser.defaults)
+      apply_default_table(Parser, raw_result, arg_names, Parser._user_config_defaults)
+   end
+
    apply_default_table(Parser, raw_result, arg_names, Parser._set_defaults)
    apply_environment(Parser, raw_result, arg_names, presence)
    merge_input_result(Parser, raw_result, arg_names, presence, InputResult, InputArgNames, InputPresence)
@@ -2118,6 +2183,7 @@ create_parser = function(Config:table):table
       license     = Config.license,
       envPrefix   = Config.envPrefix,
       defaults    = Config.defaults,
+      userConfig  = Config.userConfig,
       strict      = Config.strict,
       autoHelp    = Config.autoHelp,
       onError     = Config.onError,
@@ -2129,6 +2195,7 @@ create_parser = function(Config:table):table
    parser.autoHelp ?= true
    parser.helpArg  ?= 'help' -- In future, allow translations to user's locale
    validate_name(parser.helpArg)
+   assert(parser.userConfig is nil or (type(parser.userConfig) is 'string') or (type(parser.userConfig) is 'bool'), 'userConfig must be a string or boolean.')
    assert(parser.onError is nil or type(parser.onError) is 'function', 'onError must be a function.')
    assert(parser.onHelp is nil or type(parser.onHelp) is 'function', 'onHelp must be a function.')
 
@@ -2139,6 +2206,7 @@ create_parser = function(Config:table):table
    parser._commands       = array<table>
    parser._command_lookup = {}
    parser._set_defaults   = nil
+   parser._user_config_defaults = nil
 
    @Doc(text=[[
    Add a parameter definition to the parser
@@ -2426,6 +2494,17 @@ create_parser = function(Config:table):table
             end
             raise ERR_Terminate -- Stops the process without throwing an error
          end
+      })
+   end
+
+   if parser.userConfig then -- Can be true, empty string or file path
+      if definitions_have_name(Config.args, 'config') then
+         raise ERR_DuplicateValue, "Parameter name or alias 'config' conflicts with the reserved config token."
+      end
+
+      add_param(parser, {
+         name = 'config', type = 'path', default = type(parser.userConfig) is 'string' ? parser.userConfig :> nil, group = 'Configuration',
+         comment = 'JSON config file with option defaults.'
       })
    end
 

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -62,6 +62,16 @@ function set_test_env(Name:str, Value:any)
    assert(err is ERR_Okay, f"Failed to set environment variable '{Name}': {mSys.GetErrorMsg(err)}")
 end
 
+function write_test_file(Path:str, Content:str)
+   local file = io.open(Path, 'w')
+   file:write(Content)
+   file:close()
+end
+
+function delete_test_file(Path:str)
+   mSys.DeleteFile(Path)
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConstructEmptyParser()
@@ -549,6 +559,154 @@ end
    assert(args.count is 5, 'Input values should override environment values')
 
    set_test_env('KOTUKU_OPTIONS_PRECEDENCE_COUNT', nil)
+end
+
+@Test function UserConfigJsonDefaults()
+   local config_path = 'temp:options-user-config-defaults.json'
+   delete_test_file(config_path)
+   write_test_file(config_path, '{"count":"12","mode":"json","verbose":"true"}')
+
+   parser = options({
+      userConfig = config_path,
+      args = array<table> {
+         { name = 'count', type = 'int', required = true },
+         { name = 'mode', type = 'str' },
+         { name = 'verbose', kind = 'flag', type = 'bool' }
+      }
+   })
+
+   args = parser.process(array<string> { })
+   assert(args.config is config_path, 'Injected config parameter should report the selected path')
+   assert(args.count is 12, 'JSON config should satisfy required parameters')
+   assert(args.mode is 'json', 'JSON config should supply string defaults')
+   assert(args.verbose is true, 'JSON config defaults should be converted')
+
+   delete_test_file(config_path)
+end
+
+@Test function UserConfigPathOverrideAndMissingSkip()
+   local default_path = 'temp:options-user-config-default.json'
+   local override_path = 'temp:options-user-config-override.json'
+   local missing_path = 'temp:options-user-config-missing.json'
+
+   delete_test_file(default_path)
+   delete_test_file(override_path)
+   delete_test_file(missing_path)
+   write_test_file(default_path, '{"count":"1"}')
+   write_test_file(override_path, '{"count":"2"}')
+
+   parser = options({
+      userConfig = default_path,
+      args = array<table> {
+         { name = 'count', type = 'int', default = '9' }
+      }
+   })
+
+   args = parser.process(array<string> { 'config=' .. override_path })
+   assert(args.config is override_path, 'Explicit config path should override userConfig')
+   assert(args.count is 2, 'Explicit config path should load the selected JSON file')
+
+   missing_parser = options({
+      userConfig = missing_path,
+      args = array<table> {
+         { name = 'count', type = 'int', default = '7' }
+      }
+   })
+
+   args = missing_parser.process(array<string> { })
+   assert(args.config is missing_path, 'Missing config path should remain visible as the selected config value')
+   assert(args.count is 7, 'Missing user config files should be skipped without changing defaults')
+
+   delete_test_file(default_path)
+   delete_test_file(override_path)
+end
+
+@Test function UserConfigPrecedenceWithSetDefaultsAndInput()
+   local default_path = 'temp:options-user-config-precedence-default.json'
+   local set_path = 'temp:options-user-config-precedence-set.json'
+
+   delete_test_file(default_path)
+   delete_test_file(set_path)
+   write_test_file(default_path, '{"count":"2","mode":"default"}')
+   write_test_file(set_path, '{"count":"3","mode":"set-config"}')
+
+   parser = options({
+      userConfig = default_path,
+      args = array<table> {
+         { name = 'count', type = 'int' },
+         { name = 'mode', type = 'str' }
+      }
+   })
+   parser.setDefaults({ config = set_path, count = '4' })
+
+   args = parser.process(array<string> { })
+   assert(args.config is set_path, 'setDefaults() should be able to select the user config path')
+   assert(args.count is 4, 'setDefaults() should override JSON config defaults')
+   assert(args.mode is 'set-config', 'JSON selected by setDefaults().config should still provide lower defaults')
+
+   args = parser.process(array<string> { 'count=5' })
+   assert(args.count is 5, 'Explicit input should override JSON and setDefaults() values')
+   assert(args.mode is 'set-config', 'Explicit input should not discard unrelated JSON defaults')
+
+   delete_test_file(default_path)
+   delete_test_file(set_path)
+end
+
+@Test function UserConfigValidationFailuresAndHelp()
+   local bad_json_path = 'temp:options-user-config-bad.json'
+   local array_json_path = 'temp:options-user-config-array.json'
+
+   delete_test_file(bad_json_path)
+   delete_test_file(array_json_path)
+   write_test_file(bad_json_path, '{"count":')
+   write_test_file(array_json_path, '["count"]')
+
+   expect_options_error({
+      userConfig = 'temp:options-user-config.json',
+      args = array<table> {
+         { name = 'config' }
+      }
+   }, ERR_DuplicateValue, "Parameter name or alias 'config' conflicts with the reserved config token.")
+
+   bad_json_parser = options({
+      userConfig = bad_json_path,
+      args = array<table> {
+         { name = 'count', type = 'int' }
+      }
+   })
+   expect_error(bad_json_parser, array<string> { }, ERR_WrongType, 'requires valid JSON')
+
+   array_json_parser = options({
+      userConfig = array_json_path,
+      args = array<table> {
+         { name = 'count', type = 'int' }
+      }
+   })
+   expect_error(array_json_parser, array<string> { }, ERR_WrongType, 'requires a JSON object')
+
+   folder_parser = options({
+      userConfig = 'temp:',
+      args = array<table> {
+         { name = 'count', type = 'int' }
+      }
+   })
+   expect_error(folder_parser, array<string> { }, ERR_ExpectedFile, "User config path 'temp:' is not a file.")
+
+   help_parser = options({
+      name = 'user-config-help',
+      userConfig = bad_json_path,
+      args = array<table> {
+         { name = 'count', type = 'int', required = true, comment = 'Count value' }
+      }
+   })
+
+   result, err = help_parser.tryProcess(array<string> { 'help' })
+   assert(err is nil, 'Help requests should not load invalid user config files')
+   assert(result.help is true, 'Help should still be returned for parsers with userConfig')
+   assert(result.text:find('Usage: user-config-help'), 'Help should include the parser usage text')
+
+   delete_test_file(bad_json_path)
+   delete_test_file(array_json_path)
 end
 
 @Test function SourcePrecedenceDefersConversion()


### PR DESCRIPTION
## Summary

* Adds a `userConfig` option to the `options` parser that injects a reserved `config` parameter and loads a JSON file as lower-priority defaults
* JSON config defaults sit below `setDefaults()` and explicit command-line input in the precedence chain, allowing users to override them at any level
* HTTPServer updated to use `userConfig` instead of manual Tiri-based config loading; validation callbacks are now defined inline
* Replaces `httpserver_cfg.tiri` with `httpserver_cfg.json` as the example config template
* Adds Flute tests covering JSON defaults, path overrides, missing-file skip, precedence rules, validation failures, and help-bypass behaviour

## Test plan

- [ ] Run the existing options Flute test suite: `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_options.tiri --log-warning`
- [ ] Verify new tests pass: `UserConfigJsonDefaults`, `UserConfigPathOverrideAndMissingSkip`, `UserConfigPrecedenceWithSetDefaultsAndInput`, `UserConfigValidationFailuresAndHelp`
- [ ] Run HTTPServer with no config file and confirm defaults apply
- [ ] Run HTTPServer with a `httpserver_cfg.json` and confirm JSON values are picked up
- [ ] Run HTTPServer with an explicit `config=` override and confirm it takes precedence over the JSON defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)