### PR TITLE
[IDL] Moved source file declarations from CMake FILES args into TDL module() src option

### DIFF
--- a/docs/xml/modules/core.xml
+++ b/docs/xml/modules/core.xml
@@ -5,7 +5,12 @@
   <info>
     <name>Core</name>
     <type>module</type>
+    <comment>The core library provides system calls and controls for the Kotuku system.</comment>
     <copyright>Paul Manias 1996-2026</copyright>
+    <description>
+<p>The Kotuku Core is a system library that provides a universal API that works on multiple platforms.  It follows an object oriented design with granular resource tracking to minimise resource usage and memory leaks.</p>
+<p>The portability of the core has been safe-guarded by keeping the functions as generalised as possible.  When writing code for a target platform it will be possible for the application to be completely sandboxed if the host's system calls are avoided.</p>
+<p>This documentation is intended for technical reference and is not suitable as an introductory guide to the framework.</p></description>
     <classes>
       <class>CompressedStream</class>
       <class>Compression</class>

--- a/docs/xml/modules/font.xml
+++ b/docs/xml/modules/font.xml
@@ -5,8 +5,13 @@
   <info>
     <name>Font</name>
     <type>module</type>
+    <comment>Provides font management functionality and hosts the Font class.</comment>
     <version>1</version>
     <copyright>Paul Manias © 1998-2026</copyright>
+    <description>
+<p>The Font module is responsible for managing the font database and provides support for client queries.  Fixed size bitmap fonts are supported via the Windows .fon file format, while Truetype fonts are support for scalable fonts.</p>
+<p>Bitmap fonts can be opened and drawn by the <class name="Font">Font</class> class.  Drawing Truetype fonts is not supported by the Font module, but is instead provided by the <fl>Vector</fl> module and <class name="VectorText">VectorText</class> class.</p>
+<p>For a thorough introduction to typesetting history and terminology as it applies to computing, we recommend visiting Google Fonts Knowledge page: https://fonts.google.com/knowledge</p></description>
     <classes>
       <class>Font</class>
     </classes>

--- a/docs/xml/modules/network.xml
+++ b/docs/xml/modules/network.xml
@@ -5,10 +5,13 @@
   <info>
     <name>Network</name>
     <type>module</type>
+    <comment>Provides miscellaneous network functions and hosts the NetSocket and ClientSocket classes.</comment>
     <version>1</version>
     <status>stable</status>
     <prefix>net</prefix>
     <copyright>Paul Manias © 2005-2026</copyright>
+    <description>
+<p>The Network module exports a few miscellaneous networking functions.  For core network functionality surrounding sockets and HTTP, please refer to the <class name="NetSocket">NetSocket</class> and <class name="HTTP">HTTP</class> classes.</p></description>
     <classes>
       <class>ClientSocket</class>
       <class>NetClient</class>

--- a/docs/xml/modules/tiri.xml
+++ b/docs/xml/modules/tiri.xml
@@ -5,11 +5,15 @@
   <info>
     <name>Tiri</name>
     <type>module</type>
-    <comment>Tiri is a JIT optimised language that extends the Script class.</comment>
+    <comment>Tiri is a customised scripting language for the Script class.</comment>
     <version>1</version>
     <status>beta</status>
     <prefix>fl</prefix>
     <copyright>Paul Manias © 2006-2026</copyright>
+    <description>
+<p>Tiri is a custom scripting language for Kotuku developers.  It is implemented on the backbone of LuaJIT, a high performance version of the Lua scripting language.  It supports garbage collection, dynamic typing and a 64-bit byte-code interpreter for compiled code.</p>
+<p>Tiri files use the <code>.tiri</code> file extension.  Ideally, scripts should start with the comment '-- $TIRI' near the start of the document so that it can be correctly identified by the Tiri class.</p>
+<p>For more information on the Tiri syntax, please refer to the official Tiri Reference Manual.</p></description>
   </info>
 
   <function>

--- a/docs/xml/modules/vector.xml
+++ b/docs/xml/modules/vector.xml
@@ -5,8 +5,11 @@
   <info>
     <name>Vector</name>
     <type>module</type>
+    <comment>Create, manipulate and draw vector graphics to bitmaps.</comment>
     <version>1</version>
     <copyright>Paul Manias © 2010-2026</copyright>
