### PR TITLE
[Display] Added WM_GETMINMAXINFO handler to enforce surface min/max window size constraints on Win32

### DIFF
--- a/src/display/win32/windows.cpp
+++ b/src/display/win32/windows.cpp
@@ -1118,6 +1118,31 @@ static LRESULT CALLBACK WindowProcedure(HWND window, UINT msgcode, WPARAM wParam
          return 0;
       }
 
+      case WM_GETMINMAXINFO: {
+         auto minmax = (LPMINMAXINFO)lParam;
+
+         RECT winrect, client;
+         GetWindowRect(window, &winrect);
+         GetClientRect(window, &client);
+
+         const int h_margins = ((winrect.right - winrect.left) - (client.right - client.left));
+         const int v_margins = ((winrect.bottom - winrect.top) - (client.bottom - client.top));
+         auto surface_id = winLookupSurfaceID(window);
+
+         int min_width = minmax->ptMinTrackSize.x - h_margins;
+         int min_height = minmax->ptMinTrackSize.y - v_margins;
+         CheckWindowSize(surface_id, min_width, min_height, -1, -1, AXIS_BOTH);
+         minmax->ptMinTrackSize.x = min_width + h_margins;
+         minmax->ptMinTrackSize.y = min_height + v_margins;
+
+         int max_width = minmax->ptMaxTrackSize.x - h_margins;
+         int max_height = minmax->ptMaxTrackSize.y - v_margins;
+         CheckWindowSize(surface_id, max_width, max_height, -1, -1, AXIS_BOTH);
+         minmax->ptMaxTrackSize.x = max_width + h_margins;
+         minmax->ptMaxTrackSize.y = max_height + v_margins;
+         return 0;
+      }
+
       case WM_DPICHANGED: {
          MsgDPIChanged(winLookupSurfaceID(window));
          return 0;


### PR DESCRIPTION
## Summary

- Handles `WM_GETMINMAXINFO` in the Win32 `WindowProcedure` to enforce surface-defined minimum and maximum window dimensions during resize operations.
- Frame margins (the difference between window rect and client rect) are subtracted before calling `CheckWindowSize` and added back afterwards, so constraints apply correctly to client area dimensions rather than total window size.

## Test plan

- [ ] Resize a surface window with defined min/max constraints and verify it cannot be dragged below the minimum or above the maximum size.
- [ ] Verify behaviour on windows with non-standard frame sizes (e.g. with/without title bar, thick borders) to confirm margin calculation is correct.
- [ ] Confirm no regression on windows with no size constraints (default `ptMinTrackSize`/`ptMaxTrackSize` values should pass through unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)