### PR TITLE
[Tiri] Added choose-missing-fallback tip and per-script JIT option merging

### DIFF
--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1409,9 +1409,15 @@ LexState::LexState(lua_State* L, std::string_view Source, std::string_view Chunk
 
 #ifdef INCLUDE_TIPS
    // Initialise tip system from JIT options
-   this->tip_level = compute_tip_level(glJitOptions);
+   JOF tip_options = glJitOptions;
+   if (L and L->script and L->script->ChildPrivate) {
+      auto *prv = (prvTiri *)L->script->ChildPrivate;
+      tip_options |= prv->JitOptions;
+   }
+   this->tip_level = compute_tip_level(tip_options);
    if (this->tip_level > 0) {
-      this->tip_emitter = std::make_unique<TipEmitter>(this->tip_level);
+      bool print_tips = (tip_options & JOF::DIAGNOSE) IS JOF::NIL;
+      this->tip_emitter = std::make_unique<TipEmitter>(this->tip_level, print_tips);
    }
 #endif
 

--- a/src/tiri/jit/src/parser/parser_tips.cpp
+++ b/src/tiri/jit/src/parser/parser_tips.cpp
@@ -39,7 +39,7 @@ void TipEmitter::emit(const ParserTip &Tip, std::string_view Filename)
 {
    if (should_emit(Tip.priority)) {
       tip.push_back(Tip);
-      printf("%s\n", Tip.to_string(Filename).c_str());
+      if (this->print_output) printf("%s\n", Tip.to_string(Filename).c_str());
    }
 }
 

--- a/src/tiri/jit/src/parser/parser_tips.h
+++ b/src/tiri/jit/src/parser/parser_tips.h
@@ -42,7 +42,7 @@ struct ParserTip {
 
 class TipEmitter {
 public:
-   explicit TipEmitter(uint8_t Level) : level(Level) {}
+   explicit TipEmitter(uint8_t Level, bool PrintOutput = true) : level(Level), print_output(PrintOutput) {}
 
    // Returns true if tip at given priority should be emitted.
    [[nodiscard]] bool should_emit(uint8_t Priority) const {
@@ -65,5 +65,6 @@ public:
 
 private:
    uint8_t level;
+   bool print_output;
    std::vector<ParserTip> tip;
 };

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -153,6 +153,9 @@ private:
    // String concatenation in loop detection - warns when .. is used in loops
    void check_concat_in_loop(SourceSpan Location);
 
+   // Choose expression fallback detection - warns when no else or unguarded wildcard can handle no-match cases
+   void check_choose_missing_fallback(const ChooseExprPayload &, SourceSpan);
+
    // Track a global variable declaration
    void track_global(GCstr *Name);
    #endif
@@ -330,6 +333,23 @@ void TypeAnalyser::check_concat_in_loop(SourceSpan Location)
    this->ctx_.emit_tip(2, TipCategory::Performance,
       "String concatenation in loop; consider using array.join() for better performance",
       Token::from_span(Location, TokenKind::Cat));
+}
+
+//********************************************************************************************************************
+// Choose Missing Fallback Detection: Warns when a choose expression has no fallback branch.  Without an else branch
+// or unguarded wildcard, unmatched values evaluate to nil, which is easy to miss in assignment expressions.
+
+void TypeAnalyser::check_choose_missing_fallback(const ChooseExprPayload &Payload, SourceSpan Location)
+{
+   if (not this->ctx_.should_emit_tip(1)) return;
+
+   for (const ChooseCase &case_item : Payload.cases) {
+      if (case_item.is_else or (case_item.is_wildcard and not case_item.guard)) return;
+   }
+
+   this->ctx_.emit_tip(1, TipCategory::TypeSafety,
+      "Choose expression has no else branch; unmatched values evaluate to nil",
+      Token::from_span(Location, TokenKind::Choose));
 }
 #endif
 
@@ -1160,6 +1180,10 @@ void TypeAnalyser::analyse_expression(const ExprNode &Expression)
       case AstNodeKind::ChooseExpr: {
          auto *payload = std::get_if<ChooseExprPayload>(&Expression.data);
          if (payload) {
+            #ifdef INCLUDE_TIPS
+            this->check_choose_missing_fallback(*payload, Expression.span);
+            #endif
+
             // Analyse scrutinee (the value being matched)
             if (payload->scrutinee) this->analyse_expression(*payload->scrutinee);
             for (const auto &tuple_elem : payload->scrutinee_tuple) {

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -412,6 +412,46 @@ end
    assert(type(result.tips) is 'table', "tips should be a table")
 end
 
+function hasTipMessage(Result, Message)
+   if not Result.tips then return false end
+   for tip in values(Result.tips) do
+      if tip.message is Message then return true end
+   end
+   return false
+end
+
+@Test function ValidateChooseWithoutElseTip()
+   message = "Choose expression has no else branch; unmatched values evaluate to nil"
+   result = debug.validate([[
+      _ = choose 'missing' from
+         'found' -> 'ok'
+      end
+   ]])
+   assert(result.success is true, "Choose without else should still parse")
+   assert(hasTipMessage(result, message), "Expected missing-else choose tip")
+end
+
+@Test function ValidateChooseFallbackSuppressesTip()
+   message = "Choose expression has no else branch; unmatched values evaluate to nil"
+
+   with_else = debug.validate([[
+      _ = choose 'missing' from
+         'found' -> 'ok'
+         else -> 'fallback'
+      end
+   ]])
+   assert(with_else.success is true, "Choose with else should parse")
+   assert(not hasTipMessage(with_else, message), "Choose with else should not emit missing-else tip")
+
+   with_wildcard = debug.validate([[
+      _ = choose 'missing' from
+         _ -> 'fallback'
+      end
+   ]])
+   assert(with_wildcard.success is true, "Choose with wildcard should parse")
+   assert(not hasTipMessage(with_wildcard, message), "Choose with wildcard should not emit missing-else tip")
+end
+
 @Test function ValidateComplexCode()
    code = [[
       function hello(Name)


### PR DESCRIPTION
* Warn when a choose expression has no else branch or unguarded wildcard, as unmatched values silently evaluate to nil
* Merge per-script JitOptions with global options when initialising the tip system in LexState
* Suppress console tip output when the DIAGNOSE flag is set, storing tips for programmatic retrieval only
* Added Flute tests ValidateChooseWithoutElseTip and ValidateChooseFallbackSuppressesTip