### PR TITLE
Refactor VFX API to use options tables and add easing support

### DIFF
--- a/examples/widgets.tiri
+++ b/examples/widgets.tiri
@@ -43,9 +43,13 @@ end
 
 function widgetFocus(Widget)
    --if Widget.effect then return end
-   --Widget.effect = vfx.shake((Widget.inputViewport ? Widget.viewport), 0.2, 0, 0.2, function(Effect)
-   --   Widget.effect = nil
-   --end)
+   --Widget.effect = vfx.shake((Widget.inputViewport ? Widget.viewport), {
+   --   seconds = 0.2,
+   --   intensity = 0.2,
+   --   callback = function(Effect)
+   --      Widget.effect = nil
+   --   end
+   --})
 end
 
    menubar = gui.menubar({
@@ -344,13 +348,17 @@ end
       size   = 80,
       events = {
          show = function(Icon)
-            vfx.fadeIn(Icon.viewport, 1.0, 0.1)
+            vfx.fadeIn(Icon.viewport, { seconds=1.0, delay=0.1 })
          end,
          activate = function(Icon)
             if Icon.effect then return end
-            Icon.effect = vfx.shake(Icon.viewport, 1.0, 0, 1.0, function(Effect)
-               Icon.effect = nil
-            end)
+            Icon.effect = vfx.shake(Icon.viewport, {
+               seconds = 1.0,
+               intensity = 1.0,
+               callback = function(Effect)
+                  Icon.effect = nil
+               end
+            })
 
             sndAlarm?.acActivate()
          end
@@ -369,15 +377,15 @@ end
       text   = 'Wilhelm\'s House',
       events = {
          show = function(Icon)
-            vfx.rotate(Icon.viewport, 0.8, 0)
-            vfx.zoomIn(Icon.viewport, 0.4, 0.3)
+            vfx.rotate(Icon.viewport, { seconds=0.8 })
+            vfx.zoomIn(Icon.viewport, { seconds=0.4, delay=0.3 })
          end,
          activate = function(Icon)
             if Icon.effect then return end
 
             Icon.effect = vfx.chain({
-               vfx.rotate(Icon.viewport, 0.8),
-               vfx.zoomOut(Icon.viewport, 0.8)
+               vfx.rotate(Icon.viewport, { seconds=0.8 }),
+               vfx.zoomOut(Icon.viewport, { seconds=0.8 })
             }, function()
                Icon.viewport.free()
                Icon.viewport = nil

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -57,11 +57,13 @@ vfx.apply_easing = function(Value, Easing)
 
    if not Easing then return progress end
 
-   easing = Easing
-   if type(easing) is 'string' then
+   local easing
+   if type(Easing) is 'string' then
       easing = vfx.ease[easing]
       if not easing then error(f"Unsupported VFX easing '{Easing}'") end
-   elseif type(easing) != 'function' then
+   elseif type(Easing) is 'function' then
+      easing = Easing
+   else
       error('VFX easing must be a string or function')
    end
 
@@ -138,7 +140,7 @@ end
 -- Options.delay: Delays the initial start of the effect, measured in seconds.
 -- Options.style: 'shutter', 'simple', 'radial', 'spiral', 'clock'
 
-vfx.wipe = function(Viewport, Options)
+vfx.wipe = function(Viewport:obj, Options:table)
    Options ?= { }
    assert(type(Options) is 'table', 'VFX wipe options must be supplied as a table')
 
@@ -180,11 +182,11 @@ end
 -- Move the viewport to its indicated (x,y) position within the allotted time.  By default the move will commence from
 -- an out-of-bounds position on the left.  The client can override this with a custom FromX, FromY position.
 
-vfx.moveIn = function(Viewport, Options)
+vfx.moveIn = function(Viewport:obj, Options:table)
 
 end
 
-vfx.moveOut = function(Viewport, Options)
+vfx.moveOut = function(Viewport:obj, Options:table)
 
 end
 
@@ -194,7 +196,7 @@ end
 -- Options.seconds: Specifies the maximum number of seconds for the effect to complete.
 -- Options.delay:   Delays the initial start of the effect, measured in seconds.
 
-vfx.fadeIn = function(Viewport, Options)
+vfx.fadeIn = function(Viewport:obj, Options:table)
    config = vfx.effect_config(Options)
    state = {
       name = 'fadeIn', seconds = config.seconds, delay = config.delay,
@@ -204,7 +206,7 @@ vfx.fadeIn = function(Viewport, Options)
    local err
    Viewport.opacity = 0
    err, state.timerID = mSys.SubscribeTimer(1*vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      Viewport.exists() ?? check ERR_Terminate
+      Viewport.exists() ?? raise ERR_Terminate
 
       state.time ?= CurrentTime
       if state.delay > 0 then
@@ -218,8 +220,8 @@ vfx.fadeIn = function(Viewport, Options)
          if value >= 1.0 then
             Viewport.opacity = 1.0
             Viewport.acDraw()
-            if state.callback then state.callback(state) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          else
             Viewport.opacity = vfx.apply_easing(value, state.easing)
             Viewport.acDraw()
@@ -233,7 +235,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Scale the viewport from nothing to full-size within the allotted time.
 
-vfx.zoomIn = function(Viewport, Options)
+vfx.zoomIn = function(Viewport:obj, Options:table)
    config = vfx.effect_config(Options)
    state = {
       name = 'zoomIn', seconds = config.seconds, delay = config.delay,
@@ -249,7 +251,7 @@ vfx.zoomIn = function(Viewport, Options)
    Viewport.acDraw()
 
    err, state.timerID = mSys.SubscribeTimer(1*vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      Viewport.exists() ?? check ERR_Terminate
+      Viewport.exists() ?? raise ERR_Terminate
 
       state.time ?= CurrentTime
       if state.delay > 0 then
@@ -270,8 +272,8 @@ vfx.zoomIn = function(Viewport, Options)
          Viewport.acDraw()
 
          if value >= 1.0 then
-            if state.callback then state.callback(state) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          end
       end
    end)
@@ -282,7 +284,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Scale the viewport from full-size to nothing within the allotted time.
 
-vfx.zoomOut = function(Viewport, Options)
+vfx.zoomOut = function(Viewport:obj, Options:table)
    config = vfx.effect_config(Options)
    state = {
       name = 'zoomOut', seconds = config.seconds, delay = config.delay,
@@ -298,7 +300,7 @@ vfx.zoomOut = function(Viewport, Options)
    Viewport.acDraw()
 
    err, state.timerID = mSys.SubscribeTimer(1*vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      Viewport.exists() ?? check ERR_Terminate
+      Viewport.exists() ?? raise ERR_Terminate
 
       state.time ?= CurrentTime
       if state.delay > 0 then
@@ -319,8 +321,8 @@ vfx.zoomOut = function(Viewport, Options)
          Viewport.acDraw()
 
          if value >= 1.0 then
-            if state.callback then state.callback(state) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          end
       end
    end)
@@ -332,7 +334,7 @@ end
 -- 'Shake' a vector by applying an alternating rotation around its center.  Intensity is between 0.1 and 2.0 and
 -- affects the number of shakes and maximum angle of rotation.
 
-vfx.shake = function(Viewport, Options)
+vfx.shake = function(Viewport:obj, Options:table)
    Options ?= { }
    assert(type(Options) is 'table', 'VFX shake options must be supplied as a table')
 
@@ -358,7 +360,7 @@ vfx.shake = function(Viewport, Options)
    local err
    err, state.matrix = Viewport.mtNewMatrix(false)
    err, state.timerID = mSys.SubscribeTimer(1*vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      Viewport.exists() ?? check ERR_Terminate
+      Viewport.exists() ?? raise ERR_Terminate
 
       state.time ?= CurrentTime
       if state.delay > 0 then
@@ -372,8 +374,8 @@ vfx.shake = function(Viewport, Options)
 
          if CurrentTime > state.time + (state.seconds * 1000000) then
             Viewport.acDraw()
-            if state.callback then state.callback(state) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          end
 
          cycle = (state.seconds / SHAKES) * 1000000
@@ -404,7 +406,7 @@ end
 -- Rotate the viewport 360 degrees within the allotted time.  This feature is typically chained for use with other
 -- effects.
 
-vfx.rotate = function(Viewport, Options)
+vfx.rotate = function(Viewport:obj, Options:table)
    config = vfx.effect_config(Options)
    state = {
       name = 'rotate', seconds = config.seconds, delay = config.delay,
@@ -414,7 +416,7 @@ vfx.rotate = function(Viewport, Options)
    local err
    err, state.matrix = Viewport.mtNewMatrix(false)
    err, state.timerID = mSys.SubscribeTimer(1*vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      Viewport.exists() ?? check ERR_Terminate
+      Viewport.exists() ?? raise ERR_Terminate
 
       state.time ?= CurrentTime
       if state.delay > 0 then
@@ -434,8 +436,8 @@ vfx.rotate = function(Viewport, Options)
          Viewport.acDraw()
 
          if value >= 1.0 then
-            if state.callback then state.callback(state) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          end
       end
    end)
@@ -679,7 +681,7 @@ end
 vfx.initTimer = function(State, Options)
    local err
    err, State.timerID = mSys.SubscribeTimer(1 * vfx.fps, function(Subscriber, Elapsed, CurrentTime)
-      State.viewport.exists() ?? check ERR_Terminate
+      State.viewport.exists() ?? raise ERR_Terminate
 
       State.time ?= CurrentTime
       if State.delay > 0 then
@@ -692,8 +694,8 @@ vfx.initTimer = function(State, Options)
          value = (CurrentTime - State.time) / (State.seconds * 1000000)
          if value >= 1.0 then
             if (State.free != nil) then State:free() end
-            if State.callback then State.callback(State) end
-            check ERR_Terminate
+            state?.callback(state)
+            raise ERR_Terminate
          else
             progress = vfx.apply_easing(value, State.easing)
             State.animate(State, Options, Options.invert ? 1.0 - progress :> progress)

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -6,7 +6,82 @@
       fps = 1/60 -- Desired FPS for the effects, ideally matches the display
    }
 
-vfx.wipes = { shutter = { }, simple = { }, radial = { }, clock = { }, spiral = { }, shape = { }, pixelate = { } }
+vfx.wipes = { shutter = { }, simple = { }, radial = { }, clock = { }, spiral = { } }
+vfx.ease = { }
+
+----------------------------------------------------------------------------------------------------------------------
+
+vfx.ease.linear = function(Value)
+   return Value
+end
+
+vfx.ease.inQuad = function(Value)
+   return Value * Value
+end
+
+vfx.ease.outQuad = function(Value)
+   inverse = 1.0 - Value
+   return 1.0 - (inverse * inverse)
+end
+
+vfx.ease.inOutQuad = function(Value)
+   if Value < 0.5 then return 2.0 * Value * Value end
+
+   inverse = -2.0 * Value + 2.0
+   return 1.0 - ((inverse * inverse) * 0.5)
+end
+
+vfx.ease.inCubic = function(Value)
+   return Value * Value * Value
+end
+
+vfx.ease.outCubic = function(Value)
+   inverse = 1.0 - Value
+   return 1.0 - (inverse * inverse * inverse)
+end
+
+vfx.ease.inOutCubic = function(Value)
+   if Value < 0.5 then return 4.0 * Value * Value * Value end
+
+   inverse = -2.0 * Value + 2.0
+   return 1.0 - ((inverse * inverse * inverse) * 0.5)
+end
+
+vfx.apply_easing = function(Value, Easing)
+   progress = Value
+   if progress < 0.0 then
+      progress = 0.0
+   elseif progress > 1.0 then
+      progress = 1.0
+   end
+
+   if not Easing then return progress end
+
+   easing = Easing
+   if type(easing) is 'string' then
+      easing = vfx.ease[easing]
+      if not easing then error(f"Unsupported VFX easing '{Easing}'") end
+   elseif type(easing) != 'function' then
+      error('VFX easing must be a string or function')
+   end
+
+   eased = easing(progress)
+   assert(type(eased) is 'number', 'VFX easing function must return a number')
+
+   return eased
+end
+
+vfx.effect_config = function(Options)
+   Options ?= { }
+   assert(type(Options) is 'table', 'VFX effect options must be supplied as a table')
+
+   return {
+      seconds  = Options.seconds ?? 1.0,
+      delay    = Options.delay ?? 0,
+      callback = Options.callback,
+      easing   = Options.easing
+   }
+end
 
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -37,7 +112,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Use chain() to receive a single callback once all effects in the chain have finished processing.
 --
--- Example: vfx.chain({ vfx.zoomIn(Viewport, 0.5), vfx.fadeIn(Viewport, 0.25) }, Callback)
+-- Example: vfx.chain({ vfx.zoomIn(Viewport, { seconds=0.5 }), vfx.fadeIn(Viewport, { seconds=0.25 }) }, Callback)
 
 vfx.chain = function(Effects, CallbackOnCompletion)
    state = { effects = Effects }
@@ -59,18 +134,26 @@ end
 -- Use 'screen wipe' effects to display or hide a viewport.  The Viewport's Mask is utilised to achieve this.  A
 -- wipe-out can be achieved by setting invert=true in the Options.
 --
--- Seconds:  Specifies the maximum number of seconds for the effect to complete.
--- Delay: Delays the initial start of the effect, measured in seconds.
--- Style: 'shutter', 'simple', 'radial', 'spiral', 'clock', 'shape', 'pixelate'
+-- Options.seconds:  Specifies the maximum number of seconds for the effect to complete.
+-- Options.delay: Delays the initial start of the effect, measured in seconds.
+-- Options.style: 'shutter', 'simple', 'radial', 'spiral', 'clock'
 
-vfx.wipe = function(Viewport, Seconds, Delay, Style, Options)
+vfx.wipe = function(Viewport, Options)
    Options ?= { }
-   Style ?= 'shutter'
+   assert(type(Options) is 'table', 'VFX wipe options must be supplied as a table')
+
+   config = vfx.effect_config(Options)
+   style = Options.style ?? 'shutter'
+
+   wipe = vfx.wipes[style]
+   if (not wipe) or (not wipe.animate) then
+      error(f"Unsupported VFX wipe style '{style}'")
+   end
 
    state = {
-      name = 'wipe', viewport = Viewport, seconds = Seconds ?? 1.0, delay = Delay ?? 0,
+      name = 'wipe', viewport = Viewport, seconds = config.seconds, delay = config.delay,
       v_width = Viewport.width, v_height = Viewport.height,
-      animate = vfx.wipes[Style].animate, callback = CallbackOnCompletion,
+      animate = wipe.animate, callback = config.callback, easing = config.easing,
       path_cmd = struct.new('PathCommand')
    }
 
@@ -87,7 +170,7 @@ vfx.wipe = function(Viewport, Seconds, Delay, Style, Options)
       State.viewport.acDraw()
    end
 
-   if vfx.wipes[Style].init then vfx.wipes[Style].init(state, Options) end
+   if wipe.init then wipe.init(state, Options) end
 
    vfx.initTimer(state, Options)
    return state
@@ -97,22 +180,26 @@ end
 -- Move the viewport to its indicated (x,y) position within the allotted time.  By default the move will commence from
 -- an out-of-bounds position on the left.  The client can override this with a custom FromX, FromY position.
 
-vfx.moveIn = function(Viewport, Seconds, Delay, FromX, FromY)
+vfx.moveIn = function(Viewport, Options)
 
 end
 
-vfx.moveOut = function(Viewport, Seconds, Delay, FromX, FromY)
+vfx.moveOut = function(Viewport, Options)
 
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Fades a viewport into the display by adjusting the opacity level.
 --
--- Seconds: Specifies the maximum number of seconds for the effect to complete.
--- Delay:   Delays the initial start of the effect, measured in seconds.
+-- Options.seconds: Specifies the maximum number of seconds for the effect to complete.
+-- Options.delay:   Delays the initial start of the effect, measured in seconds.
 
-vfx.fadeIn = function(Viewport, Seconds, Delay, CallbackOnCompletion)
-   state = { name = 'fadeIn', seconds = Seconds ?? 1.0, delay = Delay ?? 0, callback = CallbackOnCompletion }
+vfx.fadeIn = function(Viewport, Options)
+   config = vfx.effect_config(Options)
+   state = {
+      name = 'fadeIn', seconds = config.seconds, delay = config.delay,
+      callback = config.callback, easing = config.easing
+   }
 
    local err
    Viewport.opacity = 0
@@ -134,7 +221,7 @@ vfx.fadeIn = function(Viewport, Seconds, Delay, CallbackOnCompletion)
             if state.callback then state.callback(state) end
             check ERR_Terminate
          else
-            Viewport.opacity = value
+            Viewport.opacity = vfx.apply_easing(value, state.easing)
             Viewport.acDraw()
          end
       end
@@ -146,11 +233,16 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Scale the viewport from nothing to full-size within the allotted time.
 
-vfx.zoomIn = function(Viewport, Seconds, Delay, CallbackOnCompletion)
-   state = { name = 'zoomIn', seconds = (Seconds ?? 1.0), delay = (Delay ?? 0), callback = CallbackOnCompletion }
+vfx.zoomIn = function(Viewport, Options)
+   config = vfx.effect_config(Options)
+   state = {
+      name = 'zoomIn', seconds = config.seconds, delay = config.delay,
+      callback = config.callback, easing = config.easing
+   }
 
    local err
    err, state.matrix = Viewport.mtNewMatrix(false)
+   value = 0.0
    mVec.Translate(state.matrix, Viewport.width*0.5, Viewport.height*0.5)
    mVec.Scale(state.matrix, value, value)
    mVec.Translate(state.matrix, -Viewport.width*0.5, -Viewport.height*0.5)
@@ -169,10 +261,11 @@ vfx.zoomIn = function(Viewport, Seconds, Delay, CallbackOnCompletion)
       else
          value = (CurrentTime - state.time) / (state.seconds * 1000000)
          if value >= 1.0 then value = 1.0 end
+         progress = vfx.apply_easing(value, state.easing)
 
          mVec.ResetMatrix(state.matrix)
          mVec.Translate(state.matrix, -Viewport.width*0.5, -Viewport.height*0.5)
-         mVec.Scale(state.matrix, value, value)
+         mVec.Scale(state.matrix, progress, progress)
          mVec.Translate(state.matrix, Viewport.width*0.5, Viewport.height*0.5)
          Viewport.acDraw()
 
@@ -189,11 +282,16 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Scale the viewport from full-size to nothing within the allotted time.
 
-vfx.zoomOut = function(Viewport, Seconds, Delay, CallbackOnCompletion)
-   state = { name = 'zoomOut', seconds = (Seconds ?? 1.0), delay = (Delay ?? 0), callback = CallbackOnCompletion }
+vfx.zoomOut = function(Viewport, Options)
+   config = vfx.effect_config(Options)
+   state = {
+      name = 'zoomOut', seconds = config.seconds, delay = config.delay,
+      callback = config.callback, easing = config.easing
+   }
 
    local err
    err, state.matrix = Viewport.mtNewMatrix(false)
+   value = 1.0
    mVec.Translate(state.matrix, Viewport.width*0.5, Viewport.height*0.5)
    mVec.Scale(state.matrix, value, value)
    mVec.Translate(state.matrix, -Viewport.width*0.5, -Viewport.height*0.5)
@@ -212,10 +310,11 @@ vfx.zoomOut = function(Viewport, Seconds, Delay, CallbackOnCompletion)
       else
          value = (CurrentTime - state.time) / (state.seconds * 1000000)
          if value >= 1.0 then value = 1.0 end
+         progress = vfx.apply_easing(value, state.easing)
 
          mVec.ResetMatrix(state.matrix)
          mVec.Translate(state.matrix, -Viewport.width*0.5, -Viewport.height*0.5)
-         mVec.Scale(state.matrix, 1.0 - value, 1.0 - value)
+         mVec.Scale(state.matrix, 1.0 - progress, 1.0 - progress)
          mVec.Translate(state.matrix, Viewport.width*0.5, Viewport.height*0.5)
          Viewport.acDraw()
 
@@ -233,17 +332,27 @@ end
 -- 'Shake' a vector by applying an alternating rotation around its center.  Intensity is between 0.1 and 2.0 and
 -- affects the number of shakes and maximum angle of rotation.
 
-vfx.shake = function(Viewport, Seconds, Delay, Intensity, CallbackOnCompletion)
-   state = { name = 'shake', intensity = (Intensity ?? 1.0), seconds = (Seconds ?? 1.0), delay = (Delay ?? 0), callback = CallbackOnCompletion }
+vfx.shake = function(Viewport, Options)
+   Options ?= { }
+   assert(type(Options) is 'table', 'VFX shake options must be supplied as a table')
+
+   config = vfx.effect_config(Options)
+   intensity = Options.intensity ?? 1.0
+
+   state = {
+      name = 'shake', intensity = intensity, seconds = config.seconds, delay = config.delay,
+      callback = config.callback, easing = config.easing
+   }
 
    state.intensity = choose state.intensity from
      < 0.1 -> 0.1
      > 2   -> 2
+     else  -> state.intensity
    end
 
-   MAX_ANGLE = 90 * Intensity
+   MAX_ANGLE = 90 * state.intensity
    QRT_ANGLE = MAX_ANGLE * 0.25
-   SHAKES    = math.round(6 * Intensity)
+   SHAKES    = math.round(6 * state.intensity)
    if SHAKES < 1 then SHAKES = 1 end
 
    local err
@@ -278,6 +387,11 @@ vfx.shake = function(Viewport, Seconds, Delay, Intensity, CallbackOnCompletion)
             angle = -QRT_ANGLE + (angle - (MAX_ANGLE - QRT_ANGLE))
          end
 
+         if state.easing then
+            progress = (CurrentTime - state.time) / (state.seconds * 1000000)
+            angle *= 1.0 - vfx.apply_easing(progress, state.easing)
+         end
+
          mVec.Rotate(state.matrix, angle, Viewport.width*0.5, Viewport.height*0.5)
          Viewport.acDraw()
       end
@@ -290,8 +404,12 @@ end
 -- Rotate the viewport 360 degrees within the allotted time.  This feature is typically chained for use with other
 -- effects.
 
-vfx.rotate = function(Viewport, Seconds, Delay, CallbackOnCompletion)
-   state = { name = 'rotate', seconds = (Seconds ?? 1.0), delay = (Delay ?? 0), callback = CallbackOnCompletion }
+vfx.rotate = function(Viewport, Options)
+   config = vfx.effect_config(Options)
+   state = {
+      name = 'rotate', seconds = config.seconds, delay = config.delay,
+      callback = config.callback, easing = config.easing
+   }
 
    local err
    err, state.matrix = Viewport.mtNewMatrix(false)
@@ -308,9 +426,10 @@ vfx.rotate = function(Viewport, Seconds, Delay, CallbackOnCompletion)
       else
          value = (CurrentTime - state.time) / (state.seconds * 1000000)
          if value >= 1.0 then value = 1.0 end
+         progress = vfx.apply_easing(value, state.easing)
 
          mVec.ResetMatrix(state.matrix)
-         mVec.Rotate(state.matrix, 360 * value, Viewport.width*0.5, Viewport.height*0.5)
+         mVec.Rotate(state.matrix, 360 * progress, Viewport.width*0.5, Viewport.height*0.5)
 
          Viewport.acDraw()
 
@@ -329,6 +448,7 @@ end
 vfx.wipes.simple.init = function(State, Options)
    if Options.rotate then
       local err
+      State.clip_path ?= State.clip.viewport.new('VectorPath', { })
       err, State.matrix = State.clip_path.mtNewMatrix(false)
       mVec.Rotate(State.matrix, Options.rotate, State.v_width * 0.5, State.v_height * 0.5)
    end
@@ -452,7 +572,8 @@ vfx.wipes.radial.init = function(State, Options)
    })
 
    for i=1,State.segments-1 do
-      radius = State.stroke_size + ((State.max_radius - State.stroke_size)) * (i / (State.segments-1)) - (State.stroke_size * 0.5)
+      radius = State.stroke_size + ((State.max_radius - State.stroke_size)) * (i / (State.segments-1)) -
+         (State.stroke_size * 0.5)
       State.ellipses:push(State.clip.viewport.new('VectorEllipse', {
          cx = State.cx, cy = State.cy, rx = radius, ry = radius, fill='none',
          stroke = 'rgb(255,255,255)', visibility = VIS_HIDDEN
@@ -506,6 +627,7 @@ end
 vfx.wipes.shutter.init = function(State, Options)
    if Options.rotate then
       local err
+      State.clip_path ?= State.clip.viewport.new('VectorPath', { })
       err, State.matrix = State.clip_path.mtNewMatrix(false)
       mVec.Rotate(State.matrix, Options.rotate, State.v_width * 0.5, State.v_height * 0.5)
    end
@@ -573,7 +695,8 @@ vfx.initTimer = function(State, Options)
             if State.callback then State.callback(State) end
             check ERR_Terminate
          else
-            State.animate(State, Options, Options.invert ? 1.0 - value :> value)
+            progress = vfx.apply_easing(value, State.easing)
+            State.animate(State, Options, Options.invert ? 1.0 - progress :> progress)
             State.viewport.acDraw()
          end
       end


### PR DESCRIPTION
## Summary

- VFX effect functions (`fadeIn`, `zoomIn`, `zoomOut`, `shake`, `rotate`, `wipe`, `moveIn`, `moveOut`) now accept a single `Options` table instead of positional parameters (`Seconds`, `Delay`, `Intensity`, `CallbackOnCompletion`)
- Added `vfx.ease` module with standard easing functions: `linear`, `inQuad`, `outQuad`, `inOutQuad`, `inCubic`, `outCubic`, `inOutCubic`
- Added `vfx.apply_easing()` and `vfx.effect_config()` helpers for normalising effect configuration across all functions
- Easing is applied throughout: `fadeIn` opacity, `zoomIn`/`zoomOut` scale, `rotate` angle, `shake` damping, and wipe progress
- Fixed missing `clip_path` initialisation in `simple` and `shutter` wipe init functions
- Updated `examples/widgets.tiri` to use the new options-based API

## Test plan

- [ ] Run `examples/widgets.tiri` and verify icon shake, fade-in, rotate, and zoom effects behave correctly
- [ ] Verify `vfx.chain()` with the new options-based calls completes its callback
- [ ] Test wipe effects with `style` option and confirm `shutter`/`simple` wipes with `rotate` option no longer crash
- [ ] Confirm easing functions produce correct output for boundary values (0.0, 0.5, 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)