### PR TITLE
[Network] Extract platform-specific socket declarations and implementations into dedicated files

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -16,6 +16,12 @@ set_module_defaults (${MOD} "Net")
 
 target_sources (${MOD} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/network.cpp")
 
+if (WIN32)
+   target_sources (${MOD} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/net_windows.cpp")
+else ()
+   target_sources (${MOD} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/net_linux.cpp")
+endif ()
+
 if (DISABLE_SSL)
    message (STATUS "Network module will not be compiled with SSL support (disabled by DISABLE_SSL).")
    target_compile_definitions (${MOD} PRIVATE "DISABLE_SSL")

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -492,7 +492,7 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct hostent *Host, DNSEntr
       if (Host->h_addrtype IS AF_INET) {
          for (unsigned i=0; Host->h_addr_list[i]; i++) {
             auto addr = *((uint32_t *)Host->h_addr_list[i]);
-            cache.Addresses.push_back({ ntohl(addr), 0, 0, 0, IPADDR::V4 });
+            cache.Addresses.push_back({ network_platform().long_to_host(addr), 0, 0, 0, IPADDR::V4 });
          }
       }
       else if (Host->h_addrtype IS AF_INET6) {
@@ -537,7 +537,7 @@ static ERR convert_addrinfo(CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
 
       if (scan->ai_family IS AF_INET) {
          auto addr = ((struct sockaddr_in *)scan->ai_addr)->sin_addr.s_addr;
-         cache.Addresses.push_back({ ntohl(addr), 0, 0, 0, IPADDR::V4 });
+         cache.Addresses.push_back({ network_platform().long_to_host(addr), 0, 0, 0, IPADDR::V4 });
       }
       else if (scan->ai_family IS AF_INET6) {
          auto addr = (struct sockaddr_in6 *)scan->ai_addr;

--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -31,10 +31,7 @@ static void disconnect(extClientSocket *Self)
    log.branch("Disconnecting socket handle %d", Self->Handle.int_value());
 
    if (Self->Handle.is_valid()) {
-
-#ifdef __linux__
-      DeregisterFD(Self->Handle);
-#endif
+      network_platform().deregister_fd(Self->Handle);
       CLOSESOCKET_THREADED(Self->Handle);
       Self->Handle = NOHANDLE;
    }
@@ -57,7 +54,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
        // If we're in the middle of SSL handshake, read raw data for handshake processing
        if (Self->State IS NTC::HANDSHAKING) {
           log.trace("Windows SSL handshake in progress, reading raw data.");
-          ERR error = WIN_RECEIVE(Self->Handle, Buffer, BufferSize, Result);
+          ERR error = network_platform().receive(Self->Handle, Buffer, BufferSize, *Result);
           if ((error IS ERR::Okay) and (*Result > 0)) {
              sslHandshakeReceived(Self, Buffer, *Result);
           }
@@ -110,7 +107,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
 
                   log.msg("SSL socket handshake requested by server.");
                   Self->HandshakeStatus = SHS::WRITE;
-                  RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, ssl_handshake_write_clientsocket, Self);
+                  network_platform().register_write(Self->Handle, ssl_handshake_write_clientsocket, Self);
                   return ERR::Okay;
 
                case SSL_ERROR_SYSCALL:
@@ -149,7 +146,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
          // For this reason we set the RECALL flag so that we can be called again manually when we know that there is
          // data pending.
 
-         RegisterFD(Self->Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
+         network_platform().register_recall_read(Self->Handle, &server_incoming_from_client, Self);
       }
 
       return ERR::Okay;
@@ -157,31 +154,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
    }
 #endif // DISABLE_SSL
 
-#ifdef __linux__
-   {
-      int result = recv(Self->Handle, Buffer, BufferSize, 0);
-
-      if (result > 0) {
-         *Result = result;
-         return ERR::Okay;
-      }
-      else if (result IS 0) { // man recv() says: The return value is 0 when the peer has performed an orderly shutdown.
-         return ERR::Disconnected;
-      }
-      else if ((errno IS EAGAIN) or (errno IS EINTR)) {
-         return ERR::Okay;
-      }
-      else {
-         const int system_error = errno;
-         log.warning("recv() failed: %s", strerror(system_error));
-         return convert_socket_error(system_error);
-      }
-   }
-#elif _WIN32
-   return WIN_RECEIVE(Self->Handle, Buffer, BufferSize, Result);
-#else
-   #error No support for RECEIVE()
-#endif
+   return network_platform().receive(Self->Handle, Buffer, BufferSize, *Result);
 }
 
 //********************************************************************************************************************
@@ -207,7 +180,7 @@ static void server_incoming_from_client_impl(HOSTHANDLE SocketFD, extClientSocke
          bool ssl_connected = false;
          std::array<char, 4096> buffer;
          size_t bytes_received;
-         ERR error = WIN_RECEIVE(client->Handle, buffer.data(), buffer.size(), &bytes_received);
+         ERR error = network_platform().receive(client->Handle, buffer.data(), buffer.size(), bytes_received);
          if ((error IS ERR::Okay) and (bytes_received > 0)) {
             SSL_ERROR_CODE accept_result = ssl_accept(client->SSLHandle, buffer.data(), bytes_received);
 
@@ -403,11 +376,7 @@ static void clientsocket_outgoing_impl(HOSTHANDLE SocketFD, extClientSocket *Cli
 
       if (ClientSocket->WriteQueue.Buffer.empty()) {
          log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle.int_value());
-         #ifdef __linux__
-            RegisterFD(ClientSocket->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
-         #elif _WIN32
-            win_socketstate(ClientSocket->Handle, std::nullopt, false);
-         #endif
+         network_platform().remove_write(ClientSocket->Handle);
       }
    }
 
@@ -435,11 +404,7 @@ static ERR CLIENTSOCKET_Deactivate(extClientSocket *Self)
    if ((Self->State IS NTC::CONNECTED) and (not Self->WriteQueue.Buffer.empty())) {
       log.msg("Delaying disconnect until queued data is flushed.");
       Self->CloseAfterWrite = true;
-      #ifdef __linux__
-         RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
-      #elif _WIN32
-         win_socketstate(Self->Handle, std::nullopt, true);
-      #endif
+      network_platform().register_write(Self->Handle, &clientsocket_outgoing, Self);
       return ERR::Okay;
    }
 
@@ -505,10 +470,7 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
    kt::ScopedObjectLock lock(Self->Client);
    if (not lock.granted()) return ERR::Lock;
 
-#ifdef __linux__
-   int non_blocking = 1;
-   ioctl(Self->Handle, FIONBIO, &non_blocking);
-#endif
+   network_platform().set_non_blocking(Self->Handle);
 
    Self->ConnectTime = PreciseTime() / 1000LL;
 
@@ -588,11 +550,8 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
    Self->State = NTC::CONNECTED;
 #endif
 
-#ifdef __linux__
-   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
-#elif _WIN32
-   win_socket_reference(Self->Handle, Self);
-#endif
+   network_platform().register_read(Self->Handle, &server_incoming_from_client, Self);
+   network_platform().set_socket_reference(Self->Handle, Self);
 
    return ERR::Okay;
 }
@@ -747,11 +706,7 @@ static ERR CS_SET_State(extClientSocket *Self, NTC Value)
 
       if ((Self->State IS NTC::CONNECTED) and ((not Self->WriteQueue.Buffer.empty()))) {
          log.msg("Sending queued data to server on connection.");
-         #ifdef __linux__
-            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
-         #elif _WIN32
-            win_socketstate(Self->Handle, std::nullopt, true);
-         #endif
+         network_platform().register_write(Self->Handle, &clientsocket_outgoing, Self);
       }
    }
 

--- a/src/network/net_linux.cpp
+++ b/src/network/net_linux.cpp
@@ -1,0 +1,385 @@
+#ifdef __linux__
+
+#include "net_platform.h"
+#include "socket_errors.h"
+
+#include <array>
+#include <cstring>
+#include <sys/resource.h>
+
+class LinuxNet : public NetworkPlatform {
+private:
+   int socket_limit_value = 0x7fffffff;
+
+public:
+   ERR initialise(OBJECTPTR Module) override
+   {
+      struct rlimit fd_limit;
+      if (getrlimit(RLIMIT_NOFILE, &fd_limit) IS 0) {
+         socket_limit_value = int(fd_limit.rlim_cur * 0.8);
+      }
+      return ERR::Okay;
+   }
+
+   void expunge() override
+   {
+   }
+
+   int socket_limit() const override
+   {
+      return socket_limit_value;
+   }
+
+   SocketHandle create_socket(void *Reference, bool Read, bool Write, bool UDP, bool &IPv6) override
+   {
+      int socket_type = UDP ? SOCK_DGRAM : SOCK_STREAM;
+      int protocol = UDP ? IPPROTO_UDP : IPPROTO_TCP;
+      SocketHandle handle;
+
+      if (auto sock = socket(PF_INET6, socket_type, protocol); sock != -1) {
+         handle = SocketHandle(sock);
+         IPv6 = true;
+
+         int v6only = 0;
+         setsockopt(handle, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only));
+
+         if (not UDP) {
+            int nodelay = 1;
+            setsockopt(handle, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+         }
+      }
+      else if (auto sock = socket(PF_INET, socket_type, protocol); sock != -1) {
+         handle = SocketHandle(sock);
+         IPv6 = false;
+
+         if (not UDP) {
+            int nodelay = 1;
+            setsockopt(handle, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+         }
+      }
+
+      if (handle.is_valid()) {
+         if (fcntl(handle, F_SETFL, fcntl(handle, F_GETFL) | O_NONBLOCK)) {
+            close_socket(handle);
+            return SocketHandle();
+         }
+      }
+
+      return handle;
+   }
+
+   void close_socket(SocketHandle Handle) override
+   {
+      if (Handle.is_invalid()) return;
+
+      kt::Log log(__FUNCTION__);
+      log.traceBranch("Handle: %d", Handle.int_value());
+
+      shutdown(Handle, SHUT_RDWR);
+
+      struct timeval timeout;
+      timeout.tv_sec = 0;
+      timeout.tv_usec = 100000;
+      setsockopt(Handle, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
+      setsockopt(Handle, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout));
+
+      std::array<char, 1024> buffer;
+      int bytes_received;
+      do {
+         bytes_received = recv(Handle, buffer.data(), buffer.size(), 0);
+      } while (bytes_received > 0);
+
+      close(Handle);
+   }
+
+   void deregister_socket(SocketHandle Handle) override
+   {
+   }
+
+   int shutdown_socket(SocketHandle Handle, int How) override
+   {
+      return shutdown(Handle, How);
+   }
+
+   ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   {
+      int result = ::connect(Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+      if (result != -1) return ERR::Okay;
+
+      if ((errno IS EINPROGRESS) or (errno IS EWOULDBLOCK) or (errno IS EAGAIN)) return ERR::Busy;
+      return convert_socket_error(errno);
+   }
+
+   ERR begin_connect_wait(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return register_write(Handle, Callback, Data);
+   }
+
+   ERR complete_connect(SocketHandle Handle) override
+   {
+      int result = EHOSTUNREACH;
+      socklen_t optlen = sizeof(result);
+      if (getsockopt(Handle, SOL_SOCKET, SO_ERROR, &result, &optlen) != 0) return convert_socket_error(errno);
+      return result ? convert_socket_error(result) : ERR::Okay;
+   }
+
+   ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   {
+      int value = 1;
+      setsockopt(Handle, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value));
+
+      if (::bind(Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size) IS -1) {
+         return convert_socket_error(errno);
+      }
+      return ERR::Okay;
+   }
+
+   ERR listen(SocketHandle Handle, int Backlog) override
+   {
+      if (::listen(Handle, Backlog) IS -1) return convert_socket_error(errno);
+      return ERR::Okay;
+   }
+
+   ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) override
+   {
+      socklen_t addr_length = sizeof(Address);
+      auto result = getsockname(Handle, (struct sockaddr *)&Address, &addr_length);
+      Length = int(addr_length);
+      return result ? convert_socket_error(errno) : ERR::Okay;
+   }
+
+   SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) override
+   {
+      socklen_t len = sizeof(Address);
+      auto client = ::accept(Server, (struct sockaddr *)&Address, &len);
+      if (client IS -1) return SocketHandle();
+
+      Family = Address.ss_family;
+
+      int non_blocking = 1;
+      ioctl(client, FIONBIO, &non_blocking);
+
+      int nodelay = 1;
+      setsockopt(client, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+      return SocketHandle(client);
+   }
+
+   void set_socket_reference(SocketHandle Handle, void *Reference) override
+   {
+   }
+
+   ERR set_non_blocking(SocketHandle Handle) override
+   {
+      int non_blocking = 1;
+      return ioctl(Handle, FIONBIO, &non_blocking) ? convert_socket_error(errno) : ERR::Okay;
+   }
+
+   ERR register_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return RegisterFD(Handle.hosthandle(), RFD::READ|RFD::SOCKET, Callback, Data);
+   }
+
+   ERR register_accept(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return register_read(Handle, Callback, Data);
+   }
+
+   ERR register_write(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return RegisterFD(Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, Callback, Data);
+   }
+
+   ERR remove_write(SocketHandle Handle) override
+   {
+      return RegisterFD(Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
+   }
+
+   ERR register_recall_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return RegisterFD(Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, Callback, Data);
+   }
+
+   ERR deregister_fd(SocketHandle Handle) override
+   {
+      return DeregisterFD(Handle.hosthandle());
+   }
+
+   ERR enable_broadcast(SocketHandle Handle) override
+   {
+      int broadcast = 1;
+      return setsockopt(Handle, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) ? ERR::SystemCall : ERR::Okay;
+   }
+
+   ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) override
+   {
+      if (IPv6) {
+         return setsockopt(Handle, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &TTL, sizeof(TTL)) ? ERR::SystemCall : ERR::Okay;
+      }
+      else {
+         return setsockopt(Handle, IPPROTO_IP, IP_MULTICAST_TTL, &TTL, sizeof(TTL)) ? ERR::SystemCall : ERR::Okay;
+      }
+   }
+
+   ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   {
+      if (IPv6) {
+         struct ipv6_mreq mreq;
+         kt::clearmem(&mreq, sizeof(mreq));
+         if (::inet_pton(AF_INET6, Group, &mreq.ipv6mr_multiaddr) != 1) return ERR::Args;
+         mreq.ipv6mr_interface = 0;
+         return setsockopt(Handle, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+      }
+      else {
+         struct ip_mreq mreq;
+         kt::clearmem(&mreq, sizeof(mreq));
+         if (::inet_pton(AF_INET, Group, &mreq.imr_multiaddr) != 1) return ERR::Args;
+         mreq.imr_interface.s_addr = INADDR_ANY;
+         return setsockopt(Handle, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+      }
+   }
+
+   ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   {
+      if (IPv6) {
+         struct ipv6_mreq mreq;
+         kt::clearmem(&mreq, sizeof(mreq));
+         if (::inet_pton(AF_INET6, Group, &mreq.ipv6mr_multiaddr) != 1) return ERR::Args;
+         mreq.ipv6mr_interface = 0;
+         return setsockopt(Handle, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+      }
+      else {
+         struct ip_mreq mreq;
+         kt::clearmem(&mreq, sizeof(mreq));
+         if (::inet_pton(AF_INET, Group, &mreq.imr_multiaddr) != 1) return ERR::Args;
+         mreq.imr_interface.s_addr = INADDR_ANY;
+         return setsockopt(Handle, IPPROTO_IP, IP_DROP_MEMBERSHIP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+      }
+   }
+
+   ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) override
+   {
+      Received = 0;
+      auto result = recv(Handle, Buffer, Length, 0);
+      if (result > 0) {
+         Received = size_t(result);
+         return ERR::Okay;
+      }
+      else if (result IS 0) return ERR::Disconnected;
+      else if ((errno IS EAGAIN) or (errno IS EINTR)) return ERR::Okay;
+      else return convert_socket_error(errno);
+   }
+
+   ERR append_receive(SocketHandle Handle, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received) override
+   {
+      std::vector<uint8_t> temp(Length);
+      auto error = receive(Handle, temp.data(), temp.size(), Received);
+      if ((error IS ERR::Okay) and (Received > 0)) {
+         Buffer.insert(Buffer.end(), temp.begin(), temp.begin() + Received);
+      }
+      return error;
+   }
+
+   ERR send(SocketHandle Handle, CPTR Buffer, size_t &Length) override
+   {
+      auto result = ::send(Handle, Buffer, Length, 0);
+      if (result >= 0) {
+         Length = size_t(result);
+         return ERR::Okay;
+      }
+
+      Length = 0;
+      if ((errno IS EAGAIN) or (errno IS EWOULDBLOCK)) return ERR::BufferOverflow;
+      else if (errno IS EMSGSIZE) return ERR::DataSize;
+      else return convert_socket_error(errno, ERR::Failed);
+   }
+
+   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) override
+   {
+      auto result = sendto(Handle, Buffer, Length, MSG_DONTWAIT, (sockaddr *)&Endpoint.storage, Endpoint.size);
+      if (result >= 0) {
+         Length = size_t(result);
+         return ERR::Okay;
+      }
+
+      Length = 0;
+      switch (errno) {
+         #if EAGAIN == EWOULDBLOCK
+            case EAGAIN: return ERR::BufferOverflow;
+         #else
+            case EAGAIN:
+            case EWOULDBLOCK: return ERR::BufferOverflow;
+         #endif
+         case ENETUNREACH: return ERR::NetworkUnreachable;
+         case EINVAL: return ERR::Args;
+         default: return convert_socket_error(errno);
+      }
+   }
+
+   ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
+      sockaddr_storage &SourceAddress, int &AddressLength) override
+   {
+      BytesRead = 0;
+      socklen_t addr_len = sizeof(SourceAddress);
+      auto result = recvfrom(Handle, Buffer, BufferSize, MSG_DONTWAIT, (struct sockaddr *)&SourceAddress, &addr_len);
+      AddressLength = int(addr_len);
+
+      if (result > 0) {
+         BytesRead = size_t(result);
+         return ERR::Okay;
+      }
+      else if (result IS 0) return ERR::Okay;
+
+      switch (errno) {
+         #if EAGAIN == EWOULDBLOCK
+            case EAGAIN: return ERR::Okay;
+         #else
+            case EAGAIN:
+            case EWOULDBLOCK: return ERR::Okay;
+         #endif
+         case EMSGSIZE: return ERR::BufferOverflow;
+         default: return convert_socket_error(errno);
+      }
+   }
+
+   uint32_t inet_addr(CSTRING Value) override
+   {
+      return ::inet_addr(Value);
+   }
+
+   int inet_pton(int Family, CSTRING Source, APTR Dest) override
+   {
+      return ::inet_pton(Family, Source, Dest);
+   }
+
+   CSTRING inet_ntop(int Family, CPTR Source, STRING Dest, size_t Size) override
+   {
+      return ::inet_ntop(Family, Source, Dest, Size);
+   }
+
+   uint32_t host_to_long(uint32_t Value) override
+   {
+      return htonl(Value);
+   }
+
+   uint32_t long_to_host(uint32_t Value) override
+   {
+      return ntohl(Value);
+   }
+
+   uint16_t host_to_short(uint16_t Value) override
+   {
+      return htons(Value);
+   }
+
+   uint16_t short_to_host(uint16_t Value) override
+   {
+      return ntohs(Value);
+   }
+};
+
+std::unique_ptr<NetworkPlatform> create_platform()
+{
+   return std::make_unique<LinuxNet>();
+}
+
+#endif

--- a/src/network/net_platform.h
+++ b/src/network/net_platform.h
@@ -1,0 +1,224 @@
+#pragma once
+#define KOTUKU_NET_PLATFORM_H TRUE
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <kotuku/main.h>
+#include <kotuku/modules/network.h>
+
+#ifdef _WIN32
+   #define INADDR_NONE 0xffffffff
+
+   #define SOCK_STREAM 1
+   #define SOCK_DGRAM 2
+
+   struct hostent {
+      char  *h_name;
+      char  **h_aliases;
+      short h_addrtype;
+      short h_length;
+      char  **h_addr_list;
+      #define h_addr h_addr_list[0]
+   };
+
+   struct in_addr {
+      union {
+         struct { uint8_t s_b1,s_b2,s_b3,s_b4; } S_un_b;
+         struct { uint16_t s_w1,s_w2; } S_un_w;
+         uint32_t S_addr;
+      } S_un;
+      #define s_addr S_un.S_addr
+      #define s_host S_un.S_un_b.s_b2
+      #define s_net S_un.S_un_b.s_b1
+      #define s_imp S_un.S_un_w.s_w2
+      #define s_impno S_un.S_un_b.s_b4
+      #define s_lh S_un.S_un_b.s_b3
+   };
+
+   struct sockaddr {
+      uint16_t sa_family;
+      char sa_data[14];
+   };
+
+   struct sockaddr_in {
+      short sin_family;
+      uint16_t sin_port;
+      struct in_addr sin_addr;
+      char sin_zero[8];
+   };
+
+   struct addrinfo {
+      int ai_flags;
+      int ai_family;
+      int ai_socktype;
+      int ai_protocol;
+      size_t ai_addrlen;
+      char *ai_canonname;
+      struct sockaddr *ai_addr;
+      struct addrinfo *ai_next;
+   };
+
+   struct in6_addr {
+      uint8_t s6_addr[16];
+   };
+
+   struct sockaddr_in6 {
+      short sin6_family;
+      uint16_t sin6_port;
+      uint32_t sin6_flowinfo;
+      struct in6_addr sin6_addr;
+      uint32_t sin6_scope_id;
+   };
+
+   struct sockaddr_storage {
+      short ss_family;
+      char __ss_pad1[6];
+      int64_t __ss_align;
+      char __ss_pad2[112];
+   };
+
+   constexpr int SOCKET_ERROR = -1;
+   constexpr int AF_INET = 2;
+   constexpr int AF_INET6 = 23;
+   constexpr int INADDR_ANY = 0;
+   constexpr int MSG_PEEK = 2;
+   constexpr int IPPROTO_IPV6 = 41;
+   constexpr int IPV6_V6ONLY = 27;
+   constexpr int AF_UNSPEC = 0;
+   constexpr int AI_CANONNAME = 2;
+   constexpr int EAI_AGAIN = 2;
+   constexpr int EAI_FAIL = 3;
+   constexpr int EAI_MEMORY = 4;
+   constexpr int EAI_SYSTEM = 5;
+
+   static const struct in6_addr in6addr_any = {{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
+
+   extern "C" {
+      int getaddrinfo(const char *Node, const char *Service, const struct addrinfo *Hints, struct addrinfo **Result);
+      void freeaddrinfo(struct addrinfo *Result);
+   }
+#else
+   #include <arpa/inet.h>
+   #include <netdb.h>
+   #include <unistd.h>
+   #include <fcntl.h>
+   #include <sys/ioctl.h>
+   #include <sys/socket.h>
+   #include <netinet/tcp.h>
+   #include <netinet/in.h>
+   #include <errno.h>
+#endif
+
+class SocketHandle {
+private:
+   SOCKET_HANDLE socket_val;
+
+public:
+   #ifdef _WIN32
+      static constexpr SOCKET_HANDLE INVALID_SOCKET_VAL = SOCKET_HANDLE(~0u);
+   #else
+      static constexpr SOCKET_HANDLE INVALID_SOCKET_VAL = -1;
+   #endif
+
+   SocketHandle() : socket_val(INVALID_SOCKET_VAL) {}
+   SocketHandle(SOCKET_HANDLE Socket) : socket_val(Socket) {}
+   #ifdef _WIN32
+      SocketHandle(int Socket) : socket_val(SOCKET_HANDLE(Socket)) {}
+   #endif
+   #ifdef _WIN32
+      SocketHandle(HOSTHANDLE Handle) : socket_val(SOCKET_HANDLE(uintptr_t(Handle))) {}
+   #endif
+
+   operator SOCKET_HANDLE() const { return socket_val; }
+   operator bool() const { return socket_val != INVALID_SOCKET_VAL; }
+
+   SOCKET_HANDLE socket() const { return socket_val; }
+   int int_value() const { return int(socket_val); }
+
+   HOSTHANDLE hosthandle() const {
+      #ifdef _WIN32
+         return (HOSTHANDLE)(uintptr_t(socket_val));
+      #else
+         return HOSTHANDLE(socket_val);
+      #endif
+   }
+
+   bool is_valid() const { return socket_val != INVALID_SOCKET_VAL; }
+   bool is_invalid() const { return socket_val IS INVALID_SOCKET_VAL; }
+
+   bool operator==(const SocketHandle &Other) const { return socket_val == Other.socket_val; }
+   bool operator!=(const SocketHandle &Other) const { return socket_val != Other.socket_val; }
+   bool operator==(SOCKET_HANDLE Socket) const { return socket_val == Socket; }
+   bool operator!=(SOCKET_HANDLE Socket) const { return socket_val != Socket; }
+
+   SocketHandle & operator=(SOCKET_HANDLE Socket) { socket_val = Socket; return *this; }
+   #ifdef _WIN32
+      SocketHandle & operator=(int Socket) { socket_val = SOCKET_HANDLE(Socket); return *this; }
+   #endif
+};
+
+static constexpr SOCKET_HANDLE NOHANDLE = SocketHandle::INVALID_SOCKET_VAL;
+
+struct socket_endpoint {
+   struct sockaddr_storage storage;
+   int size = 0;
+   CSTRING label = nullptr;
+};
+
+class NetworkPlatform {
+public:
+   virtual ~NetworkPlatform() = default;
+
+   virtual ERR initialise(OBJECTPTR Module) = 0;
+   virtual void expunge() = 0;
+   virtual int socket_limit() const = 0;
+
+   virtual SocketHandle create_socket(void *Reference, bool Read, bool Write, bool UDP, bool &IPv6) = 0;
+   virtual void close_socket(SocketHandle Handle) = 0;
+   virtual void deregister_socket(SocketHandle Handle) = 0;
+   virtual int shutdown_socket(SocketHandle Handle, int How) = 0;
+
+   virtual ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) = 0;
+   virtual ERR begin_connect_wait(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR complete_connect(SocketHandle Handle) = 0;
+   virtual ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) = 0;
+   virtual ERR listen(SocketHandle Handle, int Backlog) = 0;
+   virtual ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) = 0;
+   virtual SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) = 0;
+   virtual void set_socket_reference(SocketHandle Handle, void *Reference) = 0;
+   virtual ERR set_non_blocking(SocketHandle Handle) = 0;
+
+   virtual ERR register_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR register_accept(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR register_write(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR remove_write(SocketHandle Handle) = 0;
+   virtual ERR register_recall_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR deregister_fd(SocketHandle Handle) = 0;
+
+   virtual ERR enable_broadcast(SocketHandle Handle) = 0;
+   virtual ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) = 0;
+   virtual ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
+   virtual ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
+
+   virtual ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) = 0;
+   virtual ERR append_receive(SocketHandle Handle, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received) = 0;
+   virtual ERR send(SocketHandle Handle, CPTR Buffer, size_t &Length) = 0;
+   virtual ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) = 0;
+   virtual ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
+      sockaddr_storage &SourceAddress, int &AddressLength) = 0;
+
+   virtual uint32_t inet_addr(CSTRING Value) = 0;
+   virtual int inet_pton(int Family, CSTRING Source, APTR Dest) = 0;
+   virtual CSTRING inet_ntop(int Family, CPTR Source, STRING Dest, size_t Size) = 0;
+   virtual uint32_t host_to_long(uint32_t Value) = 0;
+   virtual uint32_t long_to_host(uint32_t Value) = 0;
+   virtual uint16_t host_to_short(uint16_t Value) = 0;
+   virtual uint16_t short_to_host(uint16_t Value) = 0;
+};
+
+NetworkPlatform & network_platform();
+std::unique_ptr<NetworkPlatform> create_platform();

