### PR TITLE
[HTTP] Fix null UserAgent dereference, add GET_UserAgent getter, and tag virtual fields

### DIFF
--- a/docs/xml/modules/classes/netclient.xml
+++ b/docs/xml/modules/classes/netclient.xml
@@ -41,8 +41,8 @@
     <field>
       <name>IP</name>
       <comment>The IP address of the client.</comment>
-      <access read="R">Read</access>
-      <type>INT8 []</type>
+      <access read="G">Get</access>
+      <type>APTR</type>
     </field>
 
     <field>

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -691,3 +691,4 @@ extern uint32_t LongToHost(uint32_t Value);
 extern ERR SetSSL(objNetSocket *NetSocket, CSTRING Command, CSTRING Value);
 } // namespace
 #endif // KOTUKU_STATIC
+

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -1826,6 +1826,9 @@ ERR NewObject(CLASSID ClassID, NF Flags, OBJECTPTR *Object)
       new (head) class Object; // Class constructors aren't expected to initialise the Object header, we do it for them
       kt::clearmem(head + 1, mc->Size - sizeof(class Object));
 
+      // NB: Clients are not permitted to make allocations that pass through AllocMemory() in NewPlacement due to
+      // the object context not yet being established.  Such allocations must be deferred to the NewObject hook.
+
       ERR error = ERR::Okay;
       if ((mc->Base) and (mc->Base->ActionTable[int(AC::NewPlacement)].PerformAction)) {
          error = mc->Base->ActionTable[int(AC::NewPlacement)].PerformAction(head, nullptr);

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -583,7 +583,7 @@ static ERR HTTP_Activate(extHTTP *Self)
 
       cmd << "CONNECT " << Self->Host << ":" << Self->Port << " HTTP/1.1" << CRLF;
       cmd << "Host: " << Self->Host << CRLF;
-      cmd << "User-Agent: " << Self->UserAgent << CRLF;
+      cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
       cmd << "Proxy-Connection: keep-alive" << CRLF;
       cmd << "Connection: keep-alive" << CRLF;
 
@@ -644,7 +644,7 @@ static ERR HTTP_Activate(extHTTP *Self)
          if ((!Self->Path) or ((Self->Path[0] IS '*') and (!Self->Path[1]))) {
             cmd << "OPTIONS * HTTP/1.1" << CRLF;
             cmd << "Host: " << Self->Host << CRLF;
-            cmd << "User-Agent: " << Self->UserAgent << CRLF;
+            cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
          }
          else set_http_method(Self, "OPTIONS", cmd);
       }