+    <description>
+<p>The Vector module exports a small number of functions to assist the <class name="Vector">Vector</class> class, as well as some primitive functions for creating paths and rendering them to bitmaps.</p></description>
     <classes>
       <class>BlurFX</class>
       <class>ColourFX</class>

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -14,7 +14,6 @@ int main() {
 idl_gen ("${MOD}.tdl" NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
    APPEND_IDL "module_def.c"
-   FILES "${MOD}.cpp" "commands.cpp"
    ARGS "output-defs=module_def.c" "output-proto=module_def.c")
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast")

--- a/src/audio/audio.tdl
+++ b/src/audio/audio.tdl
@@ -1,6 +1,6 @@
 --$TIRI:Include
 
-module({ name="Audio", copyright="Paul Manias © 2002-2026", version=1.0, timestamp=20240611, src="audio.cpp" }, function()
+module({ name="Audio", copyright="Paul Manias © 2002-2026", version=1.0, timestamp=20240611, src={ "audio.cpp", "commands.cpp" } }, function()
   flags("ADF", { comment="Optional flags for the Audio object." },
     "OVER_SAMPLING: Enables oversampling for higher quality audio at the cost of slower mixing.",
     "FILTER_LOW: Enable a low level of output filtering to minimise distortion.",

--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -42,14 +42,14 @@ if (BUILD_DEFS) # Customised idl_c() equivalent, this is for defining the output
       "${CMAKE_CURRENT_SOURCE_DIR}/module_def.c"
       "${CMAKE_CURRENT_SOURCE_DIR}/prototypes.h")
 
-   list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo "[idl_c] ${ORIGO_CMD} ${IDL_C_SCRIPT} --log-warning src=${MOD}.tdl sdk=${PROJECT_SOURCE_DIR} output-proto=prototypes.h output-defs=module_def.c files={ ${FUNCTIONS} lib_surfaces.cpp }")
+   list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo "[idl_c] ${ORIGO_CMD} ${IDL_C_SCRIPT} --log-warning src=${MOD}.tdl sdk=${PROJECT_SOURCE_DIR} output-proto=prototypes.h output-defs=module_def.c")
    list (APPEND COMMAND_LIST COMMAND ${CMAKE_COMMAND} -E echo "[idl_comp] ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} --log-warning src=${MOD}.tdl output=${CMAKE_CURRENT_SOURCE_DIR}/idl.h sdk=${PROJECT_SOURCE_DIR} format=c")
 
    add_custom_command (OUTPUT "${DISPLAY_STAMP}"
       BYPRODUCTS ${DISPLAY_OUTPUTS}
       ${COMMAND_LIST}
       COMMAND ${ORIGO_CMD} ${IDL_C_SCRIPT} "--log-warning" "src=${MOD}.tdl" "sdk=${PROJECT_SOURCE_DIR}"
-              "output-proto=prototypes.h" "output-defs=module_def.c" "files={" ${FUNCTIONS} "lib_surfaces.cpp" "}"
+              "output-proto=prototypes.h" "output-defs=module_def.c"
       COMMAND ${ORIGO_CMD} ${IDL_COMPILE_SCRIPT} "--log-warning" "src=${MOD}.tdl" "output=${CMAKE_CURRENT_SOURCE_DIR}/idl.h"
               "sdk=${PROJECT_SOURCE_DIR}" "format=c"
       COMMAND ${CMAKE_COMMAND} -E touch "${DISPLAY_STAMP}"

--- a/src/display/display.tdl
+++ b/src/display/display.tdl
@@ -1,6 +1,9 @@
 --$TIRI:Include
 
-module({ name="Display", copyright="Paul Manias © 2003-2026", version=1.0, status="stable", prefix="gfx", timestamp=20240611 }, function()
+module({
+    name="Display", copyright="Paul Manias © 2003-2026", version=1.0, status="stable", prefix="gfx", timestamp=20240611,
+    src={ "display-driver.cpp", "lib_bitmap.cpp", "lib_display.cpp", "lib_cursor.cpp", "lib_input.cpp", "lib_surfaces.cpp" }
+  }, function()
 
   restrict(function()
     loadFile(glPath .. 'common.tdl')

--- a/src/document/CMakeLists.txt
+++ b/src/document/CMakeLists.txt
@@ -4,7 +4,6 @@ set (MOD "document")
 set (INC_MOD_DOCUMENT TRUE PARENT_SCOPE)
 
 idl_gen ("defs/${MOD}.tdl" NAME ${MOD}_defs OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h" APPEND_IDL "defs/module_def.c"
-   FILES "${MOD}.cpp"
    ARGS "output-defs=defs/module_def.c" "output-proto=defs/module_def.c" "prototypes=static")
 
 idl_gen ("defs/hashes.tdl" NAME ${MOD}_hashes OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/defs/hashes.h")

--- a/src/document/defs/document.tdl
+++ b/src/document/defs/document.tdl
@@ -1,6 +1,6 @@
 --$TIRI:Include
 
-module({ name="Document", copyright="Paul Manias © 2005-2026", version=1.0, timestamp=20240611 }, function()
+module({ name="Document", copyright="Paul Manias © 2005-2026", version=1.0, timestamp=20240611, src="../document.cpp" }, function()
   restrict(function()
     loadFile(glPath .. 'common-graphics.tdl')
   end)

--- a/src/font/CMakeLists.txt
+++ b/src/font/CMakeLists.txt
@@ -6,7 +6,6 @@ set (INC_MOD_FONT TRUE PARENT_SCOPE)
 idl_gen ("${MOD}.tdl"
    NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/font.h"
-   FILES "font.cpp"
    ARGS  "output-defs=font_def.c" "output-proto=font_def.c"
    APPEND_IDL "font_def.c")
 

--- a/src/font/font.tdl
+++ b/src/font/font.tdl
@@ -1,6 +1,6 @@
 --$TIRI:Include
 
-module({ name="Font", copyright="Paul Manias © 1998-2026", version=1.0, timestamp=20240611 }, function()
+module({ name="Font", copyright="Paul Manias © 1998-2026", version=1.0, timestamp=20240611, src="font.cpp" }, function()
   restrict(function()
     loadFile(glPath .. 'common-graphics.tdl')
   end)

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -13,7 +13,6 @@ set (INC_MOD_NETWORK TRUE PARENT_SCOPE)
 
 idl_gen ("${MOD}.tdl" NAME "${MOD}_defs" OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
    APPEND_IDL "module_def.c"
-   FILES "network.cpp"
    ARGS "output-defs=module_def.c" "output-proto=module_def.c")
 
 add_library (${MOD})

--- a/src/network/network.tdl
+++ b/src/network/network.tdl
@@ -1,6 +1,8 @@
 --$TIRI:Include
 
-module({ name="Network", copyright="Paul Manias © 2005-2026", version=1.0, prefix="net", status="stable", timestamp=20240611 }, function()
+module({ name="Network", copyright="Paul Manias © 2005-2026", version=1.0, prefix="net", status="stable", timestamp=20240611,
+    src="network.cpp"
+  }, function()
   restrict(function()
     loadFile(glPath .. 'common.tdl')
   end)

--- a/src/regex/CMakeLists.txt
+++ b/src/regex/CMakeLists.txt
@@ -6,7 +6,6 @@ set (INC_MOD_REGEX TRUE PARENT_SCOPE)
 idl_gen ("${MOD}.tdl"
    NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
-   FILES "regex.cpp"
    ARGS  "output-defs=regex_def.c" "output-proto=regex_def.c"
    APPEND_IDL "${MOD}_def.c")
 

--- a/src/svg/CMakeLists.txt
+++ b/src/svg/CMakeLists.txt
@@ -4,8 +4,7 @@ set (MOD svg)
 set (INC_MOD_SVG TRUE PARENT_SCOPE)
 
 idl_gen ("${MOD}.tdl" NAME ${MOD}_defs
-   OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
-   FILES "class_rsvg.cpp" "class_svg.cpp")
+   OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h")
 
 idl_compile ("${MOD}.tdl" NAME ${MOD}_idl OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${MOD}_def.c")
 

--- a/src/svg/svg.tdl
+++ b/src/svg/svg.tdl
@@ -1,6 +1,6 @@
 --$TIRI:Include
 
-module({ name="SVG", copyright="Paul Manias © 2010-2026", version=1.0, timestamp=20240611 }, function()
+module({ name="SVG", copyright="Paul Manias © 2010-2026", version=1.0, timestamp=20240611, src="svg.cpp" }, function()
   flags("SVF", { comment="SVG flags." },
     "AUTOSCALE: In auto-resize mode, vector dimensions are scaled to the width and height of the vector page.  The @VectorScene.PageWidth and @VectorScene.PageHeight must be set for this.",
     "ALPHA: Generate an alpha channel in the rendered image.",

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -53,8 +53,7 @@ idl_gen ("hashes.tdl" NAME ${MOD}_hashes OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/has
 idl_gen ("${MOD}.tdl" NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
    APPEND_IDL "module_def.cpp"
-   ARGS "output-defs=module_def.cpp"
-   FILES "${MOD}.cpp")
+   ARGS "output-defs=module_def.cpp")
 
 # We build libFFI as a release build in all situations because ASAN doesn't like Debug builds of libFFI.
 

--- a/src/tiri/tiri.tdl
+++ b/src/tiri/tiri.tdl
@@ -6,7 +6,9 @@ module({
   version=1.0,
   prefix="fl",
   status="beta",
-  comment="Tiri is a JIT optimised language that extends the Script class."
+  src="tiri.cpp",
+  comment="Tiri is a JIT optimised language that extends the Script class.",
+  timestamp=20240611
 },
 function()
   restrict(function()

--- a/src/vector/CMakeLists.txt
+++ b/src/vector/CMakeLists.txt
@@ -4,7 +4,6 @@ set (MOD vector)
 set (INC_MOD_VECTOR TRUE PARENT_SCOPE)
 
 idl_gen ("${MOD}.tdl" NAME ${MOD}_defs OUTPUT "${INCLUDE_OUTPUT}/modules/vector.h"
-   FILES "vector_functions.cpp" "vector_readpainter.cpp"
    ARGS "output-defs=module_def.c")
 
 idl_compile ("${MOD}.tdl" NAME ${MOD}_idl OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/idl.h")

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -1,6 +1,8 @@
 --$TIRI:Include
 
-module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, timestamp=20240611 }, function()
+module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, timestamp=20240611,
+    src={ "vector_functions.cpp", "vector_readpainter.cpp" }
+  }, function()
   c_include("<kotuku/modules/display.h>", "<kotuku/modules/picture.h>")
 
   restrict(function()

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -6,7 +6,6 @@ set (INC_MOD_XML TRUE PARENT_SCOPE)
 idl_gen ("${MOD}.tdl"
    NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
-   FILES "xml.cpp"
    ARGS  "output-defs=xml_def.c" "output-proto=xml_def.c"
    APPEND_IDL "${MOD}_def.c")
 

--- a/src/xquery/CMakeLists.txt
+++ b/src/xquery/CMakeLists.txt
@@ -11,7 +11,6 @@ set (INC_MOD_XQUERY TRUE PARENT_SCOPE)
 idl_gen ("${MOD}.tdl"
    NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"
-   FILES "xquery.cpp"
    ARGS  "output-defs=xquery_def.cpp" "output-proto=xquery_def.cpp"
    APPEND_IDL "${MOD}_def.cpp")
 

--- a/src/xquery/xquery.tdl
+++ b/src/xquery/xquery.tdl
@@ -10,7 +10,7 @@ module({ name='XQuery', src='xquery.cpp', copyright='Paul Manias © 2025-2026', 
 
   -- Shared enumerations for parser and evaluator state, including map/array node kinds.
   loadFile('sdk:src/xquery/constants.tdl')
-  
+
   flags("XEF", { comment="Options for XQuery evaluation flags." },
     "LIMIT_SCOPE: For tag specific queries, limit the scope to the specified element.")
 

--- a/tools/docgen_wiki.tiri
+++ b/tools/docgen_wiki.tiri
@@ -144,6 +144,7 @@ end
          mod_header = header:replace('<title>Kōtuku Wiki</title>', '<title>Kōtuku Wiki - ' .. v.title .. '</title>')
          md_output = md_output:replace('<hr />', '<hr>') -- HTML5 compliance
          md_output = md_output:replace("\r\n", "\n") -- CRLF conversion
+         md_output = md_output:replace(".md\">", ".html\">")
 
          fl.acWrite(mod_header)
          fl.acWrite('\n<h1>' .. v.title .. '</h1>\n')

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -369,13 +369,13 @@ global function outputClassHeader(class:table, Private:str, Custom:str)
          end
 
          if not field_type:startsWith('const ') then
-            if ((f.flags & FD_STRING) != 0) and ((f.flags & FD_ARRAY) is 0) then
+            if (f.flags has FD_STRING) and ((f.flags & FD_ARRAY) is 0) then
                if field_type:startsWith('STRING') or field_type:startsWith('CSTRING') then
                   field_type = 'T &&'
                else
                   field_type = 'const ' .. field_type
                end
-            elseif (f.flags & (FD_POINTER | FD_OBJECT)) != 0 then
+            elseif f.flags has (FD_POINTER | FD_OBJECT) then
                -- Applying const to pointers can cause type conversion issues.
             else
                field_type = 'const ' .. field_type
@@ -392,8 +392,8 @@ global function outputClassHeader(class:table, Private:str, Custom:str)
             if field_type:endsWith('[]') then
                field_type = field_type:sub(0,-3) .. '*'
                output(f'   inline ERR set{fid_name}({field_type} Value, int Elements) noexcept {{')
-            elseif (f.flags & FD_ARRAY) != 0 then
-               if (f.flags & FD_CPP) != 0 then
+            elseif f.flags has FD_ARRAY then
+               if f.flags has FD_CPP then
                   output(f'   inline ERR set{fid_name}({field_type} *Value) noexcept {{')
                else
                   output(f'   inline ERR set{fid_name}({field_type} Value, int Elements) noexcept {{')
@@ -423,33 +423,33 @@ global function outputClassHeader(class:table, Private:str, Custom:str)
                output(indent .. f'auto field = FindField(this, FID_{fid_name}, &target);')
             end
 
-            if (f.flags & FD_UNIT) != 0 then
-               if (f.flags & (FD_INT|FD_INT64|FD_DOUBLE|FD_FLOAT)) != 0 then
+            if f.flags has FD_UNIT then
+               if f.flags has (FD_INT|FD_INT64|FD_DOUBLE|FD_FLOAT) then
                   output(indent .. 'Unit var(Value);')
                   output(indent .. 'return field->WriteValue(target, field, FD_UNIT, &var, 1);')
                else
                   -- Pass through as pointer; requires further analysis to determine viability
                   output(indent .. 'return field->WriteValue(target, field, FD_POINTER, Value, 1);')
                end
-            elseif (f.flags & FD_ARRAY) != 0 then
-               if (f.flags & FD_CPP) != 0 then
+            elseif f.flags has FD_ARRAY then
+               if f.flags has FD_CPP then
                   flags = string.format('%08x', f.flags):sub(-8)
                   output(indent .. 'return field->WriteValue(target, field, 0x' .. flags .. ', Value, int(Value->size()));')
                else
                   flags = string.format('%08x', f.flags):sub(-8)
                   output(indent .. 'return field->WriteValue(target, field, 0x' .. flags .. ', Value, Elements);')
                end
-            elseif (f.flags & FD_FUNCTION) != 0 then
+            elseif f.flags has FD_FUNCTION then
                output(indent .. 'return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);')
-            elseif (f.flags & FD_STRING) != 0 then
+            elseif f.flags has FD_STRING then
                flags = string.format('%08x', f.flags):sub(-8)
                output(indent .. f'return field->WriteValue(target, field, 0x{flags}, to_cstring(Value), 1);')
-            elseif (f.flags & FD_POINTER) != 0 then
+            elseif f.flags has FD_POINTER then
                flags = string.format('%08x', f.flags):sub(-8)
                output(indent .. f'return field->WriteValue(target, field, 0x{flags}, Value, 1);')
-            elseif (f.flags & (FD_DOUBLE | FD_FLOAT)) != 0 then
+            elseif f.flags has (FD_DOUBLE | FD_FLOAT) then
                output(indent .. 'return field->WriteValue(target, field, FD_DOUBLE, &Value, 1);')
-            elseif (f.flags & FD_INT64) != 0 then
+            elseif f.flags has FD_INT64 then
                output(indent .. 'return field->WriteValue(target, field, FD_INT64, &Value, 1);')
             else
                output(indent .. 'return field->WriteValue(target, field, FD_INT, &Value, 1);')

--- a/tools/idl/idl-compile.tiri
+++ b/tools/idl/idl-compile.tiri
@@ -1,7 +1,7 @@
 -- Read Kotuku TDL files and save interface information in our standard IDL string format.  IDL strings describe
 -- the structures, flags and constants used by modules in a universal format that is easy parse.  The headers can be
 -- dynamically consumed by any language for the purpose of achieving full integration with the Kotuku runtime
--- environment, which is written in C.
+-- environment, which is written in C++.
 --
 -- Usage: origo sdk:scripts/idl-tiri.tiri src=source.tdl
 -- Example: origo sdk:scripts/idl-tiri.tiri src=sdk:core/modules/core/core.tdl
@@ -36,35 +36,35 @@ global function privateNames(List:table) end
 
 -- Regex patterns for parsing
 
-local rx_key_comment     = <{ regex.new([[^(.+):\s+(.+)$]]) }>
-local rx_key_comment_ng  = <{ regex.new([[^(.*?):\s+(.+)$]]) }>
-local rx_value_only      = <{ regex.new([[^(.*?):\s+.+$]]) }>
-local rx_hex_num         = <{ regex.new([[^0x[0-9a-fA-F]+$]]) }>
-local rx_signed_int      = <{ regex.new([[^[+\-]?\d+$]]) }>
-local rx_cpp_type        = <{ regex.new([[^cpp\((.+)\)$]]) }>
-local rx_struct_type     = <{ regex.new([[^(c?)struct\((.+)\)$]]) }>
-local rx_ptr_extract     = <{ regex.new([[\*(.+)]]) }>
-local rx_obj_type        = <{ regex.new([[^obj\((.+)\)$]]) }>
-local rx_bit_type        = <{ regex.new([[^bit\((.+)\)$]]) }>
-local rx_char_flag       = <{ regex.new([[^char\(([A-Za-z]+)\)]]) }>
-local rx_non_word        = <{ regex.new([[\W]]) }>
-local rx_short_flag      = <{ regex.new([[^short\(([A-Za-z]+)\)]]) }>
-local rx_int_flag        = <{ regex.new([[^int\(([A-Za-z]+)\)]]) }>
-local rx_large_flag      = <{ regex.new([[^large\(([A-Za-z]+)\)]]) }>
-local rx_uchar_array     = <{ regex.new([[^(u?)char\((.+)\)$]]) }>
-local rx_uint_array      = <{ regex.new([[^(u?)int\((\d+)\)]]) }>
-local rx_double_count    = <{ regex.new([[^double\((.+)\)]]) }>
-local rx_float_count     = <{ regex.new([[^float\((.+)\)]]) }>
-local rx_ptr_type        = <{ regex.new([[^(c?)ptr\((.+)\)]]) }>
-local rx_array_sized     = <{ regex.new([[^array\((.+),(\d+)\)$]]) }>
-local rx_array_unsized   = <{ regex.new([[^array\((.+)\)$]]) }>
-local rx_fptr_type       = <{ regex.new([[^fptr\((.+)\)$]]) }>
-local rx_hash_comment    = <{ regex.new([[^.+#\s*(.+)$]]) }>
-local rx_hash_content    = <{ regex.new([[^(.+)#\s*.+$]]) }>
-local rx_colon_comment   = <{ regex.new([[^.+:\s*(.+)$]]) }>
-local rx_colon_content   = <{ regex.new([[^(.+):\s*.+$]]) }>
-local rx_type_name       = <{ regex.new([[^\s*(.+)\s+(\S+)\s*$]]) }>
-local rx_field_extract   = <{ regex.new([[^(.+?)[:#]\s*(.+)$]]) }> -- "type FieldName # Comment", also accepts ":"
+rx_key_comment     = <{ regex.new([[^(.+):\s+(.+)$]]) }>
+rx_key_comment_ng  = <{ regex.new([[^(.*?):\s+(.+)$]]) }>
+rx_value_only      = <{ regex.new([[^(.*?):\s+.+$]]) }>
+rx_hex_num         = <{ regex.new([[^0x[0-9a-fA-F]+$]]) }>
+rx_signed_int      = <{ regex.new([[^[+\-]?\d+$]]) }>
+rx_cpp_type        = <{ regex.new([[^cpp\((.+)\)$]]) }>
+rx_struct_type     = <{ regex.new([[^(c?)struct\((.+)\)$]]) }>
+rx_ptr_extract     = <{ regex.new([[\*(.+)]]) }>
+rx_obj_type        = <{ regex.new([[^obj\((.+)\)$]]) }>
+rx_bit_type        = <{ regex.new([[^bit\((.+)\)$]]) }>
+rx_char_flag       = <{ regex.new([[^char\(([A-Za-z]+)\)]]) }>
+rx_non_word        = <{ regex.new([[\W]]) }>
+rx_short_flag      = <{ regex.new([[^short\(([A-Za-z]+)\)]]) }>
+rx_int_flag        = <{ regex.new([[^int\(([A-Za-z]+)\)]]) }>
+rx_large_flag      = <{ regex.new([[^large\(([A-Za-z]+)\)]]) }>
+rx_uchar_array     = <{ regex.new([[^(u?)char\((.+)\)$]]) }>
+rx_uint_array      = <{ regex.new([[^(u?)int\((\d+)\)]]) }>
+rx_double_count    = <{ regex.new([[^double\((.+)\)]]) }>
+rx_float_count     = <{ regex.new([[^float\((.+)\)]]) }>
+rx_ptr_type        = <{ regex.new([[^(c?)ptr\((.+)\)]]) }>
+rx_array_sized     = <{ regex.new([[^array\((.+),(\d+)\)$]]) }>
+rx_array_unsized   = <{ regex.new([[^array\((.+)\)$]]) }>
+rx_fptr_type       = <{ regex.new([[^fptr\((.+)\)$]]) }>
+rx_hash_comment    = <{ regex.new([[^.+#\s*(.+)$]]) }>
+rx_hash_content    = <{ regex.new([[^(.+)#\s*.+$]]) }>
+rx_colon_comment   = <{ regex.new([[^.+:\s*(.+)$]]) }>
+rx_colon_content   = <{ regex.new([[^(.+):\s*.+$]]) }>
+rx_type_name       = <{ regex.new([[^\s*(.+)\s+(\S+)\s*$]]) }>
+rx_field_extract   = <{ regex.new([[^(.+?)[:#]\s*(.+)$]]) }> -- "type FieldName # Comment", also accepts ":"
 
 ----------------------------------------------------------------------------------------------------------------------
 -- TDL function
@@ -212,10 +212,10 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 global function hash(Prefix:str, Format:str, ...)
-   for k, hash_def in ipairs({...}) do
+   for hash_def in values({...}) do
       hash_name = rx_non_word.replace(hash_def, '_')
       hash_id = string.format('%08x', hash_name:hash()):sub(-8)
-      output('#define ' .. Prefix .. '_' .. hash_name .. ' ' .. string.format(Format, hash_id))
+      output(f'#define {Prefix}_{hash_name} {string.format(Format, hash_id)}')
    end
    output()
 end
@@ -280,7 +280,7 @@ global glTypes = {
 }
 
 global function cType(Field:table, Origin:str):table
-   assert(Field.type, "Field definition incorrect, missing 'type' value for '" .. (Origin ?? 'NIL') .. "'")
+   assert(Field.type, f"Field definition incorrect, missing 'type' value for '{Origin}'")
 
    do
       t = rx_cpp_type.extract(Field.type)

--- a/tools/idl/include/functions.tiri
+++ b/tools/idl/include/functions.tiri
@@ -126,8 +126,29 @@ global function module(Options:table, Function:func)
       priority()
    end
 
-   if glModule.src then -- Primary source file
-      content = io.readAll(glTDLFolder .. glModule.src)
+   if glModule.src and type(glModule.src) is 'string' then
+      glModule.src = { glTDLFolder .. glModule.src }
+   end
+
+   -- Module files used to be taken from the command-line; the src option is now preferred
+
+   if not glModule.src then
+      glModule.src = array<string>
+
+      for i=0, arg('files:size', 0)-1 do
+         glModule.src:push(arg('files(' .. i .. ')'))
+      end
+   end
+
+   -- Look for the MODULE header and process it.
+
+   if glModule.src then
+      local content
+      content = ''
+      for src in values(glModule.src) do
+         content = io.readAll(src)
+         if content:find('-MODULE-') then break end
+      end
       content = content:replace('\r\n', '\n')
 
       -- Extract possible content from within comments so that we don't get interference from the code while parsing.

--- a/tools/idl/include/functions.tiri
+++ b/tools/idl/include/functions.tiri
@@ -126,8 +126,16 @@ global function module(Options:table, Function:func)
       priority()
    end
 
-   if glModule.src and type(glModule.src) is 'string' then
-      glModule.src = { glTDLFolder .. glModule.src }
+   if glModule.src then
+      if type(glModule.src) is 'string' then
+         glModule.src = { glTDLFolder .. glModule.src }
+      else
+         fixed_path = array<string>
+         for path in values(glModule.src) do
+            fixed_path:push(glTDLFolder .. path)
+         end
+         glModule.src = fixed_path
+      end
    end
 
    -- Module files used to be taken from the command-line; the src option is now preferred

--- a/tools/idl/include/parser.tiri
+++ b/tools/idl/include/parser.tiri
@@ -1,24 +1,24 @@
 
-local rx_doc_name        = <{ regex.new("^[Nn]ame:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_combo       = <{ regex.new("^(\\w+):\\s+(.+)\\n", regex.MULTILINE) }>
-local rx_doc_comment     = <{ regex.new("^[Cc]omment:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_category    = <{ regex.new("^[Cc]ategory:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_extproto    = <{ regex.new("^[Ee]xtPrototype:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_attrib      = <{ regex.new("^[Aa]ttribute:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_status      = <{ regex.new("^[Ss]tatus:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_lookup      = <{ regex.new("^[Ll]ookup:\\s+(.+?)\\n", regex.MULTILINE) }>
-local rx_doc_desc        = <{ regex.new("\\n\\n(.+?)\\n-[A-Z]+-\\n", regex.DOT_ALL) }>
-local rx_strip_ws        = <{ regex.new("^(.*\\S)") }>
-local rx_errors_section  = <{ regex.new("^-ERRORS-\\n+(.+?)-END-", regex.DOT_ALL|regex.MULTILINE) }>
-local rx_input_section   = <{ regex.new("^-INPUT-\\n+(.+?)\\n+-[A-Z]+-\\n", regex.DOT_ALL|regex.MULTILINE) }>
-local rx_result_section  = <{ regex.new("^-RESULT-\\n+(.+?)\\n+-END-", regex.DOT_ALL|regex.MULTILINE) }>
-local rx_ecode_comment   = <{ regex.new("^([A-Za-z]+):\\s+(.+)") }>
-local rx_ecode_only      = <{ regex.new("^([A-Za-z]+):?") }>
-local rx_private         = <{ regex.new("^[Pp]rivate") }>
-local rx_param           = <{ regex.new("^\\s*(.+)\\s+(\\S+)\\s*:\\s*(.+)$") }>
-local rx_result_type     = <{ regex.new("^(.+?):\\s+(.+)$") }>
-local rx_idl_section     = <{ regex.new("--IDL_BEGIN--(.+?)--IDL_END--", regex.DOT_ALL) }>
-local rx_extract_comment = <{ regex.new([[^\/\*+(.*?)\*+\/]], regex.MULTILINE|regex.DOT_ALL) }>
+rx_doc_name        = <{ regex.new("^[Nn]ame:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_combo       = <{ regex.new("^(\\w+):\\s+(.+)\\n", regex.MULTILINE) }>
+rx_doc_comment     = <{ regex.new("^[Cc]omment:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_category    = <{ regex.new("^[Cc]ategory:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_extproto    = <{ regex.new("^[Ee]xtPrototype:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_attrib      = <{ regex.new("^[Aa]ttribute:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_status      = <{ regex.new("^[Ss]tatus:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_lookup      = <{ regex.new("^[Ll]ookup:\\s+(.+?)\\n", regex.MULTILINE) }>
+rx_doc_desc        = <{ regex.new("\\n\\n(.+?)\\n-[A-Z]+-\\n", regex.DOT_ALL) }>
+rx_strip_ws        = <{ regex.new("^(.*\\S)") }>
+rx_errors_section  = <{ regex.new("^-ERRORS-\\n+(.+?)-END-", regex.DOT_ALL|regex.MULTILINE) }>
+rx_input_section   = <{ regex.new("^-INPUT-\\n+(.+?)\\n+-[A-Z]+-\\n", regex.DOT_ALL|regex.MULTILINE) }>
+rx_result_section  = <{ regex.new("^-RESULT-\\n+(.+?)\\n+-END-", regex.DOT_ALL|regex.MULTILINE) }>
+rx_ecode_comment   = <{ regex.new("^([A-Za-z]+):\\s+(.+)") }>
+rx_ecode_only      = <{ regex.new("^([A-Za-z]+):?") }>
+rx_private         = <{ regex.new("^[Pp]rivate") }>
+rx_param           = <{ regex.new("^\\s*(.+)\\s+(\\S+)\\s*:\\s*(.+)$") }>
+rx_result_type     = <{ regex.new("^(.+?):\\s+(.+)$") }>
+rx_idl_section     = <{ regex.new("--IDL_BEGIN--(.+?)--IDL_END--", regex.DOT_ALL) }>
+rx_extract_comment = <{ regex.new([[^\/\*+(.*?)\*+\/]], regex.MULTILINE|regex.DOT_ALL) }>
 
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -309,18 +309,7 @@ end
 global function parseSourceFiles()
    if glFeedback is 'verbose' then print('Processing source files...') end
 
-   srcFiles = array<string>
-
-   for i=0, arg('files:size', 0)-1 do
-      srcFiles:push(arg('files(' .. i .. ')'))
-   end
-
-   if #srcFiles < 1 then
-      if glFeedback is 'verbose' then print('No source files were detected.') end
-      return
-   end
-
-   for path in values(srcFiles) do
+   for path in values(glModule.src ?? {}) do
       -- Process --IDL_BEGIN/END-- sections, which allow the developer to embed TDL functions in the source code.
 
       local idlExtract


### PR DESCRIPTION
## Summary

- The IDL tools now read source file paths from the `src` option in the TDL `module()` declaration rather than from command-line `FILES` arguments passed by CMake. The `src` option accepts a string or an array of strings.
- Updated `audio`, `display`, `document`, `network`, and `vector` TDL files to declare their source files via `src=`, and removed the corresponding `FILES` arguments from `idl_gen()` CMake calls.
- Cleaned up Tiri idioms in the IDL tools: replaced `(flags & FD_X) != 0` with `flags has FD_X`, de-scoped shared regex variables from `local` to global for cross-file visibility, and used f-strings in place of string concatenation.
- Fixed `docgen_wiki.tiri` to convert `.md` hrefs to `.html` in the generated wiki HTML output.

## Test plan

- [ ] Build all affected modules (`audio`, `display`, `document`, `network`, `vector`) to confirm the `idl_gen()` calls succeed without `FILES` arguments.
- [ ] Verify generated headers in `include/kotuku/modules/` are identical to those produced by the previous approach.
- [ ] Run the full integration test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure`
- [ ] Confirm wiki HTML output contains `.html` links rather than `.md` links after running `docgen_wiki.tiri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)