### PR TITLE
[Origo] Show file dialog when no parameters specified; [Tiri] sleep(0) processes messages

### DIFF
--- a/src/launcher/origo.cpp
+++ b/src/launcher/origo.cpp
@@ -262,7 +262,9 @@ extern "C" int main(int argc, char **argv)
 
                if (error IS ERR::NoSupport) {
                   printf("%s", glHelp.c_str());
+                  error = ERR::Okay;
                }
+
                result = int(error);
             }
          }

--- a/src/launcher/origo.cpp
+++ b/src/launcher/origo.cpp
@@ -63,21 +63,27 @@ The following options can be used when executing script files:
 
 static std::string glDialogScript =
 R"(STRING:import 'gui/filedialog'
-gui.dialog.file({
- filterList = { { name='Script Files', ext='.tiri' } },
- strictFilter = true,
- title      = 'Run a Script',
- okText     = 'Run Script',
- cancelText = 'Exit',
- path       = '%%PATH%%',
- feedback = function(Dialog, Path, Files)
-  if not Files then mSys.SendMessage(MSGID_QUIT) return end
-  global glRunFile = Path .. Files[0].filename
-  processing.signal()
- end
-})
-processing.sleep(nil, true)
-if glRunFile then obj.new('script', { src = glRunFile }).acActivate() end
+try
+ gui.dialog.file({
+  filterList = { { name='Script Files', ext='.tiri' } },
+  strictFilter = true,
+  title = 'Run a Script',
+  okText = 'Run Script',
+  cancelText = 'Exit',
+  path = '%%PATH%%',
+  feedback = function(Dialog, Path, Files)
+   if not Files then mSys.SendMessage(MSGID_QUIT) return end
+   global glRunFile = Path .. Files[0].filename
+   processing.signal()
+  end
+ })
+except ex
+ raise ERR_NoSupport
+end
+processing.sleep()
+if glRunFile then
+ obj.new('script', { src = glRunFile }).acActivate()
+end
 )";
 
 //********************************************************************************************************************
@@ -93,7 +99,7 @@ static ERR process_args(void)
    if ((glTask->get(FID_Parameters, glArgs) IS ERR::Okay) and (glArgs)) {
       kt::vector<std::string> &args = *glArgs;
       for (unsigned i=0; i < args.size(); i++) {
-         if (kt::iequals(args[i], "--help")) { // Print help for the user
+         if (kt::iequals(args[i], "--help") or kt::iequals(args[i], "help")) { // Print help for the user
             printf("%s", glHelp.c_str());
             return ERR::Terminate;
          }
@@ -161,6 +167,28 @@ static ERR process_args(void)
 }
 
 //********************************************************************************************************************
+
+static ERR select_file_dialog(void)
+{
+   auto driver = CSTRING(GetResourcePtr(RES::DISPLAY_DRIVER));
+   if ((driver) and kt::iequals(driver, "headless")) return ERR::NoSupport;
+
+   auto start = glDialogScript.find("%%PATH%%");
+   if (not glTargetFile.empty()) {
+      std::string::size_type n = 0;
+      while ((n = glTargetFile.find('\\', n)) != std::string::npos) {
+            glTargetFile.replace(n, 1, "\\\\");
+            n += 2;
+      }
+
+      glDialogScript.replace(start, 8, glTargetFile);
+   }
+   else glDialogScript.replace(start, 8, "kotuku:");
+
+   return exec_source(glDialogScript.c_str(), glTime, glProcedure);
+}
+
+//********************************************************************************************************************
 // Note: In Windows, if the program is failing to load and no output is printed, pipe to Out-Host to see error messages.
 // E.g. .\origo.exe --version | Out-Host
 
@@ -185,19 +213,7 @@ extern "C" int main(int argc, char **argv)
       }
 
       if (glDialog) {
-         auto start = glDialogScript.find("%%PATH%%");
-         if (not glTargetFile.empty()) {
-            std::string::size_type n = 0;
-            while ((n = glTargetFile.find('\\', n)) != std::string::npos) {
-                glTargetFile.replace(n, 1, "\\\\");
-                n += 2;
-            }
-
-            glDialogScript.replace(start, 8, glTargetFile);
-         }
-         else glDialogScript.replace(start, 8, "kotuku:");
-
-         result = int(exec_source(glDialogScript.c_str(), glTime, glProcedure));
+         result = int(select_file_dialog());
       }
       else if (not glStatement.empty()) {
          result = int(exec_source(std::string("STRING:") + glStatement, glTime, glProcedure));
@@ -214,6 +230,7 @@ extern "C" int main(int argc, char **argv)
          else result = int(exec_source(glTargetFile.c_str(), glTime, glProcedure));
       }
       else {
+         // Engage default behaviour if no parameters have been specified
          // Check for the presence of package.zip or main.tiri files in the working directory
 
          auto path = glTask->get<CSTRING>(FID_ProcessPath);
@@ -240,7 +257,14 @@ extern "C" int main(int argc, char **argv)
             if ((AnalysePath("main.tiri", &type) IS ERR::Okay) and (type IS LOC::FILE)) {
                result = (int)exec_source("main.tiri", glTime, glProcedure);
             }
-            else printf("%s", glHelp.c_str());
+            else {
+               auto error = select_file_dialog();
+
+               if (error IS ERR::NoSupport) {
+                  printf("%s", glHelp.c_str());
+               }
+               result = int(error);
+            }
          }
       }
    }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -157,6 +157,7 @@ static int processing_sleep(lua_State *Lua)
 
    log.branch("Timeout: %g", seconds);
 
