### PR TITLE
[Core] Remove deprecated Static and Target fields from the File class

### DIFF
--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -529,27 +529,6 @@
     </field>
 
     <field>
-      <name>Static</name>
-      <comment>Set to <code>true</code> if a file object should be static.</comment>
-      <access read="R" write="I">Read/Init</access>
-      <type>INT</type>
-      <description>
-<p>This field applies when a file object has been created in an object script.  By default, a file object will auto-terminate when a closing tag is received.  If the object must remain live, set this field to <code>true</code>.</p>
-      </description>
-    </field>
-
-    <field>
-      <name>Target</name>
-      <comment>Specifies a surface ID to target for user feedback and dialog boxes.</comment>
-      <access read="R" write="W">Read/Write</access>
-      <type>OBJECTID</type>
-      <description>
-<p>User feedback can be enabled for certain file operations by setting the Target field to a valid surface ID, or zero for the default target for new windows.  This field is set to <code>-1</code> by default, in order to disable this feature.</p>
-<p>If set correctly, operations such as file deletion or copying will pop-up a progress box after a certain amount of time has elapsed during the operation.  The dialog box will also provide the user with a cancel option to terminate the process early.</p>
-      </description>
-    </field>
-
-    <field>
       <name>Timestamp</name>
       <comment>The last modification time set on a file, represented as a 64-bit integer.</comment>
       <access read="G">Get</access>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2681,8 +2681,6 @@ class objFile : public Object {
 
    int64_t  Position;   // The current read/write byte position in a file.
    FL       Flags;      // File flags and options.
-   int      Static;     // Set to true if a file object should be static.
-   OBJECTID TargetID;   // Specifies a surface ID to target for user feedback and dialog boxes.
    int8_t * Buffer;     // Points to the internal data buffer if the file content is held in memory.
    public:
    inline CSTRING readLine() {
@@ -2813,17 +2811,6 @@ class objFile : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   inline ERR setStatic(const int Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
-      this->Static = Value;
-      return ERR::Okay;
-   }
-
-   inline ERR setTarget(OBJECTID Value) noexcept {
-      this->TargetID = Value;
-      return ERR::Okay;
-   }
-
    inline ERR setDate(APTR Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[10];
@@ -2844,7 +2831,7 @@ class objFile : public Object {
 
    inline ERR setPermissions(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[21];
+      auto field = &this->Class->Dictionary[19];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
@@ -2856,13 +2843,13 @@ class objFile : public Object {
 
    template <class T> inline ERR setLink(T && Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[16];
+      auto field = &this->Class->Dictionary[15];
       return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
    }
 
    inline ERR setUser(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[15];
+      auto field = &this->Class->Dictionary[14];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -710,10 +710,6 @@ static ERR FILE_Init(extFile *Self)
        }
    }
 
-   // Do not do anything if the File is used as a static object in a script
-
-   if (Self->Static and Self->Path.empty()) return ERR::Okay;
-
    if (Self->Path.starts_with(':')) {
       if ((Self->Flags & FL::FILE) != FL::NIL) return log.warning(ERR::ExpectedFile);
       log.trace("Root folder initialised.");
@@ -2581,22 +2577,6 @@ static ERR SET_Size(extFile *Self, int64_t Size)
 /*********************************************************************************************************************
 
 -FIELD-
-Static: Set to `true` if a file object should be static.
-
-This field applies when a file object has been created in an object script.  By default, a file object will
-auto-terminate when a closing tag is received.  If the object must remain live, set this field to `true`.
-
--FIELD-
-Target: Specifies a surface ID to target for user feedback and dialog boxes.
-
-User feedback can be enabled for certain file operations by setting the Target field to a valid surface ID, or zero
-for the default target for new windows.  This field is set to `-1` by default, in order to disable this feature.
-
-If set correctly, operations such as file deletion or copying will pop-up a progress box after a certain amount of time
-has elapsed during the operation.  The dialog box will also provide the user with a cancel option to terminate the
-process early.
-
--FIELD-
 Timestamp: The last modification time set on a file, represented as a 64-bit integer.
 
 The Timestamp field is a 64-bit representation of the last modification date/time set on a file.  It is not guaranteed
@@ -2739,8 +2719,6 @@ static const FieldDef PermissionFlags[] = {
 static const FieldArray FileFields[] = {
    { "Position",     FDF_INT64|FDF_RW, nullptr, SET_Position },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, SET_Flags, &clFileFlags },
-   { "Static",       FDF_INT|FDF_RI },
-   { "Target",       FDF_OBJECTID|FDF_RW, nullptr, nullptr, CLASSID::SURFACE },
    { "Buffer",       FDF_ARRAY|FDF_BYTE|FDF_R, GET_Buffer },
    // Virtual fields
    { "Date",         FDF_POINTER|FDF_STRUCT|FDF_RW, GET_Date, SET_Date, "DateTime" },

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1307,8 +1307,6 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
   class("File", { version=1.2, src="../classes/class_file.cpp", output="../classes/class_file_def.c" }, [[
     large     Position  # The current read/write byte position in a file.
     int(FL)   Flags     # File flags and options.
-    int       Static    # Set to `true` if a file object should be static.
-    oid       Target    # Specifies a surface ID to target for user feedback and dialog boxes.
     ptr(char) Buffer    # Points to the internal data buffer if the file content is held in memory.
   ]],
   nil,

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -343,8 +343,8 @@ int fcmd_loadfile(lua_State *Lua)
             objFile::create src_file = { fl::Path(path) };
             if (src_file.ok()) {
                int64_t fb_ts, src_ts;
-               fb_file->get(FID_TimeStamp, &fb_ts);
-               src_file->get(FID_TimeStamp, &src_ts);
+               fb_file->get(FID_Timestamp, &fb_ts);
+               src_file->get(FID_Timestamp, &src_ts);
 
                if (fb_ts != src_ts) {
                   log.msg("Timestamp mismatch, will recompile the cached version.");


### PR DESCRIPTION
## Summary

* Removes the long-deprecated `Static` and `Target` fields from the `File` class across the TDL definition, C++ implementation (`class_file.cpp`), generated header (`core.h`), and XML documentation.
* Removes the associated `setStatic()` and `setTarget()` inline methods from `objFile` and updates the field dictionary indices accordingly.
* Removes the static-object early-return guard in `FILE_Init` that depended on `Self->Static`.
* Fixes `FID_TimeStamp` capitalisation to `FID_Timestamp` in `tiri_functions.cpp`.

## Test plan

- [ ] Build the `core` module and verify no compilation errors
- [ ] Run the core integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L core`
- [ ] Confirm that file operations (open, read, write, delete) work correctly via Tiri script