### PR TITLE
Fixed negative index slicing to preserve inclusive/exclusive stop semantics

### DIFF
--- a/.agents/skills/tiri-programming/SKILL.md
+++ b/.agents/skills/tiri-programming/SKILL.md
@@ -97,7 +97,7 @@ search tools, and mixed editor environments.
 - Range literals use `{Start..Stop}` for exclusive stop and `{Start...Stop}` for inclusive stop.
 - Range literals do not support step expressions; use `range(Start, Stop, Inclusive, Step)` for stepped ranges.
 - Range operands can be variables but not arbitrary expressions.
-- Negative indices in slicing count from the end and behave inclusively.
+- Negative indices in slicing count from the end and preserve `..` exclusive or `...` inclusive stop semantics.
 - Ranges can iterate, slice strings/tables/arrays, test membership with `in`, and provide functional methods such as
   `each`, `map`, `filter`, `reduce`, `take`, `any`, `all`, and `find`.
 - Use native arrays for sequential data and buffers:

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -1060,10 +1060,9 @@ static int range_slice_impl(lua_State *L)
       int32_t stop = r->stop;
       int32_t step = r->step;
 
-      // Handle negative indices (always inclusive for negative ranges)
+      // Resolve negative indices while preserving the range's inclusive/exclusive mode.
       bool use_inclusive = r->inclusive;
       if (start < 0 or stop < 0) {
-         use_inclusive = true;
          if (start < 0) start += len;
          if (stop < 0) stop += len;
       }
@@ -1143,10 +1142,9 @@ static int range_slice_impl(lua_State *L)
       int32_t stop = r->stop;
       int32_t step = r->step;
 
-      // Handle negative indices
+      // Resolve negative indices while preserving the range's inclusive/exclusive mode.
       bool use_inclusive = r->inclusive;
       if (start < 0 or stop < 0) {
-         use_inclusive = true;
          if (start < 0) start += len;
          if (stop < 0) stop += len;
       }
@@ -1235,10 +1233,9 @@ static int range_slice_impl(lua_State *L)
       int32_t stop = r->stop;
       int32_t step = r->step;
 
-      // Handle negative indices
+      // Resolve negative indices while preserving the range's inclusive/exclusive mode.
       bool use_inclusive = r->inclusive;
       if (start < 0 or stop < 0) {
-         use_inclusive = true;
          if (start < 0) start += len;
          if (stop < 0) stop += len;
       }

--- a/src/tiri/jit/src/lib/lib_string.cpp
+++ b/src/tiri/jit/src/lib/lib_string.cpp
@@ -855,10 +855,9 @@ static int string_index_handler(lua_State *L)
       int32_t start = r->start;
       int32_t stop = r->stop;
 
-      // Handle negative indices (always inclusive for negative ranges)
+      // Resolve negative indices while preserving the range's inclusive/exclusive mode.
       bool use_inclusive = r->inclusive;
       if (start < 0 or stop < 0) {
-         use_inclusive = true;  // Negative indices ignore inclusive flag
          if (start < 0) start += len;
          if (stop < 0) stop += len;
       }

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -670,16 +670,24 @@ end
       arr[i] = i
    end
 
