### PR TITLE
[Network] Improve Windows SSL certificate loading with CNG KSP and separate PEM key support

### DIFF
--- a/src/network/win32/ssl_certs.cpp
+++ b/src/network/win32/ssl_certs.cpp
@@ -871,6 +871,7 @@ bool load_pkcs12_certificate(SSL_HANDLE SSL, const std::string &Path, std::optio
 
    auto wide_password = password_to_wide(Password);
    DWORD import_flags = CRYPT_EXPORTABLE | CRYPT_USER_KEYSET;
+   import_flags |= PKCS12_PREFER_CNG_KSP;
    #ifdef PKCS12_NO_PERSIST_KEY
       import_flags |= PKCS12_NO_PERSIST_KEY;
    #endif

--- a/src/network/win32/ssl_wrapper.cpp
+++ b/src/network/win32/ssl_wrapper.cpp
@@ -68,6 +68,9 @@ static void cache_connection_info(ssl_context* SSL);
 #ifndef MS_ENH_RSA_AES_PROV
 #define MS_ENH_RSA_AES_PROV "Microsoft Enhanced RSA and AES Cryptographic Provider"
 #endif
+#ifndef PKCS12_PREFER_CNG_KSP
+#define PKCS12_PREFER_CNG_KSP 0x00000100
+#endif
 
 // Buffer size for SSL operations - optimized for SSL record sizes
 constexpr size_t SSL_IO_BUFFER_SIZE = 0x8000;  // 32KB - 2x max SSL record size (16KB)

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -88,11 +88,14 @@ static ERR tls_setup_server(extNetServer *Self)
       }
    }
    else {
+      auto private_key_path = glCertPath + "localhost-key.pem";
+      std::optional<const std::string> private_key(private_key_path);
       std::optional<const std::string> no_private_key;
       std::optional<const std::string> no_password;
 
       if (!load_pkcs12_certificate(Self->TLS.Handle, glCertPath + "localhost.p12", no_password)) {
-         if (!load_pem_certificate(Self->TLS.Handle, glCertPath + "localhost.pem", no_private_key, no_password)) {
+         if ((!load_pem_certificate(Self->TLS.Handle, glCertPath + "localhost.pem", private_key, no_password)) and
+             (!load_pem_certificate(Self->TLS.Handle, glCertPath + "localhost.pem", no_private_key, no_password))) {
             ssl_free_context(Self->TLS.Handle);
             Self->TLS.Handle = nullptr;
             return log.warning(ERR::Failed);


### PR DESCRIPTION
## Summary

* Uses `PKCS12_PREFER_CNG_KSP` flag when importing PKCS12 certificates to prefer the modern CNG Key Storage Provider over the legacy CAPI provider
* Adds a portable fallback `#define` for `PKCS12_PREFER_CNG_KSP` to support toolchains that do not define it natively
* When loading a PEM certificate for TLS server setup, first attempts to load with a separate `localhost-key.pem` private key file before falling back to embedded key lookup

## Test plan

- [ ] Build the `network` module on Windows and confirm compilation succeeds
- [ ] Test TLS server startup with a PKCS12 certificate (`localhost.p12`) — verify connection succeeds
- [ ] Test TLS server startup with a PEM certificate (`localhost.pem`) + separate private key (`localhost-key.pem`) — verify connection succeeds
- [ ] Test TLS server startup with a PEM certificate that has an embedded key (no separate key file) — verify fallback path works