### PR TITLE
[Display] Removed movement limit fields and extended ScheduleRedraw() with refresh rate control

### DIFF
--- a/docs/xml/modules/classes/surface.xml
+++ b/docs/xml/modules/classes/surface.xml
@@ -356,12 +356,16 @@ the surface area first).</li>
     <method>
       <name>ScheduleRedraw</name>
       <comment>Schedules a redraw operation for the next frame.</comment>
-      <prototype>ERR drw::ScheduleRedraw(OBJECTPTR Object)</prototype>
-      <tiriPrototype>err = ScheduleRedraw()</tiriPrototype>
+      <prototype>ERR drw::ScheduleRedraw(OBJECTPTR Object, INT RefreshRate)</prototype>
+      <tiriPrototype>err = ScheduleRedraw(RefreshRate:num)</tiriPrototype>
+      <input>
+        <param type="INT" name="RefreshRate">Optional refresh rate in frames per second.  If not specified, the refresh rate from the display is used.</param>
+      </input>
       <description>
-<p>Use ScheduleRedraw() to mark a surface for redraw on the next frame cycle.  The surface and its child surfaces are redrawn together, typically on the next 1/60th of a second timer tick.  Direct redraw requests for the target surface are coalesced until the scheduled redraw is processed.</p>
-<p>Scheduling is ideal in situations where a cluster of redraw events may occur within a tight time period, and it would be inefficient to draw those changes to the display individually.</p>
-<p>Redraw schedules do not merge across the hierarchy.  If both a surface and one of its children are scheduled, two redraw operations may be triggered where one would otherwise suffice.  Schedule the highest relevant surface when a single redraw should cover a group of changes.</p>
+<p>Use ScheduleRedraw() to mark a surface for redraw on the next frame cycle.  The delay is governed by the chosen RefreshRate, which is measured in frames per second.  If a RefreshRate is not specified, the frame rate is derived from the display.</p>
+<p>Specifying a custom RefreshRate is recommended when processing an animation at a lower frame rate than that of the display would be acceptable.</p>
+<p>Scheduling with this method over <action>Draw</action> (immediate mode) is recommended when a cluster of redraw events may occur within a tight time period, and it would be inefficient to draw those changes to the display individually.  Repeated redraw requests made to the target surface are coalesced until the scheduled redraw is processed.</p>
+<p>Redraw schedules do not collapse in nested surfaces.  If both a surface and one of its children are scheduled, two redraw operations may be triggered where one would otherwise suffice.  Target the top-level surface only in such instances.</p>
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
@@ -472,17 +476,6 @@ the surface area first).</li>
     </field>
 
     <field>
-      <name>BottomLimit</name>
-      <comment>Prevents a surface object from moving beyond a given point at the bottom of its container.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>INT</type>
-      <description>
-<p>Set <code>BottomLimit</code> to reserve a margin at the bottom of the parent container.  For example, a value of <code>5</code> prevents <action>Move</action> from placing the surface inside the bottom-most five coordinate units.</p>
-<p>Movement limits apply only to <action>Move</action>.  Direct writes to coordinate fields bypass them.</p>
-      </description>
-    </field>
-
-    <field>
       <name>Buffer</name>
       <comment>Refers to the <class name="Bitmap">Bitmap</class> that stores the surface's graphics.</comment>
       <access read="R">Read</access>
@@ -584,17 +577,6 @@ the surface area first).</li>
 <p>By default the value is a fixed coordinate unit.  With the <code>FD_SCALED</code> flag, the value is treated as a multiplier of the parent surface height.</p>
 <p>Changing <code>Height</code> on a visible surface updates the displayed area immediately, including any child surfaces that need to be redrawn or resized.</p>
 <p>Before initialisation, setting <code>Height</code> to zero or less clears the height dimension so that <fl>Y</fl> and <fl>YOffset</fl> can define the height dynamically.  After initialisation, values of zero or less are invalid.</p>
-      </description>
-    </field>
-
-    <field>
-      <name>LeftLimit</name>
-      <comment>Prevents a surface object from moving beyond a given point on the left-hand side.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>INT</type>
-      <description>
-<p>Set <code>LeftLimit</code> to reserve a margin at the left-hand side of the parent container.  For example, a value of <code>3</code> prevents <action>Move</action> from placing the surface inside the left-most three coordinate units.</p>
-<p>Movement limits apply only to <action>Move</action>.  Direct writes to coordinate fields bypass them.</p>
       </description>
     </field>
 
@@ -709,32 +691,10 @@ the surface area first).</li>
     </field>
 
     <field>
-      <name>RightLimit</name>
-      <comment>Prevents a surface object from moving beyond a given point on the right-hand side.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>INT</type>
-      <description>
-<p>Set <code>RightLimit</code> to reserve a margin at the right-hand side of the parent container.  For example, a value of <code>8</code> prevents <action>Move</action> from placing the surface inside the right-most eight coordinate units.</p>
-<p>Movement limits apply only to <action>Move</action>.  Direct writes to coordinate fields bypass them.</p>
-      </description>
-    </field>
-
-    <field>
       <name>Root</name>
       <comment>Surface that is acting as a root for many surface children (useful when applying translucency)</comment>
       <access>-/-</access>
       <type>OBJECTID</type>
-    </field>
-
-    <field>
-      <name>TopLimit</name>
-      <comment>Prevents a surface object from moving beyond a given point at the top of its container.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>INT</type>
-      <description>
-<p>Set <code>TopLimit</code> to reserve a margin at the top of the parent container.  For example, a value of <code>10</code> prevents <action>Move</action> from placing the surface inside the top-most ten coordinate units.</p>
-<p>Movement limits apply only to <action>Move</action>.  Direct writes to coordinate fields bypass them.</p>
-      </description>
     </field>
 
     <field>
@@ -1177,8 +1137,8 @@ the surface area first).</li>
       <field name="VirtualHeight" type="INT">Height of the complete desktop spanning all monitors</field>
       <field name="PhysicalWidth" type="INT">Width in millimeters, 0 if unknown</field>
       <field name="PhysicalHeight" type="INT">Height in millimeters, 0 if unknown</field>
