### PR TITLE
IOCP optimisation: pipelined I/O, send queue, and fine-grained locking

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -104,6 +104,7 @@ endif()
 
 set (NETWORK_TESTS
    bind_address dns_parallel server_io client_server error_handling ipv6 concurrency ssl iocp_pipeline
+   performance
    # UDP Tests
    udp_basic udp_ipv6 udp_broadcast_multicast udp_tcp_coexistence udp_performance
 )
@@ -111,7 +112,3 @@ set (NETWORK_TESTS
 foreach (TEST_NAME ${NETWORK_TESTS})
    flute_test(network_${TEST_NAME} "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${TEST_NAME}.tiri")
 endforeach ()
-
-# Heavy load/performance coverage is intentionally manual because it is timing-sensitive and expensive.
-# Run directly with tools/flute.tiri when network throughput changes need to be profiled:
-# src/network/tests/test_performance.tiri

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -98,9 +98,17 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
    kt::SwitchContext context(Self);
 
-   // Check client limit before accepting to prevent resource exhaustion
+   auto accepted = network_platform().accept(Self, Self->Handle, Self->IPV6);
+   auto clientfd = accepted.Handle;
+   if (clientfd.is_invalid()) {
+      log.warning("accept() failed to return an FD.");
+      return;
+   }
+
+   // Accept before enforcing admission limits so IOCP-backed servers drain and close completed AcceptEx sockets.
    if ((Self->TotalClients >= Self->ClientLimit) or (Self->TotalClients >= glSocketLimit)) {
       log.error(ERR::ArrayFull);
+      network_platform().close_socket(clientfd);
       return;
    }
 
@@ -118,15 +126,9 @@ static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
       accept_count++;
       if (accept_count > 100) { // Maximum 100 accepts per second
          log.warning("Connection rate limit exceeded, rejecting connection");
+         network_platform().close_socket(clientfd);
          return;
       }
-   }
-
-   auto accepted = network_platform().accept(Self, Self->Handle, Self->IPV6);
-   auto clientfd = accepted.Handle;
-   if (clientfd.is_invalid()) {
-      log.warning("accept() failed to return an FD.");
-      return;
    }
 
    if ((accepted.Address.Type != IPADDR::V4) and (accepted.Address.Type != IPADDR::V6)) {

--- a/src/network/tests/test_iocp_pipeline.tiri
+++ b/src/network/tests/test_iocp_pipeline.tiri
@@ -147,6 +147,99 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test; @Requires(network=true, windows_platform=true)
+function LargeBidirectionalTCPTransfer()
+   target_size     = 2 * 1024 * 1024
+   server_payload  = string.rep('B', target_size)
+   client_payload  = string.rep('C', target_size)
+   server_received = 0
+   client_received = 0
+   server_bad_data = false
+   client_bad_data = false
+   server_done     = false
+   client_done     = false
+   port            = nextPort()
+
+   server = obj.new('netsocket', {
+      name     = 'IocpBidirectionalServer',
+      address  = '127.0.0.1',
+      port     = port,
+      flags    = NSF_SERVER,
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, Client, State)
+         if State is NTC_CONNECTED then
+            err, len = Client.acWrite(server_payload)
+            assert(err is ERR_Okay, 'Server failed to queue bidirectional payload: ' .. mSys.GetErrorMsg(err))
+            assert(len is target_size, 'Server bidirectional write length mismatch')
+         end
+      end,
+      incoming = function(Socket, Client)
+         buffer = string.alloc(65536)
+         while true do
+            err, read_len = Client.acRead(buffer)
+            if err is ERR_Disconnected then return end
+            assert(err is ERR_Okay, 'Server failed to read bidirectional payload: ' .. mSys.GetErrorMsg(err))
+            if read_len <= 0 then break end
+
+            chunk = buffer:sub(0, read_len)
+            if chunk != string.rep('C', read_len) then server_bad_data = true end
+            server_received += read_len
+            if server_received >= target_size then break end
+         end
+
+         if (server_received >= target_size) and (not server_done) then
+            server_done = true
+            if client_done then Socket.acSignal() end
+         end
+      end
+   })
+
+   client = obj.new('netsocket', {
+      name     = 'IocpBidirectionalClient',
+      msgLimit = target_size + 65536,
+      feedback = function(Socket, State)
+         if State is NTC_CONNECTED then
+            err, len = Socket.acWrite(client_payload)
+            assert(err is ERR_Okay, 'Client failed to queue bidirectional payload: ' .. mSys.GetErrorMsg(err))
+            assert(len is target_size, 'Client bidirectional write length mismatch')
+         end
+      end,
+      incoming = function(Socket)
+         buffer = string.alloc(65536)
+         while true do
+            err, read_len = Socket.acRead(buffer)
+            if err is ERR_Disconnected then return end
+            assert(err is ERR_Okay, 'Client failed to read bidirectional payload: ' .. mSys.GetErrorMsg(err))
+            if read_len <= 0 then break end
+
+            chunk = buffer:sub(0, read_len)
+            if chunk != string.rep('B', read_len) then client_bad_data = true end
+            client_received += read_len
+            if client_received >= target_size then break end
+         end
+
+         if (client_received >= target_size) and (not client_done) then
+            client_done = true
+            if server_done then server.acSignal() end
+         end
+      end
+   })
+
+   check client.mtConnect('127.0.0.1', port)
+
+   for i = 0, 199 do
+      if server_done and client_done then break end
+      processing.halt(0.05)
+   end
+
+   assert(not server_bad_data, 'Server received corrupted bidirectional payload')
+   assert(not client_bad_data, 'Client received corrupted bidirectional payload')
+   assert(server_received is target_size, 'Server bidirectional receive size mismatch: ' .. server_received)
+   assert(client_received is target_size, 'Client bidirectional receive size mismatch: ' .. client_received)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(network=true, windows_platform=true)
 function SlowReaderBackpressure()
    target_size = 1536 * 1024
    payload     = string.rep('S', target_size)

--- a/src/network/tests/test_performance.tiri
+++ b/src/network/tests/test_performance.tiri
@@ -34,60 +34,53 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test(priority=10) function MessageThroughput()
-   start_time = mSys.PreciseTime()
+   start_time = 0
    messages_sent = 0
-   messages_received = 0
+   read_chunks = 0
    bytes_sent = 0
    bytes_received = 0
    target_messages = 1000
