### PR TITLE
[Display] Refactored Win32 display and clipboard code to eliminate duplicated patterns

### DIFF
--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -62,6 +62,43 @@ static ERR add_clip(CLIPTYPE, const std::vector<ClipItem> &, CEF = CEF::NIL);
 static ERR add_clip(CSTRING);
 static ERR CLIPBOARD_AddObjects(objClipboard *, struct clip::AddObjects *);
 
+#ifdef _WIN32
+static std::u16string utf8_to_utf16(CSTRING String, int Length, bool SurrogatePairs)
+{
+   std::u16string result;
+   if (!String) return result;
+
+   auto str = String;
+   int chars, bytes = 0;
+   for (chars=0; (bytes < Length) and (str[bytes]); chars++) {
+      for (++bytes; (bytes < Length) and ((str[bytes] & 0xc0) IS 0x80); bytes++);
+   }
+
+   result.reserve(size_t(chars));
+
+   int pos = 0;
+   while (pos < bytes) {
+      int len = UTF8CharLength(str);
+      if ((len IS 0) or (pos + len > bytes)) break;
+
+      uint32_t codepoint;
+      if (SurrogatePairs and (len IS 1)) codepoint = *str;
+      else codepoint = UTF8ReadValue(str, nullptr);
+      if (SurrogatePairs and (codepoint >= 0x10000)) {
+         codepoint -= 0x10000;
+         result.push_back((char16_t)(0xD800 + (codepoint >> 10)));
+         result.push_back((char16_t)(0xDC00 + (codepoint & 0x3FF)));
+      }
+      else result.push_back((char16_t)codepoint);
+
+      str += len;
+      pos += len;
+   }
+
+   return result;
+}
+#endif
+
 //********************************************************************************************************************
 // Remove stale clipboard files that are over 24hrs old
 
