### PR TITLE
[Tiri] Fix JIT try-block slot materialisation to respect entry-slot boundary

### DIFF
--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -104,14 +104,16 @@ static void rec_try_emit_tvalue_store(jit_State *J, TRef SlotAddr, TRef ValueRef
    }
 }
 
-static void rec_try_materialise_slots(jit_State *J, bool ForceLoad)
+static void rec_try_materialise_slots(jit_State *J, bool ForceLoad, BCREG SlotLimit)
 {
-   if (J->maxslot IS 0) return;
+   BCREG slot_limit = SlotLimit;
+   if (slot_limit > J->maxslot) slot_limit = J->maxslot;
+   if (slot_limit IS 0) return;
 
    IRBuilder ir(J);
    bool stored = false;
 
-   for (BCREG slot = 0; slot < J->maxslot; slot++) {
+   for (BCREG slot = 0; slot < slot_limit; slot++) {
       TRef value_ref = J->base[slot];
       if (not value_ref and ForceLoad) value_ref = sload(J, slot);
       if (not value_ref or (value_ref & (TREF_FRAME | TREF_CONT))) continue;
@@ -132,7 +134,7 @@ static void rec_try_materialise_slots(jit_State *J, bool ForceLoad)
 
 void lj_record_try_materialise(jit_State *J)
 {
-   rec_try_materialise_slots(J, false);
+   rec_try_materialise_slots(J, false, J->maxslot);
 }
 
 //********************************************************************************************************************
@@ -3395,7 +3397,8 @@ void lj_record_ins(jit_State *J)
 
    case BC_TRYENTER: {
       uint16_t try_index = (uint16_t)bc_d(ins);
-      rec_try_materialise_slots(J, true);
+      // Operand A is the first free register at try entry; handlers cannot see stack slots above it.
+      rec_try_materialise_slots(J, true, bc_a(ins));
       lj_snap_add(J);
       TRef tr_func = getcurrf(J);
       TRef tr_base = REF_BASE;

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -314,10 +314,13 @@ static BCREG snap_usedef(jit_State *J, uint8_t *udf, const BCIns *pc, BCREG maxs
                for (s = bc_a(ins) - 1; s < maxslot; s++) USE_SLOT(s);
             }
             else if (op IS BC_TRYENTER) {
-               // Exception handlers can read any local in scope at the try entry point.
-               // Conservatively mark all slots as used to prevent purging.
-               for (s = 0; s < maxslot; s++) USE_SLOT(s);
-               return maxslot;
+               // Operand A is the first free register at try entry, matching TryBlockDesc::entry_slots.
+               // Exception handlers can read any slot below this boundary, but not stale temporaries above it.
+               BCREG entry_slots = bc_a(ins);
+               if (entry_slots > maxslot) entry_slots = maxslot;
+               for (s = 0; s < entry_slots; s++) USE_SLOT(s);
+               for (; s < maxslot; s++) DEF_SLOT(s);
+               return entry_slots;
             }
             break;
          default: break;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -126,6 +126,23 @@ function jit_try_repeated_throwable_helpers(Pattern)
    return "missing-error", false
 end
 
+function jit_try_inner_locals_preserve_entry_local(Pattern, Iteration)
+   local entry_label = "entry-" .. tostring(Iteration % 7)
+
+   try
+      local inner_label = "inner-" .. tostring(Iteration)
+      local combined = inner_label .. ":" .. entry_label
+      if #combined < 1 then
+         return "impossible"
+      end
+      regex.new(Pattern)
+   except e
+      return entry_label
+   end
+
+   return "missing-error"
+end
+
 @Test(hotpath=80) function JITTryRegexFailurePreservesParamName()
    jit.on()
    jit.flush()
@@ -180,6 +197,18 @@ end
       label, compiled = jit_try_repeated_throwable_helpers("(")
       assert(label is "stable-local", f"Expected stable local after repeated helpers, got '{label}'")
       assert(compiled is true, "Successful repeated regex.new() calls should update their local")
+   end
+end
+
+@Test(hotpath=80) function JITTryInnerLocalsPreserveEntryLocal()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i = 0, 99 do
+      local expected = "entry-" .. tostring(i % 7)
+      local result = jit_try_inner_locals_preserve_entry_local("(", i)
+      assert(result is expected, f"Expected handler to see entry local '{expected}', got '{result}'")
    end
 end
 


### PR DESCRIPTION
## Summary

* Adds a `SlotLimit` parameter to `rec_try_materialise_slots` so that `BC_TRYENTER` only materialises stack slots visible to exception handlers (those below the try entry boundary), preventing stale temporaries above it from being incorrectly preserved.
* Fixes `snap_usedef` in `lj_snap.cpp` to mark slots above the `BC_TRYENTER` entry boundary as `DEF` rather than `USE`, allowing the JIT to correctly eliminate unnecessary slot preservation in snapshots.
* Adds `JITTryInnerLocalsPreserveEntryLocal` Flute test to verify that entry-point locals survive JIT compilation when inner locals are present inside the try block.

## Test plan

- [ ] Run the JIT Flute test suite: `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_jit.tiri --log-warning`
- [ ] Confirm `JITTryInnerLocalsPreserveEntryLocal` passes
- [ ] Confirm existing JIT try-block tests (`JITTryRegexFailurePreservesParamName`, `JITTryRepeatedThrowableHelpers`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)