### PR TITLE
[Display] Improved thread safety and bounds checking across the display module

### DIFF
--- a/src/display/android/android.cpp
+++ b/src/display/android/android.cpp
@@ -12,8 +12,11 @@ static void android_init_window(int MsgID)
    // We want EGL to be initialised in the Kōtuku Core thread, so we set glEGLState and let
    // lock_graphics() take care of the initialisation.
 
-   glDisplayInfo.DisplayID = 0xffffffff; // Inform that a refresh of the cache is required.
-   glEGLState = EGL_REQUIRES_INIT;
+   if (!pthread_mutex_lock(&glGraphicsMutex)) {
+      glDisplayInfo.DisplayID = 0xffffffff; // Inform that a refresh of the cache is required.
+      glEGLState = EGL_REQUIRES_INIT;
+      pthread_mutex_unlock(&glGraphicsMutex);
+   }
 
    if (glActiveDisplayID) {
       // Send a Show and Draw action to the top-most graphics object of the target display.
@@ -42,4 +45,3 @@ static void android_term_window(int MsgID)
    free_egl(); // It is OK to terminate EGL in this thread.  Note that this function will do the lock_graphics() for us.
    LogReturn();
 }
-

--- a/src/display/class_bitmap.cpp
+++ b/src/display/class_bitmap.cpp
@@ -218,7 +218,11 @@ ERR lock_surface(extBitmap *Bitmap, int16_t Access)
             }
             return ERR::Okay;
          }
-         else XDestroyImage(Bitmap->x11.readable);
+         else {
+            XDestroyImage(Bitmap->x11.readable);
+            Bitmap->x11.readable = nullptr;
+            Bitmap->Data = nullptr;
+         }
       }
 
       // Generate a fresh XImage from the current drawable
@@ -245,7 +249,11 @@ ERR lock_surface(extBitmap *Bitmap, int16_t Access)
          }
          return ERR::Okay;
       }
-      else return ERR::CreateResource;
+      else {
+         free(Bitmap->Data);
+         Bitmap->Data = nullptr;
+         return ERR::CreateResource;
+      }
    }
    return ERR::Okay;
 }
@@ -1368,7 +1376,11 @@ static ERR BITMAP_Lock(extBitmap *Self)
                Self->Clip.Left, Self->Clip.Top);
             return ERR::Okay;
          }
-         else XDestroyImage(Self->x11.readable);
+         else {
+            XDestroyImage(Self->x11.readable);
+            Self->x11.readable = nullptr;
+            Self->Data = nullptr;
+         }
       }
 
       // Generate a fresh XImage from the current drawable
@@ -1383,6 +1395,7 @@ static ERR BITMAP_Lock(extBitmap *Self)
       else size = Self->ByteWidth * Self->Height;
 
       Self->Data = (uint8_t *)malloc(size);
+      if (!Self->Data) return ERR::AllocMemory;
 
       if ((bpp = Self->BitsPerPixel) IS 32) bpp = 24;
 
@@ -1393,7 +1406,11 @@ static ERR BITMAP_Lock(extBitmap *Self)
             Self->Clip.Bottom - Self->Clip.Top, 0xffffffff, ZPixmap, Self->x11.readable,
             Self->Clip.Left, Self->Clip.Top);
       }
-      else return ERR::CreateResource;
+      else {
+         free(Self->Data);
+         Self->Data = nullptr;
+         return ERR::CreateResource;
+      }
    }
 
    return ERR::Okay;
