### PR TITLE
[Core] Invoke task exit callbacks when Unix child processes finish

### DIFF
--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -19,19 +19,13 @@ end
 
 @BeforeAll function init(State)
    global glOrigoPath = resolveFirstPath(array<string> {
-      'build/agents-install/origo',
-      'build/agents-install/origo.exe',
+      'sdk:build/agents-install/origo',
+      'sdk:build/agents-install/origo.exe',
       'origo',
-      'origo.exe',
-      '../agents-install/origo',
-      '../agents-install/origo.exe',
-      '../../build/agents-install/origo',
-      '../../build/agents-install/origo.exe'
+      'origo.exe'
    })
    global glTukuPath = resolveFirstPath(array<string> {
-      'apps/tuku.tiri',
-      '../agents-install/apps/tuku.tiri',
-      '../../apps/tuku.tiri'
+      'sdk:apps/tuku.tiri',
    })
    global glFollowNoRedirectHits = 0
    global glFollowRedirectTargetHits = 0

--- a/examples/io/read_stdout.tiri
+++ b/examples/io/read_stdout.tiri
@@ -2,27 +2,25 @@
 Demonstrates how to launch a sub-process and intercept the data that it prints to stderr and stdout.
 --]]
 
-   file_out = obj.new("file", { path="temp:output-data.txt", flags="NEW|WRITE" } )
-   file_err = obj.new("file", { path="temp:error-data.txt", flags="NEW|WRITE" } )
-
    try
+      current_task = mSys.CurrentTask()
       task = obj.new("task", {
-         location = "kotuku:origo",
+         location = current_task.processPath .. 'origo',
          args   = "--help",
          outputCallback = function(Task, Data)
-            file_out.acWrite(Data)
+            io.write(Data:getString())
          end,
          errorCallback = function(Task, Data)
-            file_err.acWrite(Data)
+            io.write(Data:getString())
          end,
          exitCallback = function(Task)
             print("Detected child process exit.")
-            mSys.SendMessage(MSGID_QUIT)
+            processing.signal()
          end
       })
 
       print(f'Running {task.location}')
-      print("Press CTRL-C to exit or wait for program to finish.  Received output is saved to '" .. file_out.path .. "' and '" .. file_err.path .. "'")
+      print("Press CTRL-C to exit or wait for program to finish.  Received output is printed to stdout.")
       task.acActivate()
       processing.sleep()
    except ex

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -453,6 +453,40 @@ static ERR msg_quit(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSi
 }
 
 //********************************************************************************************************************
+
+#ifdef __unix__
+static void task_process_end(extTask *Task, int ReturnCode, bool Returned)
+{
+   check_incoming(Task);
+
+   if (Returned) {
+      Task->ReturnCode = ReturnCode;
+      Task->ReturnCodeSet = true;
+   }
+
+   if (Task->InFD != -1) {
+      RegisterFD(Task->InFD, RFD::READ|RFD::REMOVE, &task_stdout, Task);
+      close(Task->InFD);
+      Task->InFD = -1;
+   }
+
+   if (Task->ErrFD != -1) {
+      RegisterFD(Task->ErrFD, RFD::READ|RFD::REMOVE, &task_stderr, Task);
+      close(Task->ErrFD);
+      Task->ErrFD = -1;
+   }
+
+   if (Task->ExitCallback.isC()) {
+      auto routine = (void (*)(extTask *, APTR))Task->ExitCallback.Routine;
+      routine(Task, Task->ExitCallback.Meta);
+   }
+   else if (Task->ExitCallback.isScript()) {
+      sc::Call(Task->ExitCallback, std::to_array<ScriptArg>({ { "Task", Task, FD_OBJECTPTR } }));
+   }
+}
+#endif
+
+//********************************************************************************************************************
 // Determine whether or not a process is alive
 
 extern "C" ERR validate_process(int ProcessID)
@@ -476,15 +510,24 @@ extern "C" ERR validate_process(int ProcessID)
    #endif
 
    OBJECTID task_id = 0;
+   int return_code = 0;
+   bool returned = false;
+
    for (auto it = glTasks.begin(); it != glTasks.end(); it++) {
       if (it->ProcessID IS ProcessID) {
          task_id = it->TaskID;
+         return_code = it->ReturnCode;
+         returned = it->Returned;
          glTasks.erase(it);
          break;
       }
    }
 
    if (not task_id) return ERR::False;
+
+   #ifdef __unix__
+      if (auto task = (extTask *)GetObjectPtr(task_id)) task_process_end(task, return_code, returned);
+   #endif
 
    evTaskRemoved task_removed = { GetEventID(EVG::SYSTEM, "task", "removed"), task_id, ProcessID };
    BroadcastEvent(&task_removed, sizeof(task_removed));
