### PR TITLE
[Tiri] Add slot materialisation cache to JIT try-block recording

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -98,6 +98,11 @@ set (JIT_GENERATED_HEADERS
 set (JIT_VMDEF_LUA "${JIT_BUILD_DIR}/jit/vmdef.lua")
 set (JIT_COMMON_DEFS PRV_METACLASS)
 set (JIT_NON_MSVC_DEFS -DLUAJIT_DISABLE_BUFFER -DPRV_METACLASS)
+set (JIT_LAYOUT_HEADERS
+   "${JIT_SRC}/runtime/lj_obj.h"
+   "${JIT_SRC}/debug/lj_jit.h"
+   "${JIT_SRC}/lj_dispatch.h"
+)
 
 option(KOTUKU_PARSER_TRACE "Emit parser token and expectation traces" OFF)
 option(INCLUDE_TIPS "Include the parser tips system for code analysis" ON)
@@ -261,14 +266,14 @@ if (MSVC)
          ${JIT_BUILD_DIR}/buildvm_peobj.obj
          ${JIT_BUILD_DIR}/buildvm_lib.obj
          ${JIT_BUILD_DIR}/buildvm_fold.obj
-      DEPENDS ${BUILDVM_SOURCES} ${BUILDVM_ARCH_H} "${JIT_SRC}/runtime/lj_obj.h"
+      DEPENDS ${BUILDVM_SOURCES} ${BUILDVM_ARCH_H} ${JIT_LAYOUT_HEADERS}
       WORKING_DIRECTORY "${JIT_BUILD_DIR}"
       COMMENT "Building buildvm host tool for ${JIT_ARCH}"
       VERBATIM
    )
 
-   # Generate headers and VM object file using buildvm
-   # lj_obj.h dependency ensures VM is regenerated when metamethod table changes
+   # Generate headers and VM object file using buildvm.  The layout header dependency ensures VM offsets are
+   # regenerated when GG_State or jit_State changes.
    add_custom_command(
       OUTPUT ${JIT_GENERATED_HEADERS} ${JIT_VM_OBJ} ${JIT_VMDEF_LUA}
       COMMAND ${BUILDVM_TARGET} -m peobj -o ${JIT_VM_OBJ}
@@ -278,7 +283,7 @@ if (MSVC)
       COMMAND ${BUILDVM_TARGET} -m recdef -o ${JIT_BUILD_DIR}/lj_recdef.h ${LJLIB_C}
       COMMAND ${BUILDVM_TARGET} -m folddef -o ${JIT_BUILD_DIR}/lj_folddef.h ${JIT_SRC}/lj_opt_fold.cpp
       COMMAND ${BUILDVM_TARGET} -m vmdef -o ${JIT_VMDEF_LUA} ${LJLIB_C}
-      DEPENDS ${BUILDVM_TARGET} ${LJLIB_C} "${JIT_SRC}/lj_opt_fold.cpp" "${JIT_SRC}/runtime/lj_obj.h"
+      DEPENDS ${BUILDVM_TARGET} ${LJLIB_C} "${JIT_SRC}/lj_opt_fold.cpp" ${JIT_LAYOUT_HEADERS}
       WORKING_DIRECTORY "${JIT_SRC}"
       COMMENT "Generating JIT headers and VM object for ${JIT_ARCH}"
       VERBATIM
@@ -485,7 +490,7 @@ else ()
          ${JIT_NON_MSVC_DEFS}
          ${JIT_INCLUDE_DIRS}
          -o ${BUILDVM_TARGET} ${BUILDVM_SOURCES} ${JIT_MATH_LIB}
-      DEPENDS ${BUILDVM_SOURCES} ${BUILDVM_ARCH_H} "${JIT_SRC}/runtime/lj_obj.h"
+      DEPENDS ${BUILDVM_SOURCES} ${BUILDVM_ARCH_H} ${JIT_LAYOUT_HEADERS}
       COMMENT "Building buildvm host tool"
       VERBATIM
    )
