### PR TITLE
[Core] Optimise message queue and LoadFile cache paths

### DIFF
--- a/docs/html/modules/classes/compressedstream.html
+++ b/docs/html/modules/classes/compressedstream.html
@@ -157,7 +157,7 @@
 <tr><th>MEM::WRITE</th><td>The memory is explicitly marked as writeable.</td></tr>
 </tbody></table><div class="footer copyright text-right">CompressedStream module documentation © Paul Manias 1996-2026</div></div>
 <div class="docs-content" style="display:none;" id="MSF"><h1>MSF Type</h1><p class="lead">Message flags.</p><table class="table"><thead><tr><th class="col-md-1">Name</th><th>Description</th></tr></thead><tbody><tr><th>MSF::NO_DUPLICATE</th><td>If the <code>Type</code> parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with <code>ERR::Okay</code>.</td></tr>
-<tr><th>MSF::UPDATE</th><td>If the <code>Type</code> parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue.</td></tr>
+<tr><th>MSF::UPDATE</th><td>If <code>Type</code> matches a queued message, update that message's data in place.</td></tr>
 </tbody></table><div class="footer copyright text-right">CompressedStream module documentation © Paul Manias 1996-2026</div></div>
 <div class="docs-content" style="display:none;" id="MSGID"><h1>MSGID Type</h1><p class="lead">Reserved message ID's that are handled internally.</p><table class="table"><thead><tr><th class="col-md-1">Name</th><th>Description</th></tr></thead><tbody><tr><th>MSGID::ACTION</th><td></td></tr>
 <tr><th>MSGID::BREAK</th><td></td></tr>