-      <field name="Width" type="INT16">Pixel width of the display</field>
-      <field name="Height" type="INT16">Pixel height of the display</field>
+      <field name="Width" type="INT16">Pixel width of the display bitmap</field>
+      <field name="Height" type="INT16">Pixel height of the display bitmap</field>
       <field name="BitsPerPixel" type="INT16">Bits per pixel</field>
       <field name="BytesPerPixel" type="INT16">Bytes per pixel</field>
     </struct>

--- a/docs/xml/modules/display.xml
+++ b/docs/xml/modules/display.xml
@@ -1321,8 +1321,8 @@ Alpha  = CFUnpackAlpha(Format,Colour)
       <field name="VirtualHeight" type="INT">Height of the complete desktop spanning all monitors</field>
       <field name="PhysicalWidth" type="INT">Width in millimeters, 0 if unknown</field>
       <field name="PhysicalHeight" type="INT">Height in millimeters, 0 if unknown</field>
-      <field name="Width" type="INT16">Pixel width of the display</field>
-      <field name="Height" type="INT16">Pixel height of the display</field>
+      <field name="Width" type="INT16">Pixel width of the display bitmap</field>
+      <field name="Height" type="INT16">Pixel height of the display bitmap</field>
       <field name="BitsPerPixel" type="INT16">Bits per pixel</field>
       <field name="BytesPerPixel" type="INT16">Bytes per pixel</field>
     </struct>

--- a/examples/benchmark_particles.tiri
+++ b/examples/benchmark_particles.tiri
@@ -15,6 +15,7 @@ Parameters:
 
    local glWinWidth, glWinHeight, glColours, glMode, glWindow, glSurface, glParticles, glViewport, glScene
    local glTimerHandle, glFPS, glPrinted
+   local PI = math.pi
    glFrameStats = { avg = 0, best = 0, times = array<int> }
 
    MODE_PRIMITIVE    = 1 -- Tests the speed of drawing primitive rectangles (this will be much faster than drawVector() but is useful for comparative purposes)
@@ -55,7 +56,7 @@ end
 
 function newParticle()
    particle = {
-      angle    = math.pi * 2 * math.random(),
+      angle    = PI * 2 * math.random(),
       velocity = 1 + math.random() * 3,
       radius   = 6,
       x        = (glWinWidth / 2) - 6,
@@ -90,7 +91,7 @@ function timer(Subscriber, Elapsed, Current)
    glWinHeight = glSurface.height ?? 1
 
    calc_start = mSys.PreciseTime()
-   for i,p in pairs(glParticles) do
+   for p in values(glParticles) do
       -- Calculate next position of particle
 
       tx = math.cos(p.angle) * p.velocity
@@ -102,36 +103,36 @@ function timer(Subscriber, Elapsed, Current)
       -- If particle is going to move off right side of screen
 
       if nextX + p.radius * 2 > glWinWidth then
-         if ((p.angle >= 0) and (p.angle < math.pi * 0.5)) then
-            p.angle = math.pi - p.angle
-         elseif p.angle > math.pi / 2 * 3 then
-            p.angle = p.angle - (p.angle - math.pi / 2 * 3) * 2
+         if ((p.angle >= 0) and (p.angle < PI * 0.5)) then
+            p.angle = PI - p.angle
+         elseif p.angle > PI / 2 * 3 then
+            p.angle = p.angle - (p.angle - PI / 2 * 3) * 2
          end
       end
 
       -- If particle is going to move off left side of screen
 
       if nextX < 0 then  -- If angle is between 6 o'clock and 9 o'clock
-         if ((p.angle > math.pi / 2) and (p.angle < math.pi)) then
-            p.angle = math.pi - p.angle
-         elseif (p.angle > math.pi) and (p.angle < math.pi * 0.5 * 3) then
-            p.angle = p.angle + (math.pi * 0.5 * 3 - p.angle) * 2
+         if ((p.angle > PI / 2) and (p.angle < PI)) then
+            p.angle = PI - p.angle
+         elseif (p.angle > PI) and (p.angle < PI * 0.5 * 3) then
+            p.angle = p.angle + (PI * 0.5 * 3 - p.angle) * 2
          end
       end
 
       -- If particle is going to move off bottom side of screen
 
       if nextY + p.radius * 2 > glWinHeight then
-         if p.angle > 0 and p.angle < math.pi then
-            p.angle = math.pi * 2 - p.angle
+         if p.angle > 0 and p.angle < PI then
+            p.angle = PI * 2 - p.angle
          end
       end
 
       -- If particle is going to move off top side of screen
 
       if nextY < 0 then
-         if p.angle > math.pi and p.angle < math.pi * 2 then
-            p.angle = p.angle - (p.angle - math.pi) * 2
+         if p.angle > PI and p.angle < PI * 2 then
+            p.angle = p.angle - (p.angle - PI) * 2
          end
       end
 
@@ -143,9 +144,14 @@ function timer(Subscriber, Elapsed, Current)
       p.x = nextX
       p.y = nextY
    end
+
+   -- The calc_time is just how fast we ran the calculation sub-routine
    calc_time = mSys.PreciseTime() - calc_start
 
-   glViewport.acDraw()
+   glScene.surface.acDraw() -- Force a redraw
+   --glScene.surface.mtScheduleRedraw(60) -- Schedule a redraw based on frame rate
+
+   -- The frame rate is based on the rendering time returned from the scene graph
    if glScene.renderTime then glFrameStats.times:push(glScene.renderTime) end
 
    if math.round(Current / 1000000) % 2 is 0 then
@@ -240,7 +246,7 @@ end
         { r=0xcc, g=0, b=0 }, { r=0xff, g=0xcc, b=0 }, { r=0xaa, g=0xff, b=0 },
         { r=0, g=0x99, b=0xcc }, { r=0x19, g=0x4c, b=0x99 }, { r=0x66, g=0x19, b=0x99 }
       }
