### PR TITLE
[Tiri] Remove Unicode ellipsis vararg alias; reject U+2026 with a syntax error

### DIFF
--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -146,6 +146,7 @@ namespace {
 
 // Forward declarations for Unicode operator detection (defined later in this file)
 static LexToken match_unicode_operator(LexState *State, int &ByteLength) noexcept;
+inline bool is_unicode_ellipsis(LexState *State) noexcept;
 inline bool is_unicode_operator_start(LexState *State) noexcept;
 
 //********************************************************************************************************************
@@ -167,6 +168,7 @@ static void lex_number(LexState *State, TValue* tv)
       // If we see '.', check if next character is also '.' (range operator)
       if (State->c IS '.' and State->peek_next() IS '.') break;  // Don't consume '.', let parser handle '..'
       if (is_unicode_operator_start(State)) break;  // Don't consume Unicode operators like ↑
+      if (is_unicode_ellipsis(State)) break;
       c = State->c;
       lex_savenext(State);
    }
@@ -841,10 +843,6 @@ static LexToken match_unicode_operator(LexState *State, int &ByteLength) noexcep
             ByteLength = 3;
             return TK_concat;     // ‥
          }
-         else if (third IS 0xA6) {
-            ByteLength = 3;
-            return TK_dots;       // …
-         }
       }
 
       if (second IS 0x81 and third IS 0x87) {
@@ -883,6 +881,11 @@ static LexToken match_unicode_operator(LexState *State, int &ByteLength) noexcep
    }
 
    return 0;
+}
+
+inline bool is_unicode_ellipsis(LexState *State) noexcept
+{
+   return State->c IS 0xE2 and State->peek(0) IS 0x80 and State->peek(1) IS 0xA6;
 }
 
 inline bool is_unicode_operator_start(LexState *State) noexcept
@@ -1025,6 +1028,14 @@ static LexToken lex_scan(LexState *State, TValue *tv)
          continue;
       }
 
+      // U+2026 used to alias ASCII varargs.  Reject it explicitly so it cannot be silently parsed as an identifier.
+      if (is_unicode_ellipsis(State)) {
+         State->mark_token_start();
+         lj_lex_error(State, 0, ErrMsg::XSYMBOL);
+         if (State->had_lex_error) continue;
+         return TK_eof;
+      }
+
       // Check for Unicode operators before identifier scanning
       if (LexToken unicode_tok = lex_unicode_operator(State)) {
          return unicode_tok;
@@ -1043,7 +1054,8 @@ static LexToken lex_scan(LexState *State, TValue *tv)
          // Scan identifier (stop before Unicode operators like ⧺)
          do {
             lex_savenext(State);
-         } while (lj_char_isident(State->c) and not is_unicode_operator_start(State));
+         } while (lj_char_isident(State->c) and not is_unicode_operator_start(State) and
+            not is_unicode_ellipsis(State));
 
          auto str_view = std::string_view(State->sb.b, sbuflen(&State->sb));
 

--- a/src/tiri/tests/test_ellipsis.tiri
+++ b/src/tiri/tests/test_ellipsis.tiri
@@ -1,12 +1,11 @@
--- Flute tests for horizontal ellipsis (…) operator
--- The … Unicode character (U+2026) should map to ... (varargs)
+-- Flute tests for ASCII varargs and rejection of the legacy Unicode ellipsis token.
 
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
 
-@Test function EllipsisBasic()
-   function variadic(…)
-      return {…}
+@Test function AsciiVarargsBasic()
+   function variadic(...)
+      return {...}
    end
 
    result = variadic(1, 2, 3)
@@ -16,42 +15,9 @@ function enforce_hotpath() end
    assert(result[2] is 3, "Third element should be 3")
 end
 
