### PR TITLE
[Backstage] Added includeThreads parameter to /logs/start for multi-t…

### DIFF
--- a/src/backstage/interface.tiri
+++ b/src/backstage/interface.tiri
@@ -250,7 +250,8 @@ route('POST', '/logs/start', {
    desc = 'Activates internal log recording.',
    query = {
       maxLevel = { type='int', desc='Only record messages that are less or equal to this log level.' },
-      maxDepth = { type='int', desc='Only record messages that are less or equal to this depth level.' }
+      maxDepth = { type='int', desc='Only record messages that are less or equal to this depth level.' },
+      includeThreads = { type='bool', desc='Include log messages from child threads.' }
    },
    returns = 'object'
 })

--- a/src/backstage/routes.cpp
+++ b/src/backstage/routes.cpp
@@ -228,7 +228,8 @@ static constexpr std::array<std::string_view, 0> post_logs_start_path_param_name
 
 static constexpr std::array<BackstageParam, 0> post_logs_start_path_params = {};
 
-static constexpr std::array<BackstageParam, 2> post_logs_start_query_params = {
+static constexpr std::array<BackstageParam, 3> post_logs_start_query_params = {
+   BackstageParam("includeThreads", "bool", "Include log messages from child threads.", "", false),
    BackstageParam("maxDepth", "int", "Only record messages that are less or equal to this depth level.", "", false),
    BackstageParam("maxLevel", "int", "Only record messages that are less or equal to this log level.", "", false)
 };

--- a/src/backstage/routes/logs.cpp
+++ b/src/backstage/routes/logs.cpp
@@ -11,6 +11,7 @@ static std::mutex glLogRecordingLock;
 static std::vector<LogMessage> glLogMessages;
 static int glLogRecordingThread = 0;
 static bool glLogRecordingActive = false;
+static bool glLogIncludeThreads = false;
 static int glLogMaxDepth = 255;
 static int glLogMaxLevel = 9;
 
@@ -22,9 +23,26 @@ static bool parse_log_level(std::string_view Value, int &Level)
    if (Value.empty()) return false;
 
    auto result = std::from_chars(Value.data(), Value.data() + Value.size(), Level);
-   if ((not (result.ec IS std::errc())) or (result.ptr != Value.data() + Value.size())) return false;
+   if ((not (result.ec IS std::errc())) or (not (result.ptr IS Value.data() + Value.size()))) return false;
 
    return (Level >= 0) and (Level <= 9);
+}
+
+//********************************************************************************************************************
+// Parses a boolean log-recording query parameter.
+
+static bool parse_log_bool(std::string_view Value, bool &Flag)
+{
+   if (kt::iequals(Value, "true") or kt::iequals(Value, "1")) {
+      Flag = true;
+      return true;
+   }
+   else if (kt::iequals(Value, "false") or kt::iequals(Value, "0")) {
+      Flag = false;
+      return true;
+   }
+
+   return false;
 }
 
 //********************************************************************************************************************
@@ -112,6 +130,20 @@ static bool parse_optional_log_limit(const BackstageRequest &Request, const char
 }
 
 //********************************************************************************************************************
+// Reads an optional boolean query parameter, falling back to a default value when the client omits it.
+
+static bool parse_optional_log_bool(const BackstageRequest &Request, const char *Name, bool DefaultValue, bool &Flag)
+{
+   auto param = Request.queryParams.find(Name);
+   if (param IS Request.queryParams.end()) {
+      Flag = DefaultValue;
+      return true;
+   }
+
+   return parse_log_bool(param->second, Flag);
+}
+
+//********************************************************************************************************************
 // Returns a consistent JSON error payload for invalid log-recording query parameters.
 
 static void set_log_recording_error(BackstageResponse &Response, std::string_view Code, std::string_view Message)
@@ -126,17 +158,16 @@ static void set_log_recording_error(BackstageResponse &Response, std::string_vie
 }
 
 //********************************************************************************************************************
