### PR TITLE
[Network] Refine NetworkPlatform interface and migrate proxy and lookup code to platform files

### DIFF
--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -59,9 +59,7 @@ struct resolve_buffer {
 
 static ERR resolve_address(CSTRING, const IPAddress *, DNSEntry &);
 static ERR resolve_name(CSTRING, DNSEntry &);
-static ERR cache_host(HOSTMAP &, CSTRING, struct hostent *, DNSEntry &);
-static ERR convert_addrinfo(CSTRING, struct addrinfo *, DNSEntry &);
-static ERR cache_host(HOSTMAP &, CSTRING, struct addrinfo *, DNSEntry &);
+static ERR cache_host(HOSTMAP &, CSTRING, const HostLookupResult &, DNSEntry &);
 
 static std::vector<IPAddress> glNoAddresses;
 
@@ -470,97 +468,17 @@ static ERR GET_HostName(extNetLookup *Self, CSTRING *Value)
 
 //********************************************************************************************************************
 
-static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct hostent *Host, DNSEntry &Cache)
+static ERR cache_host(HOSTMAP &Store, CSTRING Key, const HostLookupResult &Result, DNSEntry &Cache)
 {
-   if (!Host) return ERR::NullArgs;
-
    if (!Key) {
-      if (!(Key = Host->h_name)) return ERR::Args;
-   }
-
-   kt::Log log(__FUNCTION__);
-
-   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->h_addr_list, (Host->h_addrtype IS AF_INET6));
-
-   if ((Host->h_addrtype != AF_INET) and (Host->h_addrtype != AF_INET6)) return ERR::Args;
-
-   DNSEntry cache;
-   if (!Host->h_name) cache.HostName = Key;
-   else cache.HostName = Host->h_name;
-
-   if (Host->h_addr_list) {
-      if (Host->h_addrtype IS AF_INET) {
-         for (unsigned i=0; Host->h_addr_list[i]; i++) {
-            auto addr = *((uint32_t *)Host->h_addr_list[i]);
-            cache.Addresses.push_back({ network_platform().long_to_host(addr), 0, 0, 0, IPADDR::V4 });
-         }
-      }
-      else if (Host->h_addrtype IS AF_INET6) {
-         for (unsigned i=0; Host->h_addr_list[i]; i++) {
-            auto addr = ((struct in6_addr **)Host->h_addr_list)[i];
-            IPAddress ip_address = { 0, 0, 0, 0, IPADDR::V6 };
-            kt::copymem(addr->s6_addr, ip_address.Data, 16);
-            cache.Addresses.push_back(ip_address);
-         }
-      }
-   }
-
-   {
-      std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
-      std::unique_lock<std::shared_mutex> lock(cache_mutex);
-      auto &entry = Store[Key];
-      entry = std::move(cache);
-      Cache = entry;
-   }
-   return ERR::Okay;
-}
-
-static ERR convert_addrinfo(CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
-{
-   if (!Host) return ERR::NullArgs;
-
-   if (!Key) {
-      if (!(Key = Host->ai_canonname)) return ERR::Args;
-   }
-
-   kt::Log log(__FUNCTION__);
-   log.detail("Key: %s, Addresses: %p (IPV6: %d)", Key, Host->ai_addr, (Host->ai_family IS AF_INET6));
-
-   DNSEntry cache;
-   if (!Host->ai_canonname) cache.HostName = Key;
-   else cache.HostName = Host->ai_canonname;
-
-   if ((Host->ai_family != AF_INET) and (Host->ai_family != AF_INET6)) return ERR::Args;
-
-   for (auto scan=Host; scan; scan=scan->ai_next) {
-      if (!scan->ai_addr) continue;
-
-      if (scan->ai_family IS AF_INET) {
-         auto addr = ((struct sockaddr_in *)scan->ai_addr)->sin_addr.s_addr;
-         cache.Addresses.push_back({ network_platform().long_to_host(addr), 0, 0, 0, IPADDR::V4 });
-      }
-      else if (scan->ai_family IS AF_INET6) {
-         auto addr = (struct sockaddr_in6 *)scan->ai_addr;
-         IPAddress ip_address = { 0, 0, 0, 0, IPADDR::V6 };
-         kt::copymem(addr->sin6_addr.s6_addr, ip_address.Data, 16);
-         cache.Addresses.push_back(ip_address);
-      }
-   }
-
-   Cache = std::move(cache);
-   return ERR::Okay;
-}
-
-static ERR cache_host(HOSTMAP &Store, CSTRING Key, struct addrinfo *Host, DNSEntry &Cache)
-{
-   if (!Host) return ERR::NullArgs;
-
-   if (!Key) {
-      if (!(Key = Host->ai_canonname)) return ERR::Args;
+      if (Result.HostName.empty()) return ERR::Args;
+      Key = Result.HostName.c_str();
    }
 
    DNSEntry cache;
-   if (auto error = convert_addrinfo(Key, Host, cache); error != ERR::Okay) return error;
+   if (Result.HostName.empty()) cache.HostName = Key;
+   else cache.HostName = Result.HostName;
+   cache.Addresses = Result.Addresses;
 
    {
       std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
@@ -584,52 +502,9 @@ static ERR resolve_address(CSTRING Address, const IPAddress *IP, DNSEntry &Info)
       }
    }
 
-#ifdef _WIN32
-   struct hostent *host = win_gethostbyaddr(IP);
-   if (!host) return ERR::Failed;
-   return cache_host(glAddresses, Address, host, Info);
-#else
-   char host_name[256], service[128];
-   int result;
-
-   if (IP->Type IS IPADDR::V4) {
-      const struct sockaddr_in sa = {
-         .sin_family = AF_INET,
-         .sin_port = 0,
-         .sin_addr = { .s_addr = IP->Data[0] }
-      };
-      result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service, sizeof(service), NI_NAMEREQD);
-   }
-   else {
-      struct sockaddr_in6 sa = {
-         .sin6_family   = AF_INET6,
-         .sin6_port     = 0,
-         .sin6_flowinfo = 0,
-         .sin6_scope_id = 0
-      };
-      kt::copymem(IP->Data, sa.sin6_addr.s6_addr, 16);
-      result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service, sizeof(service), NI_NAMEREQD);
-   }
-
-   switch(result) {
-      case 0: {
-         struct hostent host = {
-            .h_name      = host_name,
-            .h_addrtype  = (IP->Type IS IPADDR::V4) ? AF_INET : AF_INET6,
-            .h_length    = 0,
-            .h_addr_list = nullptr
-         };
-         return cache_host(glAddresses, Address, &host, Info);
-      }
-      case EAI_AGAIN:    return ERR::Retry;
-      case EAI_MEMORY:   return ERR::Memory;
-      case EAI_OVERFLOW: return ERR::BufferOverflow;
-      case EAI_SYSTEM:   return ERR::SystemCall;
-      default:           return ERR::Failed;
-   }
-
-   return ERR::Failed;
-#endif
+   HostLookupResult result;
+   if (auto error = network_platform().resolve_address(Address, *IP, result); error != ERR::Okay) return error;
+   return cache_host(glAddresses, Address, result, Info);
 }
 
 static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
@@ -645,34 +520,12 @@ static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
       }
    }
 
-   // Use getaddrinfo() on both Linux and Windows for proper IPv4 and IPv6 (AAAA record) support
-   struct addrinfo hints, *servinfo;
-
    kt::Log log(__FUNCTION__);
-   log.detail("Resolving hostname: %s using getaddrinfo", HostName);
+   log.detail("Resolving hostname: %s", HostName);
 
-   kt::clearmem(&hints, sizeof hints);
-   hints.ai_family   = AF_UNSPEC;     // Allow both IPv4 and IPv6
-   hints.ai_socktype = SOCK_STREAM;
-   hints.ai_flags    = AI_CANONNAME;
-   auto result = getaddrinfo(HostName, nullptr, &hints, &servinfo);
-
-   log.detail("getaddrinfo returned: %d", result);
-
-   switch (result) {
-      case 0: {
-         ERR error = cache_host(glHosts, HostName, servinfo, Info);
-         freeaddrinfo(servinfo);
-         return error;
-      }
-      case EAI_AGAIN:  return ERR::Retry;
-      case EAI_FAIL:   return ERR::Failed;
-      case EAI_MEMORY: return ERR::Memory;
-      case EAI_SYSTEM: return ERR::SystemCall;
-      default:         return ERR::Failed;
-   }
-
-   return ERR::Failed;
+   HostLookupResult result;
+   if (auto error = network_platform().resolve_name(HostName, result); error != ERR::Okay) return error;
+   return cache_host(glHosts, HostName, result, Info);
 }
 
 //********************************************************************************************************************

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -26,15 +26,7 @@ each entry the proxy database.  You may change existing values of any proxy and 
 
 #include <memory>
 #include <string_view>
-#include <optional>
 #include <unordered_map>
-#include <functional>
-#include <format>
-#include <array>
-
-#ifdef _WIN32
-#define HKEY_PROXY "\\HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\"
-#endif
 
 //********************************************************************************************************************
 // Global proxy configuration access.  Acquire glProxyMutex before using.
@@ -101,80 +93,6 @@ static bool parse_record_id(const std::string &GroupName, int &Record)
 
 //********************************************************************************************************************
 
-#ifdef _WIN32
-
-class WindowsProxyParser {
-public:
-   struct ProxyEntry {
-      std::string name;
-      std::string server;
-      int port;
-      int serverPort;
-      bool enabled;
-   };
-
-   static std::vector<ProxyEntry> parseProxyString(const std::string_view servers, const bool enabled) {
-      std::vector<ProxyEntry> entries;
-
-      static constexpr std::array<std::pair<std::string_view, int>, 3> protocolPorts = {{
-         {"ftp", 21}, {"http", 80}, {"https", 443}
-      }};
-
-      size_t pos = 0;
-      while (pos < servers.length()) {
-         auto entry = parseNextEntry(servers, pos, protocolPorts, enabled);
-         if (entry) entries.push_back(*entry);
-      }
-
-      return entries;
-   }
-
-private:
-   static std::optional<ProxyEntry> parseNextEntry(
-      const std::string_view servers, size_t& pos,
-      const std::array<std::pair<std::string_view, int>, 3>& protocolPorts,
-      const bool enabled) {
-
-      while (pos < servers.length() and servers[pos] == ';') ++pos;
-      if (pos >= servers.length()) return std::nullopt;
-
-      size_t start = pos;
-      while (pos < servers.length() and servers[pos] != ';') ++pos;
-
-      std::string entry(servers.substr(start, pos - start));
-
-      // Parse protocol=server:port format
-      auto equalPos = entry.find('=');
-      if (equalPos != std::string::npos) {
-         std::string protocol = entry.substr(0, equalPos);
-         std::string serverPart = entry.substr(equalPos + 1);
-
-         auto colonPos = serverPart.find(':');
-         if (colonPos != std::string::npos) {
-            std::string server = serverPart.substr(0, colonPos);
-            int serverPort = std::stoi(serverPart.substr(colonPos + 1));
-
-            auto it = std::find_if(protocolPorts.begin(), protocolPorts.end(),
-               [&protocol](const auto& pair) { return pair.first == protocol; });
-            if (it != protocolPorts.end()) {
-               return ProxyEntry{ std::format("Windows {}", protocol), server, it->second, serverPort, enabled };
-            }
-         }
-      }
-      else { // Global proxy format: server:port
-         auto colonPos = entry.find(':');
-         if (colonPos != std::string::npos) {
-            std::string server = entry.substr(0, colonPos);
-            int serverPort = std::stoi(entry.substr(colonPos + 1));
-            return ProxyEntry{ "Windows", server, 0, serverPort, enabled };
-         }
-      }
-
-      return std::nullopt;
-   }
-};
-#endif
-
 static void clear_values(extProxy *);
 static ERR get_record(extProxy *);
 
