### PR TITLE
[Network] Consolidate platform helpers, remove dead code, and fix proxy filter handling

### DIFF
--- a/docs/xml/modules/classes/proxy.xml
+++ b/docs/xml/modules/classes/proxy.xml
@@ -131,6 +131,7 @@ if (proxy.ok()) {
       <type>STRING</type>
       <description>
 <p>The GatewayFilter defines the IP address of the gateway that this proxy is limited to. It is intended to limit the results of searches performed by the <method>Find</method> method.</p>
+<p>Gateway matching is not currently implemented.  Records that define this field are skipped by <method>Find</method>.</p>
       </description>
     </field>
 
@@ -152,6 +153,7 @@ if (proxy.ok()) {
       <description>
 <p>The NetworkFilter defines the name of the network that this proxy is limited to. It is intended to limit the results of searches performed by the <method>Find</method> method.</p>
 <p>This filter must not be set if the proxy needs to work on an unnamed network.</p>
+<p>Network matching is not currently implemented.  Records that define this field are skipped by <method>Find</method>.</p>
       </description>
     </field>
 

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -8,12 +8,6 @@
 
 #define MODVERSION_NETWORK (1)
 
-#ifdef __cplusplus
-#include <unordered_set>
-#include <map>
-#include <mutex>
-#endif
-
 class objNetClient;
 class objClientSocket;
 class objProxy;
@@ -99,10 +93,6 @@ enum class NTC : int {
 #define SCV_KEYUSAGE_NO_CERTSIGN 32
 #define SCV_APPLICATION_VERIFICATION 50
 
-
-#if defined(ENABLE_SSL) && !defined(_WIN32)
- #include "openssl/ssl.h"
-#endif
 
 #ifdef __linux__
 typedef int SOCKET_HANDLE;

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -111,3 +111,7 @@ set (NETWORK_TESTS
 foreach (TEST_NAME ${NETWORK_TESTS})
    flute_test(network_${TEST_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${TEST_NAME}.tiri")
 endforeach ()
+
+# Heavy load/performance coverage is intentionally manual because it is timing-sensitive and expensive.
+# Run directly with tools/flute.tiri when network throughput changes need to be profiled:
+# src/network/tests/test_performance.tiri

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -267,6 +267,13 @@ static bool matchesEnabledFilter(const KeysType& keys, int findEnabled) {
    return false;
 }
 
+template<typename KeysType>
+static bool matchesDeferredFilter(const KeysType &Keys, CSTRING FieldName)
+{
+   auto filter = Keys.find(FieldName);
+   return (filter IS Keys.end()) or filter->second.empty();
+}
+
 static ERR find_proxy(extProxy *Self)
 {
    kt::Log log(__FUNCTION__);
@@ -290,7 +297,7 @@ static ERR find_proxy(extProxy *Self)
          if (group != groups->end()) ++group;
       }
 
-      log.trace("Finding next proxy. Port: '%d', Enabled: %d", Self->FindPort, Self->FindEnabled);
+      log.trace("Finding next proxy. Port: '%s', Enabled: %d", Self->FindPort.c_str(), Self->FindEnabled);
 
       // Search for matching proxy
       for (; group != groups->end(); ++group) {
@@ -304,14 +311,8 @@ static ERR find_proxy(extProxy *Self)
          if (!matchesPortFilter(keys, Self->FindPort)) continue;
          if (!matchesEnabledFilter(keys, Self->FindEnabled)) continue;
 
-         // TODO: Implement network and gateway filters
-         if (keys.contains("NetworkFilter")) {
-            log.error("Network filters not supported yet.");
-         }
-
-         if (keys.contains("GatewayFilter")) {
-            log.error("Gateway filters not supported yet.");
-         }
+         if (!matchesDeferredFilter(keys, "NetworkFilter")) continue;
+         if (!matchesDeferredFilter(keys, "GatewayFilter")) continue;
 
          log.trace("Found matching proxy.");
          Self->GroupName = group->first;
@@ -422,6 +423,8 @@ GatewayFilter: The IP address of the gateway that the proxy is limited to.
 The GatewayFilter defines the IP address of the gateway that this proxy is limited to. It is intended to limit the
 results of searches performed by the #Find() method.
 
+Gateway matching is not currently implemented.  Records that define this field are skipped by #Find().
+
 *********************************************************************************************************************/
 
 static ERR SET_GatewayFilter(extProxy *Self, CSTRING Value)
@@ -464,6 +467,8 @@ The NetworkFilter defines the name of the network that this proxy is limited to.
 searches performed by the #Find() method.
 
 This filter must not be set if the proxy needs to work on an unnamed network.
+
+Network matching is not currently implemented.  Records that define this field are skipped by #Find().
 
 *********************************************************************************************************************/
 

--- a/src/network/net_iocp.cpp
+++ b/src/network/net_iocp.cpp
@@ -12,8 +12,6 @@
 
 #define HKEY_PROXY "\\HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\"
 
-static_assert(sizeof(struct sockaddr_storage) <= NETWORK_ENDPOINT_STORAGE_SIZE);
-
 static MsgHandler *glIocpCompletionHandler = nullptr;
 static MSGID glIocpCompletionMsgID = MSGID::NIL;
 
@@ -33,43 +31,6 @@ extern "C" {
       unsigned long HostNameLength, char *ServiceName, unsigned long ServiceNameLength, int Flags);
    const char * WSAAPI inet_ntop(int Family, const void *Address, char *StringBuffer, size_t StringBufferLength);
 }
-
-//********************************************************************************************************************
-
-static struct sockaddr_storage & endpoint_storage(NetworkEndpoint &Endpoint)
-{
-   return *(struct sockaddr_storage *)Endpoint.Storage;
-}
-
-static const struct sockaddr_storage & endpoint_storage(const NetworkEndpoint &Endpoint)
-{
-   return *(const struct sockaddr_storage *)Endpoint.Storage;
-}
-
-//********************************************************************************************************************
-
-static ERR endpoint_to_ip(const struct sockaddr_storage &Address, IPAddress &IP)
-{
-   kt::clearmem(&IP, sizeof(IP));
-
-   if (Address.ss_family IS AF_INET) {
-      auto addr = (const struct sockaddr_in *)&Address;
-      IP.Type = IPADDR::V4;
-      IP.Port = iocp_ntohs(addr->sin_port);
-      IP.Data[0] = iocp_ntohl(addr->sin_addr.s_addr);
-      return ERR::Okay;
-   }
-   else if (Address.ss_family IS AF_INET6) {
-      auto addr = (const struct sockaddr_in6 *)&Address;
-      IP.Type = IPADDR::V6;
-      IP.Port = iocp_ntohs(addr->sin6_port);
-      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP.Data, 16);
-      return ERR::Okay;
-   }
-   else return ERR::Args;
-}
-
-//********************************************************************************************************************
 
 static ERR convert_lookup_error(int Result)
 {

--- a/src/network/net_linux.cpp
+++ b/src/network/net_linux.cpp
@@ -8,39 +8,6 @@
 #include <strings.h>
 #include <sys/resource.h>
 
-static_assert(sizeof(struct sockaddr_storage) <= NETWORK_ENDPOINT_STORAGE_SIZE);
-
-static struct sockaddr_storage & endpoint_storage(NetworkEndpoint &Endpoint)
-{
-   return *(struct sockaddr_storage *)Endpoint.Storage;
-}
-
-static const struct sockaddr_storage & endpoint_storage(const NetworkEndpoint &Endpoint)
-{
-   return *(const struct sockaddr_storage *)Endpoint.Storage;
-}
-
-static ERR endpoint_to_ip(const struct sockaddr_storage &Address, IPAddress &IP)
-{
-   kt::clearmem(&IP, sizeof(IP));
-
-   if (Address.ss_family IS AF_INET) {
-      auto addr = (const struct sockaddr_in *)&Address;
-      IP.Type = IPADDR::V4;
-      IP.Port = network_platform().short_to_host(addr->sin_port);
-      IP.Data[0] = network_platform().long_to_host(addr->sin_addr.s_addr);
-      return ERR::Okay;
-   }
-   else if (Address.ss_family IS AF_INET6) {
-      auto addr = (const struct sockaddr_in6 *)&Address;
-      IP.Type = IPADDR::V6;
-      IP.Port = network_platform().short_to_host(addr->sin6_port);
-      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP.Data, 16);
-      return ERR::Okay;
-   }
-   else return ERR::Args;
-}
-
 static ERR convert_lookup_error(int Result)
 {
    switch (Result) {

--- a/src/network/net_platform.h
+++ b/src/network/net_platform.h
@@ -243,3 +243,36 @@ public:
 
 NetworkPlatform & network_platform();
 std::unique_ptr<NetworkPlatform> create_platform();
+
+static_assert(sizeof(struct sockaddr_storage) <= NETWORK_ENDPOINT_STORAGE_SIZE);
+
+inline struct sockaddr_storage & endpoint_storage(NetworkEndpoint &Endpoint)
+{
+   return *(struct sockaddr_storage *)Endpoint.Storage;
+}
+
+inline const struct sockaddr_storage & endpoint_storage(const NetworkEndpoint &Endpoint)
+{
+   return *(const struct sockaddr_storage *)Endpoint.Storage;
+}
+
+inline ERR endpoint_to_ip(const struct sockaddr_storage &Address, IPAddress &IP)
+{
+   kt::clearmem(&IP, sizeof(IP));
+
+   if (Address.ss_family IS AF_INET) {
+      auto addr = (const struct sockaddr_in *)&Address;
+      IP.Type = IPADDR::V4;
+      IP.Port = network_platform().short_to_host(addr->sin_port);
+      IP.Data[0] = network_platform().long_to_host(addr->sin_addr.s_addr);
+      return ERR::Okay;
+   }
+   else if (Address.ss_family IS AF_INET6) {
+      auto addr = (const struct sockaddr_in6 *)&Address;
+      IP.Type = IPADDR::V6;
+      IP.Port = network_platform().short_to_host(addr->sin6_port);
+      kt::copymem((APTR)addr->sin6_addr.s6_addr, IP.Data, 16);
+      return ERR::Okay;
+   }
+   else return ERR::Args;
+}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -27,7 +27,6 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <unordered_set>
 #include <ctime>
 #include <type_traits>
-#include <array>
 
 #include <string.h>
 
@@ -221,12 +220,6 @@ JUMPTABLE_CORE
 
 //********************************************************************************************************************
 
-struct CaseInsensitiveMap {
-   bool operator() (const std::string &lhs, const std::string &rhs) const {
-      return ::strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
-   }
-};
-
 struct CaseInsensitiveHash {
    std::size_t operator()(const std::string& s) const noexcept {
       std::string lower = s;
@@ -280,14 +273,6 @@ inline void setIPV4(IPAddress &IP, uint32_t IPV4HostOrder, uint16_t Port) {
    IP.Data[0] = IPV4HostOrder;
    IP.Data[1] = IP.Data[2] = IP.Data[3] = 0;
 }
-
-inline void setIPV6(IPAddress &IP, uint8_t *Address, uint16_t Port) {
-   IP.Type = IPADDR::V6;
-   IP.Port = Port;
-   kt::copymem(Address, &IP.Data, 16);
-}
-
-//********************************************************************************************************************
 
 static bool decimal_digit(char Value)
 {
@@ -880,41 +865,6 @@ ERR NetworkPlatform::prepare_bind_address(CSTRING Address, int Port, bool IPv6, 
 
 //********************************************************************************************************************
 
-#ifndef DISABLE_SSL
-template <class T> bool tls_active(T *Self)
-{
-   return Self->TLS.Handle;
-}
-
-template <class T> bool tls_handshake_pending(T *Self)
-{
-   #ifdef _WIN32
-      return (Self->TLS.Handle) and (Self->State IS NTC::HANDSHAKING);
-   #else
-      return (Self->TLS.Handle) and (Self->TLS.HandshakeStatus != SHS::NIL);
-   #endif
-}
-
-template <class T> bool tls_waiting_for_read(T *Self)
-{
-   #ifdef _WIN32
-      return false;
-   #else
-      return (Self->TLS.Handle) and (Self->TLS.HandshakeStatus IS SHS::READ);
-   #endif
-}
-
-template <class T> bool tls_waiting_for_write(T *Self)
-{
-   #ifdef _WIN32
-      return false;
-   #else
-      return (Self->TLS.Handle) and (Self->TLS.HandshakeStatus IS SHS::WRITE);
-   #endif
-}
-#endif
-
-//********************************************************************************************************************
 // Template function to handle SSL and socket sending for both NetSocket and ClientSocket
 
 template<typename T>

--- a/src/network/network.tdl
+++ b/src/network/network.tdl
@@ -5,13 +5,7 @@ module({ name="Network", copyright="Paul Manias © 2005-2026", version=1.0, pref
     loadFile(glPath .. 'common.tdl')
   end)
 
-  cpp_include("<unordered_set>", "<map>", "<mutex>")
-
   c_insert([[
-
-#if defined(ENABLE_SSL) && !defined(_WIN32)
- #include "openssl/ssl.h"
-#endif
 
 #ifdef __linux__
 typedef int SOCKET_HANDLE;

--- a/src/network/win32/ssl_wrapper.h
+++ b/src/network/win32/ssl_wrapper.h
@@ -21,7 +21,6 @@ typedef enum {
     SSL_ERROR_CONNECTING = -7
 } SSL_ERROR_CODE;
 
-ERR ssl_wrapper_init();
 void ssl_cleanup();
 void ssl_enable_logging();
 SSL_HANDLE ssl_create_context(bool ValidateCredentials = true, bool ServerMode = false);
@@ -39,7 +38,6 @@ size_t ssl_pending_output_size(SSL_HANDLE);
 void ssl_consume_pending_output(SSL_HANDLE, size_t);
 SSL_ERROR_CODE ssl_queue_encrypted_input(SSL_HANDLE, const void *, int);
 SSL_ERROR_CODE ssl_prepare_read(SSL_HANDLE);
-int ssl_read_internal(SSL_HANDLE, void* buffer, int buffer_size, int &);
 SSL_ERROR_CODE ssl_read(SSL_HANDLE, void* buffer, int buffer_size, int* bytes_read);
 SSL_ERROR_CODE ssl_write(SSL_HANDLE, const void* buffer, size_t buffer_size, size_t* bytes_sent);
 uint32_t ssl_last_win32_error(SSL_HANDLE);
@@ -69,9 +67,6 @@ const char* ssl_get_protocol_version(SSL_HANDLE);
 const char* ssl_get_cipher_suite(SSL_HANDLE);
 int ssl_get_key_size_bits(SSL_HANDLE);
 
-// SSL Debug callback function type
-typedef void (*SSL_DEBUG_CALLBACK)(const char* message, int level);
-
 // Debug levels
 enum SSL_DEBUG_LEVEL {
    SSL_DEBUG_ERROR = 0,
@@ -80,6 +75,4 @@ enum SSL_DEBUG_LEVEL {
    SSL_DEBUG_TRACE = 3
 };
 
-// Debug functions
-void ssl_set_debug_callback(SSL_DEBUG_CALLBACK callback);
 void ssl_debug_handshake(SSL_HANDLE, const char* operation);


### PR DESCRIPTION
## Summary

- Moved `endpoint_storage`, `endpoint_to_ip`, and `static_assert` into `net_platform.h`, eliminating identical implementations that were duplicated across `net_iocp.cpp` and `net_linux.cpp`
- Removed unused dead code from `network.cpp`: `CaseInsensitiveMap`, `setIPV6`, and the four `tls_active`/`tls_handshake_pending`/`tls_waiting_for_read`/`tls_waiting_for_write` template functions
- Fixed proxy `find_proxy` to skip records that define `NetworkFilter` or `GatewayFilter` (via new `matchesDeferredFilter` helper) rather than logging spurious errors; corrected `FindPort` trace format specifier from `%d` to `%s`
- Cleaned public `network.h` and `network.tdl` of private STL/OpenSSL includes; removed unused `ssl_wrapper_init`, `ssl_read_internal`, `SSL_DEBUG_CALLBACK`, and `ssl_set_debug_callback` declarations from `ssl_wrapper.h`

## Test plan

- [ ] Build `network` module on Windows (IOCP path) and verify no compile errors
- [ ] Build `network` module on Linux and verify no compile errors
- [ ] Run existing network Flute tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L network`
- [ ] Confirm proxy filter behaviour: searches with unset `NetworkFilter`/`GatewayFilter` still match; searches against records that define those fields are skipped without error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)