@@ -633,7 +676,7 @@ static ERR TASK_Activate(extTask *Self)
    if (not glJanitorActive) {
       kt::SwitchContext ctx(glCurrentTask);
       auto call = C_FUNCTION(process_janitor);
-      SubscribeTimer(60, &call, &glProcessJanitor);
+      SubscribeTimer(0.06, &call, &glProcessJanitor);
       glJanitorActive = true;
    }
 

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -252,28 +252,38 @@ static int read_task_stdout(HOSTHANDLE FD, APTR Task)
    return len;
 }
 
-static void process_task_stdout(HOSTHANDLE FD, APTR Task, bool Drain)
+static void close_task_stdout(extTask *Task, HOSTHANDLE FD)
+{
+   if (Task->InFD IS FD) Task->InFD = -1;
+   RegisterFD(FD, RFD::READ|RFD::REMOVE, &task_stdout, Task);
+   close(FD);
+}
+
+static int process_task_stdout(HOSTHANDLE FD, APTR Task, bool Drain)
 {
    thread_local uint8_t recursive = 0;
 
-   if (recursive) return;
+   if (recursive) return -1;
 
+   int len = -1;
    recursive++;
    do {
-      auto len = read_task_stdout(FD, Task);
+      len = read_task_stdout(FD, Task);
       if ((not Drain) or (len <= 0)) break;
    } while (true);
    recursive--;
+
+   return len;
 }
 
 static void task_stdout(HOSTHANDLE FD, APTR Task)
 {
-   process_task_stdout(FD, Task, false);
+   if (process_task_stdout(FD, Task, false) IS 0) close_task_stdout((extTask *)Task, FD);
 }
 
-static void drain_task_stdout(HOSTHANDLE FD, APTR Task)
+static bool drain_task_stdout(HOSTHANDLE FD, APTR Task)
 {
-   process_task_stdout(FD, Task, true);
+   return process_task_stdout(FD, Task, true) IS 0;
 }
 
 static int read_task_stderr(HOSTHANDLE FD, APTR Task)
@@ -301,28 +311,38 @@ static int read_task_stderr(HOSTHANDLE FD, APTR Task)
    return len;
 }
 
-static void process_task_stderr(HOSTHANDLE FD, APTR Task, bool Drain)
+static void close_task_stderr(extTask *Task, HOSTHANDLE FD)
+{
+   if (Task->ErrFD IS FD) Task->ErrFD = -1;
+   RegisterFD(FD, RFD::READ|RFD::REMOVE, &task_stderr, Task);
+   close(FD);
+}
+
+static int process_task_stderr(HOSTHANDLE FD, APTR Task, bool Drain)
 {
    thread_local uint8_t recursive = 0;
 
-   if (recursive) return;
+   if (recursive) return -1;
 
+   int len = -1;
    recursive++;
    do {
-      auto len = read_task_stderr(FD, Task);
+      len = read_task_stderr(FD, Task);
       if ((not Drain) or (len <= 0)) break;
    } while (true);
    recursive--;
+
+   return len;
 }
 
 static void task_stderr(HOSTHANDLE FD, APTR Task)
 {
-   process_task_stderr(FD, Task, false);
+   if (process_task_stderr(FD, Task, false) IS 0) close_task_stderr((extTask *)Task, FD);
 }
 
-static void drain_task_stderr(HOSTHANDLE FD, APTR Task)
+static bool drain_task_stderr(HOSTHANDLE FD, APTR Task)
 {
-   process_task_stderr(FD, Task, true);
+   return process_task_stderr(FD, Task, true) IS 0;
 }
 #endif
 