--- a/docs/html/modules/core.html
+++ b/docs/html/modules/core.html
@@ -1767,7 +1767,7 @@ static ResourceManager glNodeManager = {
 <tr><th>MOVE::UP</th><td></td></tr>
 </tbody></table><div class="footer copyright text-right">Core module documentation © Paul Manias 1996-2026</div></div>
 <div class="docs-content" style="display:none;" id="MSF"><h1>MSF Type</h1><p class="lead">Message flags.</p><table class="table"><thead><tr><th class="col-md-1">Name</th><th>Description</th></tr></thead><tbody><tr><th>MSF::NO_DUPLICATE</th><td>If the <code>Type</code> parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with <code>ERR::Okay</code>.</td></tr>
-<tr><th>MSF::UPDATE</th><td>If the <code>Type</code> parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue.</td></tr>
+<tr><th>MSF::UPDATE</th><td>If <code>Type</code> matches a queued message, update that message's data in place.</td></tr>
 </tbody></table><div class="footer copyright text-right">Core module documentation © Paul Manias 1996-2026</div></div>
 <div class="docs-content" style="display:none;" id="MSGID"><h1>MSGID Type</h1><p class="lead">Reserved message ID's that are handled internally.</p><table class="table"><thead><tr><th class="col-md-1">Name</th><th>Description</th></tr></thead><tbody><tr><th>MSGID::ACTION</th><td></td></tr>
 <tr><th>MSGID::BREAK</th><td></td></tr>

--- a/docs/xml/ai/modules/core.xml
+++ b/docs/xml/ai/modules/core.xml
@@ -1196,7 +1196,7 @@
     <ai:k n="ADD" c="The default behaviour - this will add the message to the end of the queue."/>
     <ai:k n="MESSAGE_ID" c="The Type parameter refers to a unique message ID rather than a message type for this call."/>
     <ai:k n="NO_DUPLICATE" c="If the Type parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with ERR::Okay."/>
-    <ai:k n="UPDATE" c="If the Type parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue."/>
+    <ai:k n="UPDATE" c="If Type matches a queued message, update that message's data in place."/>
     <ai:k n="WAIT" c="Wait before inserting the message if the queue is at maximum capacity."/>
   </ai:c>
   <ai:c l="MSGID" c="Reserved message ID's that are handled internally.">

--- a/docs/xml/modules/classes/compressedstream.xml
+++ b/docs/xml/modules/classes/compressedstream.xml
@@ -193,7 +193,7 @@
 
     <constants lookup="MSF" comment="Message flags.">
       <const name="NO_DUPLICATE">If the <code>Type</code> parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with <code>ERR::Okay</code>.</const>
-      <const name="UPDATE">If the <code>Type</code> parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue.</const>
+      <const name="UPDATE">If <code>Type</code> matches a queued message, update that message's data in place.</const>
     </constants>
 
     <constants lookup="MSGID" comment="Reserved message ID's that are handled internally.">

--- a/docs/xml/modules/core.xml
+++ b/docs/xml/modules/core.xml
@@ -2728,7 +2728,7 @@ static ResourceManager glNodeManager = {
 
     <constants lookup="MSF" comment="Message flags.">
       <const name="NO_DUPLICATE">If the <code>Type</code> parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with <code>ERR::Okay</code>.</const>
-      <const name="UPDATE">If the <code>Type</code> parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue.</const>
+      <const name="UPDATE">If <code>Type</code> matches a queued message, update that message's data in place.</const>
     </constants>
 
     <constants lookup="MSGID" comment="Reserved message ID's that are handled internally.">

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -156,6 +156,7 @@ flute_test (core_filesystem "tests/test_filesystem.tiri")
 flute_test (core_misc "tests/test_misc.tiri")
 flute_test (core_compression "tests/test_compression.tiri")
 flute_test (core_config "tests/test_config.tiri")
+flute_test (core_messages "tests/test_messages.tiri")
 flute_test (core_time "tests/test_time.tiri")
 
 if (INSTALL_TESTS)

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -839,15 +839,15 @@ class TaskMessage {
    // Constructors
 
    public:
-   TaskMessage() : Size(0), ExtBuffer(nullptr) { }
+   TaskMessage() : Time(0), UID(0), Type(MSGID::NIL), Size(0), ExtBuffer(nullptr) { }
 
-   TaskMessage(MSGID pType, APTR pData = nullptr, int pSize = 0) {
+   TaskMessage(MSGID MsgType, APTR Data = nullptr, int DataSize = 0) {
       Time = PreciseTime();
       UID  = ++glUniqueMsgID;
-      Type = pType;
+      Type = MsgType;
       Size = 0;
       ExtBuffer = nullptr;
-      if ((pData) and (pSize)) setBuffer(pData, pSize);
+      if ((Data) and (DataSize)) setBuffer(Data, DataSize);
    }
 
    ~TaskMessage() {
@@ -855,32 +855,42 @@ class TaskMessage {
    }
 
    // Move constructor
-   TaskMessage(TaskMessage &&other) noexcept {
-      ExtBuffer = nullptr;
-      copy_from(other);
-      other.Size = 0;
-      other.ExtBuffer = nullptr; // Source loses its buffer
+   TaskMessage(TaskMessage &&Other) noexcept :
+      Time(Other.Time), UID(Other.UID), Type(Other.Type), Size(Other.Size), ExtBuffer(Other.ExtBuffer) {
+      if ((not ExtBuffer) and (Size)) copymem(Other.Buffer.data(), Buffer.data(), Size);
+      Other.Size = 0;
+      Other.ExtBuffer = nullptr;
    }
 
    // Copy constructor
-   TaskMessage(const TaskMessage &other) {
+   TaskMessage(const TaskMessage &Other) {
       ExtBuffer = nullptr;
-      copy_from(other);
+      copy_from(Other);
    }
 
    // Move assignment
-   TaskMessage& operator=(TaskMessage &&other) noexcept {
-      if (this == &other) return *this;
-      copy_from(other);
-      other.Size = 0;
-      other.ExtBuffer = nullptr; // Source loses its buffer
+   TaskMessage& operator=(TaskMessage &&Other) noexcept {
+      if (this IS &Other) return *this;
+
+      if (ExtBuffer) { delete[] ExtBuffer; ExtBuffer = nullptr; }
+
+      Time = Other.Time;
+      UID  = Other.UID;
+      Type = Other.Type;
+      Size = Other.Size;
+      ExtBuffer = Other.ExtBuffer;
+
+      if ((not ExtBuffer) and (Size)) copymem(Other.Buffer.data(), Buffer.data(), Size);
+
+      Other.Size = 0;
+      Other.ExtBuffer = nullptr;
       return *this;
    }
 
    // Copy assignment
-   TaskMessage& operator=(const TaskMessage& other) {
-      if (this == &other) return *this;
-      copy_from(other);
+   TaskMessage& operator=(const TaskMessage& Other) {
+      if (this IS &Other) return *this;
+      copy_from(Other);
       return *this;
    }
 
@@ -888,26 +898,29 @@ class TaskMessage {
 
    char * getBuffer() { return ExtBuffer ? ExtBuffer : Buffer.data(); }
 
-   void setBuffer(APTR pData, size_t pSize) {
+   void setBuffer(APTR Data, size_t Size) {
       if (ExtBuffer) { delete[] ExtBuffer; ExtBuffer = nullptr; }
 
-      if (pSize <= Buffer.size()) copymem(pData, Buffer.data(), pSize);
+      if (Size <= Buffer.size()) copymem(Data, Buffer.data(), Size);
       else {
-         ExtBuffer = new (std::nothrow) char[pSize];
-         if (ExtBuffer) copymem(pData, ExtBuffer, pSize);
+         ExtBuffer = new (std::nothrow) char[Size];
+         if (ExtBuffer) copymem(Data, ExtBuffer, Size);
       }
 
-      Size = pSize;
+      this->Size = Size;
    }
 
    private:
-   inline void copy_from(const TaskMessage &Source, bool Constructor = false) {
+   inline void copy_from(const TaskMessage &Source) {
       Time = Source.Time;
       UID  = Source.UID;
       Type = Source.Type;
       Size = Source.Size;
       if (Source.ExtBuffer) setBuffer(Source.ExtBuffer, Size);
-      else if (Size) copymem(Source.Buffer.data(), Buffer.data(), Size);
+      else {
+         if (ExtBuffer) { delete[] ExtBuffer; ExtBuffer = nullptr; }
+         if (Size) copymem(Source.Buffer.data(), Buffer.data(), Size);
+      }
    }
 };
 

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -61,7 +61,7 @@ constexpr bool defined(T flags, T test_flag) noexcept {
      "MATCH_LEN: The strings must be of equal length to be matched.")
 
   flags("MSF", { comment="Message flags." },
-     "UPDATE: If the `Type` parameter matches a message already inside the queue, the data for that message will be deleted, then the new message will be added to the end of the queue.",
+     "UPDATE: If `Type` matches a queued message, update that message's data in place.",
      "NO_DUPLICATE: If the `Type` parameter matches a message already inside the queue, the new message will not be added and the function will immediately return with `ERR::Okay`.")
 
   flags("PMF", { comment="Flags for ProcessMessages" },

--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -59,6 +59,8 @@ typedef int HANDLE;
 #include <errno.h>
 #include <map>
 #include <mutex>
+#include <condition_variable>
+#include <memory>
 #include <bit>
 
 #ifdef _WIN32
@@ -148,8 +150,17 @@ namespace std {
    };
 }
 
-static ankerl::unordered_dense::map<CacheFileIndex, extCacheFile> glCache;
+static ankerl::unordered_dense::map<CacheFileIndex, std::unique_ptr<extCacheFile>> glCache;
 static std::mutex glCacheLock;
+
+struct CacheLoadState {
+   std::mutex Lock;
+   std::condition_variable Ready;
+   bool Loading = true;
+   ERR Error = ERR::Okay;
+};
+
+static ankerl::unordered_dense::map<CacheFileIndex, std::shared_ptr<CacheLoadState>> glCacheLoading;
 
 //********************************************************************************************************************
 
@@ -174,6 +185,7 @@ static std::mutex glCacheLock;
 void free_file_cache(void)
 {
    glCache.clear();
+   glCacheLoading.clear();
 }
 
 //********************************************************************************************************************
@@ -331,14 +343,14 @@ ERR check_cache(OBJECTPTR Subscriber, int64_t Elapsed, int64_t CurrentTime)
 
    const std::lock_guard<std::mutex> lock(glCacheLock);
    for (auto it=glCache.begin(); it != glCache.end(); ) {
-      if ((CurrentTime - it->second.LastUse >= CACHE_EXPIRY_MICROSECONDS) and (it->second.Locks <= 0)) {
-         log.msg("Removing expired cache file: %.80s", it->second.Path);
+      if ((CurrentTime - it->second->LastUse >= CACHE_EXPIRY_MICROSECONDS) and (it->second->Locks <= 0)) {
+         log.msg("Removing expired cache file: %.80s", it->second->Path);
          it = glCache.erase(it);
       }
       else it++;
    }
 
-   if (glCache.empty()) {
+   if (glCache.empty() and glCacheLoading.empty()) {
       glCacheTimer = 0;
       return ERR::Terminate;
    }
@@ -887,14 +899,13 @@ ERR LoadFile(CSTRING Path, LDF Flags, CacheFile **Cache)
    kt::Log log(__FUNCTION__);
 
    if ((not Path) or (not Cache)) return ERR::NullArgs;
+   *Cache = nullptr;
 
    // Check if the file is already cached.  If it is, check that the file hasn't been written since the last time it was cached.
 
    std::string path;
    ERR error;
    if ((error = ResolvePath(Path, RSF::APPROXIMATE, &path)) != ERR::Okay) return error;
-
-   const std::lock_guard<std::mutex> lock(glCacheLock);
 
    log.branch("%.80s, Flags: $%.8x", path.c_str(), int(Flags));
 
@@ -905,39 +916,78 @@ ERR LoadFile(CSTRING Path, LDF Flags, CacheFile **Cache)
       auto timestamp = file->get<int64_t>(FID_Timestamp);
 
       CacheFileIndex index(path, timestamp, file_size);
+      std::shared_ptr<CacheLoadState> loading_state;
 
-      if (glCache.contains(index)) {
-         *((extCacheFile **)Cache) = &glCache[index];
-         if ((Flags & LDF::CHECK_EXISTS) IS LDF::NIL) glCache[index].Locks++;
-         return ERR::Okay;
+      while (true) {
+         {
+            const std::lock_guard<std::mutex> lock(glCacheLock);
+
+            if (auto cache = glCache.find(index); cache != glCache.end()) {
+               *Cache = cache->second.get();
+               (*Cache)->LastUse = PreciseTime();
+               if ((Flags & LDF::CHECK_EXISTS) IS LDF::NIL) cache->second->Locks++;
+               return ERR::Okay;
+            }
+
+            // If the client just wanted to check for the existence of the file, do not proceed in loading it.
+
+            if ((Flags & LDF::CHECK_EXISTS) != LDF::NIL) return ERR::Search;
+
+            if (auto pending = glCacheLoading.find(index); pending != glCacheLoading.end()) {
+               loading_state = pending->second;
+            }
+            else {
+               loading_state = std::make_shared<CacheLoadState>();
+               glCacheLoading.emplace(index, loading_state);
+               break;
+            }
+         }
+
+         std::unique_lock<std::mutex> pending_lock(loading_state->Lock);
+         loading_state->Ready.wait(pending_lock, [&loading_state] { return not loading_state->Loading; });
+
+         if (loading_state->Error != ERR::Okay) return loading_state->Error;
       }
 
-      // If the client just wanted to check for the existence of the file, do not proceed in loading it.
-
-      if ((Flags & LDF::CHECK_EXISTS) != LDF::NIL) {
-         return ERR::Search;
-      }
-
-      glCache.emplace(index, extCacheFile(path, file_size, timestamp));
+      auto loaded_cache = std::make_unique<extCacheFile>(path, file_size, timestamp);
 
       if (file_size) {
          int result;
-         error = file->read(glCache[index].Data, file_size, &result);
-         if ((error IS ERR::Okay) and (file_size != result)) return ERR::Read;
+         error = file->read(loaded_cache->Data, file_size, &result);
+         if ((error IS ERR::Okay) and (file_size != result)) error = ERR::Read;
       }
 
       if (error IS ERR::Okay) {
-         *((extCacheFile **)Cache) = &glCache[index];
+         {
+            const std::lock_guard<std::mutex> lock(glCacheLock);
+            auto result = glCache.emplace(index, std::move(loaded_cache));
+            auto cache = result.first;
+            *Cache = cache->second.get();
+            if (not result.second) cache->second->Locks++;
 
-         if (not glCacheTimer) {
-            kt::SwitchContext context(CurrentTask());
-            auto call = C_FUNCTION(check_cache);
-            SubscribeTimer(60, &call, &glCacheTimer);
+            if (not glCacheTimer) {
+               kt::SwitchContext context(CurrentTask());
+               auto call = C_FUNCTION(check_cache);
+               SubscribeTimer(60, &call, &glCacheTimer);
+            }
+
+            glCacheLoading.erase(index);
          }
-
-         return ERR::Okay;
       }
-      else return error;
+
+      if (error != ERR::Okay) {
+         const std::lock_guard<std::mutex> lock(glCacheLock);
+         glCacheLoading.erase(index);
+      }
+
+      {
+         const std::lock_guard<std::mutex> lock(loading_state->Lock);
+         loading_state->Error = error;
+         loading_state->Loading = false;
+      }
+
+      loading_state->Ready.notify_all();
+      return error;
    }
    else return ERR::CreateObject;
 }

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -44,8 +44,10 @@ ERR write_nonblock(int Handle, APTR Data, int Size, int64_t EndTime);
 
 static const int MAX_MSEC = 1000;
 
-static std::recursive_mutex glQueueLock;
+static constexpr size_t MESSAGE_BATCH_LIMIT = 30;
+static std::mutex glQueueLock;
 static std::deque<TaskMessage> glQueue; // Available to all threads, use glQueueLock
+static std::atomic_size_t glQueuedMessages = 0;
 
 template <class T> inline APTR ResolveAddress(T *Pointer, int Offset) {
    return APTR(((int8_t *)Pointer) + Offset);
@@ -248,6 +250,9 @@ ERR ProcessMessages(PMF Flags, int TimeOut)
       return log.warning(ERR::SystemLocked);
    }
 
+   std::vector<TaskMessage> local_batch;
+   local_batch.reserve(MESSAGE_BATCH_LIMIT);
+
    do { // Standard message handler for the core process.
       // Call all objects on the timer list (managed by SubscribeTimer()).  To manage timer locking cleanly, the loop
       // is restarted after each client call.  To prevent more than one call per cycle, the glTimerCycle is used to
@@ -333,17 +338,17 @@ timer_cycle:
       // Consume queued messages.  Drain a batch from the shared queue under the lock, then process
       // outside the lock to reduce contention with threads calling SendMessage().
 
-      std::vector<TaskMessage> local_batch;
+      local_batch.clear();
 
       {
-         const std::lock_guard<std::recursive_mutex> lock(glQueueLock);
-         auto count = std::min(glQueue.size(), size_t(30));
+         const std::lock_guard<std::mutex> lock(glQueueLock);
+         auto count = std::min(glQueue.size(), MESSAGE_BATCH_LIMIT);
          if (count > 0) {
-            local_batch.reserve(count);
             for (size_t n = 0; n < count; n++) {
-               local_batch.emplace_back(std::move(glQueue[n]));
+               local_batch.emplace_back(std::move(glQueue.front()));
+               glQueue.pop_front();
             }
-            glQueue.erase(glQueue.begin(), glQueue.begin() + count);
+            glQueuedMessages.fetch_sub(count, std::memory_order_release);
          }
       }
 
@@ -401,7 +406,8 @@ timer_cycle:
       #endif
 
       int64_t wait = 0;
-      if ((!glQueue.empty()) or (breaking) or ((glTaskState IS TSTATE::STOPPING) and ((Flags & PMF::SYSTEM_NO_BREAK) IS PMF::NIL)));
+      if ((glQueuedMessages.load(std::memory_order_acquire) > 0) or (breaking) or
+          ((glTaskState IS TSTATE::STOPPING) and ((Flags & PMF::SYSTEM_NO_BREAK) IS PMF::NIL)));
       else if (timeout_end > 0) {
          // Wait for someone to communicate with us, or stall until an interrupt is due.
 
@@ -436,7 +442,7 @@ timer_cycle:
 
       // Continue the loop?
 
-      if (!glQueue.empty()) continue; // There are messages left unprocessed
+      if (glQueuedMessages.load(std::memory_order_acquire) > 0) continue; // There are messages left unprocessed
       else if (((glTaskState IS TSTATE::STOPPING) and ((Flags & PMF::SYSTEM_NO_BREAK) IS PMF::NIL)) or (breaking)) {
          log.trace("Breaking message loop.");
          break;
@@ -504,7 +510,7 @@ ERR ScanMessages(int *Handle, MSGID Type, APTR Buffer, int BufferSize)
       return ERR::Search;
    }
 
-   const std::lock_guard<std::recursive_mutex> lock(glQueueLock);
+   const std::lock_guard<std::mutex> lock(glQueueLock);
 
    int index = *Handle;
    if (index >= int(glQueue.size())) return ERR::OutOfRange;
@@ -571,7 +577,7 @@ ERR SendMessage(MSGID Type, MSF Flags, APTR Data, int Size)
    if ((Type IS MSGID::NIL) or (Size < 0)) return log.warning(ERR::Args);
 
    {
-      const std::lock_guard<std::recursive_mutex> lock(glQueueLock);
+      const std::lock_guard<std::mutex> lock(glQueueLock);
 
       if ((Flags & (MSF::NO_DUPLICATE|MSF::UPDATE)) != MSF::NIL) {
          for (auto it=glQueue.begin(); it != glQueue.end(); it++) {
@@ -586,6 +592,7 @@ ERR SendMessage(MSGID Type, MSF Flags, APTR Data, int Size)
       }
 
       glQueue.emplace_back(Type, Data, Size); // Deque keeps message storage stable for re-entrant handlers.
+      glQueuedMessages.fetch_add(1, std::memory_order_release);
    }
 
    wake_task(); // Alert the process to indicate that there are messages available.
@@ -837,7 +844,7 @@ ERR UpdateMessage(int MessageID, MSGID Type, APTR Buffer, int BufferSize)
 {
    if (!MessageID) return ERR::NullArgs;
 
-   const std::lock_guard<std::recursive_mutex> lock(glQueueLock);
+   const std::lock_guard<std::mutex> lock(glQueueLock);
 
    for (auto it=glQueue.begin(); it != glQueue.end(); it++) {
       if (it->UID != MessageID) continue;

--- a/src/core/tests/test_messages.tiri
+++ b/src/core/tests/test_messages.tiri
@@ -1,0 +1,138 @@
+-- Message queue tests.
+
+local function new_message_id()
+   local msg_id = mSys.AllocateID(IDTYPE_MESSAGE)
+   assert(msg_id > 0, 'AllocateID(IDTYPE_MESSAGE) did not return a valid message ID.')
+   return msg_id
+end
+
+local function free_handler(Handle)
+   if Handle then
+      mSys.FreeResource(Handle)
+   end
+end
+
+local function drain_messages()
+   check mSys.ProcessMessages(0, 0)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ScanMessagesAndDrain()
+   local msg_id = new_message_id()
+
+   check mSys.SendMessage(msg_id, 0, nil, 0)
+
+   local err, handle = mSys.ScanMessages(msg_id, nil, 0)
+   assert(err is ERR_Okay, 'ScanMessages() did not find the queued message: ' .. mSys.GetErrorMsg(err))
+   assert(handle is 1, 'ScanMessages() returned an unexpected handle: ' .. tostring(handle))
+
+   drain_messages()
+
+   err, handle = mSys.ScanMessages(msg_id, nil, 0)
+   assert((err is ERR_Search) or (err is ERR_OutOfRange), 'ProcessMessages() did not drain the queued message.')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function NoDuplicateSuppressesSecondMessage()
+   local msg_id = new_message_id()
+   local seen_count = 0
+   local seen_data = ''
+   local handler
+
+   local err
+   err, handler = mSys.AddMsgHandler(msg_id, function(UID, Type, Data, Size)
+      seen_count++
+      seen_data = Data ? ('' .. Data) :> ''
+      return ERR_Okay
+   end)
+   assert(err is ERR_Okay, 'AddMsgHandler() failed: ' .. mSys.GetErrorMsg(err))
+   defer free_handler(handler) end
+
+   check mSys.SendMessage(msg_id, 0, 'first', 5)
+   check mSys.SendMessage(msg_id, MSF_NO_DUPLICATE, 'second', 6)
+
+   drain_messages()
+
+   assert(seen_count is 1, 'MSF_NO_DUPLICATE allowed a duplicate message through.')
+   assert(seen_data is 'first', 'MSF_NO_DUPLICATE replaced the queued payload unexpectedly.')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function UpdateMessageRetargetsQueuedUID()
+   local calibrate_id = new_message_id()
+   local source_id = new_message_id()
+   local target_id = new_message_id()
+   local last_uid = 0
+   local target_count = 0
+   local calibrate_handler
+   local target_handler
+
+   local err
+   err, calibrate_handler = mSys.AddMsgHandler(calibrate_id, function(UID, Type, Data, Size)
+      last_uid = UID
+      return ERR_Okay
+   end)
+   assert(err is ERR_Okay, 'AddMsgHandler() for the calibration message failed: ' .. mSys.GetErrorMsg(err))
+   defer free_handler(calibrate_handler) end
+
+   err, target_handler = mSys.AddMsgHandler(target_id, function(UID, Type, Data, Size)
+      target_count++
+      return ERR_Okay
+   end)
+   assert(err is ERR_Okay, 'AddMsgHandler() for the retargeted message failed: ' .. mSys.GetErrorMsg(err))
+   defer free_handler(target_handler) end
+
+   check mSys.SendMessage(calibrate_id, 0, nil, 0)
+   drain_messages()
+   assert(last_uid > 0, 'Calibration message did not expose a message UID.')
+
+   check mSys.SendMessage(source_id, 0, nil, 0)
+   err = mSys.UpdateMessage(last_uid + 1, target_id, nil, 0)
+   assert(err is ERR_Okay, 'UpdateMessage() failed to retarget the queued message: ' .. mSys.GetErrorMsg(err))
+
+   drain_messages()
+
+   assert(target_count is 1, 'UpdateMessage() did not dispatch the retargeted message type.')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function UpdateMessageStaysInPlace()
+   local first_id = new_message_id()
+   local second_id = new_message_id()
+   local sequence = ''
+   local first_data = ''
+   local second_data = ''
+   local first_handler
+   local second_handler
+
+   local err
+   err, first_handler = mSys.AddMsgHandler(first_id, function(UID, Type, Data, Size)
+      sequence ..= 'A'
+      first_data = Data ? ('' .. Data) :> ''
+      return ERR_Okay
+   end)
+   assert(err is ERR_Okay, 'AddMsgHandler() for the first message failed: ' .. mSys.GetErrorMsg(err))
+   defer free_handler(first_handler) end
+
+   err, second_handler = mSys.AddMsgHandler(second_id, function(UID, Type, Data, Size)
+      sequence ..= 'B'
+      second_data = Data ? ('' .. Data) :> ''
+      return ERR_Okay
+   end)
+   assert(err is ERR_Okay, 'AddMsgHandler() for the second message failed: ' .. mSys.GetErrorMsg(err))
+   defer free_handler(second_handler) end
+
+   check mSys.SendMessage(first_id, 0, 'first', 5)
+   check mSys.SendMessage(second_id, 0, 'middle', 6)
+   check mSys.SendMessage(first_id, MSF_UPDATE, 'updated', 7)
+
+   drain_messages()
+
+   assert(sequence is 'AB', 'MSF_UPDATE changed the queued message order: ' .. sequence)
+   assert(first_data is 'updated', 'MSF_UPDATE did not update the first message payload in place.')
+   assert(second_data is 'middle', 'MSF_UPDATE affected an unrelated queued message.')
+end


### PR DESCRIPTION
## Summary

- Reduce `LoadFile()` cache lock scope so file reads and path work are not held under the global cache lock.
- Make Core message queue draining cheaper by reusing the local batch, draining with `pop_front()`, and replacing unlocked queue checks with an atomic pending-message count.
- Fix `TaskMessage` move/copy ownership for external buffers and initialise default message headers.
- Add Core Flute coverage for message scanning, `UpdateMessage()`, `MSF::UPDATE`, and duplicate suppression.
- Correct `MSF::UPDATE` generated documentation to describe the current in-place update behaviour.

## Validation

- `cmake --build build/agents --config Debug --target core --parallel`
- `cmake --install build/agents --config Debug`
- `build/agents-install/origo tools/flute.tiri file=src/core/tests/test_messages.tiri --log-warning`
- `ctest --build-config Debug --test-dir build/agents --output-on-failure -L core_messages`
- `ctest --build-config Debug --test-dir build/agents --output-on-failure -L core`

## Notes

The local working tree still contains unrelated uncommitted and untracked files that are not part of this branch diff.