### PR TITLE
[Tiri] Prevent enum constants from leaking into the global registry on parse failure

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -35,7 +35,7 @@
 
 static void rollback_ast_builder_constants(void *UserData)
 {
-   ((AstBuilder *)UserData)->rollback_registered_enum_constants();
+   ((AstBuilder *)UserData)->rollback_registered_enum_hierarchy();
 }
 
 static FunctionExprPayload * function_payload_from(ExprNode &Node)
@@ -159,7 +159,7 @@ static ParserResult<StmtNodePtr> make_control_stmt(ParserContext& Context, AstNo
    return ParserResult<StmtNodePtr>::success(std::move(node));
 }
 
-AstBuilder::AstBuilder(ParserContext &Context) : ctx(Context)
+AstBuilder::AstBuilder(ParserContext &Context, AstBuilder *Parent) : ctx(Context), parent_builder(Parent)
 {
    this->ctx.set_error_rollback_callback(rollback_ast_builder_constants, this);
 }
@@ -198,6 +198,12 @@ void AstBuilder::rollback_registered_enum_constants()
       glConstantRegistry.erase(hash);
    }
    this->registered_enum_constants.clear();
+}
+
+void AstBuilder::rollback_registered_enum_hierarchy()
+{
+   this->rollback_registered_enum_constants();
+   if (this->parent_builder) this->parent_builder->rollback_registered_enum_hierarchy();
 }
 
 AstBuilder::FunctionNameScope::FunctionNameScope(AstBuilder &Builder, GCstr *FunctionName) : builder(Builder)

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -33,6 +33,11 @@
 
 // Extracts the function payload from an expression node if it's a function expression, otherwise returns null.
 