@@ -503,24 +523,12 @@ static ERR msg_quit(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSi
 #ifdef __unix__
 static void task_process_end(extTask *Task, int ReturnCode, bool Returned)
 {
-   if (Task->InFD != -1) drain_task_stdout(Task->InFD, Task);
-   if (Task->ErrFD != -1) drain_task_stderr(Task->ErrFD, Task);
+   if ((Task->InFD != -1) and (drain_task_stdout(Task->InFD, Task))) close_task_stdout(Task, Task->InFD);
+   if ((Task->ErrFD != -1) and (drain_task_stderr(Task->ErrFD, Task))) close_task_stderr(Task, Task->ErrFD);
 
    if (Returned) {
       Task->ReturnCode = ReturnCode;
       Task->ReturnCodeSet = true;
-   }
-
-   if (Task->InFD != -1) {
-      RegisterFD(Task->InFD, RFD::READ|RFD::REMOVE, &task_stdout, Task);
-      close(Task->InFD);
-      Task->InFD = -1;
-   }
-
-   if (Task->ErrFD != -1) {
-      RegisterFD(Task->ErrFD, RFD::READ|RFD::REMOVE, &task_stderr, Task);
-      close(Task->ErrFD);
-      Task->ErrFD = -1;
    }
 
    if (Task->ExitCallback.isC()) {

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -720,12 +720,14 @@ static ERR TASK_Activate(extTask *Self)
 
    if (Self->Location.empty()) return log.warning(ERR::MissingPath);
 
-   if (not glJanitorActive) {
-      kt::SwitchContext ctx(glCurrentTask);
-      auto call = C_FUNCTION(process_janitor);
-      SubscribeTimer(0.06, &call, &glProcessJanitor);
-      glJanitorActive = true;
-   }
+   #ifndef __unix__
+      if (not glJanitorActive) {
+         kt::SwitchContext ctx(glCurrentTask);
+         auto call = C_FUNCTION(process_janitor);
+         SubscribeTimer(60, &call, &glProcessJanitor);
+         glJanitorActive = true;
+      }
+   #endif
 
 #ifdef _WIN32
    // Determine the launch folder
@@ -1078,8 +1080,9 @@ static ERR TASK_Activate(extTask *Self)
          // potentially pick this up but that's fine as waitpid() will just fail with -1 in that case.
 
          int status = 0;
+         int wait_result = 0;
          int64_t ticks = PreciseTime() + int64_t(Self->TimeOut * 1000000.0);
-         while (!waitpid(pid, &status, WNOHANG)) {
+         while ((wait_result = waitpid(pid, &status, WNOHANG)) IS 0) {
             ProcessMessages(PMF::NIL, 100);
 
             auto remaining = ticks - PreciseTime();
@@ -1091,8 +1094,12 @@ static ERR TASK_Activate(extTask *Self)
 
          // Find out what error code was returned
 
-         if (WIFEXITED(status)) {
+         if ((wait_result IS pid) and WIFEXITED(status)) {
             Self->ReturnCode = (int8_t)WEXITSTATUS(status);
+            Self->ReturnCodeSet = true;
+         }
+         else if ((wait_result IS pid) and WIFSIGNALED(status)) {
+            Self->ReturnCode = 128 + WTERMSIG(status);
             Self->ReturnCodeSet = true;
          }
 
@@ -2374,16 +2381,32 @@ static ERR GET_ReturnCode(extTask *Self, int *Value)
    int status = 0;
    int result = waitpid(Self->ProcessID, &status, WNOHANG);
 
-   if ((result IS -1) or (result IS Self->ProcessID)) {
+   if (result IS Self->ProcessID) {
       // The process has exited.  Find out what error code was returned and pass it as the result.
 
       if (WIFEXITED(status)) {
          Self->ReturnCode = (int8_t)WEXITSTATUS(status);
          Self->ReturnCodeSet = true;
       }
+      else if (WIFSIGNALED(status)) {
+         Self->ReturnCode = 128 + WTERMSIG(status);
+         Self->ReturnCodeSet = true;
+      }
 
       *Value = Self->ReturnCode;
+      for (auto &task : glTasks) {
+         if (task.ProcessID IS Self->ProcessID) {
+            task.ReturnCode = Self->ReturnCode;
+            task.Returned = true;
+            break;
+         }
+      }
+
+      validate_process(Self->ProcessID);
       return ERR::Okay;
+   }
+   else if (result IS -1) {
+      return ERR::TaskStillExists;
    }
    else return ERR::TaskStillExists;
 

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -721,6 +721,7 @@ static ERR TASK_Activate(extTask *Self)
    if (Self->Location.empty()) return log.warning(ERR::MissingPath);
 
    #ifndef __unix__
+      // This is a backup in case SIGCHLD signals don't work.  It terminates automatically if no processes remain.
       if (not glJanitorActive) {
          kt::SwitchContext ctx(glCurrentTask);
          auto call = C_FUNCTION(process_janitor);
@@ -1094,21 +1095,32 @@ static ERR TASK_Activate(extTask *Self)
 
          // Find out what error code was returned
 
-         if ((wait_result IS pid) and WIFEXITED(status)) {
-            Self->ReturnCode = (int8_t)WEXITSTATUS(status);
-            Self->ReturnCodeSet = true;
-         }
-         else if ((wait_result IS pid) and WIFSIGNALED(status)) {
-            Self->ReturnCode = 128 + WTERMSIG(status);
-            Self->ReturnCodeSet = true;
-         }
+         if (wait_result IS pid) {
+            bool returned = false;
+            int return_code = 0;
 
-         if (kill(pid, 0)) {
-            for (auto it = glTasks.begin(); it != glTasks.end(); it++) {
-               if (it->ProcessID IS pid) {
-                  glTasks.erase(it);
-                  break;
+            if (WIFEXITED(status)) {
+               return_code = (int8_t)WEXITSTATUS(status);
+               returned = true;
+            }
+            else if (WIFSIGNALED(status)) {
+               return_code = 128 + WTERMSIG(status);
+               returned = true;
+            }
+
+            if (returned) {
+               Self->ReturnCode = return_code;
+               Self->ReturnCodeSet = true;
+
+               for (auto &task : glTasks) {
+                  if (task.ProcessID IS pid) {
+                     task.ReturnCode = return_code;
+                     task.Returned = true;
+                     break;
+                  }
                }
+
+               validate_process(pid);
             }
          }
       }

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -66,6 +66,12 @@ static void cleanup_task_fds(int input_fd, int out_fd, int out_errfd, int in_fd,
    if (in_fd != -1)     close(in_fd);
    if (in_errfd != -1)  close(in_errfd);
 }
+
+static void set_task_pipe_nonblocking(int FD)
+{
+   auto flags = fcntl(FD, F_GETFL);
+   if (flags != -1) fcntl(FD, F_SETFL, flags | O_NONBLOCK);
+}
 #endif
 
 #ifdef __unix__
@@ -222,14 +228,8 @@ static void check_incoming(extTask *Self)
 // sent to a callback function.
 
 #ifdef __unix__
-static void task_stdout(HOSTHANDLE FD, APTR Task)
+static int read_task_stdout(HOSTHANDLE FD, APTR Task)
 {
-   thread_local uint8_t recursive = 0;
-
-   if (recursive) return;
-
-   recursive++;
-
    int len;
    char buffer[TASK_IO_BUFFER_SIZE];
    if ((len = read(FD, buffer, sizeof(buffer)-1)) > 0) {
@@ -248,18 +248,39 @@ static void task_stdout(HOSTHANDLE FD, APTR Task)
          }));
       }
    }
-   recursive--;
+
+   return len;
 }
 
-static void task_stderr(HOSTHANDLE FD, APTR Task)
+static void process_task_stdout(HOSTHANDLE FD, APTR Task, bool Drain)
 {
-   char buffer[TASK_IO_BUFFER_SIZE];
-   int len;
    thread_local uint8_t recursive = 0;
 
    if (recursive) return;
 
    recursive++;
+   do {
+      auto len = read_task_stdout(FD, Task);
+      if ((not Drain) or (len <= 0)) break;
+   } while (true);
+   recursive--;
+}
+
+static void task_stdout(HOSTHANDLE FD, APTR Task)
+{
+   process_task_stdout(FD, Task, false);
+}
+
+static void drain_task_stdout(HOSTHANDLE FD, APTR Task)
+{
+   process_task_stdout(FD, Task, true);
+}
+
+static int read_task_stderr(HOSTHANDLE FD, APTR Task)
+{
+   char buffer[TASK_IO_BUFFER_SIZE];
+   int len;
+
    if ((len = read(FD, buffer, sizeof(buffer)-1)) > 0) {
       buffer[len] = 0;
 
@@ -276,7 +297,32 @@ static void task_stderr(HOSTHANDLE FD, APTR Task)
          }));
       }
    }
+
+   return len;
+}
+
+static void process_task_stderr(HOSTHANDLE FD, APTR Task, bool Drain)
+{
+   thread_local uint8_t recursive = 0;
+
+   if (recursive) return;
+
+   recursive++;
+   do {
+      auto len = read_task_stderr(FD, Task);
+      if ((not Drain) or (len <= 0)) break;
+   } while (true);
    recursive--;
+}
+
+static void task_stderr(HOSTHANDLE FD, APTR Task)
+{
+   process_task_stderr(FD, Task, false);
+}
+
+static void drain_task_stderr(HOSTHANDLE FD, APTR Task)
+{
+   process_task_stderr(FD, Task, true);
 }
 #endif
 
@@ -457,7 +503,8 @@ static ERR msg_quit(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSi
 #ifdef __unix__
 static void task_process_end(extTask *Task, int ReturnCode, bool Returned)
 {
-   check_incoming(Task);
+   if (Task->InFD != -1) drain_task_stdout(Task->InFD, Task);
+   if (Task->ErrFD != -1) drain_task_stderr(Task->ErrFD, Task);
 
    if (Returned) {
       Task->ReturnCode = ReturnCode;
@@ -1003,12 +1050,14 @@ static ERR TASK_Activate(extTask *Self)
       glTasks.emplace_back(Self);
 
       if (in_fd != -1) {
+         set_task_pipe_nonblocking(in_fd);
          RegisterFD(in_fd, RFD::READ, &task_stdout, Self);
          Self->InFD = in_fd;
          close(out_fd);
       }
 
       if (in_errfd != -1) {
+         set_task_pipe_nonblocking(in_errfd);
          RegisterFD(in_errfd, RFD::READ, &task_stderr, Self);
          Self->ErrFD = in_errfd;
          close(out_errfd);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -415,6 +415,18 @@ ERR OpenCore(OpenInfo *Info, struct CoreBase **JumpTable)
 
 #ifdef __unix__
    struct sigaction sig;
+   clearmem(&sig, sizeof(sig));
+   sigemptyset(&sig.sa_mask);
+
+   if (pipe(glChildSignalFD) IS -1) {
+      KERR("Failed to create child process signal pipe: %s\n", strerror(errno));
+      return ERR::SystemCall;
+   }
+
+   fcntl(glChildSignalFD[0], F_SETFL, fcntl(glChildSignalFD[0], F_GETFL) | O_NONBLOCK);
+   fcntl(glChildSignalFD[1], F_SETFL, fcntl(glChildSignalFD[1], F_GETFL) | O_NONBLOCK);
+   fcntl(glChildSignalFD[0], F_SETFD, FD_CLOEXEC);
+   fcntl(glChildSignalFD[1], F_SETFD, FD_CLOEXEC);
 
    sig.sa_flags = SA_SIGINFO;
    if (glEnableCrashHandler) {
@@ -490,20 +502,33 @@ ERR OpenCore(OpenInfo *Info, struct CoreBase **JumpTable)
 
                KMSG("Attempting to re-use an earlier bind().\n");
                if (setsockopt(glSocket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) IS -1) {
+                  close(glChildSignalFD[0]);
+                  close(glChildSignalFD[1]);
+                  glChildSignalFD[0] = -1;
+                  glChildSignalFD[1] = -1;
                   return ERR::SystemCall;
                }
             }
             else {
+               close(glChildSignalFD[0]);
+               close(glChildSignalFD[1]);
+               glChildSignalFD[0] = -1;
+               glChildSignalFD[1] = -1;
                return ERR::SystemCall;
             }
          }
       }
       else {
          KERR("Failed to create a new socket communication point.\n");
+         close(glChildSignalFD[0]);
+         close(glChildSignalFD[1]);
+         glChildSignalFD[0] = -1;
+         glChildSignalFD[1] = -1;
          return ERR::SystemCall;
       }
 
       RegisterFD(glSocket, RFD::READ, nullptr, nullptr);
+      RegisterFD(glChildSignalFD[0], RFD::READ, &process_child_signals, nullptr);
    #endif
 
    log.msg("Process: %d, Sync: %s, Root: %s", glProcessID, (glSync) ? "Y" : "N", glRootPath.c_str());
@@ -912,38 +937,10 @@ static void NullHandler(int SignalNumber, siginfo_t *Info, APTR Context)
 #ifdef __unix__
 static void child_handler(int SignalNumber, siginfo_t *Info, APTR Context)
 {
-#if 0
-   kotuku:Log log(__FUNCTION__);
-
-   int childprocess = Info->si_pid;
-
-   // Get the return code
-
-   int status = 0;
-   waitpid(Info->si_pid, &status, WNOHANG);
-   int result = WEXITSTATUS(status);
-
-   log.warning("Process #%d exited, return-code %d.", childprocess, result);
-
-   // Store the return code for this process in any Task object that is associated with it.
-   //
-   // !!! TODO: The slow methodology of this loop needs attention !!!
-
-   for (const auto & mem : glPrivateMemory) {
-      if (!(mem.Flags & MEM::OBJECT)) continue;
-
-      objTask *task;
-      if ((task = mem.Address)) {
-         if ((task->ClassID IS ID_TASK) and (task->ProcessID IS childprocess)) {
-            task->ReturnCode    = result;
-            task->ReturnCodeSet = true;
-            break;
-         }
-      }
+   if (glChildSignalFD[1] != -1) {
+      uint8_t signal_byte = 1;
+      (void)write(glChildSignalFD[1], &signal_byte, sizeof(signal_byte));
    }
-
-   validate_process(childprocess);
-#endif
 }
 #endif
 

--- a/src/core/core_close.cpp
+++ b/src/core/core_close.cpp
@@ -229,6 +229,7 @@ void CloseCore(void)
 
       #ifdef __unix__
          if (glSocket != -1) RegisterFD(glSocket, RFD::REMOVE, nullptr, nullptr);
+         if (glChildSignalFD[0] != -1) RegisterFD(glChildSignalFD[0], RFD::REMOVE, nullptr, nullptr);
       #endif
 
       // Report FD's that have not been removed by the client
@@ -239,6 +240,18 @@ void CloseCore(void)
          }
       }
    }
+
+   #ifdef __unix__
+      if (glChildSignalFD[0] != -1) {
+         close(glChildSignalFD[0]);
+         glChildSignalFD[0] = -1;
+      }
+
+      if (glChildSignalFD[1] != -1) {
+         close(glChildSignalFD[1]);
+         glChildSignalFD[1] = -1;
+      }
+   #endif
 
    if (glCodeIndex < CP_REMOVE_PRIVATE_LOCKS) {
       glCodeIndex = CP_REMOVE_PRIVATE_LOCKS;

--- a/src/core/data.cpp
+++ b/src/core/data.cpp
@@ -86,6 +86,9 @@ std::list<FDRecord> glFDTable;
 std::mutex glmInotifyLookup;
 std::unordered_map<int, OBJECTID> glInotifyLookup;
 #endif
+#ifdef __unix__
+int glChildSignalFD[2] = { -1, -1 };
+#endif
 
 std::map<std::string, ConfigKeys, CaseInsensitiveMap> glVolumes;
 std::unordered_map<std::string, std::vector<Object *>, CaseInsensitiveHash, CaseInsensitiveEqual> glObjectLookup; // Name lookups

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -840,6 +840,7 @@ extern WINHANDLE glTaskLock;
 
 #ifdef __unix__
 extern thread_local int glSocket;
+extern int glChildSignalFD[2];
 extern struct FileMonitor *glFileMonitor;
 #endif
 
@@ -1128,6 +1129,7 @@ ERR    msg_threadaction(APTR, int, int, APTR, int);
 ERR    msg_free(APTR, int, int, APTR, int);
 void   optimise_write_field(Field &);
 void   PrepareSleep(void);
+void   process_child_signals(HOSTHANDLE, APTR);
 ERR    process_janitor(OBJECTID, int, int);
 void   register_sleep(int);
 void   deregister_sleep(void);

--- a/src/core/internal.cpp
+++ b/src/core/internal.cpp
@@ -97,6 +97,7 @@ ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
 
 #ifdef __unix__
    kt::Log log(__FUNCTION__);
+   std::vector<int> finished_processes;
 
    // Call waitpid() to check for zombie processes first.  This covers all processes within our own context, so our child processes, children of those children etc.
 
@@ -108,9 +109,10 @@ ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
 
       for (auto &task : glTasks) {
          if (childprocess IS task.ProcessID) {
-            task.ReturnCode = WEXITSTATUS(status);
+            if (WIFEXITED(status)) task.ReturnCode = WEXITSTATUS(status);
+            else if (WIFSIGNALED(status)) task.ReturnCode = 128 + WTERMSIG(status);
             task.Returned   = true;
-            validate_process(childprocess);
+            finished_processes.push_back(childprocess);
             break;
          }
       }
@@ -120,10 +122,13 @@ ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
    // some problems with zombies, hence the earlier waitpid() routine to clean up such processes.
 
    for (auto &task : glTasks) {
+      if (task.Returned) continue;
       if ((kill(task.ProcessID, 0) IS -1) and (errno IS ESRCH)) {
-         validate_process(task.ProcessID);
+         finished_processes.push_back(task.ProcessID);
       }
    }
+
+   for (auto process_id : finished_processes) validate_process(process_id);
 
 #elif _WIN32
    for (auto &task : glTasks) {

--- a/src/core/internal.cpp
+++ b/src/core/internal.cpp
@@ -5,7 +5,9 @@ Functions that are internal to the Core.
 *********************************************************************************************************************/
 
 #ifdef __unix__
+ #include <errno.h>
  #include <signal.h>
+ #include <unistd.h>
  #include <sys/wait.h>
 #endif
 
@@ -88,15 +90,10 @@ CLASSID lookup_class_by_ext(CLASSID Filter, std::string_view Ext)
 
 //********************************************************************************************************************
 
-ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
+static void reap_child_processes(bool CheckAllProcesses)
 {
-   if (glTasks.empty()) {
-      glJanitorActive = false;
-      return ERR::Terminate;
-   }
-
 #ifdef __unix__
-   kt::Log log(__FUNCTION__);
+   kt::Log log("child_process");
    std::vector<int> finished_processes;
 
    // Call waitpid() to check for zombie processes first.  This covers all processes within our own context, so our child processes, children of those children etc.
@@ -105,7 +102,7 @@ ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
 
    int childprocess, status;
    while ((childprocess = waitpid(-1, &status, WNOHANG)) > 0) {
-      log.warning("Zombie process #%d discovered.", childprocess);
+      log.trace("Process #%d exited.", childprocess);
 
       for (auto &task : glTasks) {
          if (childprocess IS task.ProcessID) {
@@ -121,14 +118,42 @@ ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
    // Check all registered processes to see which ones are alive.  This routine can manage all processes, although exhibits
    // some problems with zombies, hence the earlier waitpid() routine to clean up such processes.
 
-   for (auto &task : glTasks) {
-      if (task.Returned) continue;
-      if ((kill(task.ProcessID, 0) IS -1) and (errno IS ESRCH)) {
-         finished_processes.push_back(task.ProcessID);
+   if (CheckAllProcesses) {
+      for (auto &task : glTasks) {
+         if (task.Returned) continue;
+         if ((kill(task.ProcessID, 0) IS -1) and (errno IS ESRCH)) {
+            finished_processes.push_back(task.ProcessID);
+         }
       }
    }
 
    for (auto process_id : finished_processes) validate_process(process_id);
+#endif
+}
+
+//********************************************************************************************************************
+
+void process_child_signals(HOSTHANDLE FD, APTR Data)
+{
+#ifdef __unix__
+   uint8_t buffer[64];
+   while (read(FD, &buffer, sizeof(buffer)) > 0);
+
+   reap_child_processes(false);
+#endif
+}
+
+//********************************************************************************************************************
+
+ERR process_janitor(OBJECTID SubscriberID, int Elapsed, int TotalElapsed)
+{
+   if (glTasks.empty()) {
+      glJanitorActive = false;
+      return ERR::Terminate;
+   }
+
+#ifdef __unix__
+   reap_child_processes(true);
 
 #elif _WIN32
    for (auto &task : glTasks) {

--- a/src/core/tests/test_misc.tiri
+++ b/src/core/tests/test_misc.tiri
@@ -23,6 +23,42 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+@Test function TaskExitCallback()
+   state = mSys.GetSystemState()
+   if state.platform is 'Windows' then
+      return
+   end
+
+   current_task = mSys.CurrentTask()
+   exit_called = false
+   output_text = ''
+
+   task = obj.new('task', {
+      location = current_task.processPath .. 'origo',
+      args = '--version',
+      outputCallback = function(Task, Buffer)
+         output_text ..= Buffer:getString()
+      end,
+      errorCallback = function(Task, Buffer)
+         output_text ..= Buffer:getString()
+      end,
+      exitCallback = function(Task)
+         exit_called = true
+         processing.signal()
+      end
+   })
+
+   task.acActivate()
+   check processing.sleep(3.0)
+
+   assert(exit_called is true, 'Task ExitCallback was not invoked after the child process exited.')
+   assert(#output_text > 0, 'Expected child process output to be captured before exit.')
+
+   task.free()
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test function PreciseTime()
    time = mSys.PreciseTime()
    assert(time > 0, 'PreciseTime() did not return a positive value.')

--- a/src/core/tests/test_misc.tiri
+++ b/src/core/tests/test_misc.tiri
@@ -29,6 +29,7 @@ end
       return
    end
 
+   processing.flush()
    current_task = mSys.CurrentTask()
    exit_called = false
    output_text = ''
@@ -65,14 +66,16 @@ end
       return
    end
 
+   processing.flush()
    exit_called = false
    output_text = ''
 
    task = obj.new('task', {
-      location = '(sleep 0.2; echo late) &',
+      location = '(sleep 0.01; echo late) &',
       flags = TSF_SHELL,
       outputCallback = function(Task, Buffer)
          output_text ..= Buffer:getString()
+         print(f'Received {#output_text} bytes.')
          if output_text:find('late') then
             processing.signal()
          end
@@ -81,6 +84,7 @@ end
          output_text ..= Buffer:getString()
       end,
       exitCallback = function(Task)
+         print(f'Exit trigger called.  Output length: {#output_text}')
          exit_called = true
          processing.signal()
       end
@@ -88,10 +92,10 @@ end
 
    check task.acActivate()
 
-   deadline = mSys.PreciseTime() + 3000000
-   while ((not exit_called) or (not output_text:find('late'))) and (mSys.PreciseTime() < deadline) do
-      check processing.sleep(0.05)
-   end
+   processing.sleep(3.0)
+   -- NOTE: stdout can have output pending for processing in spite of task exit.
+   processing.halt(0.3) -- need to wait for  echo to complete
+   --task.free()
 
    assert(exit_called is true, 'Task ExitCallback was not invoked after the shell process exited.')
    assert(output_text:find('late'), 'Expected output from a background descendant after shell exit, got: ' .. output_text)
@@ -105,7 +109,7 @@ end
    time = mSys.PreciseTime()
    assert(time > 0, 'PreciseTime() did not return a positive value.')
 
-   processing.sleep(1)
+   processing.halt(1)
 
    -- Acquire a new timestamp and check that the difference is between 1 and 1.5 seconds.
 

--- a/src/core/tests/test_misc.tiri
+++ b/src/core/tests/test_misc.tiri
@@ -71,7 +71,7 @@ end
    output_text = ''
 
    task = obj.new('task', {
-      location = '(sleep 0.01; echo late) &',
+      location = '(sleep 0.01; echo late) &', -- Run task in background
       flags = TSF_SHELL,
       outputCallback = function(Task, Buffer)
          output_text ..= Buffer:getString()
@@ -84,7 +84,7 @@ end
          output_text ..= Buffer:getString()
       end,
       exitCallback = function(Task)
-         print(f'Exit trigger called.  Output length: {#output_text}')
+         print(f'Exit trigger called.')
          exit_called = true
          processing.signal()
       end
@@ -92,10 +92,8 @@ end
 
    check task.acActivate()
 
-   processing.sleep(3.0)
-   -- NOTE: stdout can have output pending for processing in spite of task exit.
-   processing.halt(0.3) -- need to wait for  echo to complete
-   --task.free()
+   processing.sleep(1.0) -- Should return almost immediately because the shell detaches
+   processing.halt(0.3) -- Need to wait for echo to complete in the background
 
    assert(exit_called is true, 'Task ExitCallback was not invoked after the shell process exited.')
    assert(output_text:find('late'), 'Expected output from a background descendant after shell exit, got: ' .. output_text)

--- a/src/core/tests/test_misc.tiri
+++ b/src/core/tests/test_misc.tiri
@@ -59,6 +59,48 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+@Test function TaskBackgroundDescendantOutput()
+   state = mSys.GetSystemState()
+   if state.platform is 'Windows' then
+      return
+   end
+
+   exit_called = false
+   output_text = ''
+
+   task = obj.new('task', {
+      location = '(sleep 0.2; echo late) &',
+      flags = TSF_SHELL,
+      outputCallback = function(Task, Buffer)
+         output_text ..= Buffer:getString()
+         if output_text:find('late') then
+            processing.signal()
+         end
+      end,
+      errorCallback = function(Task, Buffer)
+         output_text ..= Buffer:getString()
+      end,
+      exitCallback = function(Task)
+         exit_called = true
+         processing.signal()
+      end
+   })
+
+   check task.acActivate()
+
+   deadline = mSys.PreciseTime() + 3000000
+   while ((not exit_called) or (not output_text:find('late'))) and (mSys.PreciseTime() < deadline) do
+      check processing.sleep(0.05)
+   end
+
+   assert(exit_called is true, 'Task ExitCallback was not invoked after the shell process exited.')
+   assert(output_text:find('late'), 'Expected output from a background descendant after shell exit, got: ' .. output_text)
+
+   task.free()
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test function PreciseTime()
    time = mSys.PreciseTime()
    assert(time > 0, 'PreciseTime() did not return a positive value.')

--- a/src/tiri/tests/test_options.tiri
+++ b/src/tiri/tests/test_options.tiri
@@ -804,17 +804,17 @@ end
    })
 
    args = parser.process(array<string> {
-      'path=scripts/options.tiri',
-      'file=scripts/options.tiri',
-      'folder=scripts'
+      'path=sdk:scripts/options.tiri',
+      'file=sdk:scripts/options.tiri',
+      'folder=sdk:scripts'
    })
-   assert(args.path is 'scripts/options.tiri', 'Existing path should parse')
-   assert(args.file is 'scripts/options.tiri', 'Existing file should parse')
-   assert(args.folder is 'scripts', 'Existing folder should parse')
+   assert(args.path is 'sdk:scripts/options.tiri', 'Existing path should parse')
+   assert(args.file is 'sdk:scripts/options.tiri', 'Existing file should parse')
+   assert(args.folder is 'sdk:scripts', 'Existing folder should parse')
 
    expect_error(parser, array<string> { 'path=does-not-exist' }, ERR_FileNotFound, "does not exist")
-   expect_error(parser, array<string> { 'file=scripts' }, ERR_ExpectedFile, "is not a file")
-   expect_error(parser, array<string> { 'folder=scripts/options.tiri' }, ERR_ExpectedFolder, "is not a folder")
+   expect_error(parser, array<string> { 'file=sdk:scripts' }, ERR_ExpectedFile, "is not a file")
+   expect_error(parser, array<string> { 'folder=sdk:scripts/options.tiri' }, ERR_ExpectedFolder, "is not a folder")
 end
 
 @Test function MultipleValuesUseValidationRules()

--- a/tools/flute.tiri
+++ b/tools/flute.tiri
@@ -24,6 +24,38 @@ Example usage:
    jit.opt.start("hotloop=3") -- Lower threshold to trigger JIT sooner, simplifies debugging
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Resolve the location of the Kotuku SDK and create an 'sdk:' volume.  Created for the benefit of some tests - but
+-- is not guaranteed to work.
+
+global function resolveSDKPath()
+   script_path = glSelf.workingPath
+   err = ERR_Failed
+   search_list = array<string>
+   search_path = 'CMakeLists.txt'
+   limit = 5
+   local sdk_path
+   while (err != ERR_Okay) and (limit > 0) do
+      search_list:push(search_path)
+      err, sdk_path = mSys.ResolvePath(script_path .. search_path)
+      search_path = f'../{search_path}'
+      limit -= 1
+   end
+
+   if err is ERR_Okay then
+      rx_cmake_path = regex.new('^(.+)CMakeLists\\.txt')
+      sdk_path = rx_cmake_path.extract(sdk_path) ?? sdk_path
+   else
+      msg = ''
+      for path in values(search_list) do
+         msg ..= path .. '\n'
+      end
+      print('Unable to find CMakeLists.txt after searching the following paths:\n' .. msg)
+   end
+
+   mSys.SetVolume('sdk', sdk_path)
+end
+
+----------------------------------------------------------------------------------------------------------------------
 
 glNetworkAvailable = thunk():bool
    try
@@ -353,5 +385,7 @@ end
 
    -- Setting an error string ensures that ctest will register a failure if the tests do not complete as planned.
    glSelf.errorMessage = 'Unexpected execution failure - tests not executed as planned.'
+
+   resolveSDKPath()
 
    runTests()


### PR DESCRIPTION
* Defer process validation until after task iteration completes
* Capture child exit status and close task pipe descriptors before invoking ExitCallback
* Add a core regression test covering task output capture and exit callbacks