@@ -1027,9 +1027,9 @@ static ERR HTTP_Init(extHTTP *Self)
 
 static ERR HTTP_NewPlacement(extHTTP *Self)
 {
+   // Note: No local object allocations are permitted due to lack of context.  Use a NewObject hook if necessary
    new (Self) extHTTP;
    Self->Error          = ERR::Okay;
-   Self->UserAgent      = kt::strclone("Kotuku Client");
    Self->DataTimeout    = 5.0;
    Self->ConnectTimeout = 10.0;
    Self->Datatype       = DATA::RAW;
@@ -1093,7 +1093,7 @@ static const FieldArray clFields[] = {
    { "Path",           FDF_STRING|FDF_RW, nullptr, SET_Path },
    { "OutputFile",     FDF_STRING|FDF_RW, nullptr, SET_OutputFile },
    { "InputFile",      FDF_STRING|FDF_RW, nullptr, SET_InputFile },
-   { "UserAgent",      FDF_STRING|FDF_RW, nullptr, SET_UserAgent },
+   { "UserAgent",      FDF_STRING|FDF_RW, GET_UserAgent, SET_UserAgent },
    { "InputObject",    FDF_OBJECTID|FDF_RW },
    { "OutputObject",   FDF_OBJECTID|FDF_RW },
    { "Method",         FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SET_Method, &clHTTPMethod },
@@ -1108,19 +1108,19 @@ static const FieldArray clFields[] = {
    { "ProxyPort",      FDF_INT|FDF_RW },
    { "BufferSize",     FDF_INT|FDF_RW, nullptr, SET_BufferSize },
    // Virtual fields
-   { "AuthCallback",   FDF_FUNCTIONPTR|FDF_RW,   GET_AuthCallback, SET_AuthCallback },
-   { "ContentType",    FDF_STRING|FDF_RW,        GET_ContentType, SET_ContentType },
-   { "Incoming",       FDF_FUNCTIONPTR|FDF_RW,   GET_Incoming, SET_Incoming },
-   { "Location",       FDF_STRING|FDF_RW,        GET_Location, SET_Location },
-   { "Outgoing",       FDF_FUNCTIONPTR|FDF_RW,   GET_Outgoing, SET_Outgoing },
-   { "Realm",          FDF_STRING|FDF_RW,        GET_Realm, SET_Realm },
-   { "RecvBuffer",     FDF_ARRAY|FDF_BYTE|FDF_R, GET_RecvBuffer },
-   { "ResponseKeys",   FDF_ARRAY|FDF_STRING|FDF_ALLOC|FDF_R, GET_ResponseKeys },
-   { "Src",            FDF_STRING|FDF_SYNONYM|FD_PRIVATE|FDF_RW, GET_Location, SET_Location }, // Deprecated by URL
-   { "URL",            FDF_STRING|FDF_SYNONYM|FDF_RW, GET_Location, SET_Location },
-   { "StateChanged",   FDF_FUNCTIONPTR|FDF_RW,   GET_StateChanged, SET_StateChanged },
-   { "Username",       FDF_STRING|FDF_W,         nullptr, SET_Username },
-   { "Password",       FDF_STRING|FDF_W,         nullptr, SET_Password },
+   { "AuthCallback",   FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_AuthCallback, SET_AuthCallback },
+   { "ContentType",    FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_ContentType, SET_ContentType },
+   { "Incoming",       FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_Incoming, SET_Incoming },
+   { "Location",       FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_Location, SET_Location },
+   { "Outgoing",       FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_Outgoing, SET_Outgoing },
+   { "Realm",          FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_Realm, SET_Realm },
+   { "RecvBuffer",     FDF_VIRTUAL|FDF_ARRAY|FDF_BYTE|FDF_R, GET_RecvBuffer },
+   { "ResponseKeys",   FDF_VIRTUAL|FDF_ARRAY|FDF_STRING|FDF_ALLOC|FDF_R, GET_ResponseKeys },
+   { "Src",            FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FD_PRIVATE|FDF_RW, GET_Location, SET_Location }, // Deprecated by URL
+   { "URL",            FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FDF_RW, GET_Location, SET_Location },
+   { "StateChanged",   FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_StateChanged, SET_StateChanged },
+   { "Username",       FDF_VIRTUAL|FDF_STRING|FDF_W,         nullptr, SET_Username },
+   { "Password",       FDF_VIRTUAL|FDF_STRING|FDF_W,         nullptr, SET_Password },
    END_FIELD
 };
 

--- a/src/http/http_fields.cpp
+++ b/src/http/http_fields.cpp
@@ -740,6 +740,13 @@ This field describes the `user-agent` value that will be sent in HTTP requests. 
 
 *********************************************************************************************************************/
 
+static ERR GET_UserAgent(extHTTP *Self, CSTRING *Value)
+{
+   if (Self->UserAgent) *Value = Self->UserAgent;
+   else *Value = "Kotuku Client";
+   return ERR::Okay;
+}
+
 static ERR SET_UserAgent(extHTTP *Self, CSTRING Value)
 {
    if (Self->UserAgent) { FreeResource(Self->UserAgent); Self->UserAgent = nullptr; }

--- a/src/http/http_functions.cpp
+++ b/src/http/http_functions.cpp
@@ -538,7 +538,7 @@ static void set_http_method(extHTTP *Self, CSTRING Method, std::ostringstream &C
    else Cmd << Method << " /" << (Self->Path ? Self->Path : (STRING)"") << " HTTP/1.1" << CRLF;
 
    Cmd << "Host: " << Self->Host << CRLF;
-   Cmd << "User-Agent: " << Self->UserAgent << CRLF;
+   Cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
 }
 
 //********************************************************************************************************************

--- a/src/http/tests/test_concurrent.tiri
+++ b/src/http/tests/test_concurrent.tiri
@@ -74,25 +74,25 @@ end
 @Test function ParallelRequests()
    results = {}
    completed = 0
-   total_req = 5
+   TOTAL_REQ <const> = 10
    wait_http = nil
 
-   for i = 0, total_req-1 do
+   for i = 0, TOTAL_REQ-1 do
       results[i] = {}
       results[i].http = obj.new('http', {
-         src    = 'http://127.0.0.1:' .. SERVER_PORT .. '/api/parallel/' .. i,
+         src    = f'http://127.0.0.1:{SERVER_PORT}/api/parallel/{i}',
          method = 'GET',
          flags  = HTF_NO_HEAD,
          incoming = function(HTTP, Buffer)
             if not results[i].data then results[i].data = '' end
             results[i].data ..= Buffer:getString()
-            print('Received: ' .. results[i].data)
+            print(f'Received: {#results[i].data} bytes')
          end,
          stateChanged = function(HTTP, State)
             if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
                completed++
-               print('Completed ' .. completed .. ' of ' .. total_req)
-               if completed >= total_req then
+               print(f'Completed {completed} of {TOTAL_REQ}')
+               if completed >= TOTAL_REQ then
                   wait_http.acSignal()
                end
             end
@@ -103,22 +103,23 @@ end
 
    proc = processing.new({ timeout = 5.0, signals = array<object> { wait_http } })
 
-   for i = 0, total_req-1 do
+   for i = 0, TOTAL_REQ-1 do
       assert(results[i].http.acActivate() is ERR_Okay, "Parallel request " .. i .. " failed to activate")
    end
 
+   print('Sleeping...')
    check proc.sleep()
 
-   assert(completed is total_req, 'Not all parallel requests completed: ' .. completed .. '/' .. total_req)
+   assert(completed is TOTAL_REQ, 'Not all parallel requests completed: ' .. completed .. '/' .. TOTAL_REQ)
 
    -- Verify all responses
-   for i = 0, total_req-1 do
+   for i = 0, TOTAL_REQ-1 do
       assert(results[i].data, 'No response for request ' .. i)
       response = json.decode(results[i].data)
       assert(response.requestId is tostring(i), 'Request ID mismatch for request ' .. i)
    end
 
-   print('Parallel requests test passed: ' .. total_req .. ' concurrent requests')
+   print('Parallel requests test passed: ' .. TOTAL_REQ .. ' concurrent requests')
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -130,7 +131,7 @@ end
    wait_http = nil
 
    for i = 0, total_posts-1 do
-      test_data = '{"id":' .. i .. ',"data":"test_data_' .. i .. '"}'
+      test_data = f'{{"id":{i},"data":"test_data_{i}"}}'
       results[i] = {}
       results[i].http = obj.new('http', {
          src         = 'http://127.0.0.1:' .. SERVER_PORT .. '/api/concurrent-post',
@@ -179,12 +180,12 @@ end
 @Test function HighLoadRequests()
    results = {}
    completed = 0
-   total_req = 10
+   TOTAL_REQ <const> = 80
    wait_http = nil
 
-   print('Starting high load test with ' .. total_req .. ' requests...')
+   print('Starting high load test with ' .. TOTAL_REQ .. ' requests...')
 
-   for i = 0, total_req-1 do
+   for i = 0, TOTAL_REQ-1 do
       results[i] = {}
       results[i].http = obj.new('http', {
          src            = 'http://127.0.0.1:' .. SERVER_PORT .. '/api/load-test/' .. i,
@@ -198,7 +199,7 @@ end
          stateChanged = function(HTTP, State)
             if (State is HGS_COMPLETED) or (State is HGS_TERMINATED) then
                completed++
-               if completed >= total_req then
+               if completed >= TOTAL_REQ then
                   wait_http.acSignal()
                end
             end
@@ -209,7 +210,7 @@ end
 
    proc = processing.new({ timeout = 5.0, signals = array<object> { wait_http } })
 
-   for i = 0, total_req-1 do
+   for i = 0, TOTAL_REQ-1 do
       assert(results[i].http.acActivate() is ERR_Okay, "High load request " .. i .. " failed to activate")
 
       -- Small delay to stagger requests slightly
@@ -219,8 +220,8 @@ end
    check proc.sleep()
 
    -- Allow for some failures under high load
-   success_rate = completed / total_req
+   success_rate = completed / TOTAL_REQ
    assert(success_rate >= 0.8, 'Success rate too low under high load: ' .. (success_rate * 100) .. '%')
 
-   print('High load test passed: ' .. completed .. '/' .. total_req .. ' requests succeeded')
+   print('High load test passed: ' .. completed .. '/' .. TOTAL_REQ .. ' requests succeeded')
 end


### PR DESCRIPTION
## Summary

- Removed `kt::strclone("Kotuku Client")` from `NewPlacement` (allocations via `AllocMemory` are not permitted at that stage); `UserAgent` now lazily defaults to `"Kotuku Client"` through a new `GET_UserAgent` getter and inline null-guards in the CONNECT tunnel, OPTIONS, and `set_http_method` code paths
- Added `FDF_VIRTUAL` flag to all virtual fields in the HTTP `clFields` table
- Increased `ParallelRequests` test to 10 concurrent requests and `HighLoadRequests` to 80; refactored loop variables to typed `<const>` constants and f-string interpolation
- Added a clarifying comment to `lib_objects.cpp` explaining the `NewPlacement` allocation restriction
- Corrected the `NetClient.IP` field in `netclient.xml` to reflect `Get`/`APTR` access

## Test plan

- [ ] Build the `http` module: `cmake --build build/agents --config Debug --target http --parallel`
- [ ] Install: `cmake --install build/agents --config Debug`
- [ ] Run HTTP concurrent tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L test_concurrent`
- [ ] Verify HTTP requests succeed with no `UserAgent` set (should default to `"Kotuku Client"`)
- [ ] Verify HTTP requests succeed with a custom `UserAgent` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)