+static void rollback_ast_builder_constants(void *UserData)
+{
+   ((AstBuilder *)UserData)->rollback_registered_enum_constants();
+}
+
 static FunctionExprPayload * function_payload_from(ExprNode &Node)
 {
    if (Node.kind != AstNodeKind::FunctionExpr) return nullptr;
@@ -156,6 +161,43 @@ static ParserResult<StmtNodePtr> make_control_stmt(ParserContext& Context, AstNo
 
 AstBuilder::AstBuilder(ParserContext &Context) : ctx(Context)
 {
+   this->ctx.set_error_rollback_callback(rollback_ast_builder_constants, this);
+}
+
+AstBuilder::~AstBuilder()
+{
+   this->rollback_registered_enum_constants();
+   this->ctx.clear_error_rollback_callback(this);
+}
+
+void AstBuilder::commit_registered_enum_constants()
+{
+   this->registered_enum_constants.clear();
+   this->enum_constants_committed = true;
+}
+
+void AstBuilder::track_registered_enum_constant(uint32_t Hash)
+{
+   this->registered_enum_constants.push_back(Hash);
+   this->enum_constants_committed = false;
+}
+
+void AstBuilder::adopt_registered_enum_constants(AstBuilder &Child)
+{
+   this->registered_enum_constants.insert(this->registered_enum_constants.end(),
+      Child.registered_enum_constants.begin(), Child.registered_enum_constants.end());
+   Child.registered_enum_constants.clear();
+}
+
+void AstBuilder::rollback_registered_enum_constants()
+{
+   if (this->enum_constants_committed or this->registered_enum_constants.empty()) return;
+
+   std::unique_lock lock(glConstantMutex);
+   for (uint32_t hash : this->registered_enum_constants) {
+      glConstantRegistry.erase(hash);
+   }
+   this->registered_enum_constants.clear();
 }
 
 AstBuilder::FunctionNameScope::FunctionNameScope(AstBuilder &Builder, GCstr *FunctionName) : builder(Builder)
@@ -170,12 +212,12 @@ AstBuilder::FunctionNameScope::~FunctionNameScope()
 
 AstBuilder::BlockDepthScope::BlockDepthScope(AstBuilder &Builder) : builder(Builder)
 {
-   this->builder.block_depth_++;
+   this->builder.block_depth++;
 }
 
 AstBuilder::BlockDepthScope::~BlockDepthScope()
 {
-   this->builder.block_depth_--;
+   this->builder.block_depth--;
 }
 
 GCstr *AstBuilder::anonymous_function_name()

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -18,7 +18,7 @@
 
 class AstBuilder {
 public:
-   explicit AstBuilder(ParserContext& context);
+   explicit AstBuilder(ParserContext& context, AstBuilder *Parent = nullptr);
    ~AstBuilder();
 
    AstBuilder(const AstBuilder &) = delete;
@@ -29,6 +29,7 @@ public:
    ParserResult<ExprNodeList> parse_expression_list();
    void commit_registered_enum_constants();
    void rollback_registered_enum_constants();
+   void rollback_registered_enum_hierarchy();
 
    [[nodiscard]] bool at_top_level() const { return function_depth IS 0 and block_depth IS 0; }
 
@@ -39,6 +40,7 @@ private:
    int function_depth = 0;           // Tracks nesting depth inside function bodies
    int block_depth = 0;              // Tracks nested statement blocks below chunk scope
    bool enum_constants_committed = false;
+   AstBuilder *parent_builder = nullptr;
    std::vector<GCstr *> function_name_stack;
    std::vector<uint32_t> registered_enum_constants;
 

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <span>
@@ -18,20 +19,28 @@
 class AstBuilder {
 public:
    explicit AstBuilder(ParserContext& context);
+   ~AstBuilder();
+
+   AstBuilder(const AstBuilder &) = delete;
+   AstBuilder& operator=(const AstBuilder &) = delete;
 
    ParserResult<std::unique_ptr<BlockStmt>> parse_chunk();
    ParserResult<ExprNodePtr> parse_expression(uint8_t precedence = 0);
    ParserResult<ExprNodeList> parse_expression_list();
+   void commit_registered_enum_constants();
+   void rollback_registered_enum_constants();
 
-   [[nodiscard]] bool at_top_level() const { return function_depth_ IS 0 and block_depth_ IS 0; }
+   [[nodiscard]] bool at_top_level() const { return function_depth IS 0 and block_depth IS 0; }
 
 private:
    ParserContext& ctx;
    bool in_guard_expression = false;  // True when parsing 'when' clause guard expression
    bool in_choose_expression = false; // True when parsing choose expression cases (for tuple pattern detection)
-   int function_depth_ = 0;           // Tracks nesting depth inside function bodies
-   int block_depth_ = 0;              // Tracks nested statement blocks below chunk scope
+   int function_depth = 0;           // Tracks nesting depth inside function bodies
+   int block_depth = 0;              // Tracks nested statement blocks below chunk scope
+   bool enum_constants_committed = false;
    std::vector<GCstr *> function_name_stack;
+   std::vector<uint32_t> registered_enum_constants;
 
    class FunctionNameScope {
    public:
@@ -69,6 +78,8 @@ private:
    ParserResult<StmtNodePtr> parse_global();
    ParserResult<StmtNodePtr> parse_enum(const Token &StartToken);
    ParserResult<int64_t> parse_enum_integer_literal();
+   void track_registered_enum_constant(uint32_t Hash);
+   void adopt_registered_enum_constants(AstBuilder &Child);
    ParserResult<StmtNodePtr> parse_function_stmt();
    ParserResult<StmtNodePtr> parse_annotated_statement();
    ParserResult<std::vector<AnnotationEntry>> parse_annotations();

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -40,9 +40,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
 
    const TokenKind terms[] = { TokenKind::EndToken };
    FunctionNameScope function_name_scope(*this, FunctionName);
-   ++this->function_depth_;
+   ++this->function_depth;
    auto body = this->parse_block(terms);
-   --this->function_depth_;
+   --this->function_depth;
    if (not body.ok()) return ParserResult<ExprNodePtr>::failure(body.error_ref());
 
    this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1202,18 +1202,19 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_imported_file(std::st
    import_lex->fs = &fs;
    import_lex->L = L;
 
-   import_lex->next(); // Prime the lexer
-
    // Create a temporary parser context for the imported file
    ParserContext import_ctx(*import_lex, fs, *L, ParserAllocator::from(L), this->ctx.config());
+   import_ctx.set_error_rollback_callback(rollback_ast_builder_constants, this);
 
    // Copy the import stack to the child context for circular detection
    for (const auto& imported_path : this->ctx.import_stack()) {
       import_ctx.push_import(imported_path);
    }
 
+   import_lex->next(); // Prime the lexer
+
    // Parse up to EOF
-   AstBuilder import_builder(import_ctx);
+   AstBuilder import_builder(import_ctx, this);
    const TokenKind terms[] = { TokenKind::EndOfFile };
    auto result = import_builder.parse_block(terms);
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -374,7 +374,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
    {
       std::unique_lock lock(glConstantMutex);
       for (const EnumConstantDecl &constant : constants) {
-         if (glConstantRegistry.contains(kt::strhash(constant.name))) {
+         uint32_t hash = kt::strhash(constant.name);
+         if (glConstantRegistry.contains(hash)) {
             duplicate_name = constant.name;
             duplicate_span = constant.span;
             break;
@@ -383,7 +384,9 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
 
       if (duplicate_name.empty()) {
          for (const EnumConstantDecl &constant : constants) {
-            glConstantRegistry.emplace(kt::strhash(constant.name), TiriConstant(constant.value));
+            uint32_t hash = kt::strhash(constant.name);
+            glConstantRegistry.emplace(hash, TiriConstant(constant.value));
+            this->track_registered_enum_constant(hash);
          }
       }
    }
@@ -1225,6 +1228,8 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_imported_file(std::st
       error.message = "in imported file '" + Path + "': " + error.message;
       return ParserResult<std::unique_ptr<BlockStmt>>::failure(error);
    }
+
+   this->adopt_registered_enum_constants(import_builder);
 
    return result;
 }

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1834,6 +1834,7 @@ static void lj_lex_error_no_skip(LexState *State, LexToken tok, ErrMsg em)
       return;  // Don't skip, don't set had_lex_error - caller returns synthetic token
    }
 
+   if (State->active_context) State->active_context->rollback_before_error();
    lj_err_lex(State->L, State->chunk_name, tokstr, State->linenumber, em, nullptr);
 }
 
@@ -1916,6 +1917,7 @@ void lj_lex_error(LexState *State, LexToken tok, ErrMsg em, ...)
       return;  // Return without throwing - caller will handle recovery
    }
 
+   if (State->active_context) State->active_context->rollback_before_error();
    lj_err_lex(State->L, State->chunk_name, tokstr, State->lastline, em, argp);
    va_end(argp);
 }

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -164,6 +164,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    auto chunk_result = builder.parse_chunk();
 
    if (not chunk_result.ok()) {
+      builder.rollback_registered_enum_constants();
       report_pipeline_error(Context, chunk_result.error_ref());
       flush_non_fatal_errors(Context);
       return;
@@ -171,6 +172,13 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
 
    std::unique_ptr<BlockStmt> chunk = std::move(chunk_result.value_ref());
    parse_timer.stop();
+
+   if (Context.diagnostics().has_errors() and Context.config().abort_on_error) {
+      builder.rollback_registered_enum_constants();
+      raise_accumulated_diagnostics(Context);
+      return;
+   }
+
    trace_ast_boundary(Context, *chunk, "parse");
    collect_parser_symbols(Context.lua(), *chunk);
 
@@ -182,6 +190,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
       // Raise errors now, required to check for type violations.
       // In diagnose mode (abort_on_error=false), continue to emit to collect more errors.
       if (Context.diagnostics().has_errors() and Context.config().abort_on_error) {
+         builder.rollback_registered_enum_constants();
          raise_accumulated_diagnostics(Context);
          return;
       }
@@ -193,10 +202,18 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    IrEmitter emitter(Context);
    auto emit_result = emitter.emit_chunk(*chunk);
    if (not emit_result.ok()) {
+      builder.rollback_registered_enum_constants();
       report_pipeline_error(Context, emit_result.error_ref());
       flush_non_fatal_errors(Context);
       return;
    }
+
+   if (Context.diagnostics().has_errors()) {
+      builder.rollback_registered_enum_constants();
+      return;
+   }
+
+   builder.commit_registered_enum_constants();
 
    emit_timer.stop();
 }

--- a/src/tiri/jit/src/parser/parser_context.cpp
+++ b/src/tiri/jit/src/parser/parser_context.cpp
@@ -28,11 +28,15 @@ ParserContext & ParserContext::operator=(ParserContext &&other) noexcept
       this->diag.set_limit(this->current_config.max_diagnostics);
       this->token_stream     = other.token_stream;
       this->previous_context = other.previous_context;
+      this->error_rollback_callback = other.error_rollback_callback;
+      this->error_rollback_user_data = other.error_rollback_user_data;
       if (this->lex_state) this->lex_state->active_context = this;
       other.lex_state        = nullptr;
       other.func_state       = nullptr;
       other.lua_state        = nullptr;
       other.previous_context = nullptr;
+      other.error_rollback_callback = nullptr;
+      other.error_rollback_user_data = nullptr;
    }
    return *this;
 }
@@ -245,9 +249,37 @@ void ParserContext::emit_error(ParserErrorCode code, const Token &token, std::st
       if (this->lua().parser_diagnostics) delete (ParserDiagnostics*)this->lua().parser_diagnostics;
       this->lua().parser_diagnostics = new ParserDiagnostics(this->diagnostics());
 
+      this->rollback_before_error();
       lj_lex_error(this->lex_state, this->lex_state->tok, ErrMsg::XTOKEN, this->lex_state->token2str(token.raw()));
    }
    // In DIAGNOSE mode (abort_on_error=false), skip logging - errors will be reported later
+}
+
+//********************************************************************************************************************
+
+void ParserContext::set_error_rollback_callback(ErrorRollbackCallback Callback, void *UserData)
+{
+   this->error_rollback_callback = Callback;
+   this->error_rollback_user_data = UserData;
+}
+
+void ParserContext::clear_error_rollback_callback(void *UserData)
+{
+   if (this->error_rollback_user_data IS UserData) {
+      this->error_rollback_callback = nullptr;
+      this->error_rollback_user_data = nullptr;
+   }
+}
+
+void ParserContext::rollback_before_error()
+{
+   if (this->error_rollback_callback) {
+      auto callback = this->error_rollback_callback;
+      auto user_data = this->error_rollback_user_data;
+      this->error_rollback_callback = nullptr;
+      this->error_rollback_user_data = nullptr;
+      callback(user_data);
+   }
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/parser_context.h
+++ b/src/tiri/jit/src/parser/parser_context.h
@@ -92,6 +92,8 @@ private:
 
 class ParserContext {
 public:
+   using ErrorRollbackCallback = void (*)(void *);
+
    static ParserContext from(LexState &lex_state, FuncState &func_state, ParserAllocator allocator,
       ParserConfig config = ParserConfig{}) {
       return ParserContext(lex_state, func_state, *lex_state.L, allocator, config);
@@ -117,12 +119,16 @@ public:
       , lua_state(other.lua_state), allocator(other.allocator)
       , current_config(other.current_config), diag(std::move(other.diag))
       , token_stream(other.token_stream), previous_context(other.previous_context)
+      , error_rollback_callback(other.error_rollback_callback)
+      , error_rollback_user_data(other.error_rollback_user_data)
    {
       if (this->lex_state) this->lex_state->active_context = this;
       other.lex_state = nullptr;
       other.func_state = nullptr;
       other.lua_state = nullptr;
       other.previous_context = nullptr;
+      other.error_rollback_callback = nullptr;
+      other.error_rollback_user_data = nullptr;
    }
 
    inline LexState & lex() const { return *this->lex_state; }
@@ -169,6 +175,9 @@ public:
 
    void emit_error(ParserErrorCode code, const Token &, std::string_view);
    void emit_warning(ParserErrorCode code, const Token &, std::string_view);
+   void set_error_rollback_callback(ErrorRollbackCallback, void *);
+   void clear_error_rollback_callback(void *);
+   void rollback_before_error();
 
    // Import stack tracking for compile-time import statement
    [[nodiscard]] bool is_importing(const std::string &) const;
@@ -195,6 +204,8 @@ private:
    ParserDiagnostics diag;
    TokenStreamAdapter token_stream;
    ParserContext *previous_context = nullptr;
+   ErrorRollbackCallback error_rollback_callback = nullptr;
+   void *error_rollback_user_data = nullptr;
    std::vector<std::string> import_stack_;  // Stack of imported file paths for circular dependency detection
 };
 

--- a/src/tiri/tests/import_enum_bad_lexer.tiri
+++ b/src/tiri/tests/import_enum_bad_lexer.tiri
@@ -1,0 +1,1 @@
+"unterminated

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -115,6 +115,33 @@ assert(debug.locality('%s_ONE') is 'nil')
 ]], prefix, prefix, prefix))
 end
 
