### PR TITLE
[Tiri] Report ranges as their own type

### DIFF
--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1096,6 +1096,8 @@ static void build_subroutines(BuildCtx *ctx)
   |  asr ITYPE, CARG1, #47
   |  cmn ITYPE, #~LJ_TISNUM
   |  csinv TMP1, TMP0, ITYPE, lo
+  |  cmp TMP1, #~LJ_TUDATA
+  |  beq ->fff_fallback
   |  add TMP1, TMP1, #offsetof(GCfuncC, upvalue)/8
   |  ldr CARG1, [CFUNC:CARG3, TMP1, lsl #3]
   |  b ->fff_restv

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1551,6 +1551,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  subfe TMP2, CARG1, CARG1
   |  orc TMP1, TMP2, TMP0
   |  addi TMP1, TMP1, ~LJ_TISNUM+1
+  |  cmpwi TMP1, ~LJ_TUDATA; beq ->fff_fallback
   |  slwi TMP1, TMP1, 3
   |.if FPU
   |   la TMP2, CFUNC:RB->upvalue

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -40,6 +40,7 @@
 #include "runtime/lj_object.h"
 #include "runtime/lj_proto_registry.h"
 #include "debug/error_guard.h"
+#include "lib_range.h"
 
 #define LJLIB_MODULE_base
 
@@ -127,6 +128,19 @@ LJLIB_ASM(assert)      LJLIB_REC(.)
 //********************************************************************************************************************
 // ORDER LJ_T
 
+constexpr uint32_t TYPE_NAME_USERDATA = 3;
+constexpr uint32_t TYPE_NAME_RANGE = 15;
+constexpr uint8_t TIRI_TYPE_RANGE_TAG = uint8_t(~LJ_TUDATA);
+
+static bool is_range_userdata(lua_State *L, GCudata *Userdata)
+{
+   GCtab *mt = tabref(Userdata->metatable);
+   if (not mt) return false;
+
+   cTValue *range_metatable = lj_tab_getstr(tabV(registry(L)), lj_str_newz(L, RANGE_METATABLE));
+   return range_metatable and tvistab(range_metatable) and tabV(range_metatable) IS mt;
+}
+
 LJLIB_PUSH("nil")
 LJLIB_PUSH("boolean")
 LJLIB_PUSH(top-1)  //  boolean
@@ -142,26 +156,32 @@ LJLIB_PUSH("table")
 LJLIB_PUSH(top-9)  //  userdata
 LJLIB_PUSH("array")
 LJLIB_PUSH("number")
+LJLIB_PUSH("range")
 LJLIB_ASM(type)      LJLIB_REC(.)
 {
    // C fallback for type() - handles thunks with declared types
    TValue *o = L->base;
+   GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
    if (tvisudata(o)) {
       GCudata *ud = udataV(o);
-      if (ud->udtype IS UDTYPE_THUNK) {
+      if (is_range_userdata(L, ud)) {
+         setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[TYPE_NAME_RANGE]));
+         return FFH_RES(1);
+      }
+      else if (ud->udtype IS UDTYPE_THUNK) {
          ThunkPayload *payload = thunk_payload(ud);
          if (payload->expected_type != 0xFF) {
             // Use the declared type string from the upvalue array
-            GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
-            GCstr *type_str = strV(&fn->c.upvalue[payload->expected_type]);
+            uint32_t type_index = payload->expected_type;
+            if (type_index IS TIRI_TYPE_RANGE_TAG) type_index = TYPE_NAME_RANGE;
+            GCstr *type_str = strV(&fn->c.upvalue[type_index]);
             setstrV(L, L->base - 1 - LJ_FR2, type_str);
             return FFH_RES(1);
          }
       }
    }
    // For non-thunk userdata, return "userdata" string (upvalue index 3)
-   GCfunc *fn = funcV(L->base - 1 - LJ_FR2);
-   setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[3]));
+   setstrV(L, L->base - 1 - LJ_FR2, strV(&fn->c.upvalue[TYPE_NAME_USERDATA]));
    return FFH_RES(1);
 }
 

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -44,6 +44,7 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 #include "lj_serialize.h"
+#include "lib_range.h"
 
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)         (&J->cur.ir[(ref)])
@@ -229,6 +230,19 @@ static void recff_assert(jit_State* J, RecordFFData* rd)
 
 //********************************************************************************************************************
 
+constexpr uint32_t TYPE_NAME_USERDATA = 3;
+constexpr uint32_t TYPE_NAME_RANGE = 15;
+constexpr uint8_t TIRI_TYPE_RANGE_TAG = uint8_t(~LJ_TUDATA);
+
+static bool recff_is_range_userdata(jit_State *J, GCudata *Userdata)
+{
+   GCtab *mt = tabref(Userdata->metatable);
+   if (not mt) return false;
+
+   cTValue *range_metatable = lj_tab_getstr(tabV(registry(J->L)), lj_str_newz(J->L, RANGE_METATABLE));
+   return range_metatable and tvistab(range_metatable) and tabV(range_metatable) IS mt;
+}
+
 static void recff_type(jit_State* J, RecordFFData* rd)
 {
    // Arguments already specialized. Result is a constant string. Neat, huh?
@@ -240,12 +254,19 @@ static void recff_type(jit_State* J, RecordFFData* rd)
 
    if (t IS ~LJ_TUDATA) {  // 12 = base value for userdata
       GCudata *ud = udataV(&rd->argv[0]);
-      if (ud->udtype IS UDTYPE_THUNK) {
+      if (recff_is_range_userdata(J, ud)) {
+         t = TYPE_NAME_RANGE;
+      }
+      else if (ud->udtype IS UDTYPE_THUNK) {
          ThunkPayload *payload = thunk_payload(ud);
          if (payload->expected_type != 0xFF) {
             // Use the declared type instead of userdata
             t = payload->expected_type;
+            if (t IS TIRI_TYPE_RANGE_TAG) t = TYPE_NAME_RANGE;
          }
+      }
+      else {
+         t = TYPE_NAME_USERDATA;
       }
    }
 

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -478,7 +478,8 @@ end
    -- Test that range literals are detected by range.check
    r = {0 to 5}
    assert(range.check(r) is true, "range.check should return true for literal")
-   assert(type(r) is "userdata", "type of range literal should be userdata")
+   assert(type(r) is "range", "type of range literal should be range")
+   assert(type(range(0, 5)) is "range", "type of constructed range should be range")
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Return `range` from `type()` for range userdata in interpreter, JIT-recorded, and VM fast-function paths.
- Route ARM64 and PPC userdata `type()` fast paths through the C fallback so ranges and thunks are handled consistently across architectures.
- Identify ranges through the existing `Tiri.range` metatable so ordinary userdata still reports as `userdata`.
- Update range tests to assert the new type name for literals and constructed ranges.

## Validation
- `cmake --build build/agents --config Debug --target tiri --parallel`
- `cmake --install build/agents --config Debug`
- `build/agents-install/origo --statement "print(type(range(0, 5))); print(type({0 to 5})); print(type(<range{ range(0, 5) }>))" --log-warning`
- `build/agents-install/origo tools/flute.tiri file=src/tiri/tests/test_ranges.tiri --log-warning`
- `ctest --build-config Debug --test-dir build/agents --output-on-failure -R "^(tiri_ranges|tiri_thunks|tiri_thunk_table_index)$"`