@@ -140,30 +177,10 @@ static ERR add_file_to_host(objClipboard *Self, const std::vector<ClipItem> &Ite
    for (auto &item : Items) {
       std::string path;
       if (ResolvePath(item.Path, RSF::NIL, &path) IS ERR::Okay) {
-         // Convert UTF-8 to UTF-16 manually
-         std::u16string dest;
-         const char *src = path.c_str();
-         while (*src) {
-            uint32_t codepoint = 0;
-            int len = UTF8CharLength(src);
-            if (len IS 1) codepoint = *src;
-            else codepoint = UTF8ReadValue(src, nullptr);
-
-            if (codepoint < 0x10000) {
-               dest.push_back((char16_t)codepoint);
-            }
-            else {
-               // Surrogate pair for codepoints >= 0x10000
-               codepoint -= 0x10000;
-               dest.push_back((char16_t)(0xD800 + (codepoint >> 10)));
-               dest.push_back((char16_t)(0xDC00 + (codepoint & 0x3FF)));
-            }
-            src += len;
-         }
-         list << dest << '\0';
+         list << utf8_to_utf16(path.c_str(), 0x7fffffff, true) << char16_t(0);
       }
    }
-   list << '\0'; // An extra null byte is required to terminate the list for Windows HDROP
+   list << char16_t(0); // An extra null byte is required to terminate the list for Windows HDROP
 
    auto str = list.str();
    auto error = (ERR)winAddFileClip(str.c_str(), str.size() * sizeof(char16_t), Cut);
@@ -183,28 +200,12 @@ static ERR add_text_to_host(objClipboard *Self, CSTRING String, int Length = 0x7
    if ((Self->Flags & CPF::DRAG_DROP) != CPF::NIL) return ERR::NoSupport;
 
 #ifdef _WIN32
-   // Copy text to the windows clipboard.  This requires a conversion from UTF-8 to UTF-16.
+   // Copy text to the Windows clipboard.  This requires a conversion from UTF-8 to UTF-16.
 
-   auto str = String;
-   int chars, bytes = 0;
-   for (chars=0; (bytes < Length) and (str[bytes]); chars++) {
-      for (++bytes; (bytes < Length) and ((str[bytes] & 0xc0) IS 0x80); bytes++);
-   }
+   auto utf16 = utf8_to_utf16(String, Length, false);
+   utf16.push_back(0);
 
-   std::vector<uint16_t> utf16(size_t(chars + 1));
-
-   int i = 0;
-   int pos = 0;
-   while (pos < bytes) {
-      int len = UTF8CharLength(str);
-      if (pos + len > bytes) break; // Avoid corrupt UTF-8 sequences resulting in minor buffer overflow
-      utf16[i++] = (uint16_t)UTF8ReadValue(str, nullptr);
-      str += len;
-      pos += len;
-   }
-   utf16[i] = 0;
-
-   auto error = (ERR)winAddClip(int(CLIPTYPE::TEXT), utf16.data(), utf16.size() * sizeof(uint16_t), false);
+   auto error = (ERR)winAddClip(int(CLIPTYPE::TEXT), utf16.data(), utf16.size() * sizeof(char16_t), false);
    if (error != ERR::Okay) log.warning(error);
    return error;
 #else

--- a/src/display/win32/clipboard.c
+++ b/src/display/win32/clipboard.c
@@ -302,17 +302,8 @@ static HRESULT STDMETHODCALLTYPE RKDT_Drop(struct rkDropTarget *Self, IDataObjec
 
 //********************************************************************************************************************
 
-static int get_data(struct rkDropTarget *Self, char *Preference, struct WinDT **OutData, int *OutTotal)
+static void clear_data(struct rkDropTarget *Self)
 {
-	IDataObject *data;
-   STGMEDIUM stgm;
-	FORMATETC fmt = { CF_TEXT, NULL, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
-   int p, error;
-
-   MSG("rkDropTarget::GetData()\n");
-
-   if ((!Preference) OR (!OutData) OR (!OutTotal)) return ERR_NullArgs;
-
    if (Self->ItemData) {
       free(Self->ItemData);
       Self->ItemData = NULL;
@@ -322,213 +313,216 @@ static int get_data(struct rkDropTarget *Self, char *Preference, struct WinDT **
       free(Self->DataItems);
       Self->DataItems = NULL;
    }
+}
+
+//********************************************************************************************************************
+
+static int lock_hglobal_data(IDataObject *Data, UINT Format, STGMEDIUM *Medium, void **OutData, int *Found)
+{
+   FORMATETC fmt = { Format, NULL, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+
+   *OutData = NULL;
+   *Found = 0;
+
+   if (!(Data->lpVtbl->GetData(Data, &fmt, Medium) IS S_OK)) return ERR_Failed;
+
+   *Found = 1;
+   if (!(*OutData = GlobalLock(Medium->hGlobal))) {
+      ReleaseStgMedium(Medium);
+      return ERR_Lock;
+   }
+
+   return ERR_Okay;
+}
+
+//********************************************************************************************************************
+
+static void unlock_hglobal_data(STGMEDIUM *Medium)
+{
+   GlobalUnlock(Medium->hGlobal);
+   ReleaseStgMedium(Medium);
+}
+
+//********************************************************************************************************************
+
+static int publish_single_data(struct rkDropTarget *Self, int Datatype, int Length, struct WinDT **OutData,
+   int *OutTotal)
+{
+   if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT)))) {
+      Self->DataItems[0].Datatype = Datatype;
+      Self->DataItems[0].Length   = Length;
+      Self->DataItems[0].Data     = Self->ItemData;
+      *OutData  = Self->DataItems;
+      *OutTotal = 1;
+      return ERR_Okay;
+   }
+   else return ERR_AllocMemory;
+}
+
+//********************************************************************************************************************
+
+static int copy_hglobal_data(struct rkDropTarget *Self, IDataObject *Data, UINT Format, int Datatype,
+   struct WinDT **OutData, int *OutTotal, int *Found)
+{
+   STGMEDIUM stgm;
+   void *raw;
+   int error, size;
+
+   error = lock_hglobal_data(Data, Format, &stgm, &raw, Found);
+   if (!*Found) return ERR_Failed;
+   if (!(error IS ERR_Okay)) return error;
+
+   size = GlobalSize(stgm.hGlobal);
+   if ((Self->ItemData = malloc(size))) {
+      memcpy(Self->ItemData, raw, size);
+      error = publish_single_data(Self, Datatype, size, OutData, OutTotal);
+   }
+   else error = ERR_AllocMemory;
+
+   unlock_hglobal_data(&stgm);
+   return error;
+}
+
+//********************************************************************************************************************
+
+static int get_data(struct rkDropTarget *Self, char *Preference, struct WinDT **OutData, int *OutTotal)
+{
+   IDataObject *data;
+   int p, error;
+
+   MSG("rkDropTarget::GetData()\n");
+
+   if ((!Preference) OR (!OutData) OR (!OutTotal)) return ERR_NullArgs;
+
+   clear_data(Self);
 
    data = Self->CurrentDataObject;
    for (p=0; p < 4; p++) { // Up to 4 data preferences may be specified
       switch (Preference[p]) {
          case DATA_TEXT:
          case DATA_XML: {
-            int chars, u8len, i, size;
+            STGMEDIUM stgm;
+            void *raw_data;
+            int chars, u8len, i, found;
             unsigned short value;
             unsigned char *u8str;
             unsigned short *wstr;
 
-            fmt.cfFormat = CF_UNICODETEXT;
-	         if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
-               if ((wstr = (unsigned short *)GlobalLock(stgm.hGlobal))) {
-                  u8len = 0;
+            error = lock_hglobal_data(data, CF_UNICODETEXT, &stgm, &raw_data, &found);
+            if (found) {
+               if (!(error IS ERR_Okay)) return error;
+
+               wstr = (unsigned short *)raw_data;
+               u8len = 0;
+               for (chars=0; wstr[chars]; chars++) {
+                  if (wstr[chars] < 128) u8len++;
+                  else if (wstr[chars] < 0x800) u8len += 2;
+                  else u8len += 3;
+               }
+
+               if ((Self->ItemData = malloc(u8len+1))) {
+                  u8str = (unsigned char *)Self->ItemData;
+                  i = 0;
                   for (chars=0; wstr[chars]; chars++) {
-                     if (wstr[chars] < 128) u8len++;
-                     else if (wstr[chars] < 0x800) u8len += 2;
-                     else u8len += 3;
-                  }
-
-                  if ((Self->ItemData = malloc(u8len+1))) {
-                     u8str = (unsigned char *)Self->ItemData;
-                     i = 0;
-                     for (chars=0; wstr[chars]; chars++) {
-                        value = wstr[chars];
-                        if (value < 128) {
-                           u8str[i++] = (unsigned char)value;
-                        }
-                        else if (value < 0x800) {
-                           u8str[i+1] = (value & 0x3f) | 0x80;
-                           value  = value>>6;
-                           u8str[i] = value | 0xc0;
-                           i += 2;
-                        }
-                        else {
-                           u8str[i+2] = (value & 0x3f)|0x80;
-                           value  = value>>6;
-                           u8str[i+1] = (value & 0x3f)|0x80;
-                           value  = value>>6;
-                           u8str[i] = value | 0xe0;
-                           i += 3;
-                        }
+                     value = wstr[chars];
+                     if (value < 128) {
+                        u8str[i++] = (unsigned char)value;
                      }
-                     u8str[i++] = 0;
-
-                     if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT)))) {
-                        Self->DataItems[0].Datatype = DATA_TEXT;
-                        Self->DataItems[0].Length = i;
-                        Self->DataItems[0].Data = Self->ItemData;
-                        *OutData  = Self->DataItems;
-                        *OutTotal = 1;
-                        error = ERR_Okay;
+                     else if (value < 0x800) {
+                        u8str[i+1] = (value & 0x3f) | 0x80;
+                        value  = value>>6;
+                        u8str[i] = value | 0xc0;
+                        i += 2;
                      }
-                     else error = ERR_AllocMemory;
+                     else {
+                        u8str[i+2] = (value & 0x3f)|0x80;
+                        value  = value>>6;
+                        u8str[i+1] = (value & 0x3f)|0x80;
+                        value  = value>>6;
+                        u8str[i] = value | 0xe0;
+                        i += 3;
+                     }
                   }
-                  else error = ERR_AllocMemory;
-
-                  GlobalUnlock(stgm.hGlobal);
+                  u8str[i++] = 0;
+                  error = publish_single_data(Self, DATA_TEXT, i, OutData, OutTotal);
                }
-               else error = ERR_Lock;
+               else error = ERR_AllocMemory;
 
-               ReleaseStgMedium(&stgm);
+               unlock_hglobal_data(&stgm);
                return error;
             }
 
-            fmt.cfFormat = CF_TEXT;
-	         if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
-               unsigned char *str;
-               if ((str = (unsigned char *)GlobalLock(stgm.hGlobal))) {
-                  size = GlobalSize(stgm.hGlobal);
-                  if ((Self->ItemData = malloc(size))) {
-                     memcpy(Self->ItemData, str, size);
-
-                     if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT)))) {
-                        Self->DataItems[0].Datatype = DATA_TEXT;
-                        Self->DataItems[0].Length   = size;
-                        Self->DataItems[0].Data     = Self->ItemData;
-                        *OutData  = Self->DataItems;
-                        *OutTotal = 1;
-                        error = ERR_Okay;
-                     }
-                     else error = ERR_AllocMemory;
-                  }
-                  else error = ERR_AllocMemory;
-                  GlobalUnlock(stgm.hGlobal);
-               }
-               else error = ERR_Lock;
-
-               ReleaseStgMedium(&stgm);
-               return error;
-            }
+            error = copy_hglobal_data(Self, data, CF_TEXT, DATA_TEXT, OutData, OutTotal, &found);
+            if (found) return error;
 
             break;
          }
 
          case DATA_IMAGE: {
-            int size;
+            int found;
 
-            fmt.cfFormat = CF_TIFF;
-	         if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
-               unsigned char *raw;
-               if ((raw = (unsigned char *)GlobalLock(stgm.hGlobal))) {
-                  size = GlobalSize(stgm.hGlobal);
-                  if ((Self->ItemData = malloc(size))) {
-                     memcpy(Self->ItemData, raw, size);
-
-                     if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT)))) {
-                        Self->DataItems[0].Datatype = DATA_IMAGE;
-                        Self->DataItems[0].Length   = size;
-                        Self->DataItems[0].Data     = Self->ItemData;
-                        *OutData  = Self->DataItems;
-                        *OutTotal = 1;
-                        error = ERR_Okay;
-                     }
-                     else error = ERR_AllocMemory;
-                  }
-                  else error = ERR_AllocMemory;
-                  GlobalUnlock(stgm.hGlobal);
-               }
-               else error = ERR_Lock;
-
-               ReleaseStgMedium(&stgm);
-               return error;
-            }
+            error = copy_hglobal_data(Self, data, CF_TIFF, DATA_IMAGE, OutData, OutTotal, &found);
+            if (found) return error;
 
             break;
          }
 
          case DATA_AUDIO: {
-            int size;
+            int found;
 
-            fmt.cfFormat = CF_RIFF;
-	         if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
-               unsigned char *raw;
-               if ((raw = (unsigned char *)GlobalLock(stgm.hGlobal))) {
-                  size = GlobalSize(stgm.hGlobal);
-                  if ((Self->ItemData = malloc(size))) {
-                     memcpy(Self->ItemData, raw, size);
-
-                     if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT)))) {
-                        Self->DataItems[0].Datatype = DATA_AUDIO;
-                        Self->DataItems[0].Length   = size;
-                        Self->DataItems[0].Data     = Self->ItemData;
-                        *OutData  = Self->DataItems;
-                        *OutTotal = 1;
-                        error = ERR_Okay;
-                     }
-                     else error = ERR_AllocMemory;
-                  }
-                  else error = ERR_AllocMemory;
-                  GlobalUnlock(stgm.hGlobal);
-               }
-               else error = ERR_Lock;
-
-               ReleaseStgMedium(&stgm);
-               return error;
-            }
+            error = copy_hglobal_data(Self, data, CF_RIFF, DATA_AUDIO, OutData, OutTotal, &found);
+            if (found) return error;
 
             break;
          }
 
          case DATA_FILE: {
+            STGMEDIUM stgm;
             HDROP raw;
-            int i, total, item, len, size;
+            void *raw_data;
+            int i, total, item, len, size, found;
             TCHAR path[MAX_PATH];
             char *str;
 
-            fmt.cfFormat = CF_HDROP;
-	         if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
-               if ((raw = (HDROP)GlobalLock(stgm.hGlobal))) {
-                  total = DragQueryFile(raw, 0xffffffff, NULL, 0);
+            error = lock_hglobal_data(data, CF_HDROP, &stgm, &raw_data, &found);
+            if (found) {
+               if (!(error IS ERR_Okay)) return error;
 
-                  size = 0;
-                  for (i=0; i < total; i++) {
-                     size += DragQueryFile(raw, i, path, sizeof(path)) + 1;
-                  }
+               raw = (HDROP)raw_data;
+               total = DragQueryFile(raw, 0xffffffff, NULL, 0);
 
-                  if (!size);
-                  else if ((Self->ItemData = malloc(size))) {
-                     if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT) * total))) {
-                        str = (char *)Self->ItemData;
-                        for (item=0; item < total; item++) {
-                           len = DragQueryFile(raw, item, str, MAX_PATH) + 1;
+               size = 0;
+               for (i=0; i < total; i++) {
+                  size += DragQueryFile(raw, i, path, sizeof(path)) + 1;
+               }
 
-                           Self->DataItems[item].Datatype = DATA_FILE;
-                           Self->DataItems[item].Length   = len;
-                           Self->DataItems[item].Data     = str;
-                           str += len;
-                        }
-                        *OutData  = Self->DataItems;
-                        *OutTotal = total;
-                        error = ERR_Okay;
+               error = ERR_Okay;
+               if (!size);
+               else if ((Self->ItemData = malloc(size))) {
+                  if ((Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT) * total))) {
+                     str = (char *)Self->ItemData;
+                     for (item=0; item < total; item++) {
+                        len = DragQueryFile(raw, item, str, MAX_PATH) + 1;
+
+                        Self->DataItems[item].Datatype = DATA_FILE;
+                        Self->DataItems[item].Length   = len;
+                        Self->DataItems[item].Data     = str;
+                        str += len;
                      }
-                     else error = ERR_AllocMemory;
+                     *OutData  = Self->DataItems;
+                     *OutTotal = total;
+                     error = ERR_Okay;
                   }
                   else error = ERR_AllocMemory;
