### PR TITLE
[Tiri] Added ordering comparison chaining

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -768,7 +768,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips tempus
-   compile_if_import overflow
+   comparison_chaining compile_if_import overflow
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -9,6 +9,16 @@
 // - Arrow functions
 // - Operator matching
 
+namespace {
+
+[[nodiscard]] inline bool is_ordering_operator(AstBinaryOperator Operator)
+{
+   return Operator IS AstBinaryOperator::LessThan or Operator IS AstBinaryOperator::LessEqual or
+      Operator IS AstBinaryOperator::GreaterThan or Operator IS AstBinaryOperator::GreaterEqual;
+}
+
+} // namespace
+
 //********************************************************************************************************************
 // Parses expression statements, handling assignments, compound assignments, conditional shorthands, and standalone expressions.
 
@@ -308,6 +318,37 @@ ParserResult<ExprNodePtr> AstBuilder::parse_expression(uint8_t precedence)
       auto op_info = this->match_binary_operator(next);
       if (not op_info.has_value()) break;
       if (op_info->left <= precedence) break;
+
+      if (is_ordering_operator(op_info->op)) {
+         ExprNodeList operands;
+         std::vector<AstBinaryOperator> operators;
+         operands.push_back(std::move(left.value_ref()));
+
+         while (op_info.has_value() and is_ordering_operator(op_info->op) and op_info->left > precedence) {
+            this->ctx.tokens().advance();
+            auto right = this->parse_expression(op_info->right);
+            if (not right.ok()) return right;
+            operators.push_back(op_info->op);
+            operands.push_back(std::move(right.value_ref()));
+
+            next = this->ctx.tokens().current();
+            op_info = this->match_binary_operator(next);
+         }
+
+         SourceSpan span = combine_spans(operands.front()->span, operands.back()->span);
+         if (operators.size() IS 1) {
+            ExprNodePtr lhs = std::move(operands[0]);
+            ExprNodePtr rhs = std::move(operands[1]);
+            left = ParserResult<ExprNodePtr>::success(
+               make_binary_expr(span, operators[0], std::move(lhs), std::move(rhs)));
+         }
+         else {
+            left = ParserResult<ExprNodePtr>::success(
+               make_comparison_chain_expr(span, std::move(operators), std::move(operands)));
+         }
+         continue;
+      }
+
       this->ctx.tokens().advance();
       auto right = this->parse_expression(op_info->right);
       if (not right.ok()) return right;

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -110,6 +110,9 @@ TiriType infer_expression_type(const ExprNode &Expr)
          break;
       }
 
