### PR TITLE
[Tiri] Reserved future syntax keywords in the parser

### DIFF
--- a/src/picture/tests/test_png.tiri
+++ b/src/picture/tests/test_png.tiri
@@ -268,34 +268,34 @@ end
    missing = array<string> { }
    mismatches = array<string> { }
 
-   for record in values(glValidPNG) do
+   for entry in values(glValidPNG) do
       local hash, bmp, pic
 
       try
-         pic = obj.new('picture', { path=glDataFolder .. record.src })
+         pic = obj.new('picture', { path=glDataFolder .. entry.src })
          bmp = pic.bitmap
          hash = mSys.GenCRC32(0, bmp.data, bmp.size)
       except ex
-         mismatches:push(record.src .. ': load failed: ' .. ex.message)
+         mismatches:push(entry.src .. ': load failed: ' .. ex.message)
          continue
       success
-         if not record.crc?? then
-            saveBitmap(bmp, record.src)
-            missing:push("   { src='" .. record.src .. "', crc=" .. formatHash(hash) .. ' },')
-         elseif record.crc != hash then
-            saveBitmap(bmp, record.src)
-            mismatches:push(record.src .. ': computed ' .. formatHash(hash) .. ', expected ' .. formatHash(record.crc))
+         if not entry.crc?? then
+            saveBitmap(bmp, entry.src)
+            missing:push("   { src='" .. entry.src .. "', crc=" .. formatHash(hash) .. ' },')
+         elseif entry.crc != hash then
+            saveBitmap(bmp, entry.src)
+            mismatches:push(entry.src .. ': computed ' .. formatHash(hash) .. ', expected ' .. formatHash(entry.crc))
          end
 
-         if record.mask_crc then
+         if entry.mask_crc then
             if not pic.mask then
-               mismatches:push(record.src .. ': expected alpha mask but none was loaded')
+               mismatches:push(entry.src .. ': expected alpha mask but none was loaded')
             else
-               local mask_hash = mSys.GenCRC32(0, pic.mask.data, pic.mask.size)
+               mask_hash = mSys.GenCRC32(0, pic.mask.data, pic.mask.size)
 
-               if record.mask_crc != mask_hash then
-                  mismatches:push(record.src .. ': mask computed ' .. formatHash(mask_hash) ..
-                     ', expected ' .. formatHash(record.mask_crc))
+               if entry.mask_crc != mask_hash then
+                  mismatches:push(entry.src .. ': mask computed ' .. formatHash(mask_hash) ..
+                     ', expected ' .. formatHash(entry.mask_crc))
                end
             end
          end
@@ -320,11 +320,11 @@ end
 @Test global function InvalidPNGsFailToLoad()
    failures = array<string> { }
 
-   for record in values(glInvalidPNG) do
+   for entry in values(glInvalidPNG) do
       try
-         obj.new('picture', { path=glDataFolder .. record })
+         obj.new('picture', { path=glDataFolder .. entry })
       success
-         failures:push(record .. ': loaded successfully but should be rejected')
+         failures:push(entry .. ': loaded successfully but should be rejected')
       end
    end
 

--- a/src/regex/tests/test_character_classes.tiri
+++ b/src/regex/tests/test_character_classes.tiri
@@ -1,37 +1,37 @@
 -- Validation for character classes, escapes, and custom ranges
 
 @Test function DigitClass()
