### PR TITLE
[Tiri] Refactor delayedCall to use a module-level message handler

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -29,6 +29,7 @@ template <class T> T ALIGN32(T a) { return (((a) + 3) & (~3)); }
 
 extern CSTRING const glBytecodeNames[];
 extern bool glPrintMsg;
+extern MSGID glDelayedCallMsgID;
 
 //********************************************************************************************************************
 
@@ -452,6 +453,7 @@ void make_struct_serial_array(lua_State *, std::string_view, int, CPTR);
 void notify_action(OBJECTPTR, ACTIONID, ERR, APTR);
 void process_error(objScript *, CSTRING);
 ERR push_object_id(lua_State *, OBJECTID ObjectID);
+extern ERR delayed_msg_handler(APTR Meta, int MsgID, int MsgType, APTR Message, int MsgSize);
 extern int object_index(lua_State *);
 extern int object_newindex(lua_State *);
 struct fstruct * push_struct(objScript *, APTR, std::string_view, bool, bool);

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -71,6 +71,8 @@ ankerl::unordered_dense::map<struct_name, struct_record, struct_hash> glStructs;
 std::shared_mutex glConstantMutex;
 
 static struct MsgHandler *glMsgThread = nullptr; // Message handler for thread callbacks
+static MsgHandler *glDelayedCallHandle = nullptr;
+MSGID glDelayedCallMsgID = MSGID::NIL;
 
 constexpr auto HASH_TRACE_TOKENS         = kt::strhash("trace-tokens");
 constexpr auto HASH_TRACE_EXPECT         = kt::strhash("trace-expect");
@@ -211,6 +213,12 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
 
    ActionList(&glActions, nullptr); // Get the global action table from the Core
 
+   glDelayedCallMsgID = MSGID(AllocateID(IDTYPE::MESSAGE));
+   auto func = C_FUNCTION(delayed_msg_handler, nullptr);
+   if (auto error = AddMsgHandler(glDelayedCallMsgID, &func, &glDelayedCallHandle); error != ERR::Okay) {
+      return ERR::Function;
+   }
+
    // Create a lookup table for converting named actions to IDs.
 
    for (int action_id=1; glActions[action_id].Name; action_id++) {
@@ -284,6 +292,7 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
 
 static ERR MODExpunge(void)
 {
+   if (glDelayedCallHandle) { FreeResource(glDelayedCallHandle); glDelayedCallHandle = nullptr; }
    if (glMsgThread) { FreeResource(glMsgThread); glMsgThread = nullptr; }
    if (clTiri)      { FreeResource(clTiri); clTiri = nullptr; }
    if (modDisplay)  { FreeResource(modDisplay); modDisplay = nullptr; }

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -214,7 +214,7 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
    ActionList(&glActions, nullptr); // Get the global action table from the Core
 
    glDelayedCallMsgID = MSGID(AllocateID(IDTYPE::MESSAGE));
-   auto func = C_FUNCTION(delayed_msg_handler, nullptr);
+   auto func = C_FUNCTION(delayed_msg_handler);
    if (auto error = AddMsgHandler(glDelayedCallMsgID, &func, &glDelayedCallHandle); error != ERR::Okay) {
       return ERR::Function;
    }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -386,18 +386,22 @@ static int processing_get(lua_State *Lua)
 //
 // Usage: processing.delayedCall(function() ... end)
 
-static MsgHandler *delayed_call_handle;
+struct delay_msg {
+   lua_State *lua;
+   int ref;
+};
 
-static ERR msg_handler(APTR Meta, int MsgID, int MsgType, APTR Message, int MsgSize)
+ERR delayed_msg_handler(APTR Meta, int MsgID, int MsgType, APTR Message, int MsgSize)
 {
-   if (MsgSize != sizeof(int)) return kt::Log(__FUNCTION__).warning(ERR::Args);
+   if (MsgSize != sizeof(delay_msg)) return kt::Log(__FUNCTION__).warning(ERR::Args);
 
-   auto lua = (lua_State *)Meta;
-   auto prv = (prvTiri *)lua->script->ChildPrivate;
-   int ref = *(int *)Message;
-   lua_rawgeti(lua, LUA_REGISTRYINDEX, ref); // Get the function from the registry
-   luaL_unref(lua, LUA_REGISTRYINDEX, ref); // Remove it
-   if (lua_pcall(prv->Lua, 0, 0, 0)) {
+   auto msg = (delay_msg *)Message;
+   auto lua = msg->lua;
+   lua_rawgeti(lua, LUA_REGISTRYINDEX, msg->ref); // Get the function from the registry
+   luaL_unref(lua, LUA_REGISTRYINDEX, msg->ref); // Remove it
+
+   kt::SwitchContext ctx(lua->script);
+   if (lua_pcall(lua, 0, 0, 0)) {
       process_error(lua->script, "delayedCall()");
    }
    return ERR::Okay;
@@ -405,19 +409,10 @@ static ERR msg_handler(APTR Meta, int MsgID, int MsgType, APTR Message, int MsgS
 
 static int processing_delayed_call(lua_State *Lua)
 {
-   static MSGID msgid = MSGID::NIL;
-   if (msgid IS MSGID::NIL) {
-      msgid = MSGID(AllocateID(IDTYPE::MESSAGE));
-      auto func = C_FUNCTION(msg_handler, Lua);
-      if (auto error = AddMsgHandler(msgid, &func, &delayed_call_handle); error != ERR::Okay) {
-         luaL_error(Lua, error);
-      }
-   }
-
    if (lua_type(Lua, 1) IS LUA_TFUNCTION) {
-      int ref = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      if (SendMessage(msgid, MSF::NIL, &ref, sizeof(ref)) != ERR::Okay) {
-         luaL_unref(Lua, LUA_REGISTRYINDEX, ref);
+      delay_msg msg = { Lua, luaL_ref(Lua, LUA_REGISTRYINDEX) };
+      if (SendMessage(glDelayedCallMsgID, MSF::NIL, &msg, sizeof(msg)) != ERR::Okay) {
+         luaL_unref(Lua, LUA_REGISTRYINDEX, msg.ref);
          luaL_error(Lua, ERR::MessageOperation);
       }
    }


### PR DESCRIPTION
## Summary

- Moved the `delayedCall` message handler registration from a lazy static inside `processing_delayed_call()` to `MODInit`/`MODExpunge`, giving it proper module lifecycle management and avoiding first-call race conditions
- Changed the message payload from a raw `int` ref to a `delay_msg` struct that carries both the `lua_State*` and the registry ref, eliminating the fragile use of the handler's `Meta` pointer to pass the Lua state
- Added `kt::SwitchContext` in `delayed_msg_handler` so the correct object context is active when the deferred Lua function executes

## Test plan

- [ ] Build the Tiri module and verify it compiles cleanly
- [ ] Run existing Tiri integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri`
- [ ] Manually verify `processing.delayedCall(function() ... end)` dispatches and executes the callback correctly
- [ ] Confirm module unload (MODExpunge) frees the handler without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)