+   ERR error;
    if (seconds != 0) {
       // Always collect your garbage before going to sleep.  Can be prevented with processing.stopCollector() if
       // absolutely necessary.
@@ -165,33 +166,33 @@ static int processing_sleep(lua_State *Lua)
          log.traceBranch("Collecting garbage.");
          lua_gc(Lua, LUA_GCCOLLECT, 0);
       }
-   }
 
-   ERR error;
-   if ((fp) and (fp->Signals) and (not fp->Signals->empty())) {
-      // Use custom signals provided by the client
-      auto signal_list_c = std::make_unique<ObjectSignal[]>(fp->Signals->size() + 1);
-      int i = 0;
-      for (auto &entry : *fp->Signals) signal_list_c[i++] = entry;
-      signal_list_c[i].Object = nullptr;
+      if ((fp) and (fp->Signals) and (not fp->Signals->empty())) {
+         // Use custom signals provided by the client
+         auto signal_list_c = std::make_unique<ObjectSignal[]>(fp->Signals->size() + 1);
+         int i = 0;
+         for (auto &entry : *fp->Signals) signal_list_c[i++] = entry;
+         signal_list_c[i].Object = nullptr;
 
-      std::scoped_lock lock(recursion);
-      auto timeout = int(seconds * 1000.0);
-      error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
-   }
-   else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
-      if (Lua->script->defined(NF::SIGNALLED)) {
-         log.detail("Tiri script already in signalled state.");
-         Lua->script->clearFlag(NF::SIGNALLED);
-         error = ERR::Okay;
-      }
-      else {
-         ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
          std::scoped_lock lock(recursion);
          auto timeout = int(seconds * 1000.0);
-         error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
+         error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
+      }
+      else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
+         if (Lua->script->defined(NF::SIGNALLED)) {
+            log.detail("Tiri script already in signalled state.");
+            Lua->script->clearFlag(NF::SIGNALLED);
+            error = ERR::Okay;
+         }
+         else {
+            ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
+            std::scoped_lock lock(recursion);
+            auto timeout = int(seconds * 1000.0);
+            error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
+         }
       }
    }
+   else error = ProcessMessages(PMF::NIL, 0);
 
    // Promote errors to exceptions
    if ((error != ERR::Okay) and (in_try_immediate_scope(Lua))) luaL_error(Lua, error);
@@ -207,6 +208,8 @@ static int processing_sleep(lua_State *Lua)
 
 static int processing_signal(lua_State *Lua)
 {
+   kt::Log log("processing.signal");
+   log.msg("Signaling Tiri object #%d.", Lua->script->UID);
    Action(AC::Signal, Lua->script, nullptr);
    return 0;
 }


### PR DESCRIPTION
## Summary

- When `origo` is launched with no parameters and no `main.tiri` is found in the working directory, a file dialog is now presented instead of printing help text. Falls back to help text only in headless mode (`NoSupport`).
- Refactored the inline dialog logic into a dedicated `select_file_dialog()` function; the dialog script updated to use `try/except` and `processing.sleep()` with no argument.
- `processing.sleep(0)` (i.e. no timeout) now calls `ProcessMessages()` directly to consume pending messages without sleeping, rather than skipping message processing entirely.
- Added `help` as an alias for `--help`.
- Added a log message to `processing_signal()` for improved diagnostics.

## Test plan

- [ ] Launch `origo` with no arguments on a desktop environment — file dialog should appear
- [ ] Launch `origo` with no arguments in headless mode — help text should be printed
- [ ] Verify `processing.sleep(0)` processes pending messages without blocking
- [ ] Confirm `origo help` behaves the same as `origo --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)