### PR TITLE
[Network] Add IOCP pipeline regression tests and migrate @Requires syntax

### DIFF
--- a/src/audio/tests/test-audio.tiri
+++ b/src/audio/tests/test-audio.tiri
@@ -19,7 +19,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- This test must result in playback of a low-tone, then followed by a high tone.
 
-@Test(requires='audio', priority=10)
+@Test(priority=10); @Requires(audio=true)
 function SequentialPlayback()
    snd = obj.new('sound', { path=glFolder .. 'low-tone.wav', volume=0.25 })
    assert(snd, 'Failed to process low-tone wav file.')
@@ -69,7 +69,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Test left and right speaker panning
 
-@Test(requires='audio', priority=20)
+@Test(priority=20); @Requires(audio=true)
 function Pan()
    proc = processing.new()
 
@@ -100,7 +100,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Test volume adjustment and OnStop trigger rates.
 
-@Test(requires='audio', priority=30)
+@Test(priority=30); @Requires(audio=true)
 function Volume()
    snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
 
@@ -130,7 +130,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Increase the pitch repeatedly
 
-@Test(requires='audio', priority=40)
+@Test(priority=40); @Requires(audio=true)
 function Tones()
    proc = processing.new()
 
@@ -155,7 +155,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test(requires='audio', priority=50)
+@Test(priority=50); @Requires(audio=true)
 function Beep()
    glAudio.mtBeep(3000, 100, 5)
 end
@@ -164,7 +164,7 @@ end
 -- Test WAVE file saving by loading a file and saving it to a temp location, then comparing the binary content of
 -- both files.
 
-@Test(requires='audio', priority=60)
+@Test(priority=60); @Requires(audio=true)
 function WaveSave()
    snd = obj.new('sound', { path=glFolder .. 'low-tone.wav' })
    output_file = obj.new('file', { path='temp:low-tone.wav', flags='!NEW|WRITE' })

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -115,9 +115,7 @@ endif()
 set (NETWORK_TESTS
    bind_address dns_parallel server_io client_server error_handling ipv6 concurrency ssl
    # UDP Tests
-   udp_basic udp_ipv6 udp_broadcast_multicast udp_tcp_coexistence
-   # Performance test (may take a while)
-   # udp_performance
+   udp_basic udp_ipv6 udp_broadcast_multicast udp_tcp_coexistence udp_performance
 )
 
 foreach (TEST_NAME ${NETWORK_TESTS})

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -113,7 +113,7 @@ else()
 endif()
 
 set (NETWORK_TESTS
-   bind_address dns_parallel server_io client_server error_handling ipv6 concurrency ssl
+   bind_address dns_parallel server_io client_server error_handling ipv6 concurrency ssl iocp_pipeline
    # UDP Tests
    udp_basic udp_ipv6 udp_broadcast_multicast udp_tcp_coexistence udp_performance
 )

--- a/src/network/tests/test_dns_parallel.tiri
+++ b/src/network/tests/test_dns_parallel.tiri
@@ -68,7 +68,7 @@ end
 -- for the same host.  In the log output you may see a thread being created for the first resolve, then the second call
 -- will hit the local DNS cache and return immediately.
 
-@Test(requires='network') function Duplication()
+@Test; @Requires(network=true) function Duplication()
    resolved = 0
 
    domains = array<string> { 'google.com', 'reddit.com' }
@@ -100,7 +100,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Non-blocking name resolution (default)
 
-@Test(requires='network') function NameResolutionAsync()
+@Test; @Requires(network=true) function NameResolutionAsync()
    nl = obj.new('NetLookup', { callback=name_resolved, flags=NLF_NO_CACHE })
 
    proc = processing.new({ timeout = 2.0, signals = array<object> { nl } })
@@ -116,7 +116,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Blocking name resolution
 
