### PR TITLE
[Display] Improve WSLg X11 display handling

### DIFF
--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -24,6 +24,16 @@ static ERR DISPLAY_Resize(extDisplay *, struct acResize *);
 
 static void alloc_display_buffer(extDisplay *Self);
 
+#ifdef __xwindows__
+static void set_x11_input_hints(Window WindowHandle)
+{
+   XWMHints hints = { };
+   hints.flags = InputHint;
+   hints.input = True;
+   XSetWMHints(XDisplay, WindowHandle, &hints);
+}
+#endif
+
 #ifdef _GLES_
 static const int attributes[] = {
    EGL_BUFFER_SIZE,
@@ -324,7 +334,9 @@ static ERR DISPLAY_Focus(extDisplay *Self)
 #ifdef _WIN32
    winFocus(Self->WindowHandle);
 #elif __xwindows__
-   if ((Self->Flags & SCR::BORDERLESS) != SCR::NIL) XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+   if ((Self->Flags & (SCR::BORDERLESS|SCR::COMPOSITE)) != SCR::NIL) {
+      XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+   }
 #endif
    return ERR::Okay;
 }
@@ -588,6 +600,11 @@ static ERR DISPLAY_Init(extDisplay *Self)
    #ifdef __xwindows__
       // If the display object will act as window manager, the dimensions must match that of the root window.
 
+      if ((glX11.WSLg) and ((Self->Flags & (SCR::BORDERLESS|SCR::MAXIMISE)) IS (SCR::BORDERLESS|SCR::MAXIMISE))) {
+         log.msg("WSLg detected; using a managed maximised window instead of fullscreen override-redirect.");
+         Self->Flags = Self->Flags & (~SCR::BORDERLESS);
+      }
+
       if ((glX11.Manager) or ((Self->Flags & SCR::MAXIMISE) != SCR::NIL)) {
          Self->Width  = glRootWindow.width;
          Self->Height = glRootWindow.height;
@@ -716,7 +733,9 @@ static ERR DISPLAY_Init(extDisplay *Self)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         Atom protocols[1] = { XWADeleteWindow };
+         set_x11_input_hints(Self->XWindowHandle);
+
+         Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
          XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));
 
          Self->Flags |= SCR::HOSTED;
@@ -2203,7 +2222,10 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
 
       #elif __xwindows__
 
-         if (glX11.Manager) return ERR::NoSupport;
+         if ((glX11.Manager) or
+             ((glX11.WSLg) and ((Value & (SCR::BORDERLESS|SCR::MAXIMISE)) IS (SCR::BORDERLESS|SCR::MAXIMISE)))) {
+            return ERR::NoSupport;
+         }
 
          XSetWindowAttributes swa;
 
