### PR TITLE
[Display] Added WSLg detection and improved X11 focus handling

### DIFF
--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -24,6 +24,16 @@ static ERR DISPLAY_Resize(extDisplay *, struct acResize *);
 
 static void alloc_display_buffer(extDisplay *Self);
 
+#ifdef __xwindows__
+static void set_x11_input_hints(Window WindowHandle)
+{
+   XWMHints hints = { };
+   hints.flags = InputHint;
+   hints.input = True;
+   XSetWMHints(XDisplay, WindowHandle, &hints);
+}
+#endif
+
 #ifdef _GLES_
 static const int attributes[] = {
    EGL_BUFFER_SIZE,
@@ -324,7 +334,9 @@ static ERR DISPLAY_Focus(extDisplay *Self)
 #ifdef _WIN32
    winFocus(Self->WindowHandle);
 #elif __xwindows__
-   if ((Self->Flags & SCR::BORDERLESS) != SCR::NIL) XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+   if ((Self->Flags & (SCR::BORDERLESS|SCR::COMPOSITE)) != SCR::NIL) {
+      XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+   }
 #endif
    return ERR::Okay;
 }
@@ -588,6 +600,11 @@ static ERR DISPLAY_Init(extDisplay *Self)
    #ifdef __xwindows__
       // If the display object will act as window manager, the dimensions must match that of the root window.
 
+      if ((glX11.WSLg) and ((Self->Flags & (SCR::BORDERLESS|SCR::MAXIMISE)) IS (SCR::BORDERLESS|SCR::MAXIMISE))) {
+         log.msg("WSLg detected; using a managed maximised window instead of fullscreen override-redirect.");
+         Self->Flags = Self->Flags & (~SCR::BORDERLESS);
+      }
+
       if ((glX11.Manager) or ((Self->Flags & SCR::MAXIMISE) != SCR::NIL)) {
          Self->Width  = glRootWindow.width;
          Self->Height = glRootWindow.height;
@@ -716,7 +733,9 @@ static ERR DISPLAY_Init(extDisplay *Self)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         Atom protocols[1] = { XWADeleteWindow };
+         set_x11_input_hints(Self->XWindowHandle);
+
+         Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
          XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));
 
          Self->Flags |= SCR::HOSTED;
@@ -2203,7 +2222,10 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
 
       #elif __xwindows__
 
-         if (glX11.Manager) return ERR::NoSupport;
+         if ((glX11.Manager) or
+             ((glX11.WSLg) and ((Value & (SCR::BORDERLESS|SCR::MAXIMISE)) IS (SCR::BORDERLESS|SCR::MAXIMISE)))) {
+            return ERR::NoSupport;
+         }
 
          XSetWindowAttributes swa;
 
