### PR TITLE
[Tiri] Array fixes: consolidated parsing, GC-aware copy/clear, and concat validation

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -783,16 +783,7 @@ LJLIB_CF(array_clear)
    GCarray *arr = lj_lib_checkarray(L, 1);
    if (arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
 
-   // For GC-tracked types, clear references to allow garbage collection
-   if (arr->elemtype IS AET::STR_GC or arr->elemtype IS AET::TABLE or arr->elemtype IS AET::ARRAY or
-       arr->elemtype IS AET::OBJECT) {
-      auto refs = arr->get<GCRef>();
-      for (MSize i = 0; i < arr->len; i++) setgcrefnull(refs[i]);
-   }
-   else if (arr->elemtype IS AET::ANY) {
-      lj_bulk_nil_tvalue(arr->get<TValue>(), arr->len);
-   }
-
+   lj_array_clear_range(arr, 0, arr->len);
    arr->len = 0;
    return 0;
 }
@@ -826,52 +817,19 @@ LJLIB_CF(array_resize)
          if (not lj_array_grow(L, arr, target_len)) lj_err_caller(L, ErrMsg::ARREXT);
       }
 
-      // Zero-initialize new elements based on type
-
-      switch (arr->elemtype) {
-         case AET::STR_GC:
-         case AET::TABLE:
-         case AET::ARRAY:
-         case AET::OBJECT: {
-            auto refs = arr->get<GCRef>();
-            for (MSize i = old_len; i < target_len; i++) setgcrefnull(refs[i]);
-            break;
-         }
-
-         case AET::ANY: {
-            lj_bulk_nil_tvalue(&arr->get<TValue>()[old_len], target_len - old_len);
-            break;
-         }
-
-         default: {
-            // Numeric types: zero-fill the new region
-            void *start = (char*)arr->arraydata() + (old_len * arr->elemsize);
-            size_t bytes = (target_len - old_len) * arr->elemsize;
-            memset(start, 0, bytes);
-            break;
-         }
+      if (arr->elemtype IS AET::STR_GC or arr->elemtype IS AET::TABLE or arr->elemtype IS AET::ARRAY or
+          arr->elemtype IS AET::OBJECT or arr->elemtype IS AET::ANY) {
+         lj_array_clear_range(arr, old_len, target_len - old_len);
+      }
+      else {
+         // Numeric types: zero-fill the new region
+         void *start = (char*)arr->arraydata() + (old_len * arr->elemsize);
+         size_t bytes = (target_len - old_len) * arr->elemsize;
+         memset(start, 0, bytes);
       }
    }
    else if (target_len < old_len) {
-      // Shrinking: clear references for GC-tracked types
-      switch (arr->elemtype) {
-         case AET::STR_GC:
-         case AET::TABLE:
-         case AET::ARRAY:
-         case AET::OBJECT: {
-            auto refs = arr->get<GCRef>();
-            for (MSize i = target_len; i < old_len; i++) setgcrefnull(refs[i]);
-            break;
-         }
-
-         case AET::ANY: {
-            lj_bulk_nil_tvalue(&arr->get<TValue>()[target_len], old_len - target_len);
-            break;
-         }
-
-         default:
-            break; // Numeric types don't need clearing
-      }
+      lj_array_clear_range(arr, target_len, old_len - target_len);
    }
 
    arr->len = target_len;
@@ -2523,38 +2481,8 @@ LJLIB_CF(array_filter)
             lj_err_caller(L, ErrMsg::ARREXT);
          }
 
-         // Copy element to result array
-         void *src = lj_array_index(arr, i);
-         void *dst = lj_array_index(result, result->len);
-
-         switch (result->elemtype) {
-            case AET::STR_GC:
-            case AET::TABLE:
-            case AET::ARRAY:
-            case AET::OBJECT: {
-               GCRef ref = *(GCRef *)src;
-               *(GCRef *)dst = ref;
-               if (gcref(ref)) lj_gc_objbarrier(L, result, gcref(ref));
-               break;
-            }
-            case AET::ANY: {
-               TValue *tv_src = (TValue *)src;
-               TValue *tv_dst = (TValue *)dst;
-               copyTV(L, tv_dst, tv_src);
-               if (tvisgcv(tv_src)) lj_gc_objbarrier(L, result, gcV(tv_src));
-               break;
-            }
-            case AET::FLOAT:  *(float *)dst = *(float *)src; break;
-            case AET::DOUBLE: *(double *)dst = *(double *)src; break;
-            case AET::INT64:  *(int64_t *)dst = *(int64_t *)src; break;
-            case AET::INT32:  *(int32_t *)dst = *(int32_t *)src; break;
-            case AET::INT16:  *(int16_t *)dst = *(int16_t *)src; break;
-            case AET::BYTE:   *(uint8_t *)dst = *(uint8_t *)src; break;
-            default:
-               memcpy(dst, src, arr->elemsize);
-               break;
-         }
          result->len = new_len;
+         lj_array_copy(L, result, new_len - 1, arr, i, 1);
       }
 
       lua_pop(L, 1);
@@ -2834,16 +2762,7 @@ LJLIB_CF(array_remove)
       else memmove(dst, src, shift_count * arr->elemsize);
    }
 
-   // Clear trailing elements for GC-tracked types
-   if (arr->elemtype IS AET::STR_GC or arr->elemtype IS AET::TABLE or arr->elemtype IS AET::OBJECT) {
-      auto refs = arr->get<GCRef>();
-      for (MSize i = arr->len - MSize(count); i < arr->len; i++) {
-         setgcrefnull(refs[i]);
-      }
-   }
-   else if (arr->elemtype IS AET::ANY) {
-      lj_bulk_nil_tvalue(&arr->get<TValue>()[arr->len - MSize(count)], MSize(count));
-   }
+   lj_array_clear_range(arr, arr->len - MSize(count), MSize(count));
 
    arr->len -= MSize(count);
    setintV(L->top++, int32_t(arr->len));
@@ -2867,51 +2786,18 @@ LJLIB_CF(array_clone)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
 
+   if (arr->elemtype IS AET::STRUCT) {
+      luaL_error(L, ERR::NoSupport, "array.clone() does not support struct types.");
+      return 0;
+   }
+
    // Create new array with same type and length
    GCarray *result = lj_array_new(L, arr->len, arr->elemtype);
    setarrayV(L, L->top++, result);
 
    if (arr->len IS 0) return 1;
 