@@ -1731,6 +1748,7 @@ static ERR BITMAP_Read(extBitmap *Self, struct acRead *Args)
 {
    if (!Self->Data) return ERR::NoData;
    if ((!Args) or (!Args->Buffer)) return ERR::NullArgs;
+   if (Args->Length < 0) return ERR::OutOfRange;
 
    int len = Args->Length;
    if (Self->Position + len > Self->Size) len = Self->Size - Self->Position;
@@ -1872,7 +1890,9 @@ setfields:
       free_shm(Self->Data, Self->x11.ShmInfo.shmid);
       Self->Data = nullptr;
 
-      alloc_shm(size, &Self->Data, &Self->x11.ShmInfo.shmid);
+      if (alloc_shm(size, &Self->Data, &Self->x11.ShmInfo.shmid) != ERR::Okay) {
+         return log.warning(ERR::AllocMemory);
+      }
 
       Self->x11.ShmInfo.readOnly = False;
       Self->x11.ShmInfo.shmaddr  = (char *)Self->Data;
@@ -1999,17 +2019,21 @@ static ERR BITMAP_SaveImage(extBitmap *Self, struct acSaveImage *Args)
 
    size = width * height * pcx.NumPlanes;
    if (AllocMemory(size, MEM::DATA|MEM::NO_CLEAR, &buffer) IS ERR::Okay) {
-      acWrite(Args->Dest, &pcx, sizeof(pcx), nullptr);
+      auto write_error = acWrite(Args->Dest, &pcx, sizeof(pcx), nullptr);
+      if (write_error != ERR::Okay) {
+         FreeResource(buffer);
+         return log.warning(write_error);
+      }
 
       int dp = 0;
       for (i=Self->Clip.Top; i < (Self->Clip.Bottom); i++) {
          if (pcx.NumPlanes IS 1) { // Save as a 256 colour image
             lastpixel = Self->ReadUCPixel(Self, Self->Clip.Left, i);
             uint8_t counter = 1;
-            for (j=Self->Clip.Left+1; j <= width; j++) {
+            for (j=Self->Clip.Left+1; j < Self->Clip.Right; j++) {
                newpixel = Self->ReadUCPixel(Self, j, i);
 
-               if ((newpixel IS lastpixel) and (j != width - 1) and (counter <= 62)) {
+               if ((newpixel IS lastpixel) and (counter < 63)) {
                   counter++;
                }
                else {
@@ -2026,6 +2050,19 @@ static ERR BITMAP_SaveImage(extBitmap *Self, struct acSaveImage *Args)
                   return log.warning(ERR::BufferOverflow);
                }
             }
+
+            if (!((counter IS 1) and (lastpixel < 192))) {
+               if (dp >= (size - 2)) {
+                  FreeResource(buffer);
+                  return log.warning(ERR::BufferOverflow);
+               }
+               buffer[dp++] = 192 + counter;
+            }
+            else if (dp >= (size - 1)) {
+               FreeResource(buffer);
+               return log.warning(ERR::BufferOverflow);
+            }
+            buffer[dp++] = lastpixel;
          }
          else { // Save as a true colour image with run-length encoding
             for (p=0; p < 3; p++) {
@@ -2086,8 +2123,9 @@ static ERR BITMAP_SaveImage(extBitmap *Self, struct acSaveImage *Args)
          }
       }
 
-      acWrite(Args->Dest, buffer, dp, nullptr);
+      write_error = acWrite(Args->Dest, buffer, dp, nullptr);
       FreeResource(buffer);
+      if (write_error != ERR::Okay) return log.warning(write_error);
 
       // Setup palette
 
@@ -2101,7 +2139,8 @@ static ERR BITMAP_SaveImage(extBitmap *Self, struct acSaveImage *Args)
             palette[j++] = Self->Palette->Col[i].Blue;
          }
 
-         acWrite(Args->Dest, palette, sizeof(palette), nullptr);
+         write_error = acWrite(Args->Dest, palette, sizeof(palette), nullptr);
+         if (write_error != ERR::Okay) return log.warning(write_error);
       }
 
       return ERR::Okay;
@@ -2118,6 +2157,8 @@ Seek: Changes the current byte position for read/write operations.
 
 static ERR BITMAP_Seek(extBitmap *Self, struct acSeek *Args)
 {
+   if (!Args) return ERR::NullArgs;
+
    if (Args->Position IS SEEK::START) Self->Position = (int)Args->Offset;
    else if (Args->Position IS SEEK::END) Self->Position = (int)(Self->Size - Args->Offset);
    else if (Args->Position IS SEEK::CURRENT) Self->Position = (int)(Self->Position + Args->Offset);
@@ -2557,7 +2598,7 @@ ERR SET_Palette(extBitmap *Self, RGBPalette *SrcPalette)
    if (SrcPalette->AmtColours <= 256) {
       if (!Self->Palette) {
          if (AllocMemory(sizeof(RGBPalette), MEM::NO_CLEAR, &Self->Palette) != ERR::Okay) {
-            log.warning(ERR::AllocMemory);
+            return log.warning(ERR::AllocMemory);
          }
       }
 

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -149,13 +149,13 @@ static ERR add_file_to_host(objClipboard *Self, const std::vector<ClipItem> &Ite
             else codepoint = UTF8ReadValue(src, nullptr);
 
             if (codepoint < 0x10000) {
-               dest.push_back(static_cast<char16_t>(codepoint));
+               dest.push_back((char16_t)codepoint);
             }
             else {
                // Surrogate pair for codepoints >= 0x10000
                codepoint -= 0x10000;
-               dest.push_back(static_cast<char16_t>(0xD800 + (codepoint >> 10)));
-               dest.push_back(static_cast<char16_t>(0xDC00 + (codepoint & 0x3FF)));
+               dest.push_back((char16_t)(0xD800 + (codepoint >> 10)));
+               dest.push_back((char16_t)(0xDC00 + (codepoint & 0x3FF)));
             }
             src += len;
          }
@@ -165,8 +165,9 @@ static ERR add_file_to_host(objClipboard *Self, const std::vector<ClipItem> &Ite
    list << '\0'; // An extra null byte is required to terminate the list for Windows HDROP
 
    auto str = list.str();
-   winAddFileClip(str.c_str(), str.size() * sizeof(char16_t), Cut);
-   return ERR::Okay;
+   auto error = (ERR)winAddFileClip(str.c_str(), str.size() * sizeof(char16_t), Cut);
+   if (error != ERR::Okay) log.warning(error);
+   return error;
 #else
    return ERR::NoSupport;
 #endif
@@ -185,18 +186,20 @@ static ERR add_text_to_host(objClipboard *Self, CSTRING String, int Length = 0x7
 
    auto str = String;
    int chars, bytes = 0;
-   for (chars=0; (str[bytes]) and (bytes < Length); chars++) {
+   for (chars=0; (bytes < Length) and (str[bytes]); chars++) {
       for (++bytes; (bytes < Length) and ((str[bytes] & 0xc0) IS 0x80); bytes++);
    }
 
-   std::vector<uint16_t> utf16(size_t(chars + 1) * sizeof(uint16_t));
+   std::vector<uint16_t> utf16(size_t(chars + 1));
 
    int i = 0;
-   while (i < bytes) {
+   int pos = 0;
+   while (pos < bytes) {
       int len = UTF8CharLength(str);
-      if (i + len >= bytes) break; // Avoid corrupt UTF-8 sequences resulting in minor buffer overflow
-      utf16[i++] = UTF8ReadValue(str, nullptr);
+      if (pos + len > bytes) break; // Avoid corrupt UTF-8 sequences resulting in minor buffer overflow
+      utf16[i++] = (uint16_t)UTF8ReadValue(str, nullptr);
       str += len;
+      pos += len;
    }
    utf16[i] = 0;
 
@@ -784,22 +787,22 @@ extern "C" void report_windows_hdrop(const char *Data, int CutOperation, char Wi
 
             // Convert to UTF-8
             if (codepoint < 0x80) {
-               utf8_path.push_back(static_cast<char>(codepoint));
+               utf8_path.push_back((char)codepoint);
             }
             else if (codepoint < 0x800) {
-               utf8_path.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
-               utf8_path.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+               utf8_path.push_back((char)(0xC0 | (codepoint >> 6)));
+               utf8_path.push_back((char)(0x80 | (codepoint & 0x3F)));
             }
             else if (codepoint < 0x10000) {
-               utf8_path.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
-               utf8_path.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
-               utf8_path.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+               utf8_path.push_back((char)(0xE0 | (codepoint >> 12)));
+               utf8_path.push_back((char)(0x80 | ((codepoint >> 6) & 0x3F)));
+               utf8_path.push_back((char)(0x80 | (codepoint & 0x3F)));
             }
             else {
-               utf8_path.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
-               utf8_path.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
-               utf8_path.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
-               utf8_path.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+               utf8_path.push_back((char)(0xF0 | (codepoint >> 18)));
+               utf8_path.push_back((char)(0x80 | ((codepoint >> 12) & 0x3F)));
+               utf8_path.push_back((char)(0x80 | ((codepoint >> 6) & 0x3F)));
+               utf8_path.push_back((char)(0x80 | (codepoint & 0x3F)));
             }
          }
          items.emplace_back(utf8_path);

--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -1165,11 +1165,10 @@ static ERR DISPLAY_Redimension(extDisplay *Self, struct acRedimension *Args)
    if (!Args) return ERR::NullArgs;
 
    struct acMoveToPoint moveto = { Args->X, Args->Y, 0, MTF::X|MTF::Y };
-   DISPLAY_MoveToPoint(Self, &moveto);
+   if (auto error = DISPLAY_MoveToPoint(Self, &moveto); error != ERR::Okay) return error;
 
    struct acResize resize = { Args->Width, Args->Height, Args->Depth };
-   DISPLAY_Resize(Self, &resize);
-   return ERR::Okay;
+   return DISPLAY_Resize(Self, &resize);
 }
 
 /*********************************************************************************************************************
@@ -1196,7 +1195,7 @@ static ERR DISPLAY_Resize(extDisplay *Self, struct acResize *Args)
       return ERR::Resize;
    }
 
-   Action(AC::Resize, Self->Bitmap, Args);
+   if (auto error = Action(AC::Resize, Self->Bitmap, Args); error != ERR::Okay) return error;
    Self->Width = Self->Bitmap->Width;
    Self->Height = Self->Bitmap->Height;
 
@@ -1209,7 +1208,7 @@ static ERR DISPLAY_Resize(extDisplay *Self, struct acResize *Args)
       XResizeWindow(XDisplay, Self->XWindowHandle, Args->Width, Args->Height);
    }
 
-   Action(AC::Resize, Self->Bitmap, Args);
+   if (auto error = Action(AC::Resize, Self->Bitmap, Args); error != ERR::Okay) return error;
    Self->Width = Self->Bitmap->Width;
    Self->Height = Self->Bitmap->Height;
 
@@ -1377,6 +1376,8 @@ NoSupport: The host platform does not support this feature.
 
 static ERR DISPLAY_SizeHints(extDisplay *Self, gfx::SizeHints *Args)
 {
+   if (!Args) return ERR::NullArgs;
+
 #ifdef __xwindows__
    XSizeHints hints = { .flags = 0 };
 

--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -1082,6 +1082,10 @@ static bool get_over_object(extPointer *Self)
       index = 0;
    }
    else for (index=0; (index < glSurfaces.size()) and (glSurfaces[index].SurfaceID != Self->SurfaceID); index++);
+   if (index >= glSurfaces.size()) {
+      Self->SurfaceID = glSurfaces[0].SurfaceID;
+      index = 0;
+   }
 
    auto i = examine_chain(Self, index, glSurfaces, glSurfaces.size());
 
@@ -1144,6 +1148,9 @@ static int examine_chain(extPointer *Self, int Index, SURFACELIST &List, int End
 {
    // NB: Traversal is in reverse to catch the front-most objects first.
 
+   if ((Index < 0) or (Index >= int(List.size()))) return 0;
+   if (End > int(List.size())) End = int(List.size());
+
    auto objectid = List[Index].SurfaceID;
    auto x = Self->X;
    auto y = Self->Y;
@@ -1151,7 +1158,7 @@ static int examine_chain(extPointer *Self, int Index, SURFACELIST &List, int End
       if ((List[i].ParentID IS objectid) and (List[i].visible())) {
          if ((x >= List[i].Left) and (x < List[i].Right) and (y >= List[i].Top) and (y < List[i].Bottom)) {
             int new_end;
-            for (new_end=i+1; List[new_end].Level > List[i].Level; new_end++); // Recalculate the end (optimisation)
+            for (new_end=i+1; (new_end < End) and (List[new_end].Level > List[i].Level); new_end++);
             return examine_chain(Self, i, List, new_end);
          }
       }

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -126,15 +126,17 @@ static void release_video(objDisplay *Display)
 
 static bool check_volatile(const SURFACELIST &List, int Index)
 {
+   if ((Index < 0) or (Index >= int(List.size()))) return false;
+
    if (List[Index].isVolatile()) return true;
 
    // If there are children with custom root layers or are volatile, that will force volatility
 
    int j;
-   for (int i=Index+1; List[i].Level > List[Index].Level; i++) {
+   for (int i=Index+1; (i < int(List.size())) and (List[i].Level > List[Index].Level); i++) {
       if (List[i].invisible()) {
          j = List[i].Level;
-         while (List[i+1].Level > j) i++;
+         while ((i + 1 < int(List.size())) and (List[i+1].Level > j)) i++;
          continue;
       }
 
@@ -376,7 +378,7 @@ static void invalidate_overlap(extSurface *Self, const SURFACELIST &list, int Ol
 skipcontent:
       // Skip past any children of the overlapping object
 
-      for (j=i+1; list[j].Level > list[i].Level; j++);
+      for (j=i+1; (j < int(list.size())) and (list[j].Level > list[i].Level); j++);
       i = j - 1;
    }
 }
@@ -605,7 +607,7 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
 {
    kt::Log log;
 
-   if (!Args) return log.warning(ERR::NullArgs);
+   if ((!Args) or (!Args->Callback)) return log.warning(ERR::NullArgs);
 
    OBJECTPTR context = ParentContext();
    OBJECTPTR call_context = nullptr;
@@ -963,11 +965,14 @@ static ERR SURFACE_Free(extSurface *Self)
 
    if (Self->InputHandle) gfx::UnsubscribeInput(Self->InputHandle);
 
-   for (auto it = glWindowHooks.begin(); it != glWindowHooks.end();) {
-      if (it->first.SurfaceID IS Self->UID) {
-         it = glWindowHooks.erase(it);
+   {
+      const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
+      for (auto it = glWindowHooks.begin(); it != glWindowHooks.end();) {
+         if (it->first.SurfaceID IS Self->UID) {
+            it = glWindowHooks.erase(it);
+         }
+         else it++;
       }
-      else it++;
    }
 
    return ERR::Okay;
@@ -1778,7 +1783,8 @@ static ERR SURFACE_MoveToFront(extSurface *Self)
 
    auto index = currentindex;
    auto level = glSurfaces[currentindex].Level;
-   for (auto i=currentindex+1; (glSurfaces[i].Level >= glSurfaces[currentindex].Level); i++) {
+   for (auto i=currentindex+1; (i < int(glSurfaces.size())) and
+         (glSurfaces[i].Level >= glSurfaces[currentindex].Level); i++) {
       if (glSurfaces[i].Level IS level) {
          if ((glSurfaces[i].Flags & RNF::POINTER) != RNF::NIL) break; // Do not move in front of the mouse cursor
          if (glSurfaces[i].PopOverID IS Self->UID) break; // A surface has been discovered that has to be in front of us.
@@ -1819,12 +1825,13 @@ static ERR SURFACE_MoveToFront(extSurface *Self)
 
    auto i = index;
    level = glSurfaces[i].Level;
-   while (glSurfaces[i+1].Level > level) i++;
+   while ((i + 1 < int(glSurfaces.size())) and (glSurfaces[i+1].Level > level)) i++;
 
    // Count the number of children that have been assigned to this surface object.
 
    int total;
-   for (total=1; glSurfaces[currentindex+total].Level > glSurfaces[currentindex].Level; total++) { };
+   for (total=1; (currentindex + total < int(glSurfaces.size())) and
+         (glSurfaces[currentindex+total].Level > glSurfaces[currentindex].Level); total++) { };
 
    // Reorder the list so that this surface object is inserted at the new index.
 
@@ -1880,6 +1887,8 @@ static ERR SURFACE_MoveToPoint(extSurface *Self, struct acMoveToPoint *Args)
 {
    struct acMove move;
 
+   if (!Args) return ERR::NullArgs;
+
    if ((Args->Flags & MTF::X) != MTF::NIL) move.DeltaX = Args->X - Self->X;
    else move.DeltaX = 0;
 
@@ -1895,6 +1904,8 @@ static ERR SURFACE_MoveToPoint(extSurface *Self, struct acMoveToPoint *Args)
 
 static ERR SURFACE_NewOwner(extSurface *Self, struct acNewOwner *Args)
 {
+   if ((!Args) or (!Args->NewOwner)) return ERR::NullArgs;
+
    if ((!Self->ParentDefined) and (!Self->initialised())) {
       OBJECTID owner_id = Args->NewOwner->UID;
       while ((owner_id) and (GetClassID(owner_id) != CLASSID::SURFACE)) {
@@ -2203,7 +2214,7 @@ static ERR SURFACE_SaveImage(extSurface *Self, struct acSaveImage *Args)
                if (list[j].invisible() or list[j].isCursor()) {
                   // Skip this surface area and all invisible children
                   level = list[j].Level;
-                  while (list[j+1].Level > level) j++;
+                  while ((j + 1 < int(list.size())) and (list[j+1].Level > level)) j++;
                   continue;
                }
 

--- a/src/display/class_surface/surface_drawing.cpp
+++ b/src/display/class_surface/surface_drawing.cpp
@@ -587,6 +587,7 @@ void move_layer(extSurface *Self, int X, int Y)
    int desty = old.Top  + Y - Self->Y;
 
    int parent_index = find_parent_list(glSurfaces, Self);
+   if (parent_index IS -1) return;
 
    // Since we do not own our graphics buffer, we need to shift the content in the buffer first, then send an
    // expose message to have the changes displayed on screen.
@@ -616,7 +617,8 @@ void move_layer(extSurface *Self, int X, int Y)
 
    // Expose underlying graphics resulting from the movement
 
-   for (vindex=index+1; glSurfaces[vindex].Level > glSurfaces[index].Level; vindex++);
+   for (vindex=index+1; (vindex < int(glSurfaces.size())) and
+         (glSurfaces[vindex].Level > glSurfaces[index].Level); vindex++);
    tlVolatileIndex = vindex;
    auto clip = glSurfaces[index].area();
    redraw_nonintersect(Self->ParentID, glSurfaces, parent_index, clip, old,
@@ -676,16 +678,18 @@ void prepare_background(extSurface *Self, const SURFACELIST &List, int Index, ex
    if (!List[end].ParentID) return;
    int parentindex = end;
    while ((parentindex > 0) and (List[parentindex].SurfaceID != List[end].ParentID)) parentindex--;
+   if (List[parentindex].SurfaceID != List[end].ParentID) return;
 
    // If the parent object is invisible, we need to scan back to a visible parent
 
    OBJECTID id = List[parentindex].SurfaceID;
-   for (j=parentindex; List[parentindex].Level > 1; j--) {
+   for (j=parentindex; (j >= 0) and (List[j].Level > 1); j--) {
       if (List[j].SurfaceID IS id) {
          if (!List[j].transparent()) break;
          id = List[j].ParentID;
       }
    }
+   if (j < 0) return;
    parentindex = j;
 
    // This loop will copy surface content to the buffered graphics area.  If the parentindex and end values are
@@ -769,7 +773,7 @@ void copy_bkgd(const SURFACELIST &List, int Index, int End, int Master, ClipRect
       // siblings that are in our way.
 
       int j = i + 1;
-      while (List[j].Level > List[i].Level) j++;
+      while ((j < End) and (j < int(List.size())) and (List[j].Level > List[i].Level)) j++;
       i = j - 1;
    }
 

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -441,6 +441,7 @@ extern std::list<ClipRecord> glClips;
 extern int glLastPort;
 
 extern ankerl::unordered_dense::map<WinHook, FUNCTION> glWindowHooks;
+extern std::recursive_mutex glWindowHookLock;
 extern std::vector<OBJECTID> glFocusList;
 extern std::recursive_mutex glFocusLock;
 extern std::recursive_mutex glSurfaceLock;

--- a/src/display/lib_display.cpp
+++ b/src/display/lib_display.cpp
@@ -9,6 +9,7 @@ Name: Display
 #include "defs.h"
 
 ankerl::unordered_dense::map<WinHook, FUNCTION> glWindowHooks;
+std::recursive_mutex glWindowHookLock;
 
 namespace gfx {
 

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -382,7 +382,9 @@ void _redraw_surface_do(extSurface *Self, const SURFACELIST &list, int Index, Cl
    // our Index field will not match with the surface that is referenced in Self.  We need to ensure
    // correctness before going any further.
 
+   if ((Index < 0) or (Index >= int(list.size()))) return;
    if (list[Index].SurfaceID != Self->UID) Index = find_surface_list(Self, list.size());
+   if ((Index < 0) or (Index >= int(list.size()))) return;
 
    // Prepare the buffer so that it matches the exposed area
 
@@ -390,6 +392,7 @@ void _redraw_surface_do(extSurface *Self, const SURFACELIST &list, int Index, Cl
    int xo = 0, yo = 0;
    if (Self->BitmapOwnerID != Self->UID) {
       for (i=Index; (i > 0) and (list[i].SurfaceID != Self->BitmapOwnerID); i--);
+      if (list[i].SurfaceID != Self->BitmapOwnerID) return;
       xo = list[Index].Left - list[i].Left;
       yo = list[Index].Top - list[i].Top;
       data = DestBitmap->offset(xo, yo);
@@ -808,6 +811,7 @@ ERR resize_layer(extSurface *Self, int X, int Y, int Width, int Height, int Insi
          for (parent_index=index-1; parent_index >= 0; parent_index--) {
             if (list[parent_index].SurfaceID IS Self->ParentID) break;
          }
+         if (parent_index < 0) return log.warning(ERR::Search);
 
          ClipRectangle region_b(list[parent_index].Left + oldx, list[parent_index].Top + oldy,
             (list[parent_index].Left + oldx) + oldw, (list[parent_index].Top + oldy) + oldh);
@@ -1502,6 +1506,7 @@ ERR WindowHook(OBJECTID SurfaceID, WH Event, FUNCTION *Callback)
    if ((!SurfaceID) or (Event IS WH::NIL) or (!Callback)) return ERR::NullArgs;
 
    const WinHook hook(SurfaceID, Event);
+   const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
    glWindowHooks[hook] = *Callback;
    return ERR::Okay;
 }

--- a/src/display/win32/clipboard.c
+++ b/src/display/win32/clipboard.c
@@ -660,7 +660,7 @@ int winInitDragDrop(HWND Window)
          RKDT_Drop
       };
 
-      if (!(glDropTarget = HeapAlloc(glHeap, 0, sizeof(RK_IDROPTARGET)))) return ERR_Failed;
+      if (!(glDropTarget = HeapAlloc(glHeap, HEAP_ZERO_MEMORY, sizeof(RK_IDROPTARGET)))) return ERR_Failed;
       glDropTarget->idt.lpVtbl   = (void *)&idt_vtbl;
       glDropTarget->lRefCount    = 1;
       glDropTarget->tb_pDragFile = NULL;

--- a/src/display/win32/handlers.cpp
+++ b/src/display/win32/handlers.cpp
@@ -264,22 +264,34 @@ void MsgWindowClose(OBJECTID SurfaceID)
 
    if (SurfaceID) {
       const WinHook hook(SurfaceID, WH::CLOSE);
+      FUNCTION func;
+      bool has_hook = false;
 
-      if (glWindowHooks.contains(hook)) {
-         auto func = &glWindowHooks[hook];
+      {
+         const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
+         if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
+            func = it->second;
+            has_hook = true;
+         }
+      }
+
+      if (has_hook) {
          ERR result;
 
-         if (func->isC()) {
-            kt::SwitchContext ctx(func->Context);
-            auto callback = (ERR (*)(OBJECTID SurfaceID, APTR))func->Routine;
-            result = callback(SurfaceID, func->Meta);
+         if (func.isC()) {
+            kt::SwitchContext ctx(func.Context);
+            auto callback = (ERR (*)(OBJECTID SurfaceID, APTR))func.Routine;
+            result = callback(SurfaceID, func.Meta);
          }
-         else if (func->isScript()) {
-            sc::Call(*func, std::to_array<ScriptArg>({ { "SurfaceID", SurfaceID, FDF_OBJECTID } }), result);
+         else if (func.isScript()) {
+            sc::Call(func, std::to_array<ScriptArg>({ { "SurfaceID", SurfaceID, FDF_OBJECTID } }), result);
          }
          else result = ERR::Okay;
 
-         if (result IS ERR::Terminate) glWindowHooks.erase(hook);
+         if (result IS ERR::Terminate) {
+            const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
+            glWindowHooks.erase(hook);
+         }
          else if (result IS ERR::Cancelled) {
             log.msg("Window closure cancelled by client.");
             return;

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -99,22 +99,34 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
                if (auto display_id = get_display(xevent.xany.window)) {
                   auto surface_id = GetOwnerID(display_id);
                   const WinHook hook(surface_id, WH::CLOSE);
+                  FUNCTION func;
+                  bool has_hook = false;
 
-                  if (glWindowHooks.contains(hook)) {
-                     auto func = &glWindowHooks[hook];
+                  {
+                     const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
+                     if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
+                        func = it->second;
+                        has_hook = true;
+                     }
+                  }
+
+                  if (has_hook) {
                      ERR result;
 
-                     if (func->isC()) {
-                        kt::SwitchContext ctx(func->Context);
-                        auto callback = (ERR (*)(OBJECTID, APTR))func->Routine;
-                        result = callback(surface_id, func->Meta);
+                     if (func.isC()) {
+                        kt::SwitchContext ctx(func.Context);
+                        auto callback = (ERR (*)(OBJECTID, APTR))func.Routine;
+                        result = callback(surface_id, func.Meta);
                      }
-                     else if (func->isScript()) {
-                        sc::Call(*func, std::to_array<ScriptArg>({ { "SurfaceID", surface_id, FDF_OBJECTID } }), result);
+                     else if (func.isScript()) {
+                        sc::Call(func, std::to_array<ScriptArg>({ { "SurfaceID", surface_id, FDF_OBJECTID } }), result);
                      }
                      else result = ERR::Okay;
 
-                     if (result IS ERR::Terminate) glWindowHooks.erase(hook);
+                     if (result IS ERR::Terminate) {
+                        const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
+                        glWindowHooks.erase(hook);
+                     }
                      else if (result IS ERR::Cancelled) {
                         log.msg("Window closure cancelled by client.");
                         break;


### PR DESCRIPTION
## Summary

- Added `glWindowHookLock` mutex to protect concurrent access to the `glWindowHooks` map in the win32 and x11 window event handlers, and in `WindowHook()` and `SURFACE_Free()`
- Fixed numerous SURFACELIST traversal loops that were missing upper-bound guards, preventing out-of-bounds reads when iterating child/sibling levels
- Added null-pointer and argument-range checks to `SURFACE_MoveToPoint`, `SURFACE_NewOwner`, `DISPLAY_SizeHints`, `BITMAP_Seek`, and `BITMAP_Read`
- Fixed resource leaks in `class_bitmap.cpp` when `XImage` destruction or shared-memory allocation fails (pointers now cleared and memory freed on error paths)
- Fixed PCX run-length encoding loop: corrected boundary condition from `j <= width` to `j < Self->Clip.Right`, and added the missing flush of the final RLE run at end of each scanline
- Fixed UTF-8 to UTF-16 conversion in `add_text_to_host` — byte position was being tracked with the wrong variable (`i` instead of a separate `pos`), and the vector was over-allocated by `sizeof(uint16_t)`
- Used `HEAP_ZERO_MEMORY` when allocating the Win32 OLE drop target to prevent uninitialised reads
- Replaced `static_cast` with C-style casts in `class_clipboard.cpp` per project coding standards

## Test plan

- [ ] Build the `display` module on Windows and Linux without errors
- [ ] Verify clipboard copy/paste works on Windows (file and text drag-drop)
- [ ] Verify window close hooks fire correctly and do not crash under concurrent access
- [ ] Verify surface move/resize operations on a multi-surface layout do not produce out-of-bounds assertions
- [ ] Run existing display integration tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L display`

🤖 Generated with [Claude Code](https://claude.com/claude-code)