### PR TITLE
[Display] Fixed resource leaks, error propagation, and thread safety

### DIFF
--- a/src/display/class_bitmap.cpp
+++ b/src/display/class_bitmap.cpp
@@ -393,6 +393,7 @@ static ERR alloc_shm(int Size, uint8_t **Data, int *ID)
    }
    else {
       log.warning("shmat() returned: %s", strerror(errno));
+      shmctl(id, IPC_RMID, nullptr);
       return ERR::LockFailed;
    }
 }
@@ -565,11 +566,12 @@ static ERR BITMAP_Compress(extBitmap *Self, struct bmp::Compress *Args)
       if (glCompress->compressBuffer(Self->Data, Self->Size, buffer, Self->Size, &result) IS ERR::Okay) {
          if (AllocMemory(result, MEM::NO_CLEAR, &Self->prvCompress) IS ERR::Okay) {
             copymem(buffer, Self->prvCompress, result);
-            FreeResource(buffer);
          }
          else error = ERR::ReallocMemory;
       }
       else error = ERR::Compression;
+
+      FreeResource(buffer);
    }
    else error = ERR::AllocMemory;
 
@@ -1817,8 +1819,7 @@ static ERR BITMAP_Resize(extBitmap *Self, struct acResize *Args)
       case 16: bytesperpixel = 2; amtcolours = 65536; break;
       case 24: bytesperpixel = 3; amtcolours = 16777216; break;
       case 32: bytesperpixel = 4; amtcolours = 16777216; break;
-      default: bytesperpixel = bpp / 8;
-               amtcolours = 1<<bpp;
+      default: return log.warning(ERR::Args);
    }
 
    if (Self->Type IS BMP::PLANAR) bytewidth = (width + (width % 16))/8;

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -47,6 +47,7 @@ static const FieldDef glDatatypes[] = {
 };
 
 std::list<ClipRecord> glClips;
+std::recursive_mutex glClipboardLock;
 static int glCounter = 1;
 static int glHistoryLimit = 1;
 static std::string glProcessID;
@@ -322,7 +323,9 @@ static ERR CLIPBOARD_AddObjects(objClipboard *Self, struct clip::AddObjects *Arg
             auto path = std::string("clipboard:") + glProcessID + "_" + get_datatype(datatype) + std::to_string(counter) + idx;
 
             auto file = objFile::create { fl::Path(path), fl::Flags(FL::WRITE|FL::NEW) };
-            if (file.ok()) acSaveToObject(*object, *file);
+            if (file.ok()) {
+               if (auto error = acSaveToObject(*object, *file); error != ERR::Okay) return log.warning(error);
+            }
             else return ERR::CreateFile;
          }
       }
@@ -382,7 +385,10 @@ static ERR CLIPBOARD_Clear(objClipboard *Self)
       CreateFolder(path.c_str(), PERMIT::READ|PERMIT::WRITE);
    }
 
-   glClips.clear();
+   {
+      const std::lock_guard<std::recursive_mutex> lock(glClipboardLock);
+      glClips.clear();
+   }
    return ERR::Okay;
 }
 
@@ -405,7 +411,11 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::TEXT) {
       log.msg("Copying text to the clipboard.");
 
-      add_text_to_host(Self, (CSTRING)Args->Buffer, Args->Size);
+      if (!Args->Buffer) return log.warning(ERR::NullArgs);
+      if (auto error = add_text_to_host(Self, (CSTRING)Args->Buffer, Args->Size);
+            (error != ERR::Okay) and (error != ERR::NoSupport)) {
+         return log.warning(error);
+      }
 
       std::vector<ClipItem> items = { std::string("clipboard:") + glProcessID + "_text" + std::to_string(glCounter++) + std::string(".000") };
       if (auto error = add_clip(CLIPTYPE::TEXT, items); error IS ERR::Okay) {
@@ -419,6 +429,8 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
       else return log.warning(error);
    }
    else if ((Args->Datatype IS DATA::REQUEST) and ((Self->Flags & CPF::DRAG_DROP) != CPF::NIL))  {
+      if ((!Args->Buffer) or (!Args->Object)) return log.warning(ERR::NullArgs);
+
       auto request = (struct dcRequest *)Args->Buffer;
       log.branch("Data request from #%d received for item %d, datatype %d", Args->Object->UID, request->Item, request->Preference[0]);
 
@@ -441,11 +453,11 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
 
       if (error IS ERR::Terminate) Self->RequestHandler.Type = CALL::NIL;
 
-      return ERR::Okay;
+      return error;
    }
    else log.warning("Unrecognised data type %d.", int(Args->Datatype));
 
-   return ERR::Okay;
+   return ERR::NoSupport;
 }
 
 //********************************************************************************************************************