-@Test function EllipsisNoArgs()
-   function variadic(…)
-      return {…}
-   end
-
-   result = variadic()
-   assert(#result is 0, "Variadic with no args should have 0 elements")
-end
-
-@Test function EllipsisSingleArg()
-   function variadic(…)
-      return {…}
-   end
-
-   result = variadic("hello")
-   assert(#result is 1, "Variadic with 1 arg should have 1 element")
-   assert(result[0] is "hello", "First element should be 'hello'")
-end
-
-@Test function EllipsisMultipleTypes()
-   function variadic(…)
-      return {…}
-   end
-
-   -- Note: nil values are dropped by Lua when captured with {...}
-   result = variadic(1, "two", 3.0, true)
-   assert(#result is 4, "Variadic with 4 args should have 4 elements")
-   assert(result[0] is 1, "First element should be 1")
-   assert(result[1] is "two", "Second element should be 'two'")
-   assert(result[2] is 3.0, "Third element should be 3.0")
-   assert(result[3] is true, "Fourth element should be true")
-end
-
-@Test function EllipsisWithNamedParams()
-   function variadic(a, b, …)
-      return a, b, {…}
+@Test function AsciiVarargsWithNamedParams()
+   function variadic(a, b, ...)
+      return a, b, {...}
    end
 
    a, b, rest = variadic(10, 20, 30, 40, 50)
@@ -63,13 +29,13 @@ end
    assert(rest[2] is 50, "Rest[2] should be 50")
 end
 
-@Test function EllipsisForwarding()
-   function inner(…)
-      return {…}
+@Test function AsciiVarargsForwarding()
+   function inner(...)
+      return {...}
    end
 
-   function wrapper(…)
-      return inner(…)
+   function wrapper(...)
+      return inner(...)
    end
 
    result = wrapper("a", "b", "c")
@@ -79,42 +45,26 @@ end
    assert(result[2] is "c", "Element 2 should be 'c'")
 end
 
-@Test function EllipsisUnpacking()
-   function variadic(…)
-      count = 0
-      for _ in ipairs({…}) do
-         count++
-      end
-      return count
+@Test function UnicodeEllipsisRejectedInParameterList()
+   try
+      exec("function variadic(\u{2026}) return {} end")
+   success
+      error("Unicode ellipsis should not be accepted as a vararg parameter")
    end
-
-   result = variadic(1, 2, 3, 4, 5)
-   assert(result is 5, "Count of 5 args should be 5")
 end
 
-@Test function EllipsisInStringFormat()
-   function format_args(fmt, …)
-      return string.format(fmt, …)
+@Test function UnicodeEllipsisRejectedInExpression()
+   try
+      exec("function variadic(...) return {\u{2026}} end")
+   success
+      error("Unicode ellipsis should not be accepted as a vararg expression")
    end
-
-   result = format_args("Number: %d, String: %s", 42, "test")
-   assert(result is "Number: 42, String: test", "Format with variadic args should work")
 end
 
-@Test function AsciiEllipsisMixedWithUnicode()
-   -- Test that both ASCII ... and Unicode … can coexist
-   function ascii_variadic(...)
-      return {...}
+@Test function UnicodeEllipsisRejectedInsideIdentifier()
+   try
+      exec("local value\u{2026} = 1")
+   success
+      error("Unicode ellipsis should not be accepted inside an identifier")
    end
-
-   function unicode_variadic(…)
-      return {…}
-   end
-
-   ascii_result = ascii_variadic(1, 2, 3)
-   unicode_result = unicode_variadic(1, 2, 3)
-
-   assert(#ascii_result is 3, "ASCII ... should work")
-   assert(#unicode_result is 3, "Unicode … should work")
-   assert(ascii_result[0] is unicode_result[0], "Both should capture same values")
 end


### PR DESCRIPTION
## Summary

- Removes the mapping of U+2026 (…) to `TK_dots` in `match_unicode_operator()`, ending support for using the Unicode horizontal ellipsis as a vararg alias
- Adds `is_unicode_ellipsis()` helper and guards in `lex_number()`, the identifier scan loop, and `lex_scan()` so that U+2026 is explicitly rejected with an `XSYMBOL` error wherever it appears, rather than being silently absorbed into an identifier or numeric literal
- Updates `test_ellipsis.tiri` to replace tests that relied on Unicode varargs with tests that verify U+2026 is correctly rejected in parameter lists, expressions, and identifiers

## Test plan

- [ ] Build `tiri` module and verify it compiles without errors
- [ ] Run `test_ellipsis.tiri` via Flute and confirm all rejection tests pass
- [ ] Confirm ASCII `...` varargs still work correctly via the retained `AsciiVarargsBasic`, `AsciiVarargsWithNamedParams`, and `AsciiVarargsForwarding` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)