@@ -199,12 +117,6 @@ static ERR PROXY_DeleteRecord(extProxy *Self)
    if ((Self->GroupName.empty()) or (!Self->Record)) return log.error(ERR::Failed);
 
    log.branch();
-
-   if (Self->Host) {
-      #ifdef _WIN32
-      // Windows host proxy deletion logic would go here
-      #endif
-   }
 
    auto cfg = objConfig::create {fl::Path("user:config/network/proxies.cfg") };
    if (!cfg.ok()) return log.error(ERR::CreateObject);
@@ -286,55 +198,7 @@ static ERR PROXY_Find(extProxy *Self, struct prx::Find *Args)
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);
 
    if (auto config [[maybe_unused]] = get_proxy_config()) {
-      #ifdef _WIN32
-         // Remove existing host proxy settings
-         ConfigGroups *groups;
-         if (config->get(FID_Data, groups) IS ERR::Okay) {
-            std::vector<std::string> hostGroups;
-            for (const auto& [group, keys] : groups[0]) {
-               if (keys.contains("Host")) hostGroups.push_back(group);
-            }
-
-            for (const auto& group : hostGroups) {
-               config->deleteGroup(group.c_str());
-            }
-         }
-
-         // Process Windows proxy settings using modern parser
-         auto task = CurrentTask();
-         CSTRING value;
-         if (task->getEnv(HKEY_PROXY "ProxyEnable", &value) IS ERR::Okay) {
-            bool enabled = (strtol(value, nullptr, 0) > 0);
-
-            CSTRING servers;
-            if (task->getEnv(HKEY_PROXY "ProxyServer", &servers) IS ERR::Okay and servers[0]) {
-               log.msg("Host has defined default proxies: %s", servers);
-
-               auto proxyEntries = WindowsProxyParser::parseProxyString(servers, enabled);
-
-               int id = 0;
-               config->read("ID", "Value", id);
-
-               for (const auto& entry : proxyEntries) {
-                  ++id;
-                  config->write("ID", "Value", std::to_string(id));
-
-                  std::string group = std::to_string(id);
-                  config->write(group, "Name", entry.name);
-                  config->write(group, "Server", entry.server);
-                  config->write(group, "Port", std::to_string(entry.port));
-                  config->write(group, "ServerPort", std::to_string(entry.serverPort));
-                  config->write(group, "Enabled", std::to_string(entry.enabled ? 1 : 0));
-                  config->write(group, "Host", "1");
-
-                  log.trace("Added Windows proxy: %s -> %s:%d",
-                     entry.name, entry.server, entry.serverPort);
-               }
-            }
-         }
-         else log.msg("Host does not have proxies enabled (registry setting: %s)", HKEY_PROXY);
-
-      #endif
+      if (auto error = network_platform().sync_host_proxies(config); error != ERR::Okay) return log.warning(error);
 
       if (Args) {
          Self->FindPort = (Args->Port > 0) ? std::to_string(Args->Port) : "";
@@ -511,64 +375,7 @@ static ERR PROXY_SaveSettings(extProxy *Self)
    log.branch("Host: %d", Self->Host);
 
    if (Self->Host) {
-      #ifdef _WIN32
-         objTask *task = CurrentTask();
-
-         ERR error;
-         if (Self->Enabled) error = task->setEnv(HKEY_PROXY "ProxyEnable", "1");
-         else error = task->setEnv(HKEY_PROXY "ProxyEnable", "0");
-         if (error != ERR::Okay) return log.warning(error);
-
-         if ((!Self->Server) or (!Self->Server[0])) {
-            log.trace("Clearing proxy server value.");
-            if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", ""); error != ERR::Okay) return log.warning(error);
-         }
-         else if (Self->Port IS 0) { // Proxy is for all ports
-            std::string buffer = std::format("{}:{}", Self->Server, Self->ServerPort);
-            log.trace("Changing all-port proxy to: %s", buffer.c_str());
-            if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", buffer.c_str()); error != ERR::Okay) {
-               return log.warning(error);
-            }
-         }
-         else {
-            std::string portname;
-            switch(Self->Port) {
-               case 21: portname = "ftp"; break;
-               case 80: portname = "http"; break;
-               case 443: portname = "https"; break;
-            }
-
-            if (!portname.empty()) {
-               CSTRING servers;
-               task->getEnv(HKEY_PROXY "ProxyServer", &servers);
-               std::string serverList = servers ? servers : "";
-
-               // Remove existing entry for this protocol
-               const std::string searchPattern = std::format("{}=", portname);
-               if (auto pos = serverList.find(searchPattern); pos != std::string::npos) {
-                  auto endPos = serverList.find(';', pos);
-                  if (endPos IS std::string::npos) endPos = serverList.length();
-                  else ++endPos; // Include the semicolon
-                  serverList.erase(pos, endPos - pos);
-               }
-
-               // Add the new entry
-               const std::string newEntry = std::format("{}={}:{}", portname, Self->Server, Self->ServerPort);
-               if (!serverList.empty() and serverList.back() != ';') {
-                  serverList += ';';
-               }
-               serverList += newEntry;
-
-               if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", serverList.c_str()); error != ERR::Okay) {
-                  return log.warning(error);
-               }
-            }
-            else return log.error(ERR::NoSupport);
-         }
-
-      #endif
-
-      return ERR::Okay;
+      return network_platform().save_host_proxy(Self->Server, Self->ServerPort, Self->Port, Self->Enabled);
    }
 
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);

--- a/src/network/net_linux.cpp
+++ b/src/network/net_linux.cpp
@@ -5,7 +5,81 @@
 
 #include <array>
 #include <cstring>
+#include <strings.h>
 #include <sys/resource.h>
+
+static_assert(sizeof(struct sockaddr_storage) <= NETWORK_ENDPOINT_STORAGE_SIZE);
+
+static struct sockaddr_storage & endpoint_storage(NetworkEndpoint &Endpoint)
+{
+   return *(struct sockaddr_storage *)Endpoint.Storage;
+}
+
+static const struct sockaddr_storage & endpoint_storage(const NetworkEndpoint &Endpoint)
+{
+   return *(const struct sockaddr_storage *)Endpoint.Storage;
+}
+
+static bool same_text(CSTRING Left, CSTRING Right)
+{
+   if ((!Left) or (!Right)) return false;
+   return strcasecmp(Left, Right) IS 0;
+}
+
+static ERR endpoint_to_ip(const struct sockaddr_storage &Address, IPAddress &IP)
+{
+   kt::clearmem(&IP, sizeof(IP));
+
+   if (Address.ss_family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)&Address;
+      IP.Type = IPADDR::V4;
+      IP.Port = network_platform().short_to_host(addr->sin_port);
+      IP.Data[0] = network_platform().long_to_host(addr->sin_addr.s_addr);
+      return ERR::Okay;
+   }
+   else if (Address.ss_family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)&Address;
+      IP.Type = IPADDR::V6;
+      IP.Port = network_platform().short_to_host(addr->sin6_port);
+      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP.Data, 16);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+static ERR copy_accepted_ip(const struct sockaddr_storage &Address, int Family, uint8_t *IP)
+{
+   if (!IP) return ERR::NullArgs;
+
+   kt::clearmem(IP, 8);
+
+   if (Family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)&Address;
+      kt::copymem(&addr->sin_addr.s_addr, IP, 4);
+      return ERR::Okay;
+   }
+   else if (Family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)&Address;
+      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP, 8);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+static ERR convert_lookup_error(int Result)
+{
+   switch (Result) {
+      case 0: return ERR::Okay;
+      case EAI_AGAIN: return ERR::Retry;
+      case EAI_FAIL: return ERR::Failed;
+      case EAI_MEMORY: return ERR::Memory;
+      #ifdef EAI_OVERFLOW
+         case EAI_OVERFLOW: return ERR::BufferOverflow;
+      #endif
+      case EAI_SYSTEM: return ERR::SystemCall;
+      default: return ERR::Failed;
+   }
+}
 
 class LinuxNet : public NetworkPlatform {
 private:
@@ -68,6 +142,11 @@ public:
       return handle;
    }
 
+   SocketHandle socket_from_hosthandle(HOSTHANDLE Handle) override
+   {
+      return SocketHandle(SOCKET_HANDLE(Handle));
+   }
+
    void close_socket(SocketHandle Handle) override
    {
       if (Handle.is_invalid()) return;
@@ -101,9 +180,129 @@ public:
       return shutdown(Handle, How);
    }
 
