### PR TITLE
Bug fixes for FileInfo tags, SVG volume path detection, and HTTP script loading

### DIFF
--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -296,7 +296,10 @@ ERR AddInfoTag(FileInfo *Info, const std::string_view &Name, const std::string_v
    auto tags = Info->getTags();
    if (not tags) return ERR::CreateResource;
 
-   if (Value.empty()) tags->erase(Name);
+   if (Value.empty()) {
+      tags->erase(Name);
+      if (tags->empty()) Info->clearTags();
+   }
    else tags->insert_or_assign(Name, Value);
    return ERR::Okay;
 }

--- a/src/http/http_incoming.cpp
+++ b/src/http/http_incoming.cpp
@@ -345,7 +345,7 @@ static ERR read_incoming_header(extHTTP *Self, objNetSocket *Socket)
                Self->setCurrentState(HGS::AUTHENTICATING);
 
                // TODO: Needs a rewrite using the dialog script
-               std::string scriptfile((const char *)glAuthScript, 0, glAuthScriptLength);
+               std::string scriptfile((const char *)glAuthScript, glAuthScriptLength);
 
                objScript::create script = { fl::String(scriptfile) };
                if (script.ok()) {

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -1953,7 +1953,8 @@ static bool has_kotuku_volume(const std::string &Path)
 {
    auto volume_end = Path.find(':');
    if ((volume_end IS std::string::npos) or (volume_end IS 0)) return false;
-   if (Path.find_first_of("/\\", 0, volume_end) != std::string::npos) return false;
+   auto separator = Path.find_first_of("/\\");
+   if ((separator != std::string::npos) and (separator < volume_end)) return false;
 
    auto volume = Path.substr(0, volume_end + 1);
 

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -886,6 +886,7 @@ static int struct_destruct(lua_State *Lua)
 {
    if (auto fs = (fstruct *)luaL_checkudata(Lua, 1, "Tiri.struct")) {
       if (fs->Def and fs->Data and ((fs->Deallocate) or (fs->Data IS (APTR)(fs + 1)))) {
+         if (fs->Def->Name IS "FileInfo") ((FileInfo *)fs->Data)->clearTags();
          destroy_struct_cpp_strings(*fs->Def, fs->Data);
       }
 

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -886,7 +886,6 @@ static int struct_destruct(lua_State *Lua)
 {
    if (auto fs = (fstruct *)luaL_checkudata(Lua, 1, "Tiri.struct")) {
       if (fs->Def and fs->Data and ((fs->Deallocate) or (fs->Data IS (APTR)(fs + 1)))) {
-         if (fs->Def->Name IS "FileInfo") ((FileInfo *)fs->Data)->clearTags();
          destroy_struct_cpp_strings(*fs->Def, fs->Data);
       }
 


### PR DESCRIPTION
* [Core] Remove the tags container from FileInfo when the last tag is erased via AddInfoTag()
* [Tiri] Clear FileInfo tags on struct destruction to prevent memory leaks
* [SVG] Fix has_kotuku_volume() to correctly detect separators that appear before the volume colon
* [HTTP] Fix std::string construction from char pointer when loading the auth script