@@ -493,7 +498,7 @@ else ()
    # Generate headers and VM file using buildvm
    # Windows (MinGW) uses peobj to generate .obj directly like MSVC
    # Unix uses elfasm to generate .S assembly source that gets compiled later
-   # lj_obj.h dependency ensures VM is regenerated when metamethod table changes
+   # The layout header dependency ensures VM offsets are regenerated when GG_State or jit_State changes.
 
    # Set platform-specific VM generation parameters
 
@@ -518,7 +523,7 @@ else ()
       COMMAND ${BUILDVM_TARGET} -m folddef -o ${JIT_BUILD_DIR}/lj_folddef.h "${JIT_SRC}/lj_opt_fold.cpp"
       COMMAND ${BUILDVM_TARGET} -m vmdef -o ${JIT_VMDEF_LUA} ${LJLIB_C}
       COMMAND ${BUILDVM_TARGET} -m ${JIT_VM_MODE} -o ${JIT_VM_OUTPUT}
-      DEPENDS ${BUILDVM_TARGET} ${LJLIB_C} "${JIT_SRC}/lj_opt_fold.cpp" "${JIT_SRC}/runtime/lj_obj.h"
+      DEPENDS ${BUILDVM_TARGET} ${LJLIB_C} "${JIT_SRC}/lj_opt_fold.cpp" ${JIT_LAYOUT_HEADERS}
       WORKING_DIRECTORY ${JIT_SRC}
       COMMENT ${JIT_VM_COMMENT}
       VERBATIM

--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -522,6 +522,10 @@ struct jit_State {
   TValue errinfo;     //  Additional info element for trace errors.
   uint8_t retryrec;   //  Retry recording.
   bool abort_in_progress; //  True while aborting trace recording (skip try handlers)
+
+  // Optimisation cache for try-block stack materialisation.  Correctness comes from forced
+  // BC_TRYENTER materialisation and CCI_T materialisation before throwable helper calls.
+  TRef trymat[LJ_MAX_JSLOTS+LJ_STACK_EXTRA];
 };
 
 #ifdef LUA_USE_ASSERT

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -55,6 +55,55 @@ static TRef sload(jit_State *J, int32_t Slot);
 //********************************************************************************************************************
 // Materialise live trace slots back to the Lua stack before a throwable helper runs inside a recorded try block.
 
+static TRef rec_try_stack_slot_addr(jit_State *J, IRBuilder& Ir, int32_t AbsoluteSlot)
+{
+   lj_assertJ(AbsoluteSlot >= 0 and AbsoluteSlot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
+      "try materialisation slot out of range");
+   int32_t byte_offset = 8 * (AbsoluteSlot - 1 - LJ_FR2);
+   return Ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, Ir.kint(byte_offset));
+}
+
+static void rec_try_emit_tvalue_store(jit_State *J, TRef SlotAddr, TRef ValueRef)
+{
+   if (tref_isnum(ValueRef)) {
+      emitir(IRT(IR_XSTORE, IRT_NUM), SlotAddr, ValueRef);
+   }
+   else if (tref_isint(ValueRef)) {
+#if LJ_DUALNUM
+      // With LJ_DUALNUM, IRT_INT is stored as a tagged integer TValue.
+      TRef store_ref = emitir(IRT(IR_CONV, IRT_I64), ValueRef,
+         (IRT_I64 << IRCONV_DSH) | IRT_INT);
+      store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), store_ref,
+         lj_ir_kint64(J, uint64_t(LJ_TISNUM) << 47));
+      emitir(IRT(IR_XSTORE, IRT_I64), SlotAddr, store_ref);
+#else
+      // Without LJ_DUALNUM, IRT_INT must be converted and stored as an IRT_NUM TValue.
+      TRef store_ref = emitir(IRT(IR_CONV, IRT_NUM), ValueRef, IRCONV_NUM_INT);
+      emitir(IRT(IR_XSTORE, IRT_NUM), SlotAddr, store_ref);
+#endif
+   }
+   else if (tref_isgcv(ValueRef)) {
+      uint32_t itype = irt_toitype_(tref_type(ValueRef));
+      TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), ValueRef,
+         lj_ir_kint64(J, uint64_t(itype) << 47));
+      emitir(IRT(IR_XSTORE, IRT_I64), SlotAddr, store_ref);
+   }
+   else if (tref_ispri(ValueRef)) {
+      TValue tv;
+      setpriV(&tv, irt_toitype_(tref_type(ValueRef)));
+      emitir(IRT(IR_XSTORE, IRT_I64), SlotAddr, lj_ir_kint64(J, tv.u64));
+   }
+   else if (tref_islightud(ValueRef)) {
+      TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), ValueRef,
+         lj_ir_kint64(J, uint64_t(LJ_TLIGHTUD) << 47));
+      emitir(IRT(IR_XSTORE, IRT_I64), SlotAddr, store_ref);
+   }
+   else {
+      setintV(&J->errinfo, int32_t(tref_type(ValueRef)));
+      lj_trace_err_info(J, LJ_TRERR_NYIIR);
+   }
+}
+
 static void rec_try_materialise_slots(jit_State *J, bool ForceLoad)
 {
    if (J->maxslot IS 0) return;
@@ -68,45 +117,13 @@ static void rec_try_materialise_slots(jit_State *J, bool ForceLoad)
       if (not value_ref or (value_ref & (TREF_FRAME | TREF_CONT))) continue;
 
       int32_t absolute_slot = int32_t(J->baseslot) + int32_t(slot);
-      int32_t byte_offset = 8 * (absolute_slot - 1 - LJ_FR2);
-      TRef slot_addr = ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, ir.kint(byte_offset));
+      lj_assertJ(absolute_slot >= 0 and absolute_slot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
+         "try materialisation slot out of range");
+      if (not ForceLoad and J->trymat[absolute_slot] IS value_ref) continue;
 
