### PR TITLE
[Tiri] Drop the deprecated ?? check in the parser

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -98,16 +98,6 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
       }
    }
 
-   // Old guard shorthand pattern: value ?? return/break/continue/raise/check
-
-   if (targets.size() IS 1 and is_presence_expr(targets[0])) {
-      Token next = this->ctx.tokens().current();
-      if (is_shorthand_statement_keyword(next.kind())) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, next,
-            "guard shorthand uses '?!'; replace '??' with '?!' before control-flow statements");
-      }
-   }
-
    if (targets.size() > 1) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
          "unexpected expression list without assignment");

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -166,7 +166,7 @@ end
 @Test function RHSOnce()
    count = 0
    function rhs()
-      count += 1
+      count++
       return "Y"
    end
    v = 0 ?? rhs()
@@ -382,7 +382,7 @@ end
 
    for i = 0, #values - 1 do
       values[i] ?! break
-      iterations += 1
+      iterations++
    end
 
    assert(iterations is 2, "Should break after 2 iterations, got " .. tostring(iterations))
@@ -429,56 +429,6 @@ end
    assert(body_executed is true, "Body should execute when condition is truthy")
 end
 
-function expect_old_guard_parse_error(Source:str, Label:str)
-   try
-      exec(Source)
-   except e
-      message = tostring(e.message ?? e)
-      assert(message:find("guard shorthand uses") != nil and message:find("?!") != nil,
-         Label .. " should report the ?! guard replacement, got: " .. message)
-      return
-   end
-
-   error(Label .. " should fail to parse")
-end
-
-@Test function OldGuardSyntaxRejected()
-   expect_old_guard_parse_error([[
-      function guardReturn(Value:any)
-         Value ?? return "default"
-         return Value
-      end
-   ]], "?? return")
-
-   expect_old_guard_parse_error([[
-      function guardBreak(Value:any)
-         for i = 0, 1 do
-            Value ?? break
-         end
-      end
-   ]], "?? break")
-
-   expect_old_guard_parse_error([[
-      function guardContinue(Value:any)
-         for i = 0, 1 do
-            Value ?? continue
-         end
-      end
-   ]], "?? continue")
-
-   expect_old_guard_parse_error([[
-      function guardRaise(Value:any)
-         Value ?? raise ERR_Failed
-      end
-   ]], "?? raise")
-
-   expect_old_guard_parse_error([[
-      function guardCheck(Value:any)
-         Value ?? check ERR_Failed
-      end
-   ]], "?? check")
-end
-
 @Test function MultiValues()
    function getValues()
       return 1, 2, 3
@@ -506,7 +456,7 @@ end
 @Test function ArrayShortCircuit()
    call_count = 0
    function rhs()
-      call_count += 1
+      call_count++
       return "RHS"
    end
    filled = array<int, 3>


### PR DESCRIPTION
## Summary

* Removes the backwards-compatibility error that fired when `??` was used before a shorthand control-flow statement — the `??` → `?!` migration was completed in #1346 and the shim is no longer needed

## Test plan

- [ ] Confirm the parser no longer references the `??` shorthand path
- [ ] Run the Tiri test suite and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)