### PR TITLE
[Tiri] Fix bytecode register and constant-index overflow in JIT parser

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -769,7 +769,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips
-   compile_if_import datetime
+   compile_if_import
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -769,7 +769,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips
-   compile_if_import
+   compile_if_import datetime
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -731,10 +731,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_annotation_registration(BCReg FuncReg, 
       }
    }
 
-   // Save base register and allocate space for the call
+   // Save base register and allocate space for the call.  The callee lookup can need temporary registers when string
+   // constants exceed the short TGETS range, so the full frame must be reserved before those lookups run.
    // With LJ_FR2=1, layout is: [base]=func, [base+1]=frame, [base+2]=arg1, [base+3]=arg2, ...
    // So args start at base + 1 + LJ_FR2 = base + 2
    BCREG base_raw = fs->freereg;
+   bcreg_reserve(fs, 5 + LJ_FR2);
 
    // Helper to get constant string index
    auto str_const = [fs](GCstr* s) -> BCREG {
@@ -770,6 +772,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_annotation_registration(BCReg FuncReg, 
    // Emit call: debug.anno.set(func, annostr, source, name)
    // BC_CALL A=base, B=2 (expect 1 result for discard), C=5 (4 args + 1)
    bcemit_ABC(fs, BC_CALL, base_raw, 2, 5);
+   fs->freereg = base_raw;
 
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 }

--- a/src/tiri/jit/src/parser/parse_internal.h
+++ b/src/tiri/jit/src/parser/parse_internal.h
@@ -123,17 +123,76 @@ static inline BCPOS bcemit_AJ(FuncState *fs, Op o, BCREG a, BCPOS j) {
 // Emit BC_TGETS with overflow protection. When the string constant index exceeds 255 (the 8-bit C field limit),
 // falls back to BC_KSTR + BC_TGETV to avoid bytecode corruption.
 
-static inline void bcemit_tgets(FuncState *fs, BCREG Dest, BCREG Table, BCREG StrConstIdx)
+static inline BCPOS bcemit_tgets(FuncState *fs, BCREG Dest, BCREG Table, BCREG StrConstIdx)
 {
    if (StrConstIdx <= BCMAX_C) {
-      bcemit_ABC(fs, BC_TGETS, Dest, Table, StrConstIdx);
+      return bcemit_ABC(fs, BC_TGETS, Dest, Table, StrConstIdx);
    }
    else {
-      BCREG key_reg = fs->freereg;
-      bcreg_reserve(fs, 1);
+      if (StrConstIdx > BCMAX_D) {
+         err_limit(fs, BCMAX_D + 1, "constants");
+         return NO_JMP;
+      }
+
+      BCREG saved_freereg = fs->freereg;
+      BCREG key_reg = saved_freereg;
+
+      if (key_reg <= Dest) key_reg = Dest + 1;
+      if (key_reg <= Table) key_reg = Table + 1;
+
+      if (not(key_reg IS saved_freereg)) {
+         kt::Log("Parser").warning("BC_TGETS constant overflow temp register adjusted from R%u to R%u "
+            "to avoid aliasing R%u/R%u at line %d",
+            unsigned(saved_freereg), unsigned(key_reg), unsigned(Dest), unsigned(Table),
+            fs->ls->effective_line().lineNumber());
+      }
+
+      fs_check_assert(fs, not(key_reg IS Dest) and not(key_reg IS Table),
+         "BC_TGETS overflow temp aliases destination/table register");
+
+      bcreg_reserve(fs, key_reg - saved_freereg + 1);
       bcemit_AD(fs, BC_KSTR, key_reg, StrConstIdx);
-      bcemit_ABC(fs, BC_TGETV, Dest, Table, key_reg);
-      fs->freereg--;
+      BCPOS pc = bcemit_ABC(fs, BC_TGETV, Dest, Table, key_reg);
+      fs->freereg = saved_freereg;
+      return pc;
+   }
+}
+
+// Emit BC_TSETS with overflow protection. When the string constant index exceeds 255 (the 8-bit C field limit),
+// falls back to BC_KSTR + BC_TSETV to avoid bytecode corruption.
+
+static inline BCPOS bcemit_tsets(FuncState *fs, BCREG Value, BCREG Table, BCREG StrConstIdx)
+{
+   if (StrConstIdx <= BCMAX_C) {
+      return bcemit_ABC(fs, BC_TSETS, Value, Table, StrConstIdx);
+   }
+   else {
+      if (StrConstIdx > BCMAX_D) {
+         err_limit(fs, BCMAX_D + 1, "constants");
+         return NO_JMP;
+      }
+
+      BCREG saved_freereg = fs->freereg;
+      BCREG key_reg = saved_freereg;
+
+      if (key_reg <= Value) key_reg = Value + 1;
+      if (key_reg <= Table) key_reg = Table + 1;
+
+      if (not(key_reg IS saved_freereg)) {
+         kt::Log("Parser").warning("BC_TSETS constant overflow temp register adjusted from R%u to R%u "
+            "to avoid aliasing R%u/R%u at line %d",
+            unsigned(saved_freereg), unsigned(key_reg), unsigned(Value), unsigned(Table),
+            fs->ls->effective_line().lineNumber());
+      }
+
+      fs_check_assert(fs, not(key_reg IS Value) and not(key_reg IS Table),
+         "BC_TSETS overflow temp aliases value/table register");
+
+      bcreg_reserve(fs, key_reg - saved_freereg + 1);
+      bcemit_AD(fs, BC_KSTR, key_reg, StrConstIdx);
+      BCPOS pc = bcemit_ABC(fs, BC_TSETV, Value, Table, key_reg);
+      fs->freereg = saved_freereg;
+      return pc;
    }
 }
 

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -291,12 +291,11 @@ static void expr_discharge(FuncState *fs, ExpDesc *e)
             ins = BCINS_ABC(BC_TGETS, 0, e->u.s.info, idx);
          }
          else {
-            // Overflow: load string constant into temp register, use TGETV
-            BCREG key_reg = fs->freereg;
-            bcreg_reserve(fs, 1);
-            bcemit_AD(fs, BC_KSTR, key_reg, BCREG(idx));
-            bcreg_free(fs, key_reg);
-            ins = BCINS_ABC(BC_TGETV, 0, e->u.s.info, key_reg);
+            BCREG table_reg = e->u.s.info;
+            e->u.s.info = bcemit_tgets(fs, 0, table_reg, BCREG(idx));
+            bcreg_free(fs, table_reg);
+            e->k = ExpKind::Relocable;
+            return;
          }
       }
       else if (rc > BCMAX_C) ins = BCINS_ABC(BC_TGETB, 0, e->u.s.info, rc - (BCMAX_C + 1));
