### PR TITLE
[Network] Fixed gcc warnings in network and Tiri builds

### DIFF
--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -671,8 +671,6 @@ template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self)
 
    log.trace("Socket: %" PF64, (MAXINT)SocketFD);
 
-   auto write_callback = std::is_same<T, extNetSocket>::value ?
-      ssl_handshake_write_netsocket : ssl_handshake_write_clientsocket;
    auto read_callback = std::is_same<T, extNetSocket>::value ?
       ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
 
@@ -709,8 +707,6 @@ template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self)
 
    auto write_callback = std::is_same<T, extNetSocket>::value ?
       ssl_handshake_write_netsocket : ssl_handshake_write_clientsocket;
-   auto read_callback = std::is_same<T, extNetSocket>::value ?
-      ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
 
    ssl_clear_error_queue();
    if (auto result = SSL_do_handshake(Self->TLS.Handle); result IS 1) { // Handshake successful, connection established

--- a/src/network/socket_errors.h
+++ b/src/network/socket_errors.h
@@ -91,7 +91,7 @@ static const SocketErrorEntry glSocketErrors[] = {
    { 0, ERR::NIL }
 };
 
-static ERR convert_socket_error(int Error = 0, ERR Default = ERR::SystemCall)
+static inline ERR convert_socket_error(int Error = 0, ERR Default = ERR::SystemCall)
 {
 #ifdef _WIN32
    if (Error IS 0) Error = WSAGetLastError();

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -110,7 +110,7 @@ static int processing_halt(lua_State *Lua)
 {
    double seconds;
    if (lua_type(Lua, 1) IS LUA_TNUMBER) seconds = lua_tonumber(Lua, 1);
-   else luaL_argerror(Lua, 1, "Seconds must be a number.");
+   else return luaL_argerror(Lua, 1, "Seconds must be a number.");
 
    if (seconds < 0) luaL_error(Lua, ERR::Args, "Seconds must be a positive number.");
 


### PR DESCRIPTION
* Removed unused OpenSSL handshake callback locals
* Made socket error conversion helper inline for header include safety
* [Tiri] Returned directly from invalid processing.halt argument handling