### PR TITLE
[Tiri] Added stepped range literal support

### DIFF
--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -647,12 +647,17 @@ LJLIB_CF(range_new)
 
 //********************************************************************************************************************
 // __tostring metamethod
-// Returns "{start to stop}" or "{start into stop}" based on inclusivity
+// Returns "{start to stop}" or "{start into stop}", including "by step" for non-default steps.
 
 static int range_tostring(lua_State *L)
 {
    auto r = get_range(L, 1);
-   if (r->inclusive) lua_pushfstring(L, "{%d into %d}", r->start, r->stop);
+   int32_t inferred_step = (r->start <= r->stop) ? 1 : -1;
+   if (r->step != inferred_step) {
+      if (r->inclusive) lua_pushfstring(L, "{%d into %d by %d}", r->start, r->stop, r->step);
+      else lua_pushfstring(L, "{%d to %d by %d}", r->start, r->stop, r->step);
+   }
+   else if (r->inclusive) lua_pushfstring(L, "{%d into %d}", r->start, r->stop);
    else lua_pushfstring(L, "{%d to %d}", r->start, r->stop);
    return 1;
 }

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -33,12 +33,12 @@
 
 // Extracts the function payload from an expression node if it's a function expression, otherwise returns null.
 
-static void rollback_ast_builder_constants(void *UserData)
+inline void rollback_ast_builder_constants(void *UserData)
 {
    ((AstBuilder *)UserData)->rollback_registered_enum_hierarchy();
 }
 