-   ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   ERR build_address(const IPAddress &IP, int Port, bool IPv6, NetworkEndpoint &Endpoint) override
    {
-      int result = ::connect(Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+      kt::clearmem(&Endpoint, sizeof(Endpoint));
+      auto &storage = endpoint_storage(Endpoint);
+
+      if ((Port < 0) or (Port > 65535)) return ERR::OutOfRange;
+
+      if (IP.Type IS IPADDR::V6) {
+         if (!IPv6) return ERR::InvalidValue;
+
+         auto addr6 = (struct sockaddr_in6 *)&storage;
+         addr6->sin6_family = AF_INET6;
+         addr6->sin6_port = host_to_short(uint16_t(Port));
+         kt::copymem((CPTR)IP.Data, &addr6->sin6_addr.s6_addr, 16);
+
+         Endpoint.Size = sizeof(struct sockaddr_in6);
+         Endpoint.Family = AF_INET6;
+         Endpoint.Label = "IPv6";
+         return ERR::Okay;
+      }
+      else if (IP.Type IS IPADDR::V4) {
+         if (IPv6) {
+            auto addr6 = (struct sockaddr_in6 *)&storage;
+            uint32_t ipv4_net = host_to_long(IP.Data[0]);
+
+            addr6->sin6_family = AF_INET6;
+            addr6->sin6_port = host_to_short(uint16_t(Port));
+            addr6->sin6_addr.s6_addr[10] = 0xff;
+            addr6->sin6_addr.s6_addr[11] = 0xff;
+            kt::copymem(&ipv4_net, &addr6->sin6_addr.s6_addr[12], sizeof(ipv4_net));
+
+            Endpoint.Size = sizeof(struct sockaddr_in6);
+            Endpoint.Family = AF_INET6;
+            Endpoint.Label = "IPv4-mapped IPv6";
+            return ERR::Okay;
+         }
+         else {
+            auto addr4 = (struct sockaddr_in *)&storage;
+            addr4->sin_family = AF_INET;
+            addr4->sin_port = host_to_short(uint16_t(Port));
+            addr4->sin_addr.s_addr = host_to_long(IP.Data[0]);
+
+            Endpoint.Size = sizeof(struct sockaddr_in);
+            Endpoint.Family = AF_INET;
+            Endpoint.Label = "IPv4";
+            return ERR::Okay;
+         }
+      }
+      else return ERR::InvalidData;
+   }
+
+   ERR prepare_bind_address(CSTRING Address, int Port, bool IPv6, NetworkEndpoint &Endpoint) override
+   {
+      kt::clearmem(&Endpoint, sizeof(Endpoint));
+      auto &storage = endpoint_storage(Endpoint);
+
+      if ((Port < 0) or (Port > 65535)) return ERR::OutOfRange;
+
+      if (Address) {
+         IPAddress ip;
+         kt::clearmem(&ip, sizeof(ip));
+
+         if (same_text(Address, "localhost") or same_text(Address, "127.0.0.1")) {
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = 0x7f000001;
+         }
+         else if (same_text(Address, "::1")) {
+            ip.Type = IPADDR::V6;
+            ((uint8_t *)ip.Data)[15] = 1;
+         }
+         else if (same_text(Address, "::")) {
+            ip.Type = IPADDR::V6;
+         }
+         else if (same_text(Address, "0.0.0.0") or same_text(Address, "*") or same_text(Address, "")) {
+            ip.Type = IPADDR::V4;
+         }
+         else if (same_text(Address, "255.255.255.255")) {
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = 0xffffffff;
+         }
+         else if (strchr(Address, ':')) {
+            struct in6_addr ipv6_addr;
+            if (::inet_pton(AF_INET6, Address, &ipv6_addr) != 1) return ERR::InvalidValue;
+            ip.Type = IPADDR::V6;
+            kt::copymem(ipv6_addr.s6_addr, ip.Data, 16);
+         }
+         else {
+            uint32_t result = ::inet_addr(Address);
+            if (result IS INADDR_NONE) return ERR::InvalidValue;
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = long_to_host(result);
+         }
+
+         return build_address(ip, Port, IPv6, Endpoint);
+      }
+
+      if (IPv6) {
+         auto addr6 = (struct sockaddr_in6 *)&storage;
+         addr6->sin6_family = AF_INET6;
+         addr6->sin6_addr = in6addr_any;
+         addr6->sin6_port = host_to_short(uint16_t(Port));
+
+         Endpoint.Size = sizeof(struct sockaddr_in6);
+         Endpoint.Family = AF_INET6;
+         Endpoint.Label = "IPv6";
+      }
+      else {
+         auto addr4 = (struct sockaddr_in *)&storage;
+         addr4->sin_family = AF_INET;
+         addr4->sin_addr.s_addr = INADDR_ANY;
+         addr4->sin_port = host_to_short(uint16_t(Port));
+
+         Endpoint.Size = sizeof(struct sockaddr_in);
+         Endpoint.Family = AF_INET;
+         Endpoint.Label = "IPv4";
+      }
+
+      return ERR::Okay;
+   }
+
+   ERR connect(SocketHandle Handle, const NetworkEndpoint &Endpoint) override
+   {
+      int result = ::connect(Handle, (struct sockaddr *)&endpoint_storage(Endpoint), Endpoint.Size);
       if (result != -1) return ERR::Okay;
 
       if ((errno IS EINPROGRESS) or (errno IS EWOULDBLOCK) or (errno IS EAGAIN)) return ERR::Busy;
@@ -123,12 +322,12 @@ public:
       return result ? convert_socket_error(result) : ERR::Okay;
    }
 
-   ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   ERR bind(SocketHandle Handle, const NetworkEndpoint &Endpoint) override
    {
       int value = 1;
       setsockopt(Handle, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value));
 
-      if (::bind(Handle, (struct sockaddr *)&Endpoint.storage, Endpoint.size) IS -1) {
+      if (::bind(Handle, (struct sockaddr *)&endpoint_storage(Endpoint), Endpoint.Size) IS -1) {
          return convert_socket_error(errno);
       }
       return ERR::Okay;
@@ -140,28 +339,38 @@ public:
       return ERR::Okay;
    }
 
-   ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) override
+   ERR get_local_ip(SocketHandle Handle, IPAddress &Address) override
    {
-      socklen_t addr_length = sizeof(Address);
-      auto result = getsockname(Handle, (struct sockaddr *)&Address, &addr_length);
-      Length = int(addr_length);
-      return result ? convert_socket_error(errno) : ERR::Okay;
+      struct sockaddr_storage storage;
+      socklen_t addr_length = sizeof(storage);
+      auto result = getsockname(Handle, (struct sockaddr *)&storage, &addr_length);
+      if (result) return convert_socket_error(errno);
+      return endpoint_to_ip(storage, Address);
    }
 
-   SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) override
+   AcceptedSocket accept(void *Reference, SocketHandle Server, bool IPv6) override
    {
-      socklen_t len = sizeof(Address);
-      auto client = ::accept(Server, (struct sockaddr *)&Address, &len);
-      if (client IS -1) return SocketHandle();
+      AcceptedSocket accepted;
+      struct sockaddr_storage address;
+      socklen_t len = sizeof(address);
+      auto client = ::accept(Server, (struct sockaddr *)&address, &len);
+      if (client IS -1) return accepted;
 
-      Family = Address.ss_family;
+      accepted.Family = address.ss_family;
 
       int non_blocking = 1;
       ioctl(client, FIONBIO, &non_blocking);
 
       int nodelay = 1;
       setsockopt(client, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
-      return SocketHandle(client);
+      accepted.Handle = SocketHandle(client);
+
+      if (copy_accepted_ip(address, accepted.Family, accepted.IP) != ERR::Okay) {
+         close_socket(accepted.Handle);
+         accepted.Handle = SocketHandle();
+      }
+
+      return accepted;
    }
 
    void set_socket_reference(SocketHandle Handle, void *Reference) override
@@ -187,6 +396,11 @@ public:
    ERR register_write(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
    {
       return RegisterFD(Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, Callback, Data);
+   }
+
+   ERR remove_read(SocketHandle Handle) override
+   {
+      return RegisterFD(Handle.hosthandle(), RFD::REMOVE|RFD::READ|RFD::SOCKET, nullptr, nullptr);
    }
 
    ERR remove_write(SocketHandle Handle) override
@@ -218,6 +432,26 @@ public:
       else {
          return setsockopt(Handle, IPPROTO_IP, IP_MULTICAST_TTL, &TTL, sizeof(TTL)) ? ERR::SystemCall : ERR::Okay;
       }
+   }
+
+   ERR parse_multicast_group(CSTRING Group, bool &IPv6) override
+   {
+      if (!Group) return ERR::Args;
+
+      struct in6_addr addr6;
+      struct in_addr addr4;
+      kt::clearmem(&addr6, sizeof(addr6));
+      kt::clearmem(&addr4, sizeof(addr4));
+
+      if (::inet_pton(AF_INET6, Group, &addr6) IS 1) {
+         IPv6 = true;
+         return ERR::Okay;
+      }
+      else if (::inet_pton(AF_INET, Group, &addr4) IS 1) {
+         IPv6 = false;
+         return ERR::Okay;
+      }
+      else return ERR::Args;
    }
 
    ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
@@ -293,9 +527,10 @@ public:
       else return convert_socket_error(errno, ERR::Failed);
    }
 
-   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) override
+   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const NetworkEndpoint &Endpoint) override
    {
-      auto result = sendto(Handle, Buffer, Length, MSG_DONTWAIT, (sockaddr *)&Endpoint.storage, Endpoint.size);
+      auto result = sendto(Handle, Buffer, Length, MSG_DONTWAIT, (sockaddr *)&endpoint_storage(Endpoint),
+         Endpoint.Size);
       if (result >= 0) {
          Length = size_t(result);
          return ERR::Okay;
@@ -316,16 +551,16 @@ public:
    }
 
    ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
-      sockaddr_storage &SourceAddress, int &AddressLength) override
+      IPAddress &SourceAddress) override
    {
       BytesRead = 0;
-      socklen_t addr_len = sizeof(SourceAddress);
-      auto result = recvfrom(Handle, Buffer, BufferSize, MSG_DONTWAIT, (struct sockaddr *)&SourceAddress, &addr_len);
-      AddressLength = int(addr_len);
+      struct sockaddr_storage source_address;
+      socklen_t addr_len = sizeof(source_address);
+      auto result = recvfrom(Handle, Buffer, BufferSize, MSG_DONTWAIT, (struct sockaddr *)&source_address, &addr_len);
 
       if (result > 0) {
          BytesRead = size_t(result);
-         return ERR::Okay;
+         return endpoint_to_ip(source_address, SourceAddress);
       }
       else if (result IS 0) return ERR::Okay;
 
@@ -339,6 +574,88 @@ public:
          case EMSGSIZE: return ERR::BufferOverflow;
          default: return convert_socket_error(errno);
       }
+   }
+
+   ERR resolve_address(CSTRING Key, const IPAddress &Address, HostLookupResult &Result) override
+   {
+      char host_name[256];
+      char service[128];
+      int result;
+
+      if (Address.Type IS IPADDR::V4) {
+         struct sockaddr_in sa;
+         kt::clearmem(&sa, sizeof(sa));
+         sa.sin_family = AF_INET;
+         sa.sin_addr.s_addr = host_to_long(Address.Data[0]);
+         result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service,
+            sizeof(service), NI_NAMEREQD);
+      }
+      else {
+         struct sockaddr_in6 sa;
+         kt::clearmem(&sa, sizeof(sa));
+         sa.sin6_family = AF_INET6;
+         kt::copymem((CPTR)Address.Data, sa.sin6_addr.s6_addr, 16);
+         result = getnameinfo((struct sockaddr *)&sa, sizeof(sa), host_name, sizeof(host_name), service,
+            sizeof(service), NI_NAMEREQD);
+      }
+
+      if (result) return convert_lookup_error(result);
+
+      Result.HostName = host_name;
+      Result.Addresses.clear();
+      Result.Addresses.push_back(Address);
+      return ERR::Okay;
+   }
+
+   ERR resolve_name(CSTRING HostName, HostLookupResult &Result) override
+   {
+      struct addrinfo hints;
+      struct addrinfo *servinfo = nullptr;
+
+      kt::clearmem(&hints, sizeof(hints));
+      hints.ai_family = AF_UNSPEC;
+      hints.ai_socktype = SOCK_STREAM;
+      hints.ai_flags = AI_CANONNAME;
+
+      auto lookup_result = getaddrinfo(HostName, nullptr, &hints, &servinfo);
+      if (lookup_result) return convert_lookup_error(lookup_result);
+
+      if (servinfo->ai_canonname) Result.HostName = servinfo->ai_canonname;
+      else Result.HostName = HostName;
+      Result.Addresses.clear();
+
+      for (auto scan = servinfo; scan; scan = scan->ai_next) {
+         if (!scan->ai_addr) continue;
+
+         IPAddress ip_address;
+         kt::clearmem(&ip_address, sizeof(ip_address));
+
+         if (scan->ai_family IS AF_INET) {
+            auto addr = (struct sockaddr_in *)scan->ai_addr;
+            ip_address.Type = IPADDR::V4;
+            ip_address.Data[0] = long_to_host(addr->sin_addr.s_addr);
+            Result.Addresses.push_back(ip_address);
+         }
+         else if (scan->ai_family IS AF_INET6) {
+            auto addr = (struct sockaddr_in6 *)scan->ai_addr;
+            ip_address.Type = IPADDR::V6;
+            kt::copymem(addr->sin6_addr.s6_addr, ip_address.Data, 16);
+            Result.Addresses.push_back(ip_address);
+         }
+      }
+
+      freeaddrinfo(servinfo);
+      return ERR::Okay;
+   }
+
+   ERR sync_host_proxies(objConfig *Config) override
+   {
+      return ERR::Okay;
+   }
+
+   ERR save_host_proxy(CSTRING Server, int ServerPort, int Port, bool Enabled) override
+   {
+      return ERR::Okay;
    }
 
    uint32_t inet_addr(CSTRING Value) override