--- a/src/network/net_windows.cpp
+++ b/src/network/net_windows.cpp
@@ -1,0 +1,225 @@
+#ifdef _WIN32
+
+#include "net_platform.h"
+#include "win32/winsockwrappers.h"
+
+class WindowsNet : public NetworkPlatform {
+public:
+   ERR initialise(OBJECTPTR Module) override
+   {
+      kt::Log log(__FUNCTION__);
+
+      CSTRING msg;
+      if ((msg = StartupWinsock()) != 0) {
+         log.warning("Winsock initialisation failed: %s", msg);
+         return ERR::SystemCall;
+      }
+
+      SetResourcePtr(RES::NET_PROCESSING, (APTR)win_net_processing);
+      return ERR::Okay;
+   }
+
+   void expunge() override
+   {
+      kt::Log log(__FUNCTION__);
+
+      SetResourcePtr(RES::NET_PROCESSING, nullptr);
+      log.msg("Closing winsock.");
+      if (ShutdownWinsock() != 0) log.warning("Warning: Winsock DLL Cleanup failed.");
+   }
+
+   int socket_limit() const override
+   {
+      return 0x7fffffff;
+   }
+
+   SocketHandle create_socket(void *Reference, bool Read, bool Write, bool UDP, bool &IPv6) override
+   {
+      return SocketHandle(win_socket_ipv6(Reference, Read, Write, IPv6, UDP));
+   }
+
+   void close_socket(SocketHandle Handle) override
+   {
+      win_closesocket(Handle.socket());
+   }
+
+   void deregister_socket(SocketHandle Handle) override
+   {
+      win_deregister_socket(Handle.socket());
+   }
+
+   int shutdown_socket(SocketHandle Handle, int How) override
+   {
+      return win_shutdown(Handle.socket(), How);
+   }
+
+   ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   {
+      return win_connect(Handle.socket(), (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+   }
+
+   ERR begin_connect_wait(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return ERR::Okay;
+   }
+
+   ERR complete_connect(SocketHandle Handle) override
+   {
+      return win_socket_connect_complete(Handle.socket());
+   }
+
+   ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   {
+      return win_bind(Handle.socket(), (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+   }
+
+   ERR listen(SocketHandle Handle, int Backlog) override
+   {
+      return win_listen(Handle.socket(), Backlog);
+   }
+
+   ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) override
+   {
+      Length = sizeof(Address);
+      int result = win_getsockname(Handle.socket(), (struct sockaddr *)&Address, &Length);
+      return result ? ERR::SystemCall : ERR::Okay;
+   }
+
+   SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) override
+   {
+      int len = sizeof(Address);
+      if (IPv6) return SocketHandle(win_accept_ipv6(Reference, Server.socket(), (struct sockaddr *)&Address, &len, &Family));
+
+      Family = AF_INET;
+      return SocketHandle(win_accept(Reference, Server.socket(), (struct sockaddr *)&Address, &len));
+   }
+
+   void set_socket_reference(SocketHandle Handle, void *Reference) override
+   {
+      win_socket_reference(Handle.socket(), Reference);
+   }
+
+   ERR set_non_blocking(SocketHandle Handle) override
+   {
+      return ERR::Okay;
+   }
+
+   ERR register_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return win_socketstate(Handle.socket(), true, std::nullopt);
+   }
+
+   ERR register_accept(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return ERR::Okay;
+   }
+
+   ERR register_write(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return win_socketstate(Handle.socket(), std::nullopt, true);
+   }
+
+   ERR remove_write(SocketHandle Handle) override
+   {
+      return win_socketstate(Handle.socket(), std::nullopt, false);
+   }
+
+   ERR register_recall_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
+   {
+      return win_socketstate(Handle.socket(), true, std::nullopt);
+   }
+
+   ERR deregister_fd(SocketHandle Handle) override
+   {
+      return ERR::Okay;
+   }
+
+   ERR enable_broadcast(SocketHandle Handle) override
+   {
+      return win_enable_broadcast(Handle.socket());
+   }
+
+   ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) override
+   {
+      return win_set_multicast_ttl(Handle.socket(), TTL, IPv6);
+   }
+
+   ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   {
+      return win_join_multicast_group(Handle.socket(), Group, IPv6);
+   }
+
+   ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   {
+      return win_leave_multicast_group(Handle.socket(), Group, IPv6);
+   }
+
+   ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) override
+   {
+      return WIN_RECEIVE(Handle.socket(), Buffer, Length, &Received);
+   }
+
+   ERR append_receive(SocketHandle Handle, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received) override
+   {
+      return WIN_APPEND(Handle.socket(), Buffer, Length, Received);
+   }
+
+   ERR send(SocketHandle Handle, CPTR Buffer, size_t &Length) override
+   {
+      return WIN_SEND(Handle.socket(), Buffer, &Length, 0);
+   }
+
+   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) override
+   {
+      return WIN_SENDTO(Handle.socket(), Buffer, &Length, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+   }
+
+   ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
+      sockaddr_storage &SourceAddress, int &AddressLength) override
+   {
+      return WIN_RECVFROM(Handle.socket(), Buffer, BufferSize, &BytesRead, (struct sockaddr *)&SourceAddress,
+         &AddressLength);
+   }
+
+   uint32_t inet_addr(CSTRING Value) override
+   {
+      return win_inet_addr(Value);
+   }
+
+   int inet_pton(int Family, CSTRING Source, APTR Dest) override
+   {
+      return win_inet_pton(Family, Source, Dest);
+   }
+
+   CSTRING inet_ntop(int Family, CPTR Source, STRING Dest, size_t Size) override
+   {
+      return win_inet_ntop(Family, Source, Dest, Size);
+   }
+
+   uint32_t host_to_long(uint32_t Value) override
+   {
+      return win_htonl(Value);
+   }
+
+   uint32_t long_to_host(uint32_t Value) override
+   {
+      return win_ntohl(Value);
+   }
+
+   uint16_t host_to_short(uint16_t Value) override
+   {
+      return win_htons(Value);
+   }
+
+   uint16_t short_to_host(uint16_t Value) override
+   {
+      return win_ntohs(Value);
+   }
+};
+
+std::unique_ptr<NetworkPlatform> create_platform()
+{
+   return std::make_unique<WindowsNet>();
+}
+
+#endif

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -116,6 +116,9 @@ static void netsocket_outgoing(HOSTHANDLE FD, APTR Data) {
 static void netsocket_connect(HOSTHANDLE FD, APTR Data) {
    netsocket_connect_impl(FD, (extNetSocket *)Data);
 }
+#else
+static void netsocket_connect(HOSTHANDLE FD, APTR Data) {
+}
 #endif
 static void server_accept_client(HOSTHANDLE FD, APTR Data) {
    server_accept_client_impl(FD, (extNetSocket *)Data);
@@ -198,7 +201,7 @@ static void complete_win_connect(extNetSocket *Socket)
       return;
    }
 
-   if (auto error = win_socket_connect_complete(Socket->Handle); error != ERR::Okay) log.warning(error);
+   if (auto error = network_platform().complete_connect(Socket->Handle); error != ERR::Okay) log.warning(error);
 
    Socket->Error = ERR::Okay;
    clear_connect_timer(Socket);
@@ -286,12 +289,6 @@ static void connect_name_resolved_nl(objNetLookup *NetLookup, ERR Error, const s
    connect_name_resolved((extNetSocket *)CurrentContext(), Error, HostName, IPs);
 }
 
-struct socket_endpoint {
-   struct sockaddr_storage storage;
-   int size = 0;
-   CSTRING label = nullptr;
-};
-
 static const IPAddress *select_connect_address(extNetSocket *Socket, const std::vector<IPAddress> &IPs)
 {
    if (!Socket->IPV6) {
@@ -314,7 +311,7 @@ static ERR build_socket_address(const IPAddress &IP, int Port, bool IPv6, socket
 
       auto addr6 = (struct sockaddr_in6 *)&Endpoint.storage;
       addr6->sin6_family = AF_INET6;
-      addr6->sin6_port = htons(Port);
+      addr6->sin6_port = network_platform().host_to_short(uint16_t(Port));
       kt::copymem(IP.Data, &addr6->sin6_addr.s6_addr, 16);
 
       Endpoint.size = sizeof(struct sockaddr_in6);
@@ -324,10 +321,10 @@ static ERR build_socket_address(const IPAddress &IP, int Port, bool IPv6, socket
    else if (IP.Type IS IPADDR::V4) {
       if (IPv6) {
          auto addr6 = (struct sockaddr_in6 *)&Endpoint.storage;
-         uint32_t ipv4_net = htonl(IP.Data[0]);
+         uint32_t ipv4_net = network_platform().host_to_long(IP.Data[0]);
 
          addr6->sin6_family = AF_INET6;
-         addr6->sin6_port = htons(Port);
+         addr6->sin6_port = network_platform().host_to_short(uint16_t(Port));
          addr6->sin6_addr.s6_addr[10] = 0xff;
          addr6->sin6_addr.s6_addr[11] = 0xff;
          kt::copymem(&ipv4_net, &addr6->sin6_addr.s6_addr[12], sizeof(ipv4_net));
@@ -339,8 +336,8 @@ static ERR build_socket_address(const IPAddress &IP, int Port, bool IPv6, socket
       else {
          auto addr4 = (struct sockaddr_in *)&Endpoint.storage;
          addr4->sin_family = AF_INET;
-         addr4->sin_port = htons(Port);
-         addr4->sin_addr.s_addr = htonl(IP.Data[0]);
+         addr4->sin_port = network_platform().host_to_short(uint16_t(Port));
+         addr4->sin_addr.s_addr = network_platform().host_to_long(IP.Data[0]);
 
          Endpoint.size = sizeof(struct sockaddr_in);
          Endpoint.label = "IPv4";
@@ -350,56 +347,25 @@ static ERR build_socket_address(const IPAddress &IP, int Port, bool IPv6, socket
    else return ERR::InvalidData;
 }
 
-#ifdef __linux__
-
 static ERR start_platform_connect(extNetSocket *Socket, const socket_endpoint &Endpoint)
 {
    kt::Log log(__FUNCTION__);
 
-   int result = connect(Socket->Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+   auto connect_error = network_platform().connect(Socket->Handle, Endpoint);
 
-   if (result IS -1) {
-      if (errno IS EINPROGRESS) {
-         log.trace("%s connection in progress...", Endpoint.label);
-      }
-      else if ((errno IS EWOULDBLOCK) or (errno IS EAGAIN)) {
-         log.trace("%s connect() attempt would block or need to try again.", Endpoint.label);
-      }
-      else {
-         const int system_error = errno;
-         log.warning("%s connect() failed: %s", Endpoint.label, strerror(system_error));
-         Socket->Error = convert_socket_error(system_error);
-         Socket->setState(NTC::DISCONNECTED);
-         return Socket->Error;
-      }
-
-      Socket->setState(NTC::CONNECTING);
-      RegisterFD(Socket->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_connect, Socket);
-   }
-   else {
-      log.trace("%s connect() successful.", Endpoint.label);
-      Socket->setState(NTC::CONNECTED);
-      RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
-   }
-
-   return ERR::Okay;
-}
-
-#elif _WIN32
-
-static ERR start_platform_connect(extNetSocket *Socket, const socket_endpoint &Endpoint)
-{
-   kt::Log log(__FUNCTION__);
-
-   auto connect_error = win_connect(Socket->Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
-   if (connect_error IS ERR::Okay) {
-      log.trace("%s connect() successful.", Endpoint.label);
-      complete_win_connect(Socket);
-   }
-   else if (connect_error IS ERR::Busy) {
+   if (connect_error IS ERR::Busy) {
       log.trace("%s connection in progress...", Endpoint.label);
-      Socket->Error = ERR::Okay;
       Socket->setState(NTC::CONNECTING);
+      network_platform().begin_connect_wait(Socket->Handle, &netsocket_connect, Socket);
+   }
+   else if (connect_error IS ERR::Okay) {
+      log.trace("%s connect() successful.", Endpoint.label);
+      #ifdef _WIN32
+         complete_win_connect(Socket);
+      #else
+         Socket->setState(NTC::CONNECTED);
+         network_platform().register_read(Socket->Handle, &netsocket_incoming, Socket);
+      #endif
    }
    else {
       Socket->Error = connect_error;
@@ -411,8 +377,6 @@ static ERR start_platform_connect(extNetSocket *Socket, const socket_endpoint &E
 
    return ERR::Okay;
 }
-
-#endif
 
 static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::string &HostName,
    const std::vector<IPAddress> &IPs)
@@ -520,11 +484,7 @@ static ERR NETSOCKET_Disable(extNetSocket *Self)
 
    log.trace("");
 
-#ifdef __linux__
-   int result = shutdown(Self->Handle, 2);
-#elif _WIN32
-   int result = win_shutdown(Self->Handle, 2);
-#endif
+   int result = network_platform().shutdown_socket(Self->Handle, 2);
 
    if (result) { // Zero is success on both platforms
       log.warning("shutdown() failed.");
@@ -671,17 +631,10 @@ static ERR NETSOCKET_GetLocalIPAddress(extNetSocket *Self, struct ns::GetLocalIP
    if ((!Args) or (!Args->Address)) return log.warning(ERR::NullArgs);
 
    struct sockaddr_storage addr_storage;
-   int result;
-
-#ifdef __linux__
-   socklen_t addr_length = sizeof(addr_storage);
-   result = getsockname(Self->Handle, (struct sockaddr *)&addr_storage, &addr_length);
-#elif _WIN32
    int addr_length = sizeof(addr_storage);
-   result = win_getsockname(Self->Handle, (struct sockaddr *)&addr_storage, &addr_length);
-#endif
+   auto result = network_platform().get_local_address(Self->Handle, addr_storage, addr_length);
 
-   if (!result) {
+   if (result IS ERR::Okay) {
       if (addr_storage.ss_family IS AF_INET6) {
          auto addr6 = (struct sockaddr_in6 *)&addr_storage;
          kt::copymem(addr6->sin6_addr.s6_addr, Args->Address->Data, 16);
@@ -701,7 +654,7 @@ static ERR NETSOCKET_GetLocalIPAddress(extNetSocket *Self, struct ns::GetLocalIP
       }
       return ERR::Okay;
    }
-   else return log.warning(ERR::SystemCall);
+   else return log.warning(result);
 }
 
 //********************************************************************************************************************
@@ -769,57 +722,27 @@ static ERR prepare_server_bind_address(extNetSocket *Self, socket_endpoint &Endp
    }
 }
 
-#ifdef __linux__
-
 static ERR activate_server_socket(extNetSocket *Self, const socket_endpoint &Endpoint)
 {
    kt::Log log(__FUNCTION__);
 
-   int value = 1;
-   setsockopt(Self->Handle, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value));
-
-   if (bind(Self->Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size) IS -1) {
-      const int system_error = errno;
-      log.warning("bind() failed with error: %s", strerror(system_error));
-      return convert_socket_error(system_error);
-   }
-
-   if ((Self->Flags & NSF::UDP) IS NSF::NIL) {
-      if (listen(Self->Handle, Self->Backlog) IS -1) {
-         const int system_error = errno;
-         log.warning("listen() failed with error: %s", strerror(system_error));
-         return convert_socket_error(system_error);
-      }
-
-      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_accept_client, Self);
-   }
-   else RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
-
-   return ERR::Okay;
-}
-
-#elif _WIN32
-
-static ERR activate_server_socket(extNetSocket *Self, const socket_endpoint &Endpoint)
-{
-   kt::Log log(__FUNCTION__);
-
-   if (auto error = win_bind(Self->Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size); error != ERR::Okay) {
+   if (auto error = network_platform().bind(Self->Handle, Endpoint); error != ERR::Okay) {
       log.warning("Bind failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
       return error;
    }
 
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) {
-      if (auto error = win_listen(Self->Handle, Self->Backlog); error != ERR::Okay) {
+      if (auto error = network_platform().listen(Self->Handle, Self->Backlog); error != ERR::Okay) {
          log.warning("Listen failed on port %d, error: %s", Self->Port, GetErrorMsg(error));
          return error;
       }
+
+      network_platform().register_accept(Self->Handle, &server_accept_client, Self);
    }
+   else network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
 
    return ERR::Okay;
 }
-
-#endif
 
 static ERR setup_server_socket(extNetSocket *Self)
 {
@@ -832,13 +755,7 @@ static ERR setup_server_socket(extNetSocket *Self)
    socket_endpoint endpoint;
    if (auto error = prepare_server_bind_address(Self, endpoint); error != ERR::Okay) return error;
 
-   #ifdef __linux__
-      return activate_server_socket(Self, endpoint);
-   #elif defined(_WIN32)
-      return activate_server_socket(Self, endpoint);
-   #else
-      return ERR::NoSupport;
-   #endif
+   return activate_server_socket(Self, endpoint);
 }
 
 //********************************************************************************************************************
@@ -863,102 +780,25 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    }
 #endif
 
-#ifdef __linux__
-
-   // Create socket - UDP or TCP, IPv6 dual-stack if available, otherwise IPv4
-   int socket_type = ((Self->Flags & NSF::UDP) != NSF::NIL) ? SOCK_DGRAM : SOCK_STREAM;
-   int protocol = ((Self->Flags & NSF::UDP) != NSF::NIL) ? IPPROTO_UDP : IPPROTO_TCP;
-
-   if (auto sock = socket(PF_INET6, socket_type, protocol); sock != -1) {
-      Self->Handle = SocketHandle(sock);
-      Self->IPV6 = true;
-
-      // Enable dual-stack mode (accept both IPv4 and IPv6)
-      int v6only = 0;
-      if (setsockopt(Self->Handle, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
-         log.warning("Failed to set dual-stack mode: %s", strerror(errno));
-      }
-
-      if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP-specific options
-         int nodelay = 1;
-         setsockopt(Self->Handle, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-      }
-   }
-   else if (auto sock = socket(PF_INET, socket_type, protocol); sock != -1) {
-      Self->Handle = SocketHandle(sock);
-      Self->IPV6 = false;
-
-      if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP-specific options
-         int nodelay = 1;
-         setsockopt(Self->Handle, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-      }
-   }
-   else {
-      const int system_error = errno;
-      log.warning("Failed to create socket: %s", strerror(system_error));
-      return convert_socket_error(system_error);
-   }
-
-   // Put the socket into non-blocking mode, this is required when registering it as an FD and also prevents connect()
-   // calls from going to sleep.
-
-   if (fcntl(Self->Handle, F_SETFL, fcntl(Self->Handle, F_GETFL) | O_NONBLOCK)) {
-      error = log.warning(convert_socket_error());
-      free_socket(Self);
-      return error;
-   }
-
-   // Set the send timeout so that connect() will timeout after a reasonable time
-
-   //int timeout = 30000;
-   //result = setsockopt(Self->Handle, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
-   //assert(result IS 0);
-
-#elif _WIN32
-
-   bool is_ipv6;
+   bool is_ipv6 = false;
    bool is_udp = ((Self->Flags & NSF::UDP) != NSF::NIL);
-   Self->Handle = win_socket_ipv6(Self, true, false, is_ipv6, is_udp);
+   Self->Handle = network_platform().create_socket(Self, true, false, is_udp, is_ipv6);
    if (Self->Handle.is_invalid()) return ERR::SystemCall;
    Self->IPV6 = is_ipv6;
-
-#endif
 
    // Configure UDP-specific socket options
 
    if ((Self->Flags & NSF::UDP) != NSF::NIL) {
       if ((Self->Flags & NSF::BROADCAST) != NSF::NIL) {
-         #ifdef __linux__
-            int broadcast = 1;
-            if (setsockopt(Self->Handle, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) != 0) {
-               log.warning("Failed to enable broadcast: %s", strerror(errno));
-            }
-         #elif _WIN32
-            // Use winsock wrapper - will be added to winsockwrappers.cpp
-            if (win_enable_broadcast(Self->Handle) != ERR::Okay) {
-               log.warning("Failed to enable broadcast");
-            }
-         #endif
+         if (network_platform().enable_broadcast(Self->Handle) != ERR::Okay) {
+            log.warning("Failed to enable broadcast");
+         }
       }
 
       if (Self->MulticastTTL > 0) {
-         #ifdef __linux__
-            int ttl = Self->MulticastTTL;
-            if (Self->IPV6) {
-               if (setsockopt(Self->Handle, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &ttl, sizeof(ttl)) != 0) {
-                  log.warning("Failed to set multicast TTL: %s", strerror(errno));
-               }
-            }
-            else {
-               if (setsockopt(Self->Handle, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) != 0) {
-                  log.warning("Failed to set multicast TTL: %s", strerror(errno));
-               }
-            }
-         #elif _WIN32
-            if (win_set_multicast_ttl(Self->Handle, Self->MulticastTTL, Self->IPV6) != ERR::Okay) {
-               log.warning("Failed to set multicast TTL");
-            }
-         #endif
+         if (network_platform().set_multicast_ttl(Self->Handle, Self->MulticastTTL, Self->IPV6) != ERR::Okay) {
+            log.warning("Failed to set multicast TTL");
+         }
       }
    }
 
@@ -977,10 +817,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
       else return ERR::Okay;
    }
    else if ((Self->Flags & NSF::UDP) != NSF::NIL) {
-      // UDP client sockets need to be registered for incoming data on Linux
-      #ifdef __linux__
-      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
-      #endif
+      network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
       return ERR::Okay;
    }
    else return ERR::Okay;
@@ -990,11 +827,6 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
 
 struct multicast_group_address {
    bool IsIPv6 = false;
-
-   #ifdef __linux__
-      struct ip_mreq Mreq4;
-      struct ipv6_mreq Mreq6;
-   #endif
 };
 
 static ERR parse_multicast_group(CSTRING Group, multicast_group_address &Address)
@@ -1006,48 +838,16 @@ static ERR parse_multicast_group(CSTRING Group, multicast_group_address &Address
    kt::clearmem(&addr4, sizeof(addr4));
    kt::clearmem(&addr6, sizeof(addr6));
 
-   #ifdef __linux__
-      kt::clearmem(&Address.Mreq4, sizeof(Address.Mreq4));
-      kt::clearmem(&Address.Mreq6, sizeof(Address.Mreq6));
-   #endif
-
    if (unified_inet_pton(AF_INET6, Group, &addr6.sin6_addr) IS 1) {
       Address.IsIPv6 = true;
-
-      #ifdef __linux__
-         Address.Mreq6.ipv6mr_multiaddr = addr6.sin6_addr;
-         Address.Mreq6.ipv6mr_interface = 0;
-      #endif
-
       return ERR::Okay;
    }
    else if (unified_inet_pton(AF_INET, Group, &addr4.sin_addr) IS 1) {
       Address.IsIPv6 = false;
-
-      #ifdef __linux__
-         Address.Mreq4.imr_multiaddr = addr4.sin_addr;
-         Address.Mreq4.imr_interface.s_addr = INADDR_ANY;
-      #endif
-
       return ERR::Okay;
    }
    else return ERR::Args;
 }
-
-#ifdef __linux__
-
-static int set_multicast_membership(SocketHandle Handle, const multicast_group_address &Address, int IPv4Option,
-   int IPv6Option)
-{
-   if (Address.IsIPv6) {
-      return setsockopt(Handle, IPPROTO_IPV6, IPv6Option, (char *)&Address.Mreq6, sizeof(Address.Mreq6));
-   }
-   else {
-      return setsockopt(Handle, IPPROTO_IP, IPv4Option, (char *)&Address.Mreq4, sizeof(Address.Mreq4));
-   }
-}
-
-#endif
 
 /*********************************************************************************************************************
 
@@ -1087,21 +887,15 @@ static ERR NETSOCKET_JoinMulticastGroup(extNetSocket *Self, struct ns::JoinMulti
       return ERR::Args;
    }
 
-#ifdef __linux__
-   if (set_multicast_membership(Self->Handle, group_address, IP_ADD_MEMBERSHIP, IPV6_JOIN_GROUP) != 0) {
+   if (network_platform().join_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
       if (group_address.IsIPv6) {
-         log.warning("Failed to join IPv6 multicast group: %s", strerror(errno));
+         log.warning("Failed to join IPv6 multicast group");
       }
       else {
-         log.warning("Failed to join IPv4 multicast group: %s", strerror(errno));
+         log.warning("Failed to join IPv4 multicast group");
       }
       return ERR::Failed;
    }
-#elif _WIN32
-   if (win_join_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
-      return log.warning(ERR::Failed);
-   }
-#endif
 
    return ERR::Okay;
 }
@@ -1142,22 +936,15 @@ static ERR NETSOCKET_LeaveMulticastGroup(extNetSocket *Self, struct ns::LeaveMul
       return ERR::Args;
    }
 
-#ifdef __linux__
-   if (set_multicast_membership(Self->Handle, group_address, IP_DROP_MEMBERSHIP, IPV6_LEAVE_GROUP) != 0) {
+   if (network_platform().leave_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
       if (group_address.IsIPv6) {
-         log.warning("Failed to leave IPv6 multicast group: %s", strerror(errno));
+         log.warning("Failed to leave IPv6 multicast group");
       }
       else {
-         log.warning("Failed to leave IPv4 multicast group: %s", strerror(errno));
+         log.warning("Failed to leave IPv4 multicast group");
       }
       return ERR::Failed;
    }
-#elif _WIN32
-   if (win_leave_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
-      log.warning("Failed to leave multicast group: %s", Args->Group);
-      return ERR::Failed;
-   }
-#endif
 
    return ERR::Okay;
 }
@@ -1259,7 +1046,7 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
 
                       log.msg("SSL socket handshake requested by server.");
                       Self->HandshakeStatus = SHS::WRITE;
-                      RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, ssl_handshake_write_netsocket, Self);
+                     network_platform().register_write(Self->Handle, ssl_handshake_write_netsocket, Self);
                       return ERR::Okay;
 
                   case SSL_ERROR_SYSCALL:
@@ -1299,7 +1086,7 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
             // For this reason we set the RECALL flag so that we can be called again manually when we know that there is
             // data pending.
 
-            RegisterFD(Self->Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
+            network_platform().register_recall_read(Self->Handle, &netsocket_incoming, Self);
          }
 
          return ERR::Okay;
@@ -1307,32 +1094,15 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
    }
 #endif
 
-#ifdef __linux__
-   auto bytes_received = recv(Self->Handle, Args->Buffer, Args->Length, 0);
+   size_t bytes_received = 0;
+   auto receive_error = network_platform().receive(Self->Handle, Args->Buffer, Args->Length, bytes_received);
+   Args->Result = int(bytes_received);
 
-   if (bytes_received > 0) {
-      Args->Result = bytes_received;
-      return ERR::Okay;
-   }
-
-   if (bytes_received IS 0) { // man recv() says: The return value is 0 when the peer has performed an orderly shutdown.
+   if (receive_error IS ERR::Disconnected) {
       free_socket(Self);
       return ERR::Disconnected;
    }
-   else if ((errno IS EAGAIN) or (errno IS EINTR)) return ERR::Okay;
-   else {
-      const int system_error = errno;
-      log.warning("recv() failed: %s", strerror(system_error));
-      return convert_socket_error(system_error);
-   }
-#elif _WIN32
-   size_t result;
-   auto error = WIN_RECEIVE(Self->Handle, (char *)Args->Buffer, Args->Length, &result);
-   Args->Result = result;
-   return error;
-#else
-   #error No support for RECEIVE()
-#endif
+   else return receive_error;
 }
 
 /*********************************************************************************************************************
@@ -1368,11 +1138,7 @@ static ERR queue_socket_write(T *Self, struct acWrite *Args, size_t MsgLimit)
 template <class T>
 static void register_socket_write(T *Self, void (*WriteCallback)(HOSTHANDLE, APTR))
 {
-   #ifdef __linux__
-      RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, WriteCallback, Self);
-   #elif _WIN32
-      win_socketstate(Self->Handle, std::nullopt, true);
-   #endif
+   network_platform().register_write(Self->Handle, WriteCallback, Self);
 }
 
 template <class T>
@@ -1515,51 +1281,24 @@ static ERR NETSOCKET_RecvFrom(extNetSocket *Self, struct ns::RecvFrom *Args)
    Args->BytesRead = 0;
 
    struct sockaddr_storage source_addr;
-
-#ifdef __linux__
-   socklen_t addr_len = sizeof(source_addr);
-   auto result = recvfrom(Self->Handle, Args->Buffer, Args->BufferSize, MSG_DONTWAIT, (struct sockaddr *)&source_addr, &addr_len);
-   if (result > 0) {
-      Args->BytesRead = result;
-   }
-   else if (result IS 0) {
-      return ERR::Okay; // No data available
-   }
-   else {
-      switch (errno) {
-#if EAGAIN == EWOULDBLOCK
-         case EAGAIN:
-            return ERR::Okay; // No data available
-#else
-         case EAGAIN:
-         case EWOULDBLOCK:
-            return ERR::Okay; // No data available
-#endif
-         case EMSGSIZE:
-            return ERR::BufferOverflow;
-         default:
-            const int system_error = errno;
-            log.warning("recvfrom() failed: %s", strerror(system_error));
-            return convert_socket_error(system_error);
-      }
-   }
-#elif _WIN32
    int addr_len = sizeof(source_addr);
-   size_t bytes_read_temp = Args->BytesRead;
-   auto error = WIN_RECVFROM(Self->Handle, Args->Buffer, Args->BufferSize, &bytes_read_temp, (struct sockaddr *)&source_addr, &addr_len);
-   Args->BytesRead = int(bytes_read_temp);
+   size_t bytes_read = 0;
+
+   auto error = network_platform().receive_from(Self->Handle, Args->Buffer, Args->BufferSize, bytes_read, source_addr,
+      addr_len);
+   Args->BytesRead = int(bytes_read);
    if (error != ERR::Okay) return error;
-#endif
 
    if (Args->BytesRead > 0) {
       // Populate IPAddress structure with source address and port
       if (source_addr.ss_family IS AF_INET) {
          auto addr4 = (sockaddr_in *)&source_addr;
-         setIPV4(*Args->Source, ntohl(addr4->sin_addr.s_addr), ntohs(addr4->sin_port));
+         setIPV4(*Args->Source, network_platform().long_to_host(addr4->sin_addr.s_addr),
+            network_platform().short_to_host(addr4->sin_port));
       }
       else if (source_addr.ss_family IS AF_INET6) {
          auto addr6 = (sockaddr_in6 *)&source_addr;
-         setIPV6(*Args->Source, addr6->sin6_addr.s6_addr, ntohs(addr6->sin6_port));
+         setIPV6(*Args->Source, addr6->sin6_addr.s6_addr, network_platform().short_to_host(addr6->sin6_port));
       }
    }
 
@@ -1624,32 +1363,9 @@ static ERR NETSOCKET_SendTo(extNetSocket *Self, struct ns::SendTo *Args)
 
    size_t bytes_to_send = Args->Length;
 
-#if defined(__linux__)
-   auto result = sendto(Self->Handle, Args->Data, bytes_to_send, MSG_DONTWAIT, (sockaddr *)&dest_addr.storage,
-      dest_addr.size);
-   if (result >= 0) {
-      Args->BytesSent = (int)result;
-      return ERR::Okay;
-   }
-   switch (errno) {
-#if EAGAIN == EWOULDBLOCK
-      case EAGAIN: return ERR::BufferOverflow;
-#else
-      case EAGAIN:
-      case EWOULDBLOCK: return ERR::BufferOverflow;
-#endif
-      case ENETUNREACH: return ERR::NetworkUnreachable;
-      case EINVAL:      return ERR::Args;
-      default:
-         const int system_error = errno;
-         log.warning("sendto() failed: %s", strerror(system_error));
-         return convert_socket_error(system_error);
-   }
-#elif defined(_WIN32)
-   auto error = WIN_SENDTO(Self->Handle, Args->Data, &bytes_to_send, (sockaddr *)&dest_addr.storage, dest_addr.size);
-   if (error IS ERR::Okay) Args->BytesSent = (int)bytes_to_send;
+   auto error = network_platform().send_to(Self->Handle, Args->Data, bytes_to_send, dest_addr);
+   if (error IS ERR::Okay) Args->BytesSent = int(bytes_to_send);
    return error;
-#endif
 }
 
 //********************************************************************************************************************

--- a/src/network/netsocket/netsocket_fields.cpp
+++ b/src/network/netsocket/netsocket_fields.cpp
@@ -210,11 +210,7 @@ static ERR SET_Outgoing(extNetSocket *Self, FUNCTION *Value)
       if ((Self->Handle.is_valid()) and (Self->State IS NTC::CONNECTED)) {
          // Setting the Outgoing field after connectivity is established will put the socket into streamed write mode.
 
-         #ifdef __linux__
-            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
-         #elif _WIN32
-            win_socketstate(Self->Handle, std::nullopt, true);
-         #endif
+         network_platform().register_write(Self->Handle, &netsocket_outgoing, Self);
       }
       else log.trace("Will not listen for socket-writes (no socket handle, or state %d != NTC::CONNECTED).", Self->State);
    }
@@ -443,11 +439,7 @@ static ERR SET_State(extNetSocket *Self, NTC Value)
 
       if ((Self->State IS NTC::CONNECTED) and ((!Self->WriteQueue.Buffer.empty()) or (Self->Outgoing.defined()))) {
          log.msg("Sending queued data to server on connection.");
-         #ifdef __linux__
-            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
-         #elif _WIN32
-            win_socketstate(Self->Handle, std::nullopt, true);
-         #endif
+         network_platform().register_write(Self->Handle, &netsocket_outgoing, Self);
       }
    }
 

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -9,7 +9,7 @@ static void free_socket(extNetSocket *Self)
 
    if (Self->Handle.is_valid()) {
       log.trace("Deregistering socket.");
-      DeregisterFD(Self->Handle.hosthandle());
+      network_platform().deregister_fd(Self->Handle);
 
       if (!Self->ExternalSocket) CLOSESOCKET_THREADED(Self->Handle);
       Self->Handle = SocketHandle();
@@ -170,10 +170,10 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
    }
    else if (Message IS NTE_ACCEPT) {
       log.traceBranch("Accept message received for new client %d.", Handle);
-      server_accept_client(Socket->Handle, Socket);
+      server_accept_client(Socket->Handle.hosthandle(), Socket);
    }
    else if (Message IS NTE_CONNECT) {
-      if (auto error = win_socket_connect_complete(Handle); error != ERR::Okay) log.warning(error);
+      if (auto error = network_platform().complete_connect(SocketHandle(Handle)); error != ERR::Okay) log.warning(error);
 
       if (Error IS ERR::Okay) {
          if (ClientSocket) { // Server mode - connect message shouldn't be received for ClientSocket
@@ -259,103 +259,28 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       }
    }
 
-   if (Self->IPV6) {
-      #ifdef __linux__
-         // For dual-stack sockets, use sockaddr_storage to handle both IPv4 and IPv6
-         struct sockaddr_storage addr_storage;
-         socklen_t len = sizeof(addr_storage);
-         clientfd = accept(SocketFD, (struct sockaddr *)&addr_storage, &len);
-         if (clientfd.is_invalid()) return;
-
-         int nodelay = 1;
-         setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-
-         if (addr_storage.ss_family IS AF_INET6) { // IPv6 connection
-            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, addr_storage.ss_family, ip);
-            if (error != ERR::Okay) {
-               log.warning(error);
-               close(clientfd);
-               return;
-            }
-            log.trace("Accepted IPv6 client connection");
-         }
-         else if (addr_storage.ss_family IS AF_INET) { // IPv4 connection on dual-stack socket
-            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, addr_storage.ss_family, ip);
-            if (error != ERR::Okay) {
-               log.warning(error);
-               close(clientfd);
-               return;
-            }
-            log.trace("Accepted IPv4 client connection on dual-stack socket");
-         }
-         else {
-            log.warning("Unsupported address family: %d", addr_storage.ss_family);
-            close(clientfd);
-            return;
-         }
-      #elif _WIN32
-         // Windows IPv6 dual-stack accept using wrapper function
-         int family;
-         struct sockaddr_storage addr_storage;
-         int len = sizeof(addr_storage);
-         clientfd = win_accept_ipv6(Self, WSW_SOCKET((uintptr_t)SocketFD), (struct sockaddr *)&addr_storage, &len, &family);
-         if (clientfd IS NOHANDLE) return;
-
-         if (family IS AF_INET6) { // IPv6 connection
-            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip);
-            if (error != ERR::Okay) {
-               log.warning(error);
-               CLOSESOCKET(clientfd);
-               return;
-            }
-            log.trace("Accepted IPv6 client connection on Windows");
-         }
-         else if (family IS AF_INET) { // IPv4 connection on dual-stack socket
-            auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip);
-            if (error != ERR::Okay) {
-               log.warning(error);
-               CLOSESOCKET(clientfd);
-               return;
-            }
-            log.trace("Accepted IPv4 client connection on dual-stack socket (Windows)");
-         }
-         else {
-            log.warning("Unsupported address family on Windows: %d", family);
-            CLOSESOCKET(clientfd);
-            return;
-         }
-      #else
-         #warning Platform requires IPV6 support.
-         return;
-      #endif
+   struct sockaddr_storage addr_storage;
+   int family = AF_INET;
+   clientfd = network_platform().accept(Self, Self->Handle, Self->IPV6, addr_storage, family);
+   if (clientfd.is_invalid()) {
+      log.warning("accept() failed to return an FD.");
+      return;
    }
-   else {
-      struct sockaddr_in addr;
 
-      #ifdef __linux__
-         socklen_t len = sizeof(addr);
-         clientfd = accept(SocketFD, (struct sockaddr *)&addr, &len);
-
-         if (clientfd.is_valid()) {
-            int nodelay = 1;
-            setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-         }
-      #elif _WIN32
-         int len = sizeof(addr);
-         clientfd = win_accept(Self, WSW_SOCKET((uintptr_t)SocketFD), (struct sockaddr *)&addr, &len);
-      #endif
-
-      if (clientfd.is_invalid()) {
-         log.warning("accept() failed to return an FD.");
-         return;
-      }
-
-      if (auto error = sockaddr_to_client_ip((struct sockaddr *)&addr, AF_INET, ip); error != ERR::Okay) {
-         log.warning(error);
-         CLOSESOCKET(clientfd);
-         return;
-      }
+   if ((family != AF_INET) and (family != AF_INET6)) {
+      log.warning("Unsupported address family: %d", family);
+      network_platform().close_socket(clientfd);
+      return;
    }
+
+   if (auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip); error != ERR::Okay) {
+      log.warning(error);
+      network_platform().close_socket(clientfd);
+      return;
+   }
+
+   if (family IS AF_INET6) log.trace("Accepted IPv6 client connection");
+   else if (Self->IPV6) log.trace("Accepted IPv4 client connection on dual-stack socket");
 
    // Check if this IP address already has a client structure from an earlier socket connection.
    // (One NetClient represents a single IP address; Multiple ClientSockets can connect from that IP address)
@@ -369,12 +294,12 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       if (NewObject(CLASSID::NETCLIENT, &client_ip) IS ERR::Okay) {
          if (InitObject(client_ip) != ERR::Okay) {
             FreeResource(client_ip);
-            CLOSESOCKET(clientfd);
+            network_platform().close_socket(clientfd);
             return;
          }
       }
       else {
-         CLOSESOCKET(clientfd);
+         network_platform().close_socket(clientfd);
          return;
       }
 
@@ -391,14 +316,14 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
    }
    else if (client_ip->TotalConnections >= Self->SocketLimit) {
       log.warning("Socket limit of %d reached for IP %d.%d.%d.%d", Self->SocketLimit, client_ip->IP[0], client_ip->IP[1], client_ip->IP[2], client_ip->IP[3]);
-      CLOSESOCKET(clientfd);
+      network_platform().close_socket(clientfd);
       return;
    }
 
    if ((Self->Flags & NSF::MULTI_CONNECT) IS NSF::NIL) { // Check if the IP is already registered and alive
       if (client_ip->Connections) {
          log.msg("Preventing second connection attempt from IP %d.%d.%d.%d", client_ip->IP[0], client_ip->IP[1], client_ip->IP[2], client_ip->IP[3]);
-         CLOSESOCKET(clientfd);
+         network_platform().close_socket(clientfd);
          return;
       }
    }
@@ -435,7 +360,7 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       }
    }
    else {
-      CLOSESOCKET(clientfd);
+      network_platform().close_socket(clientfd);
       if (!client_ip->Connections) free_client(Self, client_ip);
       return;
    }
@@ -498,16 +423,14 @@ static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
    log.trace("Connection from server received.");
 
-   int result = EHOSTUNREACH; // Default error in case getsockopt() fails
-   socklen_t optlen = sizeof(result);
-   getsockopt(SocketFD, SOL_SOCKET, SO_ERROR, &result, &optlen);
+   auto result = network_platform().complete_connect(Self->Handle);
 
    // Remove the write callback
 
-   RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::REMOVE, &netsocket_connect, Self);
+   network_platform().remove_write(Self->Handle);
 
    #ifndef DISABLE_SSL
-   if ((Self->SSLHandle) and (!result)) {
+   if ((Self->SSLHandle) and (result IS ERR::Okay)) {
       // Perform the SSL handshake
 
       log.traceBranch("Attempting SSL handshake.");
@@ -516,27 +439,27 @@ static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       if (Self->Error != ERR::Okay) return;
 
       if (Self->State IS NTC::HANDSHAKING) {
-         RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
+         network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
       }
       return;
    }
    #endif
 
-   if (!result) {
+   if (result IS ERR::Okay) {
       log.traceBranch("Connection succesful.");
 
       if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
 
       Self->setState(NTC::CONNECTED);
-      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
+      network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
       return;
    }
    else {
-      log.trace("getsockopt() result %d", result);
+      log.trace("Connect completion result %d", int(result));
 
       if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
 
-      Self->Error = convert_socket_error(result);
+      Self->Error = result;
 
       log.error(Self->Error);
 
@@ -579,7 +502,7 @@ static void netsocket_incoming_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       log.traceBranch("Windows SSL handshake in progress, reading raw data.");
       size_t result;
       std::vector<uint8_t> buffer;
-      if (ERR error = WIN_APPEND(Self->Handle, buffer, 4096, result); error IS ERR::Okay) {
+      if (ERR error = network_platform().append_receive(Self->Handle, buffer, 4096, result); error IS ERR::Okay) {
          sslHandshakeReceived(Self, buffer.data(), int(buffer.size()));
 
          if ((Self->State != NTC::CONNECTED) or (!ssl_has_decrypted_data(Self->SSLHandle) and !ssl_has_encrypted_data(Self->SSLHandle))) {
@@ -659,11 +582,7 @@ restart:
       if (Self->Handle.is_valid()) {
          Self->CloseAfterWrite = true;
          Self->Incoming.clear();
-         #ifdef __linux__
-            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
-         #elif _WIN32
-            win_socketstate(Self->Handle, std::nullopt, true);
-         #endif
+         network_platform().register_write(Self->Handle, &netsocket_outgoing, Self);
       }
    }
    else if (Self->IncomingRecursion > 1) {
@@ -791,11 +710,7 @@ static void netsocket_outgoing_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
       if ((!Self->Outgoing.defined()) and (Self->WriteQueue.Buffer.empty())) {
          log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle.int_value());
-         #ifdef __linux__
-            RegisterFD(Self->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
-         #elif _WIN32
-            if (auto error = win_socketstate(Self->Handle, std::nullopt, false); error != ERR::Okay) log.warning(error);
-         #endif
+         if (auto error = network_platform().remove_write(Self->Handle); error != ERR::Okay) log.warning(error);
       }
 
       if (error != ERR::Okay) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -27,9 +27,6 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <unordered_set>
 #include <ctime>
 #include <type_traits>
-#ifdef __linux__
- #include <sys/resource.h>
-#endif
 
 #include <string.h>
 
@@ -37,6 +34,7 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <kotuku/modules/network.h>
 #include <kotuku/strings.hpp>
 
+#include "net_platform.h"
 #include "ssl_certificate_policy.h"
 
 #ifndef DISABLE_SSL
@@ -98,174 +96,7 @@ DEFINE_ENUM_FLAG_OPERATORS(SHS)
 //********************************************************************************************************************
 
 #ifdef _WIN32
-   #define INADDR_NONE 0xffffffff
-
-   #define SOCK_STREAM 1
-   #define SOCK_DGRAM 2
-
-   struct  hostent {
-      char	*h_name;
-      char	**h_aliases;
-      short h_addrtype;
-      short h_length;
-      char  **h_addr_list;
-   #define h_addr h_addr_list[0]
-   };
-
-   struct in_addr {
-      union {
-         struct { uint8_t s_b1,s_b2,s_b3,s_b4; } S_un_b;
-         struct { uint16_t s_w1,s_w2; } S_un_w;
-         uint32_t S_addr;
-      } S_un;
-   #define s_addr  S_un.S_addr
-   #define s_host  S_un.S_un_b.s_b2
-   #define s_net   S_un.S_un_b.s_b1
-   #define s_imp   S_un.S_un_w.s_w2
-   #define s_impno S_un.S_un_b.s_b4
-   #define s_lh    S_un.S_un_b.s_b3
-   };
-
-   struct sockaddr_in {
-      short    sin_family;
-      uint16_t sin_port;
-      struct in_addr sin_addr;
-      char   sin_zero[8];
-   };
-
-   struct addrinfo {
-     int    ai_flags;
-     int    ai_family;
-     int    ai_socktype;
-     int    ai_protocol;
-     size_t ai_addrlen;
-     char   *ai_canonname;
-     struct sockaddr *ai_addr;
-     struct addrinfo *ai_next;
-   };
-
-   struct in6_addr {
-      uint8_t s6_addr[16];   // IPv6 address
-   };
-
-   struct sockaddr_in6 {
-      short sin6_family;
-      uint16_t sin6_port;
-      uint32_t sin6_flowinfo;
-      struct in6_addr sin6_addr;
-      uint32_t sin6_scope_id;
-   };
-
-   struct sockaddr_storage {
-      short ss_family;
-      char __ss_pad1[6];
-      int64_t __ss_align;
-      char __ss_pad2[112];
-   };
-
-   constexpr uint32_t NOHANDLE = (uint32_t)(~0);
-   constexpr int SOCKET_ERROR = -1;
-   constexpr int AF_INET      = 2;
-   constexpr int AF_INET6     = 23;
-   constexpr int INADDR_ANY   = 0;
-   constexpr int MSG_PEEK     = 2;
-   constexpr int IPPROTO_IPV6 = 41;
-   constexpr int IPV6_V6ONLY  = 27;
-
-   // getaddrinfo constants
-   constexpr int AF_UNSPEC    = 0;
-   constexpr int AI_CANONNAME = 2;
-   constexpr int EAI_AGAIN    = 2;
-   constexpr int EAI_FAIL     = 3;
-   constexpr int EAI_MEMORY   = 4;
-   constexpr int EAI_SYSTEM   = 5;
-
-   // IPv6 constants
-   static const struct in6_addr in6addr_any = {{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
-
-   #define CLOSESOCKET(a) win_closesocket(a);
-#endif
-
-#ifdef __linux__
-   #include <arpa/inet.h>
-   #include <netdb.h>
-   #include <unistd.h>
-   #include <fcntl.h>
-   #include <sys/ioctl.h>
-   #include <errno.h>
-   #include <string.h>
-   #include <netinet/tcp.h>
-   #include <sys/socket.h>
-
-   #define NOHANDLE -1
-
-   static void CLOSESOCKET(SOCKET_HANDLE Handle) {
-      if (Handle IS NOHANDLE) return;
-
-      kt::Log log(__FUNCTION__);
-      log.traceBranch("Handle: %d", Handle);
-
-      // Perform graceful disconnect before closing
-
-      shutdown(Handle, SHUT_RDWR);
-
-      // Set a short timeout to allow pending data to be transmitted
-      struct timeval timeout;
-      timeout.tv_sec = 0;
-      timeout.tv_usec = 100000; // 100ms timeout
-      setsockopt(Handle, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout, sizeof(timeout));
-      setsockopt(Handle, SOL_SOCKET, SO_SNDTIMEO, (char*)&timeout, sizeof(timeout));
-
-      // Drain any remaining data in the receive buffer
-      char buffer[1024];
-      int bytes_received;
-      do {
-         bytes_received = recv(Handle, buffer, sizeof(buffer), 0);
-      } while (bytes_received > 0);
-
-      close(Handle);
-   }
-
-// For Linux, create a simple wrapper that behaves like an int but with methods
-class SocketHandle {
-private:
-   int socket_val;
-public:
-   SocketHandle() : socket_val(-1) {}
-   SocketHandle(int sock) : socket_val(sock) {}
-
-   operator int() const { return socket_val; }
-   operator bool() const { return socket_val != -1; }
-
-   int int_value() const { return socket_val; }
-   int hosthandle() const { return socket_val; }
-   int socket() const { return socket_val; }
-
-   bool is_valid() const { return socket_val != -1; }
-   bool is_invalid() const { return socket_val == -1; }
-
-   bool operator==(const SocketHandle& other) const { return socket_val == other.socket_val; }
-   bool operator!=(const SocketHandle& other) const { return socket_val != other.socket_val; }
-   bool operator==(int sock) const { return socket_val == sock; }
-   bool operator!=(int sock) const { return socket_val != sock; }
-
-   SocketHandle& operator=(int sock) { socket_val = sock; return *this; }
-};
-#elif _WIN32
    #include "win32/winsockwrappers.h"
-
-   #include <string.h>
-
-   #define htons win_htons
-   #define htonl win_htonl
-   #define ntohs win_ntohs
-   #define ntohl win_ntohl
-
-   // Forward declarations for getaddrinfo functions (available in ws2_32.lib)
-   extern "C" {
-      int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
-      void freeaddrinfo(struct addrinfo *res);
-   }
 #endif
 
 #ifdef __linux__
@@ -389,7 +220,7 @@ struct CaseInsensitiveHash {
 
 struct CaseInsensitiveEqual {
    bool operator()(const std::string& lhs, const std::string& rhs) const noexcept {
-      return ::strcasecmp(lhs.c_str(), rhs.c_str()) == 0;
+      return ::strcasecmp(lhs.c_str(), rhs.c_str()) IS 0;
    }
 };
 
@@ -397,11 +228,18 @@ typedef ankerl::unordered_dense::map<std::string, DNSEntry, CaseInsensitiveHash,
 
 //********************************************************************************************************************
 
+static std::unique_ptr<NetworkPlatform> glPlatform;
+
+NetworkPlatform & network_platform()
+{
+   return *glPlatform;
+}
+
+//********************************************************************************************************************
+
 static void CLOSESOCKET_THREADED(SocketHandle Handle)
 {
-#ifdef _WIN32
-   win_deregister_socket(Handle);
-#endif
+   network_platform().deregister_socket(Handle);
 
    {
       std::lock_guard<std::mutex> lock(glmThreads);
@@ -413,7 +251,7 @@ static void CLOSESOCKET_THREADED(SocketHandle Handle)
 
    std::lock_guard<std::mutex> lock(glmThreads);
    auto thread_ptr = std::make_shared<std::jthread>();
-   *thread_ptr = std::jthread([] (SocketHandle Handle) { CLOSESOCKET(Handle); }, Handle);
+   *thread_ptr = std::jthread([] (SocketHandle Handle) { network_platform().close_socket(Handle); }, Handle);
    glThreads.insert(thread_ptr);
 }
 
@@ -436,27 +274,15 @@ inline void setIPV6(IPAddress &IP, uint8_t *Address, uint16_t Port) {
 // Unified IP address conversion functions to eliminate platform-specific duplication
 
 static uint32_t unified_inet_addr(CSTRING Str) {
-#ifdef __linux__
-   return inet_addr(Str);
-#elif _WIN32
-   return win_inet_addr(Str);
-#endif
+   return network_platform().inet_addr(Str);
 }
 
 static int unified_inet_pton(int af, CSTRING src, void *dst) {
-#ifdef __linux__
-   return inet_pton(af, src, dst);
-#elif _WIN32
-   return win_inet_pton(af, src, dst);
-#endif
+   return network_platform().inet_pton(af, src, dst);
 }
 
 static CSTRING unified_inet_ntop(int af, const void *src, char *dst, size_t size) {
-#ifdef __linux__
-   return inet_ntop(af, src, dst, size);
-#elif _WIN32
-   return win_inet_ntop(af, src, dst, size);
-#endif
+   return network_platform().inet_ntop(af, src, dst, size);
 }
 
 //********************************************************************************************************************
@@ -549,6 +375,11 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
    argModule->get(FID_Root, glNetworkModule);
 
+   glPlatform = create_platform();
+   if (!glPlatform) return ERR::NoSupport;
+   if (auto error = glPlatform->initialise(argModule); error != ERR::Okay) return error;
+   glSocketLimit = glPlatform->socket_limit();
+
    if (init_netclient() != ERR::Okay) return ERR::AddClass;
    if (init_netsocket() != ERR::Okay) return ERR::AddClass;
    if (init_clientsocket() != ERR::Okay) return ERR::AddClass;
@@ -557,18 +388,6 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
    glResolveNameMsgID = (MSGID)AllocateID(IDTYPE::MESSAGE);
    glResolveAddrMsgID = (MSGID)AllocateID(IDTYPE::MESSAGE);
-
-#ifdef _WIN32
-   // Configure Winsock
-   {
-      CSTRING msg;
-      if ((msg = StartupWinsock()) != 0) {
-         log.warning("Winsock initialisation failed: %s", msg);
-         return ERR::SystemCall;
-      }
-      SetResourcePtr(RES::NET_PROCESSING, reinterpret_cast<APTR>(win_net_processing)); // Hooks into ProcessMessages()
-   }
-#endif
 
    auto recv_function = C_FUNCTION(resolve_name_receiver);
    recv_function.Context = CurrentTask();
@@ -580,13 +399,6 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
    if (AddMsgHandler(glResolveAddrMsgID, &recv_function, &glResolveAddrHandler) != ERR::Okay) {
       return ERR::Failed;
    }
-
-#ifdef __linux__
-   struct rlimit fd_limit;
-   if (getrlimit(RLIMIT_NOFILE, &fd_limit) == 0) {
-      glSocketLimit = fd_limit.rlim_cur * 0.8; // Set a threshold at 80% of the system limit
-   }
-#endif
 
    ResolvePath("system:config/ssl/", RSF::NO_FILE_CHECK, &glCertPath);
 
@@ -611,18 +423,10 @@ static ERR MODExpunge(void)
 
    cleanup_proxy_config();
 
-#ifdef _WIN32
-   SetResourcePtr(RES::NET_PROCESSING, nullptr);
-#endif
-
    if (glResolveNameHandler) { FreeResource(glResolveNameHandler); glResolveNameHandler = nullptr; }
    if (glResolveAddrHandler) { FreeResource(glResolveAddrHandler); glResolveAddrHandler = nullptr; }
 
-#ifdef _WIN32
-   log.msg("Closing winsock.");
-
-   if (ShutdownWinsock() != 0) log.warning("Warning: Winsock DLL Cleanup failed.");
-#endif
+   if (glPlatform) glPlatform->expunge();
 
    if (clNetClient)    { FreeResource(clNetClient); clNetClient = nullptr; }
    if (clNetSocket)    { FreeResource(clNetSocket); clNetSocket = nullptr; }
@@ -662,6 +466,8 @@ static ERR MODExpunge(void)
       glThreads.clear();
    }
 
+   glPlatform.reset();
+
    return ERR::Okay;
 }
 
@@ -697,17 +503,11 @@ CSTRING AddressToStr(IPAddress *Address)
    }
    else if (Address->Type IS IPADDR::V4) {
       struct in_addr addr;
-      addr.s_addr = htonl(Address->Data[0]);
+      addr.s_addr = network_platform().host_to_long(Address->Data[0]);
 
-      STRING result;
-      #ifdef __linux__
-         result = inet_ntoa(addr);
-      #elif _WIN32
-         result = win_inet_ntoa(addr.s_addr);
-      #endif
-
-      if (!result) return nullptr;
-      return kt::strclone(result);
+      char buffer[16];
+      auto result = network_platform().inet_ntop(AF_INET, &addr, buffer, sizeof(buffer));
+      return result ? kt::strclone(result) : nullptr;
    }
    else {
       log.warning("Unsupported address type: %d", int(Address->Type));
@@ -795,7 +595,7 @@ ERR StrToAddress(CSTRING Str, IPAddress *Address)
    if (result IS INADDR_NONE) return ERR::Failed;
 
    Address->Type = IPADDR::V4;
-   Address->Data[0] = ntohl(result);
+   Address->Data[0] = network_platform().long_to_host(result);
    Address->Data[1] = 0;
    Address->Data[2] = 0;
    Address->Data[3] = 0;
@@ -819,7 +619,7 @@ uint: The word in network byte order
 
 uint32_t HostToShort(uint32_t Value)
 {
-   return (uint32_t)htons((uint16_t)Value);
+   return uint32_t(network_platform().host_to_short(uint16_t(Value)));
 }
 
 /*********************************************************************************************************************
@@ -839,7 +639,7 @@ uint: The long in network byte order
 
 uint32_t HostToLong(uint32_t Value)
 {
-   return htonl(Value);
+   return network_platform().host_to_long(Value);
 }
 
 /*********************************************************************************************************************
@@ -859,7 +659,7 @@ uint: The Value in host byte order
 
 uint32_t ShortToHost(uint32_t Value)
 {
-   return (uint32_t)ntohs((uint16_t)Value);
+   return uint32_t(network_platform().short_to_host(uint16_t(Value)));
 }
 
 /*********************************************************************************************************************
@@ -879,7 +679,7 @@ uint: The Value in host byte order.
 
 uint32_t LongToHost(uint32_t Value)
 {
-   return ntohl(Value);
+   return network_platform().long_to_host(Value);
 }
 
 /*********************************************************************************************************************
@@ -1019,7 +819,7 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
                   auto read_callback = std::is_same<T, extNetSocket>::value ?
                      ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
                   ssl_suspend_write_queue(Self->Handle.hosthandle());
-                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, read_callback, Self);
+                  network_platform().register_read(Self->Handle, read_callback, Self);
                   return ERR::Busy;
                }
 
@@ -1049,28 +849,10 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
 #endif
 
    // Fallback to regular socket send
-#ifdef __linux__
-   auto result = send(Self->Handle, Buffer, *Length, 0);
-
-   if (result >= 0) {
-      *Length = result;
-      return ERR::Okay;
-   }
-   else {
-      *Length = 0;
-      if (errno IS EAGAIN) return ERR::BufferOverflow;
-      else if (errno IS EMSGSIZE) return ERR::DataSize;
-      else {
-         const int system_error = errno;
-         log.warning("send() failed: %s", strerror(system_error));
-         return convert_socket_error(system_error, ERR::Failed);
-      }
-   }
-#elif _WIN32
-   return WIN_SEND(Self->Handle, Buffer, Length, 0);
-#else
-   #error No support for send_data()
-#endif
+   size_t sent = *Length;
+   auto error = network_platform().send(Self->Handle, Buffer, sent);
+   *Length = sent;
+   return error;
 }
 
 //********************************************************************************************************************

--- a/src/network/win32/winsockwrappers.h
+++ b/src/network/win32/winsockwrappers.h
@@ -18,46 +18,6 @@ typedef unsigned int WSW_SOCKET; // Identical to the windows SOCKET type
 struct sockaddr;
 struct hostent;
 
-// Unified handle wrapper that eliminates the need for manual casting between
-// WSW_SOCKET and HOSTHANDLE when interfacing with the core system
-
-class SocketHandle {
-private:
-   WSW_SOCKET socket_val;
-
-public:
-   static constexpr WSW_SOCKET INVALID_SOCKET_VAL = static_cast<WSW_SOCKET>(~0);
-
-   // Constructors
-   SocketHandle() : socket_val(INVALID_SOCKET_VAL) {}
-   SocketHandle(WSW_SOCKET sock) : socket_val(sock) {}
-   SocketHandle(int sock) : socket_val(static_cast<WSW_SOCKET>(sock)) {}
-   SocketHandle(HOSTHANDLE handle) : socket_val(static_cast<WSW_SOCKET>(reinterpret_cast<uintptr_t>(handle))) {}
-
-   // Conversion operators for seamless integration
-   operator WSW_SOCKET() const { return socket_val; }
-   operator HOSTHANDLE() const { return reinterpret_cast<HOSTHANDLE>(static_cast<uintptr_t>(socket_val)); }
-   operator bool() const { return socket_val != INVALID_SOCKET_VAL; } // For boolean tests
-
-   // Explicit accessors for clarity when needed
-   WSW_SOCKET socket() const { return socket_val; }
-   HOSTHANDLE hosthandle() const { return reinterpret_cast<HOSTHANDLE>(static_cast<uintptr_t>(socket_val)); }
-   int int_value() const { return static_cast<int>(socket_val); } // For printf-style formatting with %d
-
-   // Comparison operators
-   bool operator==(const SocketHandle& other) const { return socket_val == other.socket_val; }
-   bool operator!=(const SocketHandle& other) const { return socket_val != other.socket_val; }
-   bool operator==(WSW_SOCKET sock) const { return socket_val == sock; }
-   bool operator!=(WSW_SOCKET sock) const { return socket_val != sock; }
-
-   // Validity check
-   bool is_valid() const { return socket_val != INVALID_SOCKET_VAL; }
-   bool is_invalid() const { return socket_val == INVALID_SOCKET_VAL; }
-
-   // Assignment operators
-   SocketHandle& operator=(WSW_SOCKET sock) { socket_val = sock; return *this; }
-   SocketHandle& operator=(int sock) { socket_val = static_cast<WSW_SOCKET>(sock); return *this; }
-};
 void win32_netresponse(struct Object *, WSW_SOCKET, int, ERR);
 void win_net_processing(int, void *);
 WSW_SOCKET win_accept(void *, WSW_SOCKET, sockaddr *, int *);


### PR DESCRIPTION
* Introduced net_platform.h consolidating cross-platform socket type definitions previously scattered across network.cpp, netsocket.cpp, and clientsocket.cpp
* Added net_windows.cpp and net_linux.cpp for platform-specific socket implementation code
* Updated CMakeLists.txt to conditionally compile net_windows.cpp or net_linux.cpp per platform
* Eliminated platform #ifdef blocks from network.cpp, netsocket.cpp, netsocket_functions.cpp, and clientsocket.cpp