-@Test(requires='network') function BlockingNameResolution()
+@Test; @Requires(network=true) function BlockingNameResolution()
    nl = obj.new('NetLookup', { callback = name_resolved, flags=NLF_NO_CACHE })
 
    glTotalResolved = 0
@@ -129,7 +129,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-@Test(requires='network') function BlockingAddressResolution()
+@Test; @Requires(network=true) function BlockingAddressResolution()
    address_resolved = false
    nl = obj.new('NetLookup', {
       callback = function(NetLookup, Error)

--- a/src/network/tests/test_iocp_pipeline.tiri
+++ b/src/network/tests/test_iocp_pipeline.tiri
@@ -1,0 +1,235 @@
+--[[
+IOCP pipeline regression tests.
+
+These tests exercise Windows IOCP accept and receive depth without changing the public Network API.
+--]]
+
+   include 'network'
+
+   glIocpPipelinePort = 18740
+
+function nextPort()
+   glIocpPipelinePort++
+   return glIocpPipelinePort
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true) function RapidAcceptBurst()
+   client_count    = 32
+   connected       = 0
+   server_received = 0
+   client_received = 0
+   port            = nextPort()
+   client_data     = { }
+
+   server = obj.new('netsocket', {
+      name        = 'IocpAcceptBurstServer',
+      address     = '127.0.0.1',
+      port        = port,
+      flags       = NSF_SERVER|NSF_MULTI_CONNECT,
+      backlog     = client_count,
+      clientLimit = client_count + 4,
+      socketLimit = client_count + 4,
+      feedback = function(Socket, Client, State)
+         if State is NTC_CONNECTED then
+            connected++
+            err, len = Client.acWrite('ready')
+            assert(err is ERR_Okay, 'Server failed to write ready message: ' .. mSys.GetErrorMsg(err))
+         end
+      end,
+      incoming = function(Socket, Client)
+         buffer = string.alloc(128)
+         err, read_len = Client.acRead(buffer)
+         if err is ERR_Disconnected then return end
+         assert(err is ERR_Okay, 'Server failed to read burst message: ' .. mSys.GetErrorMsg(err))
+
+         server_received++
+         err, len = Client.acWrite('ack:' .. buffer:sub(0, read_len))
+         assert(err is ERR_Okay, 'Server failed to write ack: ' .. mSys.GetErrorMsg(err))
+      end
+   })
+
+   clients = { }
+   proc = processing.new({ timeout = 8.0, signals = array<object> { server } })
+
+   for i = 0, client_count-1 do
+      clients[i] = obj.new('netsocket', {
+         name     = 'IocpAcceptBurstClient' .. i,
+         incoming = function(Socket)
+            data   = client_data[Socket.id]
+            buffer = string.alloc(128)
+            err, read_len = Socket.acRead(buffer)
+            assert(err is ERR_Okay, 'Client failed to read burst response: ' .. mSys.GetErrorMsg(err))
+
+            msg = buffer:sub(0, read_len)
+            if msg is 'ready' then
+               err, len = Socket.acWrite('hello:' .. data.id)
+               assert(err is ERR_Okay, 'Client failed to write hello: ' .. mSys.GetErrorMsg(err))
+            elseif msg:startsWith('ack:') then
+               if not data.done then
+                  data.done = true
+                  client_received++
+                  if client_received is client_count then server.acSignal() end
+               end
+            end
+         end
+      })
+
+      client_data[clients[i].id] = { id = i, done = false }
+   end
+
+   for i = 0, client_count-1 do
+      check clients[i].mtConnect('127.0.0.1', port)
+   end
+
+   check proc.sleep()
+
+   assert(connected is client_count, 'Accepted connection count mismatch')
+   assert(server_received is client_count, 'Server did not receive all burst messages')
+   assert(client_received is client_count, 'Clients did not receive all acknowledgements')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true) function LargeTCPReceive()
+   target_size = 2 * 1024 * 1024
+   payload     = string.rep('P', target_size)
+   received    = 0
+   bad_data    = false
+   port        = nextPort()
+
+   server = obj.new('netsocket', {
+      name     = 'IocpLargeReceiveServer',
+      address  = '127.0.0.1',
+      port     = port,
+      flags    = 'SERVER',
+      msgLimit = target_size + 65536,
+      incoming = function(Socket, Client)
+         buffer        = string.alloc(65536)
+         err, read_len = Client.acRead(buffer)
+         if err is ERR_Disconnected then return end
+         assert(err is ERR_Okay, 'Server failed to read large payload: ' .. mSys.GetErrorMsg(err))
+         if read_len <= 0 then return end
+
+         chunk = buffer:sub(0, read_len)
+         if chunk != string.rep('P', read_len) then
+            bad_data = true
+         end
+         received += read_len
+
+         if received >= target_size then Socket.acSignal() end
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name = 'IocpLargeReceiveClient',
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, State)
+         if State is NTC_CONNECTED then
+            err, len = Socket.acWrite(payload)
+            assert(err is ERR_Okay, 'Client failed to write large payload: ' .. mSys.GetErrorMsg(err))
+            assert(len is target_size, 'Large payload write length mismatch')
+         end
+      end
+   })
+
+   proc = processing.new({ timeout = 10.0, signals = array<object> { server } })
+   check client.mtConnect('127.0.0.1', port)
+   check proc.sleep()
+
+   assert(not bad_data, 'Large receive payload was corrupted')
+   assert(received is target_size, 'Large receive size mismatch')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true) function SlowReaderBackpressure()
+   target_size = 1536 * 1024
+   payload     = string.rep('S', target_size)
+   received    = 0
+   delayed     = false
+   port        = nextPort()
+
+   server = obj.new('netsocket', {
+      name     = 'IocpSlowReaderServer',
+      address  = '127.0.0.1',
+      port     = port,
+      flags    = NSF_SERVER,
+      msgLimit = target_size + 65536,
+      incoming = function(Socket, Client)
+         if not delayed then
+            delayed = true
+            processing.halt(0.25)
+         end
+
+         buffer = string.alloc(65536)
+         while received < target_size do
+            err, read_len = Client.acRead(buffer)
+            if err is ERR_Disconnected then return end
+            assert(err is ERR_Okay, 'Slow reader failed to read: ' .. mSys.GetErrorMsg(err))
+            if read_len <= 0 then break end
+            received += read_len
+         end
+
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name     = 'IocpSlowReaderClient',
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, State)
+         if State is NTC_CONNECTED then
+            err, len = Socket.acWrite(payload)
+            assert(err is ERR_Okay, 'Slow reader client failed to write: ' .. mSys.GetErrorMsg(err))
+            assert(len is target_size, 'Slow reader write length mismatch')
+         end
+      end
+   })
+
+   check client.mtConnect('127.0.0.1', port)
+
+   for i = 0, 199 do
+      if received >= target_size then break end
+      processing.halt(0.05)
+   end
+
+   assert(received is target_size, 'Slow reader did not drain the complete payload: ' .. received)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true) function PendingOperationTeardown()
+   port = nextPort()
+   connected = false
+
+   server = obj.new('netsocket', {
+      name    = 'IocpPendingTeardownServer',
+      address = '127.0.0.1',
+      port    = port,
+      flags   = NSF_SERVER,
+      feedback = function(Socket, Client, State)
+         if State is NTC_CONNECTED then connected = true end
+      end,
+      incoming = function(Socket, Client)
+         processing.halt(0.1)
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name = 'IocpPendingTeardownClient',
+      feedback = function(Socket, State)
+         if State is NTC_CONNECTED then
+            Socket.acWrite(string.rep('T', 262144))
+         end
+      end
+   })
+
+   check client.mtConnect('127.0.0.1', port)
+   processing.halt(0.3)
+   client.acDeactivate()
+   server.acDeactivate()
+   processing.halt(0.3)
+
+   assert(connected, 'Pending teardown test did not establish a connection')
+end

