### PR TITLE
[Tiri] Add try-block materialisation diagnostic counters to JIT traces

### DIFF
--- a/src/tiri/jit/src/debug/lj_jit.h
+++ b/src/tiri/jit/src/debug/lj_jit.h
@@ -294,6 +294,10 @@ struct GCtrace {
   uint8_t topslot;   //  Top stack slot already checked to be allocated.
   TraceLink linktype;   //  Type of link.
   uint8_t unused1;
+  uint32_t try_stores;   //  Try materialisation stores emitted while recording this trace.
+  uint32_t try_skipped_stores;   //  Try materialisation stores skipped by tracking.
+  uint32_t try_enter_stores;   //  Forced stores emitted at BC_TRYENTER.
+  uint32_t try_enter_snap_removed;   //  Snapshot entries removed near BC_TRYENTER.
 #ifdef LUAJIT_USE_GDBJIT
   void *gdbjit_entry;   //  GDB JIT entry.
 #endif
@@ -522,6 +526,10 @@ struct jit_State {
   TValue errinfo;     //  Additional info element for trace errors.
   uint8_t retryrec;   //  Retry recording.
   bool abort_in_progress; //  True while aborting trace recording (skip try handlers)
+  uint32_t try_stores;   //  Try materialisation stores emitted while recording the current trace.
+  uint32_t try_skipped_stores;   //  Try materialisation stores skipped by tracking.
+  uint32_t try_enter_stores;   //  Forced stores emitted at BC_TRYENTER.
+  uint32_t try_enter_snap_removed;   //  Snapshot entries removed near BC_TRYENTER.
 
   // Optimisation cache for try-block stack materialisation.  Correctness comes from forced
   // BC_TRYENTER materialisation and CCI_T materialisation before throwable helper calls.

--- a/src/tiri/jit/src/lib/lib_jit.cpp
+++ b/src/tiri/jit/src/lib/lib_jit.cpp
@@ -304,12 +304,16 @@ LJLIB_CF(jit_util_traceInfo)
    GCtrace *T = jit_checktrace(L);
    if (T) {
       GCtab *t;
-      lua_createtable(L, 0, 8);  //  Increment hash size if fields are added.
+      lua_createtable(L, 0, 12);  //  Increment hash size if fields are added.
       t = tabV(L->top - 1);
       setintfield(L, t, "nins", (int32_t)T->nins - REF_BIAS - 1);
       setintfield(L, t, "nk", REF_BIAS - (int32_t)T->nk);
       setintfield(L, t, "link", T->link);
       setintfield(L, t, "nexit", T->nsnap);
+      setintfield(L, t, "tryStores", int32_t(T->try_stores));
+      setintfield(L, t, "trySkippedStores", int32_t(T->try_skipped_stores));
+      setintfield(L, t, "tryEnterStores", int32_t(T->try_enter_stores));
+      setintfield(L, t, "tryEnterSnapRemoved", int32_t(T->try_enter_snap_removed));
       setstrV(L, L->top++, lj_str_newz(L, jit_trlinkname[uint32_t(T->linktype)]));
       lua_setfield(L, -2, "linktype");
       // There are many more fields. Add them only when needed.

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -121,11 +121,16 @@ static void rec_try_materialise_slots(jit_State *J, bool ForceLoad, BCREG SlotLi
       int32_t absolute_slot = int32_t(J->baseslot) + int32_t(slot);
       lj_assertJ(absolute_slot >= 0 and absolute_slot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
          "try materialisation slot out of range");
-      if (not ForceLoad and J->trymat[absolute_slot] IS value_ref) continue;
+      if (not ForceLoad and J->trymat[absolute_slot] IS value_ref) {
+         J->try_skipped_stores++;
+         continue;
+      }
 
       TRef slot_addr = rec_try_stack_slot_addr(J, ir, absolute_slot);
       rec_try_emit_tvalue_store(J, slot_addr, value_ref);
       J->trymat[absolute_slot] = value_ref;
+      J->try_stores++;
+      if (ForceLoad) J->try_enter_stores++;
       stored = true;
    }
 
@@ -3557,6 +3562,10 @@ void lj_record_setup(jit_State *J)
    memset(J->slot, 0, sizeof(J->slot));
    memset(J->trymat, 0, sizeof(J->trymat));
    memset(J->chain, 0, sizeof(J->chain));
+   J->try_stores = 0;
+   J->try_skipped_stores = 0;
+   J->try_enter_stores = 0;
+   J->try_enter_snap_removed = 0;
 #ifdef LUAJIT_ENABLE_TABLE_BUMP
    memset(J->rbchash, 0, sizeof(J->rbchash));
 #endif

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -411,7 +411,9 @@ void lj_snap_shrink(jit_State* J)
    uint8_t udf[SNAP_USEDEF_SLOTS];
    BCREG maxslot = J->maxslot;
    BCREG baseslot = J->baseslot;
-   BCREG minslot = snap_usedef(J, udf, snap_pc(&map[nent]), maxslot);
+   const BCIns *pc = snap_pc(&map[nent]);
+   bool try_enter_pc = bc_op(*pc) IS BC_TRYENTER;
+   BCREG minslot = snap_usedef(J, udf, pc, maxslot);
    if (minslot < maxslot) snap_useuv(J->pt, udf);
    maxslot += baseslot;
    minslot += baseslot;
@@ -422,6 +424,7 @@ void lj_snap_shrink(jit_State* J)
          map[m++] = map[n];  //  Only copy used slots.
    }
    snap->nent = (uint8_t)m;
+   if (try_enter_pc and nent > m) J->try_enter_snap_removed += uint32_t(nent - m);
    nlim = J->cur.nsnapmap - snap->mapofs - 1;
    while (n <= nlim) map[m++] = map[n++];  //  Move PC + frame links down.
    J->cur.nsnapmap = (uint32_t)(snap->mapofs + m);  //  Free up space in map.

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -162,6 +162,10 @@ GCtrace* lj_trace_alloc(lua_State* L, GCtrace *T)
    T2->nk = T->nk;
    T2->nsnap = T->nsnap;
    T2->nsnapmap = T->nsnapmap;
+   T2->try_stores = T->try_stores;
+   T2->try_skipped_stores = T->try_skipped_stores;
+   T2->try_enter_stores = T->try_enter_stores;
+   T2->try_enter_snap_removed = T->try_enter_snap_removed;
    memcpy(p, T->ir + T->nk, szins);
    return T2;
 }
@@ -567,6 +571,10 @@ static void trace_stop(jit_State *J)
    // Commit new mcode only after all patching is done.
    lj_mcode_commit(J, J->cur.mcode);
    J->postproc = LJ_POST_NONE;
+   J->cur.try_stores = J->try_stores;
+   J->cur.try_skipped_stores = J->try_skipped_stores;
+   J->cur.try_enter_stores = J->try_enter_stores;
+   J->cur.try_enter_snap_removed = J->try_enter_snap_removed;
    trace_save(J, T);
 
    L = J->L;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -351,6 +351,11 @@ end
    assert(type(info.nins) is "number" and info.nins > 0, "traceInfo should report instruction count")
    assert(type(info.link) is "number", "traceInfo link should be numeric")
    assert(type(info.linktype) is "string", "traceInfo linktype should be a string")
+   assert(type(info.tryStores) is "number" and info.tryStores >= 0, "traceInfo should report try store count")
+   assert(type(info.trySkippedStores) is "number" and info.trySkippedStores >= 0, "traceInfo should report skipped try store count")
+   assert(type(info.tryEnterStores) is "number" and info.tryEnterStores >= 0, "traceInfo should report try-enter store count")
+   assert(type(info.tryEnterSnapRemoved) is "number" and info.tryEnterSnapRemoved >= 0,
+      "traceInfo should report try-enter snapshot removal count")
 
    allowed_links = {
       root = true,


### PR DESCRIPTION
## Summary

* Added `try_stores`, `try_skipped_stores`, `try_enter_stores`, and `try_enter_snap_removed` diagnostic counters to both `GCtrace` and `jit_State`, tracking try-block stack materialisation activity per compiled trace
* Exposed the four counters via `jit.util.traceInfo()` as `tryStores`, `trySkippedStores`, `tryEnterStores`, and `tryEnterSnapRemoved`
* Counters are incremented during slot recording in `lj_record.cpp`, snapshot removal near `BC_TRYENTER` is counted in `lj_snap_shrink`, and state is propagated to `GCtrace` at `trace_stop` and on trace copy

## Test plan

- [ ] `test_jit.tiri` passes with the four new `traceInfo` field assertions
- [ ] Existing JIT tests continue to pass
- [ ] Counter values are non-negative and increase as expected when tracing through try-blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)