-// Captures log messages from the main thread while internal Backstage log recording is active.
+// Captures log messages while internal Backstage log recording is active.
 
 static void backstage_log_callback(CSTRING Header, CSTRING Message, int Depth, int MsgLevel, int LogLevel)
 {
    auto thread_id = kt::_get_thread_id();
-   if (not glLogRecordingThread) glLogRecordingThread = GetResource(RES::MAIN_THREAD_ID);
 
    std::lock_guard<std::mutex> lock(glLogRecordingLock);
 
    if (not glLogRecordingActive) return;
-   if (not (thread_id IS glLogRecordingThread)) return;
+   if ((not glLogIncludeThreads) and (not (thread_id IS glLogRecordingThread))) return;
    if (Depth > glLogMaxDepth) return;
    if (MsgLevel > glLogMaxLevel) return;
 
@@ -157,6 +188,8 @@ static void release_backstage_logs()
    {
       std::lock_guard<std::mutex> lock(glLogRecordingLock);
       glLogRecordingActive = false;
+      glLogIncludeThreads = false;
+      glLogRecordingThread = 0;
       glLogMessages.clear();
    }
 
@@ -170,6 +203,7 @@ static ERR post_logs_start(const BackstageRequest &Request, BackstageResponse &R
 {
    int max_depth;
    int max_level;
+   bool include_threads;
 
    if (not parse_optional_log_limit(Request, "maxDepth", 255, 0, 255, max_depth)) {
       set_log_recording_error(Response, "invalid_max_depth", "Expected maxDepth query parameter from 0 to 255");
@@ -181,9 +215,17 @@ static ERR post_logs_start(const BackstageRequest &Request, BackstageResponse &R
       return ERR::Okay;
    }
 
+   if (not parse_optional_log_bool(Request, "includeThreads", false, include_threads)) {
+      set_log_recording_error(Response, "invalid_include_threads",
+         "Expected includeThreads query parameter to be true, false, 0 or 1");
+      return ERR::Okay;
+   }
+
    {
       std::lock_guard<std::mutex> lock(glLogRecordingLock);
       glLogMessages.clear();
+      glLogRecordingThread = GetResource(RES::MAIN_THREAD_ID);
+      glLogIncludeThreads = include_threads;
       glLogMaxDepth = max_depth;
       glLogMaxLevel = max_level;
       glLogRecordingActive = true;
@@ -195,7 +237,9 @@ static ERR post_logs_start(const BackstageRequest &Request, BackstageResponse &R
 
    Response.status = 200;
    Response.contentType = "application/json";
-   Response.body = "{\"active\":true,\"maxDepth\":";
+   Response.body = "{\"active\":true,\"includeThreads\":";
+   Response.body.append(include_threads ? "true" : "false");
+   Response.body.append(",\"maxDepth\":");
    Response.body.append(std::to_string(max_depth));
    Response.body.append(",\"maxLevel\":");
    Response.body.append(std::to_string(max_level));
@@ -213,6 +257,8 @@ static ERR post_logs_stop(const BackstageRequest &Request, BackstageResponse &Re
    {
       std::lock_guard<std::mutex> lock(glLogRecordingLock);
       glLogRecordingActive = false;
+      glLogIncludeThreads = false;
+      glLogRecordingThread = 0;
       total = glLogMessages.size();
    }
 
@@ -227,7 +273,8 @@ static ERR post_logs_stop(const BackstageRequest &Request, BackstageResponse &Re
 }
 
 //********************************************************************************************************************
-// @doc GET /logs Returns all logged messages, then clears the log message stack (the client is responsible for maintaining a permanent record).
+// @doc GET /logs Returns all logged messages, then clears the log message stack.  The client is responsible for
+// maintaining a permanent record.
 
 static ERR get_logs(const BackstageRequest &Request, BackstageResponse &Response)
 {

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -390,13 +390,14 @@ end
 
 @Test; @Requires(network=true)
 function LogsCanBeRecordedAndDrained()
-   start_request = 'POST /logs/start?maxLevel=5&maxDepth=255 HTTP/1.1\r\n' ..
+   start_request = 'POST /logs/start?maxLevel=5&maxDepth=255&includeThreads=true HTTP/1.1\r\n' ..
       'Host: 127.0.0.1\r\n' ..
       'Connection: close\r\n\r\n'
 
    response = request_backstage(start_request, '"active":true')
    assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/start to return 200 OK, got: ' .. response)
    assert(response:find('"maxLevel":5'), 'Expected logs/start to report maxLevel, got: ' .. response)
+   assert(response:find('"includeThreads":true'), 'Expected logs/start to report includeThreads, got: ' .. response)
 
    ping_request = 'GET /ping HTTP/1.1\r\n' ..
       'Host: 127.0.0.1\r\n' ..
@@ -424,6 +425,18 @@ function LogsCanBeRecordedAndDrained()
 
    response = request_backstage(stop_request, '"active":false')
    assert(response:find('HTTP/1.1 200 OK'), 'Expected logs/stop to return 200 OK, got: ' .. response)
+end
+
+@Test; @Requires(network=true)
+function LogsStartRejectsInvalidIncludeThreads()
+   request = 'POST /logs/start?includeThreads=maybe HTTP/1.1\r\n' ..
+      'Host: 127.0.0.1\r\n' ..
+      'Connection: close\r\n\r\n'
+
+   response = request_backstage(request, 'HTTP/1.1 400 Bad Request')
+   assert(response:find('HTTP/1.1 400 Bad Request'), 'Expected invalid includeThreads to return 400, got: ' .. response)
+   message = 'Expected invalid_include_threads JSON body, got: ' .. response
+   assert(response:find('"error":"invalid_include_threads"'), message)
 end
 
 @Test; @Requires(network=true)


### PR DESCRIPTION
…hread log capture

* Added includeThreads boolean query parameter to POST /logs/start, defaulting to false (main thread only)
* Added parse_log_bool and parse_optional_log_bool helpers for boolean query parameter parsing
* Moved glLogRecordingThread initialisation into post_logs_start and reset it on stop to avoid stale state
* Added LogsStartRejectsInvalidIncludeThreads Flute test for invalid parameter rejection