--- a/src/network/net_platform.h
+++ b/src/network/net_platform.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <kotuku/main.h>
@@ -97,10 +98,6 @@
 
    static const struct in6_addr in6addr_any = {{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
 
-   extern "C" {
-      int getaddrinfo(const char *Node, const char *Service, const struct addrinfo *Hints, struct addrinfo **Result);
-      void freeaddrinfo(struct addrinfo *Result);
-   }
 #else
    #include <arpa/inet.h>
    #include <netdb.h>
@@ -163,10 +160,24 @@ public:
 
 static constexpr SOCKET_HANDLE NOHANDLE = SocketHandle::INVALID_SOCKET_VAL;
 
-struct socket_endpoint {
-   struct sockaddr_storage storage;
-   int size = 0;
-   CSTRING label = nullptr;
+static constexpr size_t NETWORK_ENDPOINT_STORAGE_SIZE = 128;
+
+struct NetworkEndpoint {
+   alignas(uint64_t) uint8_t Storage[NETWORK_ENDPOINT_STORAGE_SIZE] = {};
+   int Size = 0;
+   int Family = 0;
+   CSTRING Label = nullptr;
+};
+
+struct AcceptedSocket {
+   SocketHandle Handle;
+   uint8_t IP[8] = {};
+   int Family = 0;
+};
+
+struct HostLookupResult {
+   std::string HostName;
+   std::vector<IPAddress> Addresses;
 };
 
 class NetworkPlatform {
@@ -178,38 +189,48 @@ public:
    virtual int socket_limit() const = 0;
 
    virtual SocketHandle create_socket(void *Reference, bool Read, bool Write, bool UDP, bool &IPv6) = 0;
+   virtual SocketHandle socket_from_hosthandle(HOSTHANDLE Handle) = 0;
    virtual void close_socket(SocketHandle Handle) = 0;
    virtual void deregister_socket(SocketHandle Handle) = 0;
    virtual int shutdown_socket(SocketHandle Handle, int How) = 0;
 
-   virtual ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) = 0;
+   virtual ERR build_address(const IPAddress &IP, int Port, bool IPv6, NetworkEndpoint &Endpoint) = 0;
+   virtual ERR prepare_bind_address(CSTRING Address, int Port, bool IPv6, NetworkEndpoint &Endpoint) = 0;
+   virtual ERR connect(SocketHandle Handle, const NetworkEndpoint &Endpoint) = 0;
    virtual ERR begin_connect_wait(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
    virtual ERR complete_connect(SocketHandle Handle) = 0;
-   virtual ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) = 0;
+   virtual ERR bind(SocketHandle Handle, const NetworkEndpoint &Endpoint) = 0;
    virtual ERR listen(SocketHandle Handle, int Backlog) = 0;
-   virtual ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) = 0;
-   virtual SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) = 0;
+   virtual ERR get_local_ip(SocketHandle Handle, IPAddress &Address) = 0;
+   virtual AcceptedSocket accept(void *Reference, SocketHandle Server, bool IPv6) = 0;
    virtual void set_socket_reference(SocketHandle Handle, void *Reference) = 0;
    virtual ERR set_non_blocking(SocketHandle Handle) = 0;
 
    virtual ERR register_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
    virtual ERR register_accept(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
    virtual ERR register_write(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
+   virtual ERR remove_read(SocketHandle Handle) = 0;
    virtual ERR remove_write(SocketHandle Handle) = 0;
    virtual ERR register_recall_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
    virtual ERR deregister_fd(SocketHandle Handle) = 0;
 
    virtual ERR enable_broadcast(SocketHandle Handle) = 0;
    virtual ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) = 0;
+   virtual ERR parse_multicast_group(CSTRING Group, bool &IPv6) = 0;
    virtual ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
    virtual ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
 
    virtual ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) = 0;
    virtual ERR append_receive(SocketHandle Handle, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received) = 0;
    virtual ERR send(SocketHandle Handle, CPTR Buffer, size_t &Length) = 0;
-   virtual ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) = 0;
+   virtual ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const NetworkEndpoint &Endpoint) = 0;
    virtual ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
-      sockaddr_storage &SourceAddress, int &AddressLength) = 0;
+      IPAddress &SourceAddress) = 0;
+
+   virtual ERR resolve_address(CSTRING Key, const IPAddress &Address, HostLookupResult &Result) = 0;
+   virtual ERR resolve_name(CSTRING HostName, HostLookupResult &Result) = 0;
+   virtual ERR sync_host_proxies(objConfig *Config) = 0;
+   virtual ERR save_host_proxy(CSTRING Server, int ServerPort, int Port, bool Enabled) = 0;
 
    virtual uint32_t inet_addr(CSTRING Value) = 0;
    virtual int inet_pton(int Family, CSTRING Source, APTR Dest) = 0;

--- a/src/network/net_windows.cpp
+++ b/src/network/net_windows.cpp
@@ -3,6 +3,166 @@
 #include "net_platform.h"
 #include "win32/winsockwrappers.h"
 
+#include <array>
+#include <charconv>
+#include <cstring>
+#include <format>
+#include <optional>
+#include <string_view>
+
+#define HKEY_PROXY "\\HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\"
+
+static_assert(sizeof(struct sockaddr_storage) <= NETWORK_ENDPOINT_STORAGE_SIZE);
+
+static struct sockaddr_storage & endpoint_storage(NetworkEndpoint &Endpoint)
+{
+   return *(struct sockaddr_storage *)Endpoint.Storage;
+}
+
+static const struct sockaddr_storage & endpoint_storage(const NetworkEndpoint &Endpoint)
+{
+   return *(const struct sockaddr_storage *)Endpoint.Storage;
+}
+
+static bool same_text(CSTRING Left, CSTRING Right)
+{
+   if ((!Left) or (!Right)) return false;
+   return _stricmp(Left, Right) IS 0;
+}
+
+static ERR endpoint_to_ip(const struct sockaddr_storage &Address, IPAddress &IP)
+{
+   kt::clearmem(&IP, sizeof(IP));
+
+   if (Address.ss_family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)&Address;
+      IP.Type = IPADDR::V4;
+      IP.Port = win_ntohs(addr->sin_port);
+      IP.Data[0] = win_ntohl(addr->sin_addr.s_addr);
+      return ERR::Okay;
+   }
+   else if (Address.ss_family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)&Address;
+      IP.Type = IPADDR::V6;
+      IP.Port = win_ntohs(addr->sin6_port);
+      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP.Data, 16);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+static ERR copy_accepted_ip(const struct sockaddr_storage &Address, int Family, uint8_t *IP)
+{
+   if (!IP) return ERR::NullArgs;
+
+   kt::clearmem(IP, 8);
+
+   if (Family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)&Address;
+      kt::copymem(&addr->sin_addr.s_addr, IP, 4);
+      return ERR::Okay;
+   }
+   else if (Family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)&Address;
+      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP, 8);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}
+
+static ERR convert_lookup_error(int Result)
+{
+   switch (Result) {
+      case 0: return ERR::Okay;
+      case EAI_AGAIN: return ERR::Retry;
+      case EAI_FAIL: return ERR::Failed;
+      case EAI_MEMORY: return ERR::Memory;
+      case EAI_SYSTEM: return ERR::SystemCall;
+      default: return ERR::Failed;
+   }
+}
+
+struct WindowsProxyEntry {
+   std::string Name;
+   std::string Server;
+   int Port = 0;
+   int ServerPort = 0;
+   bool Enabled = false;
+};
+
+static std::optional<int> parse_proxy_port(std::string_view Value)
+{
+   int port = 0;
+   auto result = std::from_chars(Value.data(), Value.data() + Value.size(), port);
+   if ((result.ec != std::errc()) or (result.ptr != Value.data() + Value.size())) return std::nullopt;
+   return port;
+}
+
+static std::optional<WindowsProxyEntry> parse_proxy_entry(std::string_view Entry, bool Enabled)
+{
+   static constexpr std::array<std::pair<std::string_view, int>, 3> protocol_ports = {{
+      {"ftp", 21}, {"http", 80}, {"https", 443}
+   }};
+
+   auto equal_pos = Entry.find('=');
+   if (equal_pos != std::string_view::npos) {
+      auto protocol = Entry.substr(0, equal_pos);
+      auto server_part = Entry.substr(equal_pos + 1);
+      auto colon_pos = server_part.find(':');
+      if (colon_pos IS std::string_view::npos) return std::nullopt;
+
+      auto port = parse_proxy_port(server_part.substr(colon_pos + 1));
+      if (!port) return std::nullopt;
+
+      for (const auto &protocol_port : protocol_ports) {
+         if (protocol_port.first IS protocol) {
+            return WindowsProxyEntry {
+               std::format("Windows {}", protocol),
+               std::string(server_part.substr(0, colon_pos)),
+               protocol_port.second,
+               *port,
+               Enabled
+            };
+         }
+      }
+   }
+   else {
+      auto colon_pos = Entry.find(':');
+      if (colon_pos IS std::string_view::npos) return std::nullopt;
+
+      auto port = parse_proxy_port(Entry.substr(colon_pos + 1));
+      if (!port) return std::nullopt;
+
+      return WindowsProxyEntry {
+         "Windows",
+         std::string(Entry.substr(0, colon_pos)),
+         0,
+         *port,
+         Enabled
+      };
+   }
+
+   return std::nullopt;
+}
+
+static std::vector<WindowsProxyEntry> parse_proxy_string(std::string_view Servers, bool Enabled)
+{
+   std::vector<WindowsProxyEntry> entries;
+
+   size_t pos = 0;
+   while (pos < Servers.length()) {
+      while ((pos < Servers.length()) and (Servers[pos] IS ';')) ++pos;
+      if (pos >= Servers.length()) break;
+
+      size_t start = pos;
+      while ((pos < Servers.length()) and (Servers[pos] != ';')) ++pos;
+
+      if (auto entry = parse_proxy_entry(Servers.substr(start, pos - start), Enabled)) entries.push_back(*entry);
+   }
+
+   return entries;
+}
+
 class WindowsNet : public NetworkPlatform {
 public:
    ERR initialise(OBJECTPTR Module) override
@@ -38,6 +198,11 @@ public:
       return SocketHandle(win_socket_ipv6(Reference, Read, Write, IPv6, UDP));
    }
 
+   SocketHandle socket_from_hosthandle(HOSTHANDLE Handle) override
+   {
+      return SocketHandle(Handle);
+   }
+
    void close_socket(SocketHandle Handle) override
    {
       win_closesocket(Handle.socket());
@@ -53,9 +218,129 @@ public:
       return win_shutdown(Handle.socket(), How);
    }
 