--- a/src/network/tests/test_iocp_pipeline.tiri
+++ b/src/network/tests/test_iocp_pipeline.tiri
@@ -15,7 +15,8 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test; @Requires(network=true, windows_platform=true) function RapidAcceptBurst()
+@Test; @Requires(network=true, windows_platform=true)
+function RapidAcceptBurst()
    client_count    = 32
    connected       = 0
    server_received = 0
@@ -92,7 +93,8 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test; @Requires(network=true, windows_platform=true) function LargeTCPReceive()
+@Test; @Requires(network=true, windows_platform=true)
+function LargeTCPReceive()
    target_size = 2 * 1024 * 1024
    payload     = string.rep('P', target_size)
    received    = 0
@@ -144,7 +146,8 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test; @Requires(network=true, windows_platform=true) function SlowReaderBackpressure()
+@Test; @Requires(network=true, windows_platform=true)
+function SlowReaderBackpressure()
    target_size = 1536 * 1024
    payload     = string.rep('S', target_size)
    received    = 0
@@ -199,7 +202,8 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test; @Requires(network=true, windows_platform=true) function PendingOperationTeardown()
+@Test; @Requires(network=true, windows_platform=true)
+function PendingOperationTeardown()
    port = nextPort()
    connected = false
 
@@ -232,4 +236,271 @@ end
    processing.halt(0.3)
 
    assert(connected, 'Pending teardown test did not establish a connection')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true)