-   elseif (glMode is MODE_VECTOR) then
+   elseif glMode is MODE_VECTOR then
       print('Drawing Mode: Vector')
 
       glColours = array<table> {
@@ -248,7 +254,7 @@ end
         { r=0, g=0x99, b=0xcc }, { r=0x19, g=0x4c, b=0x99 }, { r=0x66, g=0x19, b=0x99 }
       }
 
-   elseif (glMode is MODE_DIRECTVECTOR) then
+   elseif glMode is MODE_DIRECTVECTOR then
       print('Drawing Mode: Direct Vector')
 
       glSurface.mtAddCallback(drawDirectVector)

--- a/include/kotuku/modules/display.h
+++ b/include/kotuku/modules/display.h
@@ -493,8 +493,8 @@ struct DisplayInfo {
    int      VirtualHeight;            // Height of the complete desktop spanning all monitors
    int      PhysicalWidth;            // Width in millimeters, 0 if unknown
    int      PhysicalHeight;           // Height in millimeters, 0 if unknown
-   int16_t  Width;                    // Pixel width of the display
-   int16_t  Height;                   // Pixel height of the display
+   int16_t  Width;                    // Pixel width of the display bitmap
+   int16_t  Height;                   // Pixel height of the display bitmap
    int16_t  BitsPerPixel;             // Bits per pixel
    int16_t  BytesPerPixel;            // Bytes per pixel
 };
