### PR TITLE
Tiri: Implement enum as a reserved keyword with registry-backed constant declarations

### DIFF
--- a/src/audio/audio.tdl
+++ b/src/audio/audio.tdl
@@ -49,26 +49,26 @@ module({ name="Audio", copyright="Paul Manias © 2002-2026", version=1.0, timest
     F_BIG_ENDIAN   = "0x80000000: Combine this flag with any audio format to declare it as big endian."
   })
 
-  enum("LOOP", { type='short', start=1, comment="Loop modes for the AudioLoop structure." },
+  enums("LOOP", { type='short', start=1, comment="Loop modes for the AudioLoop structure." },
     "SINGLE: Single loop: Releasing will end the note.",
     "SINGLE_RELEASE: Single loop: Sample data after the loop will be played when the note is released.",
     "DOUBLE: Double loop: When the note is released, playing shifts to the second loop.",
     "AMIGA_NONE: Amiga loop: Do nothing.",
     "AMIGA: Single loop: Amiga style.")
 
-  enum("LTYPE", { type='char', start=1, comment="Loop types for the AudioLoop structure." },
+  enums("LTYPE", { type='char', start=1, comment="Loop types for the AudioLoop structure." },
     "UNIDIRECTIONAL: The sample playback position returns to the byte position specified in the Loop1Start field.",
     "BIDIRECTIONAL: The sample will play in reverse whenever it hits the end marker, then forwards when it hits the start marker.")
 
-  enum("STREAM", { type='int', start=1, comment="Streaming options" },
+  enums("STREAM", { type='int', start=1, comment="Streaming options" },
     "NEVER: No streaming - load all data into memory.",
     "SMART: Smart streaming is the default.  If the sample appears to be relatively small with respect to available system RAM, it will be loaded into memory.  Otherwise it will be streamed.",
     "ALWAYS: Stream if the sample length exceeds 64k.")
 
-  enum("NOTE", { start=0, comment="Definitions for the Note field.  An 'S' indicates a sharp note." },
+  enums("NOTE", { start=0, comment="Definitions for the Note field.  An 'S' indicates a sharp note." },
     "C", "CS", "D", "DS", "E", "F", "FS", "G", "GS", "A", "AS", "B", "OCTAVE")
 
-  enum("CHS", { type='char', start=0, comment="Channel status types for the AudioChannel structure." },
+  enums("CHS", { type='char', start=0, comment="Channel status types for the AudioChannel structure." },
    "STOPPED: Playing was stopped by the client.",
    "FINISHED: Playback concluded by reaching the sample end.",
    "PLAYING: Sample playing and not released.",

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -116,7 +116,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
   flags("THF", { comment="Thread flags" },
     "AUTO_FREE: Automatically destroy the Thread object when the user routine has completed.")
 
-  enum("FDT", { type="int", start=0, comment="Flags for the SetDate() file method." },
+  enums("FDT", { type="int", start=0, comment="Flags for the SetDate() file method." },
     "MODIFIED: The date on which the file was last modified.",
     "CREATED: The date on which the file was created.  On some host platforms this datestamp may be read-only.",
     "ACCESSED: The date on which the file was last accessed by a user or application.",
@@ -164,7 +164,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
     "SELF: Event applies to the monitored folder and not a contained item",
     "DEEP: Receive notifications from sub-folders (Windows only).")
 
-  enum("STT", { type="int", start=1, comment="Types for StrDatatype()." },
+  enums("STT", { type="int", start=1, comment="Types for StrDatatype()." },
     "NUMBER: The string represents a whole number.",
     "FLOAT: The string represents a floating point number.",
     "HEX: The string represents a hexadecimal number.",
@@ -184,7 +184,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
     "ROOT_PATH",
     "SCAN_MODULES")
 
-  enum("TOI", { type="int" },
+  enums("TOI", { type="int" },
     "LOCAL_CACHE",        -- For Android.  Defines the path of the local cache for assignment to localcache:
     "LOCAL_STORAGE",      -- For Android.  Defines the path of the local storage for assignment to localstorage:
     "ANDROID_ENV",        -- For Android.
@@ -225,7 +225,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
     "EXCLUDE_FILES: Exclude files when scanning this folder.",
     "EXCLUDE_FOLDERS: Exclude folders when scanning this folder.")
 
-  enum("LOC", { type="int", start=1, comment="AnalysePath() values" },
+  enums("LOC", { type="int", start=1, comment="AnalysePath() values" },
     "DIRECTORY|FOLDER: The path refers to a folder.",
     "VOLUME: The path refers to a volume name.",
     "FILE: The path refers to a file.")
@@ -233,17 +233,17 @@ constexpr bool defined(T flags, T test_flag) noexcept {
   flags("LDF", { comment="Flags for LoadFile()" },
     "CHECK_EXISTS: Limits the routine to checking the file cache for the existence of the file.  If found, the relevant cache entry is returned. The open count is not incremented by this action (it is therefore unnecessary to follow-up with a call to UnloadFile()).  If no up-to-date cache entry is available, `ERR::Search` is returned.")
 
-  enum("FBK", { type="int", start=1, comment="Flags for file feedback." },
+  enums("FBK", { type="int", start=1, comment="Flags for file feedback." },
     "MOVE_FILE: A file is to be, or has been moved.",
     "COPY_FILE: A file is to be, or has been copied.",
     "DELETE_FILE: A file is to be, or has been deleted.")
 
-  enum("FFR", { type="int", start=0, comment="Return codes available to the feedback routine" },
+  enums("FFR", { type="int", start=0, comment="Return codes available to the feedback routine" },
     "OKAY|CONTINUE: Continue processing uninterrupted.",
     "SKIP: Skip processing of this entity.",
     "ABORT: Abort the entire operation.")
 
-  enum("VAS", { type="int", start=1, comment="For use by VirtualVolume()" },
+  enums("VAS", { type="int", start=1, comment="For use by VirtualVolume()" },
     "DEREGISTER: Remove the virtual volume from the system.",
     "SCAN_DIR",
     "DELETE",
@@ -263,13 +263,13 @@ constexpr bool defined(T flags, T test_flag) noexcept {
     "CREATE_LINK",
     "DRIVER_SIZE")
 
-  enum("FDB", { type="int", start=1, comment="Feedback event indicators." },
+  enums("FDB", { type="int", start=1, comment="Feedback event indicators." },
     "DECOMPRESS_FILE",
     "COMPRESS_FILE",
     "REMOVE_FILE",
     "DECOMPRESS_OBJECT")
 
-  enum("CF", { type="int", start=1, comment="Compression stream formats" },
+  enums("CF", { type="int", start=1, comment="Compression stream formats" },
     "GZIP: The 'gzip' format",
     "ZLIB: The 'zlib' format",
     "DEFLATE: The 'deflate' format")
@@ -318,19 +318,19 @@ constexpr bool defined(T flags, T test_flag) noexcept {
      WAIT_FOR_OBJECTS = 91
   })
 
-  enum("IDTYPE", { type="int", start=1, comment="Types for AllocateID()" },
+  enums("IDTYPE", { type="int", start=1, comment="Types for AllocateID()" },
     "MESSAGE: Message ID's are allocated for the purpose of sending uniquely identifiable messages between tasks.",
     "GLOBAL: Global ID's have no specific association with anything.",
     "FUNCTION: Function ID's are used to track `FUNCTION` types and are assigned to the function ID field."
   )
 
-  enum("TSTATE", { type="char", comment="Indicates the state of a process." },
+  enums("TSTATE", { type="char", comment="Indicates the state of a process." },
     "RUNNING: The process is currently executing code.",
     "PAUSED: The process is asleep.",
     "STOPPING: The process is in its termination phase.",
     "TERMINATED: The process has closed.")
 
-  enum("RES", { type="int", start=1 },
+  enums("RES", { type="int", start=1 },
     "FREE_SWAP: The total amount of free swap memory.",
     "CONSOLE_FD: Internal reference to the FD of the console.",
     "KEY_STATE: Maintains the state of key qualifiers such as caps-lock and the shift keys.",
@@ -352,7 +352,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
     "MAIN_THREAD: Read-only, returns `true` if called from the main thread."
   )
 
-  enum("RP", { type="int", start=1, comment="Path types for SetResourcePath()" },
+  enums("RP", { type="int", start=1, comment="Path types for SetResourcePath()" },
     "MODULE_PATH: An alternative path leading to the system modules (normally `system:modules/`).  Introduced for platforms such as Android, where modules are stored in asset folders.",
     "SYSTEM_PATH: The path of the `system:` volume, which otherwise defaults to `[root]:system/`.",
     "ROOT_PATH: Overrides the root path, which defaults to the location at which Kōtuku is installed.")

--- a/src/core/defs/errors.tdl
+++ b/src/core/defs/errors.tdl
@@ -5,7 +5,7 @@
 function declareErrors()
   cpp_include("<cstdint>")
 
-  enum("ERR", { start=0, comment="Universal error codes", type="int32" },
+  enums("ERR", { start=0, comment="Universal error codes", type="int32" },
     "Okay|True",
     "False",            -- Non-fatal
     "LimitedSuccess",   -- Limited success

--- a/src/display/display.tdl
+++ b/src/display/display.tdl
@@ -14,15 +14,15 @@ module({
     c_include("<X11/Xlib.h>", "<X11/extensions/XShm.h>")
   end)
 
-  enum("DRAG", { type="int", start=0, flags="Flags for the DragStatus field." },
+  enums("DRAG", { type="int", start=0, flags="Flags for the DragStatus field." },
     "NONE: The surface is not being dragged.",
     "ANCHOR: The surface is being dragged and the mouse pointer is anchored to the surface.",
     "NORMAL: The surface is being dragged.")
 
-  enum("WH", { type="int", start=1, comment="Events for WindowHook()" },
+  enums("WH", { type="int", start=1, comment="Events for WindowHook()" },
     "CLOSE")
 
-  enum("CS", { type="int", start=1, comment="Colour space options." },
+  enums("CS", { type="int", start=1, comment="Colour space options." },
     "SRGB: The default colour-space is sRGB.",
     "LINEAR_RGB: Linear RGB is used to improve colour balance in blending operations.",
     "CIE_LAB: Cartesian L*a*b* colour space defined by CIE 15.",
@@ -57,7 +57,7 @@ module({
     "NO_DRAW: Drawing and exposures are disabled",
     "NO_EXPOSE: Drawing is enabled, exposures are disabled")
 
-  enum("SWIN", { type="int", start=0, comment="Options for the Surface WindowType field." },
+  enums("SWIN", { type="int", start=0, comment="Options for the Surface WindowType field." },
     "HOST: Default to the standard hosted window mode with full titlebar, borders and taskbar representation.",
     "TASKBAR: Create a borderless (custom) window with taskbar representation.",
     "ICON_TRAY: Create a borderless (custom) window with icon tray representation.",
@@ -93,7 +93,7 @@ module({
     { READ_ONLY = "HAS_FOCUS|CURSOR|AFTER_COPY" },
     { INIT_ONLY = "HOST|TRANSPARENT|DISABLED|PRECOPY|VIDEO|FIXED_BUFFER|PERVASIVE_COPY|FIXED_DEPTH|FULL_SCREEN|IGNORE_FOCUS" })
 
-  enum("HOST", { type="int", start=1 },
+  enums("HOST", { type="int", start=1 },
     "TRAY_ICON: All new displays are represented in the system tray when this option is active.",
     "TASKBAR: The hosted display is given a taskbar button.",
     "STICK_TO_FRONT: The hosted display sticks to the front.",
@@ -135,11 +135,11 @@ module({
     "CLIP: Enable clipping of the source coordinates.",
     "OFFSET: Adjust X and Y coordinates by the offset values defined in the @Surface.XOffset and @Surface.YOffset fields.")
 
-  enum("BMP", { type="int", start=2, comment="Bitmap types" },
+  enums("BMP", { type="int", start=2, comment="Bitmap types" },
      "PLANAR: Planar pixel mode separates pixel bits across multiple planes.  Commonly used for single bit bitmap masks.",
      "CHUNKY: Chunky pixel mode (default).")
 
-  enum("BLM", { type="int", start=0, comment="Defines the blending algorithm to use when transparent pixels are rendered to the bitmap." },
+  enums("BLM", { type="int", start=0, comment="Defines the blending algorithm to use when transparent pixels are rendered to the bitmap." },
     "AUTO: Use the most suitable of the available algorithms.",
     "NONE: Never blend transparent pixels, just copy as-is.",
     "SRGB: Use sRGB linear blending.  This algorithm is extremely efficient but produces poor quality results.",
@@ -194,19 +194,19 @@ module({
   flags("GMF", { comment="Flags for gamma operations." },
      "SAVE: Save the provided settings permanently.")
 
-  enum("DT", { type="int", start=1, comment="Flags for GetDisplayType()." },
+  enums("DT", { type="int", start=1, comment="Flags for GetDisplayType()." },
     "NATIVE: The display is native (supported by internal drivers).",
     "X11: The display is driven by the X Window System (X11, X.Org, XFree86)",
     "WINGDI: The display is driven by Microsoft Windows drivers.",
     "GLES: The display is driven by OpenGLES.")
 
-  enum("DPMS", { type="int", start=0, comment="Possible modes for the Display class' PowerMode field." },
+  enums("DPMS", { type="int", start=0, comment="Possible modes for the Display class' PowerMode field." },
     "DEFAULT: Use the default DPMS mode as defined by the display driver.",
     "OFF: Stop sending power to the display in order to turn it off (it may not be possible to restart the display without the user's intervention).",
     "SUSPEND: Puts the display into suspend mode (blanks the display output while maintaining normal power levels).",
     "STANDBY: Puts the display into standby (reduced power) mode.")
 
-  enum('CT', { type="int", start=0 }, 'DATA', 'AUDIO', 'IMAGE', 'FILE', 'OBJECT', 'TEXT', 'END')
+  enums('CT', { type="int", start=0 }, 'DATA', 'AUDIO', 'IMAGE', 'FILE', 'OBJECT', 'TEXT', 'END')
 
   -- Note: It is intentional that the CLIP types are expressed as flags and not constants.
 

--- a/src/document/defs/document.tdl
+++ b/src/document/defs/document.tdl
@@ -13,7 +13,7 @@ module({ name="Document", copyright="Paul Manias © 2005-2026", version=1.0, tim
     VERSION = "\"20240126\""
   })
 
-  enum("TT", { type="char", start=1 }, "VECTOR", "LINK", "EDIT")
+  enums("TT", { type="char", start=1 }, "VECTOR", "LINK", "EDIT")
 
   flags("DEF", { comment="Event flags for selectively receiving events from the Document object." },
     "PATH: The source file path has changed.  Useful for detecting when the user has left the page.",
@@ -26,7 +26,7 @@ module({ name="Document", copyright="Paul Manias © 2005-2026", version=1.0, tim
     { ON_CROSSING = "ON_CROSSING_IN|ON_CROSSING_OUT" }
   )
 
-  enum("DRT", { type="int", start=0, comment="Internal trigger codes" },
+  enums("DRT", { type="int", start=0, comment="Internal trigger codes" },
     "BEFORE_LAYOUT",
     "AFTER_LAYOUT",
     "USER_CLICK",

--- a/src/font/font.tdl
+++ b/src/font/font.tdl
@@ -23,7 +23,7 @@ module({ name="Font", copyright="Paul Manias © 1998-2026", version=1.0, timesta
     "HIDDEN: The font should not appear in any named list shown to the user."
   )
 
-  enum("HINT", { type="char", start=1, comment="Force hinting options for a font." },
+  enums("HINT", { type="char", start=1, comment="Force hinting options for a font." },
      "NORMAL: The hinting information provided by the font will be given preference.",
      "INTERNAL: The Freetype hinter will be forcibly imposed.",
      "LIGHT: The light version of the Freetype hinter will be forcibly imposed.")

--- a/src/http/http.tdl
+++ b/src/http/http.tdl
@@ -7,11 +7,11 @@ module({ name="HTTP", copyright="Paul Manias © 2005-2026", version=1.0, timesta
 
   c_include("<kotuku/modules/network.h>")
 
-  enum("HOM", { type="int", start=0, comment="Output mode." },
+  enums("HOM", { type="int", start=0, comment="Output mode." },
     "DATA_FEED: Use the DataFeed() action to send data to the targeted object.",
     "READ_WRITE|READ|WRITE: Use the Write() action to send data to the targeted object.")
 
-  enum("HGS", { type="int", start=0, comment="Options for defining an HTTP object's state." },
+  enums("HGS", { type="int", start=0, comment="Options for defining an HTTP object's state." },
    "READING_HEADER: The default state - this value will be indicated when no data is being written to the server and the client is waiting for a complete header from the server.",
    "AUTHENTICATING: If authentication is requested from the server, the HTTP object will enter this state.",
    "AUTHENTICATED: Following successful authentication, this state value will be set.",
@@ -23,7 +23,7 @@ module({ name="HTTP", copyright="Paul Manias © 2005-2026", version=1.0, timesta
    "TERMINATED: If an HTTP command fails to complete normally - for instance if the connection is broken before completion - then the state is set to `TERMINATED`.",
    "END: Private")
 
-  enum("HTM", { type="int", start=0, comment="The HTTP Method to use when the object is activated." },
+  enums("HTM", { type="int", start=0, comment="The HTTP Method to use when the object is activated." },
     "GET: Retrieves files from the HTTP server.  The Path field will indicate which file to retrieve.",
     "POST: Sends information to the HTTP server.",
     "PUT: Uploads a file to the HTTP server.  The data will be read from the #InputFile or #InputObject references.",

--- a/src/network/network.tdl
+++ b/src/network/network.tdl
@@ -20,7 +20,7 @@ typedef int SOCKET_HANDLE;
 #endif
   ]])
 
-  enum("IPADDR", { type="int", start=0, comment="Address types for the IPAddress structure." }, "V4", "V6")
+  enums("IPADDR", { type="int", start=0, comment="Address types for the IPAddress structure." }, "V4", "V6")
 
   struct("IPAddress", { }, [[
     uint(4) Data        # 128-bit array for supporting both V4 (32-bit host order) and V6 (8-bit byte order) IP addresses.
@@ -41,7 +41,7 @@ typedef int SOCKET_HANDLE;
   flags("NLF", { comment="Options for NetLookup" },
     "NO_CACHE: Contact the name service and do not use the local DNS cache.")
 
-  enum("NTC", { type="int", start=0, comment="NetSocket states" },
+  enums("NTC", { type="int", start=0, comment="NetSocket states" },
     "DISCONNECTED: There is no connection.",
     "RESOLVING: The host name is being resolved.",
     "CONNECTING: A connection is being established.",

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -10,8 +10,12 @@
 
 #include "ast/builder.h"
 
+#include <cmath>
+#include <cctype>
 #include <cstring>
 #include <format>
+#include <limits>
+#include <mutex>
 #include <utility>
 
 #include "../token_types.h"
@@ -162,6 +166,16 @@ AstBuilder::FunctionNameScope::FunctionNameScope(AstBuilder &Builder, GCstr *Fun
 AstBuilder::FunctionNameScope::~FunctionNameScope()
 {
    this->builder.function_name_stack.pop_back();
+}
+
+AstBuilder::BlockDepthScope::BlockDepthScope(AstBuilder &Builder) : builder(Builder)
+{
+   this->builder.block_depth_++;
+}
+
+AstBuilder::BlockDepthScope::~BlockDepthScope()
+{
+   this->builder.block_depth_--;
 }
 
 GCstr *AstBuilder::anonymous_function_name()
@@ -343,6 +357,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
       case TokenKind::Annotate:      return this->parse_annotated_statement();
       case TokenKind::Local:         return this->parse_local();
       case TokenKind::Global:        return this->parse_global();
+      case TokenKind::Enum:          return this->parse_enum(current);
       case TokenKind::Function:      return this->parse_function_stmt();
       case TokenKind::ThunkToken:    return this->parse_function_stmt();
       case TokenKind::If:            return this->parse_if();
@@ -390,6 +405,7 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_scoped_block(std::ini
 {
    std::vector<TokenKind> merged(terminators);
    merged.push_back(TokenKind::EndOfFile);
+   BlockDepthScope block_scope(*this);
    return this->parse_block(merged);
 }
 
@@ -412,6 +428,7 @@ bool AstBuilder::is_statement_start(TokenKind kind) const
    switch (kind) {
       case TokenKind::Local:
       case TokenKind::Global:
+      case TokenKind::Enum:
       case TokenKind::Function:
       case TokenKind::ThunkToken:
       case TokenKind::Annotate:

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -50,11 +50,6 @@ private:
       uint8_t right = 0;
    };
 
-   struct EnumExpansion {
-      std::vector<Identifier> names;
-      ExprNodeList values;
-   };
-
    [[nodiscard]] ParserResult<std::unique_ptr<BlockStmt>> parse_block(std::span<const TokenKind> terminators);
    ParserResult<StmtNodePtr> parse_statement();
    ParserResult<StmtNodePtr> parse_local();
@@ -94,10 +89,6 @@ private:
    ParserResult<FunctionReturnTypes> parse_return_type_annotation();
 
    ParserResult<std::vector<Identifier>> parse_name_list();
-   [[nodiscard]] bool is_enum_declaration_rhs(size_t Offset) const;
-   [[nodiscard]] bool is_enum_declaration_prefix(const Identifier &) const;
-   ParserResult<EnumExpansion> parse_enum_declaration(const Identifier &);
-   ParserResult<StmtNodePtr> make_enum_declaration_stmt(SourceSpan, Identifier, bool);
    struct ParameterListResult {
       std::vector<FunctionParameter> parameters;
       bool is_vararg = false;

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -23,13 +23,14 @@ public:
    ParserResult<ExprNodePtr> parse_expression(uint8_t precedence = 0);
    ParserResult<ExprNodeList> parse_expression_list();
 
-   [[nodiscard]] bool at_top_level() const { return function_depth_ IS 0; }
+   [[nodiscard]] bool at_top_level() const { return function_depth_ IS 0 and block_depth_ IS 0; }
 
 private:
    ParserContext& ctx;
    bool in_guard_expression = false;  // True when parsing 'when' clause guard expression
    bool in_choose_expression = false; // True when parsing choose expression cases (for tuple pattern detection)
    int function_depth_ = 0;           // Tracks nesting depth inside function bodies
+   int block_depth_ = 0;              // Tracks nested statement blocks below chunk scope
    std::vector<GCstr *> function_name_stack;
 
    class FunctionNameScope {
@@ -39,6 +40,18 @@ private:
 
       FunctionNameScope(const FunctionNameScope &) = delete;
       FunctionNameScope& operator=(const FunctionNameScope &) = delete;
+
+   private:
+      AstBuilder &builder;
+   };
+
+   class BlockDepthScope {
+   public:
+      explicit BlockDepthScope(AstBuilder &Builder);
+      ~BlockDepthScope();
+
+      BlockDepthScope(const BlockDepthScope &) = delete;
+      BlockDepthScope& operator=(const BlockDepthScope &) = delete;
 
    private:
       AstBuilder &builder;
@@ -54,6 +67,8 @@ private:
    ParserResult<StmtNodePtr> parse_statement();
    ParserResult<StmtNodePtr> parse_local();
    ParserResult<StmtNodePtr> parse_global();
+   ParserResult<StmtNodePtr> parse_enum(const Token &StartToken);
+   ParserResult<int64_t> parse_enum_integer_literal();
    ParserResult<StmtNodePtr> parse_function_stmt();
    ParserResult<StmtNodePtr> parse_annotated_statement();
    ParserResult<std::vector<AnnotationEntry>> parse_annotations();

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -954,7 +954,29 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          continue;
       }
 
-      if (token.kind() IS TokenKind::LeftParen or token.kind() IS TokenKind::String) {
+      if (token.kind() IS TokenKind::LeftParen or token.kind() IS TokenKind::LeftBrace or
+            token.kind() IS TokenKind::String) {
+         if (token.kind() IS TokenKind::LeftBrace and token.span().line != base->span.line) break;
+
+         // For table tokens in a choose expression context, check if this starts a table pattern for the next case.
+         // If the matching brace is followed by -> or 'when', don't treat it as a table-call argument.
+         if (token.kind() IS TokenKind::LeftBrace and this->in_choose_expression and not this->in_guard_expression) {
+            int brace_depth = 1;
+            size_t pos = 1;
+            while (brace_depth > 0 and pos < 100) {
+               Token ahead = this->ctx.tokens().peek(pos);
+               if (ahead.kind() IS TokenKind::LeftBrace) brace_depth++;
+               else if (ahead.kind() IS TokenKind::RightBrace) brace_depth--;
+               else if (ahead.kind() IS TokenKind::EndOfFile) break;
+               pos++;
+            }
+
+            if (brace_depth IS 0) {
+               Token after_brace = this->ctx.tokens().peek(pos);
+               if (after_brace.kind() IS TokenKind::CaseArrow or after_brace.kind() IS TokenKind::When) break;
+            }
+         }
+
          // For string tokens, check if this is actually the start of a choose case pattern
          // (string followed by ->). If so, don't treat it as a call argument.
          if (token.kind() IS TokenKind::String) {

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -31,22 +31,6 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
    if (assignment_result.has_value()) {
       AssignmentOperator assignment = assignment_result.value();
       this->ctx.tokens().advance();
-
-      if (assignment IS AssignmentOperator::Plain and this->is_enum_declaration_rhs(0)) {
-         if (not (targets.size() IS 1)) {
-            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, op,
-               "enum declaration requires a single prefix name");
-         }
-
-         ExprNodePtr& target = targets.front();
-         if (target and target->kind IS AstNodeKind::IdentifierExpr) {
-            auto *name_ref = std::get_if<NameRef>(&target->data);
-            if (name_ref and this->is_enum_declaration_prefix(name_ref->identifier)) {
-               return this->make_enum_declaration_stmt(target->span, name_ref->identifier, false);
-            }
-         }
-      }
-
       auto values = this->parse_expression_list();
       if (not values.ok()) return ParserResult<StmtNodePtr>::failure(values.error_ref());
       auto stmt = std::make_unique<StmtNode>(AstNodeKind::AssignmentStmt, op.span());
@@ -970,29 +954,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          continue;
       }
 
-      if (token.kind() IS TokenKind::LeftParen or token.kind() IS TokenKind::LeftBrace or
-            token.kind() IS TokenKind::String) {
-         if (token.kind() IS TokenKind::LeftBrace and token.span().line != base->span.line) break;
-
-         // For table tokens in a choose expression context, check if this starts a table pattern for the next case.
-         // If the matching brace is followed by -> or 'when', don't treat it as a table-call argument.
-         if (token.kind() IS TokenKind::LeftBrace and this->in_choose_expression and not this->in_guard_expression) {
-            int brace_depth = 1;
-            size_t pos = 1;
-            while (brace_depth > 0 and pos < 100) {
-               Token ahead = this->ctx.tokens().peek(pos);
-               if (ahead.kind() IS TokenKind::LeftBrace) brace_depth++;
-               else if (ahead.kind() IS TokenKind::RightBrace) brace_depth--;
-               else if (ahead.kind() IS TokenKind::EndOfFile) break;
-               pos++;
-            }
-
-            if (brace_depth IS 0) {
-               Token after_brace = this->ctx.tokens().peek(pos);
-               if (after_brace.kind() IS TokenKind::CaseArrow or after_brace.kind() IS TokenKind::When) break;
-            }
-         }
-
+      if (token.kind() IS TokenKind::LeftParen or token.kind() IS TokenKind::String) {
          // For string tokens, check if this is actually the start of a choose case pattern
          // (string followed by ->). If so, don't treat it as a call argument.
          if (token.kind() IS TokenKind::String) {

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -9,224 +9,6 @@
 // - Return statements
 // - Expression statements
 
-#include <cmath>
-
-namespace {
-
-[[nodiscard]] std::string identifier_text(const Identifier &Identifier)
-{
-   if (not Identifier.symbol) return {};
-   return std::string(strdata(Identifier.symbol), Identifier.symbol->len);
-}
-
-[[nodiscard]] bool token_is_contextual_enum(const Token &Token)
-{
-   if (not Token.is(TokenKind::Identifier)) return false;
-   GCstr *symbol = Token.identifier();
-   if (not symbol) return false;
-   return std::string_view(strdata(symbol), symbol->len) IS "enum";
-}
-
-[[nodiscard]] bool is_upper_identifier(std::string_view Text)
-{
-   if (Text.empty()) return false;
-   bool has_upper = false;
-
-   for (char ch : Text) {
-      if (ch >= 'A' and ch <= 'Z') {
-         has_upper = true;
-         continue;
-      }
-
-      if ((ch >= '0' and ch <= '9') or ch IS '_') continue;
-
-      return false;
-   }
-
-   return has_upper;
-}
-
-[[nodiscard]] bool contains_text(const std::vector<std::string> &Values, std::string_view Text)
-{
-   for (const auto &value : Values) {
-      if (value IS Text) return true;
-   }
-   return false;
-}
-
-} // namespace
-
-//********************************************************************************************************************
-// Checks for the contextual enum declaration RHS: enum { ... }
-
-bool AstBuilder::is_enum_declaration_rhs(size_t Offset) const
-{
-   return token_is_contextual_enum(this->ctx.tokens().peek(Offset)) and
-      this->ctx.tokens().peek(Offset + 1).is(TokenKind::LeftBrace);
-}
-
-//********************************************************************************************************************
-// Checks whether an assignment target has enum declaration prefix name syntax without consuming the RHS.
-
-bool AstBuilder::is_enum_declaration_prefix(const Identifier &Prefix) const
-{
-   std::string prefix = identifier_text(Prefix);
-   return not Prefix.is_blank and not prefix.empty() and is_upper_identifier(prefix);
-}
-
-//********************************************************************************************************************
-// Parses an enum declaration RHS and expands it to generated constant identifiers and numeric literal values.
-
-ParserResult<AstBuilder::EnumExpansion> AstBuilder::parse_enum_declaration(const Identifier &Prefix)
-{
-   std::string prefix = identifier_text(Prefix);
-
-   if (Prefix.is_blank or prefix.empty()) {
-      return this->fail<EnumExpansion>(ParserErrorCode::ExpectedIdentifier, Token::from_span(Prefix.span),
-         "enum prefix must be an identifier");
-   }
-
-   if (Prefix.has_close) {
-      return this->fail<EnumExpansion>(ParserErrorCode::UnexpectedToken, Token::from_span(Prefix.span),
-         "enum prefix cannot use the <close> attribute");
-   }
-
-   if (not (Prefix.type IS TiriType::Unknown)) {
-      return this->fail<EnumExpansion>(ParserErrorCode::UnexpectedToken, Token::from_span(Prefix.span),
-         "enum prefix cannot have a type annotation");
-   }
-
-   if (not is_upper_identifier(prefix)) {
-      return this->fail<EnumExpansion>(ParserErrorCode::ExpectedIdentifier, Token::from_span(Prefix.span),
-         "enum prefix must use uppercase identifier style");
-   }
-
-   Token enum_token = this->ctx.tokens().current();
-   if (not token_is_contextual_enum(enum_token)) {
-      return this->fail<EnumExpansion>(ParserErrorCode::ExpectedIdentifier, enum_token, "expected 'enum'");
-   }
-
-   this->ctx.tokens().advance();
-   this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);
-
-   if (this->ctx.check(TokenKind::RightBrace)) {
-      return this->fail<EnumExpansion>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "enum declaration requires at least one member");
-   }
-
-   EnumExpansion expansion;
-   std::vector<std::string> member_names;
-   std::vector<std::string> generated_names;
-   lua_Number next_value = 0;
-
-   auto parse_integer_literal = [&]() -> ParserResult<lua_Number> {
-      lua_Number sign = 1;
-      Token value_token = this->ctx.tokens().current();
-
-      if (value_token.is(TokenKind::Minus)) {
-         sign = -1;
-         this->ctx.tokens().advance();
-         value_token = this->ctx.tokens().current();
-      }
-      else if (value_token.is(TokenKind::Plus)) {
-         this->ctx.tokens().advance();
-         value_token = this->ctx.tokens().current();
-      }
-
-      if (not value_token.is(TokenKind::Number)) {
-         return this->fail<lua_Number>(ParserErrorCode::UnexpectedToken, value_token,
-            "enum member value must be an integer literal");
-      }
-
-      lua_Number value = sign * value_token.payload().as_number();
-      if (not (value IS std::floor(value))) {
-         return this->fail<lua_Number>(ParserErrorCode::UnexpectedToken, value_token,
-            "enum member value must be an integer literal");
-      }
-
-      this->ctx.tokens().advance();
-      return ParserResult<lua_Number>::success(value);
-   };
-
-   while (not this->ctx.check(TokenKind::RightBrace)) {
-      Token member_token = this->ctx.tokens().current();
-      if (not member_token.is(TokenKind::Identifier)) {
-         return this->fail<EnumExpansion>(ParserErrorCode::ExpectedIdentifier, member_token,
-            "enum member name must be an identifier");
-      }
-
-      Identifier member = make_identifier(member_token);
-      std::string member_name = identifier_text(member);
-      if (not is_upper_identifier(member_name)) {
-         return this->fail<EnumExpansion>(ParserErrorCode::ExpectedIdentifier, member_token,
-            "enum member name must use uppercase identifier style");
-      }
-
-      if (contains_text(member_names, member_name)) {
-         return this->fail<EnumExpansion>(ParserErrorCode::UnexpectedToken, member_token,
-            "duplicate enum member '" + member_name + "'");
-      }
-
-      this->ctx.tokens().advance();
-
-      lua_Number member_value = next_value;
-      if (this->ctx.match(TokenKind::Equals).ok()) {
-         auto explicit_value = parse_integer_literal();
-         if (not explicit_value.ok()) return ParserResult<EnumExpansion>::failure(explicit_value.error_ref());
-         member_value = explicit_value.value_ref();
-      }
-      next_value = member_value + 1;
-
-      std::string generated_name = prefix + "_" + member_name;
-      if (contains_text(generated_names, generated_name)) {
-         return this->fail<EnumExpansion>(ParserErrorCode::UnexpectedToken, member_token,
-            "duplicate enum constant '" + generated_name + "'");
-      }
-
-      Identifier generated = Identifier::from_keepstr(this->ctx.lex().keepstr(generated_name), member.span);
-      generated.has_const = true;
-      generated.type = TiriType::Num;
-
-      expansion.names.push_back(generated);
-      expansion.values.push_back(make_literal_expr(member.span, LiteralValue::number(member_value)));
-      member_names.push_back(std::move(member_name));
-      generated_names.push_back(std::move(generated_name));
-
-      if (this->ctx.match(TokenKind::Comma).ok()) continue;
-      if (this->ctx.check(TokenKind::RightBrace)) break;
-
-      return this->fail<EnumExpansion>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
-         "expected ',' or '}' after enum member");
-   }
-
-   this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
-   return ParserResult<EnumExpansion>::success(std::move(expansion));
-}
-
-//********************************************************************************************************************
-// Builds a local or global declaration statement from an enum expansion.
-
-ParserResult<StmtNodePtr> AstBuilder::make_enum_declaration_stmt(SourceSpan Span, Identifier Prefix, bool Global)
-{
-   auto expansion = this->parse_enum_declaration(Prefix);
-   if (not expansion.ok()) return ParserResult<StmtNodePtr>::failure(expansion.error_ref());
-   EnumExpansion &expanded = expansion.value_ref();
-
-   auto stmt = std::make_unique<StmtNode>(
-      Global ? AstNodeKind::GlobalDeclStmt : AstNodeKind::LocalDeclStmt, Span);
-
-   if (Global) {
-      stmt->data.emplace<GlobalDeclStmtPayload>(AssignmentOperator::Plain,
-         std::move(expanded.names), std::move(expanded.values));
-   }
-   else {
-      stmt->data.emplace<LocalDeclStmtPayload>(AssignmentOperator::Plain,
-         std::move(expanded.names), std::move(expanded.values));
-   }
-
-   return ParserResult<StmtNodePtr>::success(std::move(stmt));
-}
-
 //********************************************************************************************************************
 // Parses local variable declarations, local function statements and local thunk function statements.
 // Supports both explicit 'local' keyword and implicit local declarations with <const>/<close> attributes.
@@ -266,23 +48,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
    auto names = this->parse_name_list();
    if (not names.ok()) return ParserResult<StmtNodePtr>::failure(names.error_ref());
 
-   auto& name_list = names.value_ref();
-
    ExprNodeList values;
    AssignmentOperator assign_op = AssignmentOperator::Plain;
 
    // Check for plain = or conditional ?=/??= assignment
-   if (this->ctx.check(TokenKind::Equals)) {
-      this->ctx.tokens().advance();
-      if (this->is_enum_declaration_rhs(0) and this->is_enum_declaration_prefix(name_list.front())) {
-         if (not (name_list.size() IS 1)) {
-            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-               "enum declaration requires a single prefix name");
-         }
-
-         return this->make_enum_declaration_stmt(local_token.span(), name_list.front(), false);
-      }
-
+   if (this->ctx.match(TokenKind::Equals).ok()) {
       auto rhs = this->parse_expression_list();
       if (not rhs.ok()) return ParserResult<StmtNodePtr>::failure(rhs.error_ref());
       values = std::move(rhs.value_ref());
@@ -303,6 +73,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
    // Check if any trailing expressions beyond the name count are bare identifiers,
    // and if so, convert them to additional variable names.
 
+   auto &name_list = names.value_ref();
    size_t name_count = name_list.size();
 
    if (values.size() > name_count) {
@@ -370,23 +141,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
    auto names = this->parse_name_list();
    if (not names.ok()) return ParserResult<StmtNodePtr>::failure(names.error_ref());
 
-   auto &name_list = names.value_ref();
-
    ExprNodeList values;
    AssignmentOperator assign_op = AssignmentOperator::Plain;
 
    // Check for plain = or conditional ?=/??= assignment
-   if (this->ctx.check(TokenKind::Equals)) {
-      this->ctx.tokens().advance();
-      if (this->is_enum_declaration_rhs(0) and this->is_enum_declaration_prefix(name_list.front())) {
-         if (not (name_list.size() IS 1)) {
-            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-               "enum declaration requires a single prefix name");
-         }
-
-         return this->make_enum_declaration_stmt(global_token.span(), name_list.front(), true);
-      }
-
+   if (this->ctx.match(TokenKind::Equals).ok()) {
       auto rhs = this->parse_expression_list();
       if (not rhs.ok()) return ParserResult<StmtNodePtr>::failure(rhs.error_ref());
       values = std::move(rhs.value_ref());
@@ -407,6 +166,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
    // Check if any trailing expressions beyond the name count are bare identifiers,
    // and if so, convert them to additional variable names.
 
+   auto& name_list = names.value_ref();
    size_t name_count = name_list.size();
 
    if (values.size() > name_count) {

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -21,6 +21,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
    if (not implicit_local) {
       this->ctx.tokens().advance();  // Consume the 'local' keyword
 
+      if (this->ctx.check(TokenKind::Enum)) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+            "local enum declarations are not supported");
+      }
+
       bool is_thunk = false;
       if (this->ctx.check(TokenKind::ThunkToken)) {
          is_thunk = true;
@@ -108,6 +113,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
    Token global_token = this->ctx.tokens().current();
    this->ctx.tokens().advance();
 
+   if (this->ctx.check(TokenKind::Enum)) {
+      return this->parse_enum(global_token);
+   }
+
    // Handle `global function name()` and `global thunk name()` syntax
 
    bool is_thunk = false;
@@ -192,6 +201,200 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
    GlobalDeclStmtPayload payload(assign_op, std::move(name_list), std::move(values));
    stmt->data = std::move(payload);
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
+}
+
+//********************************************************************************************************************
+// Parses top-level enum declarations and registers their generated constants for compile-time substitution.
+
+struct EnumConstantDecl {
+   std::string name;
+   int64_t value = 0;
+   SourceSpan span{};
+};
+
+static bool is_uppercase_enum_name(GCstr *Symbol)
+{
+   if (not Symbol or Symbol->len IS 0) return false;
+
+   CSTRING text = strdata(Symbol);
+   unsigned char first = (unsigned char)text[0];
+   if (not std::isupper(int(first))) return false;
+
+   for (size_t i = 1; i < Symbol->len; ++i) {
+      unsigned char c = (unsigned char)text[i];
+      if (std::isupper(int(c)) or std::isdigit(int(c)) or c IS '_') continue;
+      return false;
+   }
+   return true;
+}
+
+static bool is_prefixed_attribute_token(TokenStreamAdapter &Tokens)
+{
+   Token current = Tokens.current();
+   if (current.raw() IS '<') return true;
+
+   if (current.kind() != TokenKind::Identifier) return false;
+   GCstr *symbol = current.identifier();
+   if (not symbol) return false;
+
+   std::string_view name(strdata(symbol), symbol->len);
+   if (name != "const" and name != "close") return false;
+   return Tokens.peek(1).raw() IS '<';
+}
+
+ParserResult<int64_t> AstBuilder::parse_enum_integer_literal()
+{
+   int sign = 1;
+   Token token = this->ctx.tokens().current();
+   if (token.kind() IS TokenKind::Plus or token.kind() IS TokenKind::Minus) {
+      if (token.kind() IS TokenKind::Minus) sign = -1;
+      this->ctx.tokens().advance();
+      token = this->ctx.tokens().current();
+   }
+
+   if (not token.is(TokenKind::Number)) {
+      return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
+         "enum values must be integer literals");
+   }
+
+   double number_value = token.payload().as_number();
+   if (not std::isfinite(number_value) or std::trunc(number_value) != number_value) {
+      return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
+         "enum values must be integer literals");
+   }
+
+   double signed_value = number_value * double(sign);
+   constexpr double min_value = double(std::numeric_limits<int64_t>::min());
+   constexpr double max_value = double(std::numeric_limits<int64_t>::max());
+   if (signed_value < min_value or signed_value > max_value) {
+      return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
+         "enum integer literal is out of range");
+   }
+
+   this->ctx.tokens().advance();
+   return ParserResult<int64_t>::success(int64_t(signed_value));
+}
+
+ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
+{
+   if (not this->at_top_level()) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "enum declarations are only allowed at top-level scope");
+   }
+
+   Token enum_token = this->ctx.tokens().current();
+   auto enum_result = this->ctx.consume(TokenKind::Enum, ParserErrorCode::ExpectedToken);
+   if (not enum_result.ok()) return ParserResult<StmtNodePtr>::failure(enum_result.error_ref());
+
+   auto prefix_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
+   if (not prefix_token.ok()) return ParserResult<StmtNodePtr>::failure(prefix_token.error_ref());
+
+   GCstr *prefix_symbol = prefix_token.value_ref().identifier();
+   if (not is_uppercase_enum_name(prefix_symbol)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, prefix_token.value_ref(),
+         "declare enum prefixes in uppercase only");
+   }
+
+   if (this->ctx.check(TokenKind::Colon)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "enum prefixes cannot use a type annotation");
+   }
+
+   if (is_prefixed_attribute_token(this->ctx.tokens())) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "enum prefixes cannot use <const> or <close> attributes");
+   }
+
+   auto open_brace = this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);
+   if (not open_brace.ok()) return ParserResult<StmtNodePtr>::failure(open_brace.error_ref());
+
+   std::vector<EnumConstantDecl> constants;
+   std::vector<std::string> members;
+   int64_t next_value = 0;
+   std::string prefix(strdata(prefix_symbol), prefix_symbol->len);
+
+   while (not this->ctx.check(TokenKind::RightBrace)) {
+      if (this->ctx.check(TokenKind::EndOfFile)) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedEndOfFile, enum_token,
+            "unterminated enum declaration");
+      }
+
+      auto member_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
+      if (not member_token.ok()) return ParserResult<StmtNodePtr>::failure(member_token.error_ref());
+
+      GCstr *member_symbol = member_token.value_ref().identifier();
+      if (not is_uppercase_enum_name(member_symbol)) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
+            "declare enum members in uppercase only");
+      }
+
+      std::string member(strdata(member_symbol), member_symbol->len);
+      for (const std::string &existing : members) {
+         if (existing IS member) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
+               "duplicate enum member '" + member + "'");
+         }
+      }
+      members.push_back(member);
+
+      int64_t value = next_value;
+      if (this->ctx.match(TokenKind::Equals).ok()) {
+         auto explicit_value = this->parse_enum_integer_literal();
+         if (not explicit_value.ok()) return ParserResult<StmtNodePtr>::failure(explicit_value.error_ref());
+         value = explicit_value.value_ref();
+      }
+
+      constants.push_back(EnumConstantDecl{ prefix + "_" + member, value, member_token.value_ref().span() });
+      if (value IS std::numeric_limits<int64_t>::max()) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
+            "enum value overflow");
+      }
+      next_value = value + 1;
+
+      if (this->ctx.match(TokenKind::Comma).ok()) {
+         continue;
+      }
+      if (not this->ctx.check(TokenKind::RightBrace)) {
+         return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
+            "expected ',' or '}' in enum declaration");
+      }
+   }
+
+   auto close_brace = this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   if (not close_brace.ok()) return ParserResult<StmtNodePtr>::failure(close_brace.error_ref());
+
+   if (constants.empty()) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, StartToken,
+         "enum declarations must contain at least one member");
+   }
+
+   std::string duplicate_name;
+   SourceSpan duplicate_span{};
+
+   {
+      std::unique_lock lock(glConstantMutex);
+      for (const EnumConstantDecl &constant : constants) {
+         if (glConstantRegistry.contains(kt::strhash(constant.name))) {
+            duplicate_name = constant.name;
+            duplicate_span = constant.span;
+            break;
+         }
+      }
+
+      if (duplicate_name.empty()) {
+         for (const EnumConstantDecl &constant : constants) {
+            glConstantRegistry.emplace(kt::strhash(constant.name), TiriConstant(constant.value));
+         }
+      }
+   }
+
+   if (not duplicate_name.empty()) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
+         Token::from_span(duplicate_span, TokenKind::Identifier),
+         "duplicate enum constant '" + duplicate_name + "'");
+   }
+
+   return ParserResult<StmtNodePtr>::success(nullptr);
 }
 
 //********************************************************************************************************************
@@ -333,6 +536,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_repeat()
    Token token = this->ctx.tokens().current();
    this->ctx.tokens().advance();
    const TokenKind terms[] = { TokenKind::Until };
+   BlockDepthScope block_scope(*this);
    auto body = this->parse_block(terms);
    if (not body.ok()) return ParserResult<StmtNodePtr>::failure(body.error_ref());
    this->ctx.consume(TokenKind::Until, ParserErrorCode::ExpectedToken);
@@ -353,6 +557,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_do()
    Token token = this->ctx.tokens().current();
    this->ctx.tokens().advance();
    const TokenKind terms[] = { TokenKind::EndToken };
+   BlockDepthScope block_scope(*this);
    auto block = this->parse_block(terms);
    if (not block.ok()) return ParserResult<StmtNodePtr>::failure(block.error_ref());
 
@@ -379,6 +584,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_with()
    this->ctx.consume(TokenKind::DoToken, ParserErrorCode::ExpectedToken);
 
    const TokenKind terms[] = { TokenKind::EndToken };
+   BlockDepthScope block_scope(*this);
    auto body = this->parse_block(terms);
    if (not body.ok()) return ParserResult<StmtNodePtr>::failure(body.error_ref());
 
@@ -407,6 +613,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_defer()
    }
 
    const TokenKind body_terms[] = { TokenKind::EndToken };
+   BlockDepthScope block_scope(*this);
    auto body = this->parse_block(body_terms);
    if (not body.ok()) return ParserResult<StmtNodePtr>::failure(body.error_ref());
    this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
@@ -529,8 +736,13 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
 
    // Parse try block body - terminates on 'except', 'success', or 'end'
    const TokenKind try_terms[] = { TokenKind::ExceptToken, TokenKind::SuccessToken, TokenKind::EndToken };
-   auto try_body = this->parse_block(try_terms);
-   if (not try_body.ok()) return ParserResult<StmtNodePtr>::failure(try_body.error_ref());
+   std::unique_ptr<BlockStmt> try_block;
+   {
+      BlockDepthScope block_scope(*this);
+      auto try_body = this->parse_block(try_terms);
+      if (not try_body.ok()) return ParserResult<StmtNodePtr>::failure(try_body.error_ref());
+      try_block = std::move(try_body.value_ref());
+   }
 
    std::vector<ExceptClause> clauses;
    bool has_catch_all = false;
@@ -611,9 +823,12 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
 
       // Parse except block body - terminates on next 'except', 'success', or 'end'
       const TokenKind except_terms[] = { TokenKind::ExceptToken, TokenKind::SuccessToken, TokenKind::EndToken };
-      auto except_body = this->parse_block(except_terms);
-      if (not except_body.ok()) return ParserResult<StmtNodePtr>::failure(except_body.error_ref());
-      clause.block = std::move(except_body.value_ref());
+      {
+         BlockDepthScope block_scope(*this);
+         auto except_body = this->parse_block(except_terms);
+         if (not except_body.ok()) return ParserResult<StmtNodePtr>::failure(except_body.error_ref());
+         clause.block = std::move(except_body.value_ref());
+      }
 
       clauses.push_back(std::move(clause));
    }
@@ -625,9 +840,12 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
 
       // Parse success block body - terminates on 'end'
       const TokenKind success_terms[] = { TokenKind::EndToken };
-      auto success_body = this->parse_block(success_terms);
-      if (not success_body.ok()) return ParserResult<StmtNodePtr>::failure(success_body.error_ref());
-      success_block = std::move(success_body.value_ref());
+      {
+         BlockDepthScope block_scope(*this);
+         auto success_body = this->parse_block(success_terms);
+         if (not success_body.ok()) return ParserResult<StmtNodePtr>::failure(success_body.error_ref());
+         success_block = std::move(success_body.value_ref());
+      }
    }
 
    this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
@@ -635,7 +853,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
    // Build the statement
    auto stmt = std::make_unique<StmtNode>(AstNodeKind::TryExceptStmt, try_token.span());
    TryExceptPayload payload;
-   payload.try_block = std::move(try_body.value_ref());
+   payload.try_block = std::move(try_block);
    payload.except_clauses = std::move(clauses);
    payload.success_block = std::move(success_block);
    payload.enable_trace = enable_trace;

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -29,6 +29,7 @@ struct TokenDefinition {
    TOKEN_DEF(else,         "else",     true) \
    TOKEN_DEF(elseif,       "elseif",   true) \
    TOKEN_DEF(end,          "end",      true) \
+   TOKEN_DEF(enum,         "enum",     true) \
    TOKEN_DEF(false,        "false",    true) \
    TOKEN_DEF(for,          "for",      true) \
    TOKEN_DEF(from,         "from",     true) \

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -32,6 +32,7 @@ enum class TokenKind : uint16_t {
    NamespaceToken = TK_namespace,
    Else = TK_else,
    ElseIf = TK_elseif,
+   Enum = TK_enum,
    For = TK_for,
    WhileToken = TK_while,
    WithToken = TK_with,
@@ -137,6 +138,7 @@ enum class TokenKind : uint16_t {
       case TokenKind::NamespaceToken: return "namespace";
       case TokenKind::Else: return "else";
       case TokenKind::ElseIf: return "elseif";
+      case TokenKind::Enum: return "enum";
       case TokenKind::For: return "for";
       case TokenKind::WhileToken: return "while";
       case TokenKind::WithToken: return "with";

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -1,4 +1,35 @@
--- Flute tests for contextual enum declarations.
+-- Flute tests for registry-backed enum declarations.
+
+enum BARE_ENUM {
+   ONE,
+   TWO,
+   THREE,
+}
+
+global enum GLOBAL_ENUM {
+   READY = 3,
+   RUNNING,
+   DONE,
+}
+
+enum NEG_ENUM {
+   LOW = -2,
+   MID,
+   HIGH = +5,
+}
+
+enum HEX_ENUM {
+   ZERO = 0x0,
+   TEN = 0xA,
+   NEXT,
+}
+
+enum FOLD_ENUM {
+   LEFT = 4,
+   RIGHT = 8,
+}
+
+global glDynamicEnumCounter = 0
 
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
@@ -7,132 +38,149 @@ function enforce_hotpath() end
 -- Successful declaration forms
 
 @Test function BareEnumDeclaration()
-   BARE_ENUM = enum {
-      ONE,
-      TWO,
-      THREE,
-   }
-
    assert(BARE_ENUM_ONE is 0, 'First bare enum value should default to 0')
    assert(BARE_ENUM_TWO is 1, 'Second bare enum value should auto-increment')
    assert(BARE_ENUM_THREE is 2, 'Third bare enum value should auto-increment')
    assert(debug.locality('BARE_ENUM') is 'nil', 'Enum prefix should not create a runtime binding')
-   assert(debug.locality('BARE_ENUM_ONE') is 'local', 'Generated bare enum constants should be local')
-end
-
-@Test function LocalEnumDeclaration()
-   local LOCAL_ENUM = enum {
-      FIRST = 10,
-      SECOND,
-      THIRD,
-   }
-
-   assert(LOCAL_ENUM_FIRST is 10, 'Explicit first enum value should be honoured')
-   assert(LOCAL_ENUM_SECOND is 11, 'Implicit value should increment from explicit value')
-   assert(LOCAL_ENUM_THIRD is 12, 'Implicit value should continue incrementing')
-   assert(debug.locality('LOCAL_ENUM') is 'nil', 'Local enum prefix should not create a runtime binding')
-   assert(debug.locality('LOCAL_ENUM_FIRST') is 'local', 'Generated local enum constants should be local')
+   assert(debug.locality('BARE_ENUM_ONE') is 'nil', 'Generated enum constants should not create runtime bindings')
 end
 
 @Test function GlobalEnumDeclaration()
-   global GLOBAL_ENUM = enum {
-      READY = 3,
-      RUNNING,
-      DONE,
-   }
-
    assert(GLOBAL_ENUM_READY is 3, 'Explicit global enum value should be honoured')
    assert(GLOBAL_ENUM_RUNNING is 4, 'Global enum value should auto-increment')
    assert(GLOBAL_ENUM_DONE is 5, 'Global enum value should auto-increment')
    assert(debug.locality('GLOBAL_ENUM') is 'nil', 'Global enum prefix should not create a runtime binding')
-   assert(debug.locality('GLOBAL_ENUM_READY') is 'global', 'Generated global enum constants should be global')
+   assert(debug.locality('GLOBAL_ENUM_READY') is 'nil', 'Generated global enum constants should not be variables')
 end
 
 @Test function NegativeAndTrailingComma()
-   local NEG_ENUM = enum {
-      LOW = -2,
-      MID,
-      HIGH = +5,
-   }
-
    assert(NEG_ENUM_LOW is -2, 'Negative enum value should be accepted')
    assert(NEG_ENUM_MID is -1, 'Auto-increment should work after a negative value')
    assert(NEG_ENUM_HIGH is 5, 'Explicit positive enum value should be accepted')
 end
 
 @Test function HexEnumValues()
-   local HEX_ENUM = enum {
-      ZERO = 0x0,
-      TEN = 0xA,
-      NEXT,
-   }
-
    assert(HEX_ENUM_ZERO is 0, 'Hex zero enum value should be accepted')
    assert(HEX_ENUM_TEN is 10, 'Hex enum value should be parsed as decimal 10')
    assert(HEX_ENUM_NEXT is 11, 'Auto-increment should work after a hex value')
 end
 
-@Test function RedundantConstPrefix()
-   local CONST_ENUM <const> = enum {
-      VALUE = 20,
-   }
-
-   assert(CONST_ENUM_VALUE is 20, 'Redundant <const> on enum prefix should be accepted')
-   assert(debug.locality('CONST_ENUM') is 'nil', 'Const enum prefix should not create a runtime binding')
+@Test function ConstantSubstitution()
+   local combined = FOLD_ENUM_LEFT | FOLD_ENUM_RIGHT
+   assert(combined is 12, 'Enum constants should be available to expressions')
+   assert((FOLD_ENUM_LEFT + FOLD_ENUM_RIGHT) is 12, 'Enum constants should be substituted as numeric constants')
+   assert((FOLD_ENUM_RIGHT has FOLD_ENUM_LEFT) is false, 'Enum constants should work with constant-folded operators')
 end
 
-@Test function EnumIdentifierStillNormal()
-   enum = 7
-   assert(enum is 7, 'enum should remain usable as a normal identifier outside enum declaration syntax')
-end
-
-@Test function EnumTableCallWithLowercaseTarget()
-   enum = function(Table)
-      return Table.ONE
-   end
-
-   x = enum { ONE = 1 }
-   assert(x is 1, 'Lowercase assignment target should parse enum {...} as a normal table call')
-
-   local local_result = enum { ONE = 2 }
-   assert(local_result is 2, 'Local declaration should parse enum {...} as a normal table call')
-
-   global global_enum_table_call_result = enum { ONE = 3 }
-   assert(global_enum_table_call_result is 3, 'Global declaration should parse enum {...} as a normal table call')
+@Test function DynamicTopLevelEnum()
+   glDynamicEnumCounter++
+   local prefix = 'EXEC_ENUM_' .. tostring(glDynamicEnumCounter)
+   exec(string.format([[
+enum %s {
+   FIRST = 20,
+   SECOND,
+}
+assert(%s_FIRST is 20)
+assert(%s_SECOND is 21)
+assert(debug.locality('%s_FIRST') is 'nil')
+]], prefix, prefix, prefix, prefix))
 end
 
 -----------------------------------------------------------------------------------------------------------------------
 -- Error cases
 
-@Test function LocalEnumReassignmentError()
+@Test function EnumKeywordIsReserved()
    try
-      exec([[
-local REASSIGN_ENUM = enum { ONE }
-REASSIGN_ENUM_ONE = 2
-]])
+      exec([[enum = 7]])
    except ex
-      assert(ex.message:find('cannot assign to const local'), f'Error should mention const local: {ex.message}')
+      assert(ex.message:find('expected identifier') or ex.message:find('Expected expression'),
+         f'Error should reject enum as an identifier: {ex.message}')
       return
    end
-   error('Reassigning generated local enum constant should fail')
+   error('enum should be a reserved keyword')
 end
 
-@Test function GlobalEnumReassignmentError()
+@Test function OldEnumSyntaxError()
    try
-      exec([[
-global REASSIGN_GLOBAL_ENUM = enum { ONE }
-REASSIGN_GLOBAL_ENUM_ONE = 2
-]])
+      exec([[OLD_ENUM = enum { ONE }]])
    except ex
-      assert(ex.message:find('cannot assign to const global'), f'Error should mention const global: {ex.message}')
+      assert(ex.message:find('Expected expression') or ex.message:find('unexpected'),
+         f'Error should reject old enum syntax: {ex.message}')
       return
    end
-   error('Reassigning generated global enum constant should fail')
+   error('Old enum assignment syntax should fail')
+end
+
+@Test function LocalEnumError()
+   try
+      exec([[local enum LOCAL_ENUM { ONE }]])
+   except ex
+      assert(ex.message:find('local enum') or ex.message:find('not supported'),
+         f'Error should mention local enum is unsupported: {ex.message}')
+      return
+   end
+   error('local enum declaration should fail')
+end
+
+@Test function EnumInsideDoBlockError()
+   try
+      exec([[
+do
+   enum BLOCK_ENUM { ONE }
+end
+]])
+   except ex
+      assert(ex.message:find('top-level'), f'Error should mention top-level enum scope: {ex.message}')
+      return
+   end
+   error('Enum inside do block should fail')
+end
+
+@Test function EnumInsideIfBlockError()
+   try
+      exec([[
+if true then
+   enum IF_ENUM { ONE }
+end
+]])
+   except ex
+      assert(ex.message:find('top-level'), f'Error should mention top-level enum scope: {ex.message}')
+      return
+   end
+   error('Enum inside if block should fail')
+end
+
+@Test function EnumInsideLoopError()
+   try
+      exec([[
+for i = 1, 1 do
+   enum LOOP_ENUM { ONE }
+end
+]])
+   except ex
+      assert(ex.message:find('top-level'), f'Error should mention top-level enum scope: {ex.message}')
+      return
+   end
+   error('Enum inside loop should fail')
+end
+
+@Test function EnumInsideFunctionError()
+   try
+      exec([[
+function defineEnum()
+   enum FUNCTION_ENUM { ONE }
+end
+]])
+   except ex
+      assert(ex.message:find('top-level'), f'Error should mention top-level enum scope: {ex.message}')
+      return
+   end
+   error('Enum inside function should fail')
 end
 
 @Test function EmptyEnumError()
    try
-      exec([[EMPTY_ENUM = enum { }]])
+      exec([[enum EMPTY_ENUM { }]])
    except ex
       assert(ex.message:find('at least one member'), f'Error should mention empty enum: {ex.message}')
       return
@@ -140,9 +188,19 @@ end
    error('Empty enum declaration should fail')
 end
 
+@Test function LowercasePrefixError()
+   try
+      exec([[enum bad_ENUM { ONE }]])
+   except ex
+      assert(ex.message:find('uppercase'), f'Error should mention uppercase style: {ex.message}')
+      return
+   end
+   error('Lowercase enum prefix should fail')
+end
+
 @Test function LowercaseMemberError()
    try
-      exec([[BAD_ENUM = enum { one }]])
+      exec([[enum BAD_ENUM { one }]])
    except ex
       assert(ex.message:find('uppercase'), f'Error should mention uppercase style: {ex.message}')
       return
@@ -152,7 +210,7 @@ end
 
 @Test function NonIntegerValueError()
    try
-      exec([[BAD_VALUE_ENUM = enum { ONE = 1.5 }]])
+      exec([[enum BAD_VALUE_ENUM { ONE = 1.5 }]])
    except ex
       assert(ex.message:find('integer literal'), f'Error should mention integer literal: {ex.message}')
       return
@@ -162,7 +220,7 @@ end
 
 @Test function DuplicateMemberError()
    try
-      exec([[DUP_ENUM = enum { ONE, ONE }]])
+      exec([[enum DUP_ENUM { ONE, ONE }]])
    except ex
       assert(ex.message:find('duplicate enum member'), f'Error should mention duplicate enum member: {ex.message}')
       return
@@ -170,19 +228,22 @@ end
    error('Duplicate enum member should fail')
 end
 
-@Test function MultiTargetEnumError()
+@Test function DuplicateRegisteredConstantError()
    try
-      exec([[A_ENUM, B_ENUM = enum { ONE }]])
+      exec([[
+enum DUP_REG_ENUM { ONE }
+enum DUP_REG_ENUM { ONE }
+]])
    except ex
-      assert(ex.message:find('single prefix'), f'Error should mention single prefix: {ex.message}')
+      assert(ex.message:find('duplicate enum constant'), f'Error should mention duplicate enum constant: {ex.message}')
       return
    end
-   error('Multi-target enum declaration should fail')
+   error('Duplicate registered enum constant should fail')
 end
 
 @Test function TypeAnnotatedPrefixError()
    try
-      exec([[local TYPED_ENUM: num = enum { ONE }]])
+      exec([[enum TYPED_ENUM: num { ONE }]])
    except ex
       assert(ex.message:find('type annotation'), f'Error should mention type annotation: {ex.message}')
       return
@@ -190,11 +251,23 @@ end
    error('Enum prefix with type annotation should fail')
 end
 
+@Test function ConstPrefixError()
+   try
+      exec([[enum CONST_ENUM <const> { ONE }]])
+   except ex
+      assert(ex.message:find('<const>') or ex.message:find('attribute'),
+         f'Error should mention const attribute: {ex.message}')
+      return
+   end
+   error('Enum prefix with <const> should fail')
+end
+
 @Test function ClosePrefixError()
    try
-      exec([[CLOSE_ENUM <close> = enum { ONE }]])
+      exec([[enum CLOSE_ENUM <close> { ONE }]])
    except ex
-      assert(ex.message:find('<close>'), f'Error should mention close attribute: {ex.message}')
+      assert(ex.message:find('<close>') or ex.message:find('attribute'),
+         f'Error should mention close attribute: {ex.message}')
       return
    end
    error('Enum prefix with <close> should fail')

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -24,26 +24,26 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
      "JOIN_PATHS: When appending a new path, use a join operation to connect the tail end to the head.",
      "ISOLATED: Enables isolation mode, which results in a bitmap buffer being allocated for the vector and its children while drawing.")
 
-  enum("VFA", { type="int", comment="Define the aspect ratio for VectorFilter unit scaling." },
+  enums("VFA", { type="int", comment="Define the aspect ratio for VectorFilter unit scaling." },
      "MEET: Scale X/Y values independently and in relation to the width/height of the parent viewport.",
      "NONE: Scale X/Y values on a `1:1` basis, in relation to the diagonal of the parent viewport.")
 
-  enum("LS", { type="int", comment="Light source identifiers." },
+  enums("LS", { type="int", comment="Light source identifiers." },
     "DISTANT: Distant light source.",
     "SPOT: Spot light source.",
     "POINT: Point light source.")
 
-  enum("LT", { type="int", start=0, comment="Lighting algorithm for the LightingFX class." },
+  enums("LT", { type="int", start=0, comment="Lighting algorithm for the LightingFX class." },
     "DIFFUSE: Select diffuse lighting.",
     "SPECULAR: Select specular lighting.")
 
-  enum("VUNIT", { type="int", start=0 },
+  enums("VUNIT", { type="int", start=0 },
     "UNDEFINED: Either the default setting will be applied or the setting will be inherited from a parent object.",
     "BOUNDING_BOX: Coordinates are scaled to the object's bounding box.",
     "USERSPACE: Coordinates are scaled to the current viewport.",
     "END: Private")
 
-  enum("VSPREAD", { type="int", start=0, comment="Spread method options define the method to use for tiling filled graphics." },
+  enums("VSPREAD", { type="int", start=0, comment="Spread method options define the method to use for tiling filled graphics." },
     "UNDEFINED: Either the default setting will be applied or the setting will be inherited from a parent object.",
     "PAD: Scale the graphic to the object bounds.",
     "REFLECT: Tile the graphic, reflecting the image alternately on the X and Y axis.",
@@ -53,28 +53,28 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "CLIP: Do not scale the graphic.  Clip it if it extends past imposed boundaries.",
     "END: Private")
 
-  enum("EM", { type="int", start=1, "Edge mode options for the convolve effect." },
+  enums("EM", { type="int", start=1, "Edge mode options for the convolve effect." },
     "DUPLICATE: The input image is extended along its borders by duplicating the color values at its edges.",
     "WRAP: The input image is extended by taking the color values from the opposite edge of the image.",
     "NONE: The input image is extended with colour values of zero.")
 
-  enum("PE", { type="int", start=1 }, "Move", "MoveRel", "Line", "LineRel", "HLine", "HLineRel", "VLine", "VLineRel",
+  enums("PE", { type="int", start=1 }, "Move", "MoveRel", "Line", "LineRel", "HLine", "HLineRel", "VLine", "VLineRel",
     "Curve", "CurveRel", "Smooth", "SmoothRel", "QuadCurve", "QuadCurveRel", "QuadSmooth", "QuadSmoothRel",
     "Arc", "ArcRel", "ClosePath")
 
-  enum("VFR", { type="int", start=1, comment="Vector fill rules for the FillRule field in the Vector class." },
+  enums("VFR", { type="int", start=1, comment="Vector fill rules for the FillRule field in the Vector class." },
     "NON_ZERO: This is the default.  This rule determines the 'insideness' of a point on the canvas by drawing a ray from that point to infinity in any direction and then examining the places where a segment of the shape crosses the ray. Starting with a count of zero, add one each time a path segment crosses the ray from left to right and subtract one each time a path segment crosses the ray from right to left. After counting the crossings, if the result is zero then the point is outside the path. Otherwise, it is inside.",
     "EVEN_ODD: This rule determines the 'insideness' of a point on the canvas by drawing a ray from that point to infinity in any direction and counting the number of path segments from the given shape that the ray crosses. If this number is odd, the point is inside; if even, the point is outside.",
     "INHERIT: The rule is inherited from the parent vector(s).",
     "END: Private")
 
-  enum("VIS", { type="int", start=0, comment="Options for the Vector class' Visibility field." },
+  enums("VIS", { type="int", start=0, comment="Options for the Vector class' Visibility field." },
     "HIDDEN: Hide the vector and its children.",
     "VISIBLE: The default.  Ensures that the vector is visible.",
     "COLLAPSE: Hide the vector and its children.  Do not use - provided for SVG compatibility only.",
     "INHERIT: Inherit the visibility state from the parent.")
 
-  enum("VOF", { type="int", comment="Viewport overflow options." },
+  enums("VOF", { type="int", comment="Viewport overflow options." },
     "VISIBLE: The content is not clipped to the viewport's boundary.  This is the default.",
     "HIDDEN: All content is clipped to within the viewport's boundary.",
     "SCROLL: All content is clipped to within the viewport's boundary.  A mechanism to scroll the viewport's content may be provided to the user (SVG capability not currently implemented).",
@@ -82,14 +82,14 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
 
   -- NB: There is a code dependency on the CMP order for RGBA being maintained at 0, 1, 2, 3.
 
-  enum("CMP", { type="int", start=-1, comment="Component selection for RemapFX methods." },
+  enums("CMP", { type="int", start=-1, comment="Component selection for RemapFX methods." },
     "ALL: All colour channels.",
     "RED: The red colour channel.",
     "GREEN: The green colour channel.",
     "BLUE: The blue colour channel.",
     "ALPHA: The alpha channel.")
 
-  enum("VLJ", { type="int", start=0, comment="Options for the look of line joins." }, // Match to agg::line_join_e
+  enums("VLJ", { type="int", start=0, comment="Options for the look of line joins." }, // Match to agg::line_join_e
     "MITER: The default.  A sharp corner is used to join path segments.  The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect. If the ‘stroke-miterlimit’ is exceeded, the line join falls back to BEVEL.",
     "MITER_SMART: An alternative form of MITER that extends beyond the intersection point, similarly to the miter-clip SVG rules.",
     "ROUND: The join is rounded.",
@@ -97,27 +97,27 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "MITER_ROUND: Default to `MITER`, but switch to `ROUND` if the miter limit is exceeded.",
     "INHERIT: Inherit the join option from the parent.")
 
-  enum("VLC", { type="int", start=1, comment="Line-cap options." }, // Match to agg::line_cap_e
+  enums("VLC", { type="int", start=1, comment="Line-cap options." }, // Match to agg::line_cap_e
     "BUTT: The default.  The line is sharply squared off at its exact end point.",
     "SQUARE: Similar to butt, the line is sharply squared off but will extend past the end point by `StrokeWidth / 2`.",
     "ROUND: The line cap is a half-circle and the line's end-point forms the center point.",
     "INHERIT: The cap type is inherited from the parent (defaults to butt if unspecified).")
 
-  enum("VIJ", { type="int", start=1, comment="Inner join options for angled lines." },  // Match to agg::inner_join_e
+  enums("VIJ", { type="int", start=1, comment="Inner join options for angled lines." },  // Match to agg::inner_join_e
     "BEVEL: Blunts the edge of the join.",
     "MITER: Forms a sharp point at the join.  Typically not the best looking option.",
     "JAG: A special non-SVG option.",
     "ROUND: Rounds the edge of the join to produce the best looking results.",
     "INHERIT: Inherit the parent's join value.")
 
-  enum("VGT", { type="int", start=0, comment="VectorGradient options." },
+  enums("VGT", { type="int", start=0, comment="VectorGradient options." },
     "LINEAR: A linear gradient is drawn from `(X1, Y1)` to `(X2, Y2)`.",
     "RADIAL: A radial gradient is drawn from `CenterX, CenterY` to `Radius`.  An optional focal point can be expressed with `FX` and `FY`.",
     "CONIC: The conic gradient is a variant on the radial type, whereby the colour values are drawn as a line that revolves around the cone's center point.",
     "DIAMOND: A diamond gradient is drawn as a square emanating from the center point.",
     "CONTOUR: Contoured gradients follow the contours of the vector path in which they are rendered.")
 
-  enum("VTS", { type="int", start=0, comment="Options for stretching text in VectorText." },
+  enums("VTS", { type="int", start=0, comment="Options for stretching text in VectorText." },
     "INHERIT",
     "NORMAL",
     "WIDER",
@@ -131,11 +131,11 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "ULTRA_EXPANDED",
     "EXTRA_EXPANDED")
 
-  enum("MOP", { type="int", start=0, comment="MorphologyFX options." },
+  enums("MOP", { type="int", start=0, comment="MorphologyFX options." },
     "ERODE: Erode (thin) the input source.",
     "DILATE: Dilate (fatten) the input source.")
 
-   enum("OP", { type="int", start=0, comment="Operators for CompositionFX." },
+   enums("OP", { type="int", start=0, comment="Operators for CompositionFX." },
     "OVER: The Porter-Duff 'over' operator, this is the default operation for standard alpha blending.",
     "IN: The Porter-Duff 'in' operator; the input alpha channel has priority and the mix channel is secondary.",
     "OUT: The Porter-Duff 'out' operator; the mix alpha channel is inversed with the input channel.",
@@ -181,12 +181,12 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "Y_MID: Align the source so that it is morphed along the middle of the target path.",
     "Y_MAX: Align the source so that it is morphed along the bottom of the target path.")
 
-  enum("VCS", { type="int", start=0, comment="Colour space options." },
+  enums("VCS", { type="int", start=0, comment="Colour space options." },
     "INHERIT: Inherit the colour space option from the parent vector.",
     "SRGB: The default colour-space is sRGB, recommended for its speed.",
     "LINEAR_RGB: Linear RGB is the default colour space for SVG and produces the best results.")
 
-  enum("VSF", { type="int", start=0, comment="Filter source types - these are used internally", restrict="c" },
+  enums("VSF", { type="int", start=0, comment="Filter source types - these are used internally", restrict="c" },
     "IGNORE|NONE: The filter does not require an input source.",
     "GRAPHIC: Represents the graphics elements that were the original input into the filter element.",
     "ALPHA: As for `GRAPHIC` except that only the alpha channel is used.",
@@ -197,17 +197,17 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "REFERENCE: This value is an assigned name for the filter primitive in the form of a custom-ident. If supplied, then graphics that result from processing this filter primitive can be referenced by an in attribute on a subsequent filter primitive within the same filter element. If no value is provided, the output will only be available for re-use as the implicit input into the next filter primitive if that filter primitive provides no value for its in attribute.",
     "PREVIOUS: Use the previous effect as input, or source graphic if no previous effect.")
 
-  enum("WVC", { type="int", start=1, comment="Wave options." },
+  enums("WVC", { type="int", start=1, comment="Wave options." },
     "NONE: Do not close the path.",
     "TOP: Close the path across the top of its area.",
     "BOTTOM: Close the path across the bottom of its area.")
 
-  enum("WVS", { type="int", start=1, comment="Wave style options." },
+  enums("WVS", { type="int", start=1, comment="Wave style options." },
     "CURVED: Standard sine-wave curvature, this is the default.",
     "ANGLED: Chevron style angles at 45 degrees either side of the peak and bottom edge.",
     "SAWTOOTH: Sawtooth patterns rise at 45 degrees to the peak, then direct 90 degrees to the bottom.")
 
-  enum("CM", { type="int", start=0, comment="Colour modes for ColourFX." },
+  enums("CM", { type="int", start=0, comment="Colour modes for ColourFX." },
     "NONE: Do nothing.",
     "MATRIX: Process the supplied 5x4 matrix values.",
     "SATURATE: Adjust colour saturation with the first parameter defining the multiplier.",
@@ -248,11 +248,11 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "RESIZE: The vector will be stretched to fit the @VectorScene.PageWidth and @VectorScene.PageHeight values, if defined by the client.",
     "OUTLINE_VIEWPORTS: Draw a green outline around all viewport paths.  Extremely useful for debugging layout issues.")
 
-  enum("TB", { type="int", start=0, "Function identifier for TurbulenceFX." },
+  enums("TB", { type="int", start=0, "Function identifier for TurbulenceFX." },
     "TURBULENCE: Use the standard turbulence function.",
     "NOISE: Use the fractal noise function.")
 
-  enum("VSM", { type="int", start=0, comments="Options for the VectorScene SampleMethod." },
+  enums("VSM", { type="int", start=0, comments="Options for the VectorScene SampleMethod." },
     "AUTO: The default option is chosen by the system.  This will typically be `BILINEAR`, but slow machines may switch to nearest neighbour and high speed machines could use more advanced methods.",
     "NEIGHBOUR: Nearest neighbour is the fastest sampler at the cost of poor quality.",
     "BILINEAR: Bilinear is a common algorithm that produces a reasonable quality image quickly.",
@@ -267,7 +267,7 @@ module({ name="Vector", copyright="Paul Manias © 2010-2026", version=1.0, times
     "LANCZOS: This well known algorithm may serve as a point of comparison for evaluating the results of other methods.  It shares characteristics with `SINC` and `BLACKMAN`.",
     "BLACKMAN: Five times slower than `BILINEAR`, the final result will be less sharp than SINC.")
 
-  enum("RQ", { type="int", start=0, comments="Options for determining the quality of a rendered path." },
+  enums("RQ", { type="int", start=0, comments="Options for determining the quality of a rendered path." },
     "AUTO: The default option is chosen by the system.",
     "FAST: Use the fastest renderer available and allow accuracy to be compromised in favour of speed.  Recommended for normalised paths that are known to be rectangular.",
     "CRISP: Use a good quality renderer that produces crisp outlines (no anti-aliasing).",

--- a/src/xml/constants.tdl
+++ b/src/xml/constants.tdl
@@ -29,7 +29,7 @@ flags("XMF", { comment="Standard flags for the XML class." },
   "STANDALONE: Automatically defined when the XML declaration specifies standalone=\"yes\".",
   { INCLUDE_SIBLINGS = "0x80000000: Include siblings when building an XML string (#GetXMLString() only)" })
 
-enum("XMI", { type="int", start=0, comment="Tag insertion options." },
+enums("XMI", { type="int", start=0, comment="Tag insertion options." },
   "PREV|PREVIOUS: Insert as the previous tag of the target.",
   "CHILD: Insert as the first child of the target.",
   "NEXT: Insert as the next tag of the target.",
@@ -42,7 +42,7 @@ flags("XTF", { comment="Standard flags for XTag." },
   "NOTATION: Tag represents a notation of the format `<!XML>`.",
   "COMMENT: Tag represents a comment of the format `<!-- Comment -->`.")
 
-enum('XPVT', { type='int', start=0, comment='Type descriptors for XPathValue' },
+enums('XPVT', { type='int', start=0, comment='Type descriptors for XPathValue' },
    'NodeSet',
    'Boolean',
    'Number',

--- a/src/xquery/constants.tdl
+++ b/src/xquery/constants.tdl
@@ -1,5 +1,5 @@
 
-enum('XQueryNodeType', { type='int', start=0 },
+enums('XQueryNodeType', { type='int', start=0 },
   -- Location path components
   'LOCATION_PATH',
   'STEP',

--- a/tools/idl/common-graphics.tdl
+++ b/tools/idl/common-graphics.tdl
@@ -1,6 +1,6 @@
 -- These graphics constants are re-usable across all modules.
 
-enum("PTC", { type="int", start=0, comment="Predefined cursor styles" },
+enums("PTC", { type="int", start=0, comment="Predefined cursor styles" },
   "NO_CHANGE",
   "DEFAULT: The default cursor (usually an arrow pointing to the upper left).",
   "SIZE_BOTTOM_LEFT: Sizing cursor - for resizing the bottom left corner of any rectangular area.",
@@ -58,7 +58,7 @@ flags("DMF", { type="int", bits=32 },
   }
 )
 
-enum("DRL", { type="int", start=0, comment="Compass directions." },
+enums("DRL", { type="int", start=0, comment="Compass directions." },
   "NORTH|UP",
   "SOUTH|DOWN",
   "EAST|RIGHT",

--- a/tools/idl/common.tdl
+++ b/tools/idl/common.tdl
@@ -5,7 +5,7 @@ flags("CLIPMODE", { comment="Clipboard modes", module="Core" },
     "COPY: Copy from the clipboard.",
     "PASTE: Paste from the clipboard.")
 
-enum("SEEK", { type="int", start=0, comment="Seek positions", module="Core" },
+enums("SEEK", { type="int", start=0, comment="Seek positions", module="Core" },
     "START: Use an index at position zero.",
     "CURRENT: Use an index at the end of the last read/write operation.",
     "END: Use an index at the end of the data buffer.",
@@ -46,7 +46,7 @@ flags("CCF", { comment="Class categories", module="Core" },
     "NETWORK: Network classes interface with system drivers to simplify network communications.",
     "MULTIMEDIA: Classes that represent more than one media type, e.g. video files.")
 
-enum("AC", { type="int", start=1, comment="Action identifiers.", module="Core" },
+enums("AC", { type="int", start=1, comment="Action identifiers.", module="Core" },
     "Signal",       "Activate",       "Redimension",  "Clear",    "FreeWarning",  "Enable",       "CopyData",
     "DataFeed",     "Deactivate",     "Draw",         "Flush",    "Focus",        "Free",         "SaveSettings",
     "GetKey",       "DragDrop",       "Hide",         "Init",     "Lock",         "LostFocus",    "Move",
@@ -149,7 +149,7 @@ flags("MEM", { comment="Memory types used by AllocMemory().  The lower 16 bits a
     { CALLER        = "0x00800000: This flag is usable only in routines that are supporting a class method.  It forces the memory allocation to be tracked to the object that made the method call.  This is particularly important in methods that return memory blocks that do not form a part of the object itself." },
     { READ_WRITE    = "READ|WRITE" })
 
-enum("EVG", { type="int", start=1, comment="Event categories.", module="Core" }, -- 5 bit limit (max 32 entries).  These constants are also managed in core.tiri and tiri_functions.c, line 493
+enums("EVG", { type="int", start=1, comment="Event categories.", module="Core" }, -- 5 bit limit (max 32 entries).  These constants are also managed in core.tiri and tiri_functions.c, line 493
     "FILESYSTEM: File system events.",
     "NETWORK: Network events.",
     "SYSTEM: System-wide events",
@@ -165,7 +165,7 @@ enum("EVG", { type="int", start=1, comment="Event categories.", module="Core" },
     "ANDROID: Android specific events that do not already fit existing categories.",
     "END: Private")
 
-enum("DATA", { type="int", start=1, comment="Data codes", module="Core" }, -- NB: Duplicated in display/win32/windows.c
+enums("DATA", { type="int", start=1, comment="Data codes", module="Core" }, -- NB: Duplicated in display/win32/windows.c
     "TEXT: Standard ASCII text",
     "RAW: Raw unprocessed data",
     "DEVICE_INPUT: Device activity",
@@ -212,7 +212,7 @@ flags("CON", { comment="Gamepad controller buttons.", module="core" },
     "RIGHT_THUMB: Right thumb stick depressed."
     )
 
-enum("JET", { type="int", start=1, comment="JET constants are documented in GetInputEvent()", module="Core" },
+enums("JET", { type="int", start=1, comment="JET constants are documented in GetInputEvent()", module="Core" },
     "BUTTON_1|LMB: Left mouse button; XBox A button, PS square button.  Value is pressure sensitive, ranging between 0 - 1.0 (0 is released, 1.0 is fully depressed).",
     "BUTTON_2|RMB: Right mouse button; XBox X button, PS cross button.",
     "BUTTON_3|MMB: Middle mouse button; XBox Y button, PS triangle.",

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -521,7 +521,7 @@ global function idlFunction(Name:str, Category:str, Comment:str, Status:str, Des
    -- Find the registered function definition that must have been pre-declared in the TDL.
 
    local func
-   for k, f in ipairs(glFunctions) do
+   for f in values(glFunctions) do
       if f.name is Name then
          func = f
          break
@@ -530,7 +530,7 @@ global function idlFunction(Name:str, Category:str, Comment:str, Status:str, Des
 
    if not func then
       list = ''
-      for k, f in ipairs(glFunctions) do
+      for f in values(glFunctions) do
          list ..= f.name .. '\n'
       end
       error("Function '" .. Name .. "' is not declared in the TDL.  Known functions are:\n" .. list)

--- a/tools/idl/idl-compile.tiri
+++ b/tools/idl/idl-compile.tiri
@@ -149,7 +149,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-global function enum(Prefix, Options:table, ...)
+global function enums(Prefix, Options:table, ...)
    Options ?= {}
 
    if Options.restrict?? or glRestrict then return end -- Restricted definitions are never exported

--- a/tools/idl/include/functions.tiri
+++ b/tools/idl/include/functions.tiri
@@ -491,7 +491,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- TDL function
 
-global function enum(Prefix:str, Options:table, ...)
+global function enums(Prefix:str, Options:table, ...)
    verbose(f'Processing {Prefix} enum.')
    if glCustomTypes[Prefix] then print(f'WARN: A "{Prefix}" constant already exists.') end
 
@@ -562,10 +562,13 @@ global function enum(Prefix:str, Options:table, ...)
    end
 
    glCustomTypes[Prefix] = {
-      prefix=Prefix, grouping='constants', list=list, comment=Options.comment,
-      restrict=(glRestrict ?? Options.restrict),
-      bits=Options.bits,
-      type=Options.type -- Promotes strong-typing to other C++ definitions
+      prefix   = Prefix,
+      grouping = 'constants',
+      list     = list,
+      comment  = Options.comment,
+      restrict = (glRestrict ?? Options.restrict),
+      bits     = Options.bits,
+      type     = Options.type -- Promotes strong-typing to other C++ definitions
    }
 end
 


### PR DESCRIPTION
## Summary

- Reimplemented `enum` as a reserved keyword in the Tiri parser, backed by the registry for constant declarations
- Renamed the TDL `enum()` function to `enums()` across all module TDL files and IDL tooling to avoid conflicts with the new keyword
- Updated Tiri parser AST (builder, expressions, statements, lexer/token types) to support the new `enum` syntax
- Expanded `test_enum.tiri` with broader coverage of the new enum declaration behaviour

## Test plan

- [ ] Build and install the project successfully
- [ ] Run `ctest` integration tests, particularly `test_enum.tiri`
- [ ] Verify TDL-generated headers compile correctly with renamed `enums()` function
- [ ] Confirm enum constants are accessible via the Tiri registry after declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)