### PR TITLE
[Network] Fix TCP read race condition and remove mutual auth requirement in SSL accept

### DIFF
--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -89,6 +89,7 @@ static std::string client_ip_label(const IPAddress &Address)
 }
 
 //********************************************************************************************************************
+
 static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    kt::Log log(__FUNCTION__);

--- a/src/network/win32/iocp.cpp
+++ b/src/network/win32/iocp.cpp
@@ -126,7 +126,6 @@ static bool glWinsockInitialised = false;
 static constexpr ULONG_PTR IOCP_SHUTDOWN_KEY = ULONG_PTR(~uintptr_t(0));
 static constexpr size_t IOCP_READ_BUFFER_SIZE = 65536;
 static constexpr size_t IOCP_TCP_READ_HIGH_WATER = 1024 * 1024;
-static constexpr size_t IOCP_TCP_READ_DEPTH = 4;
 static constexpr size_t IOCP_TCP_SEND_HIGH_WATER = 1024 * 1024;
 static constexpr size_t IOCP_TCP_SEND_DEPTH = 8;
 static constexpr size_t IOCP_UDP_BUFFER_SIZE = 65536;
@@ -135,6 +134,13 @@ static constexpr size_t IOCP_ACCEPT_BUFFER_SIZE = IOCP_ACCEPT_ADDRESS_SIZE * 2;
 static constexpr int IOCP_DEFAULT_ACCEPT_DEPTH = 16;
 static constexpr int IOCP_MIN_ACCEPT_DEPTH = 4;
 static constexpr int IOCP_MAX_ACCEPT_DEPTH = 128;
+
+// Keep TCP receives sequential (1) so later completions cannot block behind an earlier pending WSARecv().  Raising
+// this value causes a rare race condition and has a slight performance deficit, so investigation has been shelved
+// for now.  The IOCP read path could otherwise be redesigned to guarantee callbacks when out-of-order completions
+// are buffered.
+
+static constexpr size_t IOCP_TCP_READ_DEPTH = 1;
 
 //********************************************************************************************************************
 

--- a/src/network/win32/ssl_connect.cpp
+++ b/src/network/win32/ssl_connect.cpp
@@ -4,7 +4,7 @@
 
 SSL_ERROR_CODE ssl_connect(SSL_HANDLE SSL, void *SocketHandle, const std::string &HostName)
 {
-   if ((!SSL) or ((SOCKET)SocketHandle == INVALID_SOCKET)) return SSL_ERROR_ARGS;
+   if ((!SSL) or ((SOCKET)SocketHandle IS INVALID_SOCKET)) return SSL_ERROR_ARGS;
 
    SSL->socket_handle = (SOCKET)SocketHandle;
    SSL->hostname = HostName;
@@ -138,15 +138,14 @@ SSL_ERROR_CODE ssl_accept(SSL_HANDLE SSL, const void* ClientData, int DataLength
          nullptr,
          &in_buffer_desc,
          ASC_REQ_SEQUENCE_DETECT | ASC_REQ_REPLAY_DETECT | ASC_REQ_CONFIDENTIALITY |
-         ASC_REQ_EXTENDED_ERROR | ASC_REQ_ALLOCATE_MEMORY | ASC_REQ_STREAM |
-         ASC_REQ_MUTUAL_AUTH,
+         ASC_REQ_EXTENDED_ERROR | ASC_REQ_ALLOCATE_MEMORY | ASC_REQ_STREAM,
          SECURITY_NATIVE_DREP,
          &SSL->context,
          &out_buffer_desc,
          &context_attr,
          &expiry);
 
-      if (status == SEC_E_OK or status == SEC_I_CONTINUE_NEEDED) {
+      if (status IS SEC_E_OK or status IS SEC_I_CONTINUE_NEEDED) {
          SSL->context_initialised = true;
       }
    }
@@ -156,8 +155,7 @@ SSL_ERROR_CODE ssl_accept(SSL_HANDLE SSL, const void* ClientData, int DataLength
          &SSL->context,
          &in_buffer_desc,
          ASC_REQ_SEQUENCE_DETECT | ASC_REQ_REPLAY_DETECT | ASC_REQ_CONFIDENTIALITY |
-         ASC_REQ_EXTENDED_ERROR | ASC_REQ_ALLOCATE_MEMORY | ASC_REQ_STREAM |
-         ASC_REQ_MUTUAL_AUTH,
+         ASC_REQ_EXTENDED_ERROR | ASC_REQ_ALLOCATE_MEMORY | ASC_REQ_STREAM,
          SECURITY_NATIVE_DREP,
          &SSL->context,
          &out_buffer_desc,
@@ -165,8 +163,8 @@ SSL_ERROR_CODE ssl_accept(SSL_HANDLE SSL, const void* ClientData, int DataLength
          &expiry);
    }
 
-   if ((status == SEC_E_OK) or (status == SEC_I_CONTINUE_NEEDED)) {
-      if (status == SEC_E_OK) {
+   if ((status IS SEC_E_OK) or (status IS SEC_I_CONTINUE_NEEDED)) {
+      if (status IS SEC_E_OK) {
          auto stream_status = QueryContextAttributes(&SSL->context, SECPKG_ATTR_STREAM_SIZES, &SSL->stream_sizes);
          if (stream_status != SEC_E_OK) {
             SSL->last_security_status = stream_status;
@@ -180,7 +178,7 @@ SSL_ERROR_CODE ssl_accept(SSL_HANDLE SSL, const void* ClientData, int DataLength
          }
       }
 
-      if (status == SEC_E_OK) return SSL_OK;
+      if (status IS SEC_E_OK) return SSL_OK;
       else return SSL_NEED_DATA;
    }
    else {


### PR DESCRIPTION
## Summary

* Reduce `IOCP_TCP_READ_DEPTH` from 4 to 1 to keep TCP receives sequential and prevent a rare race condition where later IOCP completions could block behind an earlier pending `WSARecv()` call
* Remove `ASC_REQ_MUTUAL_AUTH` from `ssl_accept()` to stop requiring client certificates during the SSL/TLS handshake

## Test plan

- [ ] Verify SSL server accepts connections without requiring a client certificate
- [ ] Confirm TCP data flows correctly under the sequential read depth of 1
- [ ] Run network integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L network`