@@ -2254,8 +2276,10 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         Atom protocols[1] = { XWADeleteWindow };
-         XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, 1);
+         set_x11_input_hints(Self->XWindowHandle);
+
+         Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
+         XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));
 
          if (glStickToFront) {
             XSetTransientForHint(XDisplay, Self->XWindowHandle, DefaultRootWindow(XDisplay));
@@ -2278,7 +2302,9 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
 
          if ((Self->Flags & SCR::VISIBLE) != SCR::NIL) {
             acShow(Self);
-            XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+            if ((Self->Flags & (SCR::BORDERLESS|SCR::COMPOSITE)) != SCR::NIL) {
+               XSetInputFocus(XDisplay, Self->XWindowHandle, RevertToNone, CurrentTime);
+            }
             QueueAction(AC::Focus, Self->UID);
          }
 

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -493,6 +493,7 @@ extern WinCursor winCursors[24];
 
 struct X11Globals {
    bool Manager;
+   bool WSLg;
    int PixelsPerLine; // Defined by DGA
    int BankSize; // Definfed by DGA
 };
@@ -522,7 +523,7 @@ extern bool glXCompositeSupported;
 extern uint8_t KeyHeld[int(KEY::LIST_END)];
 extern KQ glKeyFlags;
 extern int glXFD, glDGAPixelsPerLine, glDGABankSize;
-extern Atom atomSurfaceID, XWADeleteWindow;
+extern Atom atomSurfaceID, XWADeleteWindow, XWATakeFocus;
 extern GC glXGC, glClipXGC;
 extern XWindowAttributes glRootWindow;
 extern Window glDisplayWindow;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -45,7 +45,7 @@ uint8_t KeyHeld[int(KEY::LIST_END)];
 uint8_t glTrayIcon = 0, glTaskBar = 1, glStickToFront = 0;
 KQ glKeyFlags = KQ::NIL;
 int glXFD = -1, glDGAPixelsPerLine = 0, glDGABankSize = 0;
-Atom atomSurfaceID = 0, XWADeleteWindow = 0;
+Atom atomSurfaceID = 0, XWADeleteWindow = 0, XWATakeFocus = 0;
 GC glXGC = 0, glClipXGC = 0;
 XWindowAttributes glRootWindow;
 Window glDisplayWindow = 0;
@@ -278,6 +278,8 @@ ERR xr_set_display_mode(int *Width, int *Height)
    int width = *Width;
    int height = *Height;
 
+   if (glX11.WSLg) return ERR::NoSupport;
+
    XRRScreenSize *sizes;
    if ((sizes = XRRSizes(XDisplay, DefaultScreen(XDisplay), &count)) and (count)) {
       int16_t index    = -1;
@@ -422,6 +424,15 @@ void unlock_graphics(void)
 
 int16_t glDGAAvailable = -1; // -1 indicates that we have not tried the setup process yet
 
+static bool detect_wslg(void)
+{
+   if (auto gui_enabled = getenv("WSL2_GUI_APPS_ENABLED")) {
+      if (gui_enabled[0] IS '1') return true;
+   }
+
+   return access("/mnt/wslg", F_OK) IS 0;
+}
+
 #ifdef XDGA_AVAILABLE
 APTR glDGAMemory = nullptr;
 
@@ -432,6 +443,18 @@ int x11DGAAvailable(APTR *VideoAddress, int *PixelsPerLine, int *BankSize)
 
    static int checked = true;
    *VideoAddress = NULL;
+
+   if (glX11.WSLg) {
+      glDGAAvailable = FALSE;
+      glDGAMemory = nullptr;
+      glDGAVideo = nullptr;
+      glX11.PixelsPerLine = 0;
+      glX11.BankSize = 0;
+
+      if (PixelsPerLine) *PixelsPerLine = 0;
+      if (BankSize) *BankSize = 0;
+      return glDGAAvailable;
+   }
 
    if (glDGAAvailable IS -1) {
       // Check for the DGA driver.  This will only work if the extension is version 2.0+ and we have permissions
@@ -884,16 +907,24 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
          // Select the X messages that we want to receive from the root window.  This will also tell us if an X11 manager
          // is currently running or not (refer to the CatchRedirectError() exception routine).
 
-         XSetErrorHandler((XErrorHandler)CatchRedirectError);
+         glX11.WSLg = detect_wslg();
 
-         XSelectInput(XDisplay, RootWindow(XDisplay, DefaultScreen(XDisplay)),
-            LeaveWindowMask|EnterWindowMask|PointerMotionMask|
-            PropertyChangeMask|SubstructureRedirectMask| // SubstructureNotifyMask |
-            KeyPressMask|ButtonPressMask|ButtonReleaseMask);
+         if (glX11.WSLg) {
+            glX11.Manager = false;
+            log.msg("WSLg detected; disabling legacy X11 direct-display features.");
+         }
+         else {
+            XSetErrorHandler((XErrorHandler)CatchRedirectError);
+
+            XSelectInput(XDisplay, RootWindow(XDisplay, DefaultScreen(XDisplay)),
+               LeaveWindowMask|EnterWindowMask|PointerMotionMask|
+               PropertyChangeMask| //SubstructureRedirectMask| // SubstructureNotifyMask |
+               KeyPressMask|ButtonPressMask|ButtonReleaseMask);
+
+            XSync(XDisplay, 0);
+         }
 
          if (!getenv("KOTUKU_XDISPLAY")) setenv("KOTUKU_XDISPLAY", strdisplay, FALSE);
-
-         XSync(XDisplay, 0);
 
          XSetErrorHandler((XErrorHandler)CatchXError);
          XSetIOErrorHandler(CatchXIOError);
@@ -940,6 +971,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       C_Default = XCreateFontCursor(XDisplay, XC_left_ptr);
 
       XWADeleteWindow = XInternAtom(XDisplay, "WM_DELETE_WINDOW", False);
+      XWATakeFocus    = XInternAtom(XDisplay, "WM_TAKE_FOCUS", False);
       atomSurfaceID   = XInternAtom(XDisplay, "KOTUKU_SCREENID", False);
 
       XGetWindowAttributes(XDisplay, DefaultRootWindow(XDisplay), &glRootWindow);
@@ -969,7 +1001,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       char buffer[512];
 
       int events;
-      if ((glX11.Manager) and (XRRQueryExtension(XDisplay, &events, &errors))) {
+      if ((not glX11.WSLg) and (glX11.Manager) and (XRRQueryExtension(XDisplay, &events, &errors))) {
          glXRRAvailable = true;
          if ((sizes = XRRSizes(XDisplay, DefaultScreen(XDisplay), &count)) and (count)) {
             glSizes = sizes;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -173,6 +173,46 @@ static XRRScreenSize glCustomSizes[] = { { 640,480,0,0 }, { 800,600,0,0 }, { 102
 static XRRScreenSize *glSizes = glCustomSizes;
 static int glSizeCount = std::ssize(glCustomSizes);
 static int glActualCount = 0;
+
+static bool get_default_xrandr_monitor_size(int *Width, int *Height)
+{
+   if ((!XDisplay) or (!Width) or (!Height)) return false;
+
+   int event_base = 0;
+   int error_base = 0;
+   if (!XRRQueryExtension(XDisplay, &event_base, &error_base)) return false;
+
+   int major_version = 0;
+   int minor_version = 0;
+   if (!XRRQueryVersion(XDisplay, &major_version, &minor_version)) return false;
+   if ((major_version < 1) or ((major_version IS 1) and (minor_version < 5))) return false;
+
+   int monitor_count = 0;
+   auto monitors = XRRGetMonitors(XDisplay, DefaultRootWindow(XDisplay), True, &monitor_count);
+   if (!monitors) return false;
+   if (!monitor_count) {
+      XRRFreeMonitors(monitors);
+      return false;
+   }
+
+   int monitor_index = 0;
+   for (int i=0; i < monitor_count; i++) {
+      if (monitors[i].primary) {
+         monitor_index = i;
+         break;
+      }
+   }
+
+   auto result = false;
+   if ((monitors[monitor_index].width > 0) and (monitors[monitor_index].height > 0)) {
+      *Width  = monitors[monitor_index].width;
+      *Height = monitors[monitor_index].height;
+      result = true;
+   }
+
+   XRRFreeMonitors(monitors);
+   return result;
+}
 #endif
 
 std::recursive_mutex glInputLock;
@@ -673,6 +713,14 @@ ERR get_display_info(OBJECTID DisplayID, DISPLAYINFO *Info, int InfoSize)
 
          Info->Width  = glRootWindow.width;
          Info->Height = glRootWindow.height;
+         #ifdef XRANDR_ENABLED
+            int monitor_width = 0;
+            int monitor_height = 0;
+            if (get_default_xrandr_monitor_size(&monitor_width, &monitor_height)) {
+               Info->Width  = int16_t(monitor_width);
+               Info->Height = int16_t(monitor_height);
+            }
+         #endif
          Info->AccelFlags = ACF(-1);
          #warning TODO: Get display density
          Info->VDensity = 96;

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -95,7 +95,7 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
          }
 
          case ClientMessage:
-            if ((Atom)xevent.xclient.data.l[0] == XWADeleteWindow) {
+            if (Atom(xevent.xclient.data.l[0]) IS XWADeleteWindow) {
                if (auto display_id = get_display(xevent.xany.window)) {
                   auto surface_id = GetOwnerID(display_id);
                   const WinHook hook(surface_id, WH::CLOSE);
@@ -128,6 +128,9 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
                   log.msg("Failed to retrieve display ID for window $%x.", (unsigned int)xevent.xany.window);
                   XDestroyWindow(XDisplay, (Window)xevent.xany.window);
                }
+            }
+            else if (Atom(xevent.xclient.data.l[0]) IS XWATakeFocus) {
+               XSetInputFocus(XDisplay, xevent.xclient.window, RevertToParent, Time(xevent.xclient.data.l[1]));
             }
             break;
 
@@ -245,7 +248,10 @@ void handle_button_release(XEvent *xevent)
 
    XFlush(XDisplay);
 
-   XSetInputFocus(XDisplay, xevent->xany.window, RevertToNone, CurrentTime);
+   XWindowAttributes attributes;
+   if ((XGetWindowAttributes(XDisplay, xevent->xany.window, &attributes)) and (attributes.override_redirect)) {
+      XSetInputFocus(XDisplay, xevent->xany.window, RevertToNone, CurrentTime);
+   }
 }
 
 //********************************************************************************************************************


### PR DESCRIPTION
## Summary

This improves Display module behaviour under WSLg and hosted X11 environments.

## Root Cause

WSLg behaves like a managed/rootless X11 environment, so legacy direct-display assumptions are not always valid. In particular, the X11 root window can span multiple physical monitors, which made `GetDisplayInfo(0)` report combined desktop dimensions such as `3840x1200` instead of the default monitor dimensions.

## Changes

* Detect WSLg and disable legacy X11 direct-display behaviour that is inappropriate for the managed WSLg environment.
* Improve X11 focus/event handling for the WSLg path.
* Add an XRandR monitor query helper for `GetDisplayInfo(0)`.
* Prefer the primary XRandR monitor, or the first active monitor when no primary is advertised.
* Preserve the existing root-window fallback when XRandR is unavailable or too old.

## Validation

* Confirmed the pre-fix `--statement` result reported `3840x1200` on WSLg.
* Confirmed XRandR reported two monitors: `1920x1200+1920+0` and `1920x1080+0+0`.
* Built `display` with `cmake --build build/agents --config Debug --target display --parallel`.
* Installed with `cmake --install build/agents --config Debug`.
* Confirmed the post-fix `--statement` result reports `1920x1200` for `GetDisplayInfo(0)`.

Note: the install step completed, but its internal `origo --verify` emitted `bind() failed on '' [1]: Operation not permitted`; this appears unrelated to the Display changes.