-   -- Slice using negative end index (negative indices are always inclusive)
-   sliced = arr:slice({0..-1})
-   assert(#sliced is 5, "slice({0..-1}) should have length 5")
-   assert(sliced[4] is 4, "slice({0..-1})[4] should be 4")
+   -- Slice using negative end index with explicit inclusive/exclusive stop semantics
+   sliced_inclusive = arr:slice({0...-1})
+   assert(#sliced_inclusive is 5, "slice({0...-1}) should have length 5")
+   assert(sliced_inclusive[4] is 4, "slice({0...-1})[4] should be 4")
+
+   sliced_exclusive = arr:slice({0..-1})
+   assert(#sliced_exclusive is 4, "slice({0..-1}) should have length 4")
+   assert(sliced_exclusive[3] is 3, "slice({0..-1})[3] should be 3")
 
    -- Slice using negative start index
-   sliced2 = arr:slice({-2..-1})
-   assert(#sliced2 is 2, "slice({-2..-1}) should have length 2")
-   assert(sliced2[0] is 3, "slice({-2..-1})[0] should be 3")
-   assert(sliced2[1] is 4, "slice({-2..-1})[1] should be 4")
+   sliced_negative_inclusive = arr:slice({-2...-1})
+   assert(#sliced_negative_inclusive is 2, "slice({-2...-1}) should have length 2")
+   assert(sliced_negative_inclusive[0] is 3, "slice({-2...-1})[0] should be 3")
+   assert(sliced_negative_inclusive[1] is 4, "slice({-2...-1})[1] should be 4")
+
+   sliced_negative_exclusive = arr:slice({-2..-1})
+   assert(#sliced_negative_exclusive is 1, "slice({-2..-1}) should have length 1")
+   assert(sliced_negative_exclusive[0] is 3, "slice({-2..-1})[0] should be 3")
 end
 
 @Test function ArraySliceEdgeCases()

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -463,14 +463,18 @@ end
 end
 
 @Test function StringSliceNegativeIndices()
-   -- Test negative indices (always inclusive per design doc)
+   -- Test negative indices with explicit inclusive/exclusive stop semantics
    s = "Hello, World!"
-   assert(s[{-6..-1}] is "World!", "s[{-6..-1}] should be 'World!', got '" .. s[{-6..-1}] .. "'")
-   assert(s[{-1..-1}] is "!", "s[{-1..-1}] should be '!', got '" .. s[{-1..-1}] .. "'")
+   assert(s[{-6...-1}] is "World!", "s[{-6...-1}] should be 'World!', got '" .. s[{-6...-1}] .. "'")
+   assert(s[{-6..-1}] is "World", "s[{-6..-1}] should be 'World', got '" .. s[{-6..-1}] .. "'")
+   assert(s[{-1...-1}] is "!", "s[{-1...-1}] should be '!', got '" .. s[{-1...-1}] .. "'")
+   assert(s[{-1..-1}] is "", "s[{-1..-1}] should be empty, got '" .. s[{-1..-1}] .. "'")
 
    s2 = "ABCDE"
-   assert(s2[{-3..-1}] is "CDE", "s2[{-3..-1}] should be 'CDE', got '" .. s2[{-3..-1}] .. "'")
-   assert(s2[{-5..-1}] is "ABCDE", "s2[{-5..-1}] should be 'ABCDE', got '" .. s2[{-5..-1}] .. "'")
+   assert(s2[{-3...-1}] is "CDE", "s2[{-3...-1}] should be 'CDE', got '" .. s2[{-3...-1}] .. "'")
+   assert(s2[{-3..-1}] is "CD", "s2[{-3..-1}] should be 'CD', got '" .. s2[{-3..-1}] .. "'")
+   assert(s2[{-5...-1}] is "ABCDE", "s2[{-5...-1}] should be 'ABCDE', got '" .. s2[{-5...-1}] .. "'")
+   assert(s2[{-5..-1}] is "ABCD", "s2[{-5..-1}] should be 'ABCD', got '" .. s2[{-5..-1}] .. "'")
 end
 
 @Test function StringSliceOutOfBounds()
@@ -505,6 +509,9 @@ end
 
    r2 = range(7, 12)
    assert(s[r2] is "World", "s[r2] with r2=range(7,12) should be 'World'")
+
+   negative_range = {-6..-1}
+   assert(s[negative_range] is "World", "s[negative_range] with {-6..-1} should be 'World'")
 end
 
 @Test function StringSliceBoundsClipping()
@@ -1151,6 +1158,9 @@ end
    s = "Hello, World!"
    result = range.slice(s, {-6...-1})
    assert(result is "World!", "negative range.slice on string should return 'World!', got: " .. result)
+
+   result = range.slice(s, {-6..-1})
+   assert(result is "World", "exclusive negative range.slice on string should return 'World', got: " .. result)
 end
 
 @Test function RangeSliceTableWithStep()
@@ -1226,6 +1236,9 @@ end
    s = "Hello, World!"
    result = s[{-1...-13}]  -- Full reverse
    assert(result is "!dlroW ,olleH", "reverse negative indices should return '!dlroW ,olleH', got: " .. result)
+
+   result = s[{-1..-13}]
+   assert(result is "!dlroW ,olle", "exclusive reverse negative indices should return '!dlroW ,olle', got: " .. result)
 end
 
 @Test function StringSliceSimpleForwardUnchanged()

--- a/src/tiri/tests/test_table_slice.tiri
+++ b/src/tiri/tests/test_table_slice.tiri
@@ -74,15 +74,23 @@ end
    assert(result[0] is 30, "first element should be 30")
    assert(result[1] is 40, "second element should be 40")
    assert(result[2] is 50, "third element should be 50")
+
+   result = t[{-3..-1}]  -- Last 3 elements, excluding the resolved stop: {30, 40}
+   assert(#result is 2, "exclusive negative slice should have 2 elements, got " .. #result)
+   assert(result[0] is 30, "exclusive first element should be 30")
+   assert(result[1] is 40, "exclusive second element should be 40")
 end
 
 @Test function TableSliceNegativeStart()
    t = {10, 20, 30, 40, 50}
-   -- Negative indices force inclusive mode per design doc
-   result = t[{-2..-1}]  -- {40, 50} (inclusive due to negative indices)
-   assert(#result is 2, "negative indices slice should have 2 elements, got " .. #result)
+   result = t[{-2...-1}]  -- {40, 50}
+   assert(#result is 2, "inclusive negative indices slice should have 2 elements, got " .. #result)
    assert(result[0] is 40, "first element should be 40")
    assert(result[1] is 50, "second element should be 50")
+
+   result = t[{-2..-1}]  -- {40}
+   assert(#result is 1, "exclusive negative indices slice should have 1 element, got " .. #result)
+   assert(result[0] is 40, "exclusive first element should be 40")
 end
 
 @Test function TableSliceNegativeEnd()
@@ -91,6 +99,11 @@ end
    assert(#result is 4, "slice to negative end should have 4 elements, got " .. #result)
    assert(result[0] is 10)
    assert(result[3] is 40)
+
+   result = t[{0..-2}]  -- From start to second-to-last (exclusive)
+   assert(#result is 3, "exclusive slice to negative end should have 3 elements, got " .. #result)
+   assert(result[0] is 10)
+   assert(result[2] is 30)
 end
 
 @Test function TableSliceMixedIndices()


### PR DESCRIPTION
## Summary

- Removes the forced `use_inclusive = true` override that was applied whenever negative indices were resolved in range slicing for strings, arrays, and tables (`lib_range.cpp`, `lib_string.cpp`)
- Negative indices now resolve to their positive equivalents and then respect the original `..` (exclusive) or `...` (inclusive) stop semantics, consistent with positive index behaviour
- Updated Flute tests (`test_ranges.tiri`, `test_array.tiri`, `test_table_slice.tiri`) to cover both `..` and `...` variants with negative indices
- Updated `SKILL.md` to reflect the corrected behaviour

## Test plan

- [ ] Run `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri` to verify all Tiri Flute tests pass
- [ ] Confirm `test_ranges.tiri` `StringSliceNegativeIndices`, `RangeSliceNegativeStringExclusive`, and `RangeSliceNegativeReverse` test cases pass
- [ ] Confirm `test_array.tiri` negative-index slice cases pass with both `..` and `...`
- [ ] Confirm `test_table_slice.tiri` `TableSliceNegativeStart`, `TableSliceNegativeEnd`, and `TableSliceNegativeStopExclusive` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)