### PR TITLE
[Vector] Fix use-after-free in VectorScene definition cleanup

### DIFF
--- a/src/document/parsing.cpp
+++ b/src/document/parsing.cpp
@@ -1554,12 +1554,10 @@ void parser::tag_button(const tag_view &Tag)
             fl::SpreadMethod(VSPREAD::CLIP)
          })) {
 
+         // Object will terminate once out-of-scope
          auto svg = objSVG::create { fl::Target(pattern_active->Scene), fl::Statement(glButtonSVG) };
 
-         if (svg.ok()) {
-            FreeResource(*svg);
-         }
-         else { // Revert to a basic rectangle if the SVG didn't process
+         if (not svg.ok()) { // Revert to a basic rectangle if the SVG didn't process
             objVectorRectangle::create::global({
                fl::Owner(pattern_active->Scene->Viewport->UID),
                fl::Width(SCALE(1.0)), fl::Height(SCALE(1.0)),
@@ -1577,12 +1575,10 @@ void parser::tag_button(const tag_view &Tag)
             fl::SpreadMethod(VSPREAD::CLIP)
          })) {
 
+         // Object will terminate once out-of-scope
          auto svg = objSVG::create { fl::Target(pattern_inactive->Scene), fl::Statement(glButtonSVG) };
 
-         if (svg.ok()) {
-            FreeResource(*svg);
-         }
-         else {
+         if (not svg.ok()) {
             objVectorRectangle::create::global({
                fl::Owner(pattern_inactive->Scene->Viewport->UID),
                fl::Width(SCALE(1.0)), fl::Height(SCALE(1.0)),

--- a/src/vector/scene/scene.cpp
+++ b/src/vector/scene/scene.cpp
@@ -122,6 +122,49 @@ restart:
 
 //********************************************************************************************************************
 
+static void clear_def_host_scene(OBJECTPTR Def, extVectorScene *Scene)
+{
+   switch(Def->classID()) {
+      case CLASSID::VECTORGRADIENT:
+         if (((extVectorGradient *)Def)->HostScene IS Scene) ((extVectorGradient *)Def)->HostScene = nullptr;
+         break;
+      case CLASSID::VECTORIMAGE:
+         if (((extVectorImage *)Def)->HostScene IS Scene) ((extVectorImage *)Def)->HostScene = nullptr;
+         break;
+      case CLASSID::VECTORPATH:
+         if (((extVectorPath *)Def)->HostScene IS Scene) ((extVectorPath *)Def)->HostScene = nullptr;
+         break;
+      case CLASSID::VECTORPATTERN:
+         if (((extVectorPattern *)Def)->HostScene IS Scene) ((extVectorPattern *)Def)->HostScene = nullptr;
+         break;
+      case CLASSID::VECTORTRANSITION:
+         if (((extVectorTransition *)Def)->HostScene IS Scene) ((extVectorTransition *)Def)->HostScene = nullptr;
+         break;
+      case CLASSID::VECTORCLIP:
+         if (((extVectorClip *)Def)->HostScene IS Scene) ((extVectorClip *)Def)->HostScene = nullptr;
+         break;
+      default:
+         break;
+   }
+}
+
+//********************************************************************************************************************
+
+static void clear_defs(extVectorScene *Self)
+{
+   for (auto &entry : Self->Defs) {
+      auto def = entry.second;
+      if (def) {
+         UnsubscribeAction(def, AC::Free);
+         clear_def_host_scene(def, Self);
+      }
+   }
+
+   Self->Defs.clear();
+}
+
+//********************************************************************************************************************
+
 static void notify_free(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 {
    auto Self = (extVectorScene *)CurrentContext();
@@ -415,7 +458,7 @@ static ERR VECTORSCENE_Flush(extVectorScene *Self)
 
 static ERR VECTORSCENE_Free(extVectorScene *Self, APTR Args)
 {
-   Self->Defs.clear(); // Required because the standard destructor is lazy and doesn't clear the table size
+   clear_defs(Self);
    Self->~extVectorScene();
 
    if (Self->Viewport) Self->Viewport->Parent = nullptr;
@@ -515,7 +558,7 @@ Reset: Clears all registered definitions and resets field values.  Child vectors
 static ERR VECTORSCENE_Reset(extVectorScene *Self)
 {
    if (Self->Buffer)  { delete Self->Buffer; Self->Buffer = nullptr; }
-   Self->Defs.clear();
+   clear_defs(Self);
    Self->Gamma = 1.0;
    return ERR::Okay;
 }


### PR DESCRIPTION
## Summary

* Adds `clear_defs()` to `scene.cpp` which unsubscribes action notifications and clears `HostScene` back-references on all definition types (gradient, image, path, pattern, transition, clip) before the definitions map is cleared
* Replaces bare `Self->Defs.clear()` in both `VECTORSCENE_Free` and `VECTORSCENE_Reset` with the new `clear_defs()` to prevent stale pointer dereference after scene teardown
* Removes redundant `FreeResource` calls on `objSVG` objects in `parsing.cpp` — these objects are freed automatically when they go out of scope via RAII

## Test plan

- [ ] Build `vector` and `document` modules and confirm clean compilation
- [ ] Verify SVG-based button rendering in the document engine is unaffected
- [ ] Run existing vector/scene integration tests to confirm no regressions