### PR TITLE
[Network] Bug-fixes and hardening across socket, SSL, proxy, and DNS subsystems

### DIFF
--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -165,7 +165,7 @@ static ERR NETLOOKUP_BlockingResolveAddress(extNetLookup *Self, struct nl::Block
 {
    kt::Log log;
 
-   if (!Args->Address) return log.warning(ERR::NullArgs);
+   if ((!Args) or (!Args->Address)) return log.warning(ERR::NullArgs);
 
    log.branch("Address: %s", Args->Address);
 
@@ -211,7 +211,7 @@ static ERR NETLOOKUP_BlockingResolveName(extNetLookup *Self, struct nl::ResolveN
 {
    kt::Log log;
 
-   if (!Args->HostName) return log.error(ERR::NullArgs);
+   if ((!Args) or (!Args->HostName)) return log.error(ERR::NullArgs);
 
    log.branch("Host: %s", Args->HostName);
 
@@ -290,7 +290,7 @@ static ERR NETLOOKUP_ResolveAddress(extNetLookup *Self, struct nl::ResolveAddres
 {
    kt::Log log;
 
-   if (!Args->Address) return log.warning(ERR::NullArgs);
+   if ((!Args) or (!Args->Address)) return log.warning(ERR::NullArgs);
    if (Self->Callback.Type IS CALL::NIL) return log.warning(ERR::FieldNotSet);
 
    log.branch("Address: %s", Args->Address);
@@ -323,7 +323,9 @@ static ERR NETLOOKUP_ResolveAddress(extNetLookup *Self, struct nl::ResolveAddres
          DNSEntry dummy;
          rb.Error = resolve_address(rb.Address.c_str(), &rb.IP, dummy);
          auto ser = rb.serialise();
-         SendMessage(glResolveAddrMsgID, MSF::NIL, ser.data(), ser.size()); // See resolve_addr_receiver()
+         if (auto error = SendMessage(glResolveAddrMsgID, MSF::NIL, ser.data(), ser.size()); error != ERR::Okay) {
+            kt::Log(__FUNCTION__).warning("Failed to queue address resolution result: %s", GetErrorMsg(error));
+         }
       }, std::move(rb))));
 
       return ERR::Okay;
@@ -357,7 +359,7 @@ static ERR NETLOOKUP_ResolveName(extNetLookup *Self, struct nl::ResolveName *Arg
 {
    kt::Log log;
 
-   if (!Args->HostName) return log.error(ERR::NullArgs);
+   if ((!Args) or (!Args->HostName)) return log.error(ERR::NullArgs);
 
    log.branch("Host: %s", Args->HostName);
 
@@ -382,11 +384,13 @@ static ERR NETLOOKUP_ResolveName(extNetLookup *Self, struct nl::ResolveName *Arg
    }
 
    resolve_buffer rb(Self->UID, Args->HostName);
-   Self->Threads.emplace_back(std::make_unique<std::jthread>(std::jthread([Self](resolve_buffer rb) {
+   Self->Threads.emplace_back(std::make_unique<std::jthread>(std::jthread([](resolve_buffer rb) {
       DNSEntry dummy;
       rb.Error = resolve_name(rb.Address.c_str(), dummy);
       auto ser = rb.serialise();
-      SendMessage(glResolveNameMsgID, MSF::NIL, ser.data(), ser.size()); // See resolve_name_receiver()
+      if (auto error = SendMessage(glResolveNameMsgID, MSF::NIL, ser.data(), ser.size()); error != ERR::Okay) {
+         kt::Log(__FUNCTION__).warning("Failed to queue name resolution result: %s", GetErrorMsg(error));
+      }
    }, std::move(rb))));
 
    return ERR::Okay;
@@ -587,13 +591,13 @@ static ERR resolve_address(CSTRING Address, const IPAddress *IP, DNSEntry &Info)
       result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service, sizeof(service), NI_NAMEREQD);
    }
    else {
-      const struct sockaddr_in6 sa = {
+      struct sockaddr_in6 sa = {
          .sin6_family   = AF_INET6,
          .sin6_port     = 0,
          .sin6_flowinfo = 0,
          .sin6_scope_id = 0
       };
-      kt::copymem(IP->Data, (APTR)sa.sin6_addr.s6_addr, 16);
+      kt::copymem(IP->Data, sa.sin6_addr.s6_addr, 16);
       result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service, sizeof(service), NI_NAMEREQD);
    }
 

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -60,9 +60,8 @@ struct resolve_buffer {
 static ERR resolve_address(CSTRING, const IPAddress *, DNSEntry &);
 static ERR resolve_name(CSTRING, DNSEntry &);
 static ERR cache_host(HOSTMAP &, CSTRING, struct hostent *, DNSEntry &);
-#ifdef __linux__
+static ERR convert_addrinfo(CSTRING, struct addrinfo *, DNSEntry &);
 static ERR cache_host(HOSTMAP &, CSTRING, struct addrinfo *, DNSEntry &);
-#endif
 
 static std::vector<IPAddress> glNoAddresses;
 
@@ -481,7 +480,7 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct hostent *Host, DNSEntr
 
    kt::Log log(__FUNCTION__);
 
-   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->h_addr_list, (Host->h_addrtype == AF_INET6));
+   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->h_addr_list, (Host->h_addrtype IS AF_INET6));
 
    if ((Host->h_addrtype != AF_INET) and (Host->h_addrtype != AF_INET6)) return ERR::Args;
 
@@ -516,9 +515,7 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct hostent *Host, DNSEntr
    return ERR::Okay;
 }
 
-#ifdef __linux__
-
-static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
+static ERR convert_addrinfo(CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
 {
    if (!Host) return ERR::NullArgs;
 
@@ -527,7 +524,7 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEnt
    }
 
    kt::Log log(__FUNCTION__);
-   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->ai_addr, (Host->ai_family == AF_INET6));
+   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->ai_addr, (Host->ai_family IS AF_INET6));
 
    DNSEntry cache;
    if (!Host->ai_canonname) cache.HostName = Key;
@@ -550,6 +547,21 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEnt
       }
    }
 
+   Cache = std::move(cache);
+   return ERR::Okay;
+}
+
+static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
+{
+   if (!Host) return ERR::NullArgs;
+
+   if (!Key) {
+      if (!(Key = Host->ai_canonname)) return ERR::Args;
+   }
+
+   DNSEntry cache;
+   if (auto error = convert_addrinfo(Key, Host, cache); error != ERR::Okay) return error;
+
    {
       std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
       std::unique_lock<std::shared_mutex> lock(cache_mutex);
@@ -559,8 +571,6 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEnt
    }
    return ERR::Okay;
 }
-
-#endif
 
 //********************************************************************************************************************
 
@@ -622,54 +632,6 @@ static ERR resolve_address(CSTRING Address, const IPAddress *IP, DNSEntry &Info)
 #endif
 }
 