+function PendingConnectFreeDropsCompletion()
+   late_feedback = 0
+   freed         = false
+
+   client = obj.new('netsocket', {
+      name = 'IocpPendingConnectFreeClient',
+      feedback = function(Socket, State)
+         if freed then late_feedback++ end
+      end
+   })
+
+   err = client.mtConnect('192.0.2.1', 12345, 2.0)
+   if err != ERR_Okay then
+      logOutput('Pending connect completed synchronously: ' .. mSys.GetErrorMsg(err))
+      return
+   end
+
+   freed = true
+   client.free()
+   client = nil
+
+   processing.collect()
+   processing.halt(0.6)
+
+   assert(late_feedback is 0, 'Freed pending connect received a late feedback callback')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true)
+function PendingAcceptFreeDropsCompletion()
+   late_accept_feedback = 0
+   freed                = false
+   port                 = nextPort()
+
+   server = obj.new('netsocket', {
+      name    = 'IocpPendingAcceptFreeServer',
+      address = '127.0.0.1',
+      port    = port,
+      flags   = NSF_SERVER,
+      feedback = function(Socket, Client, State)
+         if freed then late_accept_feedback++ end
+      end
+   })
+
+   processing.halt(0.1)
+
+   freed = true
+   server.free()
+   server = nil
+
+   processing.collect()
+   processing.halt(0.6)
+
+   assert(late_accept_feedback is 0, 'Freed listener received a late accept feedback callback')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true)
+function PendingTCPReadWriteFreeDropsCompletion()
+   port                  = nextPort()
+   connected             = false
+   client_freed          = false
+   late_client_callbacks = 0
+   accepted_client       = nil
+   target_size           = 2 * 1024 * 1024
+   payload               = string.rep('W', target_size)
+
+   server = obj.new('netsocket', {
+      name     = 'IocpPendingTCPFreeServer',
+      address  = '127.0.0.1',
+      port     = port,
+      flags    = NSF_SERVER,
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, Client, State)
+         if State is NTC_CONNECTED then
+            accepted_client = Client
+            connected = true
+            Socket.acSignal()
+         end
+      end,
+      incoming = function(Socket, Client)
+         processing.halt(0.25)
+         buffer = string.alloc(65536)
+         err, read_len = Client.acRead(buffer)
+         if (err != ERR_Okay) and (err != ERR_Disconnected) then
+            error('Server read failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
+         end
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name     = 'IocpPendingTCPFreeClient',
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, State)
+         if client_freed then late_client_callbacks++ end
+      end,
+      incoming = function(Socket)
+         if client_freed then late_client_callbacks++ end
+         buffer = string.alloc(256)
+         err, read_len = Socket.acRead(buffer)
+         if (err != ERR_Okay) and (err != ERR_Disconnected) then
+            error('Client read failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
+         end
+      end
+   })
+
+   proc = processing.new({ timeout = 4.0, signals = array<object> { server } })
+   check client.mtConnect('127.0.0.1', port)
+   check proc.sleep()
+
+   assert(connected, 'Pending TCP free test did not establish a connection')
+
+   err, len = client.acWrite(payload)
+   assert((err is ERR_Okay) or (err is ERR_BufferOverflow),
+      'Client write failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
+   assert(len > 0, 'Client write did not queue any data during pending TCP free test')
+
+   client_freed = true
+   client.free()
+   client = nil
+
+   processing.collect()
+
+   if accepted_client then
+      err, len = accepted_client.acWrite('late-read-trigger')
+      if (err != ERR_Okay) and (err != ERR_Disconnected) then
+         error('Server write failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
+      end
+   end
+
+   processing.halt(0.8)
+   server.acDeactivate()
+
+   assert(late_client_callbacks is 0, 'Freed TCP client received a late read, write, or feedback callback')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true)
+function PendingUDPReceiveSendFreeDropsCompletion()
+   port               = nextPort()
+   server_freed       = false
+   sender_freed       = false
+   late_udp_callbacks = 0
+
+   source = struct.new('IPAddress')
+   buffer = string.alloc(65536)
+
+   server = obj.new('netsocket', {
+      name          = 'IocpPendingUDPFreeServer',
+      address       = '127.0.0.1',
+      port          = port,
+      flags         = NSF_SERVER|NSF_UDP,
+      maxPacketSize = 65507,
+      incoming = function(Socket)
+         if server_freed then late_udp_callbacks++ end
+         err, read_len = Socket.mtRecvFrom(source, buffer)
+         if (err != ERR_Okay) and (err != ERR_Disconnected) then
+            error('UDP receive failed during pending UDP free test: ' .. mSys.GetErrorMsg(err))
+         end
+      end
+   })
+
+   sender = obj.new('netsocket', {
+      name          = 'IocpPendingUDPFreeSender',
+      flags         = NSF_UDP,
+      maxPacketSize = 65507,
+      incoming = function(Socket)
+         if sender_freed then late_udp_callbacks++ end
+      end,
+      feedback = function(Socket, State)
+         if sender_freed then late_udp_callbacks++ end
+      end
+   })
+
+   dest = struct.new('IPAddress')
+   check mNet.StrToAddress('127.0.0.1', dest)
+   dest.port = server.port
+
+   processing.halt(0.1)
+
+   server_freed = true
+   server.free()
+   server = nil
+
+   processing.collect()
+
+   packet = string.rep('U', 4096)
+   for i = 0, 63 do
+      err, len = sender.mtSendTo(dest, packet)
+      if (err != ERR_Okay) and (err != ERR_BufferOverflow) and (err != ERR_Disconnected) then
+         error('UDP send failed during pending UDP free test: ' .. mSys.GetErrorMsg(err))
+      end
+   end
+
+   sender_freed = true
+   sender.free()
+   sender = nil
+
+   processing.collect()
+   processing.halt(0.8)
+
+   assert(late_udp_callbacks is 0, 'Freed UDP socket received a late receive, send, or feedback callback')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, ssl=true, windows_platform=true)
+function PendingSSLFreeDropsCompletion()
+   port                  = nextPort()
+   client_freed          = false
+   late_client_callbacks = 0
+
+   server = obj.new('netsocket', {
+      name    = 'IocpPendingSSLFreeServer',
+      address = '127.0.0.1',
+      port    = port,
+      flags   = NSF_SERVER|NSF_SSL,
+      feedback = function(Socket, Client, State)
+         if State is NTC_CONNECTED then
+            Client.acWrite('ssl-late-read-trigger')
+         end
+      end,
+      incoming = function(Socket, Client)
+         buffer = string.alloc(256)
+         err, read_len = Client.acRead(buffer)
+         if (err != ERR_Okay) and (err != ERR_Disconnected) and (err != ERR_InvalidState) then
+            error('SSL server read failed during pending SSL free test: ' .. mSys.GetErrorMsg(err))
+         end
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name  = 'IocpPendingSSLFreeClient',
+      flags = NSF_SSL|NSF_DISABLE_SERVER_VERIFY,
+      feedback = function(Socket, State)
+         if client_freed then late_client_callbacks++ end
+      end,
+      incoming = function(Socket)
+         if client_freed then late_client_callbacks++ end
+         buffer = string.alloc(256)
+         err, read_len = Socket.acRead(buffer)
+         if (err != ERR_Okay) and (err != ERR_Disconnected) and (err != ERR_InvalidState) then
+            error('SSL client read failed during pending SSL free test: ' .. mSys.GetErrorMsg(err))
+         end
+      end
+   })
+
+   check client.mtConnect('127.0.0.1', port)
+   processing.halt(0.05)
+
+   client_freed = true
+   client.free()
+   client = nil
+
+   processing.collect()
+   processing.halt(1.0)
+   server.acDeactivate()
+
+   assert(late_client_callbacks is 0, 'Freed SSL client received a late handshake or read callback')
 end

