### PR TITLE
[Tiri] Centralised parser token metadata flags

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -62,22 +62,6 @@ static std::unique_ptr<FunctionExprPayload> move_function_payload(ExprNodePtr &N
    return result;
 }
 
-// Checks if a token kind is a statement keyword that can be used in conditional shorthand syntax (e.g., value ?! return).
-
-static bool is_shorthand_statement_keyword(TokenKind Kind)
-{
-   switch (Kind) {
-      case TokenKind::ReturnToken:
-      case TokenKind::BreakToken:
-      case TokenKind::ContinueToken:
-      case TokenKind::RaiseToken:
-      case TokenKind::CheckToken:
-         return true;
-      default:
-         return false;
-   }
-}
-
 // Checks for contextual range separators.  The lexer intentionally leaves `to` and `into` as identifiers so these
 // words remain available outside range-literal separator positions.
 
@@ -110,26 +94,6 @@ static bool is_terminating_statement(const StmtNode *Stmt)
       case AstNodeKind::ReturnStmt:
       case AstNodeKind::BreakStmt:
       case AstNodeKind::ContinueStmt:
-         return true;
-      default:
-         return false;
-   }
-}
-
-// Checks if a token kind is a compound assignment operator (+=, -=, etc.).
-// These are statements, not expressions, which helps provide better error messages.
-
-static bool is_compound_assignment(TokenKind Kind)
-{
-   switch (Kind) {
-      case TokenKind::CompoundAdd:
-      case TokenKind::CompoundSub:
-      case TokenKind::CompoundMul:
-      case TokenKind::CompoundDiv:
-      case TokenKind::CompoundMod:
-      case TokenKind::CompoundConcat:
-      case TokenKind::CompoundIfEmpty:
-      case TokenKind::CompoundIfNil:
          return true;
       default:
          return false;
@@ -487,36 +451,9 @@ bool AstBuilder::at_end_of_block(std::span<const TokenKind> terminators) const
 
 // Checks if a token kind can begin a statement.
 
-bool AstBuilder::is_statement_start(TokenKind kind) const
+bool AstBuilder::is_statement_start(TokenKind Kind) const
 {
-   switch (kind) {
-      case TokenKind::Local:
-      case TokenKind::Global:
-      case TokenKind::Enum:
-      case TokenKind::Function:
-      case TokenKind::ThunkToken:
-      case TokenKind::Annotate:
-      case TokenKind::If:
-      case TokenKind::WhileToken:
-      case TokenKind::Repeat:
-      case TokenKind::For:
-      case TokenKind::DoToken:
-      case TokenKind::WithToken:
-      case TokenKind::DeferToken:
-      case TokenKind::ReturnToken:
-      case TokenKind::BreakToken:
-      case TokenKind::ContinueToken:
-      case TokenKind::Choose:
-      case TokenKind::TryToken:
-      case TokenKind::RaiseToken:
-      case TokenKind::CheckToken:
-      case TokenKind::ImportToken:
-      case TokenKind::NamespaceToken:
-      case TokenKind::CompileIf:
-         return true;
-      default:
-         return false;
-   }
+   return token_kind_has_flag(Kind, TKF_STATEMENT_START);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/ast/choose.cpp
+++ b/src/tiri/jit/src/parser/ast/choose.cpp
@@ -322,26 +322,8 @@ ParserResult<ExprNodePtr> AstBuilder::parse_choose_expr()
 
       // Check if this is an assignment statement
       Token maybe_assign = this->ctx.tokens().current();
-      bool is_assignment = false;
-      switch (maybe_assign.kind()) {
-         case TokenKind::Equals:
-         case TokenKind::CompoundAdd:
-         case TokenKind::CompoundSub:
-         case TokenKind::CompoundMul:
-         case TokenKind::CompoundDiv:
-         case TokenKind::CompoundMod:
-         case TokenKind::CompoundConcat:
-         case TokenKind::CompoundIfEmpty:
-         case TokenKind::CompoundIfNil:
-            is_assignment = true;
-            break;
-         case TokenKind::Comma:
-            // Multi-target assignment: a, b = ...
-            is_assignment = true;
-            break;
-         default:
-            break;
-      }
+      bool is_assignment = maybe_assign.kind() IS TokenKind::Equals or maybe_assign.kind() IS TokenKind::Comma or
+         maybe_assign.has_flag(TKF_COMPOUND_ASSIGNMENT);
 
       if (is_assignment) {
          // Parse as statement - build assignment AST

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -49,7 +49,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
 
       this->ctx.tokens().advance();
       Token next = this->ctx.tokens().current();
-      if (not is_shorthand_statement_keyword(next.kind())) {
+      if (not next.has_flag(TKF_SHORTHAND_STATEMENT)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, next,
             "expected return, break, continue, raise, or check after guard operator '?!'");
       }
@@ -798,7 +798,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
       default: {
          std::string msg;
-         if (is_compound_assignment(current.kind())) {
+         if (current.has_flag(TKF_COMPOUND_ASSIGNMENT)) {
             msg = std::format("'{}' is a statement, not an expression; use 'do ... end' for statements in arrow functions",
                this->ctx.lex().token2str(current.raw()));
          }
@@ -876,7 +876,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
       // Check if a compound assignment follows - this indicates the user tried to use a statement
       // in an expression-body arrow function. Provide a helpful error message.
       Token next = this->ctx.tokens().current();
-      if (is_compound_assignment(next.kind())) {
+      if (next.has_flag(TKF_COMPOUND_ASSIGNMENT)) {
          return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, next,
             std::format("'{}' is a statement, not an expression; use 'do ... end' for statement bodies in arrow functions",
                this->ctx.lex().token2str(next.raw())));

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -1,5 +1,19 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+inline constexpr uint32_t TKF_NONE = 0x0000;
+inline constexpr uint32_t TKF_RESERVED = 0x0001;
+inline constexpr uint32_t TKF_CAN_END_RANGE_EXPRESSION = 0x0002;
+inline constexpr uint32_t TKF_MEMBER_NAME_CONTEXT = 0x0004;
+inline constexpr uint32_t TKF_COMPOUND_ASSIGNMENT = 0x0008;
+inline constexpr uint32_t TKF_LITERAL = 0x0010;
+inline constexpr uint32_t TKF_STATEMENT_START = 0x0020;
+inline constexpr uint32_t TKF_SHORTHAND_STATEMENT = 0x0040;
+
 struct SourceSpan {
    BCLine line = 0;
    BCLine column = 0;
@@ -11,96 +25,97 @@ struct SourceSpan {
 struct TokenDefinition {
    std::string_view name;    // Token identifier (e.g., "and", "if_empty")
    std::string_view symbol;  // Display symbol (e.g., "and", "??")
-   bool reserved;            // True for reserved words that cannot be used as identifiers
+   uint32_t flags;           // Token metadata flags
 
-   [[nodiscard]] constexpr bool is_reserved() const noexcept { return reserved; }
+   [[nodiscard]] constexpr bool has_flag(uint32_t Flag) const noexcept { return (this->flags & Flag) != 0; }
+   [[nodiscard]] constexpr bool is_reserved() const noexcept { return this->has_flag(TKF_RESERVED); }
 };
 
 // Define all tokens once using X-macro pattern
-// Format: TOKEN_DEF(name, symbol, reserved)
+// Format: TOKEN_DEF(name, symbol, flags)
 #define TOKEN_DEF_LIST \
-   TOKEN_DEF(and,          "and",      true) \
-   TOKEN_DEF(as,           "as",       true) \
-   TOKEN_DEF(break,        "break",    true) \
-   TOKEN_DEF(choose,       "choose",   true) \
-   TOKEN_DEF(continue,     "continue", true) \
-   TOKEN_DEF(defer,        "defer",    true) \
-   TOKEN_DEF(do,           "do",       true) \
-   TOKEN_DEF(else,         "else",     true) \
-   TOKEN_DEF(elseif,       "elseif",   true) \
-   TOKEN_DEF(end,          "end",      true) \
-   TOKEN_DEF(enum,         "enum",     true) \
-   TOKEN_DEF(false,        "false",    true) \
-   TOKEN_DEF(for,          "for",      true) \
-   TOKEN_DEF(from,         "from",     true) \
-   TOKEN_DEF(function,     "function", true) \
-   TOKEN_DEF(global,       "global",   true) \
-   TOKEN_DEF(has,          "has",      true) \
-   TOKEN_DEF(if,           "if",       true) \
-   TOKEN_DEF(import,       "import",   true) \
-   TOKEN_DEF(in,           "in",       true) \
-   TOKEN_DEF(is,           "is",       true) \
-   TOKEN_DEF(local,        "local",    true) \
-   TOKEN_DEF(namespace,    "namespace", true) \
-   TOKEN_DEF(nil,          "nil",      true) \
-   TOKEN_DEF(not,          "not",      true) \
-   TOKEN_DEF(or,           "or",       true) \
-   TOKEN_DEF(repeat,       "repeat",   true) \
-   TOKEN_DEF(return,       "return",   true) \
-   TOKEN_DEF(then,         "then",     true) \
-   TOKEN_DEF(thunk,        "thunk",    true) \
-   TOKEN_DEF(true,         "true",     true) \
-   TOKEN_DEF(try,          "try",      true) \
-   TOKEN_DEF(except,       "except",   true) \
-   TOKEN_DEF(until,        "until",    true) \
-   TOKEN_DEF(when,         "when",     true) \
-   TOKEN_DEF(success,      "success",  true) \
-   TOKEN_DEF(raise,        "raise",    true) \
-   TOKEN_DEF(check,        "check",    true) \
-   TOKEN_DEF(while,        "while",    true) \
-   TOKEN_DEF(with,         "with",     true) \
-   TOKEN_DEF(case_arrow,   "->",       false) \
-   TOKEN_DEF(if_empty,     "??",       false) \
-   TOKEN_DEF(guard,        "?!",       false) \
-   TOKEN_DEF(safe_field,   "?.",       false) \
-   TOKEN_DEF(safe_index,   "?[",       false) \
-   TOKEN_DEF(safe_method,  "?:",       false) \
-   TOKEN_DEF(arrow,        "=>",       false) \
-   TOKEN_DEF(concat,       "..",       false) \
-   TOKEN_DEF(dots,         "...",      false) \
-   TOKEN_DEF(eq,           "==",       false) \
-   TOKEN_DEF(ge,           ">=",       false) \
-   TOKEN_DEF(le,           "<=",       false) \
-   TOKEN_DEF(ne,           "~=",       false) \
-   TOKEN_DEF(shl,          "<<",       false) \
-   TOKEN_DEF(shr,          ">>",       false) \
-   TOKEN_DEF(ternary_sep,  ":>",       false) \
-   TOKEN_DEF(number,       "<number>", false) \
-   TOKEN_DEF(name,         "<name>",   false) \
-   TOKEN_DEF(string,       "<string>", false) \
-   TOKEN_DEF(cadd,         "+=",       false) \
-   TOKEN_DEF(csub,         "-=",       false) \
-   TOKEN_DEF(cmul,         "*=",       false) \
-   TOKEN_DEF(cdiv,         "/=",       false) \
-   TOKEN_DEF(cconcat,      "..=",      false) \
-   TOKEN_DEF(cmod,         "%=",       false) \
-   TOKEN_DEF(cif_empty,    "?\?=",     false) \
-   TOKEN_DEF(cif_nil,      "?=",       false) \
-   TOKEN_DEF(plusplus,     "++",       false) \
-   TOKEN_DEF(pow,          "**",       false) \
-   TOKEN_DEF(pipe,         "|>",       false) \
-   TOKEN_DEF(defer_open,   "<{",       false) \
-   TOKEN_DEF(defer_typed,  "<type{",   false) \
-   TOKEN_DEF(defer_close,  "}>",       false) \
-   TOKEN_DEF(array_typed,  "array<type>", false) \
-   TOKEN_DEF(annotate,     "@",        false) \
-   TOKEN_DEF(compif,       "@if",      false) \
-   TOKEN_DEF(compend,      "@end",     false) \
-   TOKEN_DEF(eof,          "<eof>",    false)
+   TOKEN_DEF(and,          "and",      TKF_RESERVED) \
+   TOKEN_DEF(as,           "as",       TKF_RESERVED) \
+   TOKEN_DEF(break,        "break",    TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
+   TOKEN_DEF(choose,       "choose",   TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(continue,     "continue", TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
+   TOKEN_DEF(defer,        "defer",    TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(do,           "do",       TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(else,         "else",     TKF_RESERVED) \
+   TOKEN_DEF(elseif,       "elseif",   TKF_RESERVED) \
+   TOKEN_DEF(end,          "end",      TKF_RESERVED | TKF_CAN_END_RANGE_EXPRESSION) \
+   TOKEN_DEF(enum,         "enum",     TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(false,        "false",    TKF_RESERVED | TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(for,          "for",      TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(from,         "from",     TKF_RESERVED) \
+   TOKEN_DEF(function,     "function", TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(global,       "global",   TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(has,          "has",      TKF_RESERVED) \
+   TOKEN_DEF(if,           "if",       TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(import,       "import",   TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(in,           "in",       TKF_RESERVED) \
+   TOKEN_DEF(is,           "is",       TKF_RESERVED) \
+   TOKEN_DEF(local,        "local",    TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(namespace,    "namespace", TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(nil,          "nil",      TKF_RESERVED | TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(not,          "not",      TKF_RESERVED) \
+   TOKEN_DEF(or,           "or",       TKF_RESERVED) \
+   TOKEN_DEF(repeat,       "repeat",   TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(return,       "return",   TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
+   TOKEN_DEF(then,         "then",     TKF_RESERVED) \
+   TOKEN_DEF(thunk,        "thunk",    TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(true,         "true",     TKF_RESERVED | TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(try,          "try",      TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(except,       "except",   TKF_RESERVED) \
+   TOKEN_DEF(until,        "until",    TKF_RESERVED) \
+   TOKEN_DEF(when,         "when",     TKF_RESERVED) \
+   TOKEN_DEF(success,      "success",  TKF_RESERVED) \
+   TOKEN_DEF(raise,        "raise",    TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
+   TOKEN_DEF(check,        "check",    TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
+   TOKEN_DEF(while,        "while",    TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(with,         "with",     TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(case_arrow,   "->",       TKF_NONE) \
+   TOKEN_DEF(if_empty,     "??",       TKF_NONE) \
+   TOKEN_DEF(guard,        "?!",       TKF_NONE) \
+   TOKEN_DEF(safe_field,   "?.",       TKF_MEMBER_NAME_CONTEXT) \
+   TOKEN_DEF(safe_index,   "?[",       TKF_NONE) \
+   TOKEN_DEF(safe_method,  "?:",       TKF_MEMBER_NAME_CONTEXT) \
+   TOKEN_DEF(arrow,        "=>",       TKF_NONE) \
+   TOKEN_DEF(concat,       "..",       TKF_NONE) \
+   TOKEN_DEF(dots,         "...",      TKF_NONE) \
+   TOKEN_DEF(eq,           "==",       TKF_NONE) \
+   TOKEN_DEF(ge,           ">=",       TKF_NONE) \
+   TOKEN_DEF(le,           "<=",       TKF_NONE) \
+   TOKEN_DEF(ne,           "~=",       TKF_NONE) \
+   TOKEN_DEF(shl,          "<<",       TKF_NONE) \
+   TOKEN_DEF(shr,          ">>",       TKF_NONE) \
+   TOKEN_DEF(ternary_sep,  ":>",       TKF_NONE) \
+   TOKEN_DEF(number,       "<number>", TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(name,         "<name>",   TKF_CAN_END_RANGE_EXPRESSION) \
+   TOKEN_DEF(string,       "<string>", TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(cadd,         "+=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(csub,         "-=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cmul,         "*=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cdiv,         "/=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cconcat,      "..=",      TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cmod,         "%=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cif_empty,    "?\?=",     TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(cif_nil,      "?=",       TKF_COMPOUND_ASSIGNMENT) \
+   TOKEN_DEF(plusplus,     "++",       TKF_CAN_END_RANGE_EXPRESSION) \
+   TOKEN_DEF(pow,          "**",       TKF_NONE) \
+   TOKEN_DEF(pipe,         "|>",       TKF_NONE) \
+   TOKEN_DEF(defer_open,   "<{",       TKF_NONE) \
+   TOKEN_DEF(defer_typed,  "<type{",   TKF_NONE) \
+   TOKEN_DEF(defer_close,  "}>",       TKF_CAN_END_RANGE_EXPRESSION) \
+   TOKEN_DEF(array_typed,  "array<type>", TKF_NONE) \
+   TOKEN_DEF(annotate,     "@",        TKF_STATEMENT_START) \
+   TOKEN_DEF(compif,       "@if",      TKF_STATEMENT_START) \
+   TOKEN_DEF(compend,      "@end",     TKF_NONE) \
+   TOKEN_DEF(eof,          "<eof>",    TKF_NONE)
 
 // Generate TOKEN_DEFINITIONS array from TOKEN_DEF_LIST
 // This array provides compile-time token metadata
-#define TOKEN_DEF(name, symbol, reserved) TokenDefinition{#name, symbol, reserved},
+#define TOKEN_DEF(name, symbol, flags) TokenDefinition{#name, symbol, flags},
 inline constexpr std::array TOKEN_DEFINITIONS = {
    TOKEN_DEF_LIST
 };
@@ -134,7 +149,7 @@ inline constexpr size_t generate_reserved_count() noexcept {
 // Generate enum values from TOKEN_DEF_LIST
 // SINGLE SOURCE OF TRUTH: All token definitions come from TOKEN_DEF_LIST above
 
-#define TOKEN_DEF(name, symbol, reserved) TK_##name,
+#define TOKEN_DEF(name, symbol, flags) TK_##name,
 enum {
    TK_OFS = 256,
    TOKEN_DEF_LIST

--- a/src/tiri/jit/src/parser/token_types.cpp
+++ b/src/tiri/jit/src/parser/token_types.cpp
@@ -50,14 +50,5 @@
 
 [[nodiscard]] bool Token::is_literal() const
 {
-   switch (this->token_kind) {
-      case TokenKind::Number:
-      case TokenKind::String:
-      case TokenKind::Nil:
-      case TokenKind::TrueToken:
-      case TokenKind::FalseToken:
-         return true;
-      default:
-         return false;
-   }
+   return this->has_flag(TKF_LITERAL);
 }

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -118,6 +118,26 @@ enum class TokenKind : uint16_t {
 
 [[nodiscard]] inline CSTRING token_kind_name(TokenKind kind, LexState &lex) { return lex.token2str((LexToken)kind); }
 
+[[nodiscard]] constexpr bool token_kind_has_flag(TokenKind Kind, uint32_t Flag) noexcept {
+   LexToken raw = (LexToken)Kind;
+   if (raw > TK_OFS) {
+      size_t index = size_t(raw - TK_OFS - 1);
+      if (index < TOKEN_DEFINITIONS.size()) return TOKEN_DEFINITIONS[index].has_flag(Flag);
+   }
+
+   switch (Kind) {
+      case TokenKind::RightParen:
+      case TokenKind::RightBracket:
+      case TokenKind::RightBrace:
+         return (Flag & TKF_CAN_END_RANGE_EXPRESSION) != 0;
+      case TokenKind::Dot:
+      case TokenKind::Colon:
+         return (Flag & TKF_MEMBER_NAME_CONTEXT) != 0;
+      default:
+         return false;
+   }
+}
+
 // Constexpr alternative for compile-time token name lookup
 // Returns a string_view without requiring a LexState reference.
 [[nodiscard]] constexpr std::string_view token_kind_name_constexpr(TokenKind kind) noexcept {
@@ -267,6 +287,9 @@ public:
    [[nodiscard]] inline LexToken raw() const { return this->raw_token; }
    [[nodiscard]] inline SourceSpan span() const { return this->source; }
    [[nodiscard]] inline bool is(TokenKind kind) const { return this->token_kind IS kind; }
+   [[nodiscard]] constexpr bool has_flag(uint32_t Flag) const noexcept {
+      return token_kind_has_flag(this->token_kind, Flag);
+   }
    [[nodiscard]] inline bool is_literal() const;
    [[nodiscard]] inline const TokenPayload & payload() const { return this->data; }
 


### PR DESCRIPTION
* Added token flags for statement starts, literals, compound assignments, range endings and shorthand statements

* Replaced parser token classification switches with metadata flag checks