-#ifdef _WIN32
-
-static ERR cache_host_from_addrinfo(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
-{
-   if (!Host) return ERR::NullArgs;
-
-   if (!Key) {
-      if (!(Key = Host->ai_canonname)) return ERR::Args;
-   }
-
-   kt::Log log(__FUNCTION__);
-   log.detail("Key: %s, Addresses: %p (IPv6: %d)", Key, Host->ai_addr, (Host->ai_family IS AF_INET6));
-
-   DNSEntry cache;
-   if (!Host->ai_canonname) cache.HostName = Key;
-   else cache.HostName = Host->ai_canonname;
-
-   if ((Host->ai_family != AF_INET) and (Host->ai_family != AF_INET6)) return ERR::Args;
-
-   for (auto scan=Host; scan; scan=scan->ai_next) {
-      if (!scan->ai_addr) continue;
-
-      if (scan->ai_family IS AF_INET) {
-         auto addr = ((struct sockaddr_in *)scan->ai_addr)->sin_addr.s_addr;
-         cache.Addresses.push_back({ ntohl(addr), 0, 0, 0, IPADDR::V4 });
-      }
-      else if (scan->ai_family IS AF_INET6) {
-         auto addr = (struct sockaddr_in6 *)scan->ai_addr;
-         cache.Addresses.push_back({
-            ((uint32_t *)&addr->sin6_addr.s6_addr)[0], ((uint32_t *)&addr->sin6_addr.s6_addr)[1],
-            ((uint32_t *)&addr->sin6_addr.s6_addr)[2], ((uint32_t *)&addr->sin6_addr.s6_addr)[3], IPADDR::V6
-         });
-      }
-   }
-
-   {
-      std::unique_lock<std::shared_mutex> lock(glHostsMutex);
-      auto &entry = Store[Key];
-      entry = std::move(cache);
-      Cache = entry;
-   }
-   return ERR::Okay;
-}
-
-#endif
-
-//********************************************************************************************************************
-
 static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
 {
    // Use the cache if available.
@@ -699,16 +661,9 @@ static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
 
    switch (result) {
       case 0: {
-#ifdef __linux__
          ERR error = cache_host(glHosts, HostName, servinfo, Info);
          freeaddrinfo(servinfo);
          return error;
-#elif _WIN32
-         // Convert getaddrinfo result to hostent format for Windows compatibility
-         ERR error = cache_host_from_addrinfo(glHosts, HostName, servinfo, Info);
-         freeaddrinfo(servinfo);
-         return error;
-#endif
       }
       case EAI_AGAIN:  return ERR::Retry;
       case EAI_FAIL:   return ERR::Failed;

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -495,15 +495,16 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct hostent *Host, DNSEntr
       else if (Host->h_addrtype IS AF_INET6) {
          for (unsigned i=0; Host->h_addr_list[i]; i++) {
             auto addr = ((struct in6_addr **)Host->h_addr_list)[i];
-            cache.Addresses.push_back({
-               ((uint32_t *)addr)[0], ((uint32_t *)addr)[1], ((uint32_t *)addr)[2], ((uint32_t *)addr)[3], IPADDR::V6
-            });
+            IPAddress ip_address = { 0, 0, 0, 0, IPADDR::V6 };
+            kt::copymem(addr->s6_addr, ip_address.Data, 16);
+            cache.Addresses.push_back(ip_address);
          }
       }
    }
 
    {
-      std::unique_lock<std::shared_mutex> lock(glAddressesMutex);
+      std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
+      std::unique_lock<std::shared_mutex> lock(cache_mutex);
       auto &entry = Store[Key];
       entry = std::move(cache);
       Cache = entry;
@@ -539,14 +540,15 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEnt
       }
       else if (scan->ai_family IS AF_INET6) {
          auto addr = (struct sockaddr_in6 *)scan->ai_addr;
-         cache.Addresses.push_back({
-            ((uint32_t *)addr)[0], ((uint32_t *)addr)[1], ((uint32_t *)addr)[2], ((uint32_t *)addr)[3], IPADDR::V6
-         });
+         IPAddress ip_address = { 0, 0, 0, 0, IPADDR::V6 };
+         kt::copymem(addr->sin6_addr.s6_addr, ip_address.Data, 16);
+         cache.Addresses.push_back(ip_address);
       }
    }
 
    {
-      std::unique_lock<std::shared_mutex> lock(glAddressesMutex);
+      std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
+      std::unique_lock<std::shared_mutex> lock(cache_mutex);
       auto &entry = Store[Key];
       entry = std::move(cache);
       Cache = entry;

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -209,8 +209,8 @@ static ERR PROXY_DeleteRecord(extProxy *Self)
    auto cfg = objConfig::create {fl::Path("user:config/network/proxies.cfg") };
    if (!cfg.ok()) return log.error(ERR::CreateObject);
 
-   cfg->deleteGroup(Self->GroupName.c_str());
-   cfg->saveSettings();
+   if (auto error = cfg->deleteGroup(Self->GroupName.c_str()); error != ERR::Okay) return log.warning(error);
+   if (auto error = cfg->saveSettings(); error != ERR::Okay) return log.warning(error);
    return ERR::Okay;
 }
 
@@ -514,17 +514,21 @@ static ERR PROXY_SaveSettings(extProxy *Self)
       #ifdef _WIN32
          objTask *task = CurrentTask();
 
-         if (Self->Enabled) task->setEnv(HKEY_PROXY "ProxyEnable", "1");
-         else task->setEnv(HKEY_PROXY "ProxyEnable", "0");
+         ERR error;
+         if (Self->Enabled) error = task->setEnv(HKEY_PROXY "ProxyEnable", "1");
+         else error = task->setEnv(HKEY_PROXY "ProxyEnable", "0");
+         if (error != ERR::Okay) return log.warning(error);
 
          if ((!Self->Server) or (!Self->Server[0])) {
             log.trace("Clearing proxy server value.");
-            task->setEnv(HKEY_PROXY "ProxyServer", "");
+            if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", ""); error != ERR::Okay) return log.warning(error);
          }
          else if (Self->Port IS 0) { // Proxy is for all ports
             std::string buffer = std::format("{}:{}", Self->Server, Self->ServerPort);
             log.trace("Changing all-port proxy to: %s", buffer.c_str());
-            task->setEnv(HKEY_PROXY "ProxyServer", buffer.c_str());
+            if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", buffer.c_str()); error != ERR::Okay) {
+               return log.warning(error);
+            }
          }
          else {
             std::string portname;
@@ -555,9 +559,11 @@ static ERR PROXY_SaveSettings(extProxy *Self)
                }
                serverList += newEntry;
 
-               task->setEnv(HKEY_PROXY "ProxyServer", serverList.c_str());
+               if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", serverList.c_str()); error != ERR::Okay) {
+                  return log.warning(error);
+               }
             }
-            else log.error("Windows' host proxy settings do not support port %d", Self->Port);
+            else return log.error(ERR::NoSupport);
          }
 
       #endif
@@ -735,7 +741,7 @@ The port used to communicate with the proxy server must be defined here.
 
 static ERR SET_ServerPort(extProxy *Self, int Value)
 {
-   if (Value > 0 and Value <= 65536) {
+   if (Value > 0 and Value <= 0xffff) {
       Self->ServerPort = Value;
       return ERR::Okay;
    }

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -81,6 +81,24 @@ public:
 
 static ERR find_proxy(extProxy *);
 
+static bool parse_record_id(const std::string &GroupName, int &Record)
+{
+   if (GroupName.empty()) return false;
+
+   int record = 0;
+   for (auto ch : GroupName) {
+      if ((ch < '0') or (ch > '9')) return false;
+
+      int digit = ch - '0';
+      if (record > ((0x7fffffff - digit) / 10)) return false;
+
+      record = (record * 10) + digit;
+   }
+
+   Record = record;
+   return true;
+}
+
 //********************************************************************************************************************
 
 #ifdef _WIN32
@@ -378,7 +396,10 @@ template<typename KeysType>
 static bool matchesEnabledFilter(const KeysType& keys, int findEnabled) {
    if (findEnabled IS -1) return true;
 
-   if (keys.contains("Enabled")) return std::stoi(keys.at("Enabled")) IS findEnabled;
+   if (keys.contains("Enabled")) {
+      int enabled;
+      return parse_record_id(keys.at("Enabled"), enabled) and (enabled IS findEnabled);
+   }
    return false;
 }
 
@@ -412,6 +433,8 @@ static ERR find_proxy(extProxy *Self)
          log.trace("Checking group: %s", group->first.c_str());
 
          const auto& keys = group->second;
+         int record;
+         if (!parse_record_id(group->first, record)) continue;
 
          // Apply filters
          if (!matchesPortFilter(keys, Self->FindPort)) continue;
@@ -768,7 +791,7 @@ static ERR get_record(extProxy *Self)
 
    log.traceBranch("Group: %s", Self->GroupName.c_str());
 
-   Self->Record = std::stoi(Self->GroupName);
+   if (!parse_record_id(Self->GroupName, Self->Record)) return ERR::Search;
 
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);
 

--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -519,9 +519,15 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
          // Server-side SSL setup - create SSL context and wait for client handshake
          Self->SSLHandle = ssl_create_context(false, true); // No verification, server mode
          if (Self->SSLHandle) {
-            ssl_set_server_certificate(server->SSLHandle, Self->SSLHandle);
-            ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle.socket()); // Set socket handle for server-side SSL
-            Self->State = NTC::HANDSHAKING;
+            if (ssl_set_server_certificate(server->SSLHandle, Self->SSLHandle) IS SSL_OK) {
+               ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle.socket()); // Set socket handle for server-side SSL
+               Self->State = NTC::HANDSHAKING;
+            }
+            else {
+               ssl_free_context(Self->SSLHandle);
+               Self->SSLHandle = nullptr;
+               Self->State = NTC::DISCONNECTED;
+            }
          }
          else Self->State = NTC::DISCONNECTED;
       }