-   // Copy elements
-   switch (arr->elemtype) {
-      case AET::STR_GC:
-      case AET::TABLE:
-      case AET::ARRAY:
-      case AET::OBJECT: {
-         // For GC-tracked types, copy references and set up barriers
-         auto src_refs = arr->get<GCRef>();
-         auto dst_refs = result->get<GCRef>();
-         for (MSize i = 0; i < arr->len; i++) {
-            GCRef ref = src_refs[i];
-            dst_refs[i] = ref;
-            if (gcref(ref)) lj_gc_objbarrier(L, result, gcref(ref));
-         }
-         break;
-      }
-      case AET::ANY: {
-         // For any-type arrays, copy TValues and set up barriers for GC values
-         auto src_slots = arr->get<TValue>();
-         auto dst_slots = result->get<TValue>();
-         lj_bulk_copy_tvalue(dst_slots, src_slots, arr->len);
-         for (MSize i = 0; i < arr->len; i++) {
-            if (tvisgcv(&src_slots[i])) lj_gc_objbarrier(L, result, gcV(&src_slots[i]));
-         }
-         break;
-      }
-      case AET::STRUCT: {
-         luaL_error(L, ERR::NoSupport, "array.clone() does not support struct types.");
-         break;
-      }
-      default: {
-         // For all other types, direct memory copy
-         void *src = arr->arraydata();
-         void *dst = result->arraydata();
-         memcpy(dst, src, size_t(arr->len) * arr->elemsize);
-         break;
-      }
-   }
-
+   lj_array_copy(L, result, 0, arr, 0, arr->len);
    return 1;
 }
 

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -475,9 +475,6 @@ LJLIB_CF(array_concat)
                else append_formatted(result, format, str.c_str());
                break;
             }
-            case AET::PTR:
-               append_formatted(result, format, arr->get<void **>()[i]);
-               break;
             case AET::FLOAT:
                append_formatted(result, format, arr->get<float>()[i]);
                break;
@@ -496,9 +493,6 @@ LJLIB_CF(array_concat)
             case AET::BYTE:
                append_formatted(result, format, arr->get<int8_t>()[i]);
                break;
-            case AET::TABLE:
-            case AET::STRUCT:
-            case AET::ARRAY:
             default:
                luaL_error(L, ERR::InvalidType, "concat() does not support %s types.", elemtype_name(arr->elemtype));
                return 0;
@@ -542,23 +536,9 @@ LJLIB_CF(array_concat)
             case AET::BYTE:
                append_integer(result, arr->get<uint8_t>()[i]);
                break;
-            case AET::PTR:
-               append_formatted(result, "%p", arr->get<void *>()[i]);
-               break;
-            case AET::TABLE:
-               // Tables cannot be meaningfully converted to strings
-               result += "table";
-               break;
-            case AET::ARRAY:
-               // Arrays cannot be meaningfully converted to strings
-               result += "array";
-               break;
-            case AET::STRUCT:
-               result += "struct";
-               break;
             default:
-               result += "?";
-               break;
+               luaL_error(L, ERR::InvalidType, "concat() does not support %s types.", elemtype_name(arr->elemtype));
+               return 0;
          }
       }
    }

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -366,6 +366,137 @@ LJLIB_CF(array_table)
 }
 
 //********************************************************************************************************************
+
+struct array_range_span {
+   int32_t start;
+   int32_t stop;
+   int32_t step;
+   bool empty;
+};
+
+struct array_count_span {
+   MSize start;
+   MSize count;
+};
+
+static int32_t array_default_remaining(MSize Length, int32_t Start)
+{
+   if (Start < 0 or MSize(Start) > Length) return 0;
+   return int32_t(Length - MSize(Start));
+}
+
+static array_range_span array_strict_inclusive_span(lua_State *L, MSize Length, int32_t Start, int32_t Stop,
+   bool Explicit)
+{
+   if (Length IS 0) {
+      if (Explicit) lj_err_caller(L, ErrMsg::IDXRNG);
+      return { 0, -1, 1, true };
+   }
+
+   if (Start < 0 or Stop < 0 or MSize(Start) >= Length or MSize(Stop) >= Length) {
+      lj_err_caller(L, ErrMsg::IDXRNG);
+   }
+
+   if (Stop < Start) return { Start, Stop, 1, true };
+   return { Start, Stop, 1, false };
+}
+
+static array_count_span array_strict_count_span(lua_State *L, int32_t Start, int32_t Count, MSize Length)
+{
+   if (Start < 0 or Count < 0 or MSize(Start) > Length) lj_err_caller(L, ErrMsg::IDXRNG);
+
+   auto start = MSize(Start);
+   auto count = MSize(Count);
+   if (count > Length - start) lj_err_caller(L, ErrMsg::IDXRNG);
+   return { start, count };
+}
+
+static array_count_span array_clamped_count_span(lua_State *L, int32_t Start, int32_t Count, MSize Length)
+{
+   if (Start < 0 or Count < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+
+   auto start = MSize(Start);
+   if (start >= Length) return { Length, 0 };
+
+   auto count = MSize(Count);
+   if (count > Length - start) count = Length - start;
+   return { start, count };
+}
+
+static array_range_span array_range_to_span(const tiri_range *Range, MSize Length)
+{
+   int32_t len = int32_t(Length);
+   int32_t start = Range->start;
+   int32_t stop = Range->stop;
+   int32_t step = Range->step;
+
+   bool use_inclusive = Range->inclusive;
+   if (start < 0 or stop < 0) {
+      use_inclusive = true;
+      if (start < 0) start += len;
+      if (stop < 0) stop += len;
+   }
+
+   bool forward = start <= stop;
+   if (step IS 0) step = forward ? 1 : -1;
+   if (forward and step < 0) step = 1;
+   if (not forward and step > 0) step = -1;
+
+   int32_t effective_stop = stop;
+   if (not use_inclusive) {
+      if (forward) effective_stop = stop - 1;
+      else effective_stop = stop + 1;
+   }
+
+   if (forward) {
+      if (start < 0) start = 0;
+      if (effective_stop >= len) effective_stop = len - 1;
+   }
+   else {
+      if (start >= len) start = len - 1;
+      if (effective_stop < 0) effective_stop = 0;
+   }
+
+   bool empty = len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop);
+   return { start, effective_stop, step, empty };
+}
+
+static array_count_span array_copy_span(lua_State *L, int32_t DestIdx, MSize DestLen, int32_t SrcIdx, MSize SrcLen,
+   int32_t Count, bool ClampSource)
+{
+   if (DestIdx < 0 or SrcIdx < 0 or Count < 0 or MSize(DestIdx) > DestLen or MSize(SrcIdx) > SrcLen) {
+      lj_err_caller(L, ErrMsg::IDXRNG);
+   }
+
+   auto dest_idx = MSize(DestIdx);
+   auto src_idx = MSize(SrcIdx);
+   auto count = MSize(Count);
+
+   if (count > SrcLen - src_idx) {
+      if (ClampSource) count = SrcLen - src_idx;
+      else lj_err_caller(L, ErrMsg::IDXRNG);
+   }
+
+   if (count > DestLen - dest_idx) lj_err_caller(L, ErrMsg::IDXRNG);
+   return { dest_idx, count };
+}
+
+static bool array_find_start(int32_t Start, MSize Length, int32_t *Result)
+{
+   if (Start < 0) Start = 0;
+   if (MSize(Start) >= Length) return false;
+   *Result = Start;
+   return true;
+}
+
+static int array_push_find_result(lua_State *L, int32_t Result)
+{
+   if (Result >= 0) setintV(L->top++, Result);
+   else lua_pushnil(L);
+   return 1;
+}
+
+//********************************************************************************************************************
 // Usage: array.concat([Separator], [StringFormat], [Start], [End])
 //
 // Concatenates array elements into a string using the specified separator and optional format.