@@ -333,7 +332,10 @@ static void expr_discharge(FuncState *fs, ExpDesc *e)
       BCREG rc = e->u.s.aux;
       fs_check_assert(fs, int32_t(rc) < 0, "object field index must be string constant");
       BCREG idx = (BCREG)~rc;
-      fs_check_assert(fs, idx <= BCMAX_C, "object field string constant index out of range");
+      if (idx > BCMAX_C) {
+         err_limit(fs, BCMAX_C + 1, "object field string constants");
+         return;
+      }
       ins = BCINS_ABCP(BC_OBGETF, 0, e->u.s.info, idx, 0xFFFFFFFFu);
       bcreg_free(fs, e->u.s.info);
    }
@@ -668,7 +670,12 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       ra = expr_toanyreg(fs, RHS);
       rc = LHS->u.s.aux;
       fs_check_assert(fs, int32_t(rc) < 0, "object field index must be string constant");
-      ins = BCINS_ABCP(BC_OBSETF, ra, LHS->u.s.info, (~rc) & 0xFFu, 0xFFFFFFFFu);
+      BCREG idx = (BCREG)~rc;
+      if (idx > BCMAX_C) {
+         err_limit(fs, BCMAX_C + 1, "object field string constants");
+         return;
+      }
+      ins = BCINS_ABCP(BC_OBSETF, ra, LHS->u.s.info, idx, 0xFFFFFFFFu);
    }
    else {
       // Table index assignment - emit BC_TSETV, BC_TSETB, or BC_TSETS
@@ -679,24 +686,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       if (int32_t(rc) < 0) {
          /* String constant key: rc encodes the index as ~index. */
          int32_t stridx = ~int32_t(rc);
-         if (stridx <= BCMAX_C) {
-            ins = BCINS_ABC(BC_TSETS, ra, LHS->u.s.info, BCREG(stridx));
-         } else {
-            /* Overflow-safe path: load string constant into a register and use TSETV. */
-            BCREG key_reg = fs->freereg;
-            bcreg_reserve(fs, 1);
-            bcemit_AD(fs, BC_KSTR, key_reg, BCREG(stridx));
-            ins = BCINS_ABC(BC_TSETV, ra, LHS->u.s.info, key_reg);
-#ifdef LUA_USE_ASSERT
-            /* Free late alloced key reg to avoid assert on free of value reg. */
-            /* This can only happen when called from expr_table(). */
-            if (RHS->k IS ExpKind::NonReloc and ra >= fs->varmap.size() and rc >= ra) bcreg_free(fs, rc);
-#endif
-            bcemit_INS(fs, ins);
-            bcreg_free(fs, key_reg);
-            expr_free(fs, RHS);
-            return;
-         }
+         bcemit_tsets(fs, ra, LHS->u.s.info, BCREG(stridx));
+         expr_free(fs, RHS);
+         return;
       } else if (rc > BCMAX_C) {
          ins = BCINS_ABC(BC_TSETB, ra, LHS->u.s.info, rc - (BCMAX_C + 1));
       } else {
@@ -723,6 +715,10 @@ static void bcemit_method(FuncState *fs, ExpDesc *e, ExpDesc *key)
    bcemit_AD(fs, BC_MOV, func + 1 + LJ_FR2, obj);  // Copy object to 1st argument.
    fs_check_assert(fs, key->is_str_constant(), "bad usage");
    idx = const_str(fs, key);
+   if (idx > BCMAX_D) {
+      err_limit(fs, BCMAX_D + 1, "constants");
+      return;
+   }
    if (idx <= BCMAX_C) {
       bcreg_reserve(fs, 2 + LJ_FR2);
       bcemit_ABC(fs, BC_TGETS, func, obj, idx);

--- a/src/tiri/tests/test_overflow.tiri
+++ b/src/tiri/tests/test_overflow.tiri
@@ -1,0 +1,329 @@
+-- Flute tests for parser and bytecode-emitter overflow regressions.
+
+-- The assignments below force individual KSTR emissions before annotation registration.  That makes the generated
+-- debug.anno.set lookup use the bcemit_tgets() overflow path without importing datetime or any other library.
+
+local constant_pool = {}
+constant_pool[0] = 'constant_000'
+constant_pool[1] = 'constant_001'
+constant_pool[2] = 'constant_002'
+constant_pool[3] = 'constant_003'
+constant_pool[4] = 'constant_004'
+constant_pool[5] = 'constant_005'
+constant_pool[6] = 'constant_006'
+constant_pool[7] = 'constant_007'
+constant_pool[8] = 'constant_008'
+constant_pool[9] = 'constant_009'
+constant_pool[10] = 'constant_010'
+constant_pool[11] = 'constant_011'
+constant_pool[12] = 'constant_012'
+constant_pool[13] = 'constant_013'
+constant_pool[14] = 'constant_014'
+constant_pool[15] = 'constant_015'
+constant_pool[16] = 'constant_016'
+constant_pool[17] = 'constant_017'
+constant_pool[18] = 'constant_018'
+constant_pool[19] = 'constant_019'
+constant_pool[20] = 'constant_020'
+constant_pool[21] = 'constant_021'
+constant_pool[22] = 'constant_022'
+constant_pool[23] = 'constant_023'
+constant_pool[24] = 'constant_024'
+constant_pool[25] = 'constant_025'
+constant_pool[26] = 'constant_026'
+constant_pool[27] = 'constant_027'
+constant_pool[28] = 'constant_028'
+constant_pool[29] = 'constant_029'
+constant_pool[30] = 'constant_030'
+constant_pool[31] = 'constant_031'
+constant_pool[32] = 'constant_032'
+constant_pool[33] = 'constant_033'
+constant_pool[34] = 'constant_034'
+constant_pool[35] = 'constant_035'
+constant_pool[36] = 'constant_036'
+constant_pool[37] = 'constant_037'
+constant_pool[38] = 'constant_038'
+constant_pool[39] = 'constant_039'
+constant_pool[40] = 'constant_040'
+constant_pool[41] = 'constant_041'
+constant_pool[42] = 'constant_042'
+constant_pool[43] = 'constant_043'
+constant_pool[44] = 'constant_044'
+constant_pool[45] = 'constant_045'
+constant_pool[46] = 'constant_046'
+constant_pool[47] = 'constant_047'
+constant_pool[48] = 'constant_048'
+constant_pool[49] = 'constant_049'
+constant_pool[50] = 'constant_050'
+constant_pool[51] = 'constant_051'
+constant_pool[52] = 'constant_052'
+constant_pool[53] = 'constant_053'
+constant_pool[54] = 'constant_054'
+constant_pool[55] = 'constant_055'
+constant_pool[56] = 'constant_056'
+constant_pool[57] = 'constant_057'
+constant_pool[58] = 'constant_058'
+constant_pool[59] = 'constant_059'
+constant_pool[60] = 'constant_060'
+constant_pool[61] = 'constant_061'
+constant_pool[62] = 'constant_062'
+constant_pool[63] = 'constant_063'
+constant_pool[64] = 'constant_064'
+constant_pool[65] = 'constant_065'
+constant_pool[66] = 'constant_066'
+constant_pool[67] = 'constant_067'
+constant_pool[68] = 'constant_068'
+constant_pool[69] = 'constant_069'
+constant_pool[70] = 'constant_070'
+constant_pool[71] = 'constant_071'
+constant_pool[72] = 'constant_072'
+constant_pool[73] = 'constant_073'
+constant_pool[74] = 'constant_074'
+constant_pool[75] = 'constant_075'
+constant_pool[76] = 'constant_076'
+constant_pool[77] = 'constant_077'
+constant_pool[78] = 'constant_078'
+constant_pool[79] = 'constant_079'
+constant_pool[80] = 'constant_080'
+constant_pool[81] = 'constant_081'
+constant_pool[82] = 'constant_082'
+constant_pool[83] = 'constant_083'
+constant_pool[84] = 'constant_084'
+constant_pool[85] = 'constant_085'
+constant_pool[86] = 'constant_086'
+constant_pool[87] = 'constant_087'
+constant_pool[88] = 'constant_088'
+constant_pool[89] = 'constant_089'
+constant_pool[90] = 'constant_090'
+constant_pool[91] = 'constant_091'
+constant_pool[92] = 'constant_092'
+constant_pool[93] = 'constant_093'
+constant_pool[94] = 'constant_094'
+constant_pool[95] = 'constant_095'
+constant_pool[96] = 'constant_096'
+constant_pool[97] = 'constant_097'
+constant_pool[98] = 'constant_098'
+constant_pool[99] = 'constant_099'
+constant_pool[100] = 'constant_100'
+constant_pool[101] = 'constant_101'
+constant_pool[102] = 'constant_102'
+constant_pool[103] = 'constant_103'
+constant_pool[104] = 'constant_104'
+constant_pool[105] = 'constant_105'
+constant_pool[106] = 'constant_106'
+constant_pool[107] = 'constant_107'
+constant_pool[108] = 'constant_108'
+constant_pool[109] = 'constant_109'
+constant_pool[110] = 'constant_110'
+constant_pool[111] = 'constant_111'
+constant_pool[112] = 'constant_112'
+constant_pool[113] = 'constant_113'
+constant_pool[114] = 'constant_114'
+constant_pool[115] = 'constant_115'
+constant_pool[116] = 'constant_116'
+constant_pool[117] = 'constant_117'
+constant_pool[118] = 'constant_118'
+constant_pool[119] = 'constant_119'
+constant_pool[120] = 'constant_120'
+constant_pool[121] = 'constant_121'
+constant_pool[122] = 'constant_122'
+constant_pool[123] = 'constant_123'
+constant_pool[124] = 'constant_124'
+constant_pool[125] = 'constant_125'
+constant_pool[126] = 'constant_126'
+constant_pool[127] = 'constant_127'
+constant_pool[128] = 'constant_128'
+constant_pool[129] = 'constant_129'
+constant_pool[130] = 'constant_130'
+constant_pool[131] = 'constant_131'
+constant_pool[132] = 'constant_132'
+constant_pool[133] = 'constant_133'
+constant_pool[134] = 'constant_134'
+constant_pool[135] = 'constant_135'
+constant_pool[136] = 'constant_136'
+constant_pool[137] = 'constant_137'
+constant_pool[138] = 'constant_138'
+constant_pool[139] = 'constant_139'
+constant_pool[140] = 'constant_140'
+constant_pool[141] = 'constant_141'
+constant_pool[142] = 'constant_142'
+constant_pool[143] = 'constant_143'
+constant_pool[144] = 'constant_144'
+constant_pool[145] = 'constant_145'
+constant_pool[146] = 'constant_146'
+constant_pool[147] = 'constant_147'
+constant_pool[148] = 'constant_148'
+constant_pool[149] = 'constant_149'
+constant_pool[150] = 'constant_150'
+constant_pool[151] = 'constant_151'
+constant_pool[152] = 'constant_152'
+constant_pool[153] = 'constant_153'
+constant_pool[154] = 'constant_154'
+constant_pool[155] = 'constant_155'
+constant_pool[156] = 'constant_156'
+constant_pool[157] = 'constant_157'
+constant_pool[158] = 'constant_158'
+constant_pool[159] = 'constant_159'
+constant_pool[160] = 'constant_160'
+constant_pool[161] = 'constant_161'
+constant_pool[162] = 'constant_162'
+constant_pool[163] = 'constant_163'
+constant_pool[164] = 'constant_164'
+constant_pool[165] = 'constant_165'
+constant_pool[166] = 'constant_166'
+constant_pool[167] = 'constant_167'
+constant_pool[168] = 'constant_168'
+constant_pool[169] = 'constant_169'
+constant_pool[170] = 'constant_170'
+constant_pool[171] = 'constant_171'
+constant_pool[172] = 'constant_172'
+constant_pool[173] = 'constant_173'
+constant_pool[174] = 'constant_174'
+constant_pool[175] = 'constant_175'
+constant_pool[176] = 'constant_176'
+constant_pool[177] = 'constant_177'
+constant_pool[178] = 'constant_178'
+constant_pool[179] = 'constant_179'
+constant_pool[180] = 'constant_180'
+constant_pool[181] = 'constant_181'
+constant_pool[182] = 'constant_182'
+constant_pool[183] = 'constant_183'
+constant_pool[184] = 'constant_184'
+constant_pool[185] = 'constant_185'
+constant_pool[186] = 'constant_186'
+constant_pool[187] = 'constant_187'
+constant_pool[188] = 'constant_188'
+constant_pool[189] = 'constant_189'
+constant_pool[190] = 'constant_190'
+constant_pool[191] = 'constant_191'
+constant_pool[192] = 'constant_192'
+constant_pool[193] = 'constant_193'
+constant_pool[194] = 'constant_194'
+constant_pool[195] = 'constant_195'
+constant_pool[196] = 'constant_196'
+constant_pool[197] = 'constant_197'
+constant_pool[198] = 'constant_198'
+constant_pool[199] = 'constant_199'
+constant_pool[200] = 'constant_200'
+constant_pool[201] = 'constant_201'
+constant_pool[202] = 'constant_202'
+constant_pool[203] = 'constant_203'
+constant_pool[204] = 'constant_204'
+constant_pool[205] = 'constant_205'
+constant_pool[206] = 'constant_206'
+constant_pool[207] = 'constant_207'
+constant_pool[208] = 'constant_208'
+constant_pool[209] = 'constant_209'
+constant_pool[210] = 'constant_210'
+constant_pool[211] = 'constant_211'
+constant_pool[212] = 'constant_212'
+constant_pool[213] = 'constant_213'
+constant_pool[214] = 'constant_214'
+constant_pool[215] = 'constant_215'
+constant_pool[216] = 'constant_216'
+constant_pool[217] = 'constant_217'
+constant_pool[218] = 'constant_218'
+constant_pool[219] = 'constant_219'
+constant_pool[220] = 'constant_220'
+constant_pool[221] = 'constant_221'
+constant_pool[222] = 'constant_222'
+constant_pool[223] = 'constant_223'
+constant_pool[224] = 'constant_224'
+constant_pool[225] = 'constant_225'
+constant_pool[226] = 'constant_226'
+constant_pool[227] = 'constant_227'
+constant_pool[228] = 'constant_228'
+constant_pool[229] = 'constant_229'
+constant_pool[230] = 'constant_230'
+constant_pool[231] = 'constant_231'
+constant_pool[232] = 'constant_232'
+constant_pool[233] = 'constant_233'
+constant_pool[234] = 'constant_234'
+constant_pool[235] = 'constant_235'
+constant_pool[236] = 'constant_236'
+constant_pool[237] = 'constant_237'
+constant_pool[238] = 'constant_238'
+constant_pool[239] = 'constant_239'
+constant_pool[240] = 'constant_240'
+constant_pool[241] = 'constant_241'
+constant_pool[242] = 'constant_242'
+constant_pool[243] = 'constant_243'
+constant_pool[244] = 'constant_244'
+constant_pool[245] = 'constant_245'
+constant_pool[246] = 'constant_246'
+constant_pool[247] = 'constant_247'
+constant_pool[248] = 'constant_248'
+constant_pool[249] = 'constant_249'
+constant_pool[250] = 'constant_250'
+constant_pool[251] = 'constant_251'
+constant_pool[252] = 'constant_252'
+constant_pool[253] = 'constant_253'
+constant_pool[254] = 'constant_254'
+constant_pool[255] = 'constant_255'
+
+@Test function AnnotationAfterLargeConstantPool()
+   assert(#constant_pool is 256, 'constant pool should remain populated')
+end
+
+function source_after_large_constant_pool(Tail)
+   local lines = array<string> { 'local constant_pool = {}' }
+
+   for i in {0..256} do
+      lines:push("constant_pool[" .. i .. "] = 'constant_" .. i .. "'")
+   end
+
+   lines:push(Tail)
+   return lines:concat('%s', '\n')
+end
+
+@Test function DatetimeImportBeforeAnnotatedFunction()
+   local result = exec([[
+      import 'datetime'
+
+      @Test function GeneratedAnnotationAfterDatetimeImport()
+         return datetime.instant(0):toUnixSeconds()
+      end
+
+      return GeneratedAnnotationAfterDatetimeImport()
+   ]])
+
+   assert(result is 0, 'Annotated function after datetime import should compile and run')
+end
+
+@Test function MethodLookupAfterLargeConstantPool()
+   local result = exec(source_after_large_constant_pool([[
+      local target = { marker = 'method-ok' }
+
+      function target:overflowMethod()
+         return self.marker
+      end
+
+      return target:overflowMethod()
+   ]]))
+
+   assert(result is 'method-ok', 'Method lookup should work after the short string constant range is exceeded')
+end
+
+@Test function TableFieldLookupAfterLargeConstantPool()
+   local result = exec(source_after_large_constant_pool([[
+      local target = {}
+      target.overflowAssignedValue = 'stored'
+
+      return target.overflowAssignedValue
+   ]]))
+
+   assert(result is 'stored', 'Table field assignment and lookup should work after the short string constant range')
+end
+
+@Test function ChoosePatternFieldAfterLargeConstantPool()
+   local result = exec(source_after_large_constant_pool([[
+      local data = { overflowPatternField = 'matched' }
+
+      return choose data from
+         { overflowPatternField = 'matched' } -> 'pattern-ok'
+         else -> 'pattern-miss'
+      end
+   ]]))
+
+   assert(result is 'pattern-ok', 'Choose table-pattern field lookup should work after the short string constant range')
+end


### PR DESCRIPTION
## Summary

* Adds `bcemit_tsets()` overflow-safe helper (BC_KSTR + BC_TSETV fallback) to mirror the existing `bcemit_tgets()`, and refactors `parse_regalloc.cpp` to use both helpers in place of duplicated inline overflow paths.
* Fixes `bcemit_tgets()` to select a temp register that avoids aliasing the destination or table registers, and to correctly restore `freereg` after the overflow path rather than always decrementing by one.
* Fixes annotation registration in `emit_function.cpp`: the full call frame is now pre-reserved before any callee lookups (which may themselves need temp registers for constant-index overflow), and `freereg` is restored after `BC_CALL` emission.
* Adds explicit bounds checks for `OBGETF`/`OBSETF` string-constant index overflow and for method string-constant index overflow.
* Adds `test_overflow.tiri` Flute regression tests covering: annotation compilation after a large constant pool, `datetime` import before an annotated function, method lookup, table field assignment/read, and `choose` pattern-field matching when the short string-constant range is exceeded.

## Test plan

- [ ] Build `tiri` module and verify clean compilation
- [ ] Run `test_overflow` Flute test: `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_overflow.tiri --log-warning`
- [ ] Run `test_datetime` Flute test to confirm the `datetime`-import-before-annotation regression is fixed
- [ ] Run full Tiri test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri`

🤖 Generated with [Claude Code](https://claude.com/claude-code)