### PR TITLE
[Backstage] Implemented internal log recording via /logs routes

### DIFF
--- a/src/backstage/backstage.cpp
+++ b/src/backstage/backstage.cpp
@@ -52,6 +52,7 @@ JUMPTABLE_NETWORK
 JUMPTABLE_REGEX
 
 static ERR init_backstage(int = 8765);
+static void release_backstage_logs();
 static void release_backstage_routes();
 static void release_backstage_websockets();
 
@@ -180,6 +181,7 @@ static ERR MODExpunge(void)
       glRequestBuffers.clear();
    }
    release_backstage_websockets();
+   release_backstage_logs();
    release_backstage_routes();
    if (glServer)   { FreeResource(glServer);   glServer = nullptr; }
    if (modRegex)   { FreeResource(modRegex);   modRegex = nullptr; }

--- a/src/backstage/interface.tiri
+++ b/src/backstage/interface.tiri
@@ -239,7 +239,7 @@ route('DELETE', '/jobs/{job}', {
 -- Log Interfaces
 
 route('PUT', '/logs/level', {
-   desc = 'Change the logging level for the program (affects console output).',
+   desc = 'Change the logging level for the program (affects console output only).',
    query = {
       level = { type='int', desc='The new log level value, ranging from 0 - 9.' },
    },
@@ -248,13 +248,15 @@ route('PUT', '/logs/level', {
 
 route('POST', '/logs/start', {
    desc = 'Activates internal log recording.',
-   body = 'json',
+   query = {
+      maxLevel = { type='int', desc='Only record messages that are less or equal to this log level.' },
+      maxDepth = { type='int', desc='Only record messages that are less or equal to this depth level.' }
+   },
    returns = 'object'
 })
 
 route('POST', '/logs/stop', {
    desc = 'Stops internal log recording.',
-   body = 'json',
    returns = 'object'
 })
 

--- a/src/backstage/routes.cpp
+++ b/src/backstage/routes.cpp
@@ -228,7 +228,10 @@ static constexpr std::array<std::string_view, 0> post_logs_start_path_param_name
 
 static constexpr std::array<BackstageParam, 0> post_logs_start_path_params = {};
 
-static constexpr std::array<BackstageParam, 0> post_logs_start_query_params = {};
+static constexpr std::array<BackstageParam, 2> post_logs_start_query_params = {
+   BackstageParam("maxDepth", "int", "Only record messages that are less or equal to this depth level.", "", false),
+   BackstageParam("maxLevel", "int", "Only record messages that are less or equal to this log level.", "", false)
+};
 
 static constexpr std::array<std::string_view, 0> post_logs_stop_path_param_names = {};
 
@@ -580,7 +583,7 @@ static std::array<BackstageRoute, 32> glRoutes = {
       put_logs_level,
       put_logs_level_path_param_names,
       BackstageRouteMetadata(
-         "Change the logging level for the program (affects console output).",
+         "Change the logging level for the program (affects console output only).",
          "",
          "object",
          "",
@@ -594,7 +597,7 @@ static std::array<BackstageRoute, 32> glRoutes = {
       post_logs_start_path_param_names,
       BackstageRouteMetadata(
          "Activates internal log recording.",
-         "json",
+         "",
          "object",
          "",
          post_logs_start_path_params,
@@ -607,7 +610,7 @@ static std::array<BackstageRoute, 32> glRoutes = {
       post_logs_stop_path_param_names,
       BackstageRouteMetadata(
          "Stops internal log recording.",
-         "json",
+         "",
          "object",
          "",
          post_logs_stop_path_params,

--- a/src/backstage/routes/logs.cpp
+++ b/src/backstage/routes/logs.cpp
@@ -1,5 +1,21 @@
+
+struct LogMessage {
+   std::string Header;
+   std::string Message;
+   int ThreadID;
+   int Depth;
+   int Level;
+};
+
+static std::mutex glLogRecordingLock;
+static std::vector<LogMessage> glLogMessages;
+static int glLogRecordingThread = 0;
+static bool glLogRecordingActive = false;
+static int glLogMaxDepth = 255;
+static int glLogMaxLevel = 9;
+
 //********************************************************************************************************************
-// @doc PUT /logs/level Change the logging level for the program (affects console output).
+// Parses a console log level query parameter.  Backstage accepts the same 0-9 range used by the core logging resource.
 
 static bool parse_log_level(std::string_view Value, int &Level)
 {
@@ -12,6 +28,232 @@ static bool parse_log_level(std::string_view Value, int &Level)
 }
 
 //********************************************************************************************************************
+// Appends a JSON string literal to a response body while escaping control characters and quote delimiters.
+
+static void append_log_json_string(std::string &Output, std::string_view Value)
+{
+   static constexpr char hex[] = "0123456789abcdef";
+
+   Output.push_back('"');
+
+   for (char c : Value) {
+      auto ch = (unsigned char)c;
+
+      if (c IS '"') Output.append("\\\"");
+      else if (c IS '\\') Output.append("\\\\");
+      else if (c IS '\b') Output.append("\\b");
+      else if (c IS '\f') Output.append("\\f");
+      else if (c IS '\n') Output.append("\\n");
+      else if (c IS '\r') Output.append("\\r");
+      else if (c IS '\t') Output.append("\\t");
+      else if (ch < 0x20) {
+         Output.append("\\u00");
+         Output.push_back(hex[ch >> 4]);
+         Output.push_back(hex[ch & 0x0f]);
+      }
+      else Output.push_back(c);
+   }
+
+   Output.push_back('"');
+}
+
+//********************************************************************************************************************
+// Appends an integer as decimal text for JSON numeric fields.
+
+static void append_log_int(std::string &Output, int Value)
+{
+   char buffer[16];
+   auto result = std::to_chars(buffer, buffer + sizeof(buffer), Value);
+   if (result.ec IS std::errc()) Output.append(buffer, result.ptr);
+}
+
+//********************************************************************************************************************
+// Serialises a captured log entry using the JSON field names exposed by the /logs route.
+
+static void append_log_message(std::string &Output, const LogMessage &Message)
+{
+   Output.append("{\"header\":");
+   append_log_json_string(Output, Message.Header);
+   Output.append(",\"message\":");
+   append_log_json_string(Output, Message.Message);
+   Output.append(",\"depth\":");
+   append_log_int(Output, Message.Depth);
+   Output.append(",\"level\":");
+   append_log_int(Output, Message.Level);
+   Output.push_back('}');
+}
+
+//********************************************************************************************************************
+// Parses bounded integer log-recording options such as maxDepth and maxLevel.
+
+static bool parse_log_limit(std::string_view Value, int Min, int Max, int &Limit)
+{
+   if (Value.empty()) return false;
+
+   auto result = std::from_chars(Value.data(), Value.data() + Value.size(), Limit);
+   if ((not (result.ec IS std::errc())) or (not (result.ptr IS Value.data() + Value.size()))) return false;
+
+   return (Limit >= Min) and (Limit <= Max);
+}
+
+//********************************************************************************************************************
+// Reads an optional query parameter, falling back to a default value when the client omits it.
+
+static bool parse_optional_log_limit(const BackstageRequest &Request, const char *Name, int DefaultValue, int Min,
+   int Max, int &Limit)
+{
+   auto param = Request.queryParams.find(Name);
+   if (param IS Request.queryParams.end()) {
+      Limit = DefaultValue;
+      return true;
+   }
+
+   return parse_log_limit(param->second, Min, Max, Limit);
+}
+
+//********************************************************************************************************************
+// Returns a consistent JSON error payload for invalid log-recording query parameters.
+
+static void set_log_recording_error(BackstageResponse &Response, std::string_view Code, std::string_view Message)
+{
+   Response.status = 400;
+   Response.contentType = "application/json";
+   Response.body = "{\"error\":";
+   append_log_json_string(Response.body, Code);
+   Response.body.append(",\"message\":");
+   append_log_json_string(Response.body, Message);
+   Response.body.push_back('}');
+}
+
+//********************************************************************************************************************
+// Captures log messages from the main thread while internal Backstage log recording is active.
+
+static void backstage_log_callback(CSTRING Header, CSTRING Message, int Depth, int MsgLevel, int LogLevel)
+{
+   auto thread_id = kt::_get_thread_id();
+   if (not glLogRecordingThread) glLogRecordingThread = GetResource(RES::MAIN_THREAD_ID);
+
+   std::lock_guard<std::mutex> lock(glLogRecordingLock);
+
+   if (not glLogRecordingActive) return;
+   if (not (thread_id IS glLogRecordingThread)) return;
+   if (Depth > glLogMaxDepth) return;
+   if (MsgLevel > glLogMaxLevel) return;
+
+   glLogMessages.emplace_back(LogMessage {
+      .Header = Header ? Header : "",
+      .Message = Message ? Message : "",
+      .ThreadID = thread_id,
+      .Depth = Depth,
+      .Level = MsgLevel
+   });
+}
+
+//********************************************************************************************************************
+// Stops internal recording and clears the in-memory message buffer before unregistering the callback.
+
+static void release_backstage_logs()
+{
+   {
+      std::lock_guard<std::mutex> lock(glLogRecordingLock);
+      glLogRecordingActive = false;
+      glLogMessages.clear();
+   }
+
+   SetLogCallback((APTR)backstage_log_callback, 0, 0);
+}
+
+//********************************************************************************************************************
+// @doc POST /logs/start Activates internal log recording.
+
+static ERR post_logs_start(const BackstageRequest &Request, BackstageResponse &Response)
+{
+   int max_depth;
+   int max_level;
+
+   if (not parse_optional_log_limit(Request, "maxDepth", 255, 0, 255, max_depth)) {
+      set_log_recording_error(Response, "invalid_max_depth", "Expected maxDepth query parameter from 0 to 255");
+      return ERR::Okay;
+   }
+
+   if (not parse_optional_log_limit(Request, "maxLevel", 9, 0, 9, max_level)) {
+      set_log_recording_error(Response, "invalid_max_level", "Expected maxLevel query parameter from 0 to 9");
+      return ERR::Okay;
+   }
+
+   {
+      std::lock_guard<std::mutex> lock(glLogRecordingLock);
+      glLogMessages.clear();
+      glLogMaxDepth = max_depth;
+      glLogMaxLevel = max_level;
+      glLogRecordingActive = true;
+   }
+
+   SetLogCallback((APTR)backstage_log_callback, max_depth IS 0 ? 1 : max_depth, max_level IS 0 ? 1 : max_level);
+
+   kt::Log("backstage_logs").msg("Internal log recording started.");
+
+   Response.status = 200;
+   Response.contentType = "application/json";
+   Response.body = "{\"active\":true,\"maxDepth\":";
+   Response.body.append(std::to_string(max_depth));
+   Response.body.append(",\"maxLevel\":");
+   Response.body.append(std::to_string(max_level));
+   Response.body.push_back('}');
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+// @doc POST /logs/stop Stops internal log recording.
+
+static ERR post_logs_stop(const BackstageRequest &Request, BackstageResponse &Response)
+{
+   size_t total = 0;
+
+   {
+      std::lock_guard<std::mutex> lock(glLogRecordingLock);
+      glLogRecordingActive = false;
+      total = glLogMessages.size();
+   }
+
+   SetLogCallback((APTR)backstage_log_callback, 0, 0);
+
+   Response.status = 200;
+   Response.contentType = "application/json";
+   Response.body = "{\"active\":false,\"pending\":";
+   Response.body.append(std::to_string(total));
+   Response.body.push_back('}');
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+// @doc GET /logs Returns all logged messages, then clears the log message stack (the client is responsible for maintaining a permanent record).
+
+static ERR get_logs(const BackstageRequest &Request, BackstageResponse &Response)
+{
+   std::vector<LogMessage> messages;
+
+   {
+      std::lock_guard<std::mutex> lock(glLogRecordingLock);
+      messages.swap(glLogMessages);
+   }
+
+   Response.status = 200;
+   Response.contentType = "application/json";
+   Response.body.reserve(2 + (messages.size() * 64));
+   Response.body.push_back('[');
+
+   for (size_t i = 0; i < messages.size(); i++) {
+      if (i > 0) Response.body.push_back(',');
+      append_log_message(Response.body, messages[i]);
+   }
+
+   Response.body.push_back(']');
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+// @doc PUT /logs/level Change the logging level for the program (affects console output).
 
 static ERR put_logs_level(const BackstageRequest &Request, BackstageResponse &Response)
 {
@@ -32,28 +274,4 @@ static ERR put_logs_level(const BackstageRequest &Request, BackstageResponse &Re
    Response.body.append(std::to_string(level));
    Response.body.push_back('}');
    return ERR::Okay;
-}
-
-//********************************************************************************************************************
-// @doc POST /logs/start Activates internal log recording.
-
-static ERR post_logs_start(const BackstageRequest &Request, BackstageResponse &Response)
-{
-   return ERR::NoSupport;
-}
-
-//********************************************************************************************************************
-// @doc POST /logs/stop Stops internal log recording.
-
-static ERR post_logs_stop(const BackstageRequest &Request, BackstageResponse &Response)
-{
-   return ERR::NoSupport;
-}
-
-//********************************************************************************************************************
-// @doc GET /logs Returns all logged messages, then clears the log message stack (the client is responsible for maintaining a permanent record).
-
-static ERR get_logs(const BackstageRequest &Request, BackstageResponse &Response)
-{
-   return ERR::NoSupport;
 }

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -37,7 +37,7 @@ end
 function request_backstage(Request:str, ExpectedToken:str):str
    response = ''
    client = obj.new('netsocket', {
-      name = 'BackstagePingClient',
+      name = 'BackstageClient',
       feedback = function(Socket:obj, State:num)
          if State is NTC_CONNECTED then
             err, len = Socket.acWrite(Request)
@@ -52,7 +52,7 @@ function request_backstage(Request:str, ExpectedToken:str):str
             Socket.acSignal()
             return
          end
-         assert(err is ERR_Okay, 'Failed to read ping response: ' .. mSys.GetErrorMsg(err))
+         assert(err is ERR_Okay, 'Failed to read response: ' .. mSys.GetErrorMsg(err))
          if read_len <= 0 then return end
 
          response ..= buffer:substr(0, read_len)
@@ -392,9 +392,7 @@ end
 function LogsCanBeRecordedAndDrained()
    start_request = 'POST /logs/start?maxLevel=5&maxDepth=255 HTTP/1.1\r\n' ..
       'Host: 127.0.0.1\r\n' ..
-      'Content-Type: application/json\r\n' ..
-      'Content-Length: 2\r\n' ..
-      'Connection: close\r\n\r\n{}'
+      'Connection: close\r\n\r\n'
 
    response = request_backstage(start_request, '"active":true')
    assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/start to return 200 OK, got: ' .. response)
@@ -422,9 +420,7 @@ function LogsCanBeRecordedAndDrained()
 
    stop_request = 'POST /logs/stop HTTP/1.1\r\n' ..
       'Host: 127.0.0.1\r\n' ..
-      'Content-Type: application/json\r\n' ..
-      'Content-Length: 2\r\n' ..
-      'Connection: close\r\n\r\n{}'
+      'Connection: close\r\n\r\n'
 
    response = request_backstage(stop_request, '"active":false')
    assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/stop to return 200 OK, got: ' .. response)

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -389,6 +389,48 @@ function LogsLevelRejectsInvalidValue()
 end
 
 @Test; @Requires(network=true)
+function LogsCanBeRecordedAndDrained()
+   start_request = 'POST /logs/start?maxLevel=5&maxDepth=255 HTTP/1.1\r\n' ..
+      'Host: 127.0.0.1\r\n' ..
+      'Content-Type: application/json\r\n' ..
+      'Content-Length: 2\r\n' ..
+      'Connection: close\r\n\r\n{}'
+
+   response = request_backstage(start_request, '"active":true')
+   assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/start to return 200 OK, got: ' .. response)
+   assert(response:find('"maxLevel":5'), 'Expected logs/start to report maxLevel, got: ' .. response)
+
+   ping_request = 'GET /ping HTTP/1.1\r\n' ..
+      'Host: 127.0.0.1\r\n' ..
+      'Connection: close\r\n\r\n'
+
+   response = request_backstage(ping_request, '{"status":"pong"}')
+   assert(response:find('HTTP/1.1 200 OK'), 'Expected ping during log recording to return 200 OK, got: ' .. response)
+
+   logs_request = 'GET /logs HTTP/1.1\r\n' ..
+      'Host: 127.0.0.1\r\n' ..
+      'Connection: close\r\n\r\n'
+
+   response = request_backstage_full(logs_request)
+   assert(response:find('HTTP/1.1 200 OK'), 'Expected logs to return 200 OK, got: ' .. response)
+   assert(response:find('"header":"backstage_logs"'), 'Expected captured start marker, got: ' .. response)
+   assert(response:find('"message":"Internal log recording started."'), 'Expected captured start message, got: ' .. response)
+
+   response = request_backstage_full(logs_request)
+   assert(response:find('HTTP/1.1 200 OK'), 'Expected drained logs request to return 200 OK, got: ' .. response)
+   assert(not response:find('"message":"Internal log recording started."'), 'Expected logs to drain after read, got: ' .. response)
+
+   stop_request = 'POST /logs/stop HTTP/1.1\r\n' ..
+      'Host: 127.0.0.1\r\n' ..
+      'Content-Type: application/json\r\n' ..
+      'Content-Length: 2\r\n' ..
+      'Connection: close\r\n\r\n{}'
+
+   response = request_backstage(stop_request, '"active":false')
+   assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/stop to return 200 OK, got: ' .. response)
+end
+
+@Test; @Requires(network=true)
 function MalformedContentLengthReturnsBadRequest()
    request = 'GET /ping HTTP/1.1\r\n' ..
       'Host: 127.0.0.1\r\n' ..


### PR DESCRIPTION
## Summary

- Implements `POST /logs/start` to activate in-process log capture with optional `maxLevel` (0–9) and `maxDepth` (0–255) query parameters
- Implements `GET /logs` to drain the captured message buffer as a JSON array (each entry includes `header`, `message`, `depth`, and `level` fields)
- Implements `POST /logs/stop` to halt recording and report the pending message count
- Registers `backstage_log_callback()` via `SetLogCallback()` to intercept main-thread log messages only, using a mutex-guarded buffer
- Added `release_backstage_logs()` called from `MODExpunge()` to stop recording and clear the buffer on module unload
- Updated `interface.tiri` and `routes.cpp` to reflect the corrected query-parameter schema for the start/stop routes

## Test plan

- [ ] Build and install the `backstage` module
- [ ] Run `ctest -L backstage` — new `LogsCanBeRecordedAndDrained` Flute test covers: start recording, generate a log entry, drain via `GET /logs`, verify drain is idempotent, stop recording
- [ ] Confirm `POST /logs/start?maxLevel=5&maxDepth=10` returns `{"active":true,"maxLevel":5,"maxDepth":10}`
- [ ] Confirm `GET /logs` returns a JSON array and clears the buffer on second call
- [ ] Confirm `POST /logs/stop` returns `{"active":false,"pending":N}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)