-   ERR connect(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   ERR build_address(const IPAddress &IP, int Port, bool IPv6, NetworkEndpoint &Endpoint) override
    {
-      return win_connect(Handle.socket(), (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+      kt::clearmem(&Endpoint, sizeof(Endpoint));
+      auto &storage = endpoint_storage(Endpoint);
+
+      if ((Port < 0) or (Port > 65535)) return ERR::OutOfRange;
+
+      if (IP.Type IS IPADDR::V6) {
+         if (!IPv6) return ERR::InvalidValue;
+
+         auto addr6 = (struct sockaddr_in6 *)&storage;
+         addr6->sin6_family = AF_INET6;
+         addr6->sin6_port = host_to_short(uint16_t(Port));
+         kt::copymem((CPTR)IP.Data, &addr6->sin6_addr.s6_addr, 16);
+
+         Endpoint.Size = sizeof(struct sockaddr_in6);
+         Endpoint.Family = AF_INET6;
+         Endpoint.Label = "IPv6";
+         return ERR::Okay;
+      }
+      else if (IP.Type IS IPADDR::V4) {
+         if (IPv6) {
+            auto addr6 = (struct sockaddr_in6 *)&storage;
+            uint32_t ipv4_net = host_to_long(IP.Data[0]);
+
+            addr6->sin6_family = AF_INET6;
+            addr6->sin6_port = host_to_short(uint16_t(Port));
+            addr6->sin6_addr.s6_addr[10] = 0xff;
+            addr6->sin6_addr.s6_addr[11] = 0xff;
+            kt::copymem(&ipv4_net, &addr6->sin6_addr.s6_addr[12], sizeof(ipv4_net));
+
+            Endpoint.Size = sizeof(struct sockaddr_in6);
+            Endpoint.Family = AF_INET6;
+            Endpoint.Label = "IPv4-mapped IPv6";
+            return ERR::Okay;
+         }
+         else {
+            auto addr4 = (struct sockaddr_in *)&storage;
+            addr4->sin_family = AF_INET;
+            addr4->sin_port = host_to_short(uint16_t(Port));
+            addr4->sin_addr.s_addr = host_to_long(IP.Data[0]);
+
+            Endpoint.Size = sizeof(struct sockaddr_in);
+            Endpoint.Family = AF_INET;
+            Endpoint.Label = "IPv4";
+            return ERR::Okay;
+         }
+      }
+      else return ERR::InvalidData;
+   }
+
+   ERR prepare_bind_address(CSTRING Address, int Port, bool IPv6, NetworkEndpoint &Endpoint) override
+   {
+      kt::clearmem(&Endpoint, sizeof(Endpoint));
+      auto &storage = endpoint_storage(Endpoint);
+
+      if ((Port < 0) or (Port > 65535)) return ERR::OutOfRange;
+
+      if (Address) {
+         IPAddress ip;
+         kt::clearmem(&ip, sizeof(ip));
+
+         if (same_text(Address, "localhost") or same_text(Address, "127.0.0.1")) {
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = 0x7f000001;
+         }
+         else if (same_text(Address, "::1")) {
+            ip.Type = IPADDR::V6;
+            ((uint8_t *)ip.Data)[15] = 1;
+         }
+         else if (same_text(Address, "::")) {
+            ip.Type = IPADDR::V6;
+         }
+         else if (same_text(Address, "0.0.0.0") or same_text(Address, "*") or same_text(Address, "")) {
+            ip.Type = IPADDR::V4;
+         }
+         else if (same_text(Address, "255.255.255.255")) {
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = 0xffffffff;
+         }
+         else if (strchr(Address, ':')) {
+            struct in6_addr ipv6_addr;
+            if (win_inet_pton(AF_INET6, Address, &ipv6_addr) != 1) return ERR::InvalidValue;
+            ip.Type = IPADDR::V6;
+            kt::copymem(ipv6_addr.s6_addr, ip.Data, 16);
+         }
+         else {
+            uint32_t result = win_inet_addr(Address);
+            if (result IS INADDR_NONE) return ERR::InvalidValue;
+            ip.Type = IPADDR::V4;
+            ip.Data[0] = win_ntohl(result);
+         }
+
+         return build_address(ip, Port, IPv6, Endpoint);
+      }
+
+      if (IPv6) {
+         auto addr6 = (struct sockaddr_in6 *)&storage;
+         addr6->sin6_family = AF_INET6;
+         addr6->sin6_addr = in6addr_any;
+         addr6->sin6_port = host_to_short(uint16_t(Port));
+
+         Endpoint.Size = sizeof(struct sockaddr_in6);
+         Endpoint.Family = AF_INET6;
+         Endpoint.Label = "IPv6";
+      }
+      else {
+         auto addr4 = (struct sockaddr_in *)&storage;
+         addr4->sin_family = AF_INET;
+         addr4->sin_addr.s_addr = INADDR_ANY;
+         addr4->sin_port = host_to_short(uint16_t(Port));
+
+         Endpoint.Size = sizeof(struct sockaddr_in);
+         Endpoint.Family = AF_INET;
+         Endpoint.Label = "IPv4";
+      }
+
+      return ERR::Okay;
+   }
+
+   ERR connect(SocketHandle Handle, const NetworkEndpoint &Endpoint) override
+   {
+      return win_connect(Handle.socket(), (struct sockaddr *)&endpoint_storage(Endpoint), Endpoint.Size);
    }
 
    ERR begin_connect_wait(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) override
@@ -68,9 +353,9 @@ public:
       return win_socket_connect_complete(Handle.socket());
    }
 
-   ERR bind(SocketHandle Handle, const socket_endpoint &Endpoint) override
+   ERR bind(SocketHandle Handle, const NetworkEndpoint &Endpoint) override
    {
-      return win_bind(Handle.socket(), (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+      return win_bind(Handle.socket(), (struct sockaddr *)&endpoint_storage(Endpoint), Endpoint.Size);
    }
 
    ERR listen(SocketHandle Handle, int Backlog) override
@@ -78,20 +363,36 @@ public:
       return win_listen(Handle.socket(), Backlog);
    }
 
-   ERR get_local_address(SocketHandle Handle, sockaddr_storage &Address, int &Length) override
+   ERR get_local_ip(SocketHandle Handle, IPAddress &Address) override
    {
-      Length = sizeof(Address);
-      int result = win_getsockname(Handle.socket(), (struct sockaddr *)&Address, &Length);
-      return result ? ERR::SystemCall : ERR::Okay;
+      struct sockaddr_storage storage;
+      int length = sizeof(storage);
+      int result = win_getsockname(Handle.socket(), (struct sockaddr *)&storage, &length);
+      if (result) return ERR::SystemCall;
+      return endpoint_to_ip(storage, Address);
    }
 
-   SocketHandle accept(void *Reference, SocketHandle Server, bool IPv6, sockaddr_storage &Address, int &Family) override
+   AcceptedSocket accept(void *Reference, SocketHandle Server, bool IPv6) override
    {
-      int len = sizeof(Address);
-      if (IPv6) return SocketHandle(win_accept_ipv6(Reference, Server.socket(), (struct sockaddr *)&Address, &len, &Family));
+      AcceptedSocket accepted;
+      struct sockaddr_storage address;
+      int len = sizeof(address);
 
-      Family = AF_INET;
-      return SocketHandle(win_accept(Reference, Server.socket(), (struct sockaddr *)&Address, &len));
+      if (IPv6) accepted.Handle = SocketHandle(win_accept_ipv6(Reference, Server.socket(), (struct sockaddr *)&address,
+         &len, &accepted.Family));
+      else {
+         accepted.Family = AF_INET;
+         accepted.Handle = SocketHandle(win_accept(Reference, Server.socket(), (struct sockaddr *)&address, &len));
+      }
+
+      if (accepted.Handle.is_valid()) {
+         if (copy_accepted_ip(address, accepted.Family, accepted.IP) != ERR::Okay) {
+            close_socket(accepted.Handle);
+            accepted.Handle = SocketHandle();
+         }
+      }
+
+      return accepted;
    }
 
    void set_socket_reference(SocketHandle Handle, void *Reference) override
@@ -119,6 +420,11 @@ public:
       return win_socketstate(Handle.socket(), std::nullopt, true);
    }
 
+   ERR remove_read(SocketHandle Handle) override
+   {
+      return win_socketstate(Handle.socket(), false, std::nullopt);
+   }
+
    ERR remove_write(SocketHandle Handle) override
    {
       return win_socketstate(Handle.socket(), std::nullopt, false);
@@ -142,6 +448,26 @@ public:
    ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) override
    {
       return win_set_multicast_ttl(Handle.socket(), TTL, IPv6);
+   }
+
+   ERR parse_multicast_group(CSTRING Group, bool &IPv6) override
+   {
+      if (!Group) return ERR::Args;
+
+      struct in6_addr addr6;
+      struct in_addr addr4;
+      kt::clearmem(&addr6, sizeof(addr6));
+      kt::clearmem(&addr4, sizeof(addr4));
+
+      if (win_inet_pton(AF_INET6, Group, &addr6) IS 1) {
+         IPv6 = true;
+         return ERR::Okay;
+      }
+      else if (win_inet_pton(AF_INET, Group, &addr4) IS 1) {
+         IPv6 = false;
+         return ERR::Okay;
+      }
+      else return ERR::Args;
    }
 
    ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
@@ -169,16 +495,204 @@ public:
       return WIN_SEND(Handle.socket(), Buffer, &Length, 0);
    }
 
-   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const socket_endpoint &Endpoint) override
+   ERR send_to(SocketHandle Handle, CPTR Buffer, size_t &Length, const NetworkEndpoint &Endpoint) override
    {
-      return WIN_SENDTO(Handle.socket(), Buffer, &Length, (struct sockaddr *)&Endpoint.storage, Endpoint.size);
+      return WIN_SENDTO(Handle.socket(), Buffer, &Length, (struct sockaddr *)&endpoint_storage(Endpoint),
+         Endpoint.Size);
    }
 
    ERR receive_from(SocketHandle Handle, APTR Buffer, size_t BufferSize, size_t &BytesRead,
-      sockaddr_storage &SourceAddress, int &AddressLength) override
+      IPAddress &SourceAddress) override
    {
-      return WIN_RECVFROM(Handle.socket(), Buffer, BufferSize, &BytesRead, (struct sockaddr *)&SourceAddress,
-         &AddressLength);
+      struct sockaddr_storage source_address;
+      int address_length = sizeof(source_address);
+      auto error = WIN_RECVFROM(Handle.socket(), Buffer, BufferSize, &BytesRead, (struct sockaddr *)&source_address,
+         &address_length);
+      if ((error IS ERR::Okay) and (BytesRead > 0)) return endpoint_to_ip(source_address, SourceAddress);
+      return error;
+   }
+
+   ERR resolve_address(CSTRING Key, const IPAddress &Address, HostLookupResult &Result) override
+   {
+      auto host = win_gethostbyaddr(&Address);
+      if (!host) return ERR::Failed;
+
+      Result.HostName = host->h_name ? host->h_name : Key;
+      Result.Addresses.clear();
+
+      if (host->h_addr_list) {
+         if (host->h_addrtype IS AF_INET) {
+            for (unsigned i = 0; host->h_addr_list[i]; ++i) {
+               auto addr = *((uint32_t *)host->h_addr_list[i]);
+               Result.Addresses.push_back({ win_ntohl(addr), 0, 0, 0, IPADDR::V4 });
+            }
+         }
+         else if (host->h_addrtype IS AF_INET6) {
+            for (unsigned i = 0; host->h_addr_list[i]; ++i) {
+               auto addr = ((struct in6_addr **)host->h_addr_list)[i];
+               IPAddress ip_address = { 0, 0, 0, 0, IPADDR::V6 };
+               kt::copymem(addr->s6_addr, ip_address.Data, 16);
+               Result.Addresses.push_back(ip_address);
+            }
+         }
+      }
+
+      if (Result.Addresses.empty()) Result.Addresses.push_back(Address);
+      return ERR::Okay;
+   }
+
+   ERR resolve_name(CSTRING HostName, HostLookupResult &Result) override
+   {
+      struct addrinfo hints;
+      struct addrinfo *servinfo = nullptr;
+
+      kt::clearmem(&hints, sizeof(hints));
+      hints.ai_family = AF_UNSPEC;
+      hints.ai_socktype = SOCK_STREAM;
+      hints.ai_flags = AI_CANONNAME;
+
+      auto lookup_result = win_getaddrinfo(HostName, nullptr, &hints, &servinfo);
+      if (lookup_result) return convert_lookup_error(lookup_result);
+
+      if (servinfo->ai_canonname) Result.HostName = servinfo->ai_canonname;
+      else Result.HostName = HostName;
+      Result.Addresses.clear();
+
+      for (auto scan = servinfo; scan; scan = scan->ai_next) {
+         if (!scan->ai_addr) continue;
+
+         IPAddress ip_address;
+         kt::clearmem(&ip_address, sizeof(ip_address));
+
+         if (scan->ai_family IS AF_INET) {
+            auto addr = (struct sockaddr_in *)scan->ai_addr;
+            ip_address.Type = IPADDR::V4;
+            ip_address.Data[0] = win_ntohl(addr->sin_addr.s_addr);
+            Result.Addresses.push_back(ip_address);
+         }
+         else if (scan->ai_family IS AF_INET6) {
+            auto addr = (struct sockaddr_in6 *)scan->ai_addr;
+            ip_address.Type = IPADDR::V6;
+            kt::copymem(addr->sin6_addr.s6_addr, ip_address.Data, 16);
+            Result.Addresses.push_back(ip_address);
+         }
+      }
+
+      win_freeaddrinfo(servinfo);
+      return ERR::Okay;
+   }
+
+   ERR sync_host_proxies(objConfig *Config) override
+   {
+      kt::Log log(__FUNCTION__);
+
+      if (!Config) return ERR::NullArgs;
+
+      ConfigGroups *groups;
+      if (Config->get(FID_Data, groups) IS ERR::Okay) {
+         std::vector<std::string> host_groups;
+         for (const auto &[group, keys] : groups[0]) {
+            if (keys.contains("Host")) host_groups.push_back(group);
+         }
+
+         for (const auto &group : host_groups) {
+            Config->deleteGroup(group.c_str());
+         }
+      }
+
+      auto task = CurrentTask();
+      CSTRING value;
+      if (task->getEnv(HKEY_PROXY "ProxyEnable", &value) != ERR::Okay) {
+         log.msg("Host does not have proxies enabled (registry setting: %s)", HKEY_PROXY);
+         return ERR::Okay;
+      }
+
+      bool enabled = (strtol(value, nullptr, 0) > 0);
+
+      CSTRING servers;
+      if ((task->getEnv(HKEY_PROXY "ProxyServer", &servers) IS ERR::Okay) and servers[0]) {
+         log.msg("Host has defined default proxies: %s", servers);
+
+         auto proxy_entries = parse_proxy_string(servers, enabled);
+
+         int id = 0;
+         Config->read("ID", "Value", id);
+
+         for (const auto &entry : proxy_entries) {
+            ++id;
+            Config->write("ID", "Value", std::to_string(id));
+
+            std::string group = std::to_string(id);
+            Config->write(group, "Name", entry.Name);
+            Config->write(group, "Server", entry.Server);
+            Config->write(group, "Port", std::to_string(entry.Port));
+            Config->write(group, "ServerPort", std::to_string(entry.ServerPort));
+            Config->write(group, "Enabled", std::to_string(entry.Enabled ? 1 : 0));
+            Config->write(group, "Host", "1");
+
+            log.trace("Added Windows proxy: %s -> %s:%d", entry.Name.c_str(), entry.Server.c_str(), entry.ServerPort);
+         }
+      }
+
+      return ERR::Okay;
+   }
+
+   ERR save_host_proxy(CSTRING Server, int ServerPort, int Port, bool Enabled) override
+   {
+      kt::Log log(__FUNCTION__);
+      objTask *task = CurrentTask();
+
+      ERR error;
+      if (Enabled) error = task->setEnv(HKEY_PROXY "ProxyEnable", "1");
+      else error = task->setEnv(HKEY_PROXY "ProxyEnable", "0");
+      if (error != ERR::Okay) return log.warning(error);
+
+      if ((!Server) or (!Server[0])) {
+         log.trace("Clearing proxy server value.");
+         if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", ""); error != ERR::Okay) return log.warning(error);
+      }
+      else if (Port IS 0) {
+         std::string buffer = std::format("{}:{}", Server, ServerPort);
+         log.trace("Changing all-port proxy to: %s", buffer.c_str());
+         if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", buffer.c_str()); error != ERR::Okay) {
+            return log.warning(error);
+         }
+      }
+      else {
+         std::string port_name;
+         switch(Port) {
+            case 21: port_name = "ftp"; break;
+            case 80: port_name = "http"; break;
+            case 443: port_name = "https"; break;
+         }
+
+         if (!port_name.empty()) {
+            CSTRING servers;
+            task->getEnv(HKEY_PROXY "ProxyServer", &servers);
+            std::string server_list = servers ? servers : "";
+
+            const std::string search_pattern = std::format("{}=", port_name);
+            if (auto pos = server_list.find(search_pattern); pos != std::string::npos) {
+               auto end_pos = server_list.find(';', pos);
+               if (end_pos IS std::string::npos) end_pos = server_list.length();
+               else ++end_pos;
+               server_list.erase(pos, end_pos - pos);
+            }
+
+            const std::string new_entry = std::format("{}={}:{}", port_name, Server, ServerPort);
+            if (!server_list.empty() and server_list.back() != ';') {
+               server_list += ';';
+            }
+            server_list += new_entry;
+
+            if (auto error = task->setEnv(HKEY_PROXY "ProxyServer", server_list.c_str()); error != ERR::Okay) {
+               return log.warning(error);
+            }
+         }
+         else return log.error(ERR::NoSupport);
+      }
+
+      return ERR::Okay;
    }
 
    uint32_t inet_addr(CSTRING Value) override

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -97,9 +97,7 @@ static CSTRING netsocket_state(NTC Value);
 // Implementation functions that take HOSTHANDLE
 static void netsocket_incoming_impl(HOSTHANDLE, extNetSocket *);
 static void netsocket_outgoing_impl(HOSTHANDLE, extNetSocket *);