-      if (tref_isnum(value_ref)) {
-         emitir(IRT(IR_XSTORE, IRT_NUM), slot_addr, value_ref);
-      }
-      else if (tref_isint(value_ref)) {
-#if LJ_DUALNUM
-         TRef store_ref = emitir(IRT(IR_CONV, IRT_I64), value_ref,
-            (IRT_I64 << IRCONV_DSH) | IRT_INT);
-         store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), store_ref,
-            lj_ir_kint64(J, uint64_t(LJ_TISNUM) << 47));
-         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
-#else
-         TRef store_ref = emitir(IRT(IR_CONV, IRT_NUM), value_ref, IRCONV_NUM_INT);
-         emitir(IRT(IR_XSTORE, IRT_NUM), slot_addr, store_ref);
-#endif
-      }
-      else if (tref_isgcv(value_ref)) {
-         uint32_t itype = irt_toitype_(tref_type(value_ref));
-         TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), value_ref,
-            lj_ir_kint64(J, uint64_t(itype) << 47));
-         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
-      }
-      else if (tref_ispri(value_ref)) {
-         TValue tv;
-         setpriV(&tv, irt_toitype_(tref_type(value_ref)));
-         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, lj_ir_kint64(J, tv.u64));
-      }
-      else if (tref_islightud(value_ref)) {
-         TRef store_ref = emitir_raw(IRT(IR_BOR, IRT_I64), value_ref,
-            lj_ir_kint64(J, uint64_t(LJ_TLIGHTUD) << 47));
-         emitir(IRT(IR_XSTORE, IRT_I64), slot_addr, store_ref);
-      }
-      else {
-         setintV(&J->errinfo, int32_t(tref_type(value_ref)));
-         lj_trace_err_info(J, LJ_TRERR_NYIIR);
-      }
-
+      TRef slot_addr = rec_try_stack_slot_addr(J, ir, absolute_slot);
+      rec_try_emit_tvalue_store(J, slot_addr, value_ref);
+      J->trymat[absolute_slot] = value_ref;
       stored = true;
    }
 
@@ -3535,6 +3552,7 @@ void lj_record_setup(jit_State *J)
 
    // Initialise state related to current trace.
    memset(J->slot, 0, sizeof(J->slot));