--- a/src/network/tests/test_server_io.tiri
+++ b/src/network/tests/test_server_io.tiri
@@ -17,7 +17,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-@Test(requires='network') function RawHTTP()
+@Test; @Requires(network=true) function RawHTTP()
    netsocket = obj.new('netsocket', {
       feedback = function(Socket, State)
          state = printableState(State)

--- a/src/network/tests/test_udp_performance.tiri
+++ b/src/network/tests/test_udp_performance.tiri
@@ -11,7 +11,7 @@ UDP Performance and Stress Test
 ------------------------------------------------------------------------------------------------------------------------
 -- Test high-frequency UDP messaging
 
-@Test(requires='network') function UDPHighFrequency()
+@Test; @Requires(network=true) function UDPHighFrequency()
    glBasePort++
    serverPort = glBasePort
    messagesReceived = 0
@@ -74,7 +74,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test large UDP packet transmission
 
-@Test(requires='network') function UDPLargePackets()
+@Test; @Requires(network=true) function UDPLargePackets()
    glBasePort++
    serverPort = glBasePort
    largePacketReceived = false
@@ -136,7 +136,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP concurrent connections
 
-@Test(requires='network') function UDPConcurrency()
+@Test; @Requires(network=true) function UDPConcurrency()
    glBasePort++
    serverPort = glBasePort
    clientsConnected = 0
@@ -205,7 +205,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test buffer overflow handling
 
-@Test(requires='network') function UDPBufferHandling()
+@Test; @Requires(network=true) function UDPBufferHandling()
    glBasePort++
 
    client = obj.new('netsocket', { flags = 'UDP' })
@@ -243,7 +243,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP performance benchmarks
 
-@Test(requires='network') function UDPPerformanceBenchmark()
+@Test; @Requires(network=true) function UDPPerformanceBenchmark()
    glBasePort++
    serverPort = glBasePort
    proc = processing.new({ timeout = 10.0 })  -- Longer timeout for benchmark

--- a/src/network/tests/test_udp_tcp_coexistence.tiri
+++ b/src/network/tests/test_udp_tcp_coexistence.tiri
@@ -9,7 +9,6 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
 --]]
 
    include 'network'
