### PR TITLE
Add __tostring, __concat, and __eq metamethods to Tiri arrays

### DIFF
--- a/src/network/tests/test_error_handling.tiri
+++ b/src/network/tests/test_error_handling.tiri
@@ -170,7 +170,7 @@ end
       end,
       incoming = function(Socket)
          -- Read only a small chunk per notification; an explicit halt here makes the timeout scale with buffered data.
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Socket.acRead(buffer)
          if err != ERR_Okay then
             logOutput('[Client] Read error: ' .. mSys.GetErrorMsg(err))

--- a/src/network/tests/test_iocp_pipeline.tiri
+++ b/src/network/tests/test_iocp_pipeline.tiri
@@ -40,13 +40,13 @@ function RapidAcceptBurst()
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(128)
+         buffer = array<byte, 128>
          err, read_len = Client.acRead(buffer)
          if err is ERR_Disconnected then return end
          assert(err is ERR_Okay, 'Server failed to read burst message: ' .. mSys.GetErrorMsg(err))
 
          server_received++
-         err, len = Client.acWrite('ack:' .. buffer:sub(0, read_len))
+         err, len = Client.acWrite('ack:' .. buffer:getString(0, read_len))
          assert(err is ERR_Okay, 'Server failed to write ack: ' .. mSys.GetErrorMsg(err))
       end
    })
@@ -59,11 +59,11 @@ function RapidAcceptBurst()
          name     = 'IocpAcceptBurstClient' .. i,
          incoming = function(Socket)
             data   = client_data[Socket.id]
-            buffer = string.alloc(128)
+            buffer = array<byte, 128>
             err, read_len = Socket.acRead(buffer)
             assert(err is ERR_Okay, 'Client failed to read burst response: ' .. mSys.GetErrorMsg(err))
 
-            msg = buffer:sub(0, read_len)
+            msg = buffer:getString(0, read_len)
             if msg is 'ready' then
                err, len = Socket.acWrite('hello:' .. data.id)
                assert(err is ERR_Okay, 'Client failed to write hello: ' .. mSys.GetErrorMsg(err))
@@ -108,13 +108,13 @@ function LargeTCPReceive()
       flags    = 'SERVER',
       msgLimit = target_size + 65536,
       incoming = function(Socket, Client)
-         buffer        = string.alloc(65536)
+         buffer        = array<byte, 65536>
          err, read_len = Client.acRead(buffer)
          if err is ERR_Disconnected then return end
          assert(err is ERR_Okay, 'Server failed to read large payload: ' .. mSys.GetErrorMsg(err))
          if read_len <= 0 then return end
 
-         chunk = buffer:sub(0, read_len)
+         chunk = buffer:getString(0, read_len)
          if chunk != string.rep('P', read_len) then
             bad_data = true
          end
@@ -173,14 +173,14 @@ function LargeBidirectionalTCPTransfer()
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
          while true do
             err, read_len = Client.acRead(buffer)
             if err is ERR_Disconnected then return end
             assert(err is ERR_Okay, 'Server failed to read bidirectional payload: ' .. mSys.GetErrorMsg(err))
             if read_len <= 0 then break end
 
-            chunk = buffer:sub(0, read_len)
+            chunk = buffer:getString(0, read_len)
             if chunk != string.rep('C', read_len) then server_bad_data = true end
             server_received += read_len
             if server_received >= target_size then break end
@@ -204,14 +204,14 @@ function LargeBidirectionalTCPTransfer()
          end
       end,
       incoming = function(Socket)
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
          while true do
             err, read_len = Socket.acRead(buffer)
             if err is ERR_Disconnected then return end
             assert(err is ERR_Okay, 'Client failed to read bidirectional payload: ' .. mSys.GetErrorMsg(err))
             if read_len <= 0 then break end
 
-            chunk = buffer:sub(0, read_len)
+            chunk = buffer:getString(0, read_len)
             if chunk != string.rep('B', read_len) then client_bad_data = true end
             client_received += read_len
             if client_received >= target_size then break end

--- a/src/network/tests/test_iocp_pipeline.tiri
+++ b/src/network/tests/test_iocp_pipeline.tiri
@@ -259,7 +259,7 @@ function SlowReaderBackpressure()
             processing.halt(0.25)
          end
 
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
          while received < target_size do
             err, read_len = Client.acRead(buffer)
             if err is ERR_Disconnected then return end