@@ -2254,8 +2276,10 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         Atom protocols[1] = { XWADeleteWindow };
-         XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, 1);
+         set_x11_input_hints(Self->XWindowHandle);
+
+         Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
+         XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));
 
          if (glStickToFront) {
             XSetTransientForHint(XDisplay, Self->XWindowHandle, DefaultRootWindow(XDisplay));
@@ -2278,7 +2302,9 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
 
          if ((Self->Flags & SCR::VISIBLE) != SCR::NIL) {
             acShow(Self);
-            XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+            if ((Self->Flags & (SCR::BORDERLESS|SCR::COMPOSITE)) != SCR::NIL) {
+               XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+            }
             QueueAction(AC::Focus, Self->UID);
          }
 

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -493,6 +493,7 @@ extern WinCursor winCursors[24];
 
 struct X11Globals {
    bool Manager;
+   bool WSLg;
    int PixelsPerLine; // Defined by DGA
    int BankSize; // Definfed by DGA
 };
@@ -522,7 +523,7 @@ extern bool glXCompositeSupported;
 extern uint8_t KeyHeld[int(KEY::LIST_END)];
 extern KQ glKeyFlags;
 extern int glXFD, glDGAPixelsPerLine, glDGABankSize;
-extern Atom atomSurfaceID, XWADeleteWindow;
+extern Atom atomSurfaceID, XWADeleteWindow, XWATakeFocus;
 extern GC glXGC, glClipXGC;
 extern XWindowAttributes glRootWindow;
 extern Window glDisplayWindow;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -898,8 +898,6 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
    if (!glHeadless) {
       // Attempt to open X11.  Use KOTUKU_XDISPLAY if set, otherwise use the DISPLAY variable.
 
-      log.msg("Attempting to open X11...");
-
       CSTRING strdisplay = getenv("KOTUKU_XDISPLAY");
       if (!strdisplay) strdisplay = getenv("DISPLAY");
 
@@ -911,14 +909,13 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
          if (glX11.WSLg) {
             glX11.Manager = false;
-            log.msg("WSLg detected; disabling legacy X11 direct-display features.");
          }
          else {
             XSetErrorHandler((XErrorHandler)CatchRedirectError);
 
             XSelectInput(XDisplay, RootWindow(XDisplay, DefaultScreen(XDisplay)),
                LeaveWindowMask|EnterWindowMask|PointerMotionMask|
-               PropertyChangeMask| //SubstructureRedirectMask| // SubstructureNotifyMask |
+               PropertyChangeMask|SubstructureRedirectMask| // SubstructureNotifyMask |
                KeyPressMask|ButtonPressMask|ButtonReleaseMask);
 
             XSync(XDisplay, 0);

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -45,7 +45,7 @@ uint8_t KeyHeld[int(KEY::LIST_END)];
 uint8_t glTrayIcon = 0, glTaskBar = 1, glStickToFront = 0;
 KQ glKeyFlags = KQ::NIL;
 int glXFD = -1, glDGAPixelsPerLine = 0, glDGABankSize = 0;
-Atom atomSurfaceID = 0, XWADeleteWindow = 0;
+Atom atomSurfaceID = 0, XWADeleteWindow = 0, XWATakeFocus = 0;
 GC glXGC = 0, glClipXGC = 0;
 XWindowAttributes glRootWindow;
 Window glDisplayWindow = 0;
@@ -278,6 +278,8 @@ ERR xr_set_display_mode(int *Width, int *Height)
    int width = *Width;
    int height = *Height;
 
+   if (glX11.WSLg) return ERR::NoSupport;
+
    XRRScreenSize *sizes;
    if ((sizes = XRRSizes(XDisplay, DefaultScreen(XDisplay), &count)) and (count)) {
       int16_t index    = -1;
@@ -422,6 +424,15 @@ void unlock_graphics(void)
 
 int16_t glDGAAvailable = -1; // -1 indicates that we have not tried the setup process yet
 
+static bool detect_wslg(void)
+{
+   if (auto gui_enabled = getenv("WSL2_GUI_APPS_ENABLED")) {
+      if (gui_enabled[0] IS '1') return true;
+   }
+
+   return access("/mnt/wslg", F_OK) IS 0;
+}
+
 #ifdef XDGA_AVAILABLE
 APTR glDGAMemory = nullptr;
 
@@ -432,6 +443,18 @@ int x11DGAAvailable(APTR *VideoAddress, int *PixelsPerLine, int *BankSize)
 
    static int checked = true;
    *VideoAddress = NULL;
+
+   if (glX11.WSLg) {
+      glDGAAvailable = FALSE;
+      glDGAMemory = nullptr;
+      glDGAVideo = nullptr;
+      glX11.PixelsPerLine = 0;
+      glX11.BankSize = 0;
+
+      if (PixelsPerLine) *PixelsPerLine = 0;
+      if (BankSize) *BankSize = 0;
+      return glDGAAvailable;
+   }
 
    if (glDGAAvailable IS -1) {
       // Check for the DGA driver.  This will only work if the extension is version 2.0+ and we have permissions
@@ -884,16 +907,24 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
          // Select the X messages that we want to receive from the root window.  This will also tell us if an X11 manager
          // is currently running or not (refer to the CatchRedirectError() exception routine).
 
-         XSetErrorHandler((XErrorHandler)CatchRedirectError);
+         glX11.WSLg = detect_wslg();
 
-         XSelectInput(XDisplay, RootWindow(XDisplay, DefaultScreen(XDisplay)),
-            LeaveWindowMask|EnterWindowMask|PointerMotionMask|
-            PropertyChangeMask|SubstructureRedirectMask| // SubstructureNotifyMask |
-            KeyPressMask|ButtonPressMask|ButtonReleaseMask);
+         if (glX11.WSLg) {
+            glX11.Manager = false;
+            log.msg("WSLg detected; disabling legacy X11 direct-display features.");
+         }
+         else {
+            XSetErrorHandler((XErrorHandler)CatchRedirectError);
+
+            XSelectInput(XDisplay, RootWindow(XDisplay, DefaultScreen(XDisplay)),
+               LeaveWindowMask|EnterWindowMask|PointerMotionMask|
+               PropertyChangeMask| //SubstructureRedirectMask| // SubstructureNotifyMask |
+               KeyPressMask|ButtonPressMask|ButtonReleaseMask);
+
+            XSync(XDisplay, 0);
+         }
 
          if (!getenv("KOTUKU_XDISPLAY")) setenv("KOTUKU_XDISPLAY", strdisplay, FALSE);
-
-         XSync(XDisplay, 0);
 
          XSetErrorHandler((XErrorHandler)CatchXError);
          XSetIOErrorHandler(CatchXIOError);
@@ -940,6 +971,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       C_Default = XCreateFontCursor(XDisplay, XC_left_ptr);
 
       XWADeleteWindow = XInternAtom(XDisplay, "WM_DELETE_WINDOW", False);
+      XWATakeFocus    = XInternAtom(XDisplay, "WM_TAKE_FOCUS", False);
       atomSurfaceID   = XInternAtom(XDisplay, "KOTUKU_SCREENID", False);
 
       XGetWindowAttributes(XDisplay, DefaultRootWindow(XDisplay), &glRootWindow);
@@ -969,7 +1001,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       char buffer[512];
 
       int events;
-      if ((glX11.Manager) and (XRRQueryExtension(XDisplay, &events, &errors))) {
+      if ((not glX11.WSLg) and (glX11.Manager) and (XRRQueryExtension(XDisplay, &events, &errors))) {
          glXRRAvailable = true;
          if ((sizes = XRRSizes(XDisplay, DefaultScreen(XDisplay), &count)) and (count)) {
             glSizes = sizes;

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -95,7 +95,7 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
          }
 
          case ClientMessage:
-            if ((Atom)xevent.xclient.data.l[0] == XWADeleteWindow) {
+            if (Atom(xevent.xclient.data.l[0]) IS XWADeleteWindow) {
                if (auto display_id = get_display(xevent.xany.window)) {
                   auto surface_id = GetOwnerID(display_id);
                   const WinHook hook(surface_id, WH::CLOSE);
@@ -128,6 +128,9 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
                   log.msg("Failed to retrieve display ID for window $%x.", (unsigned int)xevent.xany.window);
                   XDestroyWindow(XDisplay, (Window)xevent.xany.window);
                }
+            }
+            else if (Atom(xevent.xclient.data.l[0]) IS XWATakeFocus) {
+               XSetInputFocus(XDisplay, xevent.xclient.window, RevertToParent, Time(xevent.xclient.data.l[1]));
             }
             break;
 
@@ -245,7 +248,10 @@ void handle_button_release(XEvent *xevent)
 
    XFlush(XDisplay);
 
-   XSetInputFocus(XDisplay, xevent->xany.window, RevertToNone, CurrentTime);
+   XWindowAttributes attributes;
+   if ((XGetWindowAttributes(XDisplay, xevent->xany.window, &attributes)) and (attributes.override_redirect)) {
+      XSetInputFocus(XDisplay, xevent->xany.window, RevertToNone, CurrentTime);
+   }
 }
 
 //********************************************************************************************************************


### PR DESCRIPTION
* Detect WSLg environment via WSL2_GUI_APPS_ENABLED env variable and /mnt/wslg path
* Disable override-redirect fullscreen mode on WSLg; fall back to a maximised managed window
* Added WM_TAKE_FOCUS atom and WM_HINTS input flag for correct focus protocol support
* Handle WM_TAKE_FOCUS ClientMessage events by calling XSetInputFocus with the provided timestamp
* Restrict XSetInputFocus on button release to override-redirect windows only
* Disable DGA and XRandR mode switching in WSLg environments