+   send_complete = false
    throughput_complete = false
 
    server = obj.new('netsocket', {
       name = 'ThroughputServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            logOutput('[Server] Client connected, starting throughput test...')
-            -- Start sending messages rapidly
-            for i = 1, target_messages do
-               local msg = 'THROUGHPUT_MSG_' .. i
-               local err, len = Client.acWrite(msg)
-               if (err is ERR_Okay) then
-                  messages_sent = messages_sent + 1
-                  bytes_sent += string.len(msg)
-               else
-                  logOutput('[Server] Send failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
-                  break
-               end
-            end
-            logOutput('[Server] Finished sending ' .. messages_sent .. ' messages')
+            logOutput('[Server] Client connected, waiting for throughput data...')
          end
       end,
       incoming = function(Socket, Client)
-         local buffer = string.alloc(1024)
-         local err, read_len = Client.acRead(buffer)
-         if (err is ERR_Okay and read_len > 0) then
-            messages_received = messages_received + 1
+         buffer = string.alloc(65536)
+
+         while true do
+            err, read_len = Client.acRead(buffer)
+            if (err is ERR_Disconnected) then break end
+            assert(err is ERR_Okay, '[Server] Throughput read failed: ' .. mSys.GetErrorMsg(err))
+            if (read_len <= 0) then break end
+
+            read_chunks = read_chunks + 1
             bytes_received += read_len
-            logOutput('Processed: ' .. messages_received)
+         end
 
-            if (bytes_received >= bytes_sent and messages_sent >= target_messages) then
-               local end_time = mSys.PreciseTime()
-               local duration = (end_time - start_time) / 1000000
-               local throughput = messages_sent / duration
+         if ((not throughput_complete) and send_complete and (bytes_received >= bytes_sent)) then
+            end_time = mSys.PreciseTime()
+            duration = (end_time - start_time) / 1000000
+            throughput = messages_sent / duration
 
-               logOutput('[Server] Throughput test completed:')
-               logOutput('  Messages: ' .. messages_sent)
-               logOutput('  Echo reads: ' .. messages_received)
-               logOutput('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
-               logOutput('  Throughput: ' .. string.format('%.1f', throughput) .. ' messages/second')
+            logOutput('[Server] Throughput test completed:')
+            logOutput('  Messages submitted: ' .. messages_sent)
+            logOutput('  Read chunks: ' .. read_chunks)
+            logOutput('  Bytes received: ' .. bytes_received)
+            logOutput('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
+            logOutput('  Throughput: ' .. string.format('%.1f', throughput) .. ' messages/second')
 
-               glThroughputStats.messages = messages_sent
-               glThroughputStats.duration = duration
-               glThroughputStats.throughput = throughput
+            glThroughputStats.messages = messages_sent
+            glThroughputStats.duration = duration
+            glThroughputStats.throughput = throughput
 
-               throughput_complete = true
-               Socket.acSignal()
-            end
+            throughput_complete = true
+            Socket.acSignal()
          end
       end,
       port = glPort,
@@ -98,22 +91,51 @@ end
 
    client = obj.new('netsocket', {
       name = 'ThroughputClient',
-      incoming = function(Socket, Script)
-         -- Echo back all received messages as quickly as possible
-         local buffer = string.alloc(1024)
-         local err, read_len = Socket.acRead(buffer)
-         if (err is ERR_Okay) then
-            local msg = buffer:sub(0, read_len)
-            Socket.acWrite(msg) -- Echo back immediately
+      feedback = function(Socket, State)
+         if (State is NTC_CONNECTED) then
+            logOutput('[Client] Connected, starting throughput test...')
+            start_time = mSys.PreciseTime()
+
+            for i = 1, target_messages do
+               local msg = 'THROUGHPUT_MSG_' .. i
+               local err, len = Socket.acWrite(msg)
+               if (err is ERR_Okay) then
+                  messages_sent = messages_sent + 1
+                  bytes_sent += len
+               else
+                  logOutput('[Client] Send failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
+                  break
+               end
+            end
+
+            send_complete = true
+            logOutput('[Client] Finished sending ' .. messages_sent .. ' messages')
+            if ((not throughput_complete) and (bytes_received >= bytes_sent)) then
+               throughput_complete = true
+               glThroughputStats.messages = messages_sent
+               glThroughputStats.duration = (mSys.PreciseTime() - start_time) / 1000000
+               glThroughputStats.throughput = messages_sent / glThroughputStats.duration
+               logOutput('[Client] Throughput test completed before returning from feedback')
+               server.acSignal()
+            end
          end
+      end,
+      incoming = function(Socket, Script)
+         local buffer = string.alloc(256)
+         Socket.acRead(buffer)
       end
    })
 
    check client.mtConnect('127.0.0.1', glPort)
    check proc.sleep()
+   assert(client != nil, 'Throughput client was released before the test completed')
 
-   logOutput('Received ' .. messages_received .. ' messages of ' .. target_messages)
+   logOutput('Received ' .. bytes_received .. ' bytes from ' .. bytes_sent .. ' queued bytes')
    assert(throughput_complete, 'Throughput test did not complete')
+   assert(messages_sent is target_messages,
+      'Not all throughput messages were queued. Expected: ' .. target_messages .. ', queued: ' .. messages_sent)
+   assert(bytes_received >= bytes_sent,
+      'Throughput byte count mismatch. Sent: ' .. bytes_sent .. ', received: ' .. bytes_received)
 
    -- Verify minimum acceptable performance
    assert(glThroughputStats.throughput > 100,
@@ -128,6 +150,7 @@ end
    message_sizes = array<int> { 1024, 8192, 65536, 262144 } -- 1KB, 8KB, 64KB, 256KB
    transfer_results = array<table>
    current_size_index = 0
+   current_bytes_received = 0
 
    server = obj.new('netsocket', {
       name = 'LargeMessageServer',
@@ -135,12 +158,12 @@ end
          if (State is NTC_CONNECTED) then
             logOutput('[Server] Starting large message test...')
             -- Send first large message
-            local size = message_sizes[current_size_index]
-            local large_msg = string.rep('X', size)
-            local start_time = mSys.PreciseTime()
+            size = message_sizes[current_size_index]
+            large_msg = string.rep('X', size)
+            start_time = mSys.PreciseTime()
 
             logOutput('[Server] Sending ' .. size .. ' byte message...')
-            local err, len = Client.acWrite(large_msg)
+            err, len = Client.acWrite(large_msg)
             if (err is ERR_Okay) then
                transfer_results:push({ size = size, start_time = start_time })
             else
@@ -149,27 +172,27 @@ end
          end
       end,
       incoming = function(Socket, Client)
-         -- Read the echoed large message
-         local expected_size = message_sizes[current_size_index]
-         local buffer = string.alloc(expected_size + 100)
-         local total_read = 0
-         local read_start = mSys.PreciseTime()
+         if (current_size_index >= #message_sizes) then return end
 
-         -- May need multiple reads for very large messages
-         while (total_read < expected_size) do
-            local err, read_len = Client.acRead(buffer:sub(total_read))
+         expected_size = message_sizes[current_size_index]
+         buffer = string.alloc(65536)
+
+         while (current_bytes_received < expected_size) do
+            err, read_len = Client.acRead(buffer)
             if (err is ERR_Okay and read_len > 0) then
-               total_read = total_read + read_len
-            elseif (err is ERR_NoData) then
-               processing.halt(0.001) -- Brief wait for more data
+               current_bytes_received += read_len
+            elseif (err is ERR_Disconnected) then
+               return
             else
                break
             end
          end
 
-         local end_time = mSys.PreciseTime()
-         local duration = (end_time - transfer_results[current_size_index].start_time) / 1000000
-         local throughput_mbps = (expected_size * 2 / 1024 / 1024) / duration -- *2 for round trip
+         if (current_bytes_received < expected_size) then return end
+
+         end_time = mSys.PreciseTime()
+         duration = (end_time - transfer_results[current_size_index].start_time) / 1000000
+         throughput_mbps = (expected_size * 2 / 1024 / 1024) / duration -- *2 for round trip
 
          logOutput('[Server] Large message ' .. expected_size .. ' bytes:')
          logOutput('  Duration: ' .. string.format('%.3f', duration) .. ' seconds')
@@ -179,14 +202,16 @@ end
          transfer_results[current_size_index].throughput = throughput_mbps
 
          current_size_index = current_size_index + 1
+         current_bytes_received = 0
+
          if (current_size_index < #message_sizes) then
             -- Send next size
-            local size = message_sizes[current_size_index]
-            local large_msg = string.rep('Y', size)
-            local start_time = mSys.PreciseTime()
+            size = message_sizes[current_size_index]
+            large_msg = string.rep('Y', size)
+            start_time = mSys.PreciseTime()
 
             logOutput('[Server] Sending ' .. size .. ' byte message...')
-            local err, len = Client.acWrite(large_msg)
+            err, len = Client.acWrite(large_msg)
             if (err is ERR_Okay) then
                transfer_results:push({ size = size, start_time = start_time })
             end
@@ -202,21 +227,28 @@ end
 
    proc = processing.new({ timeout = 15.0, signals = array<object> { server } })
 
-   local client = obj.new('netsocket', {
+   client = obj.new('netsocket', {
       name = 'LargeMessageClient',
       incoming = function(Socket, Script)
-         -- Echo back large messages
-         local buffer = string.alloc(300000) -- Large buffer
-         local err, read_len = Socket.acRead(buffer)
-         if (err is ERR_Okay and read_len > 0) then
+         local buffer = string.alloc(65536)
+
+         while true do
+            local err, read_len = Socket.acRead(buffer)
+            if (err is ERR_Disconnected) then break end
+            assert(err is ERR_Okay, '[Client] Large message read failed: ' .. mSys.GetErrorMsg(err))
+            if (read_len <= 0) then break end
+
             local msg = buffer:sub(0, read_len)
-            Socket.acWrite(msg) -- Echo back
+            local write_err, len = Socket.acWrite(msg)
+            assert(write_err is ERR_Okay, '[Client] Large message echo failed: ' .. mSys.GetErrorMsg(write_err))
+            assert(len is read_len, '[Client] Large message echo accepted a partial chunk')
          end
       end
    })
 
    check client.mtConnect('127.0.0.1', glPort + 1)
    check proc.sleep()
+   assert(client != nil, 'Large message client was released before the test completed')
 
    assert(#transfer_results is #message_sizes,
       'Not all message sizes tested. Expected: ' .. #message_sizes .. ', Got: ' .. #transfer_results)
@@ -285,18 +317,19 @@ end
    end
 
    check proc.sleep()
+   assert(clients[max_clients] != nil, 'Scaling clients were released before the test completed')
 
    assert(scaling_complete, 'Not all clients connected within timeout')
 
    -- Analyze connection timing
    if (#connection_times > 0) then
-      local total_time = 0
-      local max_time = 0
+      total_time = 0
+      max_time = 0
       for i, time in ipairs(connection_times) do
          total_time = total_time + time
          if (time > max_time) then max_time = time end
       end
-      local avg_time = total_time / #connection_times
+      avg_time = total_time / #connection_times
 
       logOutput('Connection Scaling Results:')
       logOutput('  Successful connections: ' .. #connection_times .. '/' .. max_clients)
@@ -314,57 +347,40 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 @Test(priority=40) function WriteQueuePerformance()
-   local queue_messages = 500
-   local messages_queued = 0
-   local messages_processed = 0
-   local bytes_queued = 0
-   local bytes_processed = 0
-   local queue_test_complete = false
+   queue_messages = 500
+   messages_queued = 0
+   read_chunks = 0
+   bytes_queued = 0
+   bytes_received = 0
+   queue_complete = false
+   queue_test_complete = false
 
    logOutput('Testing write queue performance with ' .. queue_messages .. ' queued messages...')
 
-   local server = obj.new('netsocket', {
+   server = obj.new('netsocket', {
       name = 'QueueTestServer',
       feedback = function(Socket, Client, State)
          if (State is NTC_CONNECTED) then
-            logOutput('[Server] Client connected, flooding write queue...')
-            local start_time = mSys.PreciseTime()
-
-            -- Rapidly queue many messages without waiting
-            for i = 1, queue_messages do
-               local msg = 'QUEUE_TEST_' .. i .. '_' .. string.rep('DATA', 10)
-               local err, len = Client.acWrite(msg)
-               if (err is ERR_Okay) then
-                  messages_queued = messages_queued + 1
-                  bytes_queued += string.len(msg)
-               else
-                  logOutput('[Server] Queue write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
-                  break
-               end
-            end
-
-            local queue_time = mSys.PreciseTime() - start_time
-            logOutput('[Server] Queued ' .. messages_queued .. ' messages in ' ..
-                  string.format('%.3f', queue_time / 1000000) .. ' seconds')
-
-            glPerformanceResults.queue_time = queue_time / 1000000
-            glPerformanceResults.queue_rate = messages_queued / glPerformanceResults.queue_time
+            logOutput('[Server] Client connected, waiting for queued data...')
          end
       end,
       incoming = function(Socket, Client)
-         local buffer = string.alloc(1024)
-         local err, read_len = Client.acRead(buffer)
-         if (err is ERR_Okay and read_len > 0) then
-            messages_processed = messages_processed + 1
-            bytes_processed += read_len
+         buffer = string.alloc(65536)
 
-            if (bytes_processed >= bytes_queued and messages_queued >= queue_messages) then
-               logOutput('[Server] All queued messages processed: ' .. messages_processed)
-               queue_test_complete = true
-               Socket.acSignal()
-            elseif (messages_processed % 100 is 0) then
-               logOutput('[Server] Processed ' .. messages_processed .. '/' .. messages_queued .. ' messages')
-            end
+         while true do
+            err, read_len = Client.acRead(buffer)
+            if (err is ERR_Disconnected) then break end
+            assert(err is ERR_Okay, '[Server] Queue read failed: ' .. mSys.GetErrorMsg(err))
+            if (read_len <= 0) then break end
+
+            read_chunks = read_chunks + 1
+            bytes_received += read_len
+         end
+
+         if ((not queue_test_complete) and queue_complete and (bytes_received >= bytes_queued)) then
+            logOutput('[Server] All queued bytes received in ' .. read_chunks .. ' read chunks')
+            queue_test_complete = true
+            Socket.acSignal()
          end
       end,
       port = glPort + 3,
@@ -375,24 +391,55 @@ end
 
    client = obj.new('netsocket', {
       name = 'QueueTestClient',
-      incoming = function(Socket, Script)
-         -- Read and echo back messages to test queue drainage
-         local buffer = string.alloc(1024)
-         local err, read_len = Socket.acRead(buffer)
-         if (err is ERR_Okay) then
-            local msg = buffer:sub(0, read_len)
-            Socket.acWrite(msg) -- Echo data to test queue drainage
+      feedback = function(Socket, State)
+         if (State is NTC_CONNECTED) then
+            logOutput('[Client] Connected, flooding write queue...')
+            local start_time = mSys.PreciseTime()
+
+            -- Rapidly queue many messages without waiting
+            for i = 1, queue_messages do
+               local msg = 'QUEUE_TEST_' .. i .. '_' .. string.rep('DATA', 10)
+               local err, len = Socket.acWrite(msg)
+               if (err is ERR_Okay) then
+                  messages_queued = messages_queued + 1
+                  bytes_queued += len
+               else
+                  logOutput('[Client] Queue write failed at message ' .. i .. ': ' .. mSys.GetErrorMsg(err))
+                  break
+               end
+            end
+
+            queue_complete = true
+            local queue_time = mSys.PreciseTime() - start_time
+            logOutput('[Client] Queued ' .. messages_queued .. ' messages in ' ..
+                  string.format('%.3f', queue_time / 1000000) .. ' seconds')
+
+            glPerformanceResults.queue_time = queue_time / 1000000
+            glPerformanceResults.queue_rate = messages_queued / glPerformanceResults.queue_time
+
+            if ((not queue_test_complete) and (bytes_received >= bytes_queued)) then
+               logOutput('[Client] Queue test completed before returning from feedback')
+               queue_test_complete = true
+               server.acSignal()
+            end
          end
+      end,
+      incoming = function(Socket, Script)
+         local buffer = string.alloc(256)
+         Socket.acRead(buffer)
       end
    })
 
    check client.mtConnect('127.0.0.1', glPort + 3)
    check proc.sleep()
+   assert(client != nil, 'Queue test client was released before the test completed')
 
    assert(queue_test_complete, 'Queue test did not complete')
+   assert(messages_queued is queue_messages,
+      'Not all queue messages were accepted. Expected: ' .. queue_messages .. ', queued: ' .. messages_queued)
 
-   assert(bytes_processed >= bytes_queued,
-      'Too much queued data was lost. Queued: ' .. bytes_queued .. ', Processed: ' .. bytes_processed)
+   assert(bytes_received >= bytes_queued,
+      'Too much queued data was lost. Queued: ' .. bytes_queued .. ', Received: ' .. bytes_received)
 
    logOutput('Queue rate: ' .. string.format('%.1f', glPerformanceResults.queue_rate) .. ' messages/second')
 end
@@ -401,11 +448,11 @@ end
 
 @Test(priority=50) function MemoryUsageUnderLoad()
    -- This test creates and destroys many network objects to check for leaks
-   local iterations = 50
-   local objects_per_iteration = 5
+   iterations = 50
+   objects_per_iteration = 5
 
    for iter = 1, iterations do
-      local temp_objects = {}
+      temp_objects = {}
 
       -- Create multiple network objects
       for i = 1, objects_per_iteration do

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -594,7 +594,6 @@ static IocpStoreResult store_operation_result(IocpSocketRecord &Record, const Io
          glSockets[Operation.AcceptedSocket] = accepted_record;
       }
 
-      result.RearmAccept = true;
       return result;
    }
 
@@ -1495,6 +1494,8 @@ ERR iocp_accept(WSW_SOCKET Server, WSW_SOCKET &Client, void *Address, int *Addre
       std::memcpy(Address, accepted.Address.data(), size_t(copy_size));
       *AddressSize = copy_size;
    }
+
+   post_accept(Server);
 
    return ERR::Okay;
 }

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -79,6 +79,7 @@ struct IocpStoreResult {
 };
 
 struct IocpSocketRecord {
+   mutable std::mutex Mutex;
    int ObjectID = 0;
    IocpCompletionTarget Connect;
    IocpCompletionTarget Read;
@@ -109,10 +110,12 @@ struct IocpSocketRecord {
    bool UdpReadPending = false;
 };
 
+using IocpSocketRecordPtr = std::shared_ptr<IocpSocketRecord>;
+
 static HANDLE glCompletionPort = INVALID_HANDLE_VALUE;
 static std::vector<std::jthread> glWorkers;
-static std::mutex glIocpMutex;
-static std::unordered_map<WSW_SOCKET, IocpSocketRecord> glSockets;
+static std::mutex glRegistryMutex;
+static std::unordered_map<WSW_SOCKET, IocpSocketRecordPtr> glSockets;
 static std::atomic_bool glShutdownRequested = false;
 static std::atomic_size_t glPendingOperations = 0;
 static std::atomic_uint64_t glNextGeneration = 1;
@@ -155,6 +158,23 @@ static void release_operation(IocpOperation *Operation)
    delete Operation;
    glPendingOperations.fetch_sub(1);
    glPendingOperations.notify_all();
+}
+
+//********************************************************************************************************************
+
+static IocpSocketRecordPtr find_socket_record(WSW_SOCKET Socket)
+{
+   std::lock_guard<std::mutex> lock(glRegistryMutex);
+   auto record = glSockets.find(Socket);
+   if (record IS glSockets.end()) return nullptr;
+   return record->second;
+}
+
+//********************************************************************************************************************
+
+static IocpSocketRecordPtr create_socket_record()
+{
+   return std::make_shared<IocpSocketRecord>();
 }
 
 //********************************************************************************************************************
@@ -561,12 +581,18 @@ static IocpStoreResult store_operation_result(IocpSocketRecord &Record, const Io
       std::memcpy(accepted.Address.data(), remote_address, size_t(remote_size));
       Record.AcceptedSockets.push_back(accepted);
 
-      auto server_ipv6 = Record.IPv6;
-      glSockets[Operation.AcceptedSocket] = {
-         .Generation = glNextGeneration++,
-         .IPv6 = server_ipv6,
-         .Cancelled = false
-      };
+      auto accepted_record = create_socket_record();
+      {
+         std::lock_guard<std::mutex> accepted_lock(accepted_record->Mutex);
+         accepted_record->Generation = glNextGeneration++;
+         accepted_record->IPv6 = Record.IPv6;
+         accepted_record->Cancelled = false;
+      }
+
+      {
+         std::lock_guard<std::mutex> registry_lock(glRegistryMutex);
+         glSockets[Operation.AcceptedSocket] = accepted_record;
+      }
 
       result.RearmAccept = true;
       return result;
@@ -619,18 +645,19 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
    bool notify_completion = true;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Operation.Socket);
-      if (record IS glSockets.end()) {
-         close_accepted_socket(Operation);
-         return;
-      }
-      if ((record->second.Cancelled) or (record->second.Generation != Operation.Generation)) {
+      auto record = find_socket_record(Operation.Socket);
+      if (!record) {
          close_accepted_socket(Operation);
          return;
       }
 
-      auto target = completion_target(record->second, Operation.Type);
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if ((record->Cancelled) or (record->Generation != Operation.Generation)) {
+         close_accepted_socket(Operation);
+         return;
+      }
+
+      auto target = completion_target(*record, Operation.Type);
 
       if ((Operation.Type IS IocpOperationType::WRITE) and (Error IS ERR::Okay) and
           (BytesTransferred > 0) and (BytesTransferred < Operation.BufferSize)) {
@@ -638,7 +665,7 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
          else Error = tail_error;
       }
 
-      auto store_result = store_operation_result(record->second, Operation, Error);
+      auto store_result = store_operation_result(*record, Operation, Error);
       rearm_accept = store_result.RearmAccept and (target.Callback) and (target.ObjectID > 0);
       post_reads = store_result.PostRead;
       post_sends = store_result.PostSend;
@@ -669,17 +696,18 @@ static ERR queue_record_completion(WSW_SOCKET Socket, IocpOperationType Type)
    iocp_completion_message message;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      auto target = completion_target(record->second, Type);
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+
+      auto target = completion_target(*record, Type);
       if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
 
       message.Type = Type;
       message.Socket = Socket;
-      message.Generation = record->second.Generation;
+      message.Generation = record->Generation;
       message.ObjectID = target.ObjectID;
       message.Callback = target.Callback;
       message.Error = ERR::Okay;
@@ -698,20 +726,21 @@ static ERR post_udp_receive(WSW_SOCKET Socket)
    bool ipv6 = false;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.UdpReadPending) return ERR::Okay;
-      if (!record->second.Datagrams.empty()) return ERR::Okay;
-      if (record->second.ReadResult != ERR::Okay) return ERR::Okay;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      target = record->second.Read;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+      if (record->UdpReadPending) return ERR::Okay;
+      if (!record->Datagrams.empty()) return ERR::Okay;
+      if (record->ReadResult != ERR::Okay) return ERR::Okay;
+
+      target = record->Read;
       if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
 
-      record->second.UdpReadPending = true;
-      generation = record->second.Generation;
-      ipv6 = record->second.IPv6;
+      record->UdpReadPending = true;
+      generation = record->Generation;
+      ipv6 = record->IPv6;
    }
 
    if (auto error = bind_udp_ephemeral(socket_from_handle(Socket), ipv6); error != ERR::Okay) {
@@ -766,18 +795,19 @@ static ERR post_read(WSW_SOCKET Socket)
    bool udp = false;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      udp = record->second.UDP;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (!udp) {
-         if (!tcp_read_post_needed(record->second)) return ERR::Okay;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-         record->second.ReadPendingCount++;
-         generation = record->second.Generation;
-         sequence = record->second.NextReadSequence++;
-         target = record->second.Read;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      udp = record->UDP;
+      if (record->Cancelled) return ERR::Cancelled;
+      if (!udp) {
+         if (!tcp_read_post_needed(*record)) return ERR::Okay;
+
+         record->ReadPendingCount++;
+         generation = record->Generation;
+         sequence = record->NextReadSequence++;
+         target = record->Read;
       }
    }
 
@@ -816,19 +846,20 @@ static ERR post_read(WSW_SOCKET Socket)
 
 static bool read_post_needed(WSW_SOCKET Socket, ERR &Error)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) {
+   auto record = find_socket_record(Socket);
+   if (!record) {
       Error = ERR::Search;
       return false;
    }
-   if (record->second.Cancelled) {
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) {
       Error = ERR::Cancelled;
       return false;
    }
 
    Error = ERR::Okay;
-   return tcp_read_post_needed(record->second);
+   return tcp_read_post_needed(*record);
 }
 
 //********************************************************************************************************************
@@ -855,17 +886,18 @@ static ERR post_send(WSW_SOCKET Socket)
    uint64_t generation = 0;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (!tcp_send_post_needed(record->second)) return ERR::Okay;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      target = record->second.Write;
-      generation = record->second.Generation;
-      request = std::move(record->second.SendQueue.front());
-      record->second.SendQueue.pop_front();
-      record->second.SendPendingCount++;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+      if (!tcp_send_post_needed(*record)) return ERR::Okay;
+
+      target = record->Write;
+      generation = record->Generation;
+      request = std::move(record->SendQueue.front());
+      record->SendQueue.pop_front();
+      record->SendPendingCount++;
    }
 
    if ((!request.Buffer) or (!request.BufferSize)) return ERR::Okay;
@@ -902,19 +934,20 @@ static ERR post_send(WSW_SOCKET Socket)
 
 static bool send_post_needed(WSW_SOCKET Socket, ERR &Error)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) {
+   auto record = find_socket_record(Socket);
+   if (!record) {
       Error = ERR::Search;
       return false;
    }
-   if (record->second.Cancelled) {
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) {
       Error = ERR::Cancelled;
       return false;
    }
 
    Error = ERR::Okay;
-   return tcp_send_post_needed(record->second);
+   return tcp_send_post_needed(*record);
 }
 
 //********************************************************************************************************************
@@ -941,27 +974,27 @@ static ERR post_accept(WSW_SOCKET Socket)
    bool server_ipv6 = false;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.AcceptPendingCount >= size_t(record->second.AcceptDepth)) return ERR::Okay;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      target = record->second.Accept;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+      if (record->AcceptPendingCount >= size_t(record->AcceptDepth)) return ERR::Okay;
+
+      target = record->Accept;
       if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
 
-      record->second.AcceptPendingCount++;
-      generation = record->second.Generation;
-      server_ipv6 = record->second.IPv6;
+      record->AcceptPendingCount++;
+      generation = record->Generation;
+      server_ipv6 = record->IPv6;
    }
 
    bool accepted_ipv6 = false;
    auto accepted_socket = create_tcp_socket(server_ipv6, accepted_ipv6);
    if (accepted_socket IS INVALID_SOCKET) {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
-         record->second.AcceptPendingCount--;
+      if (auto record = find_socket_record(Socket); record) {
+         std::lock_guard<std::mutex> lock(record->Mutex);
+         if (record->AcceptPendingCount > 0) record->AcceptPendingCount--;
       }
       return convert_error();
    }
@@ -980,10 +1013,9 @@ static ERR post_accept(WSW_SOCKET Socket)
    auto accept_ex = get_accept_ex(socket_from_handle(Socket));
    if (!accept_ex) {
       {
-         std::lock_guard<std::mutex> lock(glIocpMutex);
-         auto record = glSockets.find(Socket);
-         if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
-            record->second.AcceptPendingCount--;
+         if (auto record = find_socket_record(Socket); record) {
+            std::lock_guard<std::mutex> lock(record->Mutex);
+            if (record->AcceptPendingCount > 0) record->AcceptPendingCount--;
          }
       }
       close_accepted_socket(*operation);
@@ -997,10 +1029,9 @@ static ERR post_accept(WSW_SOCKET Socket)
    if ((!result) and (WSAGetLastError() != WSA_IO_PENDING)) {
       auto error = convert_error();
       {
-         std::lock_guard<std::mutex> lock(glIocpMutex);
-         auto record = glSockets.find(Socket);
-         if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
-            record->second.AcceptPendingCount--;
+         if (auto record = find_socket_record(Socket); record) {
+            std::lock_guard<std::mutex> lock(record->Mutex);
+            if (record->AcceptPendingCount > 0) record->AcceptPendingCount--;
          }
       }
       close_accepted_socket(*operation);
@@ -1015,25 +1046,26 @@ static ERR post_accept(WSW_SOCKET Socket)
 
 static bool accept_post_needed(WSW_SOCKET Socket, ERR &Error)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) {
+   auto record = find_socket_record(Socket);
+   if (!record) {
       Error = ERR::Search;
       return false;
    }
-   if (record->second.Cancelled) {
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) {
       Error = ERR::Cancelled;
       return false;
    }
 
-   auto target = record->second.Accept;
+   auto target = record->Accept;
    if ((!target.Callback) or (target.ObjectID <= 0)) {
       Error = ERR::Okay;
       return false;
    }
 
    Error = ERR::Okay;
-   return record->second.AcceptPendingCount < size_t(record->second.AcceptDepth);
+   return record->AcceptPendingCount < size_t(record->AcceptDepth);
 }
 
 //********************************************************************************************************************
@@ -1081,16 +1113,17 @@ static void worker_thread()
 
 static ERR set_completion_target(WSW_SOCKET Socket, IocpOperationType Type, int ObjectID, uintptr_t Callback)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) return ERR::Search;
-   if (record->second.Cancelled) return ERR::Cancelled;
+   auto record = find_socket_record(Socket);
+   if (!record) return ERR::Search;
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) return ERR::Cancelled;
 
    auto target = IocpCompletionTarget { ObjectID, Callback };
-   if (Type IS IocpOperationType::READ) record->second.Read = target;
-   else if (Type IS IocpOperationType::WRITE) record->second.Write = target;
-   else if (Type IS IocpOperationType::ACCEPT) record->second.Accept = target;
-   else if (Type IS IocpOperationType::CONNECT) record->second.Connect = target;
+   if (Type IS IocpOperationType::READ) record->Read = target;
+   else if (Type IS IocpOperationType::WRITE) record->Write = target;
+   else if (Type IS IocpOperationType::ACCEPT) record->Accept = target;
+   else if (Type IS IocpOperationType::CONNECT) record->Connect = target;
    else return ERR::NoSupport;
 
    return ERR::Okay;
@@ -1134,16 +1167,24 @@ void iocp_expunge()
 
    if (glCompletionPort != INVALID_HANDLE_VALUE) {
       std::vector<WSW_SOCKET> sockets;
+      std::vector<IocpSocketRecordPtr> records;
 
       {
-         std::lock_guard<std::mutex> lock(glIocpMutex);
+         std::lock_guard<std::mutex> lock(glRegistryMutex);
          sockets.reserve(glSockets.size());
-         for (auto &record : glSockets) {
-            record.second.Cancelled = true;
-            record.second.Generation++;
-            sockets.push_back(record.first);
+         for (auto &entry : glSockets) {
+            sockets.push_back(entry.first);
+            records.push_back(entry.second);
+         }
+      }
 
-            for (auto &accepted : record.second.AcceptedSockets) sockets.push_back(accepted.Socket);
+      for (auto &record : records) {
+         std::lock_guard<std::mutex> record_lock(record->Mutex);
+         record->Cancelled = true;
+         record->Generation++;
+
+         for (auto &accepted : record->AcceptedSockets) {
+            sockets.push_back(accepted.Socket);
          }
       }
 
@@ -1173,7 +1214,7 @@ void iocp_expunge()
    glWorkers.clear();
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
+      std::lock_guard<std::mutex> lock(glRegistryMutex);
       glSockets.clear();
    }
 
@@ -1209,14 +1250,18 @@ WSW_SOCKET iocp_create_socket(int ObjectID, bool UDP, bool &IPv6)
 
    WSW_SOCKET result = handle_from_socket(socket);
 
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   glSockets[result] = {
-      .ObjectID = ObjectID,
-      .Generation = glNextGeneration++,
-      .IPv6 = IPv6,
-      .UDP = UDP,
-      .Cancelled = false
-   };
+   auto record = create_socket_record();
+   {
+      std::lock_guard<std::mutex> record_lock(record->Mutex);
+      record->ObjectID = ObjectID;
+      record->Generation = glNextGeneration++;
+      record->IPv6 = IPv6;
+      record->UDP = UDP;
+      record->Cancelled = false;
+   }
+
+   std::lock_guard<std::mutex> lock(glRegistryMutex);
+   glSockets[result] = record;
 
    return result;
 }
@@ -1238,12 +1283,18 @@ void iocp_close_socket(WSW_SOCKET Socket)
 
 void iocp_deregister_socket(WSW_SOCKET Socket)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record != glSockets.end()) {
-      record->second.Cancelled = true;
-      record->second.Generation++;
-      glSockets.erase(record);
+   if (auto record = find_socket_record(Socket); record) {
+      std::lock_guard<std::mutex> record_lock(record->Mutex);
+      record->Cancelled = true;
+      record->Generation++;
+   }
+
+   {
+      std::lock_guard<std::mutex> lock(glRegistryMutex);
+      auto record = glSockets.find(Socket);
+      if (record != glSockets.end()) {
+         glSockets.erase(record);
+      }
    }
 }
 
@@ -1258,9 +1309,11 @@ int iocp_shutdown_socket(WSW_SOCKET Socket, int How)
 
 void iocp_set_socket_object(WSW_SOCKET Socket, int ObjectID)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record != glSockets.end()) record->second.ObjectID = ObjectID;
+   auto record = find_socket_record(Socket);
+   if (record) {
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      record->ObjectID = ObjectID;
+   }
 }
 
 //********************************************************************************************************************
@@ -1269,14 +1322,15 @@ ERR iocp_prepare_connect(WSW_SOCKET Socket, const void *Address, int AddressSize
 {
    if ((!Address) or (AddressSize <= 0) or (AddressSize > int(IOCP_ENDPOINT_STORAGE_SIZE))) return ERR::Args;
 
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) return ERR::Search;
-   if (record->second.Cancelled) return ERR::Cancelled;
+   auto record = find_socket_record(Socket);
+   if (!record) return ERR::Search;
 
-   std::memcpy(record->second.ConnectAddress.data(), Address, size_t(AddressSize));
-   record->second.ConnectAddressSize = AddressSize;
-   record->second.ConnectResult = ERR::Busy;
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) return ERR::Cancelled;
+
+   std::memcpy(record->ConnectAddress.data(), Address, size_t(AddressSize));
+   record->ConnectAddressSize = AddressSize;
+   record->ConnectResult = ERR::Busy;
    return ERR::Busy;
 }
 
@@ -1290,19 +1344,20 @@ ERR iocp_begin_connect_wait(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
    IocpCompletionTarget target;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.ConnectAddressSize <= 0) return ERR::NotInitialised;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      record->second.Connect = { ObjectID, Callback };
-      record->second.ConnectResult = ERR::Busy;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+      if (record->ConnectAddressSize <= 0) return ERR::NotInitialised;
 
-      address = record->second.ConnectAddress;
-      address_size = record->second.ConnectAddressSize;
-      generation = record->second.Generation;
-      target = record->second.Connect;
+      record->Connect = { ObjectID, Callback };
+      record->ConnectResult = ERR::Busy;
+
+      address = record->ConnectAddress;
+      address_size = record->ConnectAddressSize;
+      generation = record->Generation;
+      target = record->Connect;
    }
 
    IocpOperation failed_operation;
@@ -1355,10 +1410,11 @@ ERR iocp_complete_connect(WSW_SOCKET Socket)
    ERR result = ERR::Okay;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      result = record->second.ConnectResult;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
+
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      result = record->ConnectResult;
    }
 
    if (result IS ERR::Okay) {
@@ -1375,11 +1431,12 @@ ERR iocp_complete_connect(WSW_SOCKET Socket)
 
 bool iocp_validate_completion(WSW_SOCKET Socket, uint64_t Generation)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) return false;
-   if (record->second.Cancelled) return false;
-   return record->second.Generation IS Generation;
+   auto record = find_socket_record(Socket);
+   if (!record) return false;
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   if (record->Cancelled) return false;
+   return record->Generation IS Generation;
 }
 
 //********************************************************************************************************************
@@ -1397,9 +1454,10 @@ ERR iocp_listen(WSW_SOCKET Socket, int Backlog)
 {
    if (listen(socket_from_handle(Socket), Backlog) IS SOCKET_ERROR) return convert_error();
 
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record != glSockets.end()) record->second.AcceptDepth = accept_depth_from_backlog(Backlog);
+   if (auto record = find_socket_record(Socket); record) {
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      record->AcceptDepth = accept_depth_from_backlog(Backlog);
+   }
 
    return ERR::Okay;
 }
@@ -1422,14 +1480,15 @@ ERR iocp_accept(WSW_SOCKET Server, WSW_SOCKET &Client, void *Address, int *Addre
    if ((!Address) or (!AddressSize)) return ERR::NullArgs;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Server);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.AcceptedSockets.empty()) return ERR::Search;
+      auto record = find_socket_record(Server);
+      if (!record) return ERR::Search;
 
-      auto accepted = record->second.AcceptedSockets.front();
-      record->second.AcceptedSockets.pop_front();
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+      if (record->AcceptedSockets.empty()) return ERR::Search;
+
+      auto accepted = record->AcceptedSockets.front();
+      record->AcceptedSockets.pop_front();
 
       Client = accepted.Socket;
       auto copy_size = std::min(*AddressSize, accepted.AddressSize);
@@ -1451,12 +1510,13 @@ ERR iocp_register_read(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
    bool terminal = false;
    bool udp = false;
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      udp = record->second.UDP;
-      buffered = udp ? !record->second.Datagrams.empty() : record->second.BufferedReadBytes > 0;
-      terminal = record->second.ReadResult != ERR::Okay;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
+
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      udp = record->UDP;
+      buffered = udp ? !record->Datagrams.empty() : record->BufferedReadBytes > 0;
+      terminal = record->ReadResult != ERR::Okay;
    }
 
    if ((buffered) or (terminal)) {
@@ -1474,10 +1534,11 @@ ERR iocp_register_write(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
 
    bool capacity_available = false;
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      capacity_available = tcp_send_capacity_available(record->second);
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
+
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      capacity_available = tcp_send_capacity_available(*record);
    }
 
    return capacity_available ? queue_record_completion(Socket, IocpOperationType::WRITE) : ERR::Okay;
@@ -1501,10 +1562,11 @@ ERR iocp_remove_write(WSW_SOCKET Socket)
 
 bool iocp_has_pending_write(WSW_SOCKET Socket)
 {
-   std::lock_guard<std::mutex> lock(glIocpMutex);
-   auto record = glSockets.find(Socket);
-   if (record IS glSockets.end()) return false;
-   return (not record->second.Cancelled) and (record->second.SendPendingBytes > 0);
+   auto record = find_socket_record(Socket);
+   if (!record) return false;
+
+   std::lock_guard<std::mutex> lock(record->Mutex);
+   return (not record->Cancelled) and (record->SendPendingBytes > 0);
 }
 
 //********************************************************************************************************************
@@ -1516,10 +1578,11 @@ ERR iocp_recall_read(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
 
    bool udp = false;
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      udp = record->second.UDP;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
+
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      udp = record->UDP;
    }
 
    return queue_record_completion(Socket, udp ? IocpOperationType::UDP_RECEIVE : IocpOperationType::READ);
@@ -1538,32 +1601,33 @@ ERR iocp_receive(WSW_SOCKET Socket, void *Buffer, size_t Length, size_t &Receive
    bool recall_read = false;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      auto available = record->second.BufferedReadBytes;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+
+      auto available = record->BufferedReadBytes;
       if (available > 0) {
          Received = std::min(Length, available);
-         std::memcpy(Buffer, record->second.ReadBuffer.data() + record->second.ReadOffset, Received);
-         record->second.ReadOffset += Received;
-         record->second.BufferedReadBytes -= Received;
+         std::memcpy(Buffer, record->ReadBuffer.data() + record->ReadOffset, Received);
+         record->ReadOffset += Received;
+         record->BufferedReadBytes -= Received;
 
-         if (record->second.BufferedReadBytes <= 0) {
-            record->second.ReadBuffer.clear();
-            record->second.ReadOffset = 0;
-            if (record->second.ReadResult IS ERR::Okay) rearm_read = true;
+         if (record->BufferedReadBytes <= 0) {
+            record->ReadBuffer.clear();
+            record->ReadOffset = 0;
+            if (record->ReadResult IS ERR::Okay) rearm_read = true;
             else recall_read = true;
          }
          else recall_read = true;
 
-         if ((record->second.ReadResult IS ERR::Okay) and (tcp_read_post_needed(record->second))) {
+         if ((record->ReadResult IS ERR::Okay) and (tcp_read_post_needed(*record))) {
             rearm_read = true;
          }
       }
       else {
-         result = record->second.ReadResult;
+         result = record->ReadResult;
          if (result IS ERR::Okay) rearm_read = true;
       }
    }
@@ -1606,13 +1670,13 @@ ERR iocp_send(WSW_SOCKET Socket, const void *Buffer, size_t &Length)
    size_t accepted = 0;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      auto capacity = IOCP_TCP_SEND_HIGH_WATER - std::min(record->second.SendPendingBytes,
-         IOCP_TCP_SEND_HIGH_WATER);
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+
+      auto capacity = IOCP_TCP_SEND_HIGH_WATER - std::min(record->SendPendingBytes, IOCP_TCP_SEND_HIGH_WATER);
       if (!capacity) {
          Length = 0;
          return ERR::BufferOverflow;
@@ -1625,8 +1689,8 @@ ERR iocp_send(WSW_SOCKET Socket, const void *Buffer, size_t &Length)
       request.Buffer = std::make_unique<uint8_t[]>(request.BufferSize);
       std::memcpy(request.Buffer.get(), Buffer, request.BufferSize);
 
-      record->second.SendQueue.push_back(std::move(request));
-      record->second.SendPendingBytes += accepted;
+      record->SendQueue.push_back(std::move(request));
+      record->SendPendingBytes += accepted;
    }
 
    Length = accepted;
@@ -1651,13 +1715,14 @@ ERR iocp_send_to(WSW_SOCKET Socket, const void *Buffer, size_t &Length, const vo
    size_t requested = std::min<size_t>(Length, 0x7fffffff);
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      generation = record->second.Generation;
-      object_id = record->second.ObjectID;
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+
+      generation = record->Generation;
+      object_id = record->ObjectID;
    }
 
    auto operation = create_operation();
@@ -1706,21 +1771,22 @@ ERR iocp_receive_from(WSW_SOCKET Socket, void *Buffer, size_t BufferSize, size_t
    bool has_datagram = false;
 
    {
-      std::lock_guard<std::mutex> lock(glIocpMutex);
-      auto record = glSockets.find(Socket);
-      if (record IS glSockets.end()) return ERR::Search;
-      if (record->second.Cancelled) return ERR::Cancelled;
+      auto record = find_socket_record(Socket);
+      if (!record) return ERR::Search;
 
-      if (!record->second.Datagrams.empty()) {
-         datagram = std::move(record->second.Datagrams.front());
-         record->second.Datagrams.erase(record->second.Datagrams.begin());
+      std::lock_guard<std::mutex> lock(record->Mutex);
+      if (record->Cancelled) return ERR::Cancelled;
+
+      if (!record->Datagrams.empty()) {
+         datagram = std::move(record->Datagrams.front());
+         record->Datagrams.erase(record->Datagrams.begin());
          has_datagram = true;
-         recall_read = !record->second.Datagrams.empty();
-         if ((!recall_read) and (record->second.ReadResult IS ERR::Okay)) rearm_read = true;
+         recall_read = !record->Datagrams.empty();
+         if ((!recall_read) and (record->ReadResult IS ERR::Okay)) rearm_read = true;
       }
       else {
-         result = record->second.ReadResult;
-         if ((result IS ERR::Okay) and (!record->second.UdpReadPending)) rearm_read = true;
+         result = record->ReadResult;
+         if ((result IS ERR::Okay) and (!record->UdpReadPending)) rearm_read = true;
       }
    }
 

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -26,88 +26,88 @@
 #include "iocp.h"
 
 struct IocpOperation {
-   OVERLAPPED Overlapped = {};
-   IocpOperationType Type = IocpOperationType::CONNECT;
-   WSW_SOCKET Socket = 0;
-   uint64_t Generation = 0;
-   int ObjectID = 0;
-   uintptr_t Callback = 0;
-   WSW_SOCKET AcceptedSocket = 0;
-   std::unique_ptr<uint8_t[]> Buffer;
-   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {};
-   int AddressSize = 0;
-   uint64_t Sequence = 0;
-   size_t BufferSize = 0;
-   size_t SendAccountedSize = 0;
-   size_t BytesTransferred = 0;
-   ERR Result = ERR::Busy;
+   OVERLAPPED Overlapped = {}; // Native overlapped state submitted to Winsock.
+   IocpOperationType Type = IocpOperationType::CONNECT; // Operation kind used when processing completion.
+   WSW_SOCKET Socket = 0;     // Socket that owns this operation.
+   uint64_t Generation = 0;   // Socket generation expected when the completion returns.
+   int ObjectID = 0;          // Fallback object UID captured when the operation was posted.
+   uintptr_t Callback = 0;    // Fallback callback captured when the operation was posted.
+   WSW_SOCKET AcceptedSocket = 0; // Socket returned by AcceptEx operations.
+   std::unique_ptr<uint8_t[]> Buffer; // Backend-owned operation buffer.
+   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {}; // Endpoint storage for UDP or accept results.
+   int AddressSize = 0;          // Size of the endpoint stored in Address.
+   uint64_t Sequence = 0;        // Ordered sequence number for TCP read operations.
+   size_t BufferSize = 0;        // Number of bytes available in Buffer.
+   size_t SendAccountedSize = 0; // Original send size charged against the socket send limit.
+   size_t BytesTransferred = 0;  // Number of bytes reported by the completion port.
+   ERR Result = ERR::Busy;       // Result assigned before the completion is queued to the main thread.
 };
 
 struct IocpCompletionTarget {
-   int ObjectID = 0;
-   uintptr_t Callback = 0;
+   int ObjectID = 0;       // UID of the object that should receive the completion.
+   uintptr_t Callback = 0; // Callback function to invoke for the completion.
 };
 
 struct IocpAcceptedSocket {
-   WSW_SOCKET Socket = 0;
-   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {};
-   int AddressSize = 0;
+   WSW_SOCKET Socket = 0; // Accepted client socket handle.
+   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {}; // Remote endpoint captured from AcceptEx.
+   int AddressSize = 0;   // Size of the accepted remote endpoint.
 };
 
 struct IocpDatagram {
-   std::vector<uint8_t> Buffer;
-   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {};
-   int AddressSize = 0;
-   ERR Result = ERR::Okay;
+   std::vector<uint8_t> Buffer; // Datagram payload waiting for the caller.
+   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {}; // Source endpoint for the datagram.
+   int AddressSize = 0;        // Size of the stored source endpoint.
+   ERR Result = ERR::Okay;     // Receive result associated with this datagram.
 };
 
 struct IocpSendRequest {
-   std::unique_ptr<uint8_t[]> Buffer;
-   size_t BufferSize = 0;
+   std::unique_ptr<uint8_t[]> Buffer; // Backend-owned TCP payload waiting for WSASend.
+   size_t BufferSize = 0;             // Number of payload bytes in Buffer.
 };
 
 struct IocpReadCompletion {
-   std::vector<uint8_t> Buffer;
-   ERR Result = ERR::Okay;
+   std::vector<uint8_t> Buffer; // Completed TCP bytes waiting for ordered delivery.
+   ERR Result = ERR::Okay;      // Read result for this sequence.
 };
 
 struct IocpStoreResult {
-   bool Notify = true;
-   bool RearmAccept = false;
-   bool PostRead = false;
-   bool PostSend = false;
+   bool Notify = true;       // True when a main-thread completion should be posted.
+   bool RearmAccept = false; // True when the accept pool should be replenished.
+   bool PostRead = false;    // True when additional TCP reads should be posted.
+   bool PostSend = false;    // True when queued TCP sends should be posted.
 };
 
 struct IocpSocketRecord {
-   mutable std::mutex Mutex;
-   int ObjectID = 0;
-   IocpCompletionTarget Connect;
-   IocpCompletionTarget Read;
-   IocpCompletionTarget Write;
-   IocpCompletionTarget Accept;
-   std::deque<IocpAcceptedSocket> AcceptedSockets;
-   std::deque<IocpSendRequest> SendQueue;
-   std::vector<IocpDatagram> Datagrams;
-   std::vector<uint8_t> ReadBuffer;
-   std::map<uint64_t, IocpReadCompletion> ReadCompletions;
-   size_t BufferedReadBytes = 0;
-   size_t ReadOffset = 0;
-   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> ConnectAddress = {};
-   int ConnectAddressSize = 0;
-   ERR ConnectResult = ERR::NotInitialised;
-   ERR ReadResult = ERR::Okay;
-   uint64_t Generation = 0;
-   uint64_t NextReadSequence = 0;
-   uint64_t NextReadCompletionSequence = 0;
-   int AcceptDepth = 16;
-   size_t AcceptPendingCount = 0;
-   size_t ReadPendingCount = 0;
-   size_t SendPendingCount = 0;
-   size_t SendPendingBytes = 0;
-   bool IPv6 = false;
-   bool UDP = false;
-   bool Cancelled = false;
-   bool UdpReadPending = false;
+   mutable std::mutex Mutex;     // Protects all mutable per-socket state in this record.
+   int ObjectID = 0;             // UID of the object currently associated with this socket.
+   IocpCompletionTarget Connect; // Target to notify when a connect operation completes.
+   IocpCompletionTarget Read;    // Target to notify when buffered read data is available.
+   IocpCompletionTarget Write;   // Target to notify when write capacity becomes available.
+   IocpCompletionTarget Accept;  // Target to notify when accepted sockets are ready.
+   std::deque<IocpAcceptedSocket> AcceptedSockets; // FIFO queue of completed AcceptEx sockets.
+   std::deque<IocpSendRequest> SendQueue; // Backend-owned TCP send buffers waiting to be posted.
+   std::vector<IocpDatagram> Datagrams;   // Completed UDP datagrams waiting for acRead or mtRecvFrom.
+   std::vector<uint8_t> ReadBuffer;       // Ordered TCP bytes buffered for acRead.
+   std::map<uint64_t, IocpReadCompletion> ReadCompletions; // Out-of-order TCP read completions by sequence.
+   size_t BufferedReadBytes = 0;   // Number of unread bytes currently held in ReadBuffer.
+   size_t ReadOffset = 0;          // Offset of the next unread byte in ReadBuffer.
+   std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> ConnectAddress = {}; // Remote endpoint for pending connect.
+   int ConnectAddressSize = 0;     // Size of the stored connect endpoint.
+   ERR ConnectResult = ERR::NotInitialised; // Result reported for the latest connect operation.
+   ERR ReadResult = ERR::Okay;     // Terminal read state once the peer disconnects or an error occurs.
+   uint64_t Generation = 0;        // Monotonic token used to reject stale completions.
+   uint64_t NextReadSequence = 0;  // Sequence number assigned to the next posted TCP read.
+   uint64_t NextReadCompletionSequence = 0; // Next TCP read sequence eligible for ordered delivery.
+   int AcceptDepth = 16;           // Maximum number of AcceptEx operations kept in flight.
+   size_t AcceptPendingCount = 0;  // Number of AcceptEx operations currently pending.
+   size_t ReadPendingCount = 0;    // Number of TCP WSARecv operations currently pending.
+   size_t SendPendingCount = 0;    // Number of TCP WSASend operations currently pending.
+   size_t SendPendingBytes = 0;    // Accepted TCP send bytes still queued or in flight.
+   bool IPv6 = false;              // True when the socket was created for IPv6 or dual-stack use.
+   bool UDP = false;               // True when this record represents a UDP socket.
+   bool Cancelled = false;         // Set once shutdown or deregistration has invalidated the record.
+   bool UdpReadPending = false;    // True while a UDP receive operation is posted.
 };
 
 using IocpSocketRecordPtr = std::shared_ptr<IocpSocketRecord>;
@@ -609,14 +609,14 @@ static ERR post_write_tail(const IocpOperation &Operation, size_t Offset)
 
    auto remaining = Operation.BufferSize - Offset;
    auto operation = create_operation();
-   operation->Type = IocpOperationType::WRITE;
-   operation->Socket = Operation.Socket;
-   operation->Generation = Operation.Generation;
-   operation->ObjectID = Operation.ObjectID;
-   operation->Callback = Operation.Callback;
-   operation->BufferSize = remaining;
+   operation->Type              = IocpOperationType::WRITE;
+   operation->Socket            = Operation.Socket;
+   operation->Generation        = Operation.Generation;
+   operation->ObjectID          = Operation.ObjectID;
+   operation->Callback          = Operation.Callback;
+   operation->BufferSize        = remaining;
    operation->SendAccountedSize = Operation.SendAccountedSize ? Operation.SendAccountedSize : Operation.BufferSize;
-   operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
+   operation->Buffer            = std::make_unique<uint8_t[]>(operation->BufferSize);
    std::memcpy(operation->Buffer.get(), Operation.Buffer.get() + Offset, remaining);
 
    WSABUF wsabuf;
@@ -666,16 +666,16 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
       }
 
       auto store_result = store_operation_result(*record, Operation, Error);
-      rearm_accept = store_result.RearmAccept and (target.Callback) and (target.ObjectID > 0);
-      post_reads = store_result.PostRead;
-      post_sends = store_result.PostSend;
+      rearm_accept      = store_result.RearmAccept and (target.Callback) and (target.ObjectID > 0);
+      post_reads        = store_result.PostRead;
+      post_sends        = store_result.PostSend;
       notify_completion = store_result.Notify;
 
-      message.Type = Operation.Type;
-      message.Socket = Operation.Socket;
+      message.Type       = Operation.Type;
+      message.Socket     = Operation.Socket;
       message.Generation = Operation.Generation;
-      message.ObjectID = target.ObjectID ? target.ObjectID : Operation.ObjectID;
-      message.Callback = target.Callback;
+      message.ObjectID   = target.ObjectID ? target.ObjectID : Operation.ObjectID;
+      message.Callback   = target.Callback;
       message.BytesTransferred = BytesTransferred;
       message.Error = Error;
    }
@@ -1726,12 +1726,12 @@ ERR iocp_send_to(WSW_SOCKET Socket, const void *Buffer, size_t &Length, const vo
    }
 
    auto operation = create_operation();
-   operation->Type = IocpOperationType::UDP_SEND;
-   operation->Socket = Socket;
-   operation->Generation = generation;
-   operation->ObjectID = object_id;
-   operation->BufferSize = requested;
-   operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
+   operation->Type        = IocpOperationType::UDP_SEND;
+   operation->Socket      = Socket;
+   operation->Generation  = generation;
+   operation->ObjectID    = object_id;
+   operation->BufferSize  = requested;
+   operation->Buffer      = std::make_unique<uint8_t[]>(operation->BufferSize);
    operation->AddressSize = AddressSize;
    std::memcpy(operation->Buffer.get(), Buffer, requested);
    std::memcpy(operation->Address.data(), Address, size_t(AddressSize));

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -38,6 +38,7 @@ struct IocpOperation {
    int AddressSize = 0;
    uint64_t Sequence = 0;
    size_t BufferSize = 0;
+   size_t SendAccountedSize = 0;
    size_t BytesTransferred = 0;
    ERR Result = ERR::Busy;
 };
@@ -60,6 +61,11 @@ struct IocpDatagram {
    ERR Result = ERR::Okay;
 };
 
+struct IocpSendRequest {
+   std::unique_ptr<uint8_t[]> Buffer;
+   size_t BufferSize = 0;
+};
+
 struct IocpReadCompletion {
    std::vector<uint8_t> Buffer;
    ERR Result = ERR::Okay;
@@ -69,6 +75,7 @@ struct IocpStoreResult {
    bool Notify = true;
    bool RearmAccept = false;
    bool PostRead = false;
+   bool PostSend = false;
 };
 
 struct IocpSocketRecord {
@@ -78,6 +85,7 @@ struct IocpSocketRecord {
    IocpCompletionTarget Write;
    IocpCompletionTarget Accept;
    std::deque<IocpAcceptedSocket> AcceptedSockets;
+   std::deque<IocpSendRequest> SendQueue;
    std::vector<IocpDatagram> Datagrams;
    std::vector<uint8_t> ReadBuffer;
    std::map<uint64_t, IocpReadCompletion> ReadCompletions;
@@ -93,11 +101,12 @@ struct IocpSocketRecord {
    int AcceptDepth = 16;
    size_t AcceptPendingCount = 0;
    size_t ReadPendingCount = 0;
+   size_t SendPendingCount = 0;
+   size_t SendPendingBytes = 0;
    bool IPv6 = false;
    bool UDP = false;
    bool Cancelled = false;
    bool UdpReadPending = false;
-   bool WritePending = false;
 };
 
 static HANDLE glCompletionPort = INVALID_HANDLE_VALUE;
@@ -115,6 +124,8 @@ static constexpr ULONG_PTR IOCP_SHUTDOWN_KEY = ULONG_PTR(~uintptr_t(0));
 static constexpr size_t IOCP_READ_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_TCP_READ_HIGH_WATER = 1024 * 1024;
 static constexpr size_t IOCP_TCP_READ_DEPTH = 4;
+static constexpr size_t IOCP_TCP_SEND_HIGH_WATER = 1024 * 1024;
+static constexpr size_t IOCP_TCP_SEND_DEPTH = 8;
 static constexpr size_t IOCP_UDP_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_ACCEPT_ADDRESS_SIZE = sizeof(sockaddr_storage) + 16;
 static constexpr size_t IOCP_ACCEPT_BUFFER_SIZE = IOCP_ACCEPT_ADDRESS_SIZE * 2;
@@ -127,6 +138,7 @@ static constexpr int IOCP_MAX_ACCEPT_DEPTH = 128;
 static ERR post_accept(WSW_SOCKET Socket);
 static ERR post_accept_pool(WSW_SOCKET Socket);
 static ERR post_read_pool(WSW_SOCKET Socket);
+static ERR post_send_pool(WSW_SOCKET Socket);
 
 //********************************************************************************************************************
 
@@ -356,6 +368,26 @@ static bool tcp_read_post_needed(const IocpSocketRecord &Record)
 
 //********************************************************************************************************************
 
+static bool tcp_send_post_needed(const IocpSocketRecord &Record)
+{
+   if (Record.UDP) return false;
+   if (Record.Cancelled) return false;
+   if (Record.SendQueue.empty()) return false;
+   if (Record.SendPendingCount >= IOCP_TCP_SEND_DEPTH) return false;
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool tcp_send_capacity_available(const IocpSocketRecord &Record)
+{
+   if (Record.UDP) return false;
+   if (Record.Cancelled) return false;
+   return Record.SendPendingBytes < IOCP_TCP_SEND_HIGH_WATER;
+}
+
+//********************************************************************************************************************
+
 static size_t append_ordered_tcp_reads(IocpSocketRecord &Record)
 {
    size_t appended = 0;
@@ -448,7 +480,14 @@ static IocpStoreResult store_operation_result(IocpSocketRecord &Record, const Io
       result.PostRead = tcp_read_post_needed(Record);
    }
    else if (Operation.Type IS IocpOperationType::WRITE) {
-      Record.WritePending = false;
+      if (Record.SendPendingCount > 0) Record.SendPendingCount--;
+
+      auto accounted_size = Operation.SendAccountedSize ? Operation.SendAccountedSize : Operation.BufferSize;
+      if (Record.SendPendingBytes >= accounted_size) Record.SendPendingBytes -= accounted_size;
+      else Record.SendPendingBytes = 0;
+
+      result.PostSend = tcp_send_post_needed(Record);
+      result.Notify = tcp_send_capacity_available(Record);
    }
    else if (Operation.Type IS IocpOperationType::UDP_SEND) {
       // The completion only confirms that backend-owned datagram storage can be released.
@@ -550,6 +589,7 @@ static ERR post_write_tail(const IocpOperation &Operation, size_t Offset)
    operation->ObjectID = Operation.ObjectID;
    operation->Callback = Operation.Callback;
    operation->BufferSize = remaining;
+   operation->SendAccountedSize = Operation.SendAccountedSize ? Operation.SendAccountedSize : Operation.BufferSize;
    operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
    std::memcpy(operation->Buffer.get(), Operation.Buffer.get() + Offset, remaining);
 
@@ -575,6 +615,7 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
    iocp_completion_message message;
    bool rearm_accept = false;
    bool post_reads = false;
+   bool post_sends = false;
    bool notify_completion = true;
 
    {
@@ -600,6 +641,7 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
       auto store_result = store_operation_result(record->second, Operation, Error);
       rearm_accept = store_result.RearmAccept and (target.Callback) and (target.ObjectID > 0);
       post_reads = store_result.PostRead;
+      post_sends = store_result.PostSend;
       notify_completion = store_result.Notify;
 
       message.Type = Operation.Type;
@@ -612,6 +654,7 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
    }
 
    if (post_reads) post_read_pool(Operation.Socket);
+   if (post_sends) post_send_pool(Operation.Socket);
    if (rearm_accept) post_accept(Operation.Socket);
 
    if ((notify_completion) and (message.ObjectID > 0) and (message.Callback) and (glPostMessage)) {
@@ -797,6 +840,92 @@ static ERR post_read_pool(WSW_SOCKET Socket)
 
    while (read_post_needed(Socket, error)) {
       if (auto post_error = post_read(Socket); post_error != ERR::Okay) return posted ? ERR::Okay : post_error;
+      posted++;
+   }
+
+   return error;
+}
+
+//********************************************************************************************************************
+
+static ERR post_send(WSW_SOCKET Socket)
+{
+   IocpCompletionTarget target;
+   IocpSendRequest request;
+   uint64_t generation = 0;
+
+   {
+      std::lock_guard<std::mutex> lock(glIocpMutex);
+      auto record = glSockets.find(Socket);
+      if (record IS glSockets.end()) return ERR::Search;
+      if (record->second.Cancelled) return ERR::Cancelled;
+      if (!tcp_send_post_needed(record->second)) return ERR::Okay;
+
+      target = record->second.Write;
+      generation = record->second.Generation;
+      request = std::move(record->second.SendQueue.front());
+      record->second.SendQueue.pop_front();
+      record->second.SendPendingCount++;
+   }
+
+   if ((!request.Buffer) or (!request.BufferSize)) return ERR::Okay;
+
+   auto operation = create_operation();
+   operation->Type = IocpOperationType::WRITE;
+   operation->Socket = Socket;
+   operation->Generation = generation;
+   operation->ObjectID = target.ObjectID;
+   operation->Callback = target.Callback;
+   operation->BufferSize = request.BufferSize;
+   operation->SendAccountedSize = request.BufferSize;
+   operation->Buffer = std::move(request.Buffer);
+
+   WSABUF wsabuf;
+   wsabuf.buf = (CHAR *)operation->Buffer.get();
+   wsabuf.len = ULONG(operation->BufferSize);
+
+   DWORD bytes = 0;
+   auto result = WSASend(socket_from_handle(Socket), &wsabuf, 1, &bytes, 0, &operation->Overlapped, nullptr);
+   if ((result IS SOCKET_ERROR) and (WSAGetLastError() != WSA_IO_PENDING)) {
+      auto error = convert_error();
+      operation->Result = error;
+      operation->BytesTransferred = 0;
+      queue_operation_completion(*operation, 0, operation->Result);
+      release_operation(operation);
+      return ERR::Okay;
+   }
+
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+static bool send_post_needed(WSW_SOCKET Socket, ERR &Error)
+{
+   std::lock_guard<std::mutex> lock(glIocpMutex);
+   auto record = glSockets.find(Socket);
+   if (record IS glSockets.end()) {
+      Error = ERR::Search;
+      return false;
+   }
+   if (record->second.Cancelled) {
+      Error = ERR::Cancelled;
+      return false;
+   }
+
+   Error = ERR::Okay;
+   return tcp_send_post_needed(record->second);
+}
+
+//********************************************************************************************************************
+
+static ERR post_send_pool(WSW_SOCKET Socket)
+{
+   ERR error = ERR::Okay;
+   size_t posted = 0;
+
+   while (send_post_needed(Socket, error)) {
+      if (auto post_error = post_send(Socket); post_error != ERR::Okay) return posted ? ERR::Okay : post_error;
       posted++;
    }
 
@@ -1343,15 +1472,15 @@ ERR iocp_register_write(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
    if (auto error = set_completion_target(Socket, IocpOperationType::WRITE, ObjectID, Callback);
        error != ERR::Okay) return error;
 
-   bool pending = false;
+   bool capacity_available = false;
    {
       std::lock_guard<std::mutex> lock(glIocpMutex);
       auto record = glSockets.find(Socket);
       if (record IS glSockets.end()) return ERR::Search;
-      pending = record->second.WritePending;
+      capacity_available = tcp_send_capacity_available(record->second);
    }
 
-   return pending ? ERR::Okay : queue_record_completion(Socket, IocpOperationType::WRITE);
+   return capacity_available ? queue_record_completion(Socket, IocpOperationType::WRITE) : ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -1375,7 +1504,7 @@ bool iocp_has_pending_write(WSW_SOCKET Socket)
    std::lock_guard<std::mutex> lock(glIocpMutex);
    auto record = glSockets.find(Socket);
    if (record IS glSockets.end()) return false;
-   return (not record->second.Cancelled) and record->second.WritePending;
+   return (not record->second.Cancelled) and (record->second.SendPendingBytes > 0);
 }
 
 //********************************************************************************************************************
@@ -1473,54 +1602,39 @@ ERR iocp_send(WSW_SOCKET Socket, const void *Buffer, size_t &Length)
    if ((!Buffer) and (Length > 0)) return ERR::NullArgs;
    if (!Length) return ERR::Okay;
 
-   IocpCompletionTarget target;
-   uint64_t generation = 0;
    size_t requested = std::min<size_t>(Length, 0x7fffffff);
+   size_t accepted = 0;
 
    {
       std::lock_guard<std::mutex> lock(glIocpMutex);
       auto record = glSockets.find(Socket);
       if (record IS glSockets.end()) return ERR::Search;
       if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.WritePending) {
+
+      auto capacity = IOCP_TCP_SEND_HIGH_WATER - std::min(record->second.SendPendingBytes,
+         IOCP_TCP_SEND_HIGH_WATER);
+      if (!capacity) {
          Length = 0;
          return ERR::BufferOverflow;
       }
 
-      record->second.WritePending = true;
-      target = record->second.Write;
-      generation = record->second.Generation;
+      accepted = std::min(requested, capacity);
+
+      IocpSendRequest request;
+      request.BufferSize = accepted;
+      request.Buffer = std::make_unique<uint8_t[]>(request.BufferSize);
+      std::memcpy(request.Buffer.get(), Buffer, request.BufferSize);
+
+      record->second.SendQueue.push_back(std::move(request));
+      record->second.SendPendingBytes += accepted;
    }
 
-   auto operation = create_operation();
-   operation->Type = IocpOperationType::WRITE;
-   operation->Socket = Socket;
-   operation->Generation = generation;
-   operation->ObjectID = target.ObjectID;
-   operation->Callback = target.Callback;
-   operation->BufferSize = requested;
-   operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
-   std::memcpy(operation->Buffer.get(), Buffer, requested);
-
-   WSABUF wsabuf;
-   wsabuf.buf = (CHAR *)operation->Buffer.get();
-   wsabuf.len = ULONG(operation->BufferSize);
-
-   DWORD bytes = 0;
-   auto result = WSASend(socket_from_handle(Socket), &wsabuf, 1, &bytes, 0, &operation->Overlapped, nullptr);
-   if ((result IS SOCKET_ERROR) and (WSAGetLastError() != WSA_IO_PENDING)) {
-      auto error = convert_error();
-      {
-         std::lock_guard<std::mutex> lock(glIocpMutex);
-         auto record = glSockets.find(Socket);
-         if (record != glSockets.end()) record->second.WritePending = false;
-      }
-      release_operation(operation);
+   Length = accepted;
+   if (auto error = post_send_pool(Socket); error != ERR::Okay) {
       Length = 0;
       return error;
    }
 
-   Length = requested;
    return ERR::Okay;
 }
 

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <cstring>
 #include <deque>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -35,6 +36,7 @@ struct IocpOperation {
    std::unique_ptr<uint8_t[]> Buffer;
    std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> Address = {};
    int AddressSize = 0;
+   uint64_t Sequence = 0;
    size_t BufferSize = 0;
    size_t BytesTransferred = 0;
    ERR Result = ERR::Busy;
@@ -58,6 +60,17 @@ struct IocpDatagram {
    ERR Result = ERR::Okay;
 };
 
+struct IocpReadCompletion {
+   std::vector<uint8_t> Buffer;
+   ERR Result = ERR::Okay;
+};
+
+struct IocpStoreResult {
+   bool Notify = true;
+   bool RearmAccept = false;
+   bool PostRead = false;
+};
+
 struct IocpSocketRecord {
    int ObjectID = 0;
    IocpCompletionTarget Connect;
@@ -67,18 +80,23 @@ struct IocpSocketRecord {
    std::deque<IocpAcceptedSocket> AcceptedSockets;
    std::vector<IocpDatagram> Datagrams;
    std::vector<uint8_t> ReadBuffer;
+   std::map<uint64_t, IocpReadCompletion> ReadCompletions;
+   size_t BufferedReadBytes = 0;
    size_t ReadOffset = 0;
    std::array<uint8_t, IOCP_ENDPOINT_STORAGE_SIZE> ConnectAddress = {};
    int ConnectAddressSize = 0;
    ERR ConnectResult = ERR::NotInitialised;
    ERR ReadResult = ERR::Okay;
    uint64_t Generation = 0;
+   uint64_t NextReadSequence = 0;
+   uint64_t NextReadCompletionSequence = 0;
    int AcceptDepth = 16;
    size_t AcceptPendingCount = 0;
+   size_t ReadPendingCount = 0;
    bool IPv6 = false;
    bool UDP = false;
    bool Cancelled = false;
-   bool ReadPending = false;
+   bool UdpReadPending = false;
    bool WritePending = false;
 };
 
@@ -95,6 +113,8 @@ static bool glWinsockInitialised = false;
 
 static constexpr ULONG_PTR IOCP_SHUTDOWN_KEY = ULONG_PTR(~uintptr_t(0));
 static constexpr size_t IOCP_READ_BUFFER_SIZE = 65536;
+static constexpr size_t IOCP_TCP_READ_HIGH_WATER = 1024 * 1024;
+static constexpr size_t IOCP_TCP_READ_DEPTH = 4;
 static constexpr size_t IOCP_UDP_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_ACCEPT_ADDRESS_SIZE = sizeof(sockaddr_storage) + 16;
 static constexpr size_t IOCP_ACCEPT_BUFFER_SIZE = IOCP_ACCEPT_ADDRESS_SIZE * 2;
@@ -106,6 +126,7 @@ static constexpr int IOCP_MAX_ACCEPT_DEPTH = 128;
 
 static ERR post_accept(WSW_SOCKET Socket);
 static ERR post_accept_pool(WSW_SOCKET Socket);
+static ERR post_read_pool(WSW_SOCKET Socket);
 
 //********************************************************************************************************************
 
@@ -321,6 +342,56 @@ static void close_accepted_socket(const IocpOperation &Operation)
 
 //********************************************************************************************************************
 
+static bool tcp_read_post_needed(const IocpSocketRecord &Record)
+{
+   if (Record.UDP) return false;
+   if (Record.Cancelled) return false;
+   if (Record.ReadResult != ERR::Okay) return false;
+   if (!Record.ReadCompletions.empty()) return false;
+   if (Record.BufferedReadBytes >= IOCP_TCP_READ_HIGH_WATER) return false;
+   if (Record.ReadPendingCount >= IOCP_TCP_READ_DEPTH) return false;
+   if ((!Record.Read.Callback) or (Record.Read.ObjectID <= 0)) return false;
+   return true;
+}
+
+//********************************************************************************************************************
+
+static size_t append_ordered_tcp_reads(IocpSocketRecord &Record)
+{
+   size_t appended = 0;
+
+   while (Record.ReadResult IS ERR::Okay) {
+      auto completion = Record.ReadCompletions.find(Record.NextReadCompletionSequence);
+      if (completion IS Record.ReadCompletions.end()) break;
+
+      auto read = std::move(completion->second);
+      Record.ReadCompletions.erase(completion);
+      Record.NextReadCompletionSequence++;
+
+      if (read.Result != ERR::Okay) {
+         Record.ReadResult = read.Result;
+         Record.ReadCompletions.clear();
+         break;
+      }
+
+      if (read.Buffer.empty()) {
+         Record.ReadResult = ERR::Disconnected;
+         Record.ReadCompletions.clear();
+         break;
+      }
+
+      auto offset = Record.ReadBuffer.size();
+      Record.ReadBuffer.resize(offset + read.Buffer.size());
+      std::memcpy(Record.ReadBuffer.data() + offset, read.Buffer.data(), read.Buffer.size());
+      Record.BufferedReadBytes += read.Buffer.size();
+      appended += read.Buffer.size();
+   }
+
+   return appended;
+}
+
+//********************************************************************************************************************
+
 static ERR bind_ephemeral(SOCKET Socket, const sockaddr *RemoteAddress)
 {
    if (!RemoteAddress) return ERR::NullArgs;
@@ -346,18 +417,35 @@ static ERR bind_ephemeral(SOCKET Socket, const sockaddr *RemoteAddress)
 
 //********************************************************************************************************************
 
-static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation &Operation, ERR Error)
+static IocpStoreResult store_operation_result(IocpSocketRecord &Record, const IocpOperation &Operation, ERR Error)
 {
+   IocpStoreResult result;
+
    if (Operation.Type IS IocpOperationType::CONNECT) Record.ConnectResult = Error;
    else if (Operation.Type IS IocpOperationType::READ) {
-      Record.ReadPending = false;
-      Record.ReadResult = ((Error IS ERR::Okay) and (!Operation.BytesTransferred)) ? ERR::Disconnected : Error;
+      result.Notify = false;
+      if (Record.ReadPendingCount > 0) Record.ReadPendingCount--;
 
-      if ((Record.ReadResult IS ERR::Okay) and (Operation.BytesTransferred > 0) and (Operation.Buffer)) {
-         auto offset = Record.ReadBuffer.size();
-         Record.ReadBuffer.resize(offset + Operation.BytesTransferred);
-         std::memcpy(Record.ReadBuffer.data() + offset, Operation.Buffer.get(), Operation.BytesTransferred);
+      if ((Record.ReadResult IS ERR::Okay) and (Operation.Sequence >= Record.NextReadCompletionSequence)) {
+         IocpReadCompletion completion;
+         completion.Result = Error;
+
+         if ((Error IS ERR::Okay) and (Operation.BytesTransferred > 0)) {
+            if (Operation.Buffer) {
+               completion.Buffer.resize(Operation.BytesTransferred);
+               std::memcpy(completion.Buffer.data(), Operation.Buffer.get(), Operation.BytesTransferred);
+            }
+            else completion.Result = ERR::Failed;
+         }
+
+         if (Record.ReadCompletions.emplace(Operation.Sequence, std::move(completion)).second) {
+            auto prior_result = Record.ReadResult;
+            auto appended = append_ordered_tcp_reads(Record);
+            result.Notify = (appended > 0) or ((prior_result IS ERR::Okay) and (Record.ReadResult != ERR::Okay));
+         }
       }
+
+      result.PostRead = tcp_read_post_needed(Record);
    }
    else if (Operation.Type IS IocpOperationType::WRITE) {
       Record.WritePending = false;
@@ -366,7 +454,7 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
       // The completion only confirms that backend-owned datagram storage can be released.
    }
    else if (Operation.Type IS IocpOperationType::UDP_RECEIVE) {
-      Record.ReadPending = false;
+      Record.UdpReadPending = false;
       Record.ReadResult = Error;
 
       if ((Error IS ERR::Okay) and (Operation.Buffer) and
@@ -387,7 +475,8 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
 
       if (Error != ERR::Okay) {
          close_accepted_socket(Operation);
-         return true;
+         result.RearmAccept = true;
+         return result;
       }
 
       auto server_socket = socket_from_handle(Operation.Socket);
@@ -396,13 +485,15 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
       if (setsockopt(accepted_socket, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char *)&server_socket,
           sizeof(server_socket)) IS SOCKET_ERROR) {
          close_accepted_socket(Operation);
-         return true;
+         result.RearmAccept = true;
+         return result;
       }
 
       auto handle = CreateIoCompletionPort((HANDLE)accepted_socket, glCompletionPort, ULONG_PTR(accepted_socket), 0);
       if (handle IS nullptr) {
          close_accepted_socket(Operation);
-         return true;
+         result.RearmAccept = true;
+         return result;
       }
 
       sockaddr *local_address = nullptr;
@@ -412,7 +503,8 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
       auto get_addresses = get_accept_ex_sockaddrs(server_socket);
       if (!get_addresses) {
          close_accepted_socket(Operation);
-         return true;
+         result.RearmAccept = true;
+         return result;
       }
 
       get_addresses(Operation.Buffer.get(), 0, IOCP_ACCEPT_ADDRESS_SIZE, IOCP_ACCEPT_ADDRESS_SIZE, &local_address,
@@ -420,7 +512,8 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
 
       if ((!remote_address) or (remote_size <= 0) or (remote_size > int(IOCP_ENDPOINT_STORAGE_SIZE))) {
          close_accepted_socket(Operation);
-         return true;
+         result.RearmAccept = true;
+         return result;
       }
 
       IocpAcceptedSocket accepted;
@@ -436,10 +529,11 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
          .Cancelled = false
       };
 
-      return true;
+      result.RearmAccept = true;
+      return result;
    }
 
-   return false;
+   return result;
 }
 
 //********************************************************************************************************************
@@ -480,6 +574,8 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
 {
    iocp_completion_message message;
    bool rearm_accept = false;
+   bool post_reads = false;
+   bool notify_completion = true;
 
    {
       std::lock_guard<std::mutex> lock(glIocpMutex);
@@ -501,8 +597,10 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
          else Error = tail_error;
       }
 
-      rearm_accept = store_operation_result(record->second, Operation, Error) and
-         (target.Callback) and (target.ObjectID > 0);
+      auto store_result = store_operation_result(record->second, Operation, Error);
+      rearm_accept = store_result.RearmAccept and (target.Callback) and (target.ObjectID > 0);
+      post_reads = store_result.PostRead;
+      notify_completion = store_result.Notify;
 
       message.Type = Operation.Type;
       message.Socket = Operation.Socket;
@@ -513,9 +611,10 @@ static void queue_operation_completion(const IocpOperation &Operation, size_t By
       message.Error = Error;
    }
 
+   if (post_reads) post_read_pool(Operation.Socket);
    if (rearm_accept) post_accept(Operation.Socket);
 
-   if ((message.ObjectID > 0) and (message.Callback) and (glPostMessage)) {
+   if ((notify_completion) and (message.ObjectID > 0) and (message.Callback) and (glPostMessage)) {
       glPostMessage(glCompletionMsgID, &message, sizeof(message));
    }
 }
@@ -560,14 +659,14 @@ static ERR post_udp_receive(WSW_SOCKET Socket)
       auto record = glSockets.find(Socket);
       if (record IS glSockets.end()) return ERR::Search;
       if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.ReadPending) return ERR::Okay;
+      if (record->second.UdpReadPending) return ERR::Okay;
       if (!record->second.Datagrams.empty()) return ERR::Okay;
       if (record->second.ReadResult != ERR::Okay) return ERR::Okay;
 
       target = record->second.Read;
       if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
 
-      record->second.ReadPending = true;
+      record->second.UdpReadPending = true;
       generation = record->second.Generation;
       ipv6 = record->second.IPv6;
    }
@@ -620,6 +719,7 @@ static ERR post_read(WSW_SOCKET Socket)
 {
    IocpCompletionTarget target;
    uint64_t generation = 0;
+   uint64_t sequence = 0;
    bool udp = false;
 
    {
@@ -629,15 +729,12 @@ static ERR post_read(WSW_SOCKET Socket)
       udp = record->second.UDP;
       if (record->second.Cancelled) return ERR::Cancelled;
       if (!udp) {
-         if (record->second.ReadPending) return ERR::Okay;
-         if (!record->second.ReadBuffer.empty()) return ERR::Okay;
-         if (record->second.ReadResult != ERR::Okay) return ERR::Okay;
+         if (!tcp_read_post_needed(record->second)) return ERR::Okay;
 
-         target = record->second.Read;
-         if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
-
-         record->second.ReadPending = true;
+         record->second.ReadPendingCount++;
          generation = record->second.Generation;
+         sequence = record->second.NextReadSequence++;
+         target = record->second.Read;
       }
    }
 
@@ -649,6 +746,7 @@ static ERR post_read(WSW_SOCKET Socket)
    operation->Generation = generation;
    operation->ObjectID = target.ObjectID;
    operation->Callback = target.Callback;
+   operation->Sequence = sequence;
    operation->BufferSize = IOCP_READ_BUFFER_SIZE;
    operation->Buffer = std::make_unique<uint8_t[]>(operation->BufferSize);
 
@@ -669,6 +767,40 @@ static ERR post_read(WSW_SOCKET Socket)
    }
 
    return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+static bool read_post_needed(WSW_SOCKET Socket, ERR &Error)
+{
+   std::lock_guard<std::mutex> lock(glIocpMutex);
+   auto record = glSockets.find(Socket);
+   if (record IS glSockets.end()) {
+      Error = ERR::Search;
+      return false;
+   }
+   if (record->second.Cancelled) {
+      Error = ERR::Cancelled;
+      return false;
+   }
+
+   Error = ERR::Okay;
+   return tcp_read_post_needed(record->second);
+}
+
+//********************************************************************************************************************
+
+static ERR post_read_pool(WSW_SOCKET Socket)
+{
+   ERR error = ERR::Okay;
+   size_t posted = 0;
+
+   while (read_post_needed(Socket, error)) {
+      if (auto post_error = post_read(Socket); post_error != ERR::Okay) return posted ? ERR::Okay : post_error;
+      posted++;
+   }
+
+   return error;
 }
 
 //********************************************************************************************************************
@@ -1194,14 +1326,14 @@ ERR iocp_register_read(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
       auto record = glSockets.find(Socket);
       if (record IS glSockets.end()) return ERR::Search;
       udp = record->second.UDP;
-      buffered = udp ? !record->second.Datagrams.empty() : !record->second.ReadBuffer.empty();
+      buffered = udp ? !record->second.Datagrams.empty() : record->second.BufferedReadBytes > 0;
       terminal = record->second.ReadResult != ERR::Okay;
    }
 
    if ((buffered) or (terminal)) {
       return queue_record_completion(Socket, udp ? IocpOperationType::UDP_RECEIVE : IocpOperationType::READ);
    }
-   else return post_read(Socket);
+   else return udp ? post_read(Socket) : post_read_pool(Socket);
 }
 
 //********************************************************************************************************************
@@ -1282,30 +1414,35 @@ ERR iocp_receive(WSW_SOCKET Socket, void *Buffer, size_t Length, size_t &Receive
       if (record IS glSockets.end()) return ERR::Search;
       if (record->second.Cancelled) return ERR::Cancelled;
 
-      auto available = record->second.ReadBuffer.size() - record->second.ReadOffset;
+      auto available = record->second.BufferedReadBytes;
       if (available > 0) {
          Received = std::min(Length, available);
          std::memcpy(Buffer, record->second.ReadBuffer.data() + record->second.ReadOffset, Received);
          record->second.ReadOffset += Received;
+         record->second.BufferedReadBytes -= Received;
 
-         if (record->second.ReadOffset >= record->second.ReadBuffer.size()) {
+         if (record->second.BufferedReadBytes <= 0) {
             record->second.ReadBuffer.clear();
             record->second.ReadOffset = 0;
             if (record->second.ReadResult IS ERR::Okay) rearm_read = true;
             else recall_read = true;
          }
          else recall_read = true;
+
+         if ((record->second.ReadResult IS ERR::Okay) and (tcp_read_post_needed(record->second))) {
+            rearm_read = true;
+         }
       }
       else {
          result = record->second.ReadResult;
-         if ((result IS ERR::Okay) and (!record->second.ReadPending)) rearm_read = true;
+         if (result IS ERR::Okay) rearm_read = true;
       }
    }
 
    if (rearm_read) {
-      if (auto error = post_read(Socket); error != ERR::Okay) return error;
+      if (auto error = post_read_pool(Socket); error != ERR::Okay) return error;
    }
-   else if (recall_read) {
+   if (recall_read) {
       if (auto error = queue_record_completion(Socket, IocpOperationType::READ); error != ERR::Okay) return error;
    }
 
@@ -1469,7 +1606,7 @@ ERR iocp_receive_from(WSW_SOCKET Socket, void *Buffer, size_t BufferSize, size_t
       }
       else {
          result = record->second.ReadResult;
-         if ((result IS ERR::Okay) and (!record->second.ReadPending)) rearm_read = true;
+         if ((result IS ERR::Okay) and (!record->second.UdpReadPending)) rearm_read = true;
       }
    }
 

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <array>
 #include <cstring>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -63,7 +64,7 @@ struct IocpSocketRecord {
    IocpCompletionTarget Read;
    IocpCompletionTarget Write;
    IocpCompletionTarget Accept;
-   std::vector<IocpAcceptedSocket> AcceptedSockets;
+   std::deque<IocpAcceptedSocket> AcceptedSockets;
    std::vector<IocpDatagram> Datagrams;
    std::vector<uint8_t> ReadBuffer;
    size_t ReadOffset = 0;
@@ -72,10 +73,11 @@ struct IocpSocketRecord {
    ERR ConnectResult = ERR::NotInitialised;
    ERR ReadResult = ERR::Okay;
    uint64_t Generation = 0;
+   int AcceptDepth = 16;
+   size_t AcceptPendingCount = 0;
    bool IPv6 = false;
    bool UDP = false;
    bool Cancelled = false;
-   bool AcceptPending = false;
    bool ReadPending = false;
    bool WritePending = false;
 };
@@ -96,10 +98,14 @@ static constexpr size_t IOCP_READ_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_UDP_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_ACCEPT_ADDRESS_SIZE = sizeof(sockaddr_storage) + 16;
 static constexpr size_t IOCP_ACCEPT_BUFFER_SIZE = IOCP_ACCEPT_ADDRESS_SIZE * 2;
+static constexpr int IOCP_DEFAULT_ACCEPT_DEPTH = 16;
+static constexpr int IOCP_MIN_ACCEPT_DEPTH = 4;
+static constexpr int IOCP_MAX_ACCEPT_DEPTH = 128;
 
 //********************************************************************************************************************
 
 static ERR post_accept(WSW_SOCKET Socket);
+static ERR post_accept_pool(WSW_SOCKET Socket);
 
 //********************************************************************************************************************
 
@@ -159,6 +165,14 @@ static ERR convert_send_to_error(int Error)
       default:
          return convert_error(Error);
    }
+}
+
+//********************************************************************************************************************
+
+static int accept_depth_from_backlog(int Backlog)
+{
+   if (Backlog <= 0) return IOCP_DEFAULT_ACCEPT_DEPTH;
+   return std::clamp(Backlog, IOCP_MIN_ACCEPT_DEPTH, IOCP_MAX_ACCEPT_DEPTH);
 }
 
 //********************************************************************************************************************
@@ -369,7 +383,7 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
       }
    }
    else if (Operation.Type IS IocpOperationType::ACCEPT) {
-      Record.AcceptPending = false;
+      if (Record.AcceptPendingCount > 0) Record.AcceptPendingCount--;
 
       if (Error != ERR::Okay) {
          close_accepted_socket(Operation);
@@ -415,11 +429,14 @@ static bool store_operation_result(IocpSocketRecord &Record, const IocpOperation
       std::memcpy(accepted.Address.data(), remote_address, size_t(remote_size));
       Record.AcceptedSockets.push_back(accepted);
 
-      glSockets[accepted.Socket] = {
+      auto server_ipv6 = Record.IPv6;
+      glSockets[Operation.AcceptedSocket] = {
          .Generation = glNextGeneration++,
-         .IPv6 = Record.IPv6,
+         .IPv6 = server_ipv6,
          .Cancelled = false
       };
+
+      return true;
    }
 
    return false;
@@ -667,12 +684,12 @@ static ERR post_accept(WSW_SOCKET Socket)
       auto record = glSockets.find(Socket);
       if (record IS glSockets.end()) return ERR::Search;
       if (record->second.Cancelled) return ERR::Cancelled;
-      if (record->second.AcceptPending) return ERR::Okay;
+      if (record->second.AcceptPendingCount >= size_t(record->second.AcceptDepth)) return ERR::Okay;
 
       target = record->second.Accept;
       if ((!target.Callback) or (target.ObjectID <= 0)) return ERR::Okay;
 
-      record->second.AcceptPending = true;
+      record->second.AcceptPendingCount++;
       generation = record->second.Generation;
       server_ipv6 = record->second.IPv6;
    }
@@ -682,7 +699,9 @@ static ERR post_accept(WSW_SOCKET Socket)
    if (accepted_socket IS INVALID_SOCKET) {
       std::lock_guard<std::mutex> lock(glIocpMutex);
       auto record = glSockets.find(Socket);
-      if (record != glSockets.end()) record->second.AcceptPending = false;
+      if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
+         record->second.AcceptPendingCount--;
+      }
       return convert_error();
    }
 
@@ -702,7 +721,9 @@ static ERR post_accept(WSW_SOCKET Socket)
       {
          std::lock_guard<std::mutex> lock(glIocpMutex);
          auto record = glSockets.find(Socket);
-         if (record != glSockets.end()) record->second.AcceptPending = false;
+         if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
+            record->second.AcceptPendingCount--;
+         }
       }
       close_accepted_socket(*operation);
       release_operation(operation);
@@ -717,7 +738,9 @@ static ERR post_accept(WSW_SOCKET Socket)
       {
          std::lock_guard<std::mutex> lock(glIocpMutex);
          auto record = glSockets.find(Socket);
-         if (record != glSockets.end()) record->second.AcceptPending = false;
+         if ((record != glSockets.end()) and (record->second.AcceptPendingCount > 0)) {
+            record->second.AcceptPendingCount--;
+         }
       }
       close_accepted_socket(*operation);
       release_operation(operation);
@@ -725,6 +748,46 @@ static ERR post_accept(WSW_SOCKET Socket)
    }
 
    return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+static bool accept_post_needed(WSW_SOCKET Socket, ERR &Error)
+{
+   std::lock_guard<std::mutex> lock(glIocpMutex);
+   auto record = glSockets.find(Socket);
+   if (record IS glSockets.end()) {
+      Error = ERR::Search;
+      return false;
+   }
+   if (record->second.Cancelled) {
+      Error = ERR::Cancelled;
+      return false;
+   }
+
+   auto target = record->second.Accept;
+   if ((!target.Callback) or (target.ObjectID <= 0)) {
+      Error = ERR::Okay;
+      return false;
+   }
+
+   Error = ERR::Okay;
+   return record->second.AcceptPendingCount < size_t(record->second.AcceptDepth);
+}
+
+//********************************************************************************************************************
+
+static ERR post_accept_pool(WSW_SOCKET Socket)
+{
+   ERR error = ERR::Okay;
+   size_t posted = 0;
+
+   while (accept_post_needed(Socket, error)) {
+      if (auto post_error = post_accept(Socket); post_error != ERR::Okay) return posted ? ERR::Okay : post_error;
+      posted++;
+   }
+
+   return error;
 }
 
 //********************************************************************************************************************
@@ -1072,6 +1135,11 @@ ERR iocp_bind(WSW_SOCKET Socket, const void *Address, int AddressSize)
 ERR iocp_listen(WSW_SOCKET Socket, int Backlog)
 {
    if (listen(socket_from_handle(Socket), Backlog) IS SOCKET_ERROR) return convert_error();
+
+   std::lock_guard<std::mutex> lock(glIocpMutex);
+   auto record = glSockets.find(Socket);
+   if (record != glSockets.end()) record->second.AcceptDepth = accept_depth_from_backlog(Backlog);
+
    return ERR::Okay;
 }
 
@@ -1082,7 +1150,7 @@ ERR iocp_register_accept(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
    if (auto error = set_completion_target(Socket, IocpOperationType::ACCEPT, ObjectID, Callback);
        error != ERR::Okay) return error;
 
-   return post_accept(Socket);
+   return post_accept_pool(Socket);
 }
 
 //********************************************************************************************************************
@@ -1092,8 +1160,6 @@ ERR iocp_accept(WSW_SOCKET Server, WSW_SOCKET &Client, void *Address, int *Addre
    Client = WSW_SOCKET(INVALID_SOCKET);
    if ((!Address) or (!AddressSize)) return ERR::NullArgs;
 
-   bool rearm_accept = false;
-
    {
       std::lock_guard<std::mutex> lock(glIocpMutex);
       auto record = glSockets.find(Server);
@@ -1102,18 +1168,14 @@ ERR iocp_accept(WSW_SOCKET Server, WSW_SOCKET &Client, void *Address, int *Addre
       if (record->second.AcceptedSockets.empty()) return ERR::Search;
 
       auto accepted = record->second.AcceptedSockets.front();
-      record->second.AcceptedSockets.erase(record->second.AcceptedSockets.begin());
+      record->second.AcceptedSockets.pop_front();
 
       Client = accepted.Socket;
       auto copy_size = std::min(*AddressSize, accepted.AddressSize);
       std::memcpy(Address, accepted.Address.data(), size_t(copy_size));
       *AddressSize = copy_size;
-
-      auto target = record->second.Accept;
-      rearm_accept = (target.Callback) and (target.ObjectID > 0) and (!record->second.AcceptPending);
    }
 
-   if (rearm_accept) post_accept(Server);
    return ERR::Okay;
 }
 

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -85,12 +85,13 @@ static std::vector<std::jthread> glWorkers;
 static std::mutex glIocpMutex;
 static std::unordered_map<WSW_SOCKET, IocpSocketRecord> glSockets;
 static std::atomic_bool glShutdownRequested = false;
+static std::atomic_size_t glPendingOperations = 0;
 static std::atomic_uint64_t glNextGeneration = 1;
 static int glCompletionMsgID = 0;
 static iocp_post_message glPostMessage = nullptr;
 static bool glWinsockInitialised = false;
 
-static constexpr int MAX_IOCP_THREADS = 4;
+static constexpr ULONG_PTR IOCP_SHUTDOWN_KEY = ULONG_PTR(~uintptr_t(0));
 static constexpr size_t IOCP_READ_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_UDP_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_ACCEPT_ADDRESS_SIZE = sizeof(sockaddr_storage) + 16;
@@ -99,6 +100,23 @@ static constexpr size_t IOCP_ACCEPT_BUFFER_SIZE = IOCP_ACCEPT_ADDRESS_SIZE * 2;
 //********************************************************************************************************************
 
 static ERR post_accept(WSW_SOCKET Socket);
+
+//********************************************************************************************************************
+
+static IocpOperation *create_operation()
+{
+   glPendingOperations.fetch_add(1);
+   return new IocpOperation();
+}
+
+//********************************************************************************************************************
+
+static void release_operation(IocpOperation *Operation)
+{
+   delete Operation;
+   glPendingOperations.fetch_sub(1);
+   glPendingOperations.notify_all();
+}
 
 //********************************************************************************************************************
 
@@ -414,7 +432,7 @@ static ERR post_write_tail(const IocpOperation &Operation, size_t Offset)
    if ((!Operation.Buffer) or (Offset >= Operation.BufferSize)) return ERR::Okay;
 
    auto remaining = Operation.BufferSize - Offset;
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::WRITE;
    operation->Socket = Operation.Socket;
    operation->Generation = Operation.Generation;
@@ -432,7 +450,7 @@ static ERR post_write_tail(const IocpOperation &Operation, size_t Offset)
    auto result = WSASend(socket_from_handle(Operation.Socket), &wsabuf, 1, &bytes, 0, &operation->Overlapped, nullptr);
    if ((result IS SOCKET_ERROR) and (WSAGetLastError() != WSA_IO_PENDING)) {
       auto error = convert_error();
-      delete operation;
+      release_operation(operation);
       return error;
    }
 
@@ -549,7 +567,7 @@ static ERR post_udp_receive(WSW_SOCKET Socket)
       return ERR::Okay;
    }
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::UDP_RECEIVE;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -572,7 +590,7 @@ static ERR post_udp_receive(WSW_SOCKET Socket)
       operation->Result = error;
       operation->BytesTransferred = 0;
       queue_operation_completion(*operation, 0, operation->Result);
-      delete operation;
+      release_operation(operation);
       return ERR::Okay;
    }
 
@@ -608,7 +626,7 @@ static ERR post_read(WSW_SOCKET Socket)
 
    if (udp) return post_udp_receive(Socket);
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::READ;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -629,7 +647,7 @@ static ERR post_read(WSW_SOCKET Socket)
       operation->Result = error;
       operation->BytesTransferred = 0;
       queue_operation_completion(*operation, 0, operation->Result);
-      delete operation;
+      release_operation(operation);
       return ERR::Okay;
    }
 
@@ -668,7 +686,7 @@ static ERR post_accept(WSW_SOCKET Socket)
       return convert_error();
    }
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::ACCEPT;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -687,7 +705,7 @@ static ERR post_accept(WSW_SOCKET Socket)
          if (record != glSockets.end()) record->second.AcceptPending = false;
       }
       close_accepted_socket(*operation);
-      delete operation;
+      release_operation(operation);
       return convert_error();
    }
 
@@ -702,7 +720,7 @@ static ERR post_accept(WSW_SOCKET Socket)
          if (record != glSockets.end()) record->second.AcceptPending = false;
       }
       close_accepted_socket(*operation);
-      delete operation;
+      release_operation(operation);
       return error;
    }
 
@@ -713,13 +731,13 @@ static ERR post_accept(WSW_SOCKET Socket)
 
 static void worker_thread()
 {
-   while (not glShutdownRequested) {
+   while (true) {
       DWORD bytes = 0;
       ULONG_PTR key = 0;
       OVERLAPPED *overlapped = nullptr;
 
       auto result = GetQueuedCompletionStatus(glCompletionPort, &bytes, &key, &overlapped, INFINITE);
-      if (glShutdownRequested) break;
+      if ((!overlapped) and (key IS IOCP_SHUTDOWN_KEY)) break;
       if (!overlapped) continue;
 
       auto operation = CONTAINING_RECORD(overlapped, IocpOperation, Overlapped);
@@ -731,7 +749,7 @@ static void worker_thread()
       operation->Result = error;
       queue_operation_completion(*operation, operation->BytesTransferred, operation->Result);
 
-      delete operation;
+      release_operation(operation);
    }
 }
 
@@ -775,8 +793,7 @@ ERR iocp_initialise(int MsgID, iocp_post_message PostMessage)
       return ERR::SystemCall;
    }
 
-   auto hardware_threads = std::thread::hardware_concurrency();
-   auto worker_count = std::min<unsigned>(std::max<unsigned>(hardware_threads, 2), MAX_IOCP_THREADS);
+   auto worker_count = std::clamp<unsigned>(std::thread::hardware_concurrency(), 2, 64);
 
    glShutdownRequested = false;
    glWorkers.reserve(worker_count);
@@ -791,8 +808,42 @@ void iocp_expunge()
 {
    glShutdownRequested = true;
 
-   for (size_t i = 0; i < glWorkers.size(); ++i) {
-      PostQueuedCompletionStatus(glCompletionPort, 0, 0, nullptr);
+   if (glCompletionPort != INVALID_HANDLE_VALUE) {
+      std::vector<WSW_SOCKET> sockets;
+
+      {
+         std::lock_guard<std::mutex> lock(glIocpMutex);
+         sockets.reserve(glSockets.size());
+         for (auto &record : glSockets) {
+            record.second.Cancelled = true;
+            record.second.Generation++;
+            sockets.push_back(record.first);
+
+            for (auto &accepted : record.second.AcceptedSockets) sockets.push_back(accepted.Socket);
+         }
+      }
+
+      std::sort(sockets.begin(), sockets.end());
+      sockets.erase(std::unique(sockets.begin(), sockets.end()), sockets.end());
+
+      for (auto socket : sockets) {
+         auto native_socket = socket_from_handle(socket);
+         if (native_socket IS INVALID_SOCKET) continue;
+
+         CancelIoEx((HANDLE)native_socket, nullptr);
+         shutdown(native_socket, SD_BOTH);
+         closesocket(native_socket);
+      }
+
+      while (true) {
+         auto pending = glPendingOperations.load();
+         if (!pending) break;
+         glPendingOperations.wait(pending);
+      }
+
+      for (size_t i = 0; i < glWorkers.size(); ++i) {
+         PostQueuedCompletionStatus(glCompletionPort, 0, IOCP_SHUTDOWN_KEY, nullptr);
+      }
    }
 
    glWorkers.clear();
@@ -954,7 +1005,7 @@ ERR iocp_begin_connect_wait(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
       return ERR::Okay;
    }
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::CONNECT;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -965,7 +1016,7 @@ ERR iocp_begin_connect_wait(WSW_SOCKET Socket, int ObjectID, uintptr_t Callback)
    auto result = connect_ex(socket, remote_address, address_size, nullptr, 0, &bytes, &operation->Overlapped);
    if ((!result) and (WSAGetLastError() != WSA_IO_PENDING)) {
       auto connect_error = convert_error();
-      delete operation;
+      release_operation(operation);
       failed_operation.Result = connect_error;
       queue_operation_completion(failed_operation, 0, failed_operation.Result);
    }
@@ -1242,7 +1293,7 @@ ERR iocp_send(WSW_SOCKET Socket, const void *Buffer, size_t &Length)
       generation = record->second.Generation;
    }
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::WRITE;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -1265,7 +1316,7 @@ ERR iocp_send(WSW_SOCKET Socket, const void *Buffer, size_t &Length)
          auto record = glSockets.find(Socket);
          if (record != glSockets.end()) record->second.WritePending = false;
       }
-      delete operation;
+      release_operation(operation);
       Length = 0;
       return error;
    }
@@ -1296,7 +1347,7 @@ ERR iocp_send_to(WSW_SOCKET Socket, const void *Buffer, size_t &Length, const vo
       object_id = record->second.ObjectID;
    }
 
-   auto operation = new IocpOperation();
+   auto operation = create_operation();
    operation->Type = IocpOperationType::UDP_SEND;
    operation->Socket = Socket;
    operation->Generation = generation;
@@ -1317,7 +1368,7 @@ ERR iocp_send_to(WSW_SOCKET Socket, const void *Buffer, size_t &Length, const vo
    auto socket_error = (result IS SOCKET_ERROR) ? WSAGetLastError() : 0;
    if ((result IS SOCKET_ERROR) and (socket_error != WSA_IO_PENDING)) {
       auto error = convert_send_to_error(socket_error);
-      delete operation;
+      release_operation(operation);
       Length = 0;
       return error;
    }


### PR DESCRIPTION
## Summary

* Replaced the single global `glIocpMutex` with a per-socket `Mutex` on `IocpSocketRecord` (now stored as `shared_ptr`) and a separate `glRegistryMutex` guarding only the socket map, eliminating a serialisation bottleneck across all concurrent socket operations
* Added pipelined TCP reads — multiple `WSARecv` operations kept in flight simultaneously with ordered sequence-number delivery, improving throughput on high-latency or high-bandwidth connections
* Added a TCP send queue with high-water flow control, allowing callers to enqueue up to `IOCP_TCP_SEND_HIGH_WATER` bytes without blocking and draining them via sequential `WSASend` completions
* Added AcceptEx depth pooling — a configurable number of `AcceptEx` operations kept pending on listening sockets to reduce accept latency under load
* Expanded the Flute test suite with pipeline, backpressure, and large bidirectional transfer tests to validate correctness under concurrent load

## Test plan

- [ ] Build `network` module and confirm no compile errors
- [ ] Run `ctest -L network` against the installed build and confirm all IOCP pipeline tests pass
- [ ] Verify `LargeBidirectionalTCPTransfer`, `SlowReaderBackpressure`, and pipelined read tests all pass on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)