### PR TITLE
[Core] Optimised get_thread_id() with thread-local fast path

### DIFF
--- a/src/core/classes/class_thread.cpp
+++ b/src/core/classes/class_thread.cpp
@@ -79,7 +79,7 @@ THREADID get_thread_id(void)
 
 ERR msg_threadcallback(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSize)
 {
-   kt::Log log;
+   kt::Log log(__FUNCTION__);
 
    auto msg = (ThreadMessage *)Message;
    auto uid = msg->ThreadID;
@@ -117,8 +117,7 @@ ERR msg_threadcallback(APTR Custom, int MsgID, int MsgType, APTR Message, int Ms
 static void thread_entry_cleanup(void *Arg)
 {
    if (tlThreadCrashed) {
-      kt::Log log("thread_cleanup");
-      log.error("A thread in this program has crashed.");
+      kt::Log("thread_cleanup").error("A thread in this program has crashed.");
       if (tlThreadRef) {
          tlThreadRef->InterruptThreadID.store(0, std::memory_order_release);
          tlThreadRef->Active = false;

--- a/src/core/classes/class_thread.cpp
+++ b/src/core/classes/class_thread.cpp
@@ -59,23 +59,17 @@ static std::atomic_int glThreadIDCount = 1;
 
 THREADID get_thread_id(void)
 {
-   if (tlUniqueThreadID.defined()) {
-      // Preserve the invariant that a defined thread ID always has a registry record.
-      std::lock_guard lock(glmThreadRegistry);
-      if (auto it = glThreadRegistry.find(int(tlUniqueThreadID)); it IS glThreadRegistry.end()) {
-         glThreadRegistry[int(tlUniqueThreadID)] = std::make_shared<ThreadRecord>();
-      }
-      return tlUniqueThreadID;
-   }
+   if ((tlUniqueThreadID.defined()) and (tlThreadRecord)) return tlUniqueThreadID;
+   if (not tlUniqueThreadID.defined()) tlUniqueThreadID = THREADID(glThreadIDCount++);
 
-   tlUniqueThreadID = THREADID(glThreadIDCount++);
+   // Register or repair the global record once, then use the thread-local record as the fast-path proof.
 
-   // Register the new thread in the global thread registry
-   auto record = std::make_shared<ThreadRecord>();
-   {
-      std::lock_guard lock(glmThreadRegistry);
-      glThreadRegistry[int(tlUniqueThreadID)] = std::move(record);
+   std::lock_guard lock(glmThreadRegistry);
+   if (auto it = glThreadRegistry.find(int(tlUniqueThreadID)); it IS glThreadRegistry.end()) {
+      tlThreadRecord = std::make_shared<ThreadRecord>();
+      glThreadRegistry[int(tlUniqueThreadID)] = tlThreadRecord;
    }
+   else tlThreadRecord = it->second;
 
    return tlUniqueThreadID;
 }
@@ -109,9 +103,7 @@ ERR msg_threadcallback(APTR Custom, int MsgID, int MsgType, APTR Message, int Ms
       // NB: If a client wants notification of the thread ending, they can use WaitForObjects()
       // if not using callbacks.
       thread->Active = false;
-      if ((thread->Flags & THF::AUTO_FREE) != THF::NIL) {
-         FreeResource(*thread);
-      }
+      if ((thread->Flags & THF::AUTO_FREE) != THF::NIL) FreeResource(*thread);
       else acSignal(*thread); // Convenience for the client
    }
    else log.warning(ERR::AccessObject);
@@ -279,8 +271,6 @@ static ERR THREAD_FreeWarning(extThread *Self)
 
 static ERR THREAD_Init(extThread *Self)
 {
-   kt::Log log;
-
    return ERR::Okay;
 }
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -248,6 +248,7 @@ struct ThreadRecord {
 
 extern std::mutex glmThreadRegistry;
 extern std::unordered_map<int, std::shared_ptr<ThreadRecord>> glThreadRegistry;
+extern thread_local std::shared_ptr<ThreadRecord> tlThreadRecord;
 
 //********************************************************************************************************************
 

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -63,8 +63,8 @@ thread_local std::shared_ptr<ThreadRecord> tlThreadRecord;
 
 void deregister_thread(void)
 {
-   tlThreadRecord.reset();
    auto tid = get_thread_id();
+   tlThreadRecord.reset();
    std::lock_guard lock(glmThreadRegistry);
    glThreadRegistry.erase(int(tid));
 }
@@ -74,11 +74,7 @@ void deregister_thread(void)
 
 std::shared_ptr<ThreadRecord> get_thread_record(void)
 {
-   if (not tlThreadRecord) {
-      auto tid = get_thread_id();
-      std::lock_guard lock(glmThreadRegistry);
-      if (auto it = glThreadRegistry.find(int(tid)); it != glThreadRegistry.end()) tlThreadRecord = it->second;
-   }
+   if (not tlThreadRecord) get_thread_id();
    return tlThreadRecord;
 }
 


### PR DESCRIPTION
## Summary

- `get_thread_id()` now exits immediately on subsequent calls when both the thread ID and `tlThreadRecord` are already initialised, eliminating the mutex lock on the hot path
- `get_thread_record()` simplified to delegate registration to `get_thread_id()`, removing duplicated registry lookup logic
- Fixed `deregister_thread()` to capture the thread ID before resetting the thread-local record, preventing a use-after-reset

## Test plan

- [ ] Build `core` module and verify compilation succeeds
- [ ] Run existing thread-related integration tests to confirm no regressions
- [ ] Confirm `deregister_thread()` correctly removes the registry entry on thread teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)