+      case AstNodeKind::ComparisonChainExpr:
+         return TiriType::Bool;
+
       // Binary operators: result type depends on operator
       case AstNodeKind::BinaryExpr: {
          const auto& payload = std::get<BinaryExprPayload>(Expr.data);
@@ -267,6 +270,10 @@ struct ExpressionChildCounter {
       size_t total = Payload.left ? 1 : 0;
       if (Payload.right) total++;
       return total;
+   }
+
+   [[nodiscard]] inline size_t operator()(const ComparisonChainExprPayload &Payload) const {
+      return Payload.operands.size();
    }
 
    [[nodiscard]] inline size_t operator()(const TernaryExprPayload &Payload) const {
@@ -494,6 +501,7 @@ SafeMethodCallTarget::~SafeMethodCallTarget() = default;
 UnaryExprPayload::~UnaryExprPayload() = default;
 UpdateExprPayload::~UpdateExprPayload() = default;
 BinaryExprPayload::~BinaryExprPayload() = default;
+ComparisonChainExprPayload::~ComparisonChainExprPayload() = default;
 TernaryExprPayload::~TernaryExprPayload() = default;
 PresenceExprPayload::~PresenceExprPayload() = default;
 PipeExprPayload::~PipeExprPayload() = default;
@@ -598,6 +606,20 @@ ExprNodePtr make_binary_expr(SourceSpan Span, AstBinaryOperator op, ExprNodePtr 
    payload.right = std::move(right);
    ExprNodePtr node = std::make_unique<ExprNode>();
    node->kind = AstNodeKind::BinaryExpr;
+   node->span = Span;
+   node->data = std::move(payload);
+   return node;
+}
+
+ExprNodePtr make_comparison_chain_expr(SourceSpan Span, std::vector<AstBinaryOperator> Operators, ExprNodeList Operands)
+{
+   assert_node(Operands.size() >= 2 and Operators.size() + 1 IS Operands.size(),
+      "comparison chain requires adjacent operators and operands");
+   ComparisonChainExprPayload payload;
+   payload.operators = std::move(Operators);
+   payload.operands = std::move(Operands);
+   ExprNodePtr node = std::make_unique<ExprNode>();
+   node->kind = AstNodeKind::ComparisonChainExpr;
    node->span = Span;
    node->data = std::move(payload);
    return node;

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -345,6 +345,17 @@ struct BinaryExprPayload {
    ~BinaryExprPayload();
 };
 
+struct ComparisonChainExprPayload {
+   ComparisonChainExprPayload() = default;
+   ComparisonChainExprPayload(const ComparisonChainExprPayload&) = delete;
+   ComparisonChainExprPayload& operator=(const ComparisonChainExprPayload&) = delete;
+   ComparisonChainExprPayload(ComparisonChainExprPayload&&) noexcept = default;
+   ComparisonChainExprPayload& operator=(ComparisonChainExprPayload&&) noexcept = default;
+   std::vector<AstBinaryOperator> operators;
+   ExprNodeList operands;
+   ~ComparisonChainExprPayload();
+};
+
 struct TernaryExprPayload {
    TernaryExprPayload() = default;
    TernaryExprPayload(const TernaryExprPayload&) = delete;
@@ -593,7 +604,7 @@ struct ExprNode {
    AstNodeKind kind = AstNodeKind::LiteralExpr;
    SourceSpan span{};
    std::variant<LiteralValue, NameRef, VarArgExprPayload, UnaryExprPayload,
-      UpdateExprPayload, BinaryExprPayload, TernaryExprPayload,
+      UpdateExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
       PresenceExprPayload, PipeExprPayload, CallExprPayload, MemberExprPayload,
       IndexExprPayload, SafeMemberExprPayload, SafeIndexExprPayload,
       ResultFilterPayload, TableExprPayload, FunctionExprPayload, DeferredExprPayload,
@@ -988,6 +999,8 @@ ExprNodePtr make_vararg_expr(SourceSpan span);
 ExprNodePtr make_unary_expr(SourceSpan span, AstUnaryOperator op, ExprNodePtr operand);
 ExprNodePtr make_update_expr(SourceSpan span, AstUpdateOperator op, bool is_postfix, ExprNodePtr target);
 ExprNodePtr make_binary_expr(SourceSpan span, AstBinaryOperator op, ExprNodePtr left, ExprNodePtr right);
+ExprNodePtr make_comparison_chain_expr(SourceSpan span, std::vector<AstBinaryOperator> operators,
+   ExprNodeList operands);
 ExprNodePtr make_ternary_expr(SourceSpan span, TernaryConditionMode mode, ExprNodePtr condition, ExprNodePtr if_true,
    ExprNodePtr if_false);
 ExprNodePtr make_presence_expr(SourceSpan span, ExprNodePtr value);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -408,6 +408,7 @@ static UnsupportedNodeRecorder glUnsupportedNodes;
       case AstNodeKind::VarArgExpr:     return "VarArgExpr";
       case AstNodeKind::UnaryExpr:      return "UnaryExpr";
       case AstNodeKind::BinaryExpr:     return "BinaryExpr";
+      case AstNodeKind::ComparisonChainExpr: return "ComparisonChainExpr";
       case AstNodeKind::UpdateExpr:     return "UpdateExpr";
       case AstNodeKind::TernaryExpr:    return "TernaryExpr";
       case AstNodeKind::PresenceExpr:   return "PresenceExpr";
@@ -1710,6 +1711,8 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
       case AstNodeKind::UnaryExpr:        return this->emit_unary_expr(std::get<UnaryExprPayload>(expr.data));
       case AstNodeKind::UpdateExpr:       return this->emit_update_expr(std::get<UpdateExprPayload>(expr.data));
       case AstNodeKind::BinaryExpr:       return this->emit_binary_expr(std::get<BinaryExprPayload>(expr.data));
+      case AstNodeKind::ComparisonChainExpr:
+         return this->emit_comparison_chain_expr(std::get<ComparisonChainExprPayload>(expr.data));
       case AstNodeKind::TernaryExpr:      return this->emit_ternary_expr(std::get<TernaryExprPayload>(expr.data));
       case AstNodeKind::PresenceExpr:     return this->emit_presence_expr(std::get<PresenceExprPayload>(expr.data));
       case AstNodeKind::PipeExpr:         return this->emit_pipe_expr(std::get<PipeExprPayload>(expr.data));
@@ -1963,6 +1966,78 @@ ParserResult<ExpDesc> IrEmitter::emit_binary_expr(const BinaryExprPayload &Paylo
    return ParserResult<ExpDesc>::success(lhs);
 }
 
+//********************************************************************************************************************
+// Emit bytecode for ordering comparison chains such as `0 <= x < 10`.
+
+ParserResult<ExpDesc> IrEmitter::emit_comparison_chain_expr(const ComparisonChainExprPayload &Payload)
+{
+   if (Payload.operands.size() < 2 or Payload.operators.size() + 1 != Payload.operands.size()) {
+      SourceSpan span = Payload.operands.empty() ? SourceSpan{} : Payload.operands.front()->span;
+      return this->unsupported_expr(AstNodeKind::ComparisonChainExpr, span);
+   }
+
+   auto lhs_result = this->emit_expression(*Payload.operands[0]);
+   if (not lhs_result.ok()) return lhs_result;
+
+   ExpDesc lhs = lhs_result.value_ref();
+   ExpDesc result;
+   std::vector<BCReg> preserved_regs;
+   bool has_result = false;
+
+   for (size_t index = 0; index < Payload.operators.size(); ++index) {
+      if (has_result) this->operator_emitter.prepare_logical_and(ExprValue(&result));
+
+      auto mapped = map_binary_operator(Payload.operators[index]);
+      if (not mapped.has_value()) {
+         SourceSpan span = Payload.operands[index] ? Payload.operands[index]->span : SourceSpan{};
+         return this->unsupported_expr(AstNodeKind::ComparisonChainExpr, span);
+      }
+
+      BinOpr opr = mapped.value();
+      this->operator_emitter.emit_binop_left(opr, ExprValue(&lhs));
+
+      auto rhs_result = this->emit_expression(*Payload.operands[index + 1]);
+      if (not rhs_result.ok()) return rhs_result;
+
+      ExpDesc rhs = rhs_result.value_ref();
+      bool preserve_rhs = index + 1 < Payload.operators.size();
+      BCReg preserved_reg = BCReg(NO_REG);
+      BCReg guard_reg = BCReg(NO_REG);
+      TiriType preserved_type = rhs.result_type;
+
+      if (preserve_rhs) {
+         this->register_allocator.discharge_to_next_register(rhs);
+         preserved_reg = BCReg(rhs.u.s.info);
+         preserved_regs.push_back(preserved_reg);
+
+         guard_reg = this->func_state.free_reg();
+         this->register_allocator.reserve(BCReg(1));
+      }
+
+      ExpDesc comparison = lhs;
+      this->operator_emitter.emit_comparison(opr, ExprValue(&comparison), rhs);
+
+      if (guard_reg.raw() != NO_REG) this->register_allocator.release_register(guard_reg);
+
+      if (has_result) this->operator_emitter.complete_logical_and(ExprValue(&result), comparison);
+      else {
+         result = comparison;
+         has_result = true;
+      }
+
+      if (preserve_rhs) {
+         lhs.init(ExpKind::NonReloc, preserved_reg.raw());
+         lhs.result_type = preserved_type;
+      }
+   }
+
+   for (auto reg = preserved_regs.rbegin(); reg != preserved_regs.rend(); ++reg) {
+      this->register_allocator.release_register(*reg);
+   }
+
+   result.result_type = TiriType::Bool;
+   return ParserResult<ExpDesc>::success(result);
+}
 //********************************************************************************************************************
 // IF_EMPTY (lhs ?? rhs) with conditional RHS emission for proper short-circuit semantics
 // Similar to ternary but with extended falsey checks (nil, false, 0, "")

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -2001,23 +2001,22 @@ ParserResult<ExpDesc> IrEmitter::emit_comparison_chain_expr(const ComparisonChai
 
       ExpDesc rhs = rhs_result.value_ref();
       bool preserve_rhs = index + 1 < Payload.operators.size();
-      BCReg preserved_reg = BCReg(NO_REG);
-      BCReg guard_reg = BCReg(NO_REG);
+      BCReg next_lhs_reg = BCReg(NO_REG);
       TiriType preserved_type = rhs.result_type;
 
       if (preserve_rhs) {
          this->register_allocator.discharge_to_next_register(rhs);
-         preserved_reg = BCReg(rhs.u.s.info);
-         preserved_regs.push_back(preserved_reg);
+         BCReg comparison_rhs_reg = BCReg(rhs.u.s.info);
+         preserved_regs.push_back(comparison_rhs_reg);
 
-         guard_reg = this->func_state.free_reg();
+         next_lhs_reg = this->func_state.free_reg();
          this->register_allocator.reserve(BCReg(1));
+         bcemit_AD(&this->func_state, BC_MOV, next_lhs_reg, comparison_rhs_reg);
+         preserved_regs.push_back(next_lhs_reg);
       }
 
       ExpDesc comparison = lhs;
       this->operator_emitter.emit_comparison(opr, ExprValue(&comparison), rhs);
-
-      if (guard_reg.raw() != NO_REG) this->register_allocator.release_register(guard_reg);
 
       if (has_result) this->operator_emitter.complete_logical_and(ExprValue(&result), comparison);
       else {
@@ -2026,7 +2025,7 @@ ParserResult<ExpDesc> IrEmitter::emit_comparison_chain_expr(const ComparisonChai
       }
 
       if (preserve_rhs) {
-         lhs.init(ExpKind::NonReloc, preserved_reg.raw());
+         lhs.init(ExpKind::NonReloc, next_lhs_reg.raw());
          lhs.result_type = preserved_type;
       }
    }

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -180,6 +180,7 @@ private:
    ParserResult<ExpDesc> emit_unary_expr(const UnaryExprPayload& payload);
    ParserResult<ExpDesc> emit_update_expr(const UpdateExprPayload& payload);
    ParserResult<ExpDesc> emit_binary_expr(const BinaryExprPayload& payload);
+   ParserResult<ExpDesc> emit_comparison_chain_expr(const ComparisonChainExprPayload& payload);
    ParserResult<ExpDesc> emit_ternary_expr(const TernaryExprPayload& payload);
    ParserResult<ExpDesc> emit_if_empty_expr(ExpDesc lhs, const ExprNode& rhs_ast);
    ParserResult<ExpDesc> emit_bitwise_expr(BinOpr opr, ExpDesc lhs, const ExprNode& rhs_ast);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1101,6 +1101,15 @@ void TypeAnalyser::analyse_expression(const ExprNode &Expression)
          }
          break;
       }
+      case AstNodeKind::ComparisonChainExpr: {
+         auto *payload = std::get_if<ComparisonChainExprPayload>(&Expression.data);
+         if (payload) {
+            for (const auto &operand : payload->operands) {
+               if (operand) this->analyse_expression(*operand);
+            }
+         }
+         break;
+      }
       case AstNodeKind::TernaryExpr: {
          auto *payload = std::get_if<TernaryExprPayload>(&Expression.data);
          if (payload) {
@@ -1332,6 +1341,10 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
          result.primary = TiriType::Any;
          break;
       }
+      case AstNodeKind::ComparisonChainExpr:
+         result.primary = TiriType::Bool;
+         return result;
+
       case AstNodeKind::BinaryExpr: {
          // Infer type from binary expression operands and operator
          auto *payload = std::get_if<BinaryExprPayload>(&Expr.data);
@@ -1419,6 +1432,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
          result.primary = TiriType::Any;
          break;
       }
+
       case AstNodeKind::UnaryExpr: {
          auto *payload = std::get_if<UnaryExprPayload>(&Expr.data);
          if (payload) {
@@ -1957,6 +1971,15 @@ bool TypeAnalyser::expression_contains_call_to(const ExprNode& Expr, GCstr *Name
          if (payload) {
             if (payload->left and this->expression_contains_call_to(*payload->left, Name)) return true;
             if (payload->right and this->expression_contains_call_to(*payload->right, Name)) return true;
+         }
+         break;
+      }
+      case AstNodeKind::ComparisonChainExpr: {
+         auto *payload = std::get_if<ComparisonChainExprPayload>(&Expr.data);
+         if (payload) {
+            for (const auto &operand : payload->operands) {
+               if (operand and this->expression_contains_call_to(*operand, Name)) return true;
+            }
          }
          break;
       }

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -78,6 +78,7 @@ enum class AstNodeKind : uint16_t {
    VarArgExpr,
    UnaryExpr,
    BinaryExpr,
+   ComparisonChainExpr,
    UpdateExpr,
    TernaryExpr,
    PresenceExpr,

--- a/src/tiri/tests/test_comparison_chaining.tiri
+++ b/src/tiri/tests/test_comparison_chaining.tiri
@@ -1,0 +1,73 @@
+-- Tests for chained ordering comparisons.
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath() end
+
+@Test function BasicRangeCheck()
+   x = 5
+   assert(0 <= x < 10, '0 <= x < 10 should be true for x=5')
+
+   x = 10
+   assert(not (0 <= x < 10), '0 <= x < 10 should be false for x=10')
+
+   x = -1
+   assert(not (0 <= x < 10), '0 <= x < 10 should be false for x=-1')
+end
+
+@Test function MixedDirections()
+   x = 5
+   assert(10 > x >= 0, '10 > x >= 0 should be true for x=5')
+
+   x = 10
+   assert(not (10 > x >= 0), '10 > x >= 0 should be false for x=10')
+
+   x = -1
+   assert(not (10 > x >= 0), '10 > x >= 0 should be false for x=-1')
+end
+
+@Test function LongerChains()
+   x = 5
+   y = 25
+   assert(0 <= x < y <= 100, 'longer chain should accept increasing values')
+
+   y = 5
+   assert(not (0 <= x < y <= 100), 'longer chain should reject equal middle values for <')
+end
+
+@Test function ChainAsValue()
+   result = 0 <= 5 < 10
+   assert(result is true, 'comparison chain should materialise true as a value')
+
+   result = 0 <= 10 < 10
+   assert(result is false, 'comparison chain should materialise false as a value')
+end
+
+@Test function MiddleOperandEvaluatesOnce()
+   calls = 0
+
+   function middle()
+      calls += 1
+      return 5
+   end
+
+   assert(0 < middle() < 10, 'middle function result should satisfy the chain')
+   assert(calls is 1, 'middle operand should be evaluated once, got ' .. calls)
+end
+
+@Test function ShortCircuitsAfterFailedComparison()
+   calls = 0
+
+   function should_not_run()
+      calls += 1
+      return 10
+   end
+
+   assert(not (10 < 0 < should_not_run()), 'chain should fail on the first comparison')
+   assert(calls is 0, 'later operand should not be evaluated after a failed comparison')
+end
+
+@Test function EqualityChainsKeepExistingSemantics()
+   assert(1 is 1 is true, 'equality chain should keep existing left-associative boolean comparison semantics')
+   assert(1 is 2 is false, 'failed equality followed by is false should stay valid')
+   assert(0 < 1 is true, 'mixed ordering/equality expression should still compare the ordering result to true')
+end


### PR DESCRIPTION
* Added ComparisonChainExpr parsing, type analysis and bytecode emission for adjacent ordering operators

* Added Flute coverage for range checks, operand reuse, short-circuiting and equality-chain compatibility