@@ -1396,7 +1396,7 @@ struct AddCallback { FUNCTION * Callback; static const AC id = AC(-6); ERR call(
 struct Minimise { static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct ResetDimensions { double X; double Y; double XOffset; double YOffset; double Width; double Height; DMF Dimensions; static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct RemoveCallback { FUNCTION * Callback; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ScheduleRedraw { static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ScheduleRedraw { int RefreshRate; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -1415,10 +1415,6 @@ class objSurface : public Object {
    int      MinHeight;  // Prevents the height of a surface object from shrinking beyond a certain value.
    int      MaxWidth;   // Prevents the width of a surface object from exceeding a certain value.
    int      MaxHeight;  // Prevents the height of a surface object from exceeding a certain value.
-   int      LeftLimit;  // Prevents a surface object from moving beyond a given point on the left-hand side.
-   int      RightLimit; // Prevents a surface object from moving beyond a given point on the right-hand side.
-   int      TopLimit;   // Prevents a surface object from moving beyond a given point at the top of its container.
-   int      BottomLimit; // Prevents a surface object from moving beyond a given point at the bottom of its container.
    OBJECTID DisplayID;  // Refers to the Display object that manages the surface's graphics.
    RNF      Flags;      // Controls optional surface behaviour.
    int      X;          // Determines the horizontal position of a surface object.
@@ -1435,12 +1431,7 @@ class objSurface : public Object {
    int      Modal;      // Sets the surface as modal (prevents user interaction with other surfaces).
 
 #ifdef PRV_SURFACE
-   // These coordinate fields are considered private but may be accessed by some internal classes, like Document
-   int     XOffset, YOffset;     // Fixed horizontal and vertical offset
-   double  XOffsetPercent;       // Scaled horizontal offset
-   double  YOffsetPercent;       // Scaled vertical offset
-   double  WidthPercent, HeightPercent; // Scaled width and height
-   double  XPercent, YPercent;   // Scaled coordinate
+
 #endif
    public:
    inline bool visible() const { return (Flags & RNF::VISIBLE) != RNF::NIL; }
@@ -1526,108 +1517,85 @@ class objSurface : public Object {
       struct drw::RemoveCallback args = { &Callback };
       return(Action(AC(-9), this, &args));
    }
-   inline ERR scheduleRedraw() noexcept {
-      return(Action(AC(-10), this, nullptr));
+   inline ERR scheduleRedraw(int RefreshRate) noexcept {
+      struct drw::ScheduleRedraw args = { RefreshRate };
+      return(Action(AC(-10), this, &args));
    }
 
    // Customised field setting
 
    inline ERR setDrag(OBJECTID Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[22];
+      auto field = &this->Class->Dictionary[20];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setParent(OBJECTID Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[48];
+      auto field = &this->Class->Dictionary[44];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setPopOver(OBJECTID Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[5];
+      auto field = &this->Class->Dictionary[4];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setMinWidth(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[33];
+      auto field = &this->Class->Dictionary[30];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setMinHeight(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[13];
+      auto field = &this->Class->Dictionary[12];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setMaxWidth(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[14];
+      auto field = &this->Class->Dictionary[13];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setMaxHeight(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[45];
-      return field->WriteValue(target, field, FD_INT, &Value, 1);
-   }
-
-   inline ERR setLeftLimit(const int Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[27];
-      return field->WriteValue(target, field, FD_INT, &Value, 1);
-   }
-
-   inline ERR setRightLimit(const int Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[20];
-      return field->WriteValue(target, field, FD_INT, &Value, 1);
-   }
-
-   inline ERR setTopLimit(const int Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[34];
-      return field->WriteValue(target, field, FD_INT, &Value, 1);
-   }
-
-   inline ERR setBottomLimit(const int Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[1];
+      auto field = &this->Class->Dictionary[41];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setFlags(const RNF Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[2];
+      auto field = &this->Class->Dictionary[1];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setX(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[29];
+      auto field = &this->Class->Dictionary[26];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }
 
    inline ERR setY(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[17];
+      auto field = &this->Class->Dictionary[16];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }
 
    inline ERR setWidth(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[36];
+      auto field = &this->Class->Dictionary[32];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }
 
    inline ERR setHeight(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[44];
+      auto field = &this->Class->Dictionary[40];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }
@@ -1639,13 +1607,13 @@ class objSurface : public Object {
 
    inline ERR setDimensions(const DMF Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[18];
+      auto field = &this->Class->Dictionary[17];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setCursor(const PTC Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[46];
+      auto field = &this->Class->Dictionary[42];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
@@ -1662,80 +1630,80 @@ class objSurface : public Object {
 
    inline ERR setModal(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[43];
+      auto field = &this->Class->Dictionary[39];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setRootLayer(OBJECTID Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[21];
+      auto field = &this->Class->Dictionary[19];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setAbsX(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[39];
+      auto field = &this->Class->Dictionary[35];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setAbsY(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[6];
+      auto field = &this->Class->Dictionary[5];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setBitsPerPixel(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[37];
+      auto field = &this->Class->Dictionary[33];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setMovement(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[25];
+      auto field = &this->Class->Dictionary[23];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setOpacity(const double Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[31];
+      auto field = &this->Class->Dictionary[28];
       return field->WriteValue(target, field, FD_DOUBLE, &Value, 1);
    }
 
    inline ERR setRevertFocus(OBJECTID Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[15];
+      auto field = &this->Class->Dictionary[14];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setVisible(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[38];
+      auto field = &this->Class->Dictionary[34];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setWindowType(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[11];
+      auto field = &this->Class->Dictionary[10];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    inline ERR setWindowHandle(APTR Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[40];
+      auto field = &this->Class->Dictionary[36];
       return field->WriteValue(target, field, 0x08000308, Value, 1);
    }
 
    inline ERR setXOffset(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[4];
+      auto field = &this->Class->Dictionary[3];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }
 
    inline ERR setYOffset(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[23];
+      auto field = &this->Class->Dictionary[21];
       Unit var(Value);
       return field->WriteValue(target, field, FD_UNIT, &var, 1);
    }

--- a/include/kotuku/system/internals.h
+++ b/include/kotuku/system/internals.h
@@ -35,12 +35,13 @@ enum {
 
 class CoreTimer {
 public:
-   int64_t   NextCall;       // Cycle when PreciseTime() reaches this value (us)
-   int64_t   LastCall;       // PreciseTime() recorded at the last call (us)
-   int64_t   Interval;       // The amount of microseconds to wait at each interval
-   OBJECTPTR Subscriber;     // The object that is subscribed (pointer, if private)
-   OBJECTID  SubscriberID;   // The object that is subscribed
-   FUNCTION  Routine;        // Routine to call if not using AC::Timer - ERR Routine(OBJECTID, int, int);
+   int64_t   NextCall;        // Cycle when PreciseTime() reaches this value (us)
+   int64_t   LastCall;        // PreciseTime() recorded at the last call (us)
+   int64_t   Interval;        // The amount of microseconds to wait at each interval
+   int64_t   PendingInterval; // Switch to this interval after completing the next cycle
+   OBJECTPTR Subscriber;      // The object that is subscribed (pointer, if private)
+   OBJECTID  SubscriberID;    // The object that is subscribed
+   FUNCTION  Routine;         // Routine to call if not using AC::Timer - ERR Routine(OBJECTID, int, int);
    uint8_t   Cycle;
    bool      Locked;
 };

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -927,6 +927,7 @@ ERR UpdateTimer(APTR Subscription, double Interval)
          auto usInterval = -(int64_t(Interval * 1000000.0));
          if (usInterval <= timer->Interval) {
             timer->Interval = usInterval;
+            timer->PendingInterval = 0;
             auto next_call = PreciseTime() + usInterval;
             if (next_call < timer->NextCall) timer->NextCall = next_call;
          }

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -869,13 +869,14 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
 
       auto it = glTimers.emplace(glTimers.end());
       auto subscribed = PreciseTime();
-      it->SubscriberID = subscriber->UID;
-      it->Interval     = usInterval;
-      it->LastCall     = subscribed;
-      it->NextCall     = subscribed + usInterval;
-      it->Routine      = *Callback;
-      it->Locked       = false;
-      it->Cycle        = glTimerCycle - 1;
+      it->SubscriberID    = subscriber->UID;
+      it->Interval        = usInterval;
+      it->PendingInterval = 0;
+      it->LastCall        = subscribed;
+      it->NextCall        = subscribed + usInterval;
+      it->Routine         = *Callback;
+      it->Locked          = false;
+      it->Cycle           = glTimerCycle - 1;
 
       if (subscriber->UID > 0) it->Subscriber = subscriber;
       else it->Subscriber = nullptr;
@@ -883,7 +884,7 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
       // For resource tracking purposes it is important for us to keep a record of the subscription so that
       // we don't treat the object address as valid when it's been removed from the system.
 
-      subscriber->setFlag(NF::TIMER_SUB);
+      subscriber->setFlag(NF::TIMER_SUB); // TODO: Use pin() instead?
       if (Subscription) *Subscription = &*it;
       return ERR::Okay;
    }
@@ -916,14 +917,20 @@ ERR UpdateTimer(APTR Subscription, double Interval)
 
    if (not Subscription) return log.warning(ERR::NullArgs);
 
-   log.msg(VLF::DETAIL|VLF::BRANCH|VLF::FUNCTION, "Subscription: %p, Interval: %.4f", Subscription, Interval);
-
    if (auto lock = std::unique_lock{glmTimer, 1000ms}) {
       auto timer = (CoreTimer *)Subscription;
+      log.msg(VLF::DETAIL|VLF::BRANCH|VLF::FUNCTION, "Subscription: %p, New Interval: %.4f, Current Interval: %.4f", Subscription, Interval, timer->Interval / 1000000.0);
       if (Interval < 0) {
-         // Special mode: Preserve existing timer settings for the subscriber (ticker values are not reset etc)
+         // Special mode:
+         //   Doesn't upgrade the timer immediately unless the new interval < existing interval.
+         //   Extending the interval will apply it on the following cycle.
          auto usInterval = -(int64_t(Interval * 1000000.0));
-         if (usInterval < timer->Interval) timer->Interval = usInterval;
+         if (usInterval <= timer->Interval) {
+            timer->Interval = usInterval;
+            auto next_call = PreciseTime() + usInterval;
+            if (next_call < timer->NextCall) timer->NextCall = next_call;
+         }
+         else timer->PendingInterval = usInterval;
          return ERR::Okay;
       }
       else if (Interval > 0) {

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -264,6 +264,11 @@ timer_cycle:
 
             int64_t elapsed = current_time - timer->LastCall;
 
+            if (timer->PendingInterval) {
+               timer->Interval = timer->PendingInterval;
+               timer->PendingInterval = 0;
+            }
+
             timer->NextCall += timer->Interval;
             if (timer->NextCall < current_time) timer->NextCall = current_time;
             timer->LastCall = current_time;

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -464,7 +464,6 @@ static void notify_redimension_parent(OBJECTPTR Object, ACTIONID ActionID, ERR R
    kt::Log log(__FUNCTION__);
    auto Self = (extSurface *)CurrentContext();
 
-   if (Self->Document) return;
    if (Self->collecting()) return;
 
    log.traceBranch("Redimension notification from parent #%d, currently %dx%d,%dx%d.", Self->ParentID, Self->X, Self->Y, Self->Width, Self->Height);
@@ -1150,24 +1149,6 @@ static ERR SURFACE_Init(extSurface *Self)
          Self->Colour.Alpha = 0;
       }
 
-      // Set FixedX/FixedY accordingly - this is used to assist in the layout process when a surface is used in a document.
-
-      if ((Self->Dimensions & DMF(0xffff)) != DMF::NIL) {
-         if ((dmf::hasAnyX(Self->Dimensions)) and dmf::has(Self->Dimensions, DMF::FIXED_WIDTH|DMF::SCALED_WIDTH|DMF::FIXED_X_OFFSET|DMF::SCALED_X_OFFSET)) {
-            Self->FixedX = true;
-         }
-         else if ((dmf::hasAnyXOffset(Self->Dimensions)) and dmf::has(Self->Dimensions, DMF::FIXED_WIDTH|DMF::SCALED_WIDTH|DMF::FIXED_X|DMF::SCALED_X)) {
-            Self->FixedX = true;
-         }
-
-         if ((dmf::hasAnyY(Self->Dimensions)) and dmf::has(Self->Dimensions, DMF::FIXED_HEIGHT|DMF::SCALED_HEIGHT|DMF::FIXED_Y_OFFSET|DMF::SCALED_Y_OFFSET)) {
-            Self->FixedY = true;
-         }
-         else if ((dmf::hasAnyYOffset(Self->Dimensions)) and dmf::has(Self->Dimensions, DMF::FIXED_HEIGHT|DMF::SCALED_HEIGHT|DMF::FIXED_Y|DMF::SCALED_Y)) {
-            Self->FixedY = true;
-         }
-      }
-
       // Recalculate coordinates if offsets are used
 
       if (dmf::hasXOffset(Self->Dimensions))         Self->setXOffset(Self->XOffset);
@@ -1662,55 +1643,7 @@ static ERR SURFACE_Move(extSurface *Self, struct acMove *Args)
 
    log.traceBranch("X,Y: %d,%d", xchange, ychange);
 
-   // Limit handling
-
-   if (!Self->ParentID) {
-      move_layer(Self, Self->X + move.DeltaX, Self->Y + move.DeltaY);
-   }
-   else {
-      const std::lock_guard<std::recursive_mutex> lock(glSurfaceLock);
-      if ((i = find_parent_list(glSurfaces, Self)) != -1) {
-         // Horizontal limit handling
-
-         if (xchange < 0) {
-            if ((Self->X + xchange) < Self->LeftLimit) {
-               if (Self->X < Self->LeftLimit) move.DeltaX = 0;
-               else move.DeltaX = -(Self->X - Self->LeftLimit);
-            }
-         }
-         else if (xchange > 0) {
-            if ((Self->X + Self->Width) > (glSurfaces[i].Width - Self->RightLimit)) move.DeltaX = 0;
-            else if ((Self->X + Self->Width + xchange) > (glSurfaces[i].Width - Self->RightLimit)) {
-               move.DeltaX = (glSurfaces[i].Width - Self->RightLimit - Self->Width) - Self->X;
-            }
-         }
-
-         // Vertical limit handling
-
-         if (ychange < 0) {
-            if ((Self->Y + ychange) < Self->TopLimit) {
-               if ((Self->Y + Self->Height) < Self->TopLimit) move.DeltaY = 0;
-               else move.DeltaY = -(Self->Y - Self->TopLimit);
-            }
-         }
-         else if (ychange > 0) {
-            if ((Self->Y + Self->Height) > (glSurfaces[i].Height - Self->BottomLimit)) move.DeltaY = 0;
-            else if ((Self->Y + Self->Height + ychange) > (glSurfaces[i].Height - Self->BottomLimit)) {
-               move.DeltaY = (glSurfaces[i].Height - Self->BottomLimit - Self->Height) - Self->Y;
-            }
-         }
-
-         // Second check: If there isn't any movement, return immediately
-
-         if ((!move.DeltaX) and (!move.DeltaY)) {
-            return ERR::Failed|ERR::Notified;
-         }
-      }
-
-      // Move the graphics layer
-
-      move_layer(Self, Self->X + move.DeltaX, Self->Y + move.DeltaY);
-   }
+   move_layer(Self, Self->X + move.DeltaX, Self->Y + move.DeltaY);
 
 /* These lines cause problems for the resizing of offset surface objects.
    if (dmf::hasAnyXOffset(Self->Dimensions)) Self->XOffset += move.DeltaX;
@@ -1962,10 +1895,6 @@ static ERR SURFACE_NewOwner(extSurface *Self, struct acNewOwner *Args)
 
 static ERR SURFACE_NewObject(extSurface *Self)
 {
-   Self->LeftLimit   = -1000000000;
-   Self->RightLimit  = -1000000000;
-   Self->TopLimit    = -1000000000;
-   Self->BottomLimit = -1000000000;
    Self->Opacity     = 1.0;
    Self->RootID      = Self->UID;
    Self->WindowType  = glpWindowType;
@@ -2160,16 +2089,23 @@ static ERR SURFACE_ResetDimensions(extSurface *Self, struct drw::ResetDimensions
 -METHOD-
 ScheduleRedraw: Schedules a redraw operation for the next frame.
 
-Use ScheduleRedraw() to mark a surface for redraw on the next frame cycle.  The surface and its child surfaces are
-redrawn together, typically on the next 1/60th of a second timer tick.  Direct redraw requests for the target surface
-are coalesced until the scheduled redraw is processed.
+Use ScheduleRedraw() to mark a surface for redraw on the next frame cycle.  The delay is governed by the chosen
+RefreshRate, which is measured in frames per second.  If a RefreshRate is not specified, the frame rate is derived
+from the display.
 
-Scheduling is ideal in situations where a cluster of redraw events may occur within a tight time period, and it
-would be inefficient to draw those changes to the display individually.
+Specifying a custom RefreshRate is recommended when processing an animation at a lower frame rate than that of the
+display would be acceptable.
 
-Redraw schedules do not merge across the hierarchy.  If both a surface and one of its children are scheduled, two
-redraw operations may be triggered where one would otherwise suffice.  Schedule the highest relevant surface when a
-single redraw should cover a group of changes.
+Scheduling with this method over #Draw() (immediate mode) is recommended when a cluster of redraw events may occur
+within a tight time period, and it would be inefficient to draw those changes to the display individually.  Repeated
+redraw requests made to the target surface are coalesced until the scheduled redraw is processed.
+
+Redraw schedules do not collapse in nested surfaces.  If both a surface and one of its children are scheduled, two
+redraw operations may be triggered where one would otherwise suffice.  Target the top-level surface only in such
+instances.
+
+-INPUT-
+int RefreshRate: Optional refresh rate in frames per second.  If not specified, the refresh rate from the display is used.
 
 -ERRORS-
 Okay
@@ -2178,21 +2114,46 @@ Failed
 
 *********************************************************************************************************************/
 
-static ERR SURFACE_ScheduleRedraw(extSurface *Self)
+static ERR SURFACE_ScheduleRedraw(extSurface *Self, struct drw::ScheduleRedraw *Args)
 {
-   // TODO Currently defaults to 60FPS, we should get the correct FPS from the Display object.
-   const double FPS = 60.0;
+   int refresh_rate;
 
-   if (Self->RedrawScheduled) return ERR::Okay;
+   if ((Args) and (Args->RefreshRate > 0)) {
+      refresh_rate = Args->RefreshRate;
+      if (refresh_rate > 255) refresh_rate = 255;
+   }
+   else {
+      if (!Self->RefreshRate) {
+         // Prefer to use the display refresh rate.  Note: Refresh rate should not be a determining factor for animation
+         // frame rates - the client application is responsible for making that determination with the user.
+         DisplayInfo *info;
+         if (gfx::GetDisplayInfo(Self->DisplayID, &info) IS ERR::Okay) {
+            if (info->RefreshRate > 255) Self->RefreshRate = 255;
+            else Self->RefreshRate = info->RefreshRate;
+         }
+
+         if (!Self->RefreshRate) Self->RefreshRate = 60;
+         else if (Self->RefreshRate < 25) Self->RefreshRate = 25;
+         else if (Self->RefreshRate > 120) Self->RefreshRate = 120;
+      }
+
+      refresh_rate = Self->RefreshRate;
+   }
+
+   Self->RedrawCountdown = refresh_rate * 2; // Maintain subscriptions for up to 2 seconds
+
+   if ((Self->RedrawScheduled) and (refresh_rate IS Self->RedrawRate)) return ERR::Okay;
 
    if (Self->RedrawTimer) {
+      UpdateTimer(Self->RedrawTimer, -(1.0 / double(refresh_rate)));
       Self->RedrawScheduled = true;
+      Self->RedrawRate = refresh_rate;
       return ERR::Okay;
    }
 
-   if (SubscribeTimer(1.0 / FPS, C_FUNCTION(redraw_timer), &Self->RedrawTimer) IS ERR::Okay) {
-      Self->RedrawCountdown = FPS * 30.0;
+   if (SubscribeTimer(1.0 / double(refresh_rate), C_FUNCTION(redraw_timer), &Self->RedrawTimer) IS ERR::Okay) {
       Self->RedrawScheduled = true;
+      Self->RedrawRate = refresh_rate;
       return ERR::Okay;
    }
    else return ERR::Failed;
@@ -2600,11 +2561,6 @@ static const FieldDef clWindowType[] = { // This table is copied from pointer_cl
    { nullptr, 0 }
 };
 
-static const FieldDef clTypeFlags[] = {
-   { "Root", RT::ROOT },
-   { nullptr, 0 }
-};
-
 #include "surface_def.c"
 
 static const FieldArray clSurfaceFields[] = {
@@ -2616,10 +2572,6 @@ static const FieldArray clSurfaceFields[] = {
    { "MinHeight",    FDF_INT|FDF_RW,  nullptr, SET_MinHeight },
    { "MaxWidth",     FDF_INT|FDF_RW,  nullptr, SET_MaxWidth },
    { "MaxHeight",    FDF_INT|FDF_RW,  nullptr, SET_MaxHeight },
-   { "LeftLimit",    FDF_INT|FDF_RW,  nullptr, SET_LeftLimit },
-   { "RightLimit",   FDF_INT|FDF_RW,  nullptr, SET_RightLimit },
-   { "TopLimit",     FDF_INT|FDF_RW,  nullptr, SET_TopLimit },
-   { "BottomLimit",  FDF_INT|FDF_RW,  nullptr, SET_BottomLimit },
    { "Display",      FDF_OBJECTID|FDF_R, nullptr, nullptr, CLASSID::DISPLAY },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, SET_Flags, &clSurfaceFlags },
    { "X",            FDF_UNIT|FDF_INT|FDF_SCALED|FDF_RW, GET_XCoord, SET_XCoord },
@@ -2632,7 +2584,7 @@ static const FieldArray clSurfaceFields[] = {
    { "DragStatus",   FDF_INT|FDF_LOOKUP|FDF_R, nullptr, nullptr, &clSurfaceDragStatus },
    { "Cursor",       FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SET_Cursor, &clSurfaceCursor },
    { "Colour",       FDF_RGB|FDF_RW },
-   { "Type",         FDF_SYSTEM|FDF_INT|FDF_RI, nullptr, nullptr, &clTypeFlags },
+   { "Type",         FDF_SYSTEM|FDF_INT|FDF_RI, nullptr, nullptr, &clSurfaceType },
    { "Modal",        FDF_INT|FDF_RW, nullptr, SET_Modal },
    // Virtual fields
    { "AbsX",          FDF_VIRTUAL|FDF_INT|FDF_RW, GET_AbsX, SET_AbsX },

--- a/src/display/class_surface/surface_def.c
+++ b/src/display/class_surface/surface_def.c
@@ -212,6 +212,7 @@ FDEF maSetOpacity[] = { { "Value", FD_DOUBLE }, { "Adjustment", FD_DOUBLE }, { 0
 FDEF maAddCallback[] = { { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
 FDEF maResetDimensions[] = { { "X", FD_DOUBLE }, { "Y", FD_DOUBLE }, { "XOffset", FD_DOUBLE }, { "YOffset", FD_DOUBLE }, { "Width", FD_DOUBLE }, { "Height", FD_DOUBLE }, { "Dimensions", FD_INT }, { 0, 0 } };
 FDEF maRemoveCallback[] = { { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
+FDEF maScheduleRedraw[] = { { "RefreshRate", FD_INT }, { 0, 0 } };
 
 static const struct MethodEntry clSurfaceMethods[] = {
    { AC(-1), (APTR)SURFACE_InheritedFocus, "InheritedFocus", maInheritedFocus, sizeof(struct drw::InheritedFocus) },
@@ -223,7 +224,7 @@ static const struct MethodEntry clSurfaceMethods[] = {
    { AC(-7), (APTR)SURFACE_Minimise, "Minimise", 0, 0 },
    { AC(-8), (APTR)SURFACE_ResetDimensions, "ResetDimensions", maResetDimensions, sizeof(struct drw::ResetDimensions) },
    { AC(-9), (APTR)SURFACE_RemoveCallback, "RemoveCallback", maRemoveCallback, sizeof(struct drw::RemoveCallback) },
-   { AC(-10), (APTR)SURFACE_ScheduleRedraw, "ScheduleRedraw", 0, 0 },
+   { AC(-10), (APTR)SURFACE_ScheduleRedraw, "ScheduleRedraw", maScheduleRedraw, sizeof(struct drw::ScheduleRedraw) },
    { AC::NIL, 0, 0, 0, 0 }
 };
 

--- a/src/display/class_surface/surface_dimensions.cpp
+++ b/src/display/class_surface/surface_dimensions.cpp
@@ -106,24 +106,6 @@ static ERR GET_Bottom(extSurface *Self, int *Bottom)
 /*********************************************************************************************************************
 
 -FIELD-
-BottomLimit: Prevents a surface object from moving beyond a given point at the bottom of its container.
-
-Set `BottomLimit` to reserve a margin at the bottom of the parent container.  For example, a value of `5` prevents
-#Move() from placing the surface inside the bottom-most five coordinate units.
-
-Movement limits apply only to #Move().  Direct writes to coordinate fields bypass them.
-
-*********************************************************************************************************************/
-
-static ERR SET_BottomLimit(extSurface *Self, int Value)
-{
-   Self->BottomLimit = Value;
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--FIELD-
 Dimensions: Indicates currently active dimension settings.
 Lookup: DMF
 
@@ -290,24 +272,6 @@ static ERR SET_Height(extSurface *Self, Unit *Value)
 /*********************************************************************************************************************
 
 -FIELD-
-LeftLimit: Prevents a surface object from moving beyond a given point on the left-hand side.
-
-Set `LeftLimit` to reserve a margin at the left-hand side of the parent container.  For example, a value of `3`
-prevents #Move() from placing the surface inside the left-most three coordinate units.
-
-Movement limits apply only to #Move().  Direct writes to coordinate fields bypass them.
-
-*********************************************************************************************************************/
-
-static ERR SET_LeftLimit(extSurface *Self, int Value)
-{
-   Self->LeftLimit = Value;
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--FIELD-
 MaxHeight: Prevents the height of a surface object from exceeding a certain value.
 
 Set `MaxHeight` to limit the maximum height that can be applied through resizing.  #Resize() cannot increase the
@@ -424,42 +388,6 @@ Right: Returns the right-most coordinate of a surface object, `X + Width`.
 static ERR GET_Right(extSurface *Self, int *Value)
 {
    *Value = Self->X + Self->Width;
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--FIELD-
-RightLimit: Prevents a surface object from moving beyond a given point on the right-hand side.
-
-Set `RightLimit` to reserve a margin at the right-hand side of the parent container.  For example, a value of `8`
-prevents #Move() from placing the surface inside the right-most eight coordinate units.
-
-Movement limits apply only to #Move().  Direct writes to coordinate fields bypass them.
-
-*********************************************************************************************************************/
-
-static ERR SET_RightLimit(extSurface *Self, int Value)
-{
-   Self->RightLimit = Value;
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--FIELD-
-TopLimit: Prevents a surface object from moving beyond a given point at the top of its container.
-
-Set `TopLimit` to reserve a margin at the top of the parent container.  For example, a value of `10` prevents #Move()
-from placing the surface inside the top-most ten coordinate units.
-
-Movement limits apply only to #Move().  Direct writes to coordinate fields bypass them.
-
-*********************************************************************************************************************/
-
-static ERR SET_TopLimit(extSurface *Self, int Value)
-{
-   Self->TopLimit = Value;
    return ERR::Okay;
 }
 

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -326,6 +326,11 @@ class extSurface : public objSurface {
    SurfaceCallback *Callback;
    APTR      Data;
    double   Opacity;
+   int     XOffset, YOffset;     // Fixed horizontal and vertical offset
+   double  XOffsetPercent;       // Scaled horizontal offset
+   double  YOffsetPercent;       // Scaled vertical offset
+   double  WidthPercent, HeightPercent; // Scaled width and height
+   double  XPercent, YPercent;   // Scaled coordinate
    WINHANDLE DisplayWindow;       // Reference to the platform dependent window representing the Surface object
    OBJECTID PrevModalID;          // Previous surface to have been modal
    OBJECTID BitmapOwnerID;        // The surface object that owns the root bitmap
@@ -335,21 +340,17 @@ class extSurface : public objSurface {
    int      InputHandle;          // Input handler for dragging of surfaces
    SWIN     WindowType;           // See SWIN constants
    TIMER    RedrawTimer;          // For ScheduleRedraw()
-   SurfaceCallback CallbackCache[4];
-   int16_t  ScrollProgress;
+   SurfaceCallback CallbackCache[3]; // For AddCallback()
    uint16_t InheritedRoot:1;      // TRUE if the user set the RootLayer manually
    uint16_t ParentDefined:1;      // TRUE if the parent field was set manually
-   uint16_t SkipPopOver:1;
-   uint16_t FixedX:1;
-   uint16_t FixedY:1;
-   uint16_t Document:1;
    uint16_t RedrawScheduled:1;
    uint16_t RedrawCountdown;      // Unsubscribe from the timer when this value reaches zero.
+   uint8_t  RefreshRate;          // Cached copy of the display refresh rate.  0 = Not queried
+   uint8_t  RedrawRate;           // Last refresh rate used for scheduled redrawing
    int8_t   BitsPerPixel;         // Bitmap bits per pixel
    int8_t   BytesPerPixel;        // Bitmap bytes per pixel
    uint8_t  CallbackCount;
    uint8_t  CallbackSize;         // Current size of the callback array.
-   int8_t   Anchored;
 };
 
 class extDisplay : public objDisplay {

--- a/src/display/display.tdl
+++ b/src/display/display.tdl
@@ -605,10 +605,6 @@ module({
     int MinHeight         # Minimum height setting
     int MaxWidth          # Maximum width setting
     int MaxHeight         # Maximum height setting
-    int LeftLimit         # Limits the surface area from moving too far left
-    int RightLimit        # Limits the surface area from moving too far right
-    int TopLimit          # Limits the surface area from moving too far up
-    int BottomLimit       # Limits the surface area from moving too far down
     oid Display           # Refers to the Display object that is managing the surface's graphics.
     int(RNF) Flags        # Special flags
     int X                 # Fixed horizontal coordinate
@@ -625,12 +621,6 @@ module({
     int Modal             # Set to 1 to enable modal mode
   ]],
   [[
-   // These coordinate fields are considered private but may be accessed by some internal classes, like Document
-   int     XOffset, YOffset;     // Fixed horizontal and vertical offset
-   double  XOffsetPercent;       // Scaled horizontal offset
-   double  YOffsetPercent;       // Scaled vertical offset
-   double  WidthPercent, HeightPercent; // Scaled width and height
-   double  XPercent, YPercent;   // Scaled coordinate
   ]],
   [[
    inline bool visible() const { return (Flags & RNF::VISIBLE) != RNF::NIL; }

--- a/src/vector/scene/scene.cpp
+++ b/src/vector/scene/scene.cpp
@@ -186,7 +186,7 @@ static void notify_redimension(OBJECTPTR Object, ACTIONID ActionID, ERR Result, 
       }
 
       kt::ScopedObjectLock<objSurface> surface(Self->SurfaceID);
-      if (surface.granted()) surface->scheduleRedraw();
+      if (surface.granted()) surface->scheduleRedraw(0);
    }
 }
 

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -248,7 +248,7 @@ static ERR VECTOR_Draw(extVector *Self, struct acDraw *Args)
 #endif
 
       if (kt::ScopedObjectLock<objSurface> surface(Self->Scene->SurfaceID); surface.granted()) {
-         surface->scheduleRedraw();
+         surface->scheduleRedraw(0);
          return ERR::Okay;
       }
       else return ERR::AccessObject;
@@ -1419,7 +1419,7 @@ static ERR VECTOR_SET_Fill(extVector *Self, CSTRING Value)
 FillColour: Defines a solid colour for filling the vector path.
 
 Set the FillColour field to define a solid colour for filling the vector path.  The colour is defined as an array
-of four 32-bit floating point values between 0 and 1.0 if restricted to sRGB colourspace.  The array elements 
+of four 32-bit floating point values between 0 and 1.0 if restricted to sRGB colourspace.  The array elements
 consist of Red, Green, Blue and Alpha values in that order.
 
 If the Alpha component is set to zero then the FillColour will be ignored by the renderer.
@@ -1570,7 +1570,7 @@ static ERR VECTOR_SET_FillRule(extVector *Self, VFR Value)
 -FIELD-
 SID: String identifier for a vector.
 
-The SID field is provided for SVG support.  Use the existing object name and UID for identification in all other 
+The SID field is provided for SVG support.  Use the existing object name and UID for identification in all other
 circumstances.
 
 *********************************************************************************************************************/


### PR DESCRIPTION
## Summary

* Removed the `LeftLimit`, `RightLimit`, `TopLimit`, and `BottomLimit` fields from the Surface class along with all associated movement-limit enforcement in `SURFACE_Move()`.
* Extended `ScheduleRedraw()` to accept an optional `RefreshRate` parameter (fps); when omitted the method queries and caches the display's native refresh rate, replacing the previous hard-coded 60 fps default.
* Added `PendingInterval` to `CoreTimer` so that `UpdateTimer()` can defer an interval *increase* to the next cycle while applying an interval *reduction* immediately, fixing a scheduling edge-case.
* Moved private coordinate fields (`XOffset`, `YOffset`, `XOffsetPercent`, etc.) from the generated `objSurface` into `extSurface`; removed unused flags `FixedX`, `FixedY`, `Document`, and `Anchored`.
* Minor script clean-up in `benchmark_particles.tiri`: cached `math.pi` as a local `PI` constant and switched the particle loop to the `values()` iterator.

## Test plan

- [ ] Build the `display` and `core` modules and confirm no compile errors.
- [ ] Verify that surfaces with no `RefreshRate` argument still redraw at the display's native rate.
- [ ] Verify that passing an explicit `RefreshRate` (e.g. 30) throttles the redraw timer correctly.
- [ ] Run the particle benchmark (`examples/benchmark_particles.tiri`) and confirm it executes without errors.
- [ ] Confirm that surfaces still move freely without movement-limit side-effects after the limit fields are removed.
- [ ] Run the full integration test suite: `ctest --build-config Debug --test-dir build/agents --output-on-failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)