### PR TITLE
[Tiri] Mutable string buffer allocation for FD_MUTABLE parameters

### DIFF
--- a/src/core/tests/test_filesystem.tiri
+++ b/src/core/tests/test_filesystem.tiri
@@ -138,6 +138,45 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function MutableStringReadBuffer()
+   read_path = glTempRoot .. 'mutable_string_read.txt'
+   expected = 'Mutable string buffer content'
+
+   resetPath(read_path)
+   writeFile(read_path, expected)
+
+   fl = obj.new('file', { src=read_path, flags=FL_READ } )
+   buffer = string.alloc(#expected)
+   err, result = fl.acRead(buffer)
+   assert(err is ERR_Okay, 'Failed to read into mutable string buffer: ' .. mSys.GetErrorMsg(err))
+   assert(result is #expected, 'Read length should match expected content size.')
+   assert(string.substr(buffer, 0, result) is expected, 'Mutable string buffer read returned unexpected content.')
+
+   try
+      fl.acSeek(POS_START, 0)
+      fl.acRead('literal')
+   success
+      error('acRead() should reject interned strings for mutable buffers')
+   end
+
+   try
+      fl.acSeek(POS_START, 0)
+      fl.acRead(buffer, #buffer + 1)
+   success
+      error('acRead() should reject sizes larger than the supplied buffer')
+   end
+
+   write_path = glTempRoot .. 'immutable_string_write.txt'
+   resetPath(write_path)
+   write_file = obj.new('file', { src=write_path, flags=FL_NEW|FL_WRITE } )
+   err, result = write_file.acWrite('ordinary input', #'ordinary input')
+   assert(err is ERR_Okay, 'acWrite() should continue accepting ordinary immutable strings.')
+   write_file.free()
+   assert(readFile(write_path) is 'ordinary input', 'Immutable string write did not persist expected content.')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function FileIcons()
    if mSys.AnalysePath('icons:') != ERR_Okay then
       -- Icons not available, skip test
@@ -344,6 +383,17 @@ end
    err = mSys.ReadFileToBuffer('~' .. glTempRoot .. 'buffer_read', approx_buffer)
    assert(err is ERR_Okay, 'ReadFileToBuffer() failed for an approximated path: ' .. mSys.GetErrorMsg(err))
    assert(approx_buffer:getString() is expected, 'ReadFileToBuffer() did not resolve the approximated path correctly.')
+
+   string_buffer = string.alloc(#expected)
+   err = mSys.ReadFileToBuffer(read_path, string_buffer)
+   assert(err is ERR_Okay, 'ReadFileToBuffer() failed for a mutable string buffer: ' .. mSys.GetErrorMsg(err))
+   assert(string.substr(string_buffer, 0, #expected) is expected, 'ReadFileToBuffer() did not fill the mutable string buffer.')
+
+   try
+      mSys.ReadFileToBuffer(read_path, 'literal')
+   success
+      error('ReadFileToBuffer() should reject interned strings for mutable buffers')
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/jit/src/lib/lib_string.cpp
+++ b/src/tiri/jit/src/lib/lib_string.cpp
@@ -180,19 +180,14 @@ LJLIB_CF(string_rep)      LJLIB_REC(.)
 //
 // 1. Takes a size parameter - Uses lj_lib_checkint(L, 1) to get the size from the first argument
 // 2. Validates the size - Checks that size is not negative and throws an error if it is
-// 3. Reserves buffer space - Uses lj_buf_need(sb, (MSize)size) to ensure the buffer has enough capacity
-// 4. Advances the write pointer - Sets sb->w += size to reserve the space without filling it
-// 5. Returns the string - Creates and returns the string with the reserved space
+// 3. Allocates a mutable GC string buffer outside the normal string interning table.
+// 4. Returns the mutable string with the requested length.
 
 LJLIB_CF(string_alloc)
 {
    int32_t size = lj_lib_checkint(L, 1);
    LJ_CHECK_ARG(L, 1, size >= 0, ErrMsg::NUMRNG);
-   SBuf *sb = lj_buf_tmp_(L);
-   lj_buf_reset(sb);
-   (void)lj_buf_need(sb, (MSize)size);
-   sb->w += size;  //  Advance write pointer to reserve space
-   setstrV(L, L->top - 1, lj_buf_str(L, sb));
+   setstrV(L, L->top - 1, lj_str_newbuf(L, MSize(size)));
    lj_gc_check(L);
    return 1;
 }

--- a/src/tiri/jit/src/runtime/lj_str.cpp
+++ b/src/tiri/jit/src/runtime/lj_str.cpp
@@ -148,6 +148,31 @@ static GCstr * lj_str_alloc(lua_State *L, const char *str, MSize len, uint32_t h
 }
 
 //********************************************************************************************************************
+// Allocate a mutable string buffer outside the interning table.
+
+GCstr * lj_str_newbuf(lua_State *L, MSize len)
+{
+   auto *g = G(L);
+
+   if (len >= LJ_MAX_STR) {
+      if (len) lj_err_msg(L, ErrMsg::STROV);
+      len = 0;
+   }
+
+   auto *s = (GCstr *)lj_mem_newgco(L, lj_str_size(len));
+   s->gct      = ~LJ_TSTR;
+   s->len      = len;
+   s->hash     = 0;
+   s->sid      = g->str.id++;
+   s->reserved = 0;
+   s->flags    = STRF_MUTABLE_BUFFER;
+
+   // Clear last 4 bytes of allocated memory. Implies zero-termination, too.
+   *(uint32_t *)(strdatawr(s) + (len & ~MSize(3))) = 0;
+   return s;
+}
+
+//********************************************************************************************************************
 // Intern a string and return string object.  Throws on failure.
 
 GCstr * lj_str_new(lua_State *L, const char *str, size_t lenx)
@@ -186,7 +211,7 @@ GCstr * lj_str_new(lua_State *L, const char *str, size_t lenx)
 
 void lj_str_free(global_State *g, GCstr *s)
 {
-   g->str.num--;
+   if (not lj_str_ismutable(s)) g->str.num--;
    lj_mem_free(g, s, lj_str_size(s->len));
 }
 

--- a/src/tiri/jit/src/runtime/lj_str.h
+++ b/src/tiri/jit/src/runtime/lj_str.h
@@ -8,6 +8,8 @@
 
 #include "lj_obj.h"
 
+inline constexpr uint8_t STRF_MUTABLE_BUFFER = 0x01;
+
 // Ordered compare of strings. Returns <0, 0, or >0.
 LJ_FUNC int32_t lj_str_cmp(GCstr* a, GCstr* b);
 
@@ -28,6 +30,9 @@ LJ_FUNC void lj_str_resize(lua_State* L, MSize newmask);
 // Intern a string and return the interned string object.
 LJ_FUNCA GCstr* lj_str_new(lua_State* L, const char* str, size_t len);
 
+// Allocate a mutable string buffer outside the interning table.
+LJ_FUNCA GCstr* lj_str_newbuf(lua_State* L, MSize len);
+
 // Free a string object (called during GC).
 LJ_FUNC void lj_str_free(global_State* g, GCstr* s);
 
@@ -42,6 +47,10 @@ LJ_FUNC void lj_str_init(lua_State* L);
 // Intern a string from std::string_view.
 [[nodiscard]] inline GCstr* lj_str_newsv(lua_State* L, std::string_view sv) noexcept {
    return lj_str_new(L, sv.data(), sv.size());
+}
+
+[[nodiscard]] inline bool lj_str_ismutable(const GCstr *s) noexcept {
+   return (s->flags & STRF_MUTABLE_BUFFER) != 0;
 }
 
 // Calculate the memory size needed for a string of given length.

--- a/src/tiri/tests/test_strings.tiri
+++ b/src/tiri/tests/test_strings.tiri
@@ -8,13 +8,22 @@ function enforce_hotpath() end
    s = string.alloc(10)
    assert(#s is 10, "String size is not 10 characters, got " .. #s)
 
+   s2 = string.alloc(10)
+   assert(not (s is s2), "Same-sized string.alloc() buffers should be distinct objects")
+
    -- Test zero size
    empty = string.alloc(0)
    assert(#empty is 0, "Zero alloc should create empty string, got " .. #empty)
 
+   empty2 = string.alloc(0)
+   assert(not (empty is empty2), "Zero-sized string.alloc() buffers should be distinct objects")
+
    -- Test large size
    big = string.alloc(1000)
    assert(#big is 1000, "Large alloc failed, expected 1000, got " .. #big)
+
+   slice = string.substr(s, #s, #s)
+   assert(slice is "", "Slices copied from mutable buffers should be normal interned strings")
 end
 
 @Test function Index()

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -12,6 +12,7 @@
 #include "lauxlib.h"
 #include "lj_obj.h"
 #include "lj_object.h"
+#include "lj_str.h"
 #include "lib.h"
 
 #include "hashes.h"
@@ -50,6 +51,11 @@ static std::set<std::string, CaseInsensitiveCompare> glLoadedConstants; // Store
 
 static int module_call(lua_State *);
 static int process_results(prvTiri *, APTR, const FunctionField *);
+
+[[nodiscard]] static GCstr * string_arg(lua_State *Lua, int Arg) noexcept
+{
+   return strV(Lua->base + Arg - 1);
+}
 
 //********************************************************************************************************************
 
@@ -517,6 +523,42 @@ static int module_call(lua_State *Lua)
                   return 0;
                }
             }
+            else if (lua_type(Lua, i) IS LUA_TSTRING) {
+               auto string = string_arg(Lua, i);
+               if (not lj_str_ismutable(string)) {
+                  cleanup();
+                  luaL_argerror(Lua, i, "Mutable buffer required.");
+                  return 0;
+               }
+
+               ((APTR *)(buffer + j))[0] = strdatawr(string);
+               arg_values[in] = buffer + j;
+               arg_types[in++] = &ffi_type_pointer;
+               j += sizeof(APTR);
+
+               if (args[i+1].Type & (FD_BUFSIZE|FD_ARRAYSIZE)) {
+                  if (args[i+1].Type & FD_INT) {
+                     ((int *)(buffer + j))[0] = int(string->len);
+                     arg_values[in]  = buffer + j;
+                     arg_types[in++] = &ffi_type_sint32;
+                     i++;
+                     j += sizeof(int);
+                  }
+                  else if (args[i+1].Type & FD_INT64) {
+                     ((int64_t *)(buffer + j))[0] = string->len;
+                     arg_values[in]  = buffer + j;
+                     arg_types[in++] = &ffi_type_sint64;
+                     i++;
+                     j += sizeof(int64_t);
+                  }
+                  else log.warning("Integer type unspecified for BUFSIZE argument in %s()", mod->Functions[index].Name);
+               }
+               else {
+                  cleanup();
+                  luaL_error(Lua, ERR::InvalidType, "Function '%s' is not compatible with Tiri.", mod->Functions[index].Name);
+                  return 0;
+               }
+            }
             else {
                cleanup();
                luaL_error(Lua, ERR::Args, "A memory buffer is required in arg #%d.", i);
@@ -619,6 +661,21 @@ static int module_call(lua_State *Lua)
             allocated_string_views.push_back(view_ptr);
             ((std::string_view **)(buffer + j))[0] = view_ptr;
          }
+         else if (argtype & FD_MUTABLE) {
+            if (type != LUA_TSTRING) {
+               cleanup();
+               luaL_argerror(Lua, i, "Mutable buffer required.");
+               return 0;
+            }
+
+            auto string = string_arg(Lua, i);
+            if (not lj_str_ismutable(string)) {
+               cleanup();
+               luaL_argerror(Lua, i, "Mutable buffer required.");
+               return 0;
+            }
+            ((CSTRING *)(buffer + j))[0] = strdatawr(string);
+         }
          else if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER) or (type IS LUA_TBOOLEAN)) {
             ((CSTRING *)(buffer + j))[0] = lua_tostring(Lua, i);
          }
@@ -680,14 +737,14 @@ static int module_call(lua_State *Lua)
                }
                else {
                   if (args[i+1].Type & FD_INT) {
-                     ((int *)(buffer + j))[0] = arr->len;
+                     ((int *)(buffer + j))[0] = (argtype & FD_BUFFER) ? arr->len * arr->elemsize : arr->len;
                      arg_values[in] = buffer + j;
                      arg_types[in++] = &ffi_type_sint32;
                      j += sizeof(int);
                      i++;
                   }
                   else if (args[i+1].Type & FD_INT64) {
-                     ((int64_t *)(buffer + j))[0] = arr->len;
+                     ((int64_t *)(buffer + j))[0] = (argtype & FD_BUFFER) ? arr->len * arr->elemsize : arr->len;
                      arg_values[in] = buffer + j;
                      arg_types[in++] = &ffi_type_sint64;
                      j += sizeof(int64_t);
@@ -716,8 +773,15 @@ static int module_call(lua_State *Lua)
          auto arg_type = lua_type(Lua, i);
          if (arg_type IS LUA_TSTRING) {
             // Lua strings need to be converted to C strings
-            size_t strlen;
-            ((CSTRING *)(buffer + j))[0] = lua_tolstring(Lua, i, &strlen);
+            auto string = string_arg(Lua, i);
+            if ((argtype & FD_MUTABLE) and (not lj_str_ismutable(string))) {
+               cleanup();
+               luaL_argerror(Lua, i, "Mutable buffer required.");
+               return 0;
+            }
+
+            size_t strlen = string->len;
+            ((CSTRING *)(buffer + j))[0] = (argtype & FD_MUTABLE) ? strdatawr(string) : strdata(string);
             arg_values[in] = buffer + j;
             arg_types[in++] = &ffi_type_pointer;
             j += sizeof(CSTRING);

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -120,6 +120,24 @@ static int object_method_call(lua_State *Lua)
 //********************************************************************************************************************
 // Build argument buffer for actions and methods.
 
+static bool check_mutable_string_arg(lua_State *Lua, int Arg, GCstr *String)
+{
+   if (not lj_str_ismutable(String)) {
+      luaL_argerror(Lua, Arg, "Mutable buffer required.");
+      return false;
+   }
+   return true;
+}
+
+static bool check_buffer_size_arg(lua_State *Lua, int Arg, int64_t Size, size_t Capacity)
+{
+   if ((Size < 0) or (uint64_t(Size) > uint64_t(Capacity))) {
+      luaL_argerror(Lua, Arg, "Buffer size exceeds supplied buffer capacity.");
+      return false;
+   }
+   return true;
+}
+
 ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *argbuffer, int *ResultCount)
 {
    kt::Log log(__FUNCTION__);
@@ -133,8 +151,12 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
    int i, n;
    int resultcount = 0;
    int j = 0;
+   size_t buffer_capacity = 0;
+   bool buffer_capacity_known = false;
    for (i=0,n=1; (args[i].Name) and (j < ArgsSize) and (top > 0); i++,n++,top--) {
       int type = lua_type(Lua, n);
+
+      if (not (args[i].Type & FD_BUFSIZE)) buffer_capacity_known = false;
 
       if (args[i].Type & FD_RESULT) resultcount = resultcount + 1;
 
@@ -154,6 +176,8 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
                // more arguments are specified in the function call.
 
                size_t memsize = array->len * array->elemsize;
+               buffer_capacity = memsize;
+               buffer_capacity_known = true;
                if (args[i+1].Type & FD_INT)  ((int *)(argbuffer + j))[0] = int(memsize);
                else if (args[i+1].Type & FD_INT64) ((int64_t *)(argbuffer + j))[0] = int64_t(memsize);
             }
@@ -168,6 +192,8 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
                // Buffer size is optional (can be nil), so set the buffer size parameter by default.
                // The user can override it if more arguments are specified in the function call.
 
+               buffer_capacity = fstruct->AlignedSize;
+               buffer_capacity_known = true;
                if (args[i+1].Type & FD_INT) ((int *)(argbuffer + j))[0] = fstruct->AlignedSize;
                else if (args[i+1].Type & FD_INT64) ((int64_t *)(argbuffer + j))[0] = fstruct->AlignedSize;
             }
@@ -175,12 +201,16 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
          }
          else if (type IS LUA_TSTRING) {
             //log.trace("Arg: %s, Value: Buffer (Source is String)", args[i].Name);
-            size_t len;
-            CSTRING str = lua_tolstring(Lua, n, &len);
+            auto string = strV(Lua->base + n - 1);
+            if ((args[i].Type & FD_MUTABLE) and (not check_mutable_string_arg(Lua, n, string))) return ERR::WrongType;
+            size_t len = string->len;
+            CSTRING str = (args[i].Type & FD_MUTABLE) ? strdatawr(string) : strdata(string);
             ((CSTRING *)(argbuffer + j))[0] = str;
             j += sizeof(APTR);
 
             if (args[i+1].Type & FD_BUFSIZE) {
+               buffer_capacity = len;
+               buffer_capacity_known = true;
                if (args[i+1].Type & FD_INT) ((int *)(argbuffer + j))[0] = len;
                else if (args[i+1].Type & FD_INT64) ((int64_t *)(argbuffer + j))[0] = len;
             }
@@ -197,7 +227,16 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
       }
       else if (args[i].Type & FD_STR) {
          j = ALIGN64(j);
-         if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER)) {
+         if (args[i].Type & FD_MUTABLE) {
+            if (type != LUA_TSTRING) {
+               luaL_argerror(Lua, n, "Mutable buffer required.");
+               return ERR::WrongType;
+            }
+            auto string = strV(Lua->base + n - 1);
+            if (not check_mutable_string_arg(Lua, n, string)) return ERR::WrongType;
+            ((CSTRING *)(argbuffer + j))[0] = strdatawr(string);
+         }
+         else if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER)) {
             ((CSTRING *)(argbuffer + j))[0] = lua_tostring(Lua, n);
          }
          else if (type <= 0) {
@@ -255,7 +294,9 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
          }
          else if (type IS LUA_TSTRING) {
             //log.trace("Arg: %s, Value: Pointer (Source is String)", args[i].Name);
-            ((CSTRING *)(argbuffer + j))[0] = lua_tostring(Lua, n);
+            auto string = strV(Lua->base + n - 1);
+            if ((args[i].Type & FD_MUTABLE) and (not check_mutable_string_arg(Lua, n, string))) return ERR::WrongType;
+            ((CSTRING *)(argbuffer + j))[0] = (args[i].Type & FD_MUTABLE) ? strdatawr(string) : strdata(string);
          }
          else if (type IS LUA_TNUMBER) {
             luaL_argerror(Lua, n, "Unable to convert number to a pointer.");
@@ -284,9 +325,25 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
             }
             else luaL_argerror(Lua, n, "Unable to convert usertype to an integer.");
          }
-         else if (type IS LUA_TBOOLEAN) ((int *)(argbuffer + j))[0] = lua_toboolean(Lua, n);
-         else if (type != LUA_TNIL) ((int *)(argbuffer + j))[0] = lua_tointeger(Lua, n);
-         else if (args[i].Type & FD_BUFSIZE); // Do not alter as the FD_BUFFER support would have managed it
+         else if (type IS LUA_TBOOLEAN) {
+            auto value = lua_toboolean(Lua, n);
+            if ((args[i].Type & FD_BUFSIZE) and buffer_capacity_known) {
+               if (not check_buffer_size_arg(Lua, n, value, buffer_capacity)) return ERR::WrongType;
+               buffer_capacity_known = false;
+            }
+            ((int *)(argbuffer + j))[0] = value;
+         }
+         else if (type != LUA_TNIL) {
+            auto value = lua_tointeger(Lua, n);
+            if ((args[i].Type & FD_BUFSIZE) and buffer_capacity_known) {
+               if (not check_buffer_size_arg(Lua, n, value, buffer_capacity)) return ERR::WrongType;
+               buffer_capacity_known = false;
+            }
+            ((int *)(argbuffer + j))[0] = value;
+         }
+         else if (args[i].Type & FD_BUFSIZE) {
+            buffer_capacity_known = false; // Do not alter as the FD_BUFFER support would have managed it
+         }
          else ((int *)(argbuffer + j))[0] = 0;
          //log.trace("Arg: %s, Value: %d / $%.8x", args[i].Name, ((int *)(argbuffer + j))[0], ((int *)(argbuffer + j))[0]);
          j += sizeof(int);
@@ -299,7 +356,17 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
       }
       else if (args[i].Type & FD_INT64) {
          j = ALIGN64(j);
-         ((int64_t *)(argbuffer + j))[0] = lua_tointeger(Lua, n);
+         if ((args[i].Type & FD_BUFSIZE) and (type IS LUA_TNIL)) {
+            buffer_capacity_known = false;
+         }
+         else {
+            auto value = lua_tointeger(Lua, n);
+            if ((args[i].Type & FD_BUFSIZE) and buffer_capacity_known) {
+               if (not check_buffer_size_arg(Lua, n, value, buffer_capacity)) return ERR::WrongType;
+               buffer_capacity_known = false;
+            }
+            ((int64_t *)(argbuffer + j))[0] = value;
+         }
          //log.trace("Arg: %s, Value: %" PF64, args[i].Name, ((LARGE *)(argbuffer + j))[0]);
          j += sizeof(int64_t);
       }


### PR DESCRIPTION
## Summary

- Introduced `lj_str_newbuf()` to allocate mutable GC string buffers outside the interning table, so `string.alloc()` always returns a distinct writable object regardless of size
- Added `STRF_MUTABLE_BUFFER` flag and `lj_str_ismutable()` helper; `lj_str_free()` now skips the interned string counter for mutable buffers
- Enforced `FD_MUTABLE` validation in `tiri_module.cpp` and `tiri_objects_calls.cpp` — passing an interned (immutable) string where a writable buffer is required now raises a clear argument error
- Added bounds checking to reject explicit buffer-size arguments that exceed the capacity of the supplied buffer
- Fixed `FD_BUFFER` array size calculation to multiply by `elemsize` before passing to `BUFSIZE` parameters

## Test plan

- [ ] Build `tiri` module and confirm clean compilation
- [ ] Run `test_strings.tiri` — verifies distinct `string.alloc()` objects and that slices from mutable buffers are interned strings
- [ ] Run `test_filesystem.tiri` — verifies `acRead()` and `ReadFileToBuffer()` accept mutable buffers and reject interned strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)