@@ -377,26 +508,17 @@ LJLIB_CF(array_table)
 LJLIB_CF(array_concat)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
-   const bool start_provided = !lua_isnoneornil(L, 4);
-   const bool end_provided = !lua_isnoneornil(L, 5);
-
-   if (arr->len < 1) {
-      if (start_provided or end_provided) lj_err_caller(L, ErrMsg::IDXRNG);
-      lua_pushstring(L, "");
-      return 1;
-   }
+   const bool start_provided = not lua_isnoneornil(L, 4);
+   const bool end_provided = not lua_isnoneornil(L, 5);
 
    size_t separator_len = 0;
    auto separator = luaL_optlstring(L, 2, "", &separator_len);
    auto format = lua_isnoneornil(L, 3) ? nullptr : luaL_checkstring(L, 3);
    auto start = start_provided ? lj_lib_checkint(L, 4) : 0;
-   auto end = end_provided ? lj_lib_checkint(L, 5) : int32_t(arr->len - 1);
+   auto end = end_provided ? lj_lib_checkint(L, 5) : array_default_remaining(arr->len, 0) - 1;
 
-   if (start < 0 or end < 0 or MSize(start) >= arr->len or MSize(end) >= arr->len) {
-      lj_err_caller(L, ErrMsg::IDXRNG);
-   }
-
-   if (end < start) {
+   auto span = array_strict_inclusive_span(L, arr->len, start, end, start_provided or end_provided);
+   if (span.empty) {
       lua_pushstring(L, "");
       return 1;
    }
@@ -449,10 +571,10 @@ LJLIB_CF(array_concat)
    }
 
    std::string result;
-   result.reserve(MSize(end - start + 1) * 16);
+   result.reserve(MSize(span.stop - span.start + 1) * 16);
 