@@ -418,7 +418,7 @@ function PendingTCPReadWriteFreeDropsCompletion()
       end,
       incoming = function(Socket, Client)
          processing.halt(0.25)
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
          err, read_len = Client.acRead(buffer)
          if (err != ERR_Okay) and (err != ERR_Disconnected) then
             error('Server read failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
@@ -434,7 +434,7 @@ function PendingTCPReadWriteFreeDropsCompletion()
       end,
       incoming = function(Socket)
          if client_freed then late_client_callbacks++ end
-         buffer = string.alloc(256)
+         buffer = array<byte, 256>
          err, read_len = Socket.acRead(buffer)
          if (err != ERR_Okay) and (err != ERR_Disconnected) then
             error('Client read failed during pending TCP free test: ' .. mSys.GetErrorMsg(err))
@@ -482,7 +482,7 @@ function PendingUDPReceiveSendFreeDropsCompletion()
    late_udp_callbacks = 0
 
    source = struct.new('IPAddress')
-   buffer = string.alloc(65536)
+   buffer = array<byte, 65536>
 
    server = obj.new('netsocket', {
       name          = 'IocpPendingUDPFreeServer',
@@ -560,7 +560,7 @@ function PendingSSLFreeDropsCompletion()
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(256)
+         buffer = array<byte, 256>
          err, read_len = Client.acRead(buffer)
          if (err != ERR_Okay) and (err != ERR_Disconnected) and (err != ERR_InvalidState) then
             error('SSL server read failed during pending SSL free test: ' .. mSys.GetErrorMsg(err))
@@ -576,7 +576,7 @@ function PendingSSLFreeDropsCompletion()
       end,
       incoming = function(Socket)
          if client_freed then late_client_callbacks++ end
-         buffer = string.alloc(256)
+         buffer = array<byte, 256>
          err, read_len = Socket.acRead(buffer)
          if (err != ERR_Okay) and (err != ERR_Disconnected) and (err != ERR_InvalidState) then
             error('SSL client read failed during pending SSL free test: ' .. mSys.GetErrorMsg(err))

--- a/src/network/tests/test_performance.tiri
+++ b/src/network/tests/test_performance.tiri
@@ -51,7 +51,7 @@ end
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
 
          while true do
             err, read_len = Client.acRead(buffer)
@@ -121,7 +121,7 @@ end
          end
       end,
       incoming = function(Socket, Script)
-         local buffer = string.alloc(256)
+         local buffer = array<byte, 256>
          Socket.acRead(buffer)
       end
    })
@@ -175,7 +175,7 @@ end
          if (current_size_index >= #message_sizes) then return end
 
          expected_size = message_sizes[current_size_index]
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
 
          while (current_bytes_received < expected_size) do
             err, read_len = Client.acRead(buffer)
@@ -230,7 +230,7 @@ end
    client = obj.new('netsocket', {
       name = 'LargeMessageClient',
       incoming = function(Socket, Script)
-         local buffer = string.alloc(65536)
+         local buffer = array<byte, 65536>
 
          while true do
             local err, read_len = Socket.acRead(buffer)
@@ -238,7 +238,7 @@ end
             assert(err is ERR_Okay, '[Client] Large message read failed: ' .. mSys.GetErrorMsg(err))
             if (read_len <= 0) then break end
 
-            local msg = buffer:sub(0, read_len)
+            local msg = buffer:getString(0, read_len)
             local write_err, len = Socket.acWrite(msg)
             assert(write_err is ERR_Okay, '[Client] Large message echo failed: ' .. mSys.GetErrorMsg(write_err))
             assert(len is read_len, '[Client] Large message echo accepted a partial chunk')
@@ -365,7 +365,7 @@ end
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(65536)
+         buffer = array<byte, 65536>
 
          while true do
             err, read_len = Client.acRead(buffer)
@@ -425,7 +425,7 @@ end
          end
       end,
       incoming = function(Socket, Script)
-         local buffer = string.alloc(256)
+         local buffer = array<byte, 256>
          Socket.acRead(buffer)
       end
    })

--- a/src/network/tests/test_server_io.tiri
+++ b/src/network/tests/test_server_io.tiri
@@ -35,10 +35,10 @@ end
       end,
       incoming = function(Socket)
          print('Incoming data...')
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Socket.acRead(buffer)
          if err is ERR_Okay then
-            print(buffer:sub(0,80))
+            print(buffer:getString(0, 80))
          elseif err is ERR_Disconnected then
             Socket.acSignal()
          else

--- a/src/network/tests/test_ssl.tiri
+++ b/src/network/tests/test_ssl.tiri
@@ -77,13 +77,13 @@ function BasicSSLCommunication()
          end
       end,
       incoming = function(Socket:obj, Client:obj)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Client.acRead(buffer)
 
          if err is ERR_Okay then
             if read_len is 0 then return end
 
-            emsg = buffer:substr(0, read_len)
+            emsg = buffer:getString(0, read_len)
             logOutput('[Server] Received encrypted message of ' .. read_len .. ' bytes: "' .. tostring(emsg) .. '"')
 
             -- Verify message integrity over SSL
@@ -126,13 +126,13 @@ function BasicSSLCommunication()
          end
       end,
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Socket.acRead(buffer)
 
          if err is ERR_Okay then
             if read_len is 0 then return end
 
-            emsg = buffer:substr(0, read_len)
+            emsg = buffer:getString(0, read_len)
             logOutput('[Client] Received encrypted message of ' .. read_len .. ' bytes: "' .. tostring(emsg) .. '"')
 
             -- Echo back the message to verify bidirectional SSL
@@ -192,11 +192,11 @@ function SSLStateTransitions()
       end,
       incoming = function(Socket, Client)
          logOutput('[Server] Incoming data callback triggered')
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Client.acRead(buffer)
          if err is ERR_Okay then
             if read_len is 0 then return end
-            emsg = buffer:substr(0, read_len)
+            emsg = buffer:getString(0, read_len)
             logOutput('[Server] Received: ' .. emsg)
             data_exchange_complete = true
             Socket.mtDisconnectSocket(Client)
@@ -219,11 +219,11 @@ function SSLStateTransitions()
       end,
       incoming = function(Socket)
          logOutput('[Client] Incoming data callback triggered')
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Socket.acRead(buffer)
          if err is ERR_Okay then
             if read_len is 0 then return end
-            emsg = buffer:substr(0, read_len)
+            emsg = buffer:getString(0, read_len)
             logOutput('[Client] Received: ' .. emsg)
             check Socket.acWrite('SSL_STATES_VERIFIED')
          elseif (err != ERR_Disconnected) then
@@ -285,11 +285,11 @@ function SSLDataIntegrity()
          end
       end,
       incoming = function(Socket:obj, Client:obj)
-         buffer = string.alloc(10240) -- Large buffer for big messages
+         buffer = array<byte, 10240> -- Large buffer for big messages
          err, read_len = Client.acRead(buffer)
 
          if err is ERR_Okay and read_len > 0 then
-            received = buffer:substr(0, read_len)
+            received = buffer:getString(0, read_len)
             expected = test_messages[msgIndex]
 
             logOutput('[Server] Received echo ' .. msgIndex .. ' (' .. read_len .. ' bytes)')
@@ -320,11 +320,11 @@ function SSLDataIntegrity()
    ssl_client = obj.new('netsocket', {
       name = 'SSLIntegrityClient',
       incoming = function(Socket)
-         buffer = string.alloc(10240)
+         buffer = array<byte, 10240>
          err, read_len = Socket.acRead(buffer)
 
          if err is ERR_Okay then
-            emsg = buffer:substr(0, read_len)
+            emsg = buffer:getString(0, read_len)
             logOutput('[Client] Received message (' .. read_len .. ' bytes), echoing back...')
 
             -- Echo back exactly what was received
@@ -388,10 +388,10 @@ function HTTPSConnection()
             -- Try to read any remaining data before disconnection
             if connection_established and not data_received then
                logOutput('Attempting final data read...')
-               buffer = string.alloc(8192)
+               buffer = array<byte, 8192>
                err, read_len = Socket.acRead(buffer)
                if err is ERR_Okay and read_len > 0 then
-                  chunk = buffer:substr(0, read_len)
+                  chunk = buffer:getString(0, read_len)
                   page_content ..= chunk
                   logOutput(f'Read {read_len} bytes during disconnect (total: {#page_content})')
                   data_received = true
@@ -408,7 +408,7 @@ function HTTPSConnection()
 
          -- Read all available data in this callback
          while true do
-            buffer = string.alloc(8192)
+            buffer = array<byte, 8192>
             err, read_len = Socket.acRead(buffer)
 
             if err is ERR_Okay then
@@ -420,7 +420,7 @@ function HTTPSConnection()
 
                chunks_received++
                callback_total += read_len
-               chunk = buffer:substr(0, read_len)
+               chunk = buffer:getString(0, read_len)
                page_content ..= chunk
 
                logOutput('Chunk ' .. chunks_received .. ' received: ' .. read_len .. ' bytes from ' ..
@@ -560,10 +560,10 @@ function CustomCertificate()
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, read_len = Client.acRead(buffer)
          if err is ERR_Okay and read_len > 0 then
-            message = buffer:substr(0, read_len)
+            message = buffer:getString(0, read_len)
             logOutput('[Server] Received: ' .. message)
             custom_cert_test_complete = true
             Socket.mtDisconnectSocket(Client)

--- a/src/network/tests/test_udp_basic.tiri
+++ b/src/network/tests/test_udp_basic.tiri
@@ -135,7 +135,7 @@ end
       flags   = NSF_SERVER|NSF_UDP,
       maxPacketSize = 65507,  -- Maximum UDP packet size
       incoming = function(Socket)
-         local buffer = string.alloc(65600)  -- Larger than max packet
+         local buffer = array<byte, 65600>  -- Larger than max packet
          local source = struct.new('IPAddress')
 
          local err, bytesRead = Socket.mtRecvFrom(source, buffer)

--- a/src/network/tests/test_udp_ipv6.tiri
+++ b/src/network/tests/test_udp_ipv6.tiri
@@ -23,12 +23,12 @@ glTestTimeout = 3.0
       address = '::1',  -- IPv6 loopback
       flags   = 'SERVER|UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          assert(err is ERR_Okay, 'Server failed to receive IPv6 UDP data: ' .. mSys.GetErrorMsg(err))
 
          if bytesRead > 0 then
-            msg = buffer:sub(0, bytesRead)
+            msg = buffer:getString(0, bytesRead)
             logOutput('[IPv6 UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
             assert(msg:startsWith('Hello IPv6'), 'Unexpected message received')
             msg_recv = true
@@ -72,13 +72,13 @@ end
       address = '::',  -- Bind to all interfaces (dual-stack)
       flags   = NSF_SERVER|NSF_UDP,
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          source = struct.new('IPAddress')
          err, bytesRead = Socket.mtRecvFrom(source, buffer)
          assert(err is ERR_Okay, 'Server failed to receive dual-stack UDP data: ' .. mSys.GetErrorMsg(err))
 
          if bytesRead > 0 then
-            msg = buffer:sub(0, bytesRead)
+            msg = buffer:getString(0, bytesRead)
             logOutput('[Dual-Stack UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
 
             if msg:endsWith('IPv4') then

--- a/src/network/tests/test_udp_performance.tiri
+++ b/src/network/tests/test_udp_performance.tiri
@@ -25,7 +25,7 @@ UDP Performance and Stress Test
       address = '127.0.0.1',
       flags   = 'SERVER|UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
             messagesReceived = messagesReceived + 1
@@ -87,7 +87,7 @@ end
       flags   = 'SERVER|UDP',
       maxPacketSize = 65507,  -- Maximum UDP payload size
       incoming = function(Socket)
-         buffer = string.alloc(65600)  -- Slightly larger buffer
+         buffer = array<byte, 65600>  -- Slightly larger buffer
          err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
             print('[Large Packet Server] Received packet of size: ' .. bytesRead)
@@ -152,11 +152,11 @@ end
       address = '127.0.0.1',
       flags   = 'SERVER|UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
             totalReceived = totalReceived + 1
-            msg = buffer:sub(0, bytesRead)
+            msg = buffer:getString(0, bytesRead)
 
             if totalReceived % 10 is 0 then
                print('[Concurrent Server] Received ' .. totalReceived .. ' messages total')
@@ -260,7 +260,7 @@ end
       address = '127.0.0.1',
       flags = 'SERVER|UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, bytesRead = Socket.mtRecvFrom(sv_source, buffer)
          if err is ERR_Okay and bytesRead > 0 then
              messagesReceived = messagesReceived + 1

--- a/src/network/tests/test_udp_tcp_coexistence.tiri
+++ b/src/network/tests/test_udp_tcp_coexistence.tiri
@@ -29,11 +29,11 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
       address = '127.0.0.1',
       flags = 'SERVER|UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          source = struct.new('IPAddress')
          err, bytesRead = Socket.mtRecvFrom(source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
-            msg = buffer:sub(0, bytesRead)
+            msg = buffer:getString(0, bytesRead)
             logOutput('[UDP Server] Received: "' .. msg .. '"')
             if (msg:startsWith('UDP Test')) then
                udpReceived = true
@@ -58,10 +58,10 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          end
       end,
       incoming = function(Socket, Client)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, readLen = Client.acRead(buffer)
          if (err is ERR_Okay and readLen > 0) then
-            msg = buffer:sub(0, readLen)
+            msg = buffer:getString(0, readLen)
             logOutput('[TCP Server] Received: "' .. msg .. '"')
             if (msg:startsWith('TCP Test')) then
                tcpReceived = true
@@ -80,11 +80,11 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
    udpClient = obj.new('netsocket', {
       flags = 'UDP',
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          source = struct.new('IPAddress')
          err, bytesRead = Socket.mtRecvFrom(source, buffer)
          if (err is ERR_Okay) and (bytesRead > 0) then
-            msg = buffer:sub(0, bytesRead)
+            msg = buffer:getString(0, bytesRead)
             logOutput('[UDP Client] Received response: "' .. msg .. '"')
          end
       end
@@ -103,10 +103,10 @@ This test verifies that UDP and TCP sockets can coexist and operate independentl
          end
       end,
       incoming = function(Socket)
-         buffer = string.alloc(1024)
+         buffer = array<byte, 1024>
          err, readLen = Socket.acRead(buffer)
          if (err is ERR_Okay and readLen > 0) then
-            msg = buffer:sub(0, readLen)
+            msg = buffer:getString(0, readLen)
             logOutput('[TCP Client] Received: "' .. msg .. '"')
          end
       end
@@ -144,7 +144,7 @@ end
          address = '127.0.0.1',
          flags = 'SERVER|UDP',
          incoming = function(Socket)
-            buffer = string.alloc(256)
+            buffer = array<byte, 256>
             source = struct.new('IPAddress')
             err, bytesRead = Socket.mtRecvFrom(source, buffer)
             if (err is ERR_Okay and bytesRead > 0) then
@@ -174,7 +174,7 @@ end
          flags = 'SERVER|UDP|BROADCAST',
          multicastTTL = 2,
          incoming = function(Socket)
-            buffer = string.alloc(256)
+            buffer = array<byte, 256>
             source = struct.new('IPAddress')
             err, bytesRead = Socket.mtRecvFrom(source, buffer)
             if (err is ERR_Okay and bytesRead > 0) then

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2896,6 +2896,79 @@ static int array_concat_meta(lua_State *L)
    return 1;
 }
 
+static bool array_string_equal(GCarray *Left, GCarray *Right)
+{
+   GCRef *left_refs = Left->get<GCRef>();
+   GCRef *right_refs = Right->get<GCRef>();
+
+   for (MSize i = 0; i < Left->len; i++) {
+      GCobj *left_obj = gcref(left_refs[i]);
+      GCobj *right_obj = gcref(right_refs[i]);
+
+      if (left_obj IS right_obj) continue;
+      if (not left_obj or not right_obj) return false;
+
+      GCstr *left_str = gco_to_string(left_obj);
+      GCstr *right_str = gco_to_string(right_obj);
+
+      if (not (left_str->hash IS right_str->hash)) return false;
+      if (not (left_str->len IS right_str->len)) return false;
+      if (not (memcmp(strdata(left_str), strdata(right_str), left_str->len) IS 0)) return false;
+   }
+
+   return true;
+}
+
+static bool array_object_equal(GCarray *Left, GCarray *Right)
+{
+   GCRef *left_refs = Left->get<GCRef>();
+   GCRef *right_refs = Right->get<GCRef>();
+
+   for (MSize i = 0; i < Left->len; i++) {
+      GCobj *left_gc = gcref(left_refs[i]);
+      GCobj *right_gc = gcref(right_refs[i]);
+
+      if (left_gc IS right_gc) continue;
+      if (not left_gc or not right_gc) return false;
+
+      GCobject *left_obj = gco_to_object(left_gc);
+      GCobject *right_obj = gco_to_object(right_gc);
+
+      if (not (left_obj->uid IS right_obj->uid)) return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+// __eq metamethod.
+
+static int array_eq_meta(lua_State *L)
+{
+   GCarray *left = lj_lib_checkarray(L, 1);
+   GCarray *right = lj_lib_checkarray(L, 2);
+
+   if ((not (left->elemtype IS right->elemtype)) or (not (left->len IS right->len))) {
+      lua_pushboolean(L, 0);
+      return 1;
+   }
+
+   if (glArrayConversion[size_t(left->elemtype)].primitive) {
+      size_t byte_count = size_t(left->len) * left->elemsize;
+      bool equal = (byte_count IS 0) or (memcmp(left->arraydata(), right->arraydata(), byte_count) IS 0);
+      lua_pushboolean(L, equal);
+   }
+   else if (left->elemtype IS AET::STR_GC) {
+      lua_pushboolean(L, array_string_equal(left, right));
+   }
+   else if (left->elemtype IS AET::OBJECT) {
+      lua_pushboolean(L, array_object_equal(left, right));
+   }
+   else lj_err_caller(L, ErrMsg::ARRTYPE);
+
+   return 1;
+}
+
 //********************************************************************************************************************
 // Registers the array library and sets up the base metatable for arrays.
 // Unlike the Lua table, arrays are created via conventional means, i.e. array.new().
@@ -2926,6 +2999,9 @@ extern "C" int luaopen_array(lua_State *L)
 
    lua_pushcfunction(L, array_concat_meta);
    lua_setfield(L, -2, "__concat");
+
+   lua_pushcfunction(L, array_eq_meta);
+   lua_setfield(L, -2, "__eq");
 
    // NOBARRIER: basemt is a GC root.
    setgcref(basemt_it(g, LJ_TARRAY), obj2gco(lib));

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2842,6 +2842,24 @@ LJLIB_CF(array_clone)
 }
 
 //********************************************************************************************************************
+// __tostring metamethod.
+
+static int array_tostring(lua_State *L)
+{
+   GCarray *arr = lj_lib_checkarray(L, 1);
+
+   if (arr->elemtype IS AET::BYTE) {
+      GCstr *s = lj_str_new(L, arr->get<const char>(), arr->len);
+      setstrV(L, L->top++, s);
+      return 1;
+   }
+
+   CSTRING type_name = elemtype_name(arr->elemtype);
+   lua_pushfstring(L, "array<%s, %d>", type_name, int(arr->len));
+   return 1;
+}
+
+//********************************************************************************************************************
 // Registers the array library and sets up the base metatable for arrays.
 // Unlike the Lua table, arrays are created via conventional means, i.e. array.new().
 //
@@ -2864,6 +2882,10 @@ extern "C" int luaopen_array(lua_State *L)
    // Add __call metamethod to the library table for iteration support.  Enables: for ... in ... do
    lua_pushcfunction(L, array_call);
    lua_setfield(L, -2, "__call");
+
+   // Byte arrays are commonly used as string buffers, so tostring() exposes their contents directly.
+   lua_pushcfunction(L, array_tostring);
+   lua_setfield(L, -2, "__tostring");
 
    // NOBARRIER: basemt is a GC root.
    setgcref(basemt_it(g, LJ_TARRAY), obj2gco(lib));

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -18,6 +18,8 @@
 #include "lj_err.h"
 #include "lj_tab.h"
 #include "lj_str.h"
+#include "lj_strfmt.h"
+#include "lj_buf.h"
 #include "lj_array.h"
 #include "lj_bulk.h"
 #include "lj_meta.h"
@@ -2860,6 +2862,41 @@ static int array_tostring(lua_State *L)
 }
 
 //********************************************************************************************************************
+// __concat metamethod.
+
+static GCstr * array_concat_value(lua_State *L, cTValue *Value)
+{
+   if (tvisstr(Value)) return strV(Value);
+   if (tvisnumber(Value)) return lj_strfmt_number(L, Value);
+
+   if (tvisarray(Value)) {
+      GCarray *arr = arrayV(Value);
+      if (arr->elemtype IS AET::BYTE) return lj_str_new(L, arr->get<const char>(), arr->len);
+   }
+
+   return nullptr;
+}
+
+static int array_concat_meta(lua_State *L)
+{
+   cTValue *left = L->base;
+   cTValue *right = L->base + 1;
+
+   GCstr *left_str = array_concat_value(L, left);
+   if (not left_str) lj_err_optype(L, left, ErrMsg::OPCAT);
+   setstrV(L, L->top++, left_str);
+
+   GCstr *right_str = array_concat_value(L, right);
+   if (not right_str) lj_err_optype(L, right, ErrMsg::OPCAT);
+   setstrV(L, L->top++, right_str);
+
+   GCstr *result = lj_buf_cat2str(L, left_str, right_str);
+   L->top -= 2;
+   setstrV(L, L->top++, result);
+   return 1;
+}
+
+//********************************************************************************************************************
 // Registers the array library and sets up the base metatable for arrays.
 // Unlike the Lua table, arrays are created via conventional means, i.e. array.new().
 //
@@ -2886,6 +2923,9 @@ extern "C" int luaopen_array(lua_State *L)
    // Byte arrays are commonly used as string buffers, so tostring() exposes their contents directly.
    lua_pushcfunction(L, array_tostring);
    lua_setfield(L, -2, "__tostring");
+
+   lua_pushcfunction(L, array_concat_meta);
+   lua_setfield(L, -2, "__concat");
 
    // NOBARRIER: basemt is a GC root.
    setgcref(basemt_it(g, LJ_TARRAY), obj2gco(lib));

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1252,6 +1252,10 @@ int lj_record_mm_lookup(jit_State *J, RecordIndex* ix, MMS mm)
       mt = tabref(tabV(&ix->tabv)->metatable);
       mix.tab = ir.fload_tab(ix->tab, IRFL_TAB_META);
    }
+   else if (tref_isarray(ix->tab)) {
+      mt = tabref(arrayV(&ix->tabv)->metatable);
+      mix.tab = ir.fload_tab(ix->tab, IRFL_ARRAY_META);
+   }
    else if (tref_isudata(ix->tab)) {
       udtype = udataV(&ix->tabv)->udtype;
       mt = tabref(udataV(&ix->tabv)->metatable);
@@ -1383,7 +1387,7 @@ static void rec_mm_callcomp(jit_State *J, RecordIndex* ix, int op)
 }
 
 //********************************************************************************************************************
-// Record call to equality comparison metamethod (for tab and udata only).
+// Record call to equality comparison metamethod.
 
 static void rec_mm_equal(jit_State *J, RecordIndex* ix, int op)
 {
@@ -1399,6 +1403,10 @@ static void rec_mm_equal(jit_State *J, RecordIndex* ix, int op)
       bv = &ix->keyv;
       if (tvistab(bv) and tabref(tabV(bv)->metatable) IS ix->mtv) {
          TRef mt2 = ir.fload_tab(ix->key, IRFL_TAB_META);
+         ir.guard_eq(mt2, ix->mt, IRT_TAB);
+      }
+      else if (tvisarray(bv) and tabref(arrayV(bv)->metatable) IS ix->mtv) {
+         TRef mt2 = ir.fload_tab(ix->key, IRFL_ARRAY_META);
          ir.guard_eq(mt2, ix->mt, IRT_TAB);
       }
       else if (tvisudata(bv) and tabref(udataV(bv)->metatable) IS ix->mtv) {
@@ -2438,14 +2446,14 @@ static void rec_comp_equality(jit_State *J, RecordOps *ops)
    RecordIndex *ix = &ops->ix;
    TValue *rav = ops->rav(), *rcv = ops->rcv();
 
-   // Emit nothing for two non-table, non-udata consts.
+   // Emit nothing for two non-table, non-array, non-udata consts.
 
-   if (tref_isk2(ra, rc) and !(tref_istab(ra) or tref_isudata(ra))) return;
+   if (tref_isk2(ra, rc) and !(tref_istab(ra) or tref_isarray(ra) or tref_isudata(ra))) return;
 
    rec_comp_prep(J);
    int diff = lj_record_objcmp(J, ra, rc, rav, rcv);
 
-   if (diff IS 2 or !(tref_istab(ra) or tref_isudata(ra))) {
+   if (diff IS 2 or !(tref_istab(ra) or tref_isarray(ra) or tref_isudata(ra))) {
       rec_comp_fixup(J, J->pc, ((int)op & 1) IS !diff);
    }
    else if (diff IS 1) { // Only check __eq if different, but same type.

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -48,6 +48,18 @@ uint8_t lj_array_elemsize(AET Type)
 }
 
 //********************************************************************************************************************
+
+static void array_attach_basemt(lua_State *L, GCarray *Arr)
+{
+   GCRef mt_ref = basemt_it(G(L), LJ_TARRAY);
+   if (gcref(mt_ref)) {
+      GCtab *mt = tabref(mt_ref);
+      setgcref(Arr->metatable, obj2gco(mt));
+      lj_gc_objbarrier(L, Arr, mt);
+   }
+}
+
+//********************************************************************************************************************
 // Create a new array structure without placing it on the Lua stack (use lua_createarray otherwise).  Throws on error.
 //
 // For string arrays (CSTRING/STRING_CPP) with caching:
@@ -82,6 +94,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
          // External arrays have capacity = length and cannot grow
          auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
          arr->init(Data, Type, elem_size, Length, Length, Flags, sdef);
+         array_attach_basemt(L, arr);
          return arr;
       }
       else {
@@ -91,7 +104,8 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             size_t byte_size = Length * sizeof(CSTRING);
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
-            if (storage) arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef);
+            arr->init(storage, AET::CSTR, sizeof(CSTRING), Length, Length, 0, sdef);
+            array_attach_basemt(L, arr);
 
             // Calculate total string content size
             size_t content_size = 0;
@@ -151,6 +165,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
             arr->init(storage, Type, elem_size, Length, Length, Flags, sdef);
+            array_attach_basemt(L, arr);
 
             auto refs = arr->get<GCRef>();
             auto objects = (OBJECTPTR *)Data;
@@ -171,6 +186,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
             void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
             auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
             arr->init(storage, Type, elem_size, Length, Length, Flags, sdef);
+            array_attach_basemt(L, arr);
             if (byte_size > 0) {
                if (Type IS AET::ANY) lj_bulk_copy_tvalue((TValue *)storage, (const TValue *)Data, Length);
                else std::memcpy(storage, Data, byte_size);
@@ -186,6 +202,7 @@ extern GCarray * lj_array_new(lua_State *L, uint32_t Length, AET Type, void *Dat
       void *storage = (byte_size > 0) ? lj_mem_new(L, byte_size) : nullptr;
       auto arr = (GCarray *)lj_mem_newgco(L, sizeof(GCarray));
       arr->init(storage, Type, elem_size, Length, Length, Flags & ~(ARRAY_EXTERNAL|ARRAY_CACHED), sdef);
+      array_attach_basemt(L, arr);
       if (storage) {
          if (Type IS AET::ANY) {
             // _ANY arrays require explicit nil initialization (nil TValue = -1, not 0)

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -488,6 +488,58 @@ end
    end
 end
 
+@Test function ArrayEqualityMetamethod()
+   int_a = array<int> { 1, 2, 3 }
+   int_b = array<int> { 1, 2, 3 }
+   int_c = array<int> { 1, 2, 4 }
+   int_short = array<int> { 1, 2 }
+   double_array = array<double> { 1.0, 2.0, 3.0 }
+
+   assert(int_a is int_b, 'Primitive arrays with identical contents should be equal')
+   assert(int_a != int_c, 'Primitive arrays with different contents should not be equal')
+   assert(int_a != int_short, 'Primitive arrays with different lengths should not be equal')
+   assert(int_a != double_array, 'Primitive arrays with different element types should not be equal')
+
+   byte_a = array<byte> { 65, 0, 66 }
+   byte_b = array<byte> { 65, 0, 66 }
+   byte_c = array<byte> { 65, 0, 67 }
+   assert(byte_a is byte_b, 'Byte arrays with embedded NUL bytes should compare equal by raw memory')
+   assert(byte_a != byte_c, 'Byte arrays with different raw bytes should not compare equal')
+
+   string_a = array<string> { 'hello', 'world' }
+   string_b = array<string> { 'hello', 'world' }
+   string_c = array<string> { 'hello', 'there' }
+   string_short = array<string> { 'hello' }
+
+   assert(string_a is string_b, 'String arrays with identical contents should be equal')
+   assert(string_a != string_c, 'String arrays with different contents should not be equal')
+   assert(string_a != string_short, 'String arrays with different lengths should not be equal')
+
+   obj_one = obj.new('time')
+   obj_two = obj.new('file')
+   obj_one_ref = obj.find(obj_one.id)
+
+   object_a = array<object> { obj_one, obj_two }
+   object_b = array<object> { obj_one_ref, obj_two }
+   object_c = array<object> { obj_two, obj_one }
+   object_short = array<object> { obj_one }
+
+   assert(object_a is object_b, 'Object arrays with matching UIDs should be equal')
+   assert(object_a != object_c, 'Object arrays with different UID order should not be equal')
+   assert(object_a != object_short, 'Object arrays with different lengths should not be equal')
+
+   table_a = array<table> { { value = 1 } }
+   table_b = array<table> { { value = 1 } }
+   try
+      unsupported_equal = table_a is table_b
+   success
+      error('Table array equality should fail until non-primitive equality is supported')
+   end
+
+   obj_one.free()
+   obj_two.free()
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Test array.find() functionality
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -433,8 +433,31 @@ end
 
 @Test function ToString()
    str_array = array.new('hello')
-   assert(string.startsWith(tostring(str_array), 'array:'), "String array tostring() failed, got '" .. tostring(str_array) .. "'")
+   assert(tostring(str_array) is 'hello', "String array tostring() failed, got '" .. tostring(str_array) .. "'")
    assert(#str_array is 5, "String array length failed, expected 5, got " .. tostring(#str_array))
+
+   char_array = array<char> { 72, 101, 108, 108, 111 }
+   assert(tostring(char_array) is 'Hello', "Char array tostring() failed, got '" .. tostring(char_array) .. "'")
+   assert(string.format('%s', char_array) is 'Hello', 'Char array string.format() conversion failed')
+   assert(f'{char_array}' is 'Hello', 'Char array f-string conversion failed')
+
+   byte_array = array<byte> { 65, 66, 67 }
+   assert(tostring(byte_array) is 'ABC', "Byte array tostring() failed, got '" .. tostring(byte_array) .. "'")
+
+   nul_array = array<byte> { 65, 0, 66 }
+   nul_text = tostring(nul_array)
+   assert(nul_text is nul_array:getString(), 'Byte array tostring() should match getString() with embedded NUL bytes')
+   assert(#nul_text is 3, "Byte array tostring() should preserve full length, got " .. tostring(#nul_text))
+
+   int_array = array<int> { 1, 2, 3 }
+   assert(tostring(int_array) is 'array<int, 3>', "Integer array tostring() failed, got '" .. tostring(int_array) .. "'")
+
+   string_array = array<string> { 'hello', 'world' }
+   assert(tostring(string_array) is 'array<string, 2>', "String array tostring() failed, got '" .. tostring(string_array) .. "'")
+
+   empty_double_array = array<double, 0>
+   assert(tostring(empty_double_array) is 'array<double, 0>',
+      "Empty double array tostring() failed, got '" .. tostring(empty_double_array) .. "'")
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -460,6 +460,34 @@ end
       "Empty double array tostring() failed, got '" .. tostring(empty_double_array) .. "'")
 end
 
+@Test function ArrayConcatMetamethod()
+   char_array = array<char> { 72, 105 }
+   byte_array = array<byte> { 33 }
+
+   assert('Say: ' .. char_array is 'Say: Hi', 'String plus char array concat failed')
+   assert(char_array .. ' there' is 'Hi there', 'Char array plus string concat failed')
+   assert(char_array .. byte_array is 'Hi!', 'Char array plus byte array concat failed')
+   assert(char_array .. 123 is 'Hi123', 'Char array plus number concat failed')
+
+   nul_array = array<byte> { 65, 0, 66 }
+   nul_result = nul_array .. 'C'
+   assert(nul_result is nul_array:getString() .. 'C', 'Byte array concat should preserve embedded NUL bytes')
+   assert(#nul_result is 4, "Byte array concat should preserve full length, got " .. tostring(#nul_result))
+
+   int_array = array<int> { 1, 2, 3 }
+   try
+      bad_result = int_array .. 'x'
+   success
+      error('Integer array left-hand concat should fail')
+   end
+
+   try
+      bad_result = 'x' .. int_array
+   success
+      error('Integer array right-hand concat should fail')
+   end
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Test array.find() functionality
 


### PR DESCRIPTION
## Summary

- Added `__tostring` metamethod for arrays, enabling `tostring()` and `print()` to produce human-readable output for all array element types
- Added `__concat` metamethod for `byte` and `char` arrays, enabling `..` string concatenation directly with array buffers
- Added `__eq` metamethod for arrays with support for primitive types (memcmp), string arrays (hash/length/content), and object arrays (UID comparison)
- Fixed base metatable attachment to cover all array construction paths, which is a prerequisite for metamethod dispatch to work correctly
- Extended JIT recorder to include arrays in equality metamethod recording and comparison paths
- Migrated all network test I/O buffers from `string.alloc()` to typed `array<byte>` buffers with `getString()` extraction

## Test plan

- [ ] Build `tiri` module and run `src/tiri/tests/test_array.tiri` via Flute — new `ArrayEqualityMetamethod` test must pass
- [ ] Run network integration tests (`test_iocp_pipeline`, `test_performance`, `test_server_io`) to confirm buffer migration is regression-free
- [ ] Verify `__tostring` output via `origo --statement` spot-checks for byte, int, and string arrays
- [ ] Verify `__concat` works for byte/char arrays concatenated with string literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)