-   mNet ?= mod.load('network')
 
    glBasePort = 19840  -- Base port for coexistence tests
    glTestTimeout = 4.0
@@ -17,7 +16,7 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
 ------------------------------------------------------------------------------------------------------------------------
 -- Test UDP and TCP servers running simultaneously
 
-@Test(requires='network') function UDPTCPCoexistence()
+@Test; @Requires(network=true) function UDPTCPCoexistence()
    udpPort = glBasePort + 1
    tcpPort = glBasePort + 2
    udpReceived = false
@@ -134,7 +133,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test mixed protocol communication patterns
 
-@Test(requires='network') function MixedProtocolPatterns()
+@Test; @Requires(network=true) function MixedProtocolPatterns()
    basePort = glBasePort + 10
    results = {}
 
@@ -219,7 +218,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 -- Test resource cleanup and port reuse
 
-@Test(requires='network') function ResourceCleanup()
+@Test; @Requires(network=true) function ResourceCleanup()
    testPort = glBasePort + 20
 
    -- Create and destroy UDP socket

--- a/tools/flute.tiri
+++ b/tools/flute.tiri
@@ -113,9 +113,9 @@ function checkAvailable(Requirement:str, Expectation:bool):bool
       return glAudioAvailable is Expectation
    elseif Requirement is 'display' then
       return glDisplayAvailable is Expectation