-static FunctionExprPayload * function_payload_from(ExprNode &Node)
+inline FunctionExprPayload * function_payload_from(ExprNode &Node)
 {
    if (Node.kind != AstNodeKind::FunctionExpr) return nullptr;
    return std::get_if<FunctionExprPayload>(&Node.data);
@@ -62,27 +62,212 @@ static std::unique_ptr<FunctionExprPayload> move_function_payload(ExprNodePtr &N
    return result;
 }
 
-// Checks for contextual range separators.  The lexer intentionally leaves `to` and `into` as identifiers so these
-// words remain available outside range-literal separator positions.
-
-static bool token_is_range_separator(const Token &Token, bool &IsInclusive)
+inline bool token_identifier_is(const Token &Token, std::string_view Text)
 {
    if (not Token.is_identifier()) return false;
 
    GCstr *symbol = Token.identifier();
    if (not symbol) return false;
 
-   std::string_view text(strdata(symbol), symbol->len);
-   if (text IS std::string_view("to")) {
+   return std::string_view(strdata(symbol), symbol->len) IS Text;
+}
+
+// Checks for contextual range separators.  The lexer intentionally leaves `to`, `into` and `by` as identifiers so
+// these words remain available outside range-literal separator positions.
+
+static bool token_is_range_separator(const Token &Token, bool &IsInclusive)
+{
+   if (token_identifier_is(Token, "to")) {
       IsInclusive = false;
       return true;
    }
-   if (text IS std::string_view("into")) {
+   if (token_identifier_is(Token, "into")) {
       IsInclusive = true;
       return true;
    }
 
    return false;
+}
+
+inline bool token_is_range_step_separator(const Token &Token)
+{
+   return token_identifier_is(Token, "by");
+}
+
+struct RangeLiteralScan {
+   bool has_step = false;
+   bool has_bare_string_operand = false;
+};
+
+inline bool range_word_matches(std::string_view Word)
+{
+   return Word IS "to" or Word IS "into";
+}
+
+static size_t skip_quoted_source(std::string_view Source, size_t Pos, char Quote)
+{
+   Pos++;
+   while (Pos < Source.size()) {
+      char c = Source[Pos];
+      if (c IS '\\') {
+         Pos += 2;
+         continue;
+      }
+      Pos++;
+      if (c IS Quote) break;
+   }
+   return Pos;
+}
+
+static bool source_has_range_separator_on_opening_line(ParserContext &Context, RangeLiteralScan &Scan)
+{
+   Token open_brace = Context.tokens().current();
+   std::string_view source = Context.lex().source;
+   size_t pos = open_brace.span().offset;
+   if (pos >= source.size()) return false;
+   pos++;
+
+   bool has_range_separator = false;
+   int depth = 0;
+   while (pos < source.size()) {
+      char c = source[pos];
+      if (c IS '\r' or c IS '\n') return false;
+
+      if (c IS '\'' or c IS '"') {
+         if (depth IS 0) Scan.has_bare_string_operand = true;
+         pos = skip_quoted_source(source, pos, c);
+         continue;
+      }
+
+      if (c IS '-' and pos + 1 < source.size() and source[pos + 1] IS '-') return false;
+
+      if (c IS '(' or c IS '[' or c IS '{') {
+         depth++;
+         pos++;
+         continue;
+      }
+
+      if (c IS ')' or c IS ']' or c IS '}') {
+         if (depth IS 0) return has_range_separator;
+         depth--;
+         pos++;
+         continue;
+      }
+
+      if (depth IS 0) {
+         if (c IS ',' or c IS ';' or c IS '=') return false;
+
+         if (std::isalpha(uint8_t(c)) or c IS '_') {
+            size_t start = pos;
+            pos++;
+            while (pos < source.size()) {
+               char word_char = source[pos];
+               if (not (std::isalnum(uint8_t(word_char)) or word_char IS '_')) break;
+               pos++;
+            }
+            if (range_word_matches(source.substr(start, pos - start))) has_range_separator = true;
+            continue;
+         }
+      }
+
+      pos++;
+   }
+
+   return false;
+}
+
+// Scans a braced expression without consuming tokens.  A range literal is recognised only when a top-level `to` or
+// `into` separator appears after a start expression, with an optional top-level `by` after the stop expression.
+// Range literals are not allowed to contain bare string literals, and new-lines also cause rejection.
+
+static bool scan_range_literal(ParserContext &Context, RangeLiteralScan &Scan)
+{
+   if (not Context.check(TokenKind::LeftBrace)) return false;
+   Scan = RangeLiteralScan{};
+   if (not source_has_range_separator_on_opening_line(Context, Scan)) return false;
+
+   bool found_range_separator = false;
+   bool found_step_separator = false;
+   bool has_start_expr_tokens = false;
+   bool has_stop_expr_tokens = false;
+   bool has_step_expr_tokens = false;
+   bool ended_on_right_brace = false;
+   bool invalid_top_level_shape = false;
+   TokenKind previous_top_level_kind = TokenKind::Unknown;
+   BCLine start_line = Context.tokens().current().span().line;
+   int depth = 0;
+
+   for (size_t i = 1; ; i++) {
+      Token tok = Context.tokens().peek(i);
+      auto kind = tok.kind();
+
+      if (kind IS TokenKind::EndOfFile) break;
+      if (tok.span().line != start_line) return false;
+
+      if (depth IS 0 and kind IS TokenKind::RightBrace) {
+         ended_on_right_brace = true;
+         break;
+      }
+
+      if (kind IS TokenKind::LeftParen or kind IS TokenKind::LeftBracket or kind IS TokenKind::LeftBrace) {
+         if (depth IS 0) {
+            if (found_step_separator) has_step_expr_tokens = true;
+            else if (found_range_separator) has_stop_expr_tokens = true;
+            else has_start_expr_tokens = true;
+         }
+         depth++;
+      }
+      else if (kind IS TokenKind::RightParen or kind IS TokenKind::RightBracket or kind IS TokenKind::RightBrace) {
+         depth--;
+         if (depth < 0) {
+            invalid_top_level_shape = true;
+            break;
+         }
+         if (depth IS 0) previous_top_level_kind = kind;
+      }
+      else if (depth IS 0) {
+         if (kind IS TokenKind::Comma or kind IS TokenKind::Semicolon or kind IS TokenKind::Equals) {
+            invalid_top_level_shape = true;
+            break;
+         }
+
+         bool member_name_context = token_kind_has_flag(previous_top_level_kind, TKF_MEMBER_NAME_CONTEXT);
+         bool previous_can_end_expression = token_kind_has_flag(previous_top_level_kind, TKF_CAN_END_RANGE_EXPRESSION);
+         bool separator_is_inclusive = false;
+         if (has_start_expr_tokens and not found_range_separator and not member_name_context and
+             previous_can_end_expression and
+             token_is_range_separator(tok, separator_is_inclusive)) {
+            found_range_separator = true;
+         }
+         else if (found_range_separator and has_stop_expr_tokens and not found_step_separator and
+                  not member_name_context and previous_can_end_expression and token_is_range_step_separator(tok)) {
+            found_step_separator = true;
+            Scan.has_step = true;
+         }
+         else if (found_range_separator and has_stop_expr_tokens and not found_step_separator and
+                  not member_name_context and previous_can_end_expression and
+                  token_is_range_separator(tok, separator_is_inclusive)) {
+            invalid_top_level_shape = true;
+            break;
+         }
+         else if (found_step_separator and has_step_expr_tokens and not member_name_context and
+                  previous_can_end_expression and
+                  (token_is_range_step_separator(tok) or token_is_range_separator(tok, separator_is_inclusive))) {
+            invalid_top_level_shape = true;
+            break;
+         }
+         else {
+            if (found_step_separator) has_step_expr_tokens = true;
+            else if (found_range_separator) has_stop_expr_tokens = true;
+            else has_start_expr_tokens = true;
+         }
+
+         previous_top_level_kind = kind;
+      }
+   }
+
+   return not invalid_top_level_shape and ended_on_right_brace and found_range_separator and has_start_expr_tokens and
+      has_stop_expr_tokens;
 }
 
 // Checks if a statement unconditionally terminates control flow (return, break, continue).

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -91,7 +91,8 @@ private:
    ParserResult<StmtNodePtr> parse_repeat();
    ParserResult<StmtNodePtr> parse_for();
    ParserResult<StmtNodePtr> parse_anonymous_for(const Token &);
-   ParserResult<ExprNodePtr> parse_range_in_braces();
+   ParserResult<ExprNodePtr> parse_scanned_range_in_braces(
+      bool HasStep, bool HasBareStringOperand);
    ParserResult<StmtNodePtr> parse_do();
    ParserResult<StmtNodePtr> parse_with();
    ParserResult<StmtNodePtr> parse_defer();
@@ -112,7 +113,7 @@ private:
    ParserResult<ExprNodePtr> parse_arrow_function(ExprNodeList parameters);
    ParserResult<ExprNodePtr> parse_function_literal(
       const Token &, bool IsThunk = false, GCstr *FunctionName = nullptr);
-   ParserResult<ExprNodePtr> parse_table_literal();
+   ParserResult<ExprNodePtr> parse_table_literal(bool AllowRange = true);
    ParserResult<ReturnStmtPayload> parse_return_payload(const Token &, bool same_line_only);
    ParserResult<FunctionReturnTypes> parse_return_type_annotation();
 
@@ -145,7 +146,7 @@ private:
    ParserResult<std::unique_ptr<BlockStmt>> parse_scoped_block(std::initializer_list<TokenKind>);
 
    [[nodiscard]] bool at_end_of_block(std::span<const TokenKind>) const;
-   [[nodiscard]] bool is_statement_start(TokenKind kind) const;
+   [[nodiscard]] bool is_statement_start(TokenKind Kind) const;
    [[nodiscard]] bool is_synchronisation_point(std::span<const TokenKind> terminators) const;
    [[nodiscard]] size_t skip_to_synchronisation_point(std::span<const TokenKind> terminators);
    [[nodiscard]] static Identifier make_identifier(const Token &);

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -600,7 +600,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          if (this->ctx.check(TokenKind::LeftBrace)) {
             has_initialiser = true;
             // Parse the table literal to extract values
-            auto table_result = this->parse_table_literal();
+            auto table_result = this->parse_table_literal(false);
             if (not table_result.ok()) return table_result;
 
             // Extract array-style values from table literal

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -51,87 +51,24 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
 
-//********************************************************************************************************************
-// Checks if the token stream matches a range literal pattern using lookahead.
-// Valid patterns: {num to num}, {ident into ident}, {-num to num}, {ident into -num}, etc.
-// Returns true if the pattern matches, and sets is_inclusive for `into`.
-
-static bool check_range_pattern(ParserContext& ctx, bool& is_inclusive)
-{
-   is_inclusive = false;
-
-   // Helper to get the token count for a simple range operand (literal, identifier, or -number)
-   // Returns 0 if not a valid range operand
-   auto operand_length = [&ctx](int start_offset) -> int {
-      Token tok = ctx.tokens().peek(start_offset);
-      if (tok.kind() IS TokenKind::Number or tok.kind() IS TokenKind::Identifier or tok.kind() IS TokenKind::Nil or
-          tok.kind() IS TokenKind::TrueToken or tok.kind() IS TokenKind::FalseToken) {
-         return 1;
-      }
-
-      if (tok.kind() IS TokenKind::Minus) {
-         Token next = ctx.tokens().peek(start_offset + 1);
-         if (next.kind() IS TokenKind::Number) return 2;  // -num
-      }
-      return 0;
-   };
-
-   // Check first operand
-
-   int first_len = operand_length(0);
-   if (first_len IS 0) return false;
-
-   // Check for range separator at expected position
-
-   Token separator = ctx.tokens().peek(first_len);
-   if (not token_is_range_separator(separator, is_inclusive)) return false;
-
-   // Check second operand
-
-   int second_len = operand_length(first_len + 1);
-   if (second_len IS 0) return false;
-
-   // Verify the range is followed by closing brace (strict pattern match)
-
-   Token closing = ctx.tokens().peek(first_len + 1 + second_len);
-   return closing.kind() IS TokenKind::RightBrace;
-}
-
-//********************************************************************************************************************
 // Parses table constructor expressions with array and record fields.
-// Also handles range literals: {start to stop} (exclusive) and {start into stop} (inclusive)
+// Also handles range literals: {start to stop} (exclusive), {start into stop} (inclusive) and optional `by step`.
 
-ParserResult<ExprNodePtr> AstBuilder::parse_table_literal()
+ParserResult<ExprNodePtr> AstBuilder::parse_table_literal(bool AllowRange)
 {
    Token token = this->ctx.tokens().current();
-   this->ctx.tokens().advance();
 
-   // Check for range literal pattern using lookahead: {expr to expr} or {expr into expr}
-   // This avoids ambiguity with string concatenation like {'str' .. func(), ...}
-
-   if (not this->ctx.check(TokenKind::RightBrace)) {
-      bool is_inclusive = false;
-
-      if (check_range_pattern(this->ctx, is_inclusive)) {
-         // Confirmed range pattern - parse start expression
-         auto first_expr = this->parse_unary();
-         if (not first_expr.ok()) return ParserResult<ExprNodePtr>::failure(first_expr.error_ref());
-
-         // Consume the range separator (already verified by lookahead)
-         this->ctx.tokens().advance();
-
-         // Parse stop expression
-         auto stop_expr = this->parse_unary();
-         if (not stop_expr.ok()) return ParserResult<ExprNodePtr>::failure(stop_expr.error_ref());
-
-         this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
-         ExprNodePtr node = make_range_expr(token.span(), std::move(first_expr.value_ref()),
-            std::move(stop_expr.value_ref()), is_inclusive);
-         return ParserResult<ExprNodePtr>::success(std::move(node));
+   if (AllowRange) {
+      RangeLiteralScan scan;
+      if (scan_range_literal(this->ctx, scan)) {
+         auto range = this->parse_scanned_range_in_braces(scan.has_step, scan.has_bare_string_operand);
+         if (not range.ok()) return range;
+         return range;
       }
    }
 
    // Standard table parsing path
+   this->ctx.tokens().advance();
    bool has_array = false;
    auto fields = this->parse_table_fields(&has_array);
    if (not fields.ok()) return ParserResult<ExprNodePtr>::failure(fields.error_ref());

--- a/src/tiri/jit/src/parser/ast/loops.cpp
+++ b/src/tiri/jit/src/parser/ast/loops.cpp
@@ -8,97 +8,14 @@
 // - Range literal optimisation for JIT compilation
 
 //********************************************************************************************************************
-// Attempts to parse a range expression enclosed in braces: {expr to expr} or {expr into expr}
-// Used by for-in loops to always interpret {Y to Z} as a range, even when Y and Z are complex expressions.
-//
-// Uses a lookahead scan to confirm that `to` or `into` exists at brace/paren/bracket depth 0 inside the braces.
-// If confirmed, parses start and stop as full expressions and returns a RangeExpr node.
-// If the scan does not find a range separator, returns failure so the caller can fall through to normal parsing.
+// Parses a range expression already confirmed by scan_range_literal(): {expr to expr} or {expr into expr}, with an
+// optional `by` step expression.
 
-ParserResult<ExprNodePtr> AstBuilder::parse_range_in_braces()
+ParserResult<ExprNodePtr> AstBuilder::parse_scanned_range_in_braces(bool HasStep, bool HasBareStringOperand)
 {
-   // Lookahead scan: starting from the token after '{', verify a strict
-   // {start_expr to stop_expr} or {start_expr into stop_expr} shape at depth 0.
-   // This avoids misclassifying table literals that merely contain unrelated identifiers.
-
-   bool found_range_separator = false;
-   bool is_inclusive = false;
-   bool has_start_expr_tokens = false;
-   bool has_stop_expr_tokens = false;
-   bool ended_on_right_brace = false;
-   bool invalid_top_level_shape = false;
-   TokenKind previous_top_level_kind = TokenKind::Unknown;
-   int depth = 0;
-
-   for (size_t i = 1; ; i++) {
-      Token tok = this->ctx.tokens().peek(i);
-      auto kind = tok.kind();
-
-      if (kind IS TokenKind::EndOfFile) {
-         break;
-      }
-
-      if (depth IS 0 and kind IS TokenKind::RightBrace) {
-         ended_on_right_brace = true;
-         break;
-      }
-
-      if (kind IS TokenKind::LeftParen or kind IS TokenKind::LeftBracket or kind IS TokenKind::LeftBrace) {
-         if (depth IS 0) {
-            if (found_range_separator) has_stop_expr_tokens = true;
-            else has_start_expr_tokens = true;
-         }
-         depth++;
-      }
-      else if (kind IS TokenKind::RightParen or kind IS TokenKind::RightBracket) {
-         depth--;
-         if (depth < 0) {
-            invalid_top_level_shape = true;
-            break;
-         }
-      }
-      else if (kind IS TokenKind::RightBrace) {
-         depth--;
-         if (depth < 0) {
-            invalid_top_level_shape = true;
-            break;
-         }
-      }
-      else if (depth IS 0) {
-         if (kind IS TokenKind::Comma) {
-            invalid_top_level_shape = true;
-            break;
-         }
-
-         bool separator_is_inclusive = false;
-         bool member_name_context = previous_top_level_kind IS TokenKind::Dot or
-            previous_top_level_kind IS TokenKind::Colon or
-            previous_top_level_kind IS TokenKind::SafeField or
-            previous_top_level_kind IS TokenKind::SafeMethod;
-         if (has_start_expr_tokens and not member_name_context and token_is_range_separator(tok, separator_is_inclusive)) {
-            // Exactly one top-level range separator is allowed, and it must
-            // appear after at least one token belonging to the start expression.
-            if (found_range_separator) {
-               invalid_top_level_shape = true;
-               break;
-            }
-
-            found_range_separator = true;
-            is_inclusive = separator_is_inclusive;
-         }
-         else {
-            if (found_range_separator) has_stop_expr_tokens = true;
-            else has_start_expr_tokens = true;
-         }
-
-         previous_top_level_kind = kind;
-      }
-   }
-
-   if (invalid_top_level_shape or not ended_on_right_brace or not found_range_separator
-      or not has_start_expr_tokens or not has_stop_expr_tokens) {
-      return ParserResult<ExprNodePtr>::failure(
-         ParserError(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(), "not a range expression"));
+   if (HasBareStringOperand) {
+      return this->fail<ExprNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "range literals do not support bare string operands");
    }
 
    // Confirmed range pattern.  Consume '{' and parse the range.
@@ -112,20 +29,52 @@ ParserResult<ExprNodePtr> AstBuilder::parse_range_in_braces()
 
    // Consume the range separator
    Token separator = this->ctx.tokens().current();
+   bool is_inclusive = false;
    if (not token_is_range_separator(separator, is_inclusive)) {
-      return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, separator, "expected 'to' or 'into' range separator");
+      return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, separator,
+         "expected 'to' or 'into' range separator");
    }
    this->ctx.tokens().advance();  // Consume `to` or `into`
 
-   // Parse stop expression (stops naturally at '}')
+   // Parse stop expression (stops naturally at `by` or `}`)
    auto stop_expr = this->parse_expression();
    if (not stop_expr.ok()) return ParserResult<ExprNodePtr>::failure(stop_expr.error_ref());
+
+   ExprNodePtr step_expr;
+   if (HasStep) {
+      Token by_token = this->ctx.tokens().current();
+      if (not token_is_range_step_separator(by_token)) {
+         return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, by_token, "expected 'by' range step separator");
+      }
+      this->ctx.tokens().advance();
+
+      auto step = this->parse_expression();
+      if (not step.ok()) return ParserResult<ExprNodePtr>::failure(step.error_ref());
+      step_expr = std::move(step.value_ref());
+   }
 
    this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
 
    ExprNodePtr node = make_range_expr(brace_token.span(), std::move(start_expr.value_ref()),
-      std::move(stop_expr.value_ref()), is_inclusive);
+      std::move(stop_expr.value_ref()), is_inclusive, std::move(step_expr));
    return ParserResult<ExprNodePtr>::success(std::move(node));
+}
+
+static bool range_literal_number(const ExprNodePtr &Expr, lua_Number &Value)
+{
+   if (not Expr or not (Expr->kind IS AstNodeKind::LiteralExpr)) return false;
+
+   auto *literal = std::get_if<LiteralValue>(&Expr->data);
+   if (not literal or not (literal->kind IS LiteralKind::Number)) return false;
+
+   Value = literal->number_value;
+   return true;
+}
+
+static bool range_literal_valid_step(lua_Number Value)
+{
+   auto int_value = int32_t(Value);
+   return Value != 0 and lua_Number(int_value) IS Value;
 }
 
 //********************************************************************************************************************
@@ -185,8 +134,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
 
    ExprNodeList iterator_nodes;
    if (this->ctx.check(TokenKind::LeftBrace)) {
-      auto range_result = this->parse_range_in_braces();
-      if (range_result.ok()) {
+      RangeLiteralScan scan;
+      if (scan_range_literal(this->ctx, scan)) {
+         auto range_result = this->parse_scanned_range_in_braces(scan.has_step, scan.has_bare_string_operand);
+         if (not range_result.ok()) return ParserResult<StmtNodePtr>::failure(range_result.error_ref());
          iterator_nodes.push_back(std::move(range_result.value_ref()));
       }
       else {
@@ -208,7 +159,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
    // Conversion: for i in {start to stop} do   =>  for i = start, stop-1, step do  (exclusive)
    //             for i in {start into stop} do =>  for i = start, stop, step do    (inclusive)
    //
-   // Step is computed at runtime based on start/stop direction.
+   // Step is inferred from start/stop direction unless an explicit literal step is supplied.
 
    if (names.size() IS 1 and iterator_nodes.size() IS 1) {
       ExprNodePtr &first = iterator_nodes[0];
@@ -217,33 +168,31 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
          if (range_payload and range_payload->start and range_payload->stop) {
             SourceSpan span = first->span;
 
-            // Move the start and stop expressions from the range
-            ExprNodePtr start_expr = std::move(range_payload->start);
-            ExprNodePtr stop_expr = std::move(range_payload->stop);
-            bool inclusive = range_payload->inclusive;
-
             // Check if both start and stop are numeric literals for compile-time optimisation.
             // When both are constants, we can compute the step direction and exclusive adjustment
             // at compile time, producing optimal BC_FORI/BC_FORL bytecode.
 
-            bool start_is_num = start_expr->kind IS AstNodeKind::LiteralExpr and
-               std::get_if<LiteralValue>(&start_expr->data) and
-               std::get<LiteralValue>(start_expr->data).kind IS LiteralKind::Number;
+            lua_Number start_val = 0;
+            lua_Number stop_val = 0;
+            lua_Number step_val = 0;
+            bool start_is_num = range_literal_number(range_payload->start, start_val);
+            bool stop_is_num = range_literal_number(range_payload->stop, stop_val);
+            bool step_is_num = false;
+            if (range_payload->step) step_is_num = range_literal_number(range_payload->step, step_val) and
+               range_literal_valid_step(step_val);
+            else {
+               step_val = (start_val <= stop_val) ? 1.0 : -1.0;
+               step_is_num = true;
+            }
 
-            bool stop_is_num = stop_expr->kind IS AstNodeKind::LiteralExpr and
-               std::get_if<LiteralValue>(&stop_expr->data) and
-               std::get<LiteralValue>(stop_expr->data).kind IS LiteralKind::Number;
-
-            if (start_is_num and stop_is_num) {
-               lua_Number start_val = std::get<LiteralValue>(start_expr->data).number_value;
-               lua_Number stop_val = std::get<LiteralValue>(stop_expr->data).number_value;
-
-               // Determine step direction based on start/stop values
-               lua_Number step_val = (start_val <= stop_val) ? 1.0 : -1.0;
+            if (start_is_num and stop_is_num and step_is_num) {
+               ExprNodePtr start_expr = std::move(range_payload->start);
+               ExprNodePtr stop_expr = std::move(range_payload->stop);
+               range_payload->step = nullptr;
 
                // For exclusive ranges, adjust stop
                lua_Number final_stop = stop_val;
-               if (not inclusive) {
+               if (not range_payload->inclusive) {
                   final_stop = (step_val > 0) ? (stop_val - 1) : (stop_val + 1);
                }
 
@@ -262,11 +211,6 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
                stmt->data = std::move(payload);
                return ParserResult<StmtNodePtr>::success(std::move(stmt));
             }
-
-            // Non-constant range: fall back to generic for loop with iterator
-            // Restore the range expression since we moved from it
-            range_payload->start = std::move(start_expr);
-            range_payload->stop = std::move(stop_expr);
          }
       }
    }
@@ -309,12 +253,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
 ParserResult<StmtNodePtr> AstBuilder::parse_anonymous_for(const Token& ForToken)
 {
    // Parse the iterator expression (expected to be a range like {0 to 10}).
-   // Try parse_range_in_braces() first to support complex expressions like {0 to total-1}.
+   // Try the range scan first to support complex expressions like {0 to total-1}.
 
    ExprNodePtr iter_expr;
    if (this->ctx.check(TokenKind::LeftBrace)) {
-      auto range_result = this->parse_range_in_braces();
-      if (range_result.ok()) {
+      RangeLiteralScan scan;
+      if (scan_range_literal(this->ctx, scan)) {
+         auto range_result = this->parse_scanned_range_in_braces(scan.has_step, scan.has_bare_string_operand);
+         if (not range_result.ok()) return ParserResult<StmtNodePtr>::failure(range_result.error_ref());
          iter_expr = std::move(range_result.value_ref());
       }
       else {
@@ -344,30 +290,29 @@ ParserResult<StmtNodePtr> AstBuilder::parse_anonymous_for(const Token& ForToken)
 
          // Check if both start and stop are numeric literals for compile-time optimisation.
 
-         bool start_is_num = range_payload->start->kind IS AstNodeKind::LiteralExpr and
-            std::get_if<LiteralValue>(&range_payload->start->data) and
-            std::get<LiteralValue>(range_payload->start->data).kind IS LiteralKind::Number;
+         lua_Number start_val = 0;
+         lua_Number stop_val = 0;
+         lua_Number step_val = 0;
+         bool start_is_num = range_literal_number(range_payload->start, start_val);
+         bool stop_is_num = range_literal_number(range_payload->stop, stop_val);
+         bool step_is_num = false;
+         if (range_payload->step) step_is_num = range_literal_number(range_payload->step, step_val) and
+            range_literal_valid_step(step_val);
+         else {
+            step_val = (start_val <= stop_val) ? 1.0 : -1.0;
+            step_is_num = true;
+         }
 
-         bool stop_is_num = range_payload->stop->kind IS AstNodeKind::LiteralExpr and
-            std::get_if<LiteralValue>(&range_payload->stop->data) and
-            std::get<LiteralValue>(range_payload->stop->data).kind IS LiteralKind::Number;
-
-         if (start_is_num and stop_is_num) {
-            lua_Number start_val = std::get<LiteralValue>(range_payload->start->data).number_value;
-            lua_Number stop_val = std::get<LiteralValue>(range_payload->stop->data).number_value;
-            bool inclusive = range_payload->inclusive;
-
-            // Determine step direction based on start/stop values
-            lua_Number step_val = (start_val <= stop_val) ? 1.0 : -1.0;
-
+         if (start_is_num and stop_is_num and step_is_num) {
             // For exclusive ranges, adjust stop
             lua_Number final_stop = stop_val;
-            if (not inclusive) {
+            if (not range_payload->inclusive) {
                final_stop = (step_val > 0) ? (stop_val - 1) : (stop_val + 1);
             }
 
             // Move the start expression from the range
             ExprNodePtr start_expr = std::move(range_payload->start);
+            range_payload->step = nullptr;
 
             // Create literals for stop and step
             ExprNodePtr final_stop_expr = make_literal_expr(span, LiteralValue::number(final_stop));
@@ -379,8 +324,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_anonymous_for(const Token& ForToken)
             this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
 
             StmtNodePtr stmt = std::make_unique<StmtNode>(AstNodeKind::NumericForStmt, ForToken.span());
-            stmt->data.emplace<NumericForStmtPayload>(std::move(blank_id), std::move(start_expr), std::move(final_stop_expr),
-               std::move(step_expr), std::move(body.value_ref()));
+            stmt->data.emplace<NumericForStmtPayload>(std::move(blank_id), std::move(start_expr),
+               std::move(final_stop_expr), std::move(step_expr), std::move(body.value_ref()));
             return ParserResult<StmtNodePtr>::success(std::move(stmt));
          }
       }

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -343,6 +343,7 @@ struct ExpressionChildCounter {
    {
       size_t total = Payload.start ? 1 : 0;
       if (Payload.stop) total++;
+      if (Payload.step) total++;
       return total;
    }
 
@@ -875,13 +876,15 @@ ExprNodePtr make_deferred_expr(SourceSpan Span, ExprNodePtr inner, TiriType Type
    return node;
 }
 
-ExprNodePtr make_range_expr(SourceSpan Span, ExprNodePtr Start, ExprNodePtr Stop, bool Inclusive)
+ExprNodePtr make_range_expr(SourceSpan Span, ExprNodePtr Start, ExprNodePtr Stop, bool Inclusive, ExprNodePtr Step)
 {
    assert_node(ensure_operand(Start), "range expression requires start expression");
    assert_node(ensure_operand(Stop), "range expression requires stop expression");
+   if (Step) assert_node(ensure_operand(Step), "range expression requires valid step expression");
    RangeExprPayload payload;
    payload.start = std::move(Start);
    payload.stop = std::move(Stop);
+   payload.step = std::move(Step);
    payload.inclusive = Inclusive;
    ExprNodePtr node = std::make_unique<ExprNode>();
    node->kind = AstNodeKind::RangeExpr;

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -527,6 +527,7 @@ struct RangeExprPayload {
    RangeExprPayload& operator=(RangeExprPayload&&) noexcept = default;
    ExprNodePtr start;      // Start index expression
    ExprNodePtr stop;       // Stop index expression
+   ExprNodePtr step;       // Optional step expression
    bool inclusive = false; // True for `into` (inclusive), false for `to` (exclusive)
    ~RangeExprPayload();
 };
@@ -1003,7 +1004,8 @@ ExprNodePtr make_result_filter_expr(SourceSpan span, ExprNodePtr expression, uin
 ExprNodePtr make_table_expr(SourceSpan span, std::vector<TableField> fields, bool has_array_part);
 ExprNodePtr make_function_expr(SourceSpan span, std::vector<FunctionParameter> parameters, bool is_vararg, std::unique_ptr<BlockStmt> body, bool is_thunk = false, TiriType thunk_return_type = TiriType::Any, FunctionReturnTypes return_types = {});
 ExprNodePtr make_deferred_expr(SourceSpan span, ExprNodePtr inner, TiriType type = TiriType::Unknown, bool type_explicit = false);
-ExprNodePtr make_range_expr(SourceSpan span, ExprNodePtr start, ExprNodePtr stop, bool inclusive);
+ExprNodePtr make_range_expr(SourceSpan span, ExprNodePtr start, ExprNodePtr stop, bool inclusive,
+   ExprNodePtr step = nullptr);
 ExprNodePtr make_choose_expr(SourceSpan span, ExprNodePtr scrutinee, std::vector<ChooseCase> cases, size_t inferred_arity = 0);
 ExprNodePtr make_choose_expr_tuple(SourceSpan span, ExprNodeList scrutinee_tuple, std::vector<ChooseCase> cases);
 std::unique_ptr<FunctionExprPayload> make_function_payload(std::vector<FunctionParameter> parameters, bool is_vararg, std::unique_ptr<BlockStmt> body, bool is_thunk = false, TiriType thunk_return_type = TiriType::Any, FunctionReturnTypes return_types = {});

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -2672,7 +2672,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload
 
 //********************************************************************************************************************
 // Emit bytecode for a range literal expression ({start to stop} or {start into stop}).
-// Emits a call to the global `range` function: range(start, stop, inclusive)
+// Emits a call to the global `range` function: range(start, stop, inclusive [, step])
 
 ParserResult<ExpDesc> IrEmitter::emit_range_expr(const RangeExprPayload &Payload)
 {
@@ -2710,9 +2710,18 @@ ParserResult<ExpDesc> IrEmitter::emit_range_expr(const RangeExprPayload &Payload
    ExpDesc inclusive_expr(Payload.inclusive);
    this->materialise_to_next_reg(inclusive_expr, "range inclusive");
 
-   // Emit CALL instruction: range(start, stop, inclusive)
-   // BC_CALL A=base, B=2 (expect 1 result), C=4 (3 args + 1)
-   BCIns ins = BCINS_ABC(BC_CALL, base, 2, 4);
+   uint8_t argument_count = 3;
+   if (Payload.step) {
+      auto step_result = this->emit_expression(*Payload.step);
+      if (not step_result.ok()) return step_result;
+      ExpDesc step_expr = step_result.value_ref();
+      this->materialise_to_next_reg(step_expr, "range step");
+      argument_count = 4;
+   }
+
+   // Emit CALL instruction: range(start, stop, inclusive [, step])
+   // BC_CALL A=base, B=2 (expect 1 result), C=args + 1
+   BCIns ins = BCINS_ABC(BC_CALL, base, 2, argument_count + 1);
 
    ExpDesc result;
    result.init(ExpKind::Call, bcemit_INS(fs, ins));

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -19,6 +19,42 @@ function enforce_hotpath() end
    assert(err is ERR_Okay, "Script parsing failed, error: " .. script.errorMessage)
 end
 
+@Test function NonRangeTableWithFStringBraces()
+   -- Verify range lookahead does not scan through table assignment fields and corrupt f-string token buffering.
+
+   script = obj.new('script', { statement=[[
+   port = 8080
+   request = {
+      src = f'http://127.0.0.1:{port}/upload/file',
+      payload = f'value:{port}'
+   }
+   assert(request.src is 'http://127.0.0.1:8080/upload/file')
+   assert(request.payload is 'value:8080')
+   ]] })
+
+   err = script.acActivate()
+   assert(err is ERR_Okay, "Table field f-string parsing failed: " .. script.errorMessage)
+end
+
+@Test function NonRangeTypedArrayWithFStringBraces()
+   -- Verify multiline typed array initialisers bypass range lookahead before f-string expansion.
+
+   script = obj.new('script', { statement=[[
+   port = 8080
+   args = array<string> {
+      f'url=http://127.0.0.1:{port}/echo',
+      'data=plain',
+      'json={}'
+   }
+   assert(args[0] is 'url=http://127.0.0.1:8080/echo')
+   assert(args[1] is 'data=plain')
+   assert(args[2] is 'json={}')
+   ]] })
+
+   err = script.acActivate()
+   assert(err is ERR_Okay, "Typed array f-string parsing failed: " .. script.errorMessage)
+end
+
 @Test function ForInNonRangeBraceWithConcatParses()
    -- Verify for-in does not misclassify {a, b .. c} as a range literal.
    -- Guard execution so this validates parser behaviour only.
@@ -223,6 +259,8 @@ end
    -- Literal membership without variables
    assert(5 in {0 to 10}, "5 should be in literal range 0 to 10")
    assert(not (10 in {0 to 10}), "10 should NOT be in literal exclusive range 0 to 10")
+   assert(4 in {0 to 10 by 2}, "4 should be in literal range 0 to 10 by 2")
+   assert(not (5 in {0 to 10 by 2}), "5 should NOT be in literal range 0 to 10 by 2")
 end
 
 @Test function RangeMembershipInIf()
@@ -350,6 +388,33 @@ end
    assert(#r is 5, "{1 into 5} should have 5 elements (1,2,3,4,5)")
 end
 
+@Test function RangeLiteralWithStep()
+   -- Test range literal syntax with an explicit step
+   r = {0 to 10 by 2}
+   assert(r.start is 0, "literal start should be 0")
+   assert(r.stop is 10, "literal stop should be 10")
+   assert(r.step is 2, "literal step should be 2")
+   assert(r.inclusive is false, "{to} should be exclusive")
+   assert(#r is 5, "{0 to 10 by 2} should have 5 elements")
+
+   ri = {0 into 10 by 2}
+   assert(ri.inclusive is true, "{into} should be inclusive")
+   assert(#ri is 6, "{0 into 10 by 2} should have 6 elements")
+end
+
+@Test function RangeLiteralReverseWithStep()
+   -- Explicit steps are passed exactly, including their sign
+   r = {10 to 0 by -2}
+   assert(r.start is 10, "reverse start should be 10")
+   assert(r.stop is 0, "reverse stop should be 0")
+   assert(r.step is -2, "reverse explicit step should be -2")
+   assert(#r is 5, "{10 to 0 by -2} should have 5 elements")
+
+   empty = {10 to 0 by 2}
+   assert(empty.step is 2, "positive reverse step should be preserved")
+   assert(#empty is 0, "{10 to 0 by 2} should be empty")
+end
+
 @Test function RangeLiteralReverse()
    -- Test reverse range literal
    r = {10 to 1}
@@ -377,6 +442,10 @@ end
    lit2 = {0 into 5}
    con2 = range(0, 5, true)
    assert(lit2 is con2, "{0 into 5} should equal range(0, 5, true)")
+
+   stepped_lit = {0 to 10 by 2}
+   stepped_con = range(0, 10, false, 2)
+   assert(stepped_lit is stepped_con, "{0 to 10 by 2} should equal range(0, 10, false, 2)")
 end
 
 @Test function RangeLiteralToString()
@@ -386,6 +455,12 @@ end
 
    r2 = {0 into 5}
    assert(tostring(r2) is "{0 into 5}", "inclusive literal tostring should be {0 into 5}")
+
+   r3 = {0 to 10 by 2}
+   assert(tostring(r3) is "{0 to 10 by 2}", "stepped literal tostring should include by clause")
+
+   r4 = {10 into 0 by -2}
+   assert(tostring(r4) is "{10 into 0 by -2}", "reverse stepped literal tostring should include signed step")
 end
 
 @Test function RangeLiteralContains()
@@ -395,6 +470,10 @@ end
    assert(r:contains(5) is true, "5 should be in {0 to 10}")
    assert(r:contains(9) is true, "9 should be in {0 to 10}")
    assert(r:contains(10) is false, "10 should NOT be in {0 to 10} (exclusive)")
+
+   stepped = {0 to 10 by 2}
+   assert(stepped:contains(4) is true, "4 should be in {0 to 10 by 2}")
+   assert(stepped:contains(5) is false, "5 should NOT be in {0 to 10 by 2}")
 end
 
 @Test function RangeLiteralWithVariables()
@@ -407,6 +486,18 @@ end
    assert(#r is 5, "{3 to 8} should have 5 elements")
 end
 
+@Test function RangeLiteralWithExpressionsAndStep()
+   -- Test range literals with general expressions in all positions
+   start = 1
+   stop = 5
+   step = 2
+   r = {start + 1 to stop * 2 by step}
+   assert(r.start is 2, "expression start should be 2")
+   assert(r.stop is 10, "expression stop should be 10")
+   assert(r.step is 2, "expression step should be 2")
+   assert(#r is 4, "{2 to 10 by 2} should have 4 elements")
+end
+
 @Test function RangeLiteralContextualSeparatorNames()
    -- Verify `to` and `into` remain valid identifiers outside the separator position.
    to = 2
@@ -415,6 +506,23 @@ end
    assert(r.start is 2, "range start should come from variable named to")
    assert(r.stop is 6, "range stop should come from variable named into")
    assert(r.inclusive is false, "second to token should be the exclusive separator")
+
+   by = 2
+   stepped = {0 to 10 by by}
+   assert(stepped.step is 2, "range step should come from variable named by")
+
+   config = { by=3, into=9 }
+   member_step = {0 to config.into by config.by}
+   assert(member_step.stop is 9, "member named into should not be a range separator")
+   assert(member_step.step is 3, "member named by should not be a step separator")
+
+   stop_with_by = {0 to config.into + by}
+   assert(stop_with_by.stop is 11, "identifier named by should remain part of the stop expression")
+   assert(stop_with_by.step is 1, "range should not gain a step when by is used as a stop expression variable")
+
+   parenthesised_stop = {0 to (config.into + by) by 2}
+   assert(parenthesised_stop.stop is 11, "parenthesised stop expression should parse before by step")
+   assert(parenthesised_stop.step is 2, "by after parenthesised stop should be treated as the step separator")
 end
 
 @Test function ForInRangeWithComplexStopExpression()
@@ -441,6 +549,48 @@ end
       inclusive_sum += i
    end
    assert(inclusive_sum is 9, "member named to should not be treated as range separator, got " .. inclusive_sum)
+end
+
+@Test function ForInRangeWithNestedStringCallArgument()
+   script = obj.new('script', { statement=[[
+   function hello(Str)
+      return 4
+   end
+
+   sum = 0
+   for i in {hello('goodbye') to 10} do
+      sum += i
+   end
+   assert(sum is 39, "range should start from function result")
+   ]] })
+
+   err = script.acActivate()
+   assert(err is ERR_Okay, "range with nested string call argument should parse: " .. script.errorMessage)
+end
+
+@Test function ForInRangeRejectsBareStringOperandAtParseTime()
+   script = obj.new('script', { statement=[[
+   if false then
+      for i in {'fart' to 10} do
+      end
+   end
+   ]] })
+
+   err = script.acActivate()
+   assert(err != ERR_Okay, "bare string range operand should be rejected during parsing")
+end
+
+@Test function ForInNonRangeBareStringConcatToParses()
+   script = obj.new('script', { statement=[[
+   to = 'b'
+   if false then
+      for i in {'a' .. to} do
+      end
+   end
+   ]] })
+
+   err = script.acActivate()
+   assert(err is ERR_Okay, "non-range table expression with variable named to should parse: " .. script.errorMessage)
 end
 
 @Test function RangeLiteralNegativeValues()
@@ -479,6 +629,13 @@ end
    s = "Hello, World!"
    assert(s[{0 to 5}] is "Hello", "s[{0 to 5}] should be 'Hello', got '" .. s[{0 to 5}] .. "'")
    assert(s[{7 to 12}] is "World", "s[{7 to 12}] should be 'World', got '" .. s[{7 to 12}] .. "'")
+end
+
+@Test function StringSliceWithLiteralStep()
+   -- Test stepped range literal string slicing
+   s = "abcdef"
+   assert(s[{0 to 6 by 2}] is "ace", "s[{0 to 6 by 2}] should be 'ace', got '" .. s[{0 to 6 by 2}] .. "'")
+   assert(s[{5 into 0 by -2}] is "fdb", "s[{5 into 0 by -2}] should be 'fdb', got '" .. s[{5 into 0 by -2}] .. "'")
 end
 
 @Test function StringSliceInclusive()
@@ -649,6 +806,18 @@ end
    success
       error("range literal with nil stop should throw")
    end
+
+   try
+      result = {0 to 10 by 0}
+   success
+      error("range literal with zero step should throw")
+   end
+
+   try
+      result = {0 to 10 by 1.5}
+   success
+      error("range literal with non-integer step should throw")
+   end
 end
 
 @Test function StringIndexOutOfBounds()
@@ -721,6 +890,29 @@ end
    end
    assert(#result is 6, "range(0,10,true,2) should have 6 elements, got " .. #result)
    assert(result[5] is 10, "last element should be 10")
+end
+
+@Test function RangeIterationWithLiteralStep()
+   -- Test direct iteration over stepped range literals
+   result = {}
+   for i in {0 to 10 by 2} do
+      result[#result] = i
+   end
+   assert(#result is 5, "{0 to 10 by 2} should have 5 elements, got " .. #result)
+   assert(result[0] is 0, "first element should be 0")
+   assert(result[1] is 2, "second element should be 2")
+   assert(result[4] is 8, "last element should be 8")
+end
+
+@Test function RangeIterationWithReverseLiteralStep()
+   -- Test direct reverse iteration over stepped range literals
+   result = {}
+   for i in {10 into 0 by -2} do
+      result[#result] = i
+   end
+   assert(#result is 6, "{10 into 0 by -2} should have 6 elements, got " .. #result)
+   assert(result[0] is 10, "first element should be 10")
+   assert(result[5] is 0, "last element should be 0")
 end
 
 @Test function RangeIterationEmpty()


### PR DESCRIPTION
* Added by-step parsing for range literals and emitted the step through range() construction
* Optimised constant stepped range loops into numeric for loops when safe
* Avoided duplicate range literal scans by passing scan results into the range parser
* Extended range Flute coverage for stepped literals, iteration, slicing and contextual separator names