-#ifdef __linux__
 static void netsocket_connect_impl(HOSTHANDLE, extNetSocket *);
-#endif
 static void server_accept_client_impl(HOSTHANDLE, extNetSocket *);
 static void server_incoming_from_client_impl(HOSTHANDLE, extClientSocket *);
 static void clientsocket_outgoing_impl(HOSTHANDLE, extClientSocket *);
@@ -112,14 +110,11 @@ static void netsocket_incoming(HOSTHANDLE FD, APTR Data) {
 static void netsocket_outgoing(HOSTHANDLE FD, APTR Data) {
    netsocket_outgoing_impl(FD, (extNetSocket *)Data);
 }
-#ifdef __linux__
+
 static void netsocket_connect(HOSTHANDLE FD, APTR Data) {
    netsocket_connect_impl(FD, (extNetSocket *)Data);
 }
-#else
-static void netsocket_connect(HOSTHANDLE FD, APTR Data) {
-}
-#endif
+
 static void server_accept_client(HOSTHANDLE FD, APTR Data) {
    server_accept_client_impl(FD, (extNetSocket *)Data);
 }
@@ -191,8 +186,7 @@ static void clear_connect_timer(extNetSocket *Socket)
    if (Socket->TimerHandle) { UpdateTimer(Socket->TimerHandle, 0); Socket->TimerHandle = 0; }
 }
 
-#ifdef _WIN32
-static void complete_win_connect(extNetSocket *Socket)
+static void complete_socket_connect(extNetSocket *Socket, ERR Result)
 {
    kt::Log log(__FUNCTION__);
 
@@ -201,19 +195,36 @@ static void complete_win_connect(extNetSocket *Socket)
       return;
    }
 
-   if (auto error = network_platform().complete_connect(Socket->Handle); error != ERR::Okay) log.warning(error);
+   network_platform().remove_write(Socket->Handle);
+
+   if (Result != ERR::Okay) {
+      log.trace("Connect completion result %d", int(Result));
+      clear_connect_timer(Socket);
+      Socket->Error = Result;
+      Socket->setState(NTC::DISCONNECTED);
+      return;
+   }
 
    Socket->Error = ERR::Okay;
    clear_connect_timer(Socket);
 
    #ifndef DISABLE_SSL
-      if (Socket->SSLHandle) sslConnect(Socket);
-      else Socket->setState(NTC::CONNECTED);
+      if (Socket->SSLHandle) {
+         sslConnect(Socket);
+         if (Socket->Error != ERR::Okay) return;
+         if (Socket->State IS NTC::HANDSHAKING) network_platform().register_read(Socket->Handle, &netsocket_incoming,
+            Socket);
+         return;
+      }
+      else {
+         Socket->setState(NTC::CONNECTED);
+         network_platform().register_read(Socket->Handle, &netsocket_incoming, Socket);
+      }
    #else
       Socket->setState(NTC::CONNECTED);
+      network_platform().register_read(Socket->Handle, &netsocket_incoming, Socket);
    #endif
 }