-   local matcher = regex.new("\\d+")
-   local match = matcher.search("abc123def")
-   assert(match, "\\d+ should capture digits")
-   assert(#match is 1, "Should find one match, got " .. tostring(#match))
-   assert(match[0][0] is "123", "Digit capture should equal the numeric run, got " .. tostring(match[0]))
+   matcher = regex.new("\\d+")
+   m = matcher.search("abc123def")
+   assert(m, "\\d+ should capture digits")
+   assert(#m is 1, "Should find one match, got {#m}")
+   assert(m[0][0] is "123", f"Digit capture should equal the numeric run, got {m[0]}")
 end
 
 @Test function WordClass()
-   local matcher = regex.new("(\\w+)")
-   local results = matcher.search("mix_of words42")
+   matcher = regex.new("(\\w+)")
+   results = matcher.search("mix_of words42")
    assert(results and #results >= 2, "search should capture multiple words")
    assert(results[0][0] is "mix_of", "Word class should include underscore")
    assert(results[1][0] is "words42", "Word class should include trailing digits")
 end
 
 @Test function WhitespaceClass()
-   local matcher = regex.new("^foo\\s+bar$")
+   matcher = regex.new("^foo\\s+bar$")
    assert(matcher.test("foo\t bar"), "\\s should consume tabs")
    assert(not matcher.test("foo bar baz"), "Anchors should enforce full match with whitespace class")
 end
 
 @Test function NegatedClass()
-   local matcher = regex.new("[^aeiou]+")
-   local match = matcher.search("strength")
+   matcher = regex.new("[^aeiou]+")
+   m = matcher.search("strength")
    -- Expecting [ "str", "ngth" ]
-   assert(match, "No match found for negated vowel class")
-   assert(match[0][0] is "str", "Negated vowel class should consume consonant prefix, got " .. tostring(match[0][0]))
+   assert(m, "No match found for negated vowel class")
+   assert(m[0][0] is "str", "Negated vowel class should consume consonant prefix, got {m[0][0]}")
 end
 
 @Test function EscapedDot()
-   local matcher = regex.new("a\\.b")
+   matcher = regex.new("a\\.b")
    assert(matcher.test("a.b"), "Escaped dot should match literal period")
    assert(not matcher.test("acb"), "Escaped dot should not behave as wildcard")
 end

--- a/src/regex/tests/test_groups_backrefs.tiri
+++ b/src/regex/tests/test_groups_backrefs.tiri
@@ -1,37 +1,37 @@
 -- Group handling, numbering, and backreference semantics
 
 @Test function NestedCaptures()
-   local matcher = regex.new("((\\w+)-(\\d+))")
-   local match = matcher.match("item-42")
-   assert(match, "Nested groups should capture content")
-   assert(match[0] is "item-42", "Full match should be first entry")
-   assert(match[1] is "item-42", "Outer group should mirror full match")
-   assert(match[2] is "item", "Inner word capture should extract prefix")
-   assert(match[3] is "42", "Inner numeric capture should extract suffix")
+   matcher = regex.new("((\\w+)-(\\d+))")
+   m = matcher.match("item-42")
+   assert(m, "Nested groups should capture content")
+   assert(m[0] is "item-42", "Full match should be first entry")
+   assert(m[1] is "item-42", "Outer group should mirror full match")
+   assert(m[2] is "item", "Inner word capture should extract prefix")
+   assert(m[3] is "42", "Inner numeric capture should extract suffix")
 end
 
 @Test function NonCapturingGroupCount()
-   local matcher = regex.new("(?:pre-)?(value)")
-   local match = matcher.match("pre-value")
-   assert(match and #match is 2, "Non capturing groups should not appear in result table")
-   assert(match[1] is "value", "Capturing group should contain the payload")
+   matcher = regex.new("(?:pre-)?(value)")
+   m = matcher.match("pre-value")
+   assert(m and #m is 2, "Non capturing groups should not appear in result table")
+   assert(m[1] is "value", "Capturing group should contain the payload")
 end
 
 @Test function OptionalBackreference()
-   local matcher = regex.new("(\\w+)\\s+\\1")
+   matcher = regex.new("(\\w+)\\s+\\1")
    assert(matcher.test("hello hello"), "Backreference should match repeated word")
    assert(not matcher.test("hello world"), "Mismatched second word should fail backreference")
 end
 
 @Test function BackreferenceInReplace()
-   local matcher = regex.new("(\\w+),(\\w+)")
-   local result = matcher.replace("last,first", "$2 $1")
+   matcher = regex.new("(\\w+),(\\w+)")
+   result = matcher.replace("last,first", "$2 $1")
    assert(result is "first last", "Replacement should respect capture ordering")
 end
 
 @Test function SearchCapturesPreserveIndices()
-   local matcher = regex.new("(a)?b")
-   local results = matcher.search("bbab")
+   matcher = regex.new("(a)?b")
+   results = matcher.search("bbab")
    assert(results and #results is 3, "Search should produce one entry per match")
    assert(results[0][1] is "", "Optional group should be empty when unmatched")
    assert(results[1][1] is "", "Second match should also record empty capture")
@@ -39,19 +39,19 @@ end
 end
 
 @Test function NamedBackreference()
-   local matcher = regex.new("(?<word>\\w+)-\\k<word>")
+   matcher = regex.new("(?<word>\\w+)-\\k<word>")
    assert(matcher.test("repeat-repeat"), "Named backreference should accept identical tokens")
    assert(not matcher.test("repeat-other"), "Named backreference should reject differing suffix")
 end
 
 @Test function LookaheadNamedBackreference()
-   local matcher = regex.new("^(?=(?<prefix>\\w{3}))\\w+\\k<prefix>$")
+   matcher = regex.new("^(?=(?<prefix>\\w{3}))\\w+\\k<prefix>$")
    assert(matcher.test("foobarfoo"), "Lookahead capture should be reusable later in the pattern")
    assert(not matcher.test("foobarbar"), "Lookahead capture should still enforce the trailing repetition")
 end
 
 @Test function MixedNamedAndNumberedReferences()
-   local matcher = regex.new("^(?<word>\\w+)-(\\d+) \\1 \\k<word>$")
+   matcher = regex.new("^(?<word>\\w+)-(\\d+) \\1 \\k<word>$")
    assert(matcher.test("value-01 value value"), "Named and numbered references should target the same capture")
    assert(not matcher.test("value-01 value other"), "Mismatch should cause the combined reference check to fail")
 end

--- a/src/regex/tests/test_quantifiers.tiri
+++ b/src/regex/tests/test_quantifiers.tiri
@@ -1,39 +1,39 @@
 -- Coverage for quantifiers, alternation precedence, and optional constructs
 
 @Test function GreedyAndLazy()
-   local greedy = regex.new("<.+>")
-   local lazy = regex.new("<.+?>")
-   local text = "<em>bold</em>"
+   greedy = regex.new("<.+>")
+   lazy = regex.new("<.+?>")
+   text = "<em>bold</em>"
 
-   local match = greedy.search(text)
-   assert(match[0][0] is "<em>bold</em>", "Greedy quantifier should consume closing tag, got " .. tostring(match[0][0]))
+   m = greedy.search(text)
+   assert(m[0][0] is "<em>bold</em>", f"Greedy quantifier should consume closing tag, got {m[0][0]}")
 
-   match = lazy.search(text)
-   assert(match[0][0] is "<em>", "Lazy quantifier should stop at first closing bracket, got " .. tostring(match[0][0]))
+   m = lazy.search(text)
+   assert(m[0][0] is "<em>", f"Lazy quantifier should stop at first closing bracket, got {m[0][0]}")
 end
 
 @Test function BoundedQuantifier()
-   local matcher = regex.new("^\\d{2,4}$")
+   matcher = regex.new("^\\d{2,4}$")
    assert(matcher.test("42"), "Lower bound of range should pass")
    assert(matcher.test("1234"), "Upper bound of range should pass")
    assert(not matcher.test("12345"), "Values beyond upper bound should fail")
 end
 
 @Test function OptionalGroup()
-   local matcher = regex.new("colou?r")
+   matcher = regex.new("colou?r")
    assert(matcher.test("color"), "Optional group should allow American spelling")
    assert(matcher.test("colour"), "Optional group should allow British spelling")
 end
 
 @Test function AlternationPrecedence()
-   local matcher = regex.new("(cat|dog)s?")
+   matcher = regex.new("(cat|dog)s?")
    assert(matcher.test("cats"), "Alternation should apply before suffix quantifier")
    assert(matcher.test("dog"), "Optional suffix should allow singular form")
    assert(matcher.test("cater"), "Initial match to cat should succeed")
 end
 
 @Test function ZeroLengthMatchHandling()
-   local matcher = regex.new("a*")
-   local result = matcher.search("bbb")
+   matcher = regex.new("a*")
+   result = matcher.search("bbb")
    assert(result and result[0][0] is "", "Zero length matches should be represented as empty strings, got " .. tostring(result[0][0]))
 end

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -768,7 +768,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips tempus
-   comparison_chaining compile_if_import overflow
+   comparison_chaining reserved_keywords compile_if_import overflow
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -294,6 +294,7 @@ static bool extract_arrow_parameter(const ExprNodePtr &Expr, FunctionParameter &
 
    auto *name_ref = std::get_if<NameRef>(&Expr->data);
    if (name_ref IS nullptr) return false;
+   if (name_ref->identifier.is_future_reserved) return false;
 
    Parameter.name = name_ref->identifier;
    return true;
@@ -313,6 +314,25 @@ static bool build_arrow_parameters(const ExprNodeList &Expressions, std::vector<
       Parameters.push_back(param);
    }
    return true;
+}
+
+static const Identifier * future_reserved_identifier_expr(const ExprNodePtr &Expression)
+{
+   if (not Expression) return nullptr;
+   if (not (Expression->kind IS AstNodeKind::IdentifierExpr)) return nullptr;
+
+   auto *name_ref = std::get_if<NameRef>(&Expression->data);
+   if (name_ref IS nullptr) return nullptr;
+   if (not name_ref->identifier.is_future_reserved) return nullptr;
+
+   return &name_ref->identifier;
+}
+
+static std::string future_reserved_variable_message(const Identifier &IdentifierValue)
+{
+   std::string_view name = "<keyword>";
+   if (IdentifierValue.symbol) name = std::string_view(strdata(IdentifierValue.symbol), IdentifierValue.symbol->len);
+   return std::format("'{}' is reserved for future syntax and cannot be used as a variable name", name);
 }
 
 static ParserResult<StmtNodePtr> make_control_stmt(ParserContext& Context, AstNodeKind Kind, const Token& Token)
@@ -683,6 +703,7 @@ Identifier AstBuilder::make_identifier(const Token &Token)
    Identifier id;
    id.symbol   = Token.identifier();
    id.span     = Token.span();
+   id.is_future_reserved = Token.is_future_reserved_keyword();
    // Check if the identifier is a blank placeholder (single underscore)
    id.is_blank = id.symbol and id.symbol->len IS 1 and strdata(id.symbol)[0] IS '_';
    return id;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -422,7 +422,17 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          this->ctx.tokens().advance();
          break;
 
-      case TokenKind::Identifier: {
+      case TokenKind::Identifier:
+      case TokenKind::ClassToken:
+      case TokenKind::InterfaceToken:
+      case TokenKind::RecordToken:
+      case TokenKind::TypeToken:
+      case TokenKind::ExportToken:
+      case TokenKind::AwaitToken:
+      case TokenKind::MatchToken:
+      case TokenKind::FinallyToken:
+      case TokenKind::YieldToken:
+      case TokenKind::UsingToken: {
          Identifier id = make_identifier(current);
          NameRef name;
          name.identifier = id;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -39,6 +39,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
    auto assignment_result = token_to_assignment_op(op.kind());
 
    if (assignment_result.has_value()) {
+      for (const ExprNodePtr &target : targets) {
+         if (const Identifier *identifier = future_reserved_identifier_expr(target)) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::InvalidAssignment,
+               Token::from_span(identifier->span, TokenKind::Identifier),
+               future_reserved_variable_message(*identifier));
+         }
+      }
+
       AssignmentOperator assignment = assignment_result.value();
       this->ctx.tokens().advance();
       auto values = this->parse_expression_list();
@@ -426,13 +434,13 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
       case TokenKind::ClassToken:
       case TokenKind::InterfaceToken:
       case TokenKind::RecordToken:
-      case TokenKind::TypeToken:
+      case TokenKind::ExtendsToken:
       case TokenKind::ExportToken:
       case TokenKind::AwaitToken:
-      case TokenKind::MatchToken:
       case TokenKind::FinallyToken:
       case TokenKind::YieldToken:
-      case TokenKind::UsingToken: {
+      case TokenKind::UsingToken:
+      case TokenKind::WhereToken: {
          Identifier id = make_identifier(current);
          NameRef name;
          name.identifier = id;

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -336,7 +336,8 @@ ParserResult<std::vector<TableField>> AstBuilder::parse_table_fields(bool *has_a
          field.key = std::move(key.value_ref());
          field.value = std::move(value.value_ref());
       }
-      else if (current.kind() IS TokenKind::Identifier and this->ctx.tokens().peek(1).kind() IS TokenKind::Equals) {
+      else if (current.is_identifier_or_future_reserved() and
+         this->ctx.tokens().peek(1).kind() IS TokenKind::Equals) {
          this->ctx.tokens().advance();
          this->ctx.tokens().advance();
          auto value = this->parse_expression();

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -203,6 +203,7 @@ struct Identifier {
    bool is_blank = false;
    bool has_close = false;
    bool has_const = false;  // Const attribute flag - variable cannot be reassigned
+   bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
 
    // Default constructor
@@ -221,6 +222,7 @@ struct Identifier {
       id.is_blank = false;
       id.has_close = false;
       id.has_const = false;
+      id.is_future_reserved = false;
       return id;
    }
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -87,6 +87,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
          if (expr and expr->kind IS AstNodeKind::IdentifierExpr) {
             auto* name_ref = std::get_if<NameRef>(&expr->data);
             if (name_ref) { // Convert this identifier expression to a variable name
+               if (name_ref->identifier.is_future_reserved) {
+                  return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier,
+                     Token::from_span(name_ref->identifier.span, TokenKind::Identifier),
+                     future_reserved_variable_message(name_ref->identifier));
+               }
                name_list.push_back(name_ref->identifier);
             }
          }
@@ -184,6 +189,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
          if (expr and expr->kind IS AstNodeKind::IdentifierExpr) {
             if (auto *name_ref = std::get_if<NameRef>(&expr->data)) {
                // Convert this identifier expression to a variable name
+               if (name_ref->identifier.is_future_reserved) {
+                  return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier,
+                     Token::from_span(name_ref->identifier.span, TokenKind::Identifier),
+                     future_reserved_variable_message(name_ref->identifier));
+               }
                name_list.push_back(name_ref->identifier);
             }
          }

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -74,6 +74,18 @@ struct TokenDefinition {
    TOKEN_DEF(check,        "check",    TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
    TOKEN_DEF(while,        "while",    TKF_RESERVED | TKF_STATEMENT_START) \
    TOKEN_DEF(with,         "with",     TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(class,        "class",    TKF_RESERVED) \
+   TOKEN_DEF(interface,    "interface", TKF_RESERVED) \
+   TOKEN_DEF(record,       "record",   TKF_RESERVED) \
+   TOKEN_DEF(extends,      "extends",  TKF_RESERVED) \
+   TOKEN_DEF(type,         "type",     TKF_RESERVED) \
+   TOKEN_DEF(export,       "export",   TKF_RESERVED) \
+   TOKEN_DEF(await,        "await",    TKF_RESERVED) \
+   TOKEN_DEF(match,        "match",    TKF_RESERVED) \
+   TOKEN_DEF(finally,      "finally",  TKF_RESERVED) \
+   TOKEN_DEF(yield,        "yield",    TKF_RESERVED) \
+   TOKEN_DEF(using,        "using",    TKF_RESERVED) \
+   TOKEN_DEF(where,        "where",    TKF_RESERVED) \
    TOKEN_DEF(case_arrow,   "->",       TKF_NONE) \
    TOKEN_DEF(if_empty,     "??",       TKF_NONE) \
    TOKEN_DEF(guard,        "?!",       TKF_NONE) \
@@ -153,7 +165,7 @@ inline constexpr size_t generate_reserved_count() noexcept {
 enum {
    TK_OFS = 256,
    TOKEN_DEF_LIST
-   TK_RESERVED = TK_with - TK_OFS
+   TK_RESERVED = TK_where - TK_OFS
 };
 #undef TOKEN_DEF
 

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -96,10 +96,8 @@ enum class TokenKind : uint16_t {
    InterfaceToken = TK_interface,
    RecordToken = TK_record,
    ExtendsToken = TK_extends,
-   TypeToken = TK_type,
    ExportToken = TK_export,
    AwaitToken = TK_await,
-   MatchToken = TK_match,
    FinallyToken = TK_finally,
    YieldToken = TK_yield,
    UsingToken = TK_using,
@@ -234,10 +232,8 @@ enum class TokenKind : uint16_t {
       case TokenKind::InterfaceToken: return "interface";
       case TokenKind::RecordToken: return "record";
       case TokenKind::ExtendsToken: return "extends";
-      case TokenKind::TypeToken: return "type";
       case TokenKind::ExportToken: return "export";
       case TokenKind::AwaitToken: return "await";
-      case TokenKind::MatchToken: return "match";
       case TokenKind::FinallyToken: return "finally";
       case TokenKind::YieldToken: return "yield";
       case TokenKind::UsingToken: return "using";
@@ -324,10 +320,8 @@ public:
          case TokenKind::InterfaceToken:
          case TokenKind::RecordToken:
          case TokenKind::ExtendsToken:
-         case TokenKind::TypeToken:
          case TokenKind::ExportToken:
          case TokenKind::AwaitToken:
-         case TokenKind::MatchToken:
          case TokenKind::FinallyToken:
          case TokenKind::YieldToken:
          case TokenKind::UsingToken:

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -92,6 +92,18 @@ enum class TokenKind : uint16_t {
    SuccessToken = TK_success,
    RaiseToken = TK_raise,
    CheckToken = TK_check,
+   ClassToken = TK_class,
+   InterfaceToken = TK_interface,
+   RecordToken = TK_record,
+   ExtendsToken = TK_extends,
+   TypeToken = TK_type,
+   ExportToken = TK_export,
+   AwaitToken = TK_await,
+   MatchToken = TK_match,
+   FinallyToken = TK_finally,
+   YieldToken = TK_yield,
+   UsingToken = TK_using,
+   WhereToken = TK_where,
    EndOfFile = TK_eof,
 #undef TOKEN_KIND_ENUM
 #undef TOKEN_KIND_ENUM_SYM
@@ -218,6 +230,18 @@ enum class TokenKind : uint16_t {
       case TokenKind::SuccessToken: return "success";
       case TokenKind::RaiseToken: return "raise";
       case TokenKind::CheckToken: return "check";
+      case TokenKind::ClassToken: return "class";
+      case TokenKind::InterfaceToken: return "interface";
+      case TokenKind::RecordToken: return "record";
+      case TokenKind::ExtendsToken: return "extends";
+      case TokenKind::TypeToken: return "type";
+      case TokenKind::ExportToken: return "export";
+      case TokenKind::AwaitToken: return "await";
+      case TokenKind::MatchToken: return "match";
+      case TokenKind::FinallyToken: return "finally";
+      case TokenKind::YieldToken: return "yield";
+      case TokenKind::UsingToken: return "using";
+      case TokenKind::WhereToken: return "where";
       case TokenKind::EndOfFile: return "<eof>";
       case TokenKind::LeftParen: return "(";
       case TokenKind::RightParen: return ")";
@@ -294,6 +318,28 @@ public:
    [[nodiscard]] inline const TokenPayload & payload() const { return this->data; }
 
    [[nodiscard]] constexpr bool is_identifier() const noexcept { return this->token_kind IS TokenKind::Identifier; }
+   [[nodiscard]] constexpr bool is_future_reserved_keyword() const noexcept {
+      switch (this->token_kind) {
+         case TokenKind::ClassToken:
+         case TokenKind::InterfaceToken:
+         case TokenKind::RecordToken:
+         case TokenKind::ExtendsToken:
+         case TokenKind::TypeToken:
+         case TokenKind::ExportToken:
+         case TokenKind::AwaitToken:
+         case TokenKind::MatchToken:
+         case TokenKind::FinallyToken:
+         case TokenKind::YieldToken:
+         case TokenKind::UsingToken:
+         case TokenKind::WhereToken:
+            return true;
+         default:
+            return false;
+      }
+   }
+   [[nodiscard]] constexpr bool is_identifier_or_future_reserved() const noexcept {
+      return this->is_identifier() or this->is_future_reserved_keyword();
+   }
    [[nodiscard]] constexpr bool is_eof() const noexcept { return this->token_kind IS TokenKind::EndOfFile; }
    [[nodiscard]] inline GCstr * identifier() const { return this->data.as_string(); }
 

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -211,20 +211,23 @@ end
 
 @Test function IfEmptyArgumentLeakCapture()
    Function = { status = 'Hello' }
-   record = { count = 0, first = nil, second = nil }
+   capture_record = { count = 0, first = nil, second = nil }
 
    function capture(...)
       local args = { ... }
-      record.count = #args
-      record.first = args[0]
-      record.second = args[1]
+      capture_record.count = #args
+      capture_record.first = args[0]
+      capture_record.second = args[1]
    end
 
    capture(Function.status ?? 'then')
 
-   assert(record.count is 1, "Expected a single argument after fixing the leak, got '" .. tostring(record.count) .. "'")
-   assert(record.first is 'Hello', "Expected first argument to remain 'Hello', got '" .. tostring(record.first) .. "'")
-   assert(record.second is nil, "Expected leaked slot to be cleared, got '" .. tostring(record.second) .. "'")
+   assert(capture_record.count is 1,
+      "Expected a single argument after fixing the leak, got '" .. tostring(capture_record.count) .. "'")
+   assert(capture_record.first is 'Hello',
+      "Expected first argument to remain 'Hello', got '" .. tostring(capture_record.first) .. "'")
+   assert(capture_record.second is nil,
+      "Expected leaked slot to be cleared, got '" .. tostring(capture_record.second) .. "'")
 end
 
 @Test function IfEmptyStringFindError()

--- a/src/tiri/tests/test_reserved_keywords.tiri
+++ b/src/tiri/tests/test_reserved_keywords.tiri
@@ -1,0 +1,48 @@
+-- Tests for keywords reserved for future Tiri syntax.
+
+@BeforeEach(hotpath=false)
+function enforce_hotpath() end
+
+reserved_keywords = array<string> {
+   'class',
+   'interface',
+   'record',
+   'extends',
+   'type',
+   'export',
+   'await',
+   'match',
+   'finally',
+   'yield',
+   'using',
+   'where',
+}
+
+@Test function FutureKeywordsRejectLocalDeclarations()
+   for _, keyword in reserved_keywords do
+      try
+         exec('local ' .. keyword .. ' = 1')
+      success
+         error(keyword .. ' should be reserved and rejected as a local declaration name')
+      end
+   end
+end
+
+@Test function FutureKeywordsRemainAvailableAsMemberNames()
+   for _, keyword in reserved_keywords do
+      result = exec("local object = { }; object." .. keyword .. " = '" .. keyword .. "'; return object." .. keyword)
+      assert(result is keyword, keyword .. ' should remain usable as a member name')
+   end
+end
+
+@Test function FutureKeywordsRemainAvailableAsTableFieldNames()
+   for _, keyword in reserved_keywords do
+      result = exec('local object = { ' .. keyword .. " = '" .. keyword .. "' }; return object." .. keyword)
+      assert(result is keyword, keyword .. ' should remain usable as a table field name')
+   end
+end
+
+@Test function ExistingTypeBuiltinRemainsCallable()
+   assert(type(1) is 'number', 'type() should remain callable while type is reserved for declarations')
+   assert(type({}) is 'table', 'type() should still return table for table values')
+end

--- a/src/tiri/tests/test_reserved_keywords.tiri
+++ b/src/tiri/tests/test_reserved_keywords.tiri
@@ -18,12 +18,26 @@ reserved_keywords = array<string> {
    'where',
 }
 
+assignment_operators = array<string> { '=', '?=', '??=' }
+
 @Test function FutureKeywordsRejectLocalDeclarations()
    for _, keyword in reserved_keywords do
       try
          exec('local ' .. keyword .. ' = 1')
       success
          error(keyword .. ' should be reserved and rejected as a local declaration name')
+      end
+   end
+end
+
+@Test function FutureKeywordsRejectInferredLocalAssignments()
+   for _, keyword in reserved_keywords do
+      for _, op in assignment_operators do
+         try
+            exec(keyword .. ' ' .. op .. ' 1')
+         success
+            error(keyword .. ' should be reserved and rejected as an inferred local assignment with ' .. op)
+         end
       end
    end
 end


### PR DESCRIPTION
* Added future syntax keywords to the lexer token set while keeping them usable as member and table field names

* Registered reserved keyword Flute coverage and updated affected tests to avoid reserved local names