### PR TITLE
[Network] Fixed IOCP close-after-write truncation

### DIFF
--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -367,7 +367,8 @@ static void clientsocket_outgoing_impl(HOSTHANDLE SocketFD, extClientSocket *Cli
       }
    }
 
-   if ((error IS ERR::Okay) and (ClientSocket->CloseAfterWrite) and (ClientSocket->WriteQueue.Buffer.empty())) {
+   if ((error IS ERR::Okay) and (ClientSocket->CloseAfterWrite) and (ClientSocket->WriteQueue.Buffer.empty()) and
+       (not network_platform().has_pending_write(ClientSocket->Handle))) {
       ClientSocket->CloseAfterWrite = false;
       disconnect(ClientSocket);
       ClientSocket->InUse--;
@@ -400,7 +401,7 @@ static void clientsocket_outgoing_impl(HOSTHANDLE SocketFD, extClientSocket *Cli
       // If the write queue is empty then we remove the FD-Write registration so that
       // we don't tax system resources.
 
-      if (ClientSocket->WriteQueue.Buffer.empty()) {
+      if (ClientSocket->WriteQueue.Buffer.empty() and (not network_platform().has_pending_write(ClientSocket->Handle))) {
          log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle.int_value());
          network_platform().remove_write(ClientSocket->Handle);
       }
@@ -427,7 +428,8 @@ static ERR CLIENTSOCKET_Deactivate(extClientSocket *Self)
    kt::Log log;
    log.branch();
 
-   if ((Self->State IS NTC::CONNECTED) and (not Self->WriteQueue.Buffer.empty())) {
+   if ((Self->State IS NTC::CONNECTED) and
+       ((not Self->WriteQueue.Buffer.empty()) or network_platform().has_pending_write(Self->Handle))) {
       log.msg("Delaying disconnect until queued data is flushed.");
       Self->CloseAfterWrite = true;
       network_platform().register_write(Self->Handle, &clientsocket_outgoing, Self);

--- a/src/network/net_iocp.cpp
+++ b/src/network/net_iocp.cpp
@@ -428,6 +428,11 @@ public:
       return ERR::Okay;
    }
 
+   bool has_pending_write(SocketHandle Handle) override
+   {
+      return iocp_has_pending_write(Handle.socket());
+   }
+
    ERR enable_broadcast(SocketHandle Handle) override
    {
       return iocp_enable_broadcast(Handle.socket());

--- a/src/network/net_linux.cpp
+++ b/src/network/net_linux.cpp
@@ -322,6 +322,11 @@ public:
       return DeregisterFD(Handle.hosthandle());
    }
 
+   bool has_pending_write(SocketHandle Handle) override
+   {
+      return false;
+   }
+
    ERR enable_broadcast(SocketHandle Handle) override
    {
       int broadcast = 1;

--- a/src/network/net_platform.h
+++ b/src/network/net_platform.h
@@ -214,6 +214,7 @@ public:
    virtual ERR remove_write(SocketHandle Handle) = 0;
    virtual ERR register_recall_read(SocketHandle Handle, void (*Callback)(HOSTHANDLE, APTR), APTR Data) = 0;
    virtual ERR deregister_fd(SocketHandle Handle) = 0;
+   virtual bool has_pending_write(SocketHandle Handle) = 0;
 
    virtual ERR enable_broadcast(SocketHandle Handle) = 0;
    virtual ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) = 0;

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -525,7 +525,8 @@ static void netsocket_outgoing_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
    // Before feeding new data into the queue, the current buffer must be empty.
 
-   if ((error IS ERR::Okay) and Self->CloseAfterWrite and Self->WriteQueue.Buffer.empty()) {
+   if ((error IS ERR::Okay) and Self->CloseAfterWrite and Self->WriteQueue.Buffer.empty() and
+       (not network_platform().has_pending_write(Self->Handle))) {
       Self->InUse--;
       Self->OutgoingRecursion--;
       free_socket(Self);
@@ -551,7 +552,8 @@ static void netsocket_outgoing_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       // we don't tax the system resources.  The WriteSocket function is also dropped because it is intended to
       // be assigned temporarily.
 
-      if ((!Self->Outgoing.defined()) and (Self->WriteQueue.Buffer.empty())) {
+      if ((!Self->Outgoing.defined()) and (Self->WriteQueue.Buffer.empty()) and
+          (not network_platform().has_pending_write(Self->Handle))) {
          log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle.int_value());
          if (auto error = network_platform().remove_write(Self->Handle); error != ERR::Okay) log.warning(error);
       }

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -409,6 +409,38 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
 
 //********************************************************************************************************************
 
+static ERR post_write_tail(const IocpOperation &Operation, size_t Offset)
+{
+   if ((!Operation.Buffer) or (Offset >= Operation.BufferSize)) return ERR::Okay;
+
+   auto remaining = Operation.BufferSize - Offset;
+   auto operation = new IocpOperation();
+   operation->Type = IocpOperationType::WRITE;
+   operation->Socket = Operation.Socket;
+   operation->Generation = Operation.Generation;
+   operation->ObjectID = Operation.ObjectID;
+   operation->Callback = Operation.Callback;
+   operation->BufferSize = remaining;
+   operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
+   std::memcpy(operation->Buffer.get(), Operation.Buffer.get() + Offset, remaining);
+
+   WSABUF wsabuf;
+   wsabuf.buf = (CHAR *)operation->Buffer.get();
+   wsabuf.len = ULONG(operation->BufferSize);
+
+   DWORD bytes = 0;
+   auto result = WSASend(socket_from_handle(Operation.Socket), &wsabuf, 1, &bytes, 0, &operation->Overlapped, nullptr);
+   if ((result IS SOCKET_ERROR) and (WSAGetLastError() != WSA_IO_PENDING)) {
+      auto error = convert_error();
+      delete operation;
+      return error;
+   }
+
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
 static void queue_operation_completion(const IocpOperation &Operation, size_t BytesTransferred, ERR Error)
 {
    iocp_completion_message message;
@@ -427,6 +459,13 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
       }
 
       auto target = completion_target(record->second, Operation.Type);
+
+      if ((Operation.Type IS IocpOperationType::WRITE) and (Error IS ERR::Okay) and
+          (BytesTransferred > 0) and (BytesTransferred < Operation.BufferSize)) {
+         if (auto tail_error = post_write_tail(Operation, BytesTransferred); tail_error IS ERR::Okay) return;
+         else Error = tail_error;
+      }
+
       rearm_accept = store_operation_result(record->second, Operation, Error) and
          (target.Callback) and (target.ObjectID > 0);
 
@@ -812,7 +851,12 @@ WSW_SOCKET iocp_create_socket(int ObjectID, bool UDP, bool &IPv6)
 void iocp_close_socket(WSW_SOCKET Socket)
 {
    iocp_deregister_socket(Socket);
-   closesocket(socket_from_handle(Socket));
+
+   auto native_socket = socket_from_handle(Socket);
+   if (native_socket IS INVALID_SOCKET) return;
+
+   shutdown(native_socket, SD_SEND);
+   closesocket(native_socket);
 }
 
 //********************************************************************************************************************
@@ -1081,6 +1125,16 @@ ERR iocp_remove_write(WSW_SOCKET Socket)
 
 //********************************************************************************************************************
 
+bool iocp_has_pending_write(WSW_SOCKET Socket)
+{
+   std::lock_guard<std::mutex> lock(glIocpMutex);
+   auto record = glSockets.find(Socket);
+   if (record IS glSockets.end()) return false;
+   return (not record->second.Cancelled) and record->second.WritePending;
+}
+
+//********************************************************************************************************************
+
 ERR iocp_recall_read(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
 {
    if (auto error = set_completion_target(Socket, IocpOperationType::READ, ObjectID, Callback);
@@ -1125,7 +1179,7 @@ ERR iocp_receive(WSW_SOCKET Socket, void *Buffer, size_t Length, size_t &Receive
             record->second.ReadBuffer.clear();
             record->second.ReadOffset = 0;
             if (record->second.ReadResult IS ERR::Okay) rearm_read = true;
-            else result = record->second.ReadResult;
+            else recall_read = true;
          }
          else recall_read = true;
       }

--- a/src/network/win32/iocp.h
+++ b/src/network/win32/iocp.h
@@ -54,6 +54,7 @@ ERR iocp_register_write(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback);
 ERR iocp_remove_read(WSW_SOCKET Socket);
 ERR iocp_remove_write(WSW_SOCKET Socket);
 ERR iocp_recall_read(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback);
+bool iocp_has_pending_write(WSW_SOCKET Socket);
 
 ERR iocp_receive(WSW_SOCKET Socket, void *Buffer, size_t Length, size_t &Received);
 ERR iocp_append_receive(WSW_SOCKET Socket, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received);


### PR DESCRIPTION
## Summary

* Added pending write checks before closing sockets or removing write callbacks, preventing premature closure while data is still in flight.
* Resubmitted partial IOCP write completions and preserved buffered reads before disconnect, ensuring data integrity during teardown.
* Requested send-side shutdown before closing Windows IOCP sockets, allowing the peer to receive all queued data before the connection is torn down.

## Test plan

- [ ] Run IOCP pipeline regression tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L network`
- [ ] Verify close-after-write scenarios no longer truncate transmitted data on Windows.
- [ ] Confirm Linux network path is unaffected.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)