-#endif
 
 static ERR NETSOCKET_Connect(extNetSocket *Self, struct ns::Connect *Args)
 {
@@ -300,76 +311,24 @@ static const IPAddress *select_connect_address(extNetSocket *Socket, const std::
    else return &IPs[0];
 }
 
-static ERR build_socket_address(const IPAddress &IP, int Port, bool IPv6, socket_endpoint &Endpoint)
-{
-   kt::clearmem(&Endpoint.storage, sizeof(Endpoint.storage));
-
-   if ((Port < 0) or (Port > 65535)) return ERR::OutOfRange;
-
-   if (IP.Type IS IPADDR::V6) {
-      if (!IPv6) return ERR::InvalidValue;
-
-      auto addr6 = (struct sockaddr_in6 *)&Endpoint.storage;
-      addr6->sin6_family = AF_INET6;
-      addr6->sin6_port = network_platform().host_to_short(uint16_t(Port));
-      kt::copymem(IP.Data, &addr6->sin6_addr.s6_addr, 16);
-
-      Endpoint.size = sizeof(struct sockaddr_in6);
-      Endpoint.label = "IPv6";
-      return ERR::Okay;
-   }
-   else if (IP.Type IS IPADDR::V4) {
-      if (IPv6) {
-         auto addr6 = (struct sockaddr_in6 *)&Endpoint.storage;
-         uint32_t ipv4_net = network_platform().host_to_long(IP.Data[0]);
-
-         addr6->sin6_family = AF_INET6;
-         addr6->sin6_port = network_platform().host_to_short(uint16_t(Port));
-         addr6->sin6_addr.s6_addr[10] = 0xff;
-         addr6->sin6_addr.s6_addr[11] = 0xff;
-         kt::copymem(&ipv4_net, &addr6->sin6_addr.s6_addr[12], sizeof(ipv4_net));
-
-         Endpoint.size = sizeof(struct sockaddr_in6);
-         Endpoint.label = "IPv4-mapped IPv6";
-         return ERR::Okay;
-      }
-      else {
-         auto addr4 = (struct sockaddr_in *)&Endpoint.storage;
-         addr4->sin_family = AF_INET;
-         addr4->sin_port = network_platform().host_to_short(uint16_t(Port));
-         addr4->sin_addr.s_addr = network_platform().host_to_long(IP.Data[0]);
-
-         Endpoint.size = sizeof(struct sockaddr_in);
-         Endpoint.label = "IPv4";
-         return ERR::Okay;
-      }
-   }
-   else return ERR::InvalidData;
-}
-
-static ERR start_platform_connect(extNetSocket *Socket, const socket_endpoint &Endpoint)
+static ERR start_platform_connect(extNetSocket *Socket, const NetworkEndpoint &Endpoint)
 {
    kt::Log log(__FUNCTION__);
 
    auto connect_error = network_platform().connect(Socket->Handle, Endpoint);
 
    if (connect_error IS ERR::Busy) {
-      log.trace("%s connection in progress...", Endpoint.label);
+      log.trace("%s connection in progress...", Endpoint.Label);
       Socket->setState(NTC::CONNECTING);
       network_platform().begin_connect_wait(Socket->Handle, &netsocket_connect, Socket);
    }
    else if (connect_error IS ERR::Okay) {
-      log.trace("%s connect() successful.", Endpoint.label);
-      #ifdef _WIN32
-         complete_win_connect(Socket);
-      #else
-         Socket->setState(NTC::CONNECTED);
-         network_platform().register_read(Socket->Handle, &netsocket_incoming, Socket);
-      #endif
+      log.trace("%s connect() successful.", Endpoint.Label);
+      complete_socket_connect(Socket, network_platform().complete_connect(Socket->Handle));
    }
    else {
       Socket->Error = connect_error;
-      log.warning("%s connect() failed: %s", Endpoint.label, GetErrorMsg(Socket->Error));
+      log.warning("%s connect() failed: %s", Endpoint.Label, GetErrorMsg(Socket->Error));
       clear_connect_timer(Socket);
       Socket->setState(NTC::DISCONNECTED);
       return Socket->Error;
@@ -417,8 +376,8 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
       return;
    }
 
-   socket_endpoint endpoint;
-   if (auto error = build_socket_address(*addr, Socket->Port, Socket->IPV6, endpoint); error != ERR::Okay) {
+   NetworkEndpoint endpoint;
+   if (auto error = network_platform().build_address(*addr, Socket->Port, Socket->IPV6, endpoint); error != ERR::Okay) {
       Socket->Error = log.warning(error);
       Socket->setState(NTC::DISCONNECTED);
       return;
@@ -630,99 +589,12 @@ static ERR NETSOCKET_GetLocalIPAddress(extNetSocket *Self, struct ns::GetLocalIP
 
    if ((!Args) or (!Args->Address)) return log.warning(ERR::NullArgs);
 
-   struct sockaddr_storage addr_storage;
-   int addr_length = sizeof(addr_storage);
-   auto result = network_platform().get_local_address(Self->Handle, addr_storage, addr_length);
-
-   if (result IS ERR::Okay) {
-      if (addr_storage.ss_family IS AF_INET6) {
-         auto addr6 = (struct sockaddr_in6 *)&addr_storage;
-         kt::copymem(addr6->sin6_addr.s6_addr, Args->Address->Data, 16);
-         Args->Address->Type = IPADDR::V6;
-      }
-      else if (addr_storage.ss_family IS AF_INET) {
-         auto addr4 = (struct sockaddr_in *)&addr_storage;
-         Args->Address->Data[0] = net::LongToHost(addr4->sin_addr.s_addr);
-         Args->Address->Data[1] = 0;
-         Args->Address->Data[2] = 0;
-         Args->Address->Data[3] = 0;
-         Args->Address->Type = IPADDR::V4;
-      }
-      else {
-         log.warning("Unsupported address family: %d", addr_storage.ss_family);
-         return ERR::Failed;
-      }
-      return ERR::Okay;
-   }
+   auto result = network_platform().get_local_ip(Self->Handle, *Args->Address);
+   if (result IS ERR::Okay) return ERR::Okay;
    else return log.warning(result);
 }
 
-//********************************************************************************************************************
-// Parse a bind address string and convert it to the appropriate sockaddr structure
-
-static ERR parse_bind_address(CSTRING Address, bool IPv6, void *AddrOut)
-{
-   kt::Log log(__FUNCTION__);
-
-   if ((!Address) or (!AddrOut)) return log.warning(ERR::NullArgs);
-
-   IPAddress ip;
-   if (net::StrToAddress(Address, &ip) IS ERR::Okay) {
-      socket_endpoint endpoint;
-      if (auto error = build_socket_address(ip, 0, IPv6, endpoint); error != ERR::Okay) return log.warning(error);
-
-      if (IPv6) kt::copymem(&endpoint.storage, AddrOut, sizeof(struct sockaddr_in6));
-      else kt::copymem(&endpoint.storage, AddrOut, sizeof(struct sockaddr_in));
-
-      return ERR::Okay;
-   }
-   else {
-      // If not an IP address, could be a hostname - however we leave it up to the user to perform the
-      // name resolution in that case.
-      log.warning("Bind address '%s' is not an IP address.", Address);
-      return ERR::InvalidValue;
-   }
-}
-
-static ERR prepare_server_bind_address(extNetSocket *Self, socket_endpoint &Endpoint)
-{
-   kt::clearmem(&Endpoint.storage, sizeof(Endpoint.storage));
-
-   if (Self->IPV6) {
-      auto addr = (struct sockaddr_in6 *)&Endpoint.storage;
-
-      if (Self->Address) {
-         if (auto error = parse_bind_address(Self->Address, true, addr); error != ERR::Okay) return error;
-      }
-      else {
-         addr->sin6_family = AF_INET6;
-         addr->sin6_addr = in6addr_any;
-      }
-
-      addr->sin6_port = net::HostToShort(Self->Port);
-      Endpoint.size = sizeof(struct sockaddr_in6);
-      Endpoint.label = "IPv6";
-      return ERR::Okay;
-   }
-   else {
-      auto addr = (struct sockaddr_in *)&Endpoint.storage;
-
-      if (Self->Address) {
-         if (auto error = parse_bind_address(Self->Address, false, addr); error != ERR::Okay) return error;
-      }
-      else {
-         addr->sin_family = AF_INET;
-         addr->sin_addr.s_addr = INADDR_ANY;
-      }
-
-      addr->sin_port = net::HostToShort(Self->Port);
-      Endpoint.size = sizeof(struct sockaddr_in);
-      Endpoint.label = "IPv4";
-      return ERR::Okay;
-   }
-}
-
-static ERR activate_server_socket(extNetSocket *Self, const socket_endpoint &Endpoint)
+static ERR activate_server_socket(extNetSocket *Self, const NetworkEndpoint &Endpoint)
 {
    kt::Log log(__FUNCTION__);
 
@@ -752,8 +624,9 @@ static ERR setup_server_socket(extNetSocket *Self)
 
    Self->State = NTC::MULTISTATE; // Permanent value to indicate that the socket serves multiple clients.
 
-   socket_endpoint endpoint;
-   if (auto error = prepare_server_bind_address(Self, endpoint); error != ERR::Okay) return error;
+   NetworkEndpoint endpoint;
+   if (auto error = network_platform().prepare_bind_address(Self->Address, Self->Port, Self->IPV6, endpoint);
+      error != ERR::Okay) return error;
 
    return activate_server_socket(Self, endpoint);
 }
@@ -825,30 +698,6 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
 
 //********************************************************************************************************************
 
-struct multicast_group_address {
-   bool IsIPv6 = false;
-};
-
-static ERR parse_multicast_group(CSTRING Group, multicast_group_address &Address)
-{
-   if (!Group) return ERR::Args;
-
-   struct sockaddr_in addr4;
-   struct sockaddr_in6 addr6;
-   kt::clearmem(&addr4, sizeof(addr4));
-   kt::clearmem(&addr6, sizeof(addr6));
-
-   if (unified_inet_pton(AF_INET6, Group, &addr6.sin6_addr) IS 1) {
-      Address.IsIPv6 = true;
-      return ERR::Okay;
-   }
-   else if (unified_inet_pton(AF_INET, Group, &addr4.sin_addr) IS 1) {
-      Address.IsIPv6 = false;
-      return ERR::Okay;
-   }
-   else return ERR::Args;
-}
-
 /*********************************************************************************************************************
 
 -METHOD-
@@ -881,14 +730,14 @@ static ERR NETSOCKET_JoinMulticastGroup(extNetSocket *Self, struct ns::JoinMulti
 
    log.branch("%s", Args->Group);
 
-   multicast_group_address group_address;
-   if (parse_multicast_group(Args->Group, group_address) != ERR::Okay) {
+   bool group_ipv6 = false;
+   if (network_platform().parse_multicast_group(Args->Group, group_ipv6) != ERR::Okay) {
       log.warning("Invalid multicast address: %s", Args->Group);
       return ERR::Args;
    }
 
-   if (network_platform().join_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
-      if (group_address.IsIPv6) {
+   if (network_platform().join_multicast_group(Self->Handle, Args->Group, group_ipv6) != ERR::Okay) {
+      if (group_ipv6) {
          log.warning("Failed to join IPv6 multicast group");
       }
       else {
@@ -930,14 +779,14 @@ static ERR NETSOCKET_LeaveMulticastGroup(extNetSocket *Self, struct ns::LeaveMul
 
    log.branch("%s", Args->Group);
 
-   multicast_group_address group_address;
-   if (parse_multicast_group(Args->Group, group_address) != ERR::Okay) {
+   bool group_ipv6 = false;
+   if (network_platform().parse_multicast_group(Args->Group, group_ipv6) != ERR::Okay) {
       log.warning("Invalid multicast address: %s", Args->Group);
       return ERR::Args;
    }
 
-   if (network_platform().leave_multicast_group(Self->Handle, Args->Group, group_address.IsIPv6) != ERR::Okay) {
-      if (group_address.IsIPv6) {
+   if (network_platform().leave_multicast_group(Self->Handle, Args->Group, group_ipv6) != ERR::Okay) {
+      if (group_ipv6) {
          log.warning("Failed to leave IPv6 multicast group");
       }
       else {
@@ -1280,27 +1129,15 @@ static ERR NETSOCKET_RecvFrom(extNetSocket *Self, struct ns::RecvFrom *Args)
 
    Args->BytesRead = 0;
 
-   struct sockaddr_storage source_addr;
-   int addr_len = sizeof(source_addr);
    size_t bytes_read = 0;
+   IPAddress source_address;
 
-   auto error = network_platform().receive_from(Self->Handle, Args->Buffer, Args->BufferSize, bytes_read, source_addr,
-      addr_len);
+   auto error = network_platform().receive_from(Self->Handle, Args->Buffer, Args->BufferSize, bytes_read,
+      source_address);
    Args->BytesRead = int(bytes_read);
    if (error != ERR::Okay) return error;
 
-   if (Args->BytesRead > 0) {
-      // Populate IPAddress structure with source address and port
-      if (source_addr.ss_family IS AF_INET) {
-         auto addr4 = (sockaddr_in *)&source_addr;
-         setIPV4(*Args->Source, network_platform().long_to_host(addr4->sin_addr.s_addr),
-            network_platform().short_to_host(addr4->sin_port));
-      }
-      else if (source_addr.ss_family IS AF_INET6) {
-         auto addr6 = (sockaddr_in6 *)&source_addr;
-         setIPV6(*Args->Source, addr6->sin6_addr.s6_addr, network_platform().short_to_host(addr6->sin6_port));
-      }
-   }
+   if (Args->BytesRead > 0) *Args->Source = source_address;
 
    return ERR::Okay;
 }
@@ -1356,10 +1193,9 @@ static ERR NETSOCKET_SendTo(extNetSocket *Self, struct ns::SendTo *Args)
 
    Args->BytesSent = 0;
 
-   socket_endpoint dest_addr;
-   if (auto error = build_socket_address(*Args->Dest, Args->Dest->Port, Self->IPV6, dest_addr); error != ERR::Okay) {
-      return log.warning(error);
-   }
+   NetworkEndpoint dest_addr;
+   if (auto error = network_platform().build_address(*Args->Dest, Args->Dest->Port, Self->IPV6, dest_addr);
+      error != ERR::Okay) return log.warning(error);
 
    size_t bytes_to_send = Args->Length;
 

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -173,8 +173,6 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
       server_accept_client(Socket->Handle.hosthandle(), Socket);
    }
    else if (Message IS NTE_CONNECT) {
-      if (auto error = network_platform().complete_connect(SocketHandle(Handle)); error != ERR::Okay) log.warning(error);
-
       if (Error IS ERR::Okay) {
          if (ClientSocket) { // Server mode - connect message shouldn't be received for ClientSocket
             log.warning("Unexpected connect message for ClientSocket, ignoring.");
@@ -183,7 +181,7 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
          }
          else {
             log.traceBranch("Connection to host granted.");
-            complete_win_connect(Socket);
+            complete_socket_connect(Socket, network_platform().complete_connect(SocketHandle(Handle)));
          }
       }
       else {
@@ -201,35 +199,10 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
 #endif
 
 //********************************************************************************************************************
-// Called when a server socket handle detects a new client wanting to connect to it.
-// Used by Win32 (Windows message loop) & Linux (FD hook)
-
-static ERR sockaddr_to_client_ip(const struct sockaddr *Address, int Family, uint8_t *IP)
-{
-   if ((!Address) or (!IP)) return ERR::NullArgs;
-
-   kt::clearmem(IP, 8);
-
-   if (Family IS AF_INET) {
-      auto addr = (const struct sockaddr_in *)Address;
-      kt::copymem(&addr->sin_addr.s_addr, IP, 4);
-      return ERR::Okay;
-   }
-   else if (Family IS AF_INET6) {
-      auto addr = (const struct sockaddr_in6 *)Address;
-      kt::copymem(addr->sin6_addr.s6_addr, IP, 8);
-      return ERR::Okay;
-   }
-   else return ERR::Args;
-}
-
-//********************************************************************************************************************
 
 static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    kt::Log log(__FUNCTION__);
-   uint8_t ip[8];
-   SocketHandle clientfd;
 
    log.traceBranch("NetSocket: #%d, FD: %" PRId64, Self->UID, int64_t(SocketFD));
 
@@ -259,27 +232,20 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       }
    }
 
-   struct sockaddr_storage addr_storage;
-   int family = AF_INET;
-   clientfd = network_platform().accept(Self, Self->Handle, Self->IPV6, addr_storage, family);
+   auto accepted = network_platform().accept(Self, Self->Handle, Self->IPV6);
+   auto clientfd = accepted.Handle;
    if (clientfd.is_invalid()) {
       log.warning("accept() failed to return an FD.");
       return;
    }
 
-   if ((family != AF_INET) and (family != AF_INET6)) {
-      log.warning("Unsupported address family: %d", family);
+   if ((accepted.Family != AF_INET) and (accepted.Family != AF_INET6)) {
+      log.warning("Unsupported address family: %d", accepted.Family);
       network_platform().close_socket(clientfd);
       return;
    }
 
-   if (auto error = sockaddr_to_client_ip((struct sockaddr *)&addr_storage, family, ip); error != ERR::Okay) {
-      log.warning(error);
-      network_platform().close_socket(clientfd);
-      return;
-   }
-
-   if (family IS AF_INET6) log.trace("Accepted IPv6 client connection");
+   if (accepted.Family IS AF_INET6) log.trace("Accepted IPv6 client connection");
    else if (Self->IPV6) log.trace("Accepted IPv4 client connection on dual-stack socket");
 
    // Check if this IP address already has a client structure from an earlier socket connection.
@@ -287,7 +253,7 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
    objNetClient *client_ip;
    for (client_ip=Self->Clients; client_ip; client_ip=client_ip->Next) {
-      if (((int64_t *)&ip)[0] IS ((int64_t *)&client_ip->IP)[0]) break;
+      if (((int64_t *)&accepted.IP)[0] IS ((int64_t *)&client_ip->IP)[0]) break;
    }
 
    if (!client_ip) {
@@ -303,7 +269,7 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
          return;
       }
 
-      ((int64_t *)&client_ip->IP)[0] = ((int64_t *)&ip)[0];
+      ((int64_t *)&client_ip->IP)[0] = ((int64_t *)&accepted.IP)[0];
       client_ip->TotalConnections = 0;
       Self->TotalClients++;
 
@@ -414,7 +380,6 @@ static void free_client(extNetSocket *Socket, objNetClient *Client)
 //********************************************************************************************************************
 // See win32_netresponse() for the Windows version.
 
-#ifdef __linux__
 static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    kt::Log log(__FUNCTION__);
@@ -424,49 +389,8 @@ static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
    log.trace("Connection from server received.");
 
    auto result = network_platform().complete_connect(Self->Handle);
-
-   // Remove the write callback
-
-   network_platform().remove_write(Self->Handle);
-
-   #ifndef DISABLE_SSL
-   if ((Self->SSLHandle) and (result IS ERR::Okay)) {
-      // Perform the SSL handshake
-
-      log.traceBranch("Attempting SSL handshake.");
-
-      sslConnect(Self);
-      if (Self->Error != ERR::Okay) return;
-
-      if (Self->State IS NTC::HANDSHAKING) {
-         network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
-      }
-      return;
-   }
-   #endif
-
-   if (result IS ERR::Okay) {
-      log.traceBranch("Connection succesful.");
-
-      if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
-
-      Self->setState(NTC::CONNECTED);
-      network_platform().register_read(Self->Handle, &netsocket_incoming, Self);
-      return;
-   }
-   else {
-      log.trace("Connect completion result %d", int(result));
-
-      if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
-
-      Self->Error = result;
-
-      log.error(Self->Error);
-
-      Self->setState(NTC::DISCONNECTED);
-   }
+   complete_socket_connect(Self, result);
 }
-#endif
 
 //********************************************************************************************************************
 // If the socket is the client of a server, messages from the server will come in through here.

--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -40,14 +40,14 @@ template <class T> void ssl_handshake_read(SocketHandle Socket, T *Self) {
 
 static void ssl_suspend_write_queue(HOSTHANDLE SocketFD)
 {
-   RegisterFD(SocketFD, RFD::WRITE|RFD::REMOVE|RFD::SOCKET, nullptr, nullptr);
+   network_platform().remove_write(network_platform().socket_from_hosthandle(SocketFD));
 }
 
 template <class T> void ssl_resume_write_handshake(HOSTHANDLE SocketFD, T *Self)
 {
    auto write_callback = std::is_same<T, extNetSocket>::value ?
       ssl_handshake_write_netsocket : ssl_handshake_write_clientsocket;
-   RegisterFD(SocketFD, RFD::WRITE|RFD::SOCKET, write_callback, Self);
+   network_platform().register_write(network_platform().socket_from_hosthandle(SocketFD), write_callback, Self);
 }
 
 template <class T> void ssl_resume_write_queue(HOSTHANDLE SocketFD, T *Self)
@@ -63,7 +63,7 @@ template <class T> void ssl_resume_write_queue(HOSTHANDLE SocketFD, T *Self)
    }
 
    auto outgoing_callback = std::is_same<T, extNetSocket>::value ? netsocket_outgoing : clientsocket_outgoing;
-   RegisterFD(SocketFD, RFD::WRITE|RFD::SOCKET, outgoing_callback, Self);
+   network_platform().register_write(network_platform().socket_from_hosthandle(SocketFD), outgoing_callback, Self);
 }
 
 static bool ssl_has_buffered_read_data(SSL *SSLHandle)
@@ -621,7 +621,7 @@ static ERR sslConnect(extNetSocket *Self)
 template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self)
 {
    kt::Log log(__FUNCTION__);
-   SocketHandle Socket(SocketFD);
+   auto Socket = network_platform().socket_from_hosthandle(SocketFD);
 
    log.trace("Socket: %" PF64, (MAXINT)SocketFD);
 
@@ -632,15 +632,15 @@ template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self)
 
    ssl_clear_error_queue();
    if (auto result = SSL_do_handshake(Self->SSLHandle); result IS 1) { // Handshake successful, connection established
-      RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::REMOVE|RFD::SOCKET, write_callback, Self);
+      network_platform().remove_write(Socket);
       Self->HandshakeStatus = SHS::NIL;
       ssl_resume_write_queue(Socket.hosthandle(), Self);
    }
    else switch (auto ssl_error = SSL_get_error(Self->SSLHandle, result)) {
       case SSL_ERROR_WANT_READ:
-         RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::REMOVE|RFD::SOCKET, write_callback, Self);
+         network_platform().remove_write(Socket);
          Self->HandshakeStatus = SHS::READ;
-         RegisterFD(Socket.hosthandle(), RFD::READ|RFD::SOCKET, read_callback, Self);
+         network_platform().register_read(Socket, read_callback, Self);
          break;
 
       case SSL_ERROR_WANT_WRITE:
@@ -657,7 +657,7 @@ template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self)
 template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self)
 {
    kt::Log log(__FUNCTION__);
-   SocketHandle Socket(SocketFD);
+   auto Socket = network_platform().socket_from_hosthandle(SocketFD);
 
    log.trace("Socket: %" PF64, (MAXINT)SocketFD);
 
@@ -668,7 +668,7 @@ template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self)
 
    ssl_clear_error_queue();
    if (auto result = SSL_do_handshake(Self->SSLHandle); result IS 1) { // Handshake successful, connection established
-      RegisterFD(Socket.hosthandle(), RFD::READ|RFD::REMOVE|RFD::SOCKET, read_callback, Self);
+      network_platform().remove_read(Socket);
       Self->HandshakeStatus = SHS::NIL;
       ssl_resume_write_queue(Socket.hosthandle(), Self);
    }
@@ -678,9 +678,9 @@ template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self)
          break;
 
       case SSL_ERROR_WANT_WRITE:
-         RegisterFD(Socket.hosthandle(), RFD::READ|RFD::REMOVE|RFD::SOCKET, read_callback, Self);
+         network_platform().remove_read(Socket);
          Self->HandshakeStatus = SHS::WRITE;
-         RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::SOCKET, write_callback, Self);
+         network_platform().register_write(Socket, write_callback, Self);
          break;
 
       default:

--- a/src/network/win32/winsockwrappers.cpp
+++ b/src/network/win32/winsockwrappers.cpp
@@ -96,6 +96,16 @@ struct hostent * win_gethostbyaddr(const struct IPAddress *Address)
    else return gethostbyaddr((const char *)&Address->Data, 16, AF_INET6);
 }
 
+int win_getaddrinfo(const char *Node, const char *Service, const struct addrinfo *Hints, struct addrinfo **Result)
+{
+   return getaddrinfo(Node, Service, Hints, Result);
+}
+
+void win_freeaddrinfo(struct addrinfo *Result)
+{
+   freeaddrinfo(Result);
+}
+
 //********************************************************************************************************************
 
 static LRESULT CALLBACK win_messages(HWND window, UINT msgcode, WPARAM wParam, LPARAM lParam)

--- a/src/network/win32/winsockwrappers.h
+++ b/src/network/win32/winsockwrappers.h
@@ -17,6 +17,7 @@ struct socket_info;
 typedef unsigned int WSW_SOCKET; // Identical to the windows SOCKET type
 struct sockaddr;
 struct hostent;
+struct addrinfo;
 
 void win32_netresponse(struct Object *, WSW_SOCKET, int, ERR);
 void win_net_processing(int, void *);
@@ -27,6 +28,8 @@ void win_deregister_socket(WSW_SOCKET);
 ERR win_connect(WSW_SOCKET, const sockaddr *, int);
 hostent * win_gethostbyaddr(const IPAddress *);
 hostent * win_gethostbyname(const char *);
+int win_getaddrinfo(const char *, const char *, const addrinfo *, addrinfo **);
+void win_freeaddrinfo(addrinfo *);
 int win_getpeername(WSW_SOCKET, sockaddr *, int *);
 int win_getsockname(WSW_SOCKET, sockaddr *, int *);
 uint32_t win_inet_addr(const char *);


### PR DESCRIPTION
## Summary

- Renamed `socket_endpoint` to `NetworkEndpoint` with aligned storage, explicit `Family` field, and upper-camel-case members
- Added `AcceptedSocket` and `HostLookupResult` value types, removing raw `sockaddr_storage` and `hostent` usage at call sites
- Extended the `NetworkPlatform` virtual interface with `build_address()`, `prepare_bind_address()`, `get_local_ip()`, and `socket_from_hosthandle()`
- Migrated Windows proxy parsing from `class_proxy.cpp` into `net_windows.cpp`
- Simplified `class_netlookup.cpp` `cache_host()` to consume `HostLookupResult` instead of raw `hostent` and `addrinfo` structs

## Test plan

- [ ] Build the `network` module on Windows and Linux to confirm both `net_windows.cpp` and `net_linux.cpp` compile cleanly
- [ ] Run network integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L network`
- [ ] Verify DNS resolution via `NetLookup` works correctly
- [ ] Verify proxy settings are read correctly on Windows
- [ ] Confirm NetSocket connect/bind/accept paths function end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)