### PR TITLE
[Tiri] Implement io.close() for the default output file

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -346,20 +346,6 @@ struct finput {
    int8_t Mode;
 };
 
-enum { NUM_DOUBLE=1, NUM_FLOAT, NUM_INT64, NUM_INT, NUM_INT16, NUM_BYTE };
-
-struct fnumber { // TODO: Use std::variant
-   int Type;     // Expressed as an FD_ flag.
-   union {
-      double  f64;
-      float   f32;
-      int64_t i64;
-      int     i32;
-      int16_t i16;
-      int8_t  i8;
-   };
-};
-
 struct module {
    struct Function *Functions = nullptr;
    OBJECTPTR Module = nullptr;
@@ -373,12 +359,6 @@ struct module {
 constexpr uint32_t simple_hash(CSTRING String, uint32_t Hash = 0) {
    auto crc = kt::detail::crc32c_finalise(Hash);
    while (auto c = *String++) crc = kt::detail::crc32c_byte(crc, uint8_t(c));
-   return kt::detail::crc32c_finalise(crc);
-}
-
-constexpr uint32_t char_hash(char Char, uint32_t Hash = 0) {
-   auto crc = kt::detail::crc32c_finalise(Hash);
-   crc = kt::detail::crc32c_byte(crc, uint8_t(Char));
    return kt::detail::crc32c_finalise(crc);
 }
 

--- a/src/tiri/tests/test_io.tiri
+++ b/src/tiri/tests/test_io.tiri
@@ -5,7 +5,7 @@ glTestFolder = 'temp:'
 glTestFiles = array<string>
 
 @AfterAll function cleanup()
-   for _, path in glTestFiles do
+   for path in values(glTestFiles) do
       logOutput('Deleting test file ' .. path)
       mSys.DeleteFile(path)
    end
@@ -86,6 +86,28 @@ end
    assert(result is true, 'io.close should return true on success')
    file_type = io.type(file)
    assert(file_type is 'closed file', 'File should be marked as closed, got ' .. tostring(file_type))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test(labels=['io', 'file', 'defaults']) function IOCloseDefaultOutput()
+   output_path = glTestFolder .. 'test_close_default_output.txt'
+   output_file = io.output(output_path)
+   glTestFiles:push(output_path)
+
+   io.write('closed default output')
+   result = io.close()
+
+   assert(result is true, 'io.close() should return true when closing the default output')
+   assert(io.type(output_file) is 'closed file', 'Previous default output should be marked as closed')
+
+   content = readFileContent(output_path)
+   assert(content is 'closed default output', 'Default output content should be flushed when closed')
+
+   current_output = io.output()
+   assert(io.type(current_output) is 'file', 'io.output() should create a new default output after io.close()')
+   assert(current_output != output_file, 'io.output() should not return the closed default output handle')
+   io.close()
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -126,8 +126,26 @@ static int io_open(lua_State *Lua)
 static int io_close(lua_State *Lua)
 {
    if (lua_gettop(Lua) IS 0) {
-      // TODO: Close default output file with FreeResource() and remove it from the registry
-      return 0;
+      lua_pushstring(Lua, "io.defaultOutput");
+      lua_gettable(Lua, LUA_REGISTRYINDEX);
+
+      if (lua_isnil(Lua, -1)) {
+         lua_pop(Lua, 1);
+         lua_pushcfunction(Lua, io_output);
+         lua_call(Lua, 0, 1);
+      }
+
+      if (lua_isnil(Lua, -1)) luaL_error(Lua, ERR::ExpectedFile);
+
+      auto handle = check_file_handle(Lua, -1);
+      handle->close();
+
+      lua_pushstring(Lua, "io.defaultOutput");
+      lua_pushnil(Lua);
+      lua_settable(Lua, LUA_REGISTRYINDEX);
+
+      lua_pushboolean(Lua, 1);
+      return 1;
    }
 
    if (auto handle = check_file_handle(Lua, 1)) {
@@ -435,16 +453,6 @@ static int io_lines(lua_State *Lua)
       return 1;
    }
    else luaL_error(Lua, ERR::File);
-}
-
-//********************************************************************************************************************
-// TODO: Open pipe to running process - requires Task integration and using callbacks to receive data from stdout.
-// This is equivalent to Lua's io.popen()
-
-static int io_openPipe(lua_State *Lua)
-{
-   luaL_error(Lua, ERR::NoSupport, "io.openPipe not yet implemented");
-   return 0;
 }
 
 //********************************************************************************************************************
@@ -813,7 +821,6 @@ void register_io_class(lua_State *Lua)
       { "lines",        io_lines },
       { "open",         io_open },
       { "output",       io_output },
-      { "openPipe",     io_openPipe }, //
       { "read",         io_read },
       { "readAll",      io_readAll },
       { "sanitisePath", io_sanitisePath },
@@ -875,7 +882,6 @@ void register_io_class(lua_State *Lua)
    reg_iface_prototype("io", "input", { TiriType::Any }, { TiriType::Any });
    reg_iface_prototype("io", "output", { TiriType::Any }, { TiriType::Any });
    reg_iface_prototype("io", "lines", { TiriType::Func }, { TiriType::Any });
-   reg_iface_prototype("io", "openPipe", {}, { TiriType::Str });
    reg_iface_prototype("io", "tempFile", { TiriType::Any }, {});
    reg_iface_prototype("io", "type", { TiriType::Str }, { TiriType::Any });
    reg_iface_prototype("io", "readAll", { TiriType::Str }, { TiriType::Str });


### PR DESCRIPTION
## Summary

- Implements `io.close()` when called with no arguments to close and deregister the default output file handle
- Removes the unimplemented `io.openPipe()` stub and its interface registration
- Removes unused `fnumber` struct, `NUM_*` enum, and `char_hash()` helper from `defs.h`

## Test plan

- [ ] Run the `IOCloseDefaultOutput` Flute test to verify `io.close()` correctly closes the default output, flushes content, marks the handle as closed, and resets to a new default output handle
- [ ] Run the full Tiri IO test suite (`ctest -L tiri` or equivalent) to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)