-                  GlobalUnlock(stgm.hGlobal);
                }
-               else error = ERR_Lock;
+               else error = ERR_AllocMemory;
 
-               ReleaseStgMedium(&stgm);
+               unlock_hglobal_data(&stgm);
                return error;
             }
 
-            fmt.cfFormat = fmtShellIDList;
-            if (data->lpVtbl->GetData(data, &fmt, &stgm) IS S_OK) {
+            error = lock_hglobal_data(data, fmtShellIDList, &stgm, &raw_data, &found);
+            if (found) {
                LPIDA pida;
                TCHAR path[MAX_PATH], folderpath[MAX_PATH];
                LPCITEMIDLIST item, folder;
@@ -536,77 +530,76 @@ static int get_data(struct rkDropTarget *Self, char *Preference, struct WinDT **
 
                MSG("ShellIDList discovered.\n");
 
+               if (!(error IS ERR_Okay)) return error;
+
                error = ERR_Okay;
+               pida = (LPIDA)raw_data;
+               folder = HIDA_GetPIDLFolder(pida);
+               if (SHGetPathFromIDList(folder, folderpath)) {
+                  // Calculate the size of the file strings: (FolderLength * Total) + (Lengths of each filename)
 
-               if ((pida = (LPIDA)GlobalLock(stgm.hGlobal))) {
-                  folder = HIDA_GetPIDLFolder(pida);
-                  if (SHGetPathFromIDList(folder, folderpath)) {
-                     // Calculate the size of the file strings: (FolderLength * Total) + (Lengths of each filename)
+                  for (folderlen=0; folderpath[folderlen]; folderlen++);
+                  size = folderlen * pida->cidl;
 
-                     for (folderlen=0; folderpath[folderlen]; folderlen++);
-                     size = folderlen * pida->cidl;
+                  // Add lengths of each file name
 
-                     // Add lengths of each file name
-
-                     for (index=0; index < (int)pida->cidl; index++) {
-                        item = HIDA_GetPIDLItem(pida, index);
-                        if (SHGetPathFromIDList(item, path)) {
-                           for (j=0; path[j]; j++);
-                           while ((j > 0) AND (path[j-1] != '/') AND (path[j-1] != '\\')) j--;
-                           for (i=0; path[j+i]; i++);
-                           size += i + 1;
-                        }
-                        else {
-                           error = ERR_Failed;
-                           break;
-                        }
+                  for (index=0; index < (int)pida->cidl; index++) {
+                     item = HIDA_GetPIDLItem(pida, index);
+                     if (SHGetPathFromIDList(item, path)) {
+                        for (j=0; path[j]; j++);
+                        while ((j > 0) AND (path[j-1] != '/') AND (path[j-1] != '\\')) j--;
+                        for (i=0; path[j+i]; i++);
+                        size += i + 1;
                      }
-
-                     if (!error) {
-                        if ((Self->ItemData = malloc(size)) AND (Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT) * pida->cidl))) {
-                           char *str = (char *)Self->ItemData;
-                           pos = 0;
-                           for (index=0; index < (int)pida->cidl; index++) {
-                              item = HIDA_GetPIDLItem(pida, index);
-                              if (SHGetPathFromIDList(item, path)) {
-                                 Self->DataItems[index].Datatype = DATA_FILE;
-                                 Self->DataItems[index].Data     = str + pos;
-
-                                 // Copy the root folder path first
-
-                                 for (j=0; folderpath[j]; j++) str[pos++] = folderpath[j];
-
-                                 // Go to the end of the string and then find the start of the filename
-
-                                 for (j=0; path[j]; j++);
-                                 while ((j > 0) AND (path[j-1] != '/') AND (path[j-1] != '\\')) j--;
-
-                                 while (path[j]) str[pos++] = path[j++];
-                                 str[pos++] = 0;
-
-                                 Self->DataItems[index].Length = (int)(((char *)str + pos) - (char *)Self->DataItems[index].Data);
-                              }
-                              else {
-                                 error = ERR_Failed;
-                                 break;
-                              }
-                           }
-
-                           if (!error) {
-                              *OutData  = Self->DataItems;
-                              *OutTotal = pida->cidl;
-                           }
-                        }
-                        else error = ERR_AllocMemory;
+                     else {
+                        error = ERR_Failed;
+                        break;
                      }
                   }
-                  else error = ERR_Failed;
 
-                  GlobalUnlock(stgm.hGlobal);
+                  if (!error) {
+                     if ((Self->ItemData = malloc(size)) AND
+                         (Self->DataItems = (struct WinDT *)malloc(sizeof(struct WinDT) * pida->cidl))) {
+                        char *str = (char *)Self->ItemData;
+                        pos = 0;
+                        for (index=0; index < (int)pida->cidl; index++) {
+                           item = HIDA_GetPIDLItem(pida, index);
+                           if (SHGetPathFromIDList(item, path)) {
+                              Self->DataItems[index].Datatype = DATA_FILE;
+                              Self->DataItems[index].Data     = str + pos;
+
+                              // Copy the root folder path first
+
+                              for (j=0; folderpath[j]; j++) str[pos++] = folderpath[j];
+
+                              // Go to the end of the string and then find the start of the filename
+
+                              for (j=0; path[j]; j++);
+                              while ((j > 0) AND (path[j-1] != '/') AND (path[j-1] != '\\')) j--;
+
+                              while (path[j]) str[pos++] = path[j++];
+                              str[pos++] = 0;
+
+                              Self->DataItems[index].Length = (int)(((char *)str + pos) -
+                                 (char *)Self->DataItems[index].Data);
+                           }
+                           else {
+                              error = ERR_Failed;
+                              break;
+                           }
+                        }
+
+                        if (!error) {
+                           *OutData  = Self->DataItems;
+                           *OutTotal = pida->cidl;
+                        }
+                     }
+                     else error = ERR_AllocMemory;
+                  }
                }
-               else error = ERR_Lock;
+               else error = ERR_Failed;
 
-               ReleaseStgMedium(&stgm);
+               unlock_hglobal_data(&stgm);
                return error;
             }
             break;

--- a/src/display/win32/windows.cpp
+++ b/src/display/win32/windows.cpp
@@ -1559,16 +1559,12 @@ void precalc_rgb(unsigned char *Data, unsigned char *Dest, int Width, int Height
    }
 }
 
-void win32RedrawWindow(HWND Window, HDC WindowDC, int X, int Y, int Width,
-   int Height, int XDest, int YDest, int ScanWidth, int ScanHeight,
-   int BPP, unsigned char *Data, int RedMask, int GreenMask, int BlueMask, int AlphaMask, unsigned char Opacity)
+//********************************************************************************************************************
+
+static BITMAPV4HEADER make_bitmap_v4_header(int ScanWidth, int ScanHeight, int BPP, int RedMask, int GreenMask,
+   int BlueMask, int AlphaMask)
 {
-   POINT ptSrc = { 0, 0 };
-   SIZE size;
-   char direct_blit;
-   BITMAPV4HEADER info;
-   RECT rect;
-   unsigned char *alpha_data;
+   BITMAPV4HEADER info = { };
 
    info.bV4Size          = sizeof(info);
    info.bV4Width         = ScanWidth;     // Width in pixels
@@ -1591,10 +1587,29 @@ void win32RedrawWindow(HWND Window, HDC WindowDC, int X, int Y, int Width,
 
    // NB: wingdi.h sometimes defines bV4Compression as bV4V4Compression
 
-   if (BPP == 24) info.bV4V4Compression = BI_RGB; // Must use BI_RGB in 24bit mode, or GDI does nothing
-   else info.bV4V4Compression = BI_BITFIELDS; // Must use BI_BITFIELDS and set the RGB masks in other packed modes
+   switch (BPP) {
+      case 24: info.bV4V4Compression = BI_RGB; break; // Must use BI_RGB in 24bit mode, or GDI does nothing
+      default: info.bV4V4Compression = BI_BITFIELDS; break; // Must set the RGB masks in other packed modes
+   }
 
-   if (info.bV4BitCount == 15) info.bV4BitCount = 16;
+   switch (info.bV4BitCount) {
+      case 15: info.bV4BitCount = 16; break;
+      default: break;
+   }
+
+   return info;
+}
+
+void win32RedrawWindow(HWND Window, HDC WindowDC, int X, int Y, int Width,
+   int Height, int XDest, int YDest, int ScanWidth, int ScanHeight,
+   int BPP, unsigned char *Data, int RedMask, int GreenMask, int BlueMask, int AlphaMask, unsigned char Opacity)
+{
+   POINT ptSrc = { 0, 0 };
+   SIZE size;
+   char direct_blit;
+   auto info = make_bitmap_v4_header(ScanWidth, ScanHeight, BPP, RedMask, GreenMask, BlueMask, AlphaMask);
+   RECT rect;
+   unsigned char *alpha_data;
 
    direct_blit = TRUE;
    if (GetWindowLong(Window, GWL_EXSTYLE) & WS_EX_LAYERED) {
@@ -1719,33 +1734,7 @@ void winSetDIBitsToDevice(HDC hdc, int xdest, int ydest, int width, int height,
         int xstart, int ystart, int scanwidth, int scanheight, int bpp, void *data,
         int redmask, int greenmask, int bluemask)
 {
-   BITMAPV4HEADER info;
-
-   info.bV4Size          = sizeof(info);
-   info.bV4Width         = scanwidth;     // Width in pixels
-   info.bV4Height        = -scanheight;   // Height in pixels
-   info.bV4Planes        = 1;             // Always 1
-   info.bV4BitCount      = bpp;           // Bits per pixel
-   info.bV4SizeImage     = 0;
-   info.bV4XPelsPerMeter = 0;
-   info.bV4YPelsPerMeter = 0;
-   info.bV4ClrUsed       = 0;
-   info.bV4ClrImportant  = 0;
-   info.bV4RedMask       = redmask;
-   info.bV4GreenMask     = greenmask;
-   info.bV4BlueMask      = bluemask;
-   info.bV4AlphaMask     = 0;
-   info.bV4CSType        = 0;
-   info.bV4GammaRed      = 0;
-   info.bV4GammaGreen    = 0;
-   info.bV4GammaBlue     = 0;
-
-   // NB: wingdi.h sometimes defines bV4Compression as bV4V4Compression
-
-   if (bpp == 24) info.bV4V4Compression = BI_RGB; // Must use BI_RGB in 24bit mode, or GDI does nothing
-   else info.bV4V4Compression = BI_BITFIELDS; // Must use BI_BITFIELDS and set the RGB masks in other packed modes
-
-   if (info.bV4BitCount == 15) info.bV4BitCount = 16;
+   auto info = make_bitmap_v4_header(scanwidth, scanheight, bpp, redmask, greenmask, bluemask, 0);
 
    ystart = scanheight - (ystart + height);
    SetDIBitsToDevice(hdc, xdest, ydest, width, height, xstart, ystart, 0, scanheight, data, (BITMAPINFO *)&info, DIB_RGB_COLORS);


### PR DESCRIPTION
## Summary

* Extracted `utf8_to_utf16()` helper in `class_clipboard.cpp`, replacing two inline UTF-8 to UTF-16 conversion blocks in `add_file_to_host()` and `add_text_to_host()`
* Extracted `make_bitmap_v4_header()` static helper in `windows.cpp`, replacing duplicated `BITMAPV4HEADER` initialisation in `win32RedrawWindow()` and `winSetDIBitsToDevice()`
* Introduced `lock_hglobal_data()`, `unlock_hglobal_data()`, `copy_hglobal_data()`, `clear_data()`, and `publish_single_data()` helpers in `clipboard.c` to decompose `get_data()` and eliminate repeated GlobalLock/ReleaseStgMedium boilerplate across all data type branches

## Test plan

- [ ] Build the Display module on Windows and verify it compiles cleanly
- [ ] Verify clipboard copy/paste of text, files, images, and audio via drag-and-drop still functions correctly
- [ ] Verify window redraw (24-bit and non-24-bit BPP paths) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)