+   memset(J->trymat, 0, sizeof(J->trymat));
    memset(J->chain, 0, sizeof(J->chain));
 #ifdef LUAJIT_ENABLE_TABLE_BUMP
    memset(J->rbchash, 0, sizeof(J->rbchash));

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -85,6 +85,47 @@ function jit_regex_failure_convert(Value:any, Param:table):any
    end
 end
 
+function jit_try_local_before_entry(Pattern)
+   local label = "before-entry"
+
+   try
+      regex.new(Pattern)
+   except e
+      return label
+   end
+
+   return "missing-error"
+end
+
+function jit_try_mutated_local_before_throw(Pattern, Iteration)
+   local status = "initial"
+
+   try
+      status = "mutated-" .. tostring(Iteration % 5)
+      regex.new(Pattern)
+   except e
+      return status
+   end
+
+   return "missing-error"
+end
+
+function jit_try_repeated_throwable_helpers(Pattern)
+   local stable_label = "stable-local"
+   local compiled = nil
+
+   try
+      for i = 0, 5 do
+         compiled = regex.new("a+")
+      end
+      regex.new(Pattern)
+   except e
+      return stable_label, compiled != nil
+   end
+
+   return "missing-error", false
+end
+
 @Test(hotpath=80) function JITTryRegexFailurePreservesParamName()
    jit.on()
    jit.flush()
@@ -104,6 +145,41 @@ end
       assert(err != nil, "Invalid regex should raise an error")
       assert(err.code is ERR_WrongType, f"Expected ERR_WrongType, got {err.code}")
       assert(err.message is expected_message, f"Expected '{expected_message}', got '{err.message}'")
+   end
+end
+
+@Test(hotpath=80) function JITTryLocalBeforeEntrySurvivesRegexThrow()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i = 0, 99 do
+      result = jit_try_local_before_entry("(")
+      assert(result is "before-entry", f"Expected local captured before try entry, got '{result}'")
+   end
+end
+
+@Test(hotpath=80) function JITTryLocalMutatedInsideTrySurvivesRegexThrow()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i = 0, 99 do
+      expected = "mutated-" .. tostring(i % 5)
+      result = jit_try_mutated_local_before_throw("(", i)
+      assert(result is expected, f"Expected handler to see '{expected}', got '{result}'")
+   end
+end
+
+@Test(hotpath=80) function JITTryRepeatedThrowableHelpersDoNotCorruptLocals()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i = 0, 99 do
+      label, compiled = jit_try_repeated_throwable_helpers("(")
+      assert(label is "stable-local", f"Expected stable local after repeated helpers, got '{label}'")
+      assert(compiled is true, "Successful repeated regex.new() calls should update their local")
    end
 end
 


### PR DESCRIPTION
## Summary

* Adds `trymat[]` cache to `jit_State` to track the last materialised `TRef` per slot, skipping redundant `XSTORE` emissions when a slot's value has not changed since the previous materialisation pass
* Extracts `rec_try_stack_slot_addr()` and `rec_try_emit_tvalue_store()` as standalone helpers, reducing duplication in `rec_try_materialise_slots()`
* Expands `JIT_LAYOUT_HEADERS` to cover `lj_jit.h` and `lj_dispatch.h` so `buildvm` (and therefore all generated VM headers) is rebuilt whenever `GG_State` or `jit_State` layout changes — previously only `lj_obj.h` was tracked
* Adds three Flute tests covering: locals captured before try-entry, locals mutated inside the try body, and locals that must remain stable across multiple throwable helper calls within a recorded loop

## Test plan

- [ ] Build `tiri` module and confirm clean compile
- [ ] Install and run `JITTryLocalBeforeEntrySurvivesRegexThrow` — expects `"before-entry"` from all 100 iterations
- [ ] Run `JITTryLocalMutatedInsideTrySurvivesRegexThrow` — expects correct `"mutated-N"` string from each iteration
- [ ] Run `JITTryRepeatedThrowableHelpersDoNotCorruptLocals` — expects `"stable-local"` and `compiled == true` from all iterations
- [ ] Run full JIT test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri`

🤖 Generated with [Claude Code](https://claude.com/claude-code)