@@ -513,6 +525,8 @@ static ERR CLIPBOARD_GetFiles(objClipboard *Self, struct clip::GetFiles *Args)
       if (winCurrentClipboardID() != glLastClipID) winCopyClipboard();
 #endif
    }
+
+   const std::lock_guard<std::recursive_mutex> lock(glClipboardLock);
 
    if (glClips.empty()) return ERR::NoData;
 
@@ -613,6 +627,8 @@ static ERR CLIPBOARD_Remove(objClipboard *Self, struct clip::Remove *Args)
 
    log.branch("Datatype: $%x", int(Args->Datatype));
 
+   const std::lock_guard<std::recursive_mutex> lock(glClipboardLock);
+
    for (auto it=glClips.begin(); it != glClips.end();) {
       if ((it->Datatype & Args->Datatype) != CLIPTYPE::NIL) {
          if (it IS glClips.begin()) {
@@ -681,6 +697,8 @@ static ERR add_clip(CLIPTYPE Datatype, const std::vector<ClipItem> &Items, CEF F
 
    if (Items.empty()) return ERR::Args;
 
+   const std::lock_guard<std::recursive_mutex> lock(glClipboardLock);
+
    if ((Flags & CEF::EXTEND) != CEF::NIL) {
       // Search for an existing clip that matches the requested datatype
       for (auto it = glClips.begin(); it != glClips.end(); it++) {
@@ -723,7 +741,7 @@ static ERR add_clip(CSTRING String)
    if (auto error = add_clip(CLIPTYPE::TEXT, items); error IS ERR::Okay) {
       kt::Create<objFile> file = { fl::Path(items[0].Path), fl::Flags(FL::WRITE|FL::NEW), fl::Permissions(PERMIT::READ|PERMIT::WRITE) };
       if (file.ok()) {
-         file->write(String, strlen(String), 0);
+         if (auto error = file->write(String, strlen(String), 0); error != ERR::Okay) return log.warning(error);
          return ERR::Okay;
       }
       else return log.warning(ERR::CreateFile);

--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -17,6 +17,10 @@ The Display is a primitive, hardware oriented interface.  It is recommended that
 using namespace display;
 #endif
 
+#ifdef __xwindows__
+static ankerl::unordered_dense::map<Window, Colormap> glX11Colormaps;
+#endif
+
 // Class definition at end of this source file.
 
 static ERR DISPLAY_Resize(extDisplay *, struct acResize *);
@@ -225,6 +229,7 @@ static ERR DISPLAY_DataFeed(extDisplay *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::REQUEST) {
       // Supported for handling the windows clipboard
 
+      if ((!Args->Buffer) or (!Args->Object)) return log.warning(ERR::NullArgs);
       auto request = (struct dcRequest *)Args->Buffer;
 
       log.traceBranch("Received data request from object %d, item %d", Args->Object ? Args->Object->UID : 0, request->Item);
@@ -252,7 +257,9 @@ static ERR DISPLAY_DataFeed(extDisplay *Self, struct acDataFeed *Args)
          dc.Datatype = DATA::RECEIPT;
          dc.Buffer   = kt::strclone(result);
          dc.Size     = result.size() + 1;
-         Action(AC::DataFeed, Args->Object, &dc);
+         auto error = Action(AC::DataFeed, Args->Object, &dc);
+         FreeResource(dc.Buffer);
+         return error;
       }
       else return log.warning(ERR::NoSupport);
       #endif
@@ -362,6 +369,13 @@ static ERR DISPLAY_Free(extDisplay *Self)
       XFreePixmap(XDisplay, Self->XPixmap);
       Self->XPixmap = 0;
       ((extBitmap *)Self->Bitmap)->x11.drawable = 0;
+   }
+
+   if (Self->XWindowHandle) {
+      if (auto colormap = glX11Colormaps.find(Self->XWindowHandle); colormap != glX11Colormaps.end()) {
+         XFreeColormap(XDisplay, colormap->second);
+         glX11Colormaps.erase(colormap);
+      }
    }
 
    // Kill all expose events associated with the X Window owned by the display
@@ -667,8 +681,10 @@ static ERR DISPLAY_Init(extDisplay *Self)
          int cwflags   = CWEventMask|CWOverrideRedirect;
          int depth     = CopyFromParent;
          Visual *visual = CopyFromParent;
+         Colormap colormap = 0;
          if ((swa.override_redirect) and (glXCompositeSupported)) {
-            swa.colormap         = XCreateColormap(XDisplay, DefaultRootWindow(XDisplay), glXInfoAlpha.visual, AllocNone);
+            colormap             = XCreateColormap(XDisplay, DefaultRootWindow(XDisplay), glXInfoAlpha.visual, AllocNone);
+            swa.colormap         = colormap;
             swa.background_pixel = 0;
             swa.border_pixel     = 0;
             cwflags |= CWColormap|CWBackPixel|CWBorderPixel;
@@ -684,15 +700,19 @@ static ERR DISPLAY_Init(extDisplay *Self)
             if (!(Self->XWindowHandle = XCreateWindow(XDisplay, DefaultRootWindow(XDisplay),
                   Self->X, Self->Y, Self->Width, Self->Height, 0 /* Border */, depth, InputOutput,
                   visual, cwflags, &swa))) {
+               if (colormap) XFreeColormap(XDisplay, colormap);
                return log.warning(ERR::SystemCall);
             }
          }
          else { // If the WindowHandle field is already set, use it as the parent for the new window.
             if (!(Self->XWindowHandle = XCreateWindow(XDisplay, Self->XWindowHandle,
                   0, 0, Self->Width, Self->Height, 0, depth, InputOutput, visual, cwflags, &swa))) {
+               if (colormap) XFreeColormap(XDisplay, colormap);
                return log.warning(ERR::SystemCall);
             }
          }
+
+         if (colormap) glX11Colormaps[Self->XWindowHandle] = colormap;
 
          bmp->x11.window = Self->XWindowHandle;
 

--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -625,7 +625,7 @@ static ERR PTR_MoveToPoint(extPointer *Self, struct acMoveToPoint *Args)
 #ifdef __xwindows__
    OBJECTPTR surface;
 
-   if (AccessObject(Self->SurfaceID, 3000, &surface) IS ERR::Okay) {
+   if (auto error = AccessObject(Self->SurfaceID, 3000, &surface); error IS ERR::Okay) {
       APTR xwin;
 
       if (surface->get(FID_WindowHandle, xwin) IS ERR::Okay) {
@@ -640,10 +640,11 @@ static ERR PTR_MoveToPoint(extPointer *Self, struct acMoveToPoint *Args)
       }
       ReleaseObject(surface);
    }
+   else return log.warning(error)|ERR::Notified;
 #elif _WIN32
    OBJECTPTR surface;
 
-   if (AccessObject(Self->SurfaceID, 3000, &surface) IS ERR::Okay) {
+   if (auto error = AccessObject(Self->SurfaceID, 3000, &surface); error IS ERR::Okay) {
       if ((Args->Flags & MTF::X) != MTF::NIL) Self->X = Args->X;
       if ((Args->Flags & MTF::Y) != MTF::NIL) Self->Y = Args->Y;
       if (Self->X < 0) Self->X = 0;
@@ -654,6 +655,7 @@ static ERR PTR_MoveToPoint(extPointer *Self, struct acMoveToPoint *Args)
       Self->HostY = Self->Y;
       ReleaseObject(surface);
    }
+   else return log.warning(error)|ERR::Notified;
 #endif
 
    // Determine the surface object that we are currently positioned over.  If it has set a cursor image, switch to it if the pointer is not locked.
@@ -729,10 +731,10 @@ static ERR PTR_SaveToObject(extPointer *Self, struct acSaveToObject *Args)
       config->write("POINTER", "MaxSpeed", std::to_string(Self->MaxSpeed));
       config->write("POINTER", "WheelSpeed", std::to_string(Self->WheelSpeed));
       config->write("POINTER", "ButtonOrder", Self->ButtonOrder);
-      config->saveToObject(Args->Dest);
+      return config->saveToObject(Args->Dest);
    }
 
-   return ERR::Okay;
+   return log.warning(ERR::CreateObject);
 }
 
 /*********************************************************************************************************************

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -2225,8 +2225,12 @@ static ERR SURFACE_SaveImage(extSurface *Self, struct acSaveImage *Args)
 
                   extBitmap *picbmp;
                   picture->get(FID_Bitmap, picbmp);
-                  gfx::CopySurface(list[j].SurfaceID, picbmp, BDF::NIL, 0, 0, list[j].Width, list[j].Height,
-                     list[j].Left - list[i].Left, list[j].Top - list[i].Top);
+                  if (auto error = gfx::CopySurface(list[j].SurfaceID, picbmp, BDF::NIL, 0, 0, list[j].Width,
+                        list[j].Height, list[j].Left - list[i].Left, list[j].Top - list[i].Top);
+                        error != ERR::Okay) {
+                     FreeResource(picture);
+                     return log.warning(error);
+                  }
                }
             }
          }

--- a/src/display/class_surface/surface_dimensions.cpp
+++ b/src/display/class_surface/surface_dimensions.cpp
@@ -201,9 +201,7 @@ static ERR SET_Dimensions(extSurface *Self, DMF Value)
 
       resize.Z = 0;
       resize.Depth  = 0;
-      Action(acRedimension::id, Self, &resize);
-
-      return ERR::Okay;
+      return Action(acRedimension::id, Self, &resize);
    }
    else return ERR::Search;
 }
@@ -944,4 +942,3 @@ static ERR SET_YOffset(extSurface *Self, Unit *Value)
    }
    return ERR::Okay;
 }
-

--- a/src/display/class_surface/surface_drawing.cpp
+++ b/src/display/class_surface/surface_drawing.cpp
@@ -364,8 +364,14 @@ ERR SURFACE_Draw(extSurface *Self, struct acDraw *Args)
 
 
    log.traceBranch("%dx%d,%dx%d", x, y, width, height);
-   RedrawSurface(Self->UID, x, y, width, height, IRF::RELATIVE|IRF::IGNORE_CHILDREN);
-   gfx::ExposeSurface(Self->UID, x, y, width, height, EXF::REDRAW_VOLATILE);
+   if (auto error = RedrawSurface(Self->UID, x, y, width, height, IRF::RELATIVE|IRF::IGNORE_CHILDREN);
+         error != ERR::Okay) {
+      return error|ERR::Notified;
+   }
+   if (auto error = gfx::ExposeSurface(Self->UID, x, y, width, height, EXF::REDRAW_VOLATILE);
+         error != ERR::Okay) {
+      return error|ERR::Notified;
+   }
    return ERR::Okay|ERR::Notified;
 }
 
@@ -525,12 +531,24 @@ static ERR SURFACE_InvalidateRegion(extSurface *Self, struct drw::InvalidateRegi
 
 
    if (Args) {
-      RedrawSurface(Self->UID, Args->X, Args->Y, Args->Width, Args->Height, IRF::RELATIVE);
-      gfx::ExposeSurface(Self->UID, Args->X, Args->Y, Args->Width, Args->Height, EXF::CHILDREN|EXF::REDRAW_VOLATILE_OVERLAP);
+      if (auto error = RedrawSurface(Self->UID, Args->X, Args->Y, Args->Width, Args->Height, IRF::RELATIVE);
+            error != ERR::Okay) {
+         return error|ERR::Notified;
+      }
+      if (auto error = gfx::ExposeSurface(Self->UID, Args->X, Args->Y, Args->Width, Args->Height,
+            EXF::CHILDREN|EXF::REDRAW_VOLATILE_OVERLAP); error != ERR::Okay) {
+         return error|ERR::Notified;
+      }
    }
    else {
-      RedrawSurface(Self->UID, 0, 0, Self->Width, Self->Height, IRF::RELATIVE);
-      gfx::ExposeSurface(Self->UID, 0, 0, Self->Width, Self->Height, EXF::CHILDREN|EXF::REDRAW_VOLATILE_OVERLAP);
+      if (auto error = RedrawSurface(Self->UID, 0, 0, Self->Width, Self->Height, IRF::RELATIVE);
+            error != ERR::Okay) {
+         return error|ERR::Notified;
+      }
+      if (auto error = gfx::ExposeSurface(Self->UID, 0, 0, Self->Width, Self->Height,
+            EXF::CHILDREN|EXF::REDRAW_VOLATILE_OVERLAP); error != ERR::Okay) {
+         return error|ERR::Notified;
+      }
    }
 
    return ERR::Okay|ERR::Notified;

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -438,6 +438,7 @@ extern char glpDPMS[20];
 extern uint8_t *glDemultiply;
 extern std::array<uint8_t, 256 * 256> glAlphaLookup;
 extern std::list<ClipRecord> glClips;
+extern std::recursive_mutex glClipboardLock;
 extern int glLastPort;
 
 extern ankerl::unordered_dense::map<WinHook, FUNCTION> glWindowHooks;
@@ -542,6 +543,7 @@ template <typename T>
 void UpdateSurfaceField(objSurface *Self, T SurfaceRecord::*LValue, T Value)
 {
    if (Self->initialised()) {
+      const std::lock_guard<std::recursive_mutex> lock(glSurfaceLock);
       for (auto &record : glSurfaces) {
          if (record.SurfaceID IS Self->UID) {
             record.*LValue = Value;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -1250,7 +1250,10 @@ static ERR MODExpunge(void)
 
    if (clDisplay) {
       clean_clipboard();
-      glClips.clear();
+      {
+         const std::lock_guard<std::recursive_mutex> lock(glClipboardLock);
+         glClips.clear();
+      }
    }
 
    if (glRefreshPointerTimer) { UpdateTimer(glRefreshPointerTimer, 0); glRefreshPointerTimer = 0; }
@@ -1517,10 +1520,9 @@ void free_egl(void)
 
    log.branch("Current Display: $%x", (int)glEGLDisplay);
 
-   glEGLState = EGL_TERMINATED; // The sooner we set this, the better.  It stops other threads from thinking that it's OK to keep using OpenGL.
-
    if (!pthread_mutex_lock(&glGraphicsMutex)) {
       log.msg("Lock granted - terminating EGL resources.");
+      glEGLState = EGL_TERMINATED;
 
       if (glEGLDisplay != EGL_NO_DISPLAY) {
          eglMakeCurrent(glEGLDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);

--- a/src/display/win32/clipboard.c
+++ b/src/display/win32/clipboard.c
@@ -884,6 +884,7 @@ void winCopyClipboard(void)
                      report_windows_hdrop((LPIDA)(((const char *)df) + (ptrdiff_t)df->pFiles), cut_operation, df->fWide);
                      GlobalUnlock(stgm.hGlobal);
                   }
+                  ReleaseStgMedium(&stgm);
                }
                break;
             }

--- a/src/display/win32/windows.cpp
+++ b/src/display/win32/windows.cpp
@@ -231,7 +231,7 @@ char GetMonitorSizeFromEDID(const HKEY hDevRegKey, short *WidthMm, short *Height
 
     for (int i = 0, retValue = ERROR_SUCCESS; retValue != ERROR_NO_MORE_ITEMS; ++i) {
         retValue = RegEnumValue ( hDevRegKey, i, &valueName[0], &AcutalValueNameLength, nullptr, &dwType, EDIDdata, &edidsize);
-        if (retValue != ERROR_SUCCESS || 0 != _tcscmp(valueName,_T("EDID"))) continue;
+        if ((retValue != ERROR_SUCCESS) or (0 != _tcscmp(valueName,_T("EDID"))) or (edidsize <= 68)) continue;
         *WidthMm  = ((EDIDdata[68] & 0xF0) << 4) + EDIDdata[66];
         *HeightMm = ((EDIDdata[68] & 0x0F) << 8) + EDIDdata[67];
         return TRUE; // valid EDID found
@@ -277,14 +277,14 @@ void get_dpi(void)
    dd.cb = sizeof(dd);
    DWORD dev = 0; // device index
    char bFoundDevice = FALSE;
-   while (EnumDisplayDevices(0, dev, &dd, 0) && !bFoundDevice) {
+   while (EnumDisplayDevices(0, dev, &dd, 0) and !bFoundDevice) {
       DISPLAY_DEVICE ddMon;
       ZeroMemory(&ddMon, sizeof(ddMon));
       ddMon.cb = sizeof(ddMon);
       DWORD devMon = 0;
 
-      while (EnumDisplayDevices(dd.DeviceName, devMon, &ddMon, 0) && !bFoundDevice) {
-         if (ddMon.StateFlags & DISPLAY_DEVICE_ACTIVE && !(ddMon.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER)) {
+      while (EnumDisplayDevices(dd.DeviceName, devMon, &ddMon, 0) and !bFoundDevice) {
+         if ((ddMon.StateFlags & DISPLAY_DEVICE_ACTIVE) and !(ddMon.StateFlags & DISPLAY_DEVICE_MIRRORING_DRIVER)) {
             // THIS IS UNTESTED
             char device_id[9], buffer[80];
             vsprintf(buffer, sizeof(buffer), "%s", ddMon.DeviceID);
@@ -649,7 +649,7 @@ static void HandleKeyPress(WPARAM value)
       result = ToUnicode(value, MapVirtualKey(value, 0), keystate, printable, sizeof(printable)/sizeof(printable[0]), 0);
 
       int flags = 0;
-      if ((value >= 0x60) && (value < 0x70)) flags |= KQ_NUM_PAD;
+      if ((value >= 0x60) and (value < 0x70)) flags |= KQ_NUM_PAD;
       if (LOWORD(GetKeyState(VK_CAPITAL)) == 1) flags |= KQ_CAPS_LOCK;
       if (keyconv[value]) MsgKeyPress(flags|glQualifiers, keyconv[value], printable[0]);
       else MSG("No equivalent key value for MS key %d.\n", (int)value);
@@ -1275,12 +1275,14 @@ HWND winCreateScreen(HWND PopOver, int *X, int *Y, int *Width, int *Height, char
       SetLastError(0);
       if (!SetWindowLong(Window, GWL_EXSTYLE, GetWindowLong(Window, GWL_EXSTYLE) | WS_EX_LAYERED)) {
          if (!GetLastError()) {
+            DestroyWindow(Window);
             return nullptr;
          }
       }
 
       if (!Composite) {
          if (!SetLayeredWindowAttributes(Window, 0, Opacity, LWA_ALPHA)) {
+            DestroyWindow(Window);
             return nullptr;
          }
       }
@@ -1392,6 +1394,7 @@ int winDestroyWindow(HWND window)
    NOTIFYICONDATA notify;
 
    if (window == glMainScreen) glMainScreen = nullptr;
+   RevokeDragDrop(window);
 
    ZeroMemory(&notify, sizeof(notify));
    notify.cbSize = sizeof(notify);


### PR DESCRIPTION
## Summary

* **Resource leaks fixed:** shared memory not freed on `shmat()` failure; X11 colormaps tracked in `glX11Colormaps` and freed in `DISPLAY_Free`; `dc.Buffer` freed before returning in `DISPLAY_DataFeed`; `ReleaseStgMedium` added in `winCopyClipboard`; `DestroyWindow` called on failure paths in `winCreateScreen`
* **Thread safety:** `glClipboardLock` recursive mutex added to protect all `glClips` access; `glSurfaceLock` added in `UpdateSurfaceField`; `glEGLState = EGL_TERMINATED` moved inside the graphics mutex in `free_egl()`
* **Error propagation:** surface drawing (`SURFACE_Draw`, `SURFACE_InvalidateRegion`), clipboard operations, pointer `MoveToPoint`, and `PTR_SaveToObject` now propagate errors correctly rather than silently returning `ERR::Okay`
* **Bounds/null checks:** EDID buffer bounds check (`edidsize <= 68`) prevents out-of-bounds reads; null pointer guards added in `DISPLAY_DataFeed` and `CLIPBOARD_DataFeed`
* **Other fixes:** invalid BPP in `BITMAP_Resize` returns `ERR::Args` instead of computing bogus values; `RevokeDragDrop` called in `winDestroyWindow`; buffer freed unconditionally in `BITMAP_Compress` regardless of allocation outcome

## Test plan

- [ ] Build the display module and confirm it compiles cleanly on Windows and Linux
- [ ] Exercise clipboard copy/paste under concurrent access to verify no deadlocks with `glClipboardLock`
- [ ] Verify X11 window creation and teardown leaves no colormap leaks (valgrind or X11 resource tracking)
- [ ] Run existing display Flute tests: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L display`