-   elseif Requirement in 'windows_platform' then
+   elseif Requirement is 'windows_platform' then
       return glWindowsPlatform is Expectation
-   elseif Requirement in 'linux_platform' then
+   elseif Requirement is 'linux_platform' then
       return glLinuxPlatform is Expectation
    else
       error('Invalid requirement: ' .. Requirement)

--- a/tools/flute.tiri
+++ b/tools/flute.tiri
@@ -90,6 +90,16 @@ global glSSLAvailable = thunk():bool
    return mNet.setSSL(nil, nil, nil) != ERR_NoSecureSockets
 end
 
+global glWindowsPlatform = thunk():bool
+   state = mSys.GetSystemState()
+   return state.platform is 'Windows'
+end
+
+global glLinuxPlatform = thunk():bool
+   state = mSys.GetSystemState()
+   return state.platform is 'Linux'
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 
 function checkAvailable(Requirement:str, Expectation:bool):bool
@@ -103,6 +113,10 @@ function checkAvailable(Requirement:str, Expectation:bool):bool
       return glAudioAvailable is Expectation
    elseif Requirement is 'display' then
       return glDisplayAvailable is Expectation
+   elseif Requirement in 'windows_platform' then
+      return glWindowsPlatform is Expectation
+   elseif Requirement in 'linux_platform' then
+      return glLinuxPlatform is Expectation
    else
       error('Invalid requirement: ' .. Requirement)
    end


### PR DESCRIPTION
## Summary

* Added `test_iocp_pipeline.tiri` with four Windows-only IOCP regression tests: `RapidAcceptBurst`, `LargeTCPReceive`, `SlowReaderBackpressure`, and `PendingOperationTeardown`, exercising accept depth, large payload receive, backpressure under a slow reader, and clean teardown with pending operations
* Extended Flute with `windows_platform` and `linux_platform` platform-detection thunks, and added `@Requires(windows_platform=true)` / `@Requires(linux_platform=true)` support to `checkAvailable()`
* Migrated all network and audio Flute tests from the deprecated `@Test(requires='...')` syntax to the current `@Test; @Requires(...=true)` form
* Enabled `udp_performance` in the `CMakeLists.txt` network test list (was previously commented out)

## Test plan

- [ ] CI passes on Windows with the new `test_iocp_pipeline` tests executing (requires `windows_platform=true`)
- [ ] CI passes on Linux with the IOCP tests correctly skipped via `@Requires(windows_platform=true)`
- [ ] All existing network tests (`bind_address`, `dns_parallel`, `server_io`, `client_server`, `error_handling`, `ipv6`, `concurrency`, `ssl`, UDP suite) continue to pass
- [ ] `udp_performance` test runs and passes in CI
- [ ] Audio tests pass with the migrated `@Requires` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)