### PR TITLE
[Tiri] Added `raise message` shorthand that defaults the error code to ERR_Exception

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4466,8 +4466,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov CARG2w, RAw                // 2nd arg: error code
     |  mov CARG1, L                   // 1st arg: lua_State *L
     |  bl extern lj_raise_with_msg    // Never returns
-    |3:  // Not a number - use ERR_Failed (13) as default error code
-    |  mov RAw, #13                    // ERR_Failed = 13
+    |3:  // Not a number - use ERR_Exception (162) as default error code
+    |  mov RAw, #162                   // ERR_Exception = 162
     |  str RAw, [L, #L_CAUGHTERROR_OFS]  // Set L->CaughtError
     |  b <2
     break;

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6480,8 +6480,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mr CARG2, TMP1                 // 2nd arg: error code
     |  mr CARG1, L                    // 1st arg: lua_State *L
     |  bl extern lj_raise_with_msg    // Never returns
-    |3:  // Not a number - use ERR_Failed (13) as default error code
-    |  li TMP1, 13                     // ERR_Failed = 13
+    |3:  // Not a number - use ERR_Exception (162) as default error code
+    |  li TMP1, 162                    // ERR_Exception = 162
     |  stw TMP1, L_CAUGHTERROR_OFS(L)  // Set L->CaughtError
     |  b <2
     break;

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5393,7 +5393,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endif
     |  call extern lj_raise_with_msg  // Never returns
     |3:
-    |  mov RAd, 13                      // ERR_Failed = 13
+    |  mov RAd, 162                     // ERR_Exception = 162
     |  jmp <2
     break;
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -816,7 +816,7 @@ struct TryExceptPayload {
    ~TryExceptPayload();
 };
 
-// Raise statement payload: raise error_code [, message]
+// Raise statement payload: raise error_code [, message] or raise message
 struct RaiseStmtPayload {
    RaiseStmtPayload() = default;
    RaiseStmtPayload(const RaiseStmtPayload&) = delete;
@@ -824,8 +824,8 @@ struct RaiseStmtPayload {
    RaiseStmtPayload(RaiseStmtPayload&&) noexcept = default;
    RaiseStmtPayload& operator=(RaiseStmtPayload&&) noexcept = default;
 
-   ExprNodePtr error_code;   // Required: expression evaluating to error code
-   ExprNodePtr message;      // Optional: custom error message
+   ExprNodePtr error_code;   // Required: expression evaluating to error code, or message when no explicit code is used
+   ExprNodePtr message;      // Optional: explicit custom error message
 
    ~RaiseStmtPayload();
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -868,7 +868,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
 //********************************************************************************************************************
 // Parses raise statements: raise expression [, message]
 //
-// The raise keyword always triggers an exception with the given error code.
+// The first expression is normally the error code.  If it evaluates to a string and no comma message is supplied, the
+// emitter treats it as the custom message and lets the runtime default the error code to ERR::Exception.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_raise()
 {

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -240,10 +240,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_try_except_stmt(const TryExceptPayload 
 }
 
 //********************************************************************************************************************
-// Emit bytecode for raise statement: raise error_code [, message]
+// Emit bytecode for raise statement:
+//   raise error_code
+//   raise error_code, message
+//   raise message
 //
 // Bytecode structure:
-//   BC_RAISE  A=error_reg, D=msg_reg (0xFF if no message)
+//   BC_RAISE  A=error_reg, D=msg_reg
 
 ParserResult<IrEmitUnit> IrEmitter::emit_raise_stmt(const RaiseStmtPayload &Payload, const SourceSpan &Span)
 {
@@ -262,8 +265,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_raise_stmt(const RaiseStmtPayload &Payl
    expr_toanyreg(fs, &code_expr);
    auto error_reg = BCReg(code_expr.u.s.info);
    BCReg msg_reg = BCReg(0);
+   bool release_msg_reg = false;
 
-   // Evaluate optional message expression, or emit nil if not provided
+   // Evaluate optional message expression.  If there is no explicit comma message, copy the first expression to a
+   // separate message slot so that `raise "message"` defaults the code to ERR::Exception and keeps the custom text.
 
    if (Payload.message) {
       auto msg_result = this->emit_expression(*Payload.message);
@@ -277,14 +282,14 @@ ParserResult<IrEmitUnit> IrEmitter::emit_raise_stmt(const RaiseStmtPayload &Payl
       expr_free(fs, &msg_expr);
    }
    else {
-      // No message provided - emit nil to a register
       msg_reg = BCReg(fs->freereg++);
-      bcemit_AD(fs, BC_KPRI, msg_reg, BCREG(ExpKind::Nil));
-      fs->freereg--;  // Free the nil register
+      release_msg_reg = true;
+      bcemit_AD(fs, BC_MOV, msg_reg, error_reg);
    }
 
    // Emit BC_RAISE: A=error_reg, D=msg_reg
    bcemit_AD(fs, BC_RAISE, error_reg, msg_reg);
+   if (release_msg_reg) fs->freereg--;
    expr_free(fs, &code_expr);
 
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -112,7 +112,7 @@ enum class AstNodeKind : uint16_t {
    DoStmt,
    ConditionalShorthandStmt,
    TryExceptStmt,  // try...except...end exception handling
-   RaiseStmt,      // raise expression [, message]
+   RaiseStmt,      // raise error_code [, message] or raise message
    CheckStmt,      // check expression
    ImportStmt,     // import 'module' statement
    WithStmt,       // with obj1, obj2 do ... end

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -1396,13 +1396,37 @@ end
    error("raise with message did not throw an exception")
 end
 
-@Test(priority=62) function CheckBelowThreshold()
+@Test(priority=62) function RaiseWithDefaultCodeMessage()
+   try
+      raise "Default code message"
+   except e
+      assert(e.code is ERR_Exception, "raise with only a message should default to ERR_Exception")
+      assert(e.message is "Default code message", "raise should use the first string expression as the message")
+      return
+   end
+   error("raise with default code message did not throw an exception")
+end
+
+@Test(priority=63) function RaiseWithDefaultCodeMessageVariable()
+   err_text = "Variable default code message"
+
+   try
+      raise err_text
+   except e
+      assert(e.code is ERR_Exception, "raise with only a message variable should default to ERR_Exception")
+      assert(e.message is "Variable default code message", "raise should use the first string variable as the message")
+      return
+   end
+   error("raise with default code message variable did not throw an exception")
+end
+
+@Test(priority=64) function CheckBelowThreshold()
    -- ERR_Okay should not raise an exception
    check ERR_Okay
    -- If we reach here, the test passed
 end
 
-@Test(priority=63) function CheckAboveThreshold()
+@Test(priority=65) function CheckAboveThreshold()
    try
       check ERR_Failed
    except e
@@ -1412,7 +1436,7 @@ end
    error("check should have raised an exception for ERR_Failed")
 end
 
-@Test(priority=64) function CheckWithExpression()
+@Test(priority=66) function CheckWithExpression()
    function returns_error()
       return ERR_Args
    end
@@ -1425,7 +1449,7 @@ end
    error("check with expression should have thrown")
 end
 
-@Test(priority=65) function RaiseWithVariable()
+@Test(priority=67) function RaiseWithVariable()
    -- Test that raise works with variables, not just constants
    err_code = ERR_Failed
    caught = false
@@ -1440,7 +1464,7 @@ end
    assert(caught, "Exception should have been caught")
 end
 
-@Test(priority=66) function RaiseConditionalShorthand()
+@Test(priority=68) function RaiseConditionalShorthand()
    truthy_value = "has_something"
    falsy_value = nil
 
@@ -1460,7 +1484,7 @@ end
    assert(caught, "Falsy value should have triggered raise")
 end
 
-@Test(priority=67) function CheckConditionalShorthand()
+@Test(priority=69) function CheckConditionalShorthand()
    truthy_value = true
    falsy_value = nil
 


### PR DESCRIPTION
## Summary

* `raise "message"` and `raise variable` are now valid forms — the emitter copies the first expression into the message slot and the runtime defaults the error code to `ERR_Exception` (162)
* Changed the non-numeric raise fallback in the x64, ARM64, and PPC VM backends from `ERR_Failed` (13) to `ERR_Exception` (162) to be consistent with the new shorthand behaviour
* Added two Flute tests: `RaiseWithDefaultCodeMessage` and `RaiseWithDefaultCodeMessageVariable`

## Test plan

- [ ] Run `ctest -L test_try_except` and confirm all tests pass, including the two new priority-62/63 tests
- [ ] Verify `raise "message"` in a Tiri script produces `e.code == ERR_Exception` and `e.message == "message"` in the except block
- [ ] Verify the existing `raise error_code` and `raise error_code, message` forms are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)