### PR TITLE
[Display] Fixed loop condition bugs, resource leaks, and atomic access

### DIFF
--- a/src/display/class_controller.cpp
+++ b/src/display/class_controller.cpp
@@ -81,7 +81,7 @@ TotalPorts: Reports the total number of controllers connected to the system.
 static ERR CONTROLLER_GET_TotalPorts(extSurface *Self, int &Value)
 {
 #ifdef _WIN32
-   if (glLastPort >= 0) Value = glLastPort;
+   if (glLastPort.load() >= 0) Value = glLastPort.load();
    else Value = 0;
    return ERR::Okay;
 #endif

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -23,6 +23,7 @@
 
 #include <unordered_set>
 #include <mutex>
+#include <atomic>
 #include <queue>
 #include <sstream>
 #include <array>
@@ -439,7 +440,7 @@ extern uint8_t *glDemultiply;
 extern std::array<uint8_t, 256 * 256> glAlphaLookup;
 extern std::list<ClipRecord> glClips;
 extern std::recursive_mutex glClipboardLock;
-extern int glLastPort;
+extern std::atomic<int> glLastPort;
 
 extern ankerl::unordered_dense::map<WinHook, FUNCTION> glWindowHooks;
 extern std::recursive_mutex glWindowHookLock;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -238,7 +238,7 @@ int glpMaximise = FALSE, glpFullScreen = FALSE;
 SWIN glpWindowType = SWIN::HOST;
 char glpDPMS[20] = "Standby";
 uint8_t *glDemultiply = nullptr;
-int glLastPort = -1;
+std::atomic<int> glLastPort = -1;
 
 std::vector<OBJECTID> glFocusList;
 std::recursive_mutex glFocusLock;

--- a/src/display/lib_bitmap.cpp
+++ b/src/display/lib_bitmap.cpp
@@ -1038,7 +1038,7 @@ ERR CopyArea(objBitmap *Source, objBitmap *Dest, BAF Flags, int X, int Y, int Wi
                }
                else {
                   while (Height > 0) {
-                     for (i=0; (size_t)i > sizeof(int); i += sizeof(int)) {
+                     for (i=0; i + int(sizeof(int)) <= Width; i += sizeof(int)) {
                         ((int *)(data+i))[0] = ((int *)(srcdata+i))[0];
                      }
                      while (i < Width) { data[i] = srcdata[i]; i++; }
@@ -1501,7 +1501,7 @@ ERR CopyRawBitmap(BITMAPSURFACE *Surface, objBitmap *Bitmap, CSRF Flags, int X, 
             Width   = Width * Surface->BytesPerPixel;
 
             while (Height > 0) {
-               for (i=0; (size_t)i > sizeof(int); i += sizeof(int)) {
+               for (i=0; i + int(sizeof(int)) <= Width; i += sizeof(int)) {
                   ((int *)(data+i))[0] = ((int *)(srcdata+i))[0];
                }
                while (i < Width) { data[i] = srcdata[i]; i++; }

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -10,6 +10,7 @@ Name: Surfaces
 
 SURFACELIST glSurfaces;
 static OBJECTID glModalID = 0;
+static std::recursive_mutex glModalLock;
 
 //********************************************************************************************************************
 // Called when windows has an item to be dropped on our display area.
@@ -1167,6 +1168,8 @@ oid: The UID of the modal surface, or zero.
 
 OBJECTID GetModalSurface(void)
 {
+   const std::lock_guard<std::recursive_mutex> lock(glModalLock);
+
    // Safety check: Confirm that the object still exists
    if ((glModalID) and (CheckObjectExists(glModalID) != ERR::True)) {
       kt::Log log(__FUNCTION__);
@@ -1441,6 +1444,7 @@ oid: The object ID of the previous modal surface is returned (zero if there was 
 OBJECTID SetModalSurface(OBJECTID SurfaceID)
 {
    kt::Log log(__FUNCTION__);
+   const std::lock_guard<std::recursive_mutex> lock(glModalLock);
 
    log.branch("#%d, CurrentFocus: %d", SurfaceID, gfx::GetUserFocus());
 

--- a/src/display/win32/clipboard.c
+++ b/src/display/win32/clipboard.c
@@ -729,7 +729,10 @@ int winAddClip(int Datatype, const void *Data, int Size, int Cut)
             }
             else error = ERR_Okay;
          }
-         else error = ERR_Lock;
+         else {
+            GlobalFree(hdata);
+            error = ERR_Lock;
+         }
       }
       else error = ERR_AllocMemory;
 
@@ -770,7 +773,10 @@ int winAddFileClip(const unsigned short *Path, int Size, int Cut)
             }
             else error = ERR_Okay;
          }
-         else error = ERR_Lock;
+         else {
+            GlobalFree(hdata);
+            error = ERR_Lock;
+         }
       }
       else error = ERR_AllocMemory;
 

--- a/src/display/win32/windows.cpp
+++ b/src/display/win32/windows.cpp
@@ -18,6 +18,7 @@
 #include <objidl.h>
 #include <xinput.h>
 #include <map>
+#include <atomic>
 
 #include <kotuku/system/errors.h>
 
@@ -68,7 +69,7 @@ typedef long long int64_t;
 #define MSG(...)
 
 extern HINSTANCE glInstance;
-extern int glLastPort;
+extern std::atomic<int> glLastPort;
 void KillMessageHook(void);
 
 static HWND glMainScreen = 0;
@@ -797,7 +798,7 @@ static LRESULT CALLBACK WindowProcedure(HWND window, UINT msgcode, WPARAM wParam
             glLastPort = 0;
             for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
                XINPUT_CAPABILITIES cap;
-               if (XInputGetCapabilities(i, XINPUT_FLAG_GAMEPAD, &cap) == ERROR_SUCCESS) {
+               if (!XInputGetCapabilities(i, XINPUT_FLAG_GAMEPAD, &cap)) {
                   glLastPort = i;
                }
                else break;
@@ -1603,11 +1604,14 @@ int winGetPixelFormat(int *redmask, int *greenmask, int *bluemask, int *alphamas
    // WARNING: Calling DescribePixelFormat() causes layered windows to flicker for some bizarre reason.  Therefore this routine has been modified so that DescribePixelFormat() is only called once.
 
    if (!mred) {
-      if (DescribePixelFormat(GetDC(nullptr), 1, sizeof(PIXELFORMATDESCRIPTOR), &pfd)) {
-         if (pfd.cRedBits <= 8) mred = formats[pfd.cRedBits] << pfd.cRedShift;
-         if (pfd.cGreenBits <= 8) mgreen = formats[pfd.cGreenBits] << pfd.cGreenShift;
-         if (pfd.cBlueBits <= 8) mblue = formats[pfd.cBlueBits] << pfd.cBlueShift;
-         if (pfd.cAlphaBits <= 8) malpha = formats[pfd.cAlphaBits] << pfd.cAlphaShift;
+      if (auto dc = GetDC(nullptr)) {
+         if (DescribePixelFormat(dc, 1, sizeof(PIXELFORMATDESCRIPTOR), &pfd)) {
+            if (pfd.cRedBits <= 8) mred = formats[pfd.cRedBits] << pfd.cRedShift;
+            if (pfd.cGreenBits <= 8) mgreen = formats[pfd.cGreenBits] << pfd.cGreenShift;
+            if (pfd.cBlueBits <= 8) mblue = formats[pfd.cBlueBits] << pfd.cBlueShift;
+            if (pfd.cAlphaBits <= 8) malpha = formats[pfd.cAlphaBits] << pfd.cAlphaShift;
+         }
+         ReleaseDC(nullptr, dc);
       }
    }
 


### PR DESCRIPTION
* Fixed CopyArea and CopyRawBitmap loop conditions that never iterated due to incorrect comparison `(size_t)i > sizeof(int)`, replaced with `i + int(sizeof(int)) <= Width`
* Changed glLastPort to std::atomic<int> for safe cross-thread access from the XInput gamepad handler
* Added glModalLock mutex protecting GetModalSurface and SetModalSurface
* Fixed GlobalFree memory leak in winAddClip and winAddFileClip when OpenClipboard fails after allocation
* Fixed DC resource leak in winGetPixelFormat by pairing GetDC with ReleaseDC