--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -462,16 +462,26 @@ static ERR CLIENTSOCKET_Free(extClientSocket *Self)
    if (Self->Client) { // If undefined, ClientSocket was never initialised
       kt::ScopedObjectLock lock(Self->Client);
       if (lock.granted()) {
-         if (Self->Prev) {
-            Self->Prev->Next = Self->Next;
-            if (Self->Next) Self->Next->Prev = Self->Prev;
-         }
-         else {
-            Self->Client->Connections = Self->Next;
-            if (Self->Next) Self->Next->Prev = nullptr;
+         bool linked = false;
+         for (auto scan=Self->Client->Connections; scan; scan=scan->Next) {
+            if (scan IS Self) {
+               linked = true;
+               break;
+            }
          }
 
-         Self->Client->TotalConnections--;
+         if (linked) {
+            if (Self->Prev) {
+               Self->Prev->Next = Self->Next;
+               if (Self->Next) Self->Next->Prev = Self->Prev;
+            }
+            else {
+               Self->Client->Connections = Self->Next;
+               if (Self->Next) Self->Next->Prev = nullptr;
+            }
+
+            if (Self->Client->TotalConnections > 0) Self->Client->TotalConnections--;
+         }
 
          if (not Self->Client->Connections) {
             log.msg("No more connections for this IP, removing client.");
@@ -616,6 +626,8 @@ static ERR CLIENTSOCKET_Read(extClientSocket *Self, struct acRead *Args)
 {
    kt::Log log;
    if ((not Args) or (not Args->Buffer)) return log.error(ERR::NullArgs);
+   Args->Result = 0;
+   if (Args->Length < 0) return log.warning(ERR::Args);
    if (Self->Handle.is_invalid()) {
       // Lack of a handle means that disconnection has already been processed, so the client code
       // shouldn't be calling us (client probably needs to be plugged into the feedback mechanisms)
@@ -657,7 +669,8 @@ static ERR CLIENTSOCKET_Write(extClientSocket *Self, struct acWrite *Args)
 
    if (not Args) return ERR::NullArgs;
    Args->Result = 0;
-   if (Args->Length <= 0) return ERR::Okay;
+   if (Args->Length < 0) return log.warning(ERR::Args);
+   if (!Args->Length) return ERR::Okay;
    if (not Args->Buffer) return ERR::NullArgs;
 
    auto server = (extNetSocket *)(Self->Client->Owner);

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -750,7 +750,7 @@ static ERR NETSOCKET_GetLocalIPAddress(extNetSocket *Self, struct ns::GetLocalIP
    if (!result) {
       if (addr_storage.ss_family IS AF_INET6) {
          auto addr6 = (struct sockaddr_in6 *)&addr_storage;
-         kt::copymem(Args->Address->Data, &addr6->sin6_addr.s6_addr, 16);
+         kt::copymem(addr6->sin6_addr.s6_addr, Args->Address->Data, 16);
          Args->Address->Type = IPADDR::V6;
       }
       else if (addr_storage.ss_family IS AF_INET) {
@@ -1149,6 +1149,7 @@ static ERR NETSOCKET_JoinMulticastGroup(extNetSocket *Self, struct ns::JoinMulti
 {
    kt::Log log;
 
+   if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return ERR::NoSupport;
    if (!Args->Group) return ERR::Args;
 
@@ -1221,6 +1222,7 @@ static ERR NETSOCKET_LeaveMulticastGroup(extNetSocket *Self, struct ns::LeaveMul
 {
    kt::Log log;
 
+   if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return ERR::NoSupport;
    if (!Args->Group) return ERR::Args;
 
@@ -1479,8 +1481,10 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
 
    if ((Self->Handle.is_invalid()) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
       log.trace("Saving %d bytes to queue.", Args->Length);
-      Self->WriteQueue.write(Args->Buffer, std::min<size_t>(Args->Length, Self->MsgLimit));
-      return ERR::Okay;
+      auto len = std::min<size_t>(Args->Length, Self->MsgLimit);
+      if (auto error = Self->WriteQueue.write(Args->Buffer, len); error != ERR::Okay) return error;
+      Args->Result = int(len);
+      return (len < size_t(Args->Length)) ? ERR::BufferOverflow : ERR::Okay;
    }
 
    // Note that if a write queue has been setup, there is no way that we can write to the server until the queue has
@@ -1510,7 +1514,15 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
       if ((error IS ERR::DataSize) or (error IS ERR::BufferOverflow) or (ssl_read_blocked) or (len > 0))  {
          // Put data into the write queue and register the socket for write events
          log.trace("Error: '%s', queuing %d/%d bytes for transfer...", GetErrorMsg(error), Args->Length - len, Args->Length);
-         Self->WriteQueue.write((int8_t *)Args->Buffer + len, std::min<size_t>(Args->Length - len, Self->MsgLimit));
+         auto remaining = size_t(Args->Length) - len;
+         auto queue_len = std::min<size_t>(remaining, Self->MsgLimit);
+         if (auto queue_error = Self->WriteQueue.write((int8_t *)Args->Buffer + len, queue_len);
+             queue_error != ERR::Okay) {
+            Args->Result = int(len);
+            return queue_error;
+         }
+         auto queue_overflow = queue_len < remaining;
+         if (queue_overflow) Args->Result = int(len + queue_len);
          if (ssl_write_blocked) {
             #if !defined(DISABLE_SSL) and !defined(_WIN32)
                ssl_resume_write_handshake(Self->Handle.hosthandle(), Self);
@@ -1523,6 +1535,8 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
                win_socketstate(Self->Handle, std::nullopt, true);
             #endif
          }
+
+         if (queue_overflow) return ERR::BufferOverflow;
       }
       else {
          Self->ErrorCountdown--;
@@ -1667,6 +1681,7 @@ static ERR NETSOCKET_SendTo(extNetSocket *Self, struct ns::SendTo *Args)
 {
    kt::Log log;
 
+   if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return log.warning(ERR::InvalidState);
    if ((!Args->Dest) or (!Args->Data) or (!Args->Length)) return log.warning(ERR::NullArgs);
    if (Args->Length <= 0) return log.warning(ERR::Args);

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -883,7 +883,9 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    // calls from going to sleep.
 
    if (fcntl(Self->Handle, F_SETFL, fcntl(Self->Handle, F_GETFL) | O_NONBLOCK)) {
-      return log.warning(convert_socket_error());
+      error = log.warning(convert_socket_error());
+      free_socket(Self);
+      return error;
    }
 
    // Set the send timeout so that connect() will timeout after a reasonable time
@@ -941,7 +943,11 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    }
 
    if ((Self->Flags & NSF::SERVER) != NSF::NIL) {
-      if (!Self->Port) return log.warning(ERR::FieldNotSet);
+      if (!Self->Port) {
+         error = log.warning(ERR::FieldNotSet);
+         free_socket(Self);
+         return error;
+      }
       Self->State = NTC::MULTISTATE; // Permanent value to indicate that the socket serves multiple clients.
 
       if (Self->IPV6) {
@@ -951,6 +957,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             // Use parse_bind_address if Address is specified, otherwise bind to all interfaces
             if (Self->Address) {
                if (auto error = parse_bind_address(Self->Address, true, &addr); error != ERR::Okay) {
+                  free_socket(Self);
                   return error;
                }
                addr.sin6_port = net::HostToShort(Self->Port);
@@ -968,7 +975,12 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
 
             if ((result = bind(Self->Handle, (struct sockaddr *)&addr, sizeof(addr))) != -1) {
                if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP server - needs listen()
-                  listen(Self->Handle, Self->Backlog);
+                  if (listen(Self->Handle, Self->Backlog) IS -1) {
+                     const int system_error = errno;
+                     log.warning("listen() failed with error: %s", strerror(system_error));
+                     free_socket(Self);
+                     return convert_socket_error(system_error);
+                  }
                   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_accept_client, Self);
                }
                else { // UDP server - just register for data reception
@@ -976,7 +988,11 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
                }
                return ERR::Okay;
             }
-            else return log.warning(convert_socket_error());
+            else {
+               error = log.warning(convert_socket_error());
+               free_socket(Self);
+               return error;
+            }
          #elif _WIN32
             // Windows IPv6 dual-stack server binding
             struct sockaddr_in6 addr;
@@ -984,6 +1000,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             // Use parse_bind_address if Address is specified, otherwise bind to all interfaces
             if (Self->Address) {
                if (auto error = parse_bind_address(Self->Address, true, &addr); error != ERR::Okay) {
+                  free_socket(Self);
                   return error;
                }
                addr.sin6_port = net::HostToShort(Self->Port);
@@ -1002,6 +1019,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
                   }
                   else {
                      log.warning("Listen failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
+                     free_socket(Self);
                      return error;
                   }
                }
@@ -1011,9 +1029,11 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             }
             else {
                log.warning("Bind failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
+               free_socket(Self);
                return error;
             }
          #else
+            free_socket(Self);
             return ERR::NoSupport;
          #endif
       }
@@ -1024,6 +1044,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
          // Use parse_bind_address if Address is specified, otherwise bind to all interfaces
          if (Self->Address) {
             if (auto error = parse_bind_address(Self->Address, false, &addr); error != ERR::Okay) {
+               free_socket(Self);
                return error;
             }
             addr.sin_port = net::HostToShort(Self->Port);
@@ -1042,7 +1063,12 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
 
             if ((result = bind(Self->Handle, (struct sockaddr *)&addr, sizeof(addr))) != -1) {
                if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP server - needs listen()
-                  listen(Self->Handle, Self->Backlog);
+                  if (listen(Self->Handle, Self->Backlog) IS -1) {
+                     const int system_error = errno;
+                     log.warning("listen() failed with error: %s", strerror(system_error));
+                     free_socket(Self);
+                     return convert_socket_error(system_error);
+                  }
                   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_accept_client, Self);
                }
                else { // UDP server - just register for data reception
@@ -1053,6 +1079,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             else {
                const int system_error = errno;
                log.warning("bind() failed with error: %s", strerror(system_error));
+               free_socket(Self);
                return convert_socket_error(system_error);
             }
          #elif _WIN32
@@ -1063,6 +1090,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
                   }
                   else {
                      log.warning("Listen failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
+                     free_socket(Self);
                      return error;
                   }
                }
@@ -1072,6 +1100,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             }
             else {
                log.warning("Bind failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
+               free_socket(Self);
                return error;
             }
          #endif
@@ -1079,6 +1108,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    }
    else if ((Self->Address) and (Self->Port > 0)) {
       if ((error = Self->connect(Self->Address, Self->Port, 0)) != ERR::Okay) {
+         free_socket(Self);
          return error;
       }
       else return ERR::Okay;
@@ -1277,6 +1307,8 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
    kt::Log log;
 
    if ((!Args) or (!Args->Buffer)) return log.warning(ERR::NullArgs);
+   Args->Result = 0;
+   if (Args->Length < 0) return log.warning(ERR::Args);
 
    if ((Self->Flags & NSF::SERVER) != NSF::NIL) { // Not allowed - client must read from the ClientSocket.
       return ERR::NoSupport;
@@ -1285,7 +1317,6 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
    if (Self->Handle.is_invalid()) return log.warning(ERR::Disconnected);
 
    Self->ReadCalled = true;
-   Args->Result = 0;
 
    if (!Args->Length) return ERR::Okay;
 
@@ -1438,6 +1469,8 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
    if (!Args) return log.warning(ERR::NullArgs);
 
    Args->Result = 0;
+   if (Args->Length < 0) return log.warning(ERR::Args);
+   if ((!Args->Buffer) and (Args->Length > 0)) return log.warning(ERR::NullArgs);
 
    if ((Self->Flags & NSF::SERVER) != NSF::NIL) {
       log.warning("Write to the ClientSocket objects of this server.");
@@ -1538,8 +1571,10 @@ static ERR NETSOCKET_RecvFrom(extNetSocket *Self, struct ns::RecvFrom *Args)
 {
    kt::Log log;
 
+   if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return log.warning(ERR::NoSupport);
-   if ((!Args->Buffer) or (!Args->BufferSize) or (!Args->Source)) return log.warning(ERR::NullArgs);
+   if ((!Args->Buffer) or (!Args->Source)) return log.warning(ERR::NullArgs);
+   if (Args->BufferSize <= 0) return log.warning(ERR::Args);
 
    Self->ReadCalled = true;
 

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -1123,6 +1123,69 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    else return ERR::Okay;
 }
 
+//********************************************************************************************************************
+
+struct multicast_group_address {
+   bool IsIPv6 = false;
+
+   #ifdef __linux__
+      struct ip_mreq Mreq4;
+      struct ipv6_mreq Mreq6;
+   #endif
+};
+
+static ERR parse_multicast_group(CSTRING Group, multicast_group_address &Address)
+{
+   if (!Group) return ERR::Args;
+
+   struct sockaddr_in addr4;
+   struct sockaddr_in6 addr6;
+   kt::clearmem(&addr4, sizeof(addr4));
+   kt::clearmem(&addr6, sizeof(addr6));
+
+   #ifdef __linux__
+      kt::clearmem(&Address.Mreq4, sizeof(Address.Mreq4));
+      kt::clearmem(&Address.Mreq6, sizeof(Address.Mreq6));
+   #endif
+
+   if (unified_inet_pton(AF_INET6, Group, &addr6.sin6_addr) IS 1) {
+      Address.IsIPv6 = true;
+
+      #ifdef __linux__
+         Address.Mreq6.ipv6mr_multiaddr = addr6.sin6_addr;
+         Address.Mreq6.ipv6mr_interface = 0;
+      #endif
+
+      return ERR::Okay;
+   }
+   else if (unified_inet_pton(AF_INET, Group, &addr4.sin_addr) IS 1) {
+      Address.IsIPv6 = false;
+
+      #ifdef __linux__
+         Address.Mreq4.imr_multiaddr = addr4.sin_addr;
+         Address.Mreq4.imr_interface.s_addr = INADDR_ANY;
+      #endif
+
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+#ifdef __linux__
+
+static int set_multicast_membership(SocketHandle Handle, const multicast_group_address &Address, int IPv4Option,
+   int IPv6Option)
+{
+   if (Address.IsIPv6) {
+      return setsockopt(Handle, IPPROTO_IPV6, IPv6Option, (char *)&Address.Mreq6, sizeof(Address.Mreq6));
+   }
+   else {
+      return setsockopt(Handle, IPPROTO_IP, IPv4Option, (char *)&Address.Mreq4, sizeof(Address.Mreq4));
+   }
+}
+
+#endif
+
 /*********************************************************************************************************************
 
 -METHOD-
@@ -1155,42 +1218,24 @@ static ERR NETSOCKET_JoinMulticastGroup(extNetSocket *Self, struct ns::JoinMulti
 
    log.branch("%s", Args->Group);
 
-   // Parse the multicast address
-   struct sockaddr_storage mcast_addr;
-   bool is_ipv6 = false;
-
-   auto addr4 = (struct sockaddr_in *)&mcast_addr;
-   auto addr6 = (struct sockaddr_in6 *)&mcast_addr;
-
-   if (unified_inet_pton(AF_INET6, Args->Group, &addr6->sin6_addr) IS 1) is_ipv6 = true;
-   else if (unified_inet_pton(AF_INET, Args->Group, &addr4->sin_addr) IS 1) is_ipv6 = false;
-   else {
+   multicast_group_address group_address;
+   if (parse_multicast_group(Args->Group, group_address) != ERR::Okay) {
       log.warning("Invalid multicast address: %s", Args->Group);
       return ERR::Args;
    }
 
-   // Join the multicast group
 #ifdef __linux__
-   if (is_ipv6) {
-      struct ipv6_mreq mreq6;
-      mreq6.ipv6mr_multiaddr = addr6->sin6_addr;
-      mreq6.ipv6mr_interface = 0;
-      if (setsockopt(Self->Handle, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char*)&mreq6, sizeof(mreq6)) != 0) {
+   if (set_multicast_membership(Self->Handle, group_address, IP_ADD_MEMBERSHIP, IPV6_JOIN_GROUP) != 0) {
+      if (group_address.IsIPv6) {
          log.warning("Failed to join IPv6 multicast group: %s", strerror(errno));
-         return ERR::Failed;
       }
-   }
-   else {
-      struct ip_mreq mreq;
-      mreq.imr_multiaddr = addr4->sin_addr;
-      mreq.imr_interface.s_addr = INADDR_ANY;
-      if (setsockopt(Self->Handle, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&mreq, sizeof(mreq)) != 0) {
+      else {
          log.warning("Failed to join IPv4 multicast group: %s", strerror(errno));
-         return ERR::Failed;
       }
+      return ERR::Failed;
    }
 #elif _WIN32
-   if (win_join_multicast_group(Self->Handle, Args->Group, is_ipv6) != ERR::Okay) {
+   if (win_join_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
       return log.warning(ERR::Failed);
    }
 #endif
@@ -1228,45 +1273,24 @@ static ERR NETSOCKET_LeaveMulticastGroup(extNetSocket *Self, struct ns::LeaveMul
 
    log.branch("%s", Args->Group);
 
-   // Parse the multicast address
-   struct sockaddr_storage mcast_addr;
-   bool is_ipv6 = false;
-
-   auto addr4 = (struct sockaddr_in *)&mcast_addr;
-   auto addr6 = (struct sockaddr_in6 *)&mcast_addr;
-
-   if (unified_inet_pton(AF_INET6, Args->Group, &addr6->sin6_addr) IS 1) is_ipv6 = true;
-   else if (unified_inet_pton(AF_INET, Args->Group, &addr4->sin_addr) IS 1) is_ipv6 = false;
-   else {
+   multicast_group_address group_address;
+   if (parse_multicast_group(Args->Group, group_address) != ERR::Okay) {
       log.warning("Invalid multicast address: %s", Args->Group);
       return ERR::Args;
    }
 
-   // Leave the multicast group
 #ifdef __linux__
-   if (is_ipv6) {
-      struct ipv6_mreq mreq6;
-      mreq6.ipv6mr_multiaddr = addr6->sin6_addr;
-      mreq6.ipv6mr_interface = 0; // Use default interface
-
-      if (setsockopt(Self->Handle, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (char*)&mreq6, sizeof(mreq6)) != 0) {
+   if (set_multicast_membership(Self->Handle, group_address, IP_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP) != 0) {
+      if (group_address.IsIPv6) {
          log.warning("Failed to leave IPv6 multicast group: %s", strerror(errno));
-         return ERR::Failed;
       }
-   }
-   else {
-      struct ip_mreq mreq;
-      mreq.imr_multiaddr = addr4->sin_addr;
-      mreq.imr_interface.s_addr = INADDR_ANY; // Use default interface
-
-      if (setsockopt(Self->Handle, IPPROTO_IP, IP_DROP_MEMBERSHIP, (char*)&mreq, sizeof(mreq)) != 0) {
+      else {
          log.warning("Failed to leave IPv4 multicast group: %s", strerror(errno));
-         return ERR::Failed;
       }
+      return ERR::Failed;
    }
 #elif _WIN32
-   // Use winsock wrapper - will be added to winsockwrappers.cpp
-   if (win_leave_multicast_group(Self->Handle, Args->Group, is_ipv6) != ERR::Okay) {
+   if (win_leave_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
       log.warning("Failed to leave multicast group: %s", Args->Group);
       return ERR::Failed;
    }

--- a/src/network/netsocket/netsocket_fields.cpp
+++ b/src/network/netsocket/netsocket_fields.cpp
@@ -281,12 +281,7 @@ static ERR SET_SSLCertificate(extNetSocket *Self, CSTRING Value)
 
       LOC type;
       if ((AnalysePath(Value, &type) IS ERR::Okay) and (type IS LOC::FILE)) {
-         // Check file extension for supported formats
-         std::string path(Value);
-         std::string ext = path.substr(path.find_last_of(".") + 1);
-         std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-
-         if ((ext IS "pem") or (ext IS "crt") or (ext IS "cert") or (ext IS "p12") or (ext IS "pfx")) {
+         if (ssl_certificate_format(Value) != SSLCERTFORMAT::NIL) {
             Self->SSLCertificate = kt::strclone(Value);
          }
          else return log.warning(ERR::InvalidData);
@@ -317,11 +312,7 @@ static ERR SET_SSLPrivateKey(extNetSocket *Self, CSTRING Value)
 
       LOC type;
       if ((AnalysePath(Value, &type) IS ERR::Okay) and (type IS LOC::FILE)) {
-         // Check file extension for supported formats
-         std::string path(Value);
-         std::string ext = path.substr(path.find_last_of(".") + 1);
-         std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-         if ((ext IS "pem") or (ext IS "key")) {
+         if (ssl_private_key_format(Value) != SSLCERTFORMAT::NIL) {
             Self->SSLPrivateKey = kt::strclone(Value);
          }
          else return log.warning(ERR::InvalidData);

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -466,7 +466,7 @@ static void free_client(extNetSocket *Socket, objNetClient *Client)
    }
    else {
       Socket->Clients = Client->Next;
-      if ((Socket->Clients) and (Socket->Clients->Next)) Socket->Clients->Next->Prev = nullptr;
+      if (Socket->Clients) Socket->Clients->Prev = nullptr;
    }
 
    FreeResource(Client);
@@ -646,7 +646,15 @@ restart:
 
    if (error IS ERR::Terminate) {
       log.traceBranch("Socket % " PRId64 " will be terminated.", int64_t(SocketFD));
-      if (Self->Handle.is_valid()) free_socket(Self);
+      if (Self->Handle.is_valid()) {
+         Self->CloseAfterWrite = true;
+         Self->Incoming.clear();
+         #ifdef __linux__
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
+         #elif _WIN32
+            win_socketstate(Self->Handle, std::nullopt, true);
+         #endif
+      }
    }
    else if (Self->IncomingRecursion > 1) {
       // If netsocket_incoming() was called again during the callback, there is more
@@ -744,6 +752,13 @@ static void netsocket_outgoing_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
    }
 
    // Before feeding new data into the queue, the current buffer must be empty.
+
+   if (Self->CloseAfterWrite and Self->WriteQueue.Buffer.empty()) {
+      Self->InUse--;
+      Self->OutgoingRecursion--;
+      free_socket(Self);
+      return;
+   }
 
    if ((Self->WriteQueue.Buffer.empty()) or
        (Self->WriteQueue.Index >= Self->WriteQueue.Buffer.size())) {

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -375,7 +375,7 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       if (!Self->Clients) Self->Clients = client_ip;
       else {
          if (Self->LastClient) Self->LastClient->Next = client_ip;
-         if (Self->Clients) Self->Clients->Prev = Self->LastClient;
+         client_ip->Prev = Self->LastClient;
       }
       Self->LastClient = client_ip;
    }
@@ -418,7 +418,11 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
             }
          }
       }
-      else log.warning(ERR::Init);
+      else {
+         log.warning(ERR::Init);
+         FreeResource(client_socket);
+         return;
+      }
    }
    else {
       CLOSESOCKET(clientfd);

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -204,6 +204,27 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
 // Called when a server socket handle detects a new client wanting to connect to it.
 // Used by Win32 (Windows message loop) & Linux (FD hook)
 
+static ERR sockaddr_to_client_ip(const struct sockaddr *Address, int Family, uint8_t *IP)
+{
+   if ((!Address) or (!IP)) return ERR::NullArgs;
+
+   kt::clearmem(IP, 8);
+
+   if (Family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)Address;
+      kt::copymem(&addr->sin_addr.s_addr, IP, 4);
+      return ERR::Okay;
+   }
+   else if (Family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)Address;
+      kt::copymem(addr->sin6_addr.s6_addr, IP, 8);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+//********************************************************************************************************************
+
 static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    kt::Log log(__FUNCTION__);
@@ -250,25 +271,21 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
          setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
 
          if (addr_storage.ss_family IS AF_INET6) { // IPv6 connection
-            struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&addr_storage;
-            ip[0] = addr6->sin6_addr.s6_addr[0];
-            ip[1] = addr6->sin6_addr.s6_addr[1];
-            ip[2] = addr6->sin6_addr.s6_addr[2];
-            ip[3] = addr6->sin6_addr.s6_addr[3];
-            ip[4] = addr6->sin6_addr.s6_addr[4];
-            ip[5] = addr6->sin6_addr.s6_addr[5];
-            ip[6] = addr6->sin6_addr.s6_addr[6];
-            ip[7] = addr6->sin6_addr.s6_addr[7];
+            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, addr_storage.ss_family, ip);
+            if (error != ERR::Okay) {
+               log.warning(error);
+               close(clientfd);
+               return;
+            }
             log.trace("Accepted IPv6 client connection");
          }
          else if (addr_storage.ss_family IS AF_INET) { // IPv4 connection on dual-stack socket
-            struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr_storage;
-            uint32_t ipv4_addr = net::LongToHost(addr4->sin_addr.s_addr);
-            ip[0] = ipv4_addr & 0xff;
-            ip[1] = (ipv4_addr >> 8) & 0xff;
-            ip[2] = (ipv4_addr >> 16) & 0xff;
-            ip[3] = (ipv4_addr >> 24) & 0xff;
-            ip[4] = ip[5] = ip[6] = ip[7] = 0;
+            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, addr_storage.ss_family, ip);
+            if (error != ERR::Okay) {
+               log.warning(error);
+               close(clientfd);
+               return;
+            }
             log.trace("Accepted IPv4 client connection on dual-stack socket");
          }
          else {
@@ -285,25 +302,21 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
          if (clientfd IS NOHANDLE) return;
 
          if (family IS AF_INET6) { // IPv6 connection
-            struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&addr_storage;
-            ip[0] = addr6->sin6_addr.s6_addr[0];
-            ip[1] = addr6->sin6_addr.s6_addr[1];
-            ip[2] = addr6->sin6_addr.s6_addr[2];
-            ip[3] = addr6->sin6_addr.s6_addr[3];
-            ip[4] = addr6->sin6_addr.s6_addr[4];
-            ip[5] = addr6->sin6_addr.s6_addr[5];
-            ip[6] = addr6->sin6_addr.s6_addr[6];
-            ip[7] = addr6->sin6_addr.s6_addr[7];
+            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip);
+            if (error != ERR::Okay) {
+               log.warning(error);
+               CLOSESOCKET(clientfd);
+               return;
+            }
             log.trace("Accepted IPv6 client connection on Windows");
          }
          else if (family IS AF_INET) { // IPv4 connection on dual-stack socket
-            struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr_storage;
-            uint32_t ipv4_addr = net::LongToHost(addr4->sin_addr.s_addr);
-            ip[0] = ipv4_addr & 0xff;
-            ip[1] = (ipv4_addr >> 8) & 0xff;
-            ip[2] = (ipv4_addr >> 16) & 0xff;
-            ip[3] = (ipv4_addr >> 24) & 0xff;
-            ip[4] = ip[5] = ip[6] = ip[7] = 0;
+            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip);
+            if (error != ERR::Okay) {
+               log.warning(error);
+               CLOSESOCKET(clientfd);
+               return;
+            }
             log.trace("Accepted IPv4 client connection on dual-stack socket (Windows)");
          }
          else {
@@ -337,14 +350,11 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
          return;
       }
 
-      ip[0] = addr.sin_addr.s_addr;
-      ip[1] = addr.sin_addr.s_addr>>8;
-      ip[2] = addr.sin_addr.s_addr>>16;
-      ip[3] = addr.sin_addr.s_addr>>24;
-      ip[4] = 0;
-      ip[5] = 0;
-      ip[6] = 0;
-      ip[7] = 0;
+      if (auto error = sockaddr_to_client_ip((struct sockaddr *)&addr, AF_INET, ip); error != ERR::Okay) {
+         log.warning(error);
+         CLOSESOCKET(clientfd);
+         return;
+      }
    }
 
    // Check if this IP address already has a client structure from an earlier socket connection.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -309,6 +309,7 @@ class extNetSocket : public objNetSocket {
    uint8_t InUse;                 // Recursion counter to signal that the object is doing something.
    uint8_t IncomingRecursion;     // Used by netsocket_client to prevent recursive handling of incoming data.
    uint8_t OutgoingRecursion;
+   bool CloseAfterWrite = false;  // True if termination is waiting for queued data to flush
    uint8_t ErrorCountdown = 8;    // Counts down on each error, disconnect occurs at zero.
    TIMER   TimerHandle = 0;       // Timer subscription handle for timeout
    #ifdef _WIN32
@@ -400,27 +401,18 @@ static void CLOSESOCKET_THREADED(SocketHandle Handle)
    win_deregister_socket(Handle);
 #endif
 
-   // Clean up completed threads periodically to prevent collection growth
-
-   static std::atomic<int> cleanup_counter{0};
-   if (++cleanup_counter % 50 == 0) {
+   {
       std::lock_guard<std::mutex> lock(glmThreads);
-      std::erase_if(glThreads, [](const auto& thread_ptr) {
-         if ((!thread_ptr) or (!thread_ptr->joinable())) return true;
-         // For completed threads, join them and remove from collection
-         if (thread_ptr->get_id() == std::jthread::id{}) {
-            if (thread_ptr->joinable()) thread_ptr->join();
-            return true;
-         }
-         return false;
-      });
+      for (auto it = glThreads.begin(); it != glThreads.end();) {
+         if (*it and (*it)->joinable()) (*it)->join();
+         it = glThreads.erase(it);
+      }
    }
 
    std::lock_guard<std::mutex> lock(glmThreads);
    auto thread_ptr = std::make_shared<std::jthread>();
    *thread_ptr = std::jthread([] (SocketHandle Handle) { CLOSESOCKET(Handle); }, Handle);
    glThreads.insert(thread_ptr);
-   // Don't detach, threads need to be joinable for proper cleanup
 }
 
 //********************************************************************************************************************

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -37,6 +37,8 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <kotuku/modules/network.h>
 #include <kotuku/strings.hpp>
 
+#include "ssl_certificate_policy.hpp"
+
 #ifndef DISABLE_SSL
   #ifdef _WIN32
     #include "win32/ssl_wrapper.h"
@@ -476,6 +478,41 @@ static std::string glCertPath;
 //********************************************************************************************************************
 
 #ifndef DISABLE_SSL
+   struct ssl_certificate_paths {
+      std::string Certificate;
+      std::string PrivateKeyPath;
+      std::optional<const std::string> PrivateKey;
+      std::optional<const std::string> Password;
+      SSLCERTFORMAT Format = SSLCERTFORMAT::NIL;
+   };
+
+   static ERR resolve_ssl_certificate_paths(extNetSocket *Self, ssl_certificate_paths &Paths)
+   {
+      if ((!Self) or (!Self->SSLCertificate) or (!*Self->SSLCertificate)) return ERR::FieldNotSet;
+
+      Paths.Format = ssl_certificate_format(Self->SSLCertificate);
+      if (Paths.Format IS SSLCERTFORMAT::NIL) return ERR::InvalidData;
+
+      if (auto error = ResolvePath(Self->SSLCertificate, RSF::NIL, &Paths.Certificate); error != ERR::Okay) {
+         return error;
+      }
+
+      if (Self->SSLPrivateKey) {
+         if (ssl_private_key_format(Self->SSLPrivateKey) IS SSLCERTFORMAT::NIL) return ERR::InvalidData;
+
+         if (auto error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &Paths.PrivateKeyPath); error != ERR::Okay) {
+            return error;
+         }
+         Paths.PrivateKey.emplace(Paths.PrivateKeyPath);
+      }
+
+      if (Self->SSLKeyPassword) Paths.Password.emplace(Self->SSLKeyPassword);
+
+      return ERR::Okay;
+   }
+
+//********************************************************************************************************************
+
   #ifdef _WIN32
     #include "win32/win32_ssl.cpp"
   #else

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -37,7 +37,7 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <kotuku/modules/network.h>
 #include <kotuku/strings.hpp>
 
-#include "ssl_certificate_policy.hpp"
+#include "ssl_certificate_policy.h"
 
 #ifndef DISABLE_SSL
   #ifdef _WIN32

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1021,9 +1021,12 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
 
    // Fallback to regular socket send
 #ifdef __linux__
-   *Length = send(Self->Handle, Buffer, *Length, 0);
+   auto result = send(Self->Handle, Buffer, *Length, 0);
 
-   if (*Length >= 0) return ERR::Okay;
+   if (result >= 0) {
+      *Length = result;
+      return ERR::Okay;
+   }
    else {
       *Length = 0;
       if (errno IS EAGAIN) return ERR::BufferOverflow;

--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -205,38 +205,16 @@ static ERR loadCustomCertificateOpenSSL(extNetSocket *Self, SSL_CTX *ctx)
 {
    kt::Log log(__FUNCTION__);
 
-   if (!Self->SSLCertificate or !*Self->SSLCertificate) return ERR::FieldNotSet;
+   ssl_certificate_paths paths;
+   if (auto error = resolve_ssl_certificate_paths(Self, paths); error != ERR::Okay) return log.warning(error);
 
-   // Determine certificate format from file extension
-   std::string cp(Self->SSLCertificate);
-   std::string ext = cp.substr(cp.find_last_of(".") + 1);
-   std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-
-   std::string cert_path, key_path;
-   if (auto cert_error = ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path); cert_error IS ERR::Okay) {
-      auto opt_password = std::make_optional<const std::string>();
-      auto opt_key_path = std::make_optional<const std::string>();
-
-      if (Self->SSLPrivateKey) {
-         if (auto key_error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path); key_error != ERR::Okay) {
-            return log.warning(key_error);
-         }
-         opt_key_path.emplace(key_path);
-      }
-
-      if (Self->SSLKeyPassword) opt_password.emplace(Self->SSLKeyPassword);
-
-      if ((ext IS "p12") or (ext IS "pfx")) {
-         return loadPKCS12Certificate(cert_path, opt_password, ctx);
-      }
-      else if ((ext IS "pem") or (ext IS "crt") or (ext IS "cert")) {
-         return loadPEMCertificate(cert_path, opt_key_path, opt_password, ctx);
-      }
-      else return log.warning(ERR::InvalidData);
+   if (paths.Format IS SSLCERTFORMAT::PKCS12) {
+      return loadPKCS12Certificate(paths.Certificate, paths.Password, ctx);
    }
-   else return log.warning(cert_error);
-
-   return ERR::Failed;
+   else if (paths.Format IS SSLCERTFORMAT::PEM) {
+      return loadPEMCertificate(paths.Certificate, paths.PrivateKey, paths.Password, ctx);
+   }
+   else return log.warning(ERR::InvalidData);
 }
 
 //********************************************************************************************************************

--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -213,12 +213,14 @@ static ERR loadCustomCertificateOpenSSL(extNetSocket *Self, SSL_CTX *ctx)
    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
    std::string cert_path, key_path;
-   if (ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path) IS ERR::Okay) {
+   if (auto cert_error = ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path); cert_error IS ERR::Okay) {
       auto opt_password = std::make_optional<const std::string>();
       auto opt_key_path = std::make_optional<const std::string>();
 
       if (Self->SSLPrivateKey) {
-         ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path);
+         if (auto key_error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path); key_error != ERR::Okay) {
+            return log.warning(key_error);
+         }
          opt_key_path.emplace(key_path);
       }
 
@@ -232,8 +234,9 @@ static ERR loadCustomCertificateOpenSSL(extNetSocket *Self, SSL_CTX *ctx)
       }
       else return log.warning(ERR::InvalidData);
    }
+   else return log.warning(cert_error);
 
-   return ERR::Okay;
+   return ERR::Failed;
 }
 
 //********************************************************************************************************************

--- a/src/network/ssl_certificate_policy.h
+++ b/src/network/ssl_certificate_policy.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+enum class SSLCERTFORMAT : uint8_t {
+   NIL,
+   PEM,
+   PKCS12,
+   PRIVATE_KEY
+};
+
+static std::string ssl_file_extension(std::string_view Path)
+{
+   auto dot = Path.find_last_of('.');
+   if (dot >= Path.size()) return {};
+
+   std::string ext(Path.substr(dot + 1));
+   std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char Char) { return char(std::tolower(Char)); });
+   return ext;
+}
+
+static SSLCERTFORMAT ssl_certificate_format(std::string_view Path)
+{
+   auto ext = ssl_file_extension(Path);
+
+   if ((!ext.compare("pem")) or (!ext.compare("crt")) or (!ext.compare("cert"))) return SSLCERTFORMAT::PEM;
+   if ((!ext.compare("p12")) or (!ext.compare("pfx"))) return SSLCERTFORMAT::PKCS12;
+
+   return SSLCERTFORMAT::NIL;
+}
+
+static SSLCERTFORMAT ssl_private_key_format(std::string_view Path)
+{
+   auto ext = ssl_file_extension(Path);
+
+   if ((!ext.compare("pem")) or (!ext.compare("key"))) return SSLCERTFORMAT::PRIVATE_KEY;
+
+   return SSLCERTFORMAT::NIL;
+}

--- a/src/network/win32/ssl_certs.cpp
+++ b/src/network/win32/ssl_certs.cpp
@@ -96,7 +96,9 @@ bool load_pem_certificate(SSL_HANDLE SSL, const std::string &Path)
    if (existing_cert) {
       CertFreeCertificateContext(cert_context);
       CertCloseStore(cert_store, 0);
-      return existing_cert;
+      if (SSL->server_certificate) CertFreeCertificateContext(SSL->server_certificate);
+      SSL->server_certificate = existing_cert;
+      return true;
    }
 
    if (!CertAddCertificateContextToStore(cert_store, cert_context, CERT_STORE_ADD_REPLACE_EXISTING, nullptr)) {

--- a/src/network/win32/ssl_connect.cpp
+++ b/src/network/win32/ssl_connect.cpp
@@ -9,6 +9,8 @@ SSL_ERROR_CODE ssl_connect(SSL_HANDLE SSL, void *SocketHandle, const std::string
    SSL->socket_handle = (SOCKET)SocketHandle;
    SSL->hostname = HostName;
 
+   if (auto error = flush_handshake_buffer(SSL); error != SSL_OK) return error;
+
    if (SSL->context_initialised) return SSL_ERROR_CONNECTING; // Already in handshake process
 
    // Acquire credentials
@@ -59,17 +61,7 @@ SSL_ERROR_CODE ssl_connect(SSL_HANDLE SSL, void *SocketHandle, const std::string
 
    // Send initial handshake data
    if ((out_buffer.cbBuffer > 0) and (out_buffer.pvBuffer != nullptr)) {
-      int sent = send(SSL->socket_handle, (char*)out_buffer.pvBuffer, out_buffer.cbBuffer, 0);
-      FreeContextBuffer(out_buffer.pvBuffer);
-
-      if (sent == SOCKET_ERROR) {
-         int error = WSAGetLastError();
-         SSL->last_win32_error = error;
-         if (error == WSAEWOULDBLOCK) {
-            return SSL_ERROR_WOULD_BLOCK;
-         }
-         return SSL_ERROR_FAILED;
-      }
+      if (auto error = queue_handshake_token(SSL, out_buffer.pvBuffer, out_buffer.cbBuffer); error != SSL_OK) return error;
    }
 
    // For simplicity, full handshake would need more rounds

--- a/src/network/win32/ssl_handshake.cpp
+++ b/src/network/win32/ssl_handshake.cpp
@@ -8,6 +8,7 @@ SSL_ERROR_CODE ssl_continue_handshake(SSL_HANDLE SSL, const void *ServerData, in
    ConsumedOut = 0;
 
    if (!SSL->context_initialised) return SSL_ERROR_FAILED;
+   if (auto error = flush_handshake_buffer(SSL); error != SSL_OK) return error;
 
    // Append new handshake data to receive buffer to handle fragmentation
    std::span<const unsigned char> server_data_span(static_cast<const unsigned char*>(ServerData), DataLength);
@@ -77,12 +78,8 @@ SSL_ERROR_CODE ssl_continue_handshake(SSL_HANDLE SSL, const void *ServerData, in
       if (status == SEC_E_OK) {
 
          if (out_buffer.cbBuffer > 0 and out_buffer.pvBuffer != nullptr) {
-            int sent = send(SSL->socket_handle, (char*)out_buffer.pvBuffer, out_buffer.cbBuffer, 0);
-            FreeContextBuffer(out_buffer.pvBuffer);
-
-            if (sent == SOCKET_ERROR) {
-               SSL->last_win32_error = WSAGetLastError();
-               return SSL_ERROR_FAILED;
+            if (auto error = queue_handshake_token(SSL, out_buffer.pvBuffer, out_buffer.cbBuffer); error != SSL_OK) {
+               return error;
             }
          }
 
@@ -113,14 +110,8 @@ SSL_ERROR_CODE ssl_continue_handshake(SSL_HANDLE SSL, const void *ServerData, in
       }
       else if (status == SEC_I_CONTINUE_NEEDED) {
          if ((out_buffer.cbBuffer > 0) and (out_buffer.pvBuffer != nullptr)) {
-            int sent = send(SSL->socket_handle, (char*)out_buffer.pvBuffer, out_buffer.cbBuffer, 0);
-            FreeContextBuffer(out_buffer.pvBuffer);
-
-            if (sent == SOCKET_ERROR) {
-               int error = WSAGetLastError();
-               SSL->last_win32_error = error;
-               if (error == WSAEWOULDBLOCK) return SSL_ERROR_WOULD_BLOCK;
-               return SSL_ERROR_FAILED;
+            if (auto error = queue_handshake_token(SSL, out_buffer.pvBuffer, out_buffer.cbBuffer); error != SSL_OK) {
+               return error;
             }
          }
 

--- a/src/network/win32/ssl_wrapper.cpp
+++ b/src/network/win32/ssl_wrapper.cpp
@@ -29,6 +29,7 @@ Pure Windows implementation that avoids all Kotuku headers to prevent conflicts.
 #include <span>
 
 #include "ssl_wrapper.h"
+#include "../ssl_certificate_policy.hpp"
 
 static void ssl_debug_log(int level, const char* format, ...);
 extern "C" void ssl_debug_to_kotuku_log(const char* message, int level);
@@ -601,15 +602,18 @@ SSL_ERROR_CODE ssl_load_server_certificate(SSL_HANDLE SSL, const std::string &Ce
 {
    if (!SSL->is_server_mode) return SSL_ERROR_FAILED;
 
-   std::string ext = CertPath.substr(CertPath.find_last_of(".") + 1);
-   std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-
    bool success = false;
-   if ((ext == "p12") or (ext == "pfx")) { // Load PKCS#12 certificate
-      success = load_pkcs12_certificate(SSL, CertPath);
-   }
-   else if ((ext == "pem") or (ext == "crt") or (ext == "cert")) { // Load PEM certificate
-      success = load_pem_certificate(SSL, CertPath);
+   switch (ssl_certificate_format(CertPath)) {
+      case SSLCERTFORMAT::PKCS12:
+         success = load_pkcs12_certificate(SSL, CertPath);
+         break;
+
+      case SSLCERTFORMAT::PEM:
+         success = load_pem_certificate(SSL, CertPath);
+         break;
+
+      default:
+         break;
    }
 
    return success ? SSL_OK : SSL_ERROR_FAILED;

--- a/src/network/win32/ssl_wrapper.cpp
+++ b/src/network/win32/ssl_wrapper.cpp
@@ -143,6 +143,7 @@ struct ssl_context {
    SSLBuffer io_buffer;
    SSLBuffer recv_buffer;                      // Persistent buffer for incomplete SSL messages
    SSLBuffer send_buffer;                      // Buffer for SSL encryption
+   SSLBuffer handshake_buffer;                 // Pending handshake token data for non-blocking sends
    SSLBuffer decrypted_buffer;                 // Buffer for leftover decrypted data
    size_t decrypted_buffer_offset;             // Bytes already returned to user
    SECURITY_STATUS last_security_status;
@@ -172,6 +173,7 @@ struct ssl_context {
       , io_buffer(SSL_INITIAL_BUFFER_SIZE)
       , recv_buffer(SSL_INITIAL_BUFFER_SIZE)
       , send_buffer(SSL_INITIAL_BUFFER_SIZE)
+      , handshake_buffer(SSL_INITIAL_BUFFER_SIZE)
       , decrypted_buffer(SSL_MAX_RECORD_SIZE)
       , decrypted_buffer_offset(0)
       , last_security_status(SEC_E_OK)
@@ -191,6 +193,7 @@ struct ssl_context {
       io_buffer.reserve(SSL_IO_BUFFER_SIZE);
       recv_buffer.reserve(SSL_IO_BUFFER_SIZE);
       send_buffer.reserve(SSL_IO_BUFFER_SIZE);
+      handshake_buffer.reserve(SSL_IO_BUFFER_SIZE);
       decrypted_buffer.reserve(SSL_MAX_RECORD_SIZE);
    }
 
@@ -245,6 +248,44 @@ static void set_error_status(ssl_context* Ctx, SECURITY_STATUS Status)
 {
    Ctx->last_security_status = Status;
    Ctx->last_win32_error = GetLastError();
+}
+
+//********************************************************************************************************************
+
+static SSL_ERROR_CODE flush_handshake_buffer(SSL_HANDLE SSL)
+{
+   while (!SSL->handshake_buffer.empty()) {
+      auto pending = SSL->handshake_buffer.used_data();
+      int sent = send(SSL->socket_handle, (const char*)pending.data(), int(pending.size()), 0);
+
+      if (sent > 0) SSL->handshake_buffer.consume_front(sent);
+      else if (sent == 0) return SSL_ERROR_WOULD_BLOCK;
+      else {
+         int error = WSAGetLastError();
+         SSL->last_win32_error = error;
+         if (error == WSAEWOULDBLOCK) return SSL_ERROR_WOULD_BLOCK;
+         return SSL_ERROR_FAILED;
+      }
+   }
+
+   return SSL_OK;
+}
+
+//********************************************************************************************************************
+
+static SSL_ERROR_CODE queue_handshake_token(SSL_HANDLE SSL, void *Buffer, DWORD Size)
+{
+   if ((Size > 0) and (Buffer)) {
+      std::span<const unsigned char> token_span((const unsigned char*)Buffer, Size);
+      if (!SSL->handshake_buffer.append(token_span)) {
+         FreeContextBuffer(Buffer);
+         return SSL_ERROR_MEMORY;
+      }
+   }
+
+   if (Buffer) FreeContextBuffer(Buffer);
+
+   return flush_handshake_buffer(SSL);
 }
 
 //********************************************************************************************************************

--- a/src/network/win32/ssl_wrapper.cpp
+++ b/src/network/win32/ssl_wrapper.cpp
@@ -576,9 +576,16 @@ SSL_ERROR_CODE ssl_load_server_certificate(SSL_HANDLE SSL, const std::string &Ce
 
 //********************************************************************************************************************
 
-void ssl_set_server_certificate(SSL_HANDLE Server, SSL_HANDLE Client)
+SSL_ERROR_CODE ssl_set_server_certificate(SSL_HANDLE Server, SSL_HANDLE Client)
 {
-   Client->server_certificate = Server->server_certificate;
+   if ((!Server) or (!Client) or (!Server->server_certificate)) return SSL_ERROR_ARGS;
+
+   auto server_certificate = CertDuplicateCertificateContext(Server->server_certificate);
+   if (!server_certificate) return SSL_ERROR_MEMORY;
+
+   if (Client->server_certificate) CertFreeCertificateContext(Client->server_certificate);
+   Client->server_certificate = server_certificate;
+   return SSL_OK;
 }
 
 #include "ssl_handshake.cpp"

--- a/src/network/win32/ssl_wrapper.h
+++ b/src/network/win32/ssl_wrapper.h
@@ -40,7 +40,7 @@ uint32_t ssl_last_win32_error(SSL_HANDLE);
 int ssl_last_security_status(SSL_HANDLE);
 bool ssl_get_verify_result(SSL_HANDLE);
 SSL_ERROR_CODE ssl_load_server_certificate(SSL_HANDLE, const std::string &, std::optional<const std::string> &, std::optional<const std::string> &);
-void ssl_set_server_certificate(SSL_HANDLE Server, SSL_HANDLE Client);
+SSL_ERROR_CODE ssl_set_server_certificate(SSL_HANDLE Server, SSL_HANDLE Client);
 bool load_pem_certificate(SSL_HANDLE SSL, const std::string &Path);
 bool load_pkcs12_certificate(SSL_HANDLE SSL, const std::string &Path);
 

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -57,32 +57,18 @@ static ERR sslSetup(extNetSocket *Self)
       if (Self->SSLCertificate) {
          log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate);
 
-         std::string cert_path, key_path;
-         if (auto cert_error = ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path); cert_error IS ERR::Okay) {
-            auto opt_password = std::make_optional<const std::string>();
-            auto opt_key_path = std::make_optional<const std::string>();
-
-            if (Self->SSLPrivateKey) {
-               if (auto key_error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path); key_error != ERR::Okay) {
-                  ssl_free_context(Self->SSLHandle);
-                  Self->SSLHandle = nullptr;
-                  return log.warning(key_error);
-               }
-               opt_key_path.emplace(key_path);
-            }
-
-            if (Self->SSLKeyPassword) opt_password.emplace(Self->SSLKeyPassword);
-
-            if (auto error = ssl_load_server_certificate(Self->SSLHandle, cert_path, opt_key_path, opt_password); error != SSL_OK) {
-               ssl_free_context(Self->SSLHandle);
-               Self->SSLHandle = nullptr;
-               return log.warning(ERR::Failed);
-            }
-         }
-         else {
+         ssl_certificate_paths paths;
+         if (auto error = resolve_ssl_certificate_paths(Self, paths); error != ERR::Okay) {
             ssl_free_context(Self->SSLHandle);
             Self->SSLHandle = nullptr;
-            return log.warning(cert_error);
+            return log.warning(error);
+         }
+
+         auto error = ssl_load_server_certificate(Self->SSLHandle, paths.Certificate, paths.PrivateKey, paths.Password);
+         if (error != SSL_OK) {
+            ssl_free_context(Self->SSLHandle);
+            Self->SSLHandle = nullptr;
+            return log.warning(ERR::Failed);
          }
       }
       else {

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -58,12 +58,16 @@ static ERR sslSetup(extNetSocket *Self)
          log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate);
 
          std::string cert_path, key_path;
-         if (ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path) IS ERR::Okay) {
+         if (auto cert_error = ResolvePath(Self->SSLCertificate, RSF::NIL, &cert_path); cert_error IS ERR::Okay) {
             auto opt_password = std::make_optional<const std::string>();
             auto opt_key_path = std::make_optional<const std::string>();
 
             if (Self->SSLPrivateKey) {
-               ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path);
+               if (auto key_error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &key_path); key_error != ERR::Okay) {
+                  ssl_free_context(Self->SSLHandle);
+                  Self->SSLHandle = nullptr;
+                  return log.warning(key_error);
+               }
                opt_key_path.emplace(key_path);
             }
 
@@ -75,10 +79,17 @@ static ERR sslSetup(extNetSocket *Self)
                return log.warning(ERR::Failed);
             }
          }
+         else {
+            ssl_free_context(Self->SSLHandle);
+            Self->SSLHandle = nullptr;
+            return log.warning(cert_error);
+         }
       }
       else {
          if (!load_pkcs12_certificate(Self->SSLHandle, glCertPath + "localhost.p12")) {
             if (!load_pem_certificate(Self->SSLHandle, glCertPath + "localhost.pem")) {
+               ssl_free_context(Self->SSLHandle);
+               Self->SSLHandle = nullptr;
                return log.warning(ERR::Failed);
             }
          }

--- a/src/network/win32/winsockwrappers.cpp
+++ b/src/network/win32/winsockwrappers.cpp
@@ -113,41 +113,50 @@ static LRESULT CALLBACK win_messages(HWND window, UINT msgcode, WPARAM wParam, L
    int event = WSAGETSELECTEVENT(lParam);
 
    if (msgcode IS WM_NETWORK) {
-      const lock_guard<recursive_mutex> lock(csNetLookup);
       auto socket_handle = (WSW_SOCKET)wParam;
-      if (glNetLookup.contains(socket_handle)) {
-         int state;
-         int resub_write = false;
-         switch (event) {
-            case FD_READ:    state = NTE_READ; break;
-            case FD_WRITE:   state = NTE_WRITE; resub_write = true; break; // Keep the socket subscribed while writing
-            case FD_ACCEPT:  state = NTE_ACCEPT; break;
-            case FD_CLOSE:   state = NTE_CLOSE; break;
-            case FD_CONNECT: state = NTE_CONNECT; break;
-            default:         state = 0; break;
-         }
+      int state;
+      int resub_write = false;
+      switch (event) {
+         case FD_READ:    state = NTE_READ; break;
+         case FD_WRITE:   state = NTE_WRITE; resub_write = true; break; // Keep the socket subscribed while writing
+         case FD_ACCEPT:  state = NTE_ACCEPT; break;
+         case FD_CLOSE:   state = NTE_CLOSE; break;
+         case FD_CONNECT: state = NTE_CONNECT; break;
+         default:         state = 0; break;
+      }
 
-         ERR error;
-         if (winerror IS WSAEWOULDBLOCK) error = ERR::Okay;
-         else if (winerror) error = convert_error(winerror);
-         else error = ERR::Okay;
+      ERR error;
+      if (winerror IS WSAEWOULDBLOCK) error = ERR::Okay;
+      else if (winerror) error = convert_error(winerror);
+      else error = ERR::Okay;
+
+      void *reference = nullptr;
+      int flags = 0;
+      bool read_disabled = false;
+
+      {
+         const lock_guard<recursive_mutex> lock(csNetLookup);
+         if (!glNetLookup.contains(socket_handle)) return 0;
 
          socket_info &info = glNetLookup[socket_handle];
-         bool read_disabled = false;
-         if ((info.Flags & FD_READ) and (!glSocketsDisabled)) {
-            WSAAsyncSelect(socket_handle, glNetWindow, WM_NETWORK, info.Flags & (~FD_READ));
+         reference = info.Reference;
+         flags = info.Flags;
+
+         if ((state IS NTE_WRITE) and (!(flags & FD_WRITE))) {
+            return 0; // Ignore queued write messages after write events are disabled.
+         }
+
+         if ((flags & FD_READ) and (!glSocketsDisabled)) {
+            WSAAsyncSelect(socket_handle, glNetWindow, WM_NETWORK, flags & (~FD_READ));
             read_disabled = true;
          }
+      }
 
-         if (info.Reference) {
-            if ((state IS NTE_WRITE) and (!(info.Flags & FD_WRITE))) {
-               // Do nothing when receiving queued write messages for a socket that has turned them off.
-               return 0;
-            }
-            else win32_netresponse((struct Object *)info.Reference, socket_handle, state, error);
-         }
-         else printf("win_messages() Missing reference for FD %d, state %d\n", socket_handle, state);
+      if (reference) win32_netresponse((struct Object *)reference, socket_handle, state, error);
+      else printf("win_messages() Missing reference for FD %d, state %d\n", socket_handle, state);
 
+      {
+         const lock_guard<recursive_mutex> lock(csNetLookup);
          // Re-enable read events if we disabled them and sockets are still active
          if ((read_disabled) and (!glSocketsDisabled)) {
             if (glNetLookup.contains(socket_handle) and (glNetLookup[socket_handle].Flags & FD_READ)) {
@@ -160,8 +169,8 @@ static LRESULT CALLBACK win_messages(HWND window, UINT msgcode, WPARAM wParam, L
                WSAAsyncSelect(socket_handle, glNetWindow, WM_NETWORK, glNetLookup[socket_handle].Flags);
             }
          }
-         return 0;
       }
+      return 0;
    }
    else return DefWindowProc(window, msgcode, wParam, lParam);
 
@@ -429,10 +438,12 @@ template <class T> ERR WIN_APPEND(WSW_SOCKET SocketHandle, std::vector<uint8_t> 
    Result = 0;
    if (!Len) return ERR::Okay;
    auto offset = Buffer.size();
-   Buffer.resize(Buffer.size() + Len);
-   auto result = recv(SocketHandle, (char *)Buffer.data() + offset, Len, 0);
+   std::vector<uint8_t> temp;
+   temp.resize(Len);
+   auto result = recv(SocketHandle, (char *)temp.data(), Len, 0);
    if (result > 0) {
-      if (size_t(result) < Len) Buffer.resize(offset + result);
+      Buffer.resize(offset + result);
+      memcpy(Buffer.data() + offset, temp.data(), result);
       Result = result;
       return ERR::Okay;
    }

--- a/src/network/win32/winsockwrappers.cpp
+++ b/src/network/win32/winsockwrappers.cpp
@@ -38,7 +38,8 @@ enum {
 
 enum {
    WM_NETWORK = WM_USER + 101, // WM_USER = 1024, 1125
-   WM_RESOLVENAME // 1126
+   WM_RESOLVENAME, // 1126
+   WM_NETWORK_RESPONSE
 };
 
 #define IS ==
@@ -52,6 +53,13 @@ public:
    HANDLE ResolveHandle = INVALID_HANDLE_VALUE; // For win_async_resolvename() and WM_RESOLVENAME
    WSW_SOCKET SocketHandle = 0; // Winsock socket FD (same as the key)
    int Flags = 0;
+};
+
+struct queued_netresponse {
+   struct Object *SocketObject;
+   WSW_SOCKET Handle;
+   int Message;
+   ERR Error;
 };
 
 static std::recursive_mutex csNetLookup;
@@ -92,6 +100,15 @@ struct hostent * win_gethostbyaddr(const struct IPAddress *Address)
 
 static LRESULT CALLBACK win_messages(HWND window, UINT msgcode, WPARAM wParam, LPARAM lParam)
 {
+   if (msgcode IS WM_NETWORK_RESPONSE) {
+      auto response = (queued_netresponse *)lParam;
+      if (response) {
+         win32_netresponse(response->SocketObject, response->Handle, response->Message, response->Error);
+         delete response;
+      }
+      return 0;
+   }
+
    int winerror = WSAGETSELECTERROR(lParam);
    int event = WSAGETSELECTEVENT(lParam);
 
@@ -566,11 +583,27 @@ ERR win_leave_multicast_group(WSW_SOCKET Socket, const char *Group, bool IPv6)
 
 //********************************************************************************************************************
 
+void win32_queue_netresponse(struct Object *SocketObject, WSW_SOCKET Handle, int Message, ERR Error)
+{
+   auto response = new queued_netresponse{ SocketObject, Handle, Message, Error };
+
+   if ((!glNetWindow) or (!PostMessage(glNetWindow, WM_NETWORK_RESPONSE, 0, (LPARAM)response))) {
+      win32_netresponse(SocketObject, Handle, Message, Error);
+      delete response;
+   }
+}
+
+//********************************************************************************************************************
+
 ERR WIN_SEND(WSW_SOCKET Socket, const void *Buffer, size_t *Length, int Flags)
 {
    if (!*Length) return ERR::Okay;
-   *Length = send(Socket, reinterpret_cast<const char *>(Buffer), *Length, Flags);
-   if (*Length >= 0) return ERR::Okay;
+   int send_length = (*Length > size_t(0x7fffffff)) ? 0x7fffffff : int(*Length);
+   int result = send(Socket, (const char *)Buffer, send_length, Flags);
+   if (result >= 0) {
+      *Length = result;
+      return ERR::Okay;
+   }
    else {
       *Length = 0;
 


### PR DESCRIPTION
## Summary

- Fixed non-blocking SSL handshake failures by buffering handshake tokens instead of calling `send()` directly (eliminating `WSAEWOULDBLOCK` errors during TLS negotiation)
- Added `CloseAfterWrite` to defer socket teardown until all queued write data has been flushed, preventing data loss on graceful close
- Narrowed `csNetLookup` lock scope in `win_messages()` to release the lock before invoking the `win32_netresponse()` callback, eliminating a potential deadlock
- Fixed `WIN_APPEND()` to `recv()` into a staging buffer so partial reads no longer corrupt the output vector
- Fixed linked-list pointer corruption in `free_client()` when removing the head client node
- Fixed `copymem()` argument order (src/dst swapped) in `GetLocalIPAddress`
- Added null-pointer guards on `Args` in `JoinMulticastGroup`, `LeaveMulticastGroup`, and `SendTo`
- Improved write-queue error propagation and `BufferOverflow` reporting when queued data is truncated by `MsgLimit`
- Fixed SSL certificate handling for server-side client sockets
- Consolidated SSL certificate format detection into `ssl_certificate_policy.hpp` and `resolve_ssl_certificate_paths()`, eliminating duplicated extension-parsing across OpenSSL and Win32 backends
- Extracted `sockaddr_to_client_ip()` to replace three separate copies of byte-by-byte IP extraction in `server_accept_client_impl()`
- Extracted `parse_multicast_group()` and `set_multicast_membership()` to eliminate duplicated multicast address handling in `JoinMulticastGroup` and `LeaveMulticastGroup`
- Shared `addrinfo`-based DNS conversion helper

## Test plan

- [ ] Build the `network` module and verify no compilation errors
- [ ] Run existing network integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L network`
- [ ] Verify SSL client connections complete handshake successfully on Windows
- [ ] Verify graceful socket close flushes pending write data before teardown
- [ ] Verify multicast join/leave still functions correctly on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)