-   for (MSize i = MSize(start); i <= MSize(end); i++) {
-      if (i > MSize(start)) result.append(separator, separator_len);
+   for (MSize i = MSize(span.start); i <= MSize(span.stop); i++) {
+      if (i > MSize(span.start)) result.append(separator, separator_len);
 
       if (format) {
          switch(arr->elemtype) {
@@ -1049,59 +1171,35 @@ LJLIB_CF(array_copy)
 
    if (dest->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
 
-   size_t strlen;
+   size_t str_len;
    auto src_type = lua_type(L, 2);
    if (src_type IS LUA_TARRAY) {
       GCarray *src  = lj_lib_checkarray(L, 2);
       auto dest_idx = lj_lib_optint(L, 3, 0);
       auto src_idx  = lj_lib_optint(L, 4, 0);
-      if (dest_idx < 0 or src_idx < 0 or MSize(dest_idx) > dest->len or MSize(src_idx) > src->len) {
-         lj_err_caller(L, ErrMsg::IDXRNG);
-      }
+      auto count = lj_lib_optint(L, 5, array_default_remaining(src->len, src_idx));
 
-      auto count = lj_lib_optint(L, 5, int32_t(src->len - MSize(src_idx)));
-      if (count < 0) lj_err_caller(L, ErrMsg::IDXRNG);
       if (not (dest->elemtype IS src->elemtype)) lj_err_caller(L, ErrMsg::ARRTYPE);
-      if (count IS 0) return 0;
-      if (MSize(count) > src->len - MSize(src_idx) or MSize(count) > dest->len - MSize(dest_idx)) {
-         lj_err_caller(L, ErrMsg::IDXRNG);
-      }
+      auto span = array_copy_span(L, dest_idx, dest->len, src_idx, src->len, count, false);
+      if (span.count IS 0) return 0;
 
-      lj_array_copy(L, dest, dest_idx, src, src_idx, count);
+      lj_array_copy(L, dest, span.start, src, MSize(src_idx), span.count);
       return 0;
    }
    else if (src_type IS LUA_TSTRING) {
       // Treat string sequences as a byte array
-      auto str = lua_tolstring(L, 2, &strlen);
-      if (!str or strlen < 1) return 0; // Do nothing - no error necessary
+      auto str = lua_tolstring(L, 2, &str_len);
+      if (not str or str_len < 1) return 0; // Do nothing - no error necessary
 
       auto dest_idx   = lj_lib_optint(L, 3, 0);
       auto src_idx    = lj_lib_optint(L, 4, 0);
-      auto copy_total = lj_lib_optint(L, 5, int32_t(strlen - src_idx));
-
-      // Bounds check source
-
-      if ((src_idx < 0) or (size_t(src_idx) >= strlen)) {
-         luaL_error(L, ERR::OutOfRange, "Source index %d out of bounds (string length: %d).", src_idx, int(strlen));
-         return 0;
-      }
-      if (size_t(src_idx + copy_total) > strlen) copy_total = int32_t(strlen) - src_idx;
-
-      // Bounds check destination
-
-      if ((dest_idx < 0) or (MSize(dest_idx) >= dest->len)) {
-         luaL_error(L, ERR::OutOfRange, "Destination index %d out of bounds (array size: %d).", dest_idx, int(dest->len));
-         return 0;
-      }
-
-      if (MSize(dest_idx + copy_total) > dest->len) {
-         luaL_error(L, ERR::OutOfRange, "String copy would exceed array bounds (%d+%d > %d).", dest_idx, copy_total, int(dest->len));
-         return 0;
-      }
+      auto copy_total = lj_lib_optint(L, 5, array_default_remaining(MSize(str_len), src_idx));
+      auto span = array_copy_span(L, dest_idx, dest->len, src_idx, MSize(str_len), copy_total, true);
+      if (span.count IS 0) return 0;
 
       // Copy string bytes to array
-      auto data = dest->get<uint8_t>() + dest_idx;
-      memcpy(data, str + src_idx, copy_total);
+      auto data = dest->get<uint8_t>() + span.start;
+      memcpy(data, str + src_idx, span.count);
       return 0;
    }
    else if (src_type IS LUA_TTABLE) {
@@ -1114,33 +1212,17 @@ LJLIB_CF(array_copy)
 
       auto dest_idx   = lj_lib_optint(L, 3, 0);
       auto src_idx    = lj_lib_optint(L, 4, 0);
-      auto copy_total = lj_lib_optint(L, 5, int32_t(table_len - src_idx));
-
-      // Bounds check source index
-      if ((src_idx < 0) or (MSize(src_idx) >= table_len)) {
-         luaL_error(L, ERR::OutOfRange, "Source index %d out of bounds (table length: %d).", src_idx, int(table_len));
-         return 0;
-      }
-
-      if (MSize(copy_total) > table_len - MSize(src_idx)) copy_total = int32_t(table_len - MSize(src_idx));
-
-      // Check bounds for destination array
-      if ((dest_idx < 0) or (MSize(dest_idx) >= dest->len)) {
-         luaL_error(L, ERR::OutOfRange, "Destination index out of bounds: %d (array size: %d).", dest_idx, dest->len);
-         return 0;
-      }
-
-      if (MSize(dest_idx + copy_total) > dest->len) {
-         luaL_error(L, ERR::OutOfRange, "Table copy would exceed array bounds (%d+%d > %d).", dest_idx, copy_total, dest->len);
-         return 0;
-      }
+      auto copy_total = lj_lib_optint(L, 5, array_default_remaining(table_len, src_idx));
+      auto span = array_copy_span(L, dest_idx, dest->len, src_idx, table_len, copy_total, true);
+      if (span.count IS 0) return 0;
 
       // Copy table elements using ipairs-style iteration
 
-      auto c_index = dest_idx;
+      auto c_index = span.start;
 
-      for (int i = 0; i < copy_total; i++) {
-         lua_pushinteger(L, src_idx + i);
+      for (MSize i = 0; i < span.count; i++) {
+         int32_t source_index = src_idx + int32_t(i);
+         lua_pushinteger(L, source_index);
          lua_gettable(L, 2);        // Get table[src_idx + i]
 
          MSize dest_index = c_index + i;
@@ -1201,7 +1283,7 @@ LJLIB_CF(array_copy)
                   setgcrefnull(dest->get<GCRef>()[dest_index]);
                }
                else {
-                  luaL_error(L, ERR::InvalidType, "Expected object value at index %d.", src_idx + i);
+                  luaL_error(L, ERR::InvalidType, "Expected object value at index %d.", source_index);
                   lua_pop(L, 1);
                   return 0;
                }
@@ -1218,7 +1300,7 @@ LJLIB_CF(array_copy)
                   setgcrefnull(dest->get<GCRef>()[dest_index]);
                }
                else {
-                  luaL_error(L, ERR::InvalidType, "Expected table value at index %d.", src_idx + i);
+                  luaL_error(L, ERR::InvalidType, "Expected table value at index %d.", source_index);
                   lua_pop(L, 1);
                   return 0;
                }
@@ -1235,7 +1317,7 @@ LJLIB_CF(array_copy)
                   setgcrefnull(dest->get<GCRef>()[dest_index]);
                }
                else {
-                  luaL_error(L, ERR::InvalidType, "Expected array value at index %d.", src_idx + i);
+                  luaL_error(L, ERR::InvalidType, "Expected array value at index %d.", source_index);
                   lua_pop(L, 1);
                   return 0;
                }
@@ -1270,17 +1352,14 @@ LJLIB_CF(array_getString)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
 
-   if (arr->elemtype != AET::BYTE) lj_err_caller(L, ErrMsg::ARRSTR);
+   if (not (arr->elemtype IS AET::BYTE)) lj_err_caller(L, ErrMsg::ARRSTR);
 
    auto start = lj_lib_optint(L, 2, 0);
-   if (start < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+   auto len = lj_lib_optint(L, 3, array_default_remaining(arr->len, start));
+   auto span = array_strict_count_span(L, start, len, arr->len);
 
-   auto len = lj_lib_optint(L, 3, arr->len - start);
-   if (len < 0) lj_err_caller(L, ErrMsg::IDXRNG);
-   if (start + len > int(arr->len)) lj_err_caller(L, ErrMsg::IDXRNG);
-
-   auto data = arr->get<const char>() + start;
-   GCstr *s = lj_str_new(L, data, len);
+   auto data = (span.count > 0) ? arr->get<const char>() + span.start : "";
+   GCstr *s = lj_str_new(L, data, span.count);
    setstrV(L, L->top++, s);
    return 1;
 }
@@ -1300,27 +1379,18 @@ LJLIB_CF(array_setString)
    GCarray *arr = lj_lib_checkarray(L, 1);
    GCstr *str = lj_lib_checkstr(L, 2);
 
-   if (arr->elemtype != AET::BYTE) lj_err_caller(L, ErrMsg::ARRSTR);
+   if (not (arr->elemtype IS AET::BYTE)) lj_err_caller(L, ErrMsg::ARRSTR);
    if (arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
 
    auto start = lj_lib_optint(L, 3, 0);
-   if (start < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+   auto span = array_clamped_count_span(L, start, int32_t(str->len), arr->len);
 
-   auto len = int(str->len);
-
-   // Clamp length to fit in array
-
-   if (start >= int(arr->len)) {
-      setintV(L->top++, 0);
-      return 1;
+   if (span.count > 0) {
+      auto data = arr->get<char>() + span.start;
+      memcpy(data, strdata(str), span.count);
    }
 
-   if (start + len > int(arr->len)) len = arr->len - start;
-
-   auto data = arr->get<char>() + start;
-   memcpy(data, strdata(str), len);
-
-   setintV(L->top++, int32_t(len));
+   setintV(L->top++, int32_t(span.count));
    return 1;
 }
 
@@ -1439,62 +1509,21 @@ LJLIB_CF(array_fill)
    // Check if third argument is a range
    tiri_range *r = check_range(L, 3);
    if (r) {
-      int32_t len = int32_t(arr->len);
-      int32_t start = r->start;
-      int32_t stop = r->stop;
-      int32_t step = r->step;
+      auto span = array_range_to_span(r, arr->len);
+      if (span.empty) return 0;
 
-      // Handle negative indices
-      bool use_inclusive = r->inclusive;
-      if (start < 0 or stop < 0) {
-         use_inclusive = true;
-         if (start < 0) start += len;
-         if (stop < 0) stop += len;
-      }
-
-      // Determine iteration direction
-      bool forward = (start <= stop);
-      if (step IS 0) step = forward ? 1 : -1;
-      if (forward and step < 0) step = 1;
-      if (not forward and step > 0) step = -1;
-
-      // Calculate effective stop for exclusive ranges
-      int32_t effective_stop = stop;
-      if (not use_inclusive) {
-         if (forward) effective_stop = stop - 1;
-         else effective_stop = stop + 1;
-      }
-
-      // Bounds clipping
-      if (forward) {
-         if (start < 0) start = 0;
-         if (effective_stop >= len) effective_stop = len - 1;
-      }
-      else {
-         if (start >= len) start = len - 1;
-         if (effective_stop < 0) effective_stop = 0;
-      }
-
-      // Check for empty/invalid ranges
-      if (len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop)) {
-         return 0;
-      }
-
-      fill_array_elements(arr, value, start, effective_stop, step);
+      fill_array_elements(arr, value, span.start, span.stop, span.step);
       return 0;
    }
 
    // Original integer-based fill
    auto start = lj_lib_optint(L, 3, 0);
-   if (start < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+   auto count = lj_lib_optint(L, 4, array_default_remaining(arr->len, start));
+   auto span = array_clamped_count_span(L, start, count, arr->len);
 
-   auto count = lj_lib_optint(L, 4, int32_t(arr->len - start));
-   if (count < 0) lj_err_caller(L, ErrMsg::IDXRNG);
+   if (span.count IS 0) return 0;
 
-   if (MSize(start) >= arr->len) return 0;
-   if (MSize(start + count) > arr->len) count = int32_t(arr->len) - start;
-
-   fill_array_elements(arr, value, start, start + count - 1, 1);
+   fill_array_elements(arr, value, int32_t(span.start), int32_t(span.start + span.count - 1), 1);
    return 0;
 }
 
@@ -1650,229 +1679,44 @@ LJLIB_CF(array_find)
 
    if (arr->elemtype IS AET::OBJECT) {
       auto search_uid = object_uid_from_value(L, 2);
-
-      // Check if third argument is a range
-      tiri_range *r = check_range(L, 3);
-      if (r) {
-         auto len = int32_t(arr->len);
-         int32_t start = r->start;
-         int32_t stop = r->stop;
-         int32_t step = r->step;
-
-         // Handle negative indices
-         bool use_inclusive = r->inclusive;
-         if (start < 0 or stop < 0) {
-            use_inclusive = true;
-            if (start < 0) start += len;
-            if (stop < 0) stop += len;
-         }
-
-         // Determine iteration direction
-         bool forward = (start <= stop);
-         if (step IS 0) step = forward ? 1 : -1;
-         if (forward and step < 0) step = 1;
-         if (not forward and step > 0) step = -1;
-
-         // Calculate effective stop for exclusive ranges
-         int32_t effective_stop = stop;
-         if (not use_inclusive) {
-            if (forward) effective_stop = stop - 1;
-            else effective_stop = stop + 1;
-         }
-
-         // Bounds clipping
-         if (forward) {
-            if (start < 0) start = 0;
-            if (effective_stop >= len) effective_stop = len - 1;
-         }
-         else {
-            if (start >= len) start = len - 1;
-            if (effective_stop < 0) effective_stop = 0;
-         }
-
-         // Check for empty/invalid ranges
-         if (len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop)) {
-            lua_pushnil(L);
-            return 1;
-         }
-
-         int32_t result = find_object_in_array(arr, search_uid, start, effective_stop, step);
-         if (result >= 0) {
-            setintV(L->top++, result);
-            return 1;
-         }
-         lua_pushnil(L);
-         return 1;
+      if (tiri_range *r = check_range(L, 3)) {
+         auto span = array_range_to_span(r, arr->len);
+         if (span.empty) return array_push_find_result(L, -1);
+         return array_push_find_result(L, find_object_in_array(arr, search_uid, span.start, span.stop, span.step));
       }
 
       auto start = lj_lib_optint(L, 3, 0);
-
-      if (start < 0) start = 0;
-      if (MSize(start) >= arr->len) {
-         lua_pushnil(L);
-         return 1;
-      }
-
-      int32_t result = find_object_in_array(arr, search_uid, start, int32_t(arr->len - 1), 1);
-      if (result >= 0) {
-         setintV(L->top++, result);
-         return 1;
-      }
-
-      lua_pushnil(L);
-      return 1;
+      if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_object_in_array(arr, search_uid, start, int32_t(arr->len - 1), 1));
    }
    else if (arr->elemtype IS AET::STR_GC) { // Handle string arrays (STR_GC)
       GCstr *search_str = lj_lib_checkstr(L, 2);
 
-      // Check if third argument is a range
-      tiri_range *r = check_range(L, 3);
-      if (r) {
-         auto len = int32_t(arr->len);
-         int32_t start = r->start;
-         int32_t stop = r->stop;
-         int32_t step = r->step;
-
-         // Handle negative indices
-         bool use_inclusive = r->inclusive;
-         if (start < 0 or stop < 0) {
-            use_inclusive = true;
-            if (start < 0) start += len;
-            if (stop < 0) stop += len;
-         }
-
-         // Determine iteration direction
-         bool forward = (start <= stop);
-         if (step IS 0) step = forward ? 1 : -1;
-         if (forward and step < 0) step = 1;
-         if (not forward and step > 0) step = -1;
-
-         // Calculate effective stop for exclusive ranges
-         int32_t effective_stop = stop;
-         if (not use_inclusive) {
-            if (forward) effective_stop = stop - 1;
-            else effective_stop = stop + 1;
-         }
-
-         // Bounds clipping
-         if (forward) {
-            if (start < 0) start = 0;
-            if (effective_stop >= len) effective_stop = len - 1;
-         }
-         else {
-            if (start >= len) start = len - 1;
-            if (effective_stop < 0) effective_stop = 0;
-         }
-
-         // Check for empty/invalid ranges
-         if (len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop)) {
-            lua_pushnil(L);
-            return 1;
-         }
-
-         int32_t result = find_string_in_array(arr, search_str, start, effective_stop, step);
-         if (result >= 0) {
-            setintV(L->top++, result);
-            return 1;
-         }
-         lua_pushnil(L);
-         return 1;
+      if (tiri_range *r = check_range(L, 3)) {
+         auto span = array_range_to_span(r, arr->len);
+         if (span.empty) return array_push_find_result(L, -1);
+         return array_push_find_result(L, find_string_in_array(arr, search_str, span.start, span.stop, span.step));
       }
 
       auto start = lj_lib_optint(L, 3, 0);
-
-      if (start < 0) start = 0;
-      if (MSize(start) >= arr->len) {
-         lua_pushnil(L);
-         return 1;
-      }
-
-      int32_t result = find_string_in_array(arr, search_str, start, int32_t(arr->len - 1), 1);
-      if (result >= 0) {
-         setintV(L->top++, result);
-         return 1;
-      }
-
-      lua_pushnil(L);
-      return 1;
+      if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_string_in_array(arr, search_str, start, int32_t(arr->len - 1), 1));
    }
 
    int ok;
    lua_Number value = lua_tonumberx(L, 2, &ok);
    if (not ok) luaL_error(L, "Unsupported value type '%s'", lua_typename(L, lua_type(L, 2)));
 
-   // Check if third argument is a range
-   tiri_range *r = check_range(L, 3);
-   if (r) {
-      int32_t len = int32_t(arr->len);
-      int32_t start = r->start;
-      int32_t stop = r->stop;
-      int32_t step = r->step;
-
-      // Handle negative indices
-      bool use_inclusive = r->inclusive;
-      if (start < 0 or stop < 0) {
-         use_inclusive = true;
-         if (start < 0) start += len;
-         if (stop < 0) stop += len;
-      }
-
-      // Determine iteration direction
-      bool forward = (start <= stop);
-      if (step IS 0) step = forward ? 1 : -1;
-      if (forward and step < 0) step = 1;
-      if (not forward and step > 0) step = -1;
-
-      // Calculate effective stop for exclusive ranges
-      int32_t effective_stop = stop;
-      if (not use_inclusive) {
-         if (forward) effective_stop = stop - 1;
-         else effective_stop = stop + 1;
-      }
-
-      // Bounds clipping
-      if (forward) {
-         if (start < 0) start = 0;
-         if (effective_stop >= len) effective_stop = len - 1;
-      }
-      else {
-         if (start >= len) start = len - 1;
-         if (effective_stop < 0) effective_stop = 0;
-      }
-
-      // Check for empty/invalid ranges
-      if (len IS 0 or (forward and start > effective_stop) or (not forward and start < effective_stop)) {
-         lua_pushnil(L);
-         return 1;
-      }
-
-      // Search within the range using optimised template dispatch
-      int32_t result = find_in_array(arr, value, start, effective_stop, step);
-      if (result >= 0) {
-         setintV(L->top++, result);
-         return 1;
-      }
-      lua_pushnil(L);
-      return 1;
+   if (tiri_range *r = check_range(L, 3)) {
+      auto span = array_range_to_span(r, arr->len);
+      if (span.empty) return array_push_find_result(L, -1);
+      return array_push_find_result(L, find_in_array(arr, value, span.start, span.stop, span.step));
    }
 
    // Original integer-based find
    auto start = lj_lib_optint(L, 3, 0);
-
-   if (start < 0) start = 0;
-   if (MSize(start) >= arr->len) {
-      lua_pushnil(L);
-      return 1;
-   }
-
-   int32_t result = find_in_array(arr, value, start, int32_t(arr->len - 1), 1);
-   if (result >= 0) {
-      setintV(L->top++, result);
-      return 1;
-   }
-
-   lua_pushnil(L);
-   return 1;
+   if (not array_find_start(start, arr->len, &start)) return array_push_find_result(L, -1);
+   return array_push_find_result(L, find_in_array(arr, value, start, int32_t(arr->len - 1), 1));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_array.cpp
+++ b/src/tiri/jit/src/runtime/lj_array.cpp
@@ -49,6 +49,13 @@ uint8_t lj_array_elemsize(AET Type)
 
 //********************************************************************************************************************
 
+static bool array_is_gc_ref_type(AET Type)
+{
+   return Type IS AET::STR_GC or Type IS AET::TABLE or Type IS AET::ARRAY or Type IS AET::OBJECT;
+}
+
+//********************************************************************************************************************
+
 static void array_attach_basemt(lua_State *L, GCarray *Arr)
 {
    GCRef mt_ref = basemt_it(G(L), LJ_TARRAY);
@@ -270,17 +277,47 @@ void lj_array_free(global_State *g, GCarray *Array)
 
 //********************************************************************************************************************
 
+void lj_array_clear_range(GCarray *Array, MSize Start, MSize Count)
+{
+   if (Count IS 0) return;
+
+   if (array_is_gc_ref_type(Array->elemtype)) {
+      auto refs = &Array->get<GCRef>()[Start];
+      for (MSize i = 0; i < Count; i++) setgcrefnull(refs[i]);
+   }
+   else if (Array->elemtype IS AET::ANY) {
+      lj_bulk_nil_tvalue(&Array->get<TValue>()[Start], Count);
+   }
+}
+
+//********************************************************************************************************************
+
 void lj_array_copy(lua_State *L, GCarray *Dest, uint32_t DstIdx, GCarray *Src, uint32_t SrcIdx, uint32_t Count)
 {
-   // Safety checks - unsigned types can't be negative so just check bounds
-   if (SrcIdx + Count > Src->len or DstIdx + Count > Dest->len) lj_err_caller(L, ErrMsg::IDXRNG);
+   if (SrcIdx > Src->len or Count > Src->len - SrcIdx or DstIdx > Dest->len or Count > Dest->len - DstIdx) {
+      lj_err_caller(L, ErrMsg::IDXRNG);
+   }
    if (Dest->is_readonly()) lj_err_caller(L, ErrMsg::ARRRO);
-   if (Dest->elemtype != Src->elemtype) lj_err_caller(L, ErrMsg::ARRTYPE);
+   if (not (Dest->elemtype IS Src->elemtype)) lj_err_caller(L, ErrMsg::ARRTYPE);
+   if (Count IS 0) return;
 
    void *dst_ptr = lj_array_index(Dest, DstIdx);
    void *src_ptr = lj_array_index(Src, SrcIdx);
    if (Dest->elemtype IS AET::ANY) {
       lj_bulk_move_tvalue((TValue *)dst_ptr, (const TValue *)src_ptr, Count);
+      auto dst_slots = (TValue *)dst_ptr;
+      for (MSize i = 0; i < Count; i++) {
+         if (tvisgcv(&dst_slots[i])) lj_gc_objbarrier(L, Dest, gcV(&dst_slots[i]));
+      }
+   }
+   else if (array_is_gc_ref_type(Dest->elemtype)) {
+      size_t byte_count = Count * Dest->elemsize;
+      memmove(dst_ptr, src_ptr, byte_count);
+
+      auto refs = (GCRef *)dst_ptr;
+      for (MSize i = 0; i < Count; i++) {
+         if (gcref(refs[i])) lj_gc_objbarrier(L, Dest, gcref(refs[i]));
+      }
    }
    else {
       size_t byte_count = Count * Dest->elemsize;

--- a/src/tiri/jit/src/runtime/lj_array.h
+++ b/src/tiri/jit/src/runtime/lj_array.h
@@ -8,6 +8,7 @@
 extern GCarray * lj_array_new(lua_State *, uint32_t, AET, void *Data = nullptr, uint8_t Flags = 0, std::string_view StructName = {});
 extern void lj_array_free(global_State *, GCarray *);
 [[nodiscard]] extern uint8_t lj_array_elemsize(AET);
+extern void lj_array_clear_range(GCarray *, MSize Start, MSize Count);
 extern void lj_array_copy(lua_State *, GCarray *, uint32_t dstidx, GCarray *, uint32_t srcidx, uint32_t count);
 extern GCtab* lj_array_to_table(lua_State *, GCarray *);
 extern bool lj_array_grow(lua_State *, GCarray *, MSize MinCapacity);

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -263,6 +263,29 @@ end
    end
 end
 
+@Test function ArrayCopyArrayReferences()
+   first = array<int> { 1, 10 }
+   second = array<int> { 2, 20 }
+   third = array<int> { 3, 30 }
+   source = array<array> { first, second, third }
+   dest = array<array, 3>
+
+   dest:copy(source, 0, 1, 2)
+   assert(dest[0][0] is 2 and dest[0][1] is 20, "copy() should copy first nested array reference")
+   assert(dest[1][0] is 3 and dest[1][1] is 30, "copy() should copy second nested array reference")
+   assert(dest[2] is nil, "copy() should leave untouched destination slots as nil")
+
+   second:push(200)
+   assert(dest[0][2] is 200, "Array copy should preserve shallow nested array references")
+
+   second = nil
+   third = nil
+   source = nil
+   processing.collect()
+   assert(dest[0][0] is 2, "Copied nested array should survive GC")
+   assert(dest[1][0] is 3, "Second copied nested array should survive GC")
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Verify native array iteration uses the specialised iterator semantics.
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -184,6 +184,12 @@ end
    result = arr:getString(0, 5)
    assert(result is 'Hello', 'Valid substring extraction failed')
 
+   result = arr:getString(11, 0)
+   assert(result is '', 'Zero-length getString() at the end should return an empty string')
+
+   result = arr:getString(11)
+   assert(result is '', 'Default zero-length getString() at the end should return an empty string')
+
    -- Test invalid start index
    try
       t = arr:getString(-1, 5)
@@ -203,6 +209,26 @@ end
       t = arr:getString(0, -5)
    success
       error('Should reject negative length')
+   end
+end
+
+@Test function SetStringBounds()
+   arr = array<byte, 5>
+   written = arr:setString('Hello')
+   assert(written is 5, 'setString should write the full string when it fits')
+   assert(arr:getString() is 'Hello', 'setString should write expected bytes')
+
+   written = arr:setString('XYZ', 3)
+   assert(written is 2, 'setString should clamp writes to the available byte span')
+   assert(arr:getString() is 'HelXY', 'setString should only overwrite the clamped byte span')
+
+   written = arr:setString('!', 5)
+   assert(written is 0, 'setString at the end should write zero bytes')
+
+   try
+      arr:setString('!', -1)
+   success
+      error('setString should reject negative start indexes')
    end
 end
 
@@ -234,6 +260,12 @@ end
       dest:copy(source, 15) -- Beyond array size 10
    success
       error('Should reject destination index beyond array size')
+   end
+
+   try
+      dest:copy(source, 0, 0, -1)
+   success
+      error('Should reject negative string copy count')
    end
 end
 
@@ -452,6 +484,18 @@ end
       arr:copy(table_data, 2)  -- Start at 2, table has 4 elements, would exceed array size 3
    success
       error('Should reject copy that would exceed array bounds')
+   end
+
+   try
+      arr:copy(table_data, 0, -1, 1)
+   success
+      error('Should reject negative table source index')
+   end
+
+   try
+      arr:copy(table_data, 0, 0, -1)
+   success
+      error('Should reject negative table copy count')
    end
 
    -- Test with empty table
@@ -801,6 +845,8 @@ end
    assert(arr:find(30, {0..5}) is 3, "find in range: should find 30 at index 3")
    assert(arr:find(50, {0..5}) is nil, "find in range: 50 should not be found (outside range)")
    assert(arr:find(70, {5..10}) is 7, "find in range: should find 70 at index 7")
+   assert(arr:find(30, {-20...3}) is 3, "find in clipped negative range should still find 30")
+   assert(arr:find(30, {20..30}) is nil, "find in empty clipped range should return nil")
 end
 
 @Test function ArrayFindWithInclusiveRange()
@@ -837,6 +883,7 @@ end
 
    -- Find searching backwards (should find the later occurrence first)
    assert(arr:find(20, {4...0}) is 3, "find reverse: should find 20 at index 3 (searching from end)")
+   assert(arr:find(10, range.new(4, 0, false, -1)) is nil, "exclusive reverse range should exclude the stop boundary")
 end
 
 @Test function ArrayFindWithSteppedRange()
@@ -1695,6 +1742,13 @@ end
       arr:concat(',', nil, 0, 3)
    success
       error('concat should reject End indexes beyond the array length')
+   end
+
+   empty = array<string>
+   try
+      empty:concat(',', nil, 0, 0)
+   success
+      error('concat should reject explicit ranges on empty arrays')
    end
 end
 

--- a/src/tiri/tests/test_array.tiri
+++ b/src/tiri/tests/test_array.tiri
@@ -1760,15 +1760,6 @@ end
    assert(rejoined is original, "concat should reverse split, got '" .. rejoined .. "'")
 end
 
-@Test function ArrayConcatTable()
-   arr = array<table, 2>
-   arr[0] = {x = 1}
-   arr[1] = {y = 2}
-   result = arr:concat(', ')
-   -- Tables should be converted to "table" placeholder
-   assert(result is 'table, table', "concat on table array should use 'table' placeholder, got '" .. result .. "'")
-end
-
 @Test function ArrayJoinRemoved()
    arr = array<string> { 'a', 'b' }
    try

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -190,6 +190,26 @@ end
    assert(aWords[0] is 'apple' and aWords[1] is 'apricot', "filter() should return correct string matches")
 end
 
+@Test function FilterArrayArray()
+   one = array<int> { 1 }
+   two = array<int> { 2, 20 }
+   three = array<int> { 3, 30, 300 }
+   arr = array<array> { one, two, three }
+
+   result = arr:filter(item => #item > 1)
+   assert(#result is 2, "filter() should keep two nested arrays")
+   assert(result[0][0] is 2 and result[0][1] is 20, "filter() should keep the first matching nested array")
+   assert(result[1][0] is 3 and result[1][2] is 300, "filter() should keep the second matching nested array")
+
+   one = nil
+   two = nil
+   three = nil
+   arr = nil
+   processing.collect()
+   assert(result[0][0] is 2, "Filtered nested array should survive GC")
+   assert(result[1][0] is 3, "Second filtered nested array should survive GC")
+end
+
 @Test function FilterFloatArray()
    arr = array<float> { 1.5, 2.5, 3.0, 4.5, 5.0 }
    whole = arr:filter(v => v % 1 is 0)

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -671,6 +671,28 @@ end
    assert(arr[1].name is 'fourth', "arr[1].name should still be 'fourth' after GC")
 end
 
+@Test function ArrayRemoveArrayGC()
+   first = array<int> { 1 }
+   second = array<int> { 2 }
+   third = array<int> { 3 }
+   arr = array<array> { first, second, third }
+
+   arr:remove(1)
+   assert(#arr is 2, "Array should have 2 elements")
+   assert(arr[0][0] is 1, "arr[0][0] should be 1")
+   assert(arr[1][0] is 3, "arr[1][0] should be 3")
+
+   second = nil
+   processing.collect()
+   assert(arr[0][0] is 1, "arr[0][0] should still be 1 after GC")
+   assert(arr[1][0] is 3, "arr[1][0] should still be 3 after GC")
+
+   fourth = array<int> { 4 }
+   arr:push(fourth)
+   assert(#arr is 3, "Array should accept pushes after nested array removal")
+   assert(arr[2][0] is 4, "arr[2][0] should be 4")
+end
+
 @Test function ArrayRemoveAllStringsGC()
    -- Remove all elements from a string array
    arr = array<string> { 'one', 'two', 'three' }
@@ -860,6 +882,28 @@ end
    -- Note: For tables, it's a shallow copy (same table references)
    original[0].x = 100
    assert(copy[0].x is 100, "Table clone is shallow - same reference")
+end
+
+@Test function ArrayCloneArray()
+   first = array<int> { 1, 10 }
+   second = array<int> { 2, 20 }
+   original = array<array> { first, second }
+   copy = original:clone()
+
+   assert(#copy is 2, "Clone should have same length")
+   assert(copy:type() is 'array', "Clone should preserve array element type")
+   assert(copy[0][0] is 1 and copy[0][1] is 10, "Clone should copy first nested array")
+   assert(copy[1][0] is 2 and copy[1][1] is 20, "Clone should copy second nested array")
+
+   first:push(100)
+   assert(copy[0][2] is 100, "Nested array clone should be shallow")
+
+   first = nil
+   second = nil
+   original = nil
+   processing.collect()
+   assert(copy[0][0] is 1, "Copied nested array should survive GC")
+   assert(copy[1][0] is 2, "Copied second nested array should survive GC")
 end
 
 @Test function ArrayCloneObject()

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -1406,6 +1406,25 @@ end
    assert(arr[9] is 0, "fill stepped: arr[9] should be 0")
 end
 
+@Test function ArrayFillWithClippedAndEmptyRange()
+   arr = array<int, 5>
+   arr:fill(0)
+
+   arr:fill(11, {-20...1})
+   assert(arr[0] is 11 and arr[1] is 11, "fill should clip negative ranges to the array start")
+   assert(arr[2] is 0, "fill should not extend past the clipped stop")
+
+   arr:fill(22, {20..30})
+   assert(arr[0] is 11 and arr[1] is 11 and arr[2] is 0 and arr[3] is 0 and arr[4] is 0,
+      "empty clipped fill ranges should leave the array unchanged")
+
+   arr:fill(33, 4, 10)
+   assert(arr[4] is 33, "integer fill should clamp count to the remaining span")
+
+   arr:fill(44, 5, 10)
+   assert(arr[4] is 33, "integer fill starting at the end should be a no-op")
+end
+
 @Test function ArrayFillOriginalSyntax()
    -- Verify original syntax still works
    arr = array<int, 10>


### PR DESCRIPTION
## Summary

- Centralise GC-aware element copy/clear logic into shared helpers in `lj_array.cpp`, reducing duplication across array operations
- Consolidate array index and range parsing into a single code path, simplifying `lib_array.cpp` significantly (net -101 lines)
- Throw a proper error when non-primitive elements are passed to `array.concat()`, preventing silent misbehaviour

## Test plan

- [ ] `test_array.tiri` — extended with new coverage for index/range parsing and `array.concat()` error paths
- [ ] `test_array_functional.tiri` — new functional tests for updated array operations
- [ ] `test_array_manip.tiri` — new manipulation tests covering GC-aware copy/clear scenarios
- [ ] Run full Tiri test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure -L tiri`

🤖 Generated with [Claude Code](https://claude.com/claude-code)