+@Test function LexerErrorChunkDoesNotLeakEnumConstants()
+   glDynamicEnumCounter++
+   local prefix = 'LEX_LEAK_ENUM_' .. tostring(glDynamicEnumCounter)
+   local failed = false
+
+   try
+      exec(string.format([[
+enum %s {
+   ONE,
+}
+local broken = "unterminated
+]], prefix))
+   except ex
+      failed = true
+   end
+
+   assert(failed, 'Broken lexer chunk should fail before constants are committed')
+
+   exec(string.format([[
+enum %s {
+   ONE,
+}
+assert(%s_ONE is 0)
+assert(debug.locality('%s_ONE') is 'nil')
+]], prefix, prefix, prefix))
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Error cases
 

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -142,6 +142,33 @@ assert(debug.locality('%s_ONE') is 'nil')
 ]], prefix, prefix, prefix))
 end
 
+@Test function ImportLexerErrorDoesNotLeakParentEnumConstants()
+   glDynamicEnumCounter++
+   local prefix = 'IMPORT_LEAK_ENUM_' .. tostring(glDynamicEnumCounter)
+   local failed = false
+
+   try
+      exec(string.format([[
+enum %s {
+   ONE,
+}
+import './src/tiri/tests/import_enum_bad_lexer'
+]], prefix))
+   except ex
+      failed = true
+   end
+
+   assert(failed, 'Broken imported chunk should fail before parent constants are committed')
+
+   exec(string.format([[
+enum %s {
+   ONE,
+}
+assert(%s_ONE is 0)
+assert(debug.locality('%s_ONE') is 'nil')
+]], prefix, prefix, prefix))
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Error cases
 

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -86,6 +86,35 @@ assert(debug.locality('%s_FIRST') is 'nil')
 ]], prefix, prefix, prefix, prefix))
 end
 
+@Test function FailedChunkDoesNotLeakEnumConstants()
+   glDynamicEnumCounter++
+   local prefix = 'LEAK_ENUM_' .. tostring(glDynamicEnumCounter)
+   local failed = false
+
+   try
+      exec(string.format([[
+enum %s {
+   ONE,
+}
+if true then
+]], prefix))
+   except ex
+      failed = true
+      assert(ex.message:find('expected') or ex.message:find('unexpected') or ex.message:find('end'),
+         f'Broken enum chunk should fail with a parse error: {ex.message}')
+   end
+
+   assert(failed, 'Broken enum chunk should fail before constants are committed')
+
+   exec(string.format([[
+enum %s {
+   ONE,
+}
+assert(%s_ONE is 0)
+assert(debug.locality('%s_ONE') is 'nil')
+]], prefix, prefix, prefix))
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Error cases
 


### PR DESCRIPTION
## Summary

- `AstBuilder` now tracks the hash of every enum constant it registers in `glConstantRegistry` and rolls them all back if compilation fails, preventing stale entries from surviving into subsequent compilations
- `ParserContext` gains a lightweight error-rollback callback (`set_error_rollback_callback` / `clear_error_rollback_callback` / `rollback_before_error`) invoked just before a fatal parse error is raised, ensuring cleanup happens even on the `lj_lex_error` path
- The parser pipeline (`run_ast_pipeline`) commits enum constants only when the entire pipeline succeeds; every failure path (AST parse error, post-parse diagnostic check, type-checker error, IR emission error, late diagnostic check) now calls `rollback_registered_enum_constants` before returning
- Enum constants from `import`-ed files are adopted into the parent builder so they participate in the same commit/rollback lifecycle

## Test plan

- [ ] Build the Tiri module (`cmake --build build/agents --config Debug --target tiri --parallel`) and install
- [ ] Run the existing enum test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L test_enum`
- [ ] Verify the new `FailedChunkDoesNotLeakEnumConstants` test passes — it compiles a broken chunk containing an `enum` declaration and asserts that the constant is not visible in a subsequent successful compilation
- [ ] Confirm no regressions in other Tiri parser tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)