### PR TITLE
[Tiri] Reserved future syntax keywords in the parser

### DIFF
--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -12,7 +12,7 @@ glTask = mSys.CurrentTask()
 
 function resolveFirstPath(Candidates:array):str
    for candidate in values(Candidates) do
-      err, resolved = mSys.ResolvePath(candidate)
+      err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
    end
 
@@ -23,9 +23,7 @@ end
    global glOrigoPath = resolveFirstPath(array<string> {
       glTask.processPath .. 'origo',
       'sdk:build/agents-install/origo',
-      'sdk:build/agents-install/origo.exe',
-      'origo',
-      'origo.exe'
+      'origo'
    })
    global glTukuPath = resolveFirstPath(array<string> {
       'sdk:apps/tuku.tiri',

--- a/src/picture/tests/test_png.tiri
+++ b/src/picture/tests/test_png.tiri
@@ -268,34 +268,34 @@ end
    missing = array<string> { }
    mismatches = array<string> { }
 
-   for record in values(glValidPNG) do
+   for entry in values(glValidPNG) do
       local hash, bmp, pic
 
       try
-         pic = obj.new('picture', { path=glDataFolder .. record.src })
+         pic = obj.new('picture', { path=glDataFolder .. entry.src })
          bmp = pic.bitmap
          hash = mSys.GenCRC32(0, bmp.data, bmp.size)
       except ex
-         mismatches:push(record.src .. ': load failed: ' .. ex.message)
+         mismatches:push(entry.src .. ': load failed: ' .. ex.message)
          continue
       success
-         if not record.crc?? then
-            saveBitmap(bmp, record.src)
-            missing:push("   { src='" .. record.src .. "', crc=" .. formatHash(hash) .. ' },')
-         elseif record.crc != hash then
-            saveBitmap(bmp, record.src)
-            mismatches:push(record.src .. ': computed ' .. formatHash(hash) .. ', expected ' .. formatHash(record.crc))
+         if not entry.crc?? then
+            saveBitmap(bmp, entry.src)
+            missing:push("   { src='" .. entry.src .. "', crc=" .. formatHash(hash) .. ' },')
+         elseif entry.crc != hash then
+            saveBitmap(bmp, entry.src)
+            mismatches:push(entry.src .. ': computed ' .. formatHash(hash) .. ', expected ' .. formatHash(entry.crc))
          end
 
-         if record.mask_crc then
+         if entry.mask_crc then
             if not pic.mask then
-               mismatches:push(record.src .. ': expected alpha mask but none was loaded')
+               mismatches:push(entry.src .. ': expected alpha mask but none was loaded')
             else
-               local mask_hash = mSys.GenCRC32(0, pic.mask.data, pic.mask.size)
+               mask_hash = mSys.GenCRC32(0, pic.mask.data, pic.mask.size)
 
-               if record.mask_crc != mask_hash then
-                  mismatches:push(record.src .. ': mask computed ' .. formatHash(mask_hash) ..
-                     ', expected ' .. formatHash(record.mask_crc))
+               if entry.mask_crc != mask_hash then
+                  mismatches:push(entry.src .. ': mask computed ' .. formatHash(mask_hash) ..
+                     ', expected ' .. formatHash(entry.mask_crc))
                end
             end
          end
@@ -320,11 +320,11 @@ end
 @Test global function InvalidPNGsFailToLoad()
    failures = array<string> { }
 
-   for record in values(glInvalidPNG) do
+   for entry in values(glInvalidPNG) do
       try
-         obj.new('picture', { path=glDataFolder .. record })
+         obj.new('picture', { path=glDataFolder .. entry })
       success
-         failures:push(record .. ': loaded successfully but should be rejected')
+         failures:push(entry .. ': loaded successfully but should be rejected')
       end
    end
 

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -768,7 +768,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug numeric_limits return_types url tips tempus
-   comparison_chaining compile_if_import overflow
+   comparison_chaining reserved_keywords compile_if_import overflow
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -294,6 +294,7 @@ static bool extract_arrow_parameter(const ExprNodePtr &Expr, FunctionParameter &
 
    auto *name_ref = std::get_if<NameRef>(&Expr->data);
    if (name_ref IS nullptr) return false;
+   if (name_ref->identifier.is_future_reserved) return false;
 
    Parameter.name = name_ref->identifier;
    return true;
@@ -313,6 +314,25 @@ static bool build_arrow_parameters(const ExprNodeList &Expressions, std::vector<
       Parameters.push_back(param);
    }
    return true;
+}
+
+static const Identifier * future_reserved_identifier_expr(const ExprNodePtr &Expression)
+{
+   if (not Expression) return nullptr;
+   if (not (Expression->kind IS AstNodeKind::IdentifierExpr)) return nullptr;
+
+   auto *name_ref = std::get_if<NameRef>(&Expression->data);
+   if (name_ref IS nullptr) return nullptr;
+   if (not name_ref->identifier.is_future_reserved) return nullptr;
+
+   return &name_ref->identifier;
+}
+
+static std::string future_reserved_variable_message(const Identifier &IdentifierValue)
+{
+   std::string_view name = "<keyword>";
+   if (IdentifierValue.symbol) name = std::string_view(strdata(IdentifierValue.symbol), IdentifierValue.symbol->len);
+   return std::format("'{}' is reserved for future syntax and cannot be used as a variable name", name);
 }
 
 static ParserResult<StmtNodePtr> make_control_stmt(ParserContext& Context, AstNodeKind Kind, const Token& Token)
@@ -683,6 +703,7 @@ Identifier AstBuilder::make_identifier(const Token &Token)
    Identifier id;
    id.symbol   = Token.identifier();
    id.span     = Token.span();
+   id.is_future_reserved = Token.is_future_reserved_keyword();
    // Check if the identifier is a blank placeholder (single underscore)
    id.is_blank = id.symbol and id.symbol->len IS 1 and strdata(id.symbol)[0] IS '_';
    return id;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -39,6 +39,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_expression_stmt()
    auto assignment_result = token_to_assignment_op(op.kind());
 
    if (assignment_result.has_value()) {
+      for (const ExprNodePtr &target : targets) {
+         if (const Identifier *identifier = future_reserved_identifier_expr(target)) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::InvalidAssignment,
+               Token::from_span(identifier->span, TokenKind::Identifier),
+               future_reserved_variable_message(*identifier));
+         }
+      }
+
       AssignmentOperator assignment = assignment_result.value();
       this->ctx.tokens().advance();
       auto values = this->parse_expression_list();
@@ -422,7 +430,17 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          this->ctx.tokens().advance();
          break;
 
-      case TokenKind::Identifier: {
+      case TokenKind::Identifier:
+      case TokenKind::ClassToken:
+      case TokenKind::InterfaceToken:
+      case TokenKind::RecordToken:
+      case TokenKind::ExtendsToken:
+      case TokenKind::ExportToken:
+      case TokenKind::AwaitToken:
+      case TokenKind::FinallyToken:
+      case TokenKind::YieldToken:
+      case TokenKind::UsingToken:
+      case TokenKind::WhereToken: {
          Identifier id = make_identifier(current);
          NameRef name;
          name.identifier = id;

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -336,7 +336,8 @@ ParserResult<std::vector<TableField>> AstBuilder::parse_table_fields(bool *has_a
          field.key = std::move(key.value_ref());
          field.value = std::move(value.value_ref());
       }
-      else if (current.kind() IS TokenKind::Identifier and this->ctx.tokens().peek(1).kind() IS TokenKind::Equals) {
+      else if (current.is_identifier_or_future_reserved() and
+         this->ctx.tokens().peek(1).kind() IS TokenKind::Equals) {
          this->ctx.tokens().advance();
          this->ctx.tokens().advance();
          auto value = this->parse_expression();

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -203,6 +203,7 @@ struct Identifier {
    bool is_blank = false;
    bool has_close = false;
    bool has_const = false;  // Const attribute flag - variable cannot be reassigned
+   bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
 
    // Default constructor
@@ -221,6 +222,7 @@ struct Identifier {
       id.is_blank = false;
       id.has_close = false;
       id.has_const = false;
+      id.is_future_reserved = false;
       return id;
    }
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -87,6 +87,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
          if (expr and expr->kind IS AstNodeKind::IdentifierExpr) {
             auto* name_ref = std::get_if<NameRef>(&expr->data);
             if (name_ref) { // Convert this identifier expression to a variable name
+               if (name_ref->identifier.is_future_reserved) {
+                  return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier,
+                     Token::from_span(name_ref->identifier.span, TokenKind::Identifier),
+                     future_reserved_variable_message(name_ref->identifier));
+               }
                name_list.push_back(name_ref->identifier);
             }
          }
@@ -184,6 +189,11 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
          if (expr and expr->kind IS AstNodeKind::IdentifierExpr) {
             if (auto *name_ref = std::get_if<NameRef>(&expr->data)) {
                // Convert this identifier expression to a variable name
+               if (name_ref->identifier.is_future_reserved) {
+                  return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier,
+                     Token::from_span(name_ref->identifier.span, TokenKind::Identifier),
+                     future_reserved_variable_message(name_ref->identifier));
+               }
                name_list.push_back(name_ref->identifier);
             }
          }

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -74,6 +74,16 @@ struct TokenDefinition {
    TOKEN_DEF(check,        "check",    TKF_RESERVED | TKF_STATEMENT_START | TKF_SHORTHAND_STATEMENT) \
    TOKEN_DEF(while,        "while",    TKF_RESERVED | TKF_STATEMENT_START) \
    TOKEN_DEF(with,         "with",     TKF_RESERVED | TKF_STATEMENT_START) \
+   TOKEN_DEF(class,        "class",    TKF_RESERVED) \
+   TOKEN_DEF(interface,    "interface", TKF_RESERVED) \
+   TOKEN_DEF(record,       "record",   TKF_RESERVED) \
+   TOKEN_DEF(extends,      "extends",  TKF_RESERVED) \
+   TOKEN_DEF(export,       "export",   TKF_RESERVED) \
+   TOKEN_DEF(await,        "await",    TKF_RESERVED) \
+   TOKEN_DEF(finally,      "finally",  TKF_RESERVED) \
+   TOKEN_DEF(yield,        "yield",    TKF_RESERVED) \
+   TOKEN_DEF(using,        "using",    TKF_RESERVED) \
+   TOKEN_DEF(where,        "where",    TKF_RESERVED) \
    TOKEN_DEF(case_arrow,   "->",       TKF_NONE) \
    TOKEN_DEF(if_empty,     "??",       TKF_NONE) \
    TOKEN_DEF(guard,        "?!",       TKF_NONE) \
@@ -153,7 +163,7 @@ inline constexpr size_t generate_reserved_count() noexcept {
 enum {
    TK_OFS = 256,
    TOKEN_DEF_LIST
-   TK_RESERVED = TK_with - TK_OFS
+   TK_RESERVED = TK_where - TK_OFS
 };
 #undef TOKEN_DEF
 

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -92,6 +92,16 @@ enum class TokenKind : uint16_t {
    SuccessToken = TK_success,
    RaiseToken = TK_raise,
    CheckToken = TK_check,
+   ClassToken = TK_class,
+   InterfaceToken = TK_interface,
+   RecordToken = TK_record,
+   ExtendsToken = TK_extends,
+   ExportToken = TK_export,
+   AwaitToken = TK_await,
+   FinallyToken = TK_finally,
+   YieldToken = TK_yield,
+   UsingToken = TK_using,
+   WhereToken = TK_where,
    EndOfFile = TK_eof,
 #undef TOKEN_KIND_ENUM
 #undef TOKEN_KIND_ENUM_SYM
@@ -218,6 +228,16 @@ enum class TokenKind : uint16_t {
       case TokenKind::SuccessToken: return "success";
       case TokenKind::RaiseToken: return "raise";
       case TokenKind::CheckToken: return "check";
+      case TokenKind::ClassToken: return "class";
+      case TokenKind::InterfaceToken: return "interface";
+      case TokenKind::RecordToken: return "record";
+      case TokenKind::ExtendsToken: return "extends";
+      case TokenKind::ExportToken: return "export";
+      case TokenKind::AwaitToken: return "await";
+      case TokenKind::FinallyToken: return "finally";
+      case TokenKind::YieldToken: return "yield";
+      case TokenKind::UsingToken: return "using";
+      case TokenKind::WhereToken: return "where";
       case TokenKind::EndOfFile: return "<eof>";
       case TokenKind::LeftParen: return "(";
       case TokenKind::RightParen: return ")";
@@ -294,6 +314,26 @@ public:
    [[nodiscard]] inline const TokenPayload & payload() const { return this->data; }
 
    [[nodiscard]] constexpr bool is_identifier() const noexcept { return this->token_kind IS TokenKind::Identifier; }
+   [[nodiscard]] constexpr bool is_future_reserved_keyword() const noexcept {
+      switch (this->token_kind) {
+         case TokenKind::ClassToken:
+         case TokenKind::InterfaceToken:
+         case TokenKind::RecordToken:
+         case TokenKind::ExtendsToken:
+         case TokenKind::ExportToken:
+         case TokenKind::AwaitToken:
+         case TokenKind::FinallyToken:
+         case TokenKind::YieldToken:
+         case TokenKind::UsingToken:
+         case TokenKind::WhereToken:
+            return true;
+         default:
+            return false;
+      }
+   }
+   [[nodiscard]] constexpr bool is_identifier_or_future_reserved() const noexcept {
+      return this->is_identifier() or this->is_future_reserved_keyword();
+   }
    [[nodiscard]] constexpr bool is_eof() const noexcept { return this->token_kind IS TokenKind::EndOfFile; }
    [[nodiscard]] inline GCstr * identifier() const { return this->data.as_string(); }
 

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -211,20 +211,23 @@ end
 
 @Test function IfEmptyArgumentLeakCapture()
    Function = { status = 'Hello' }
-   record = { count = 0, first = nil, second = nil }
+   capture_record = { count = 0, first = nil, second = nil }
 
    function capture(...)
       local args = { ... }
-      record.count = #args
-      record.first = args[0]
-      record.second = args[1]
+      capture_record.count = #args
+      capture_record.first = args[0]
+      capture_record.second = args[1]
    end
 
    capture(Function.status ?? 'then')
 
-   assert(record.count is 1, "Expected a single argument after fixing the leak, got '" .. tostring(record.count) .. "'")
-   assert(record.first is 'Hello', "Expected first argument to remain 'Hello', got '" .. tostring(record.first) .. "'")
-   assert(record.second is nil, "Expected leaked slot to be cleared, got '" .. tostring(record.second) .. "'")
+   assert(capture_record.count is 1,
+      "Expected a single argument after fixing the leak, got '" .. tostring(capture_record.count) .. "'")
+   assert(capture_record.first is 'Hello',
+      "Expected first argument to remain 'Hello', got '" .. tostring(capture_record.first) .. "'")
+   assert(capture_record.second is nil,
+      "Expected leaked slot to be cleared, got '" .. tostring(capture_record.second) .. "'")
 end
 
 @Test function IfEmptyStringFindError()

--- a/src/tiri/tests/test_reserved_keywords.tiri
+++ b/src/tiri/tests/test_reserved_keywords.tiri
@@ -1,0 +1,60 @@
+-- Tests for keywords reserved for future Tiri syntax.
+
+@BeforeEach(hotpath=false)
+function enforce_hotpath() end
+
+reserved_keywords = array<string> {
+   'class',
+   'interface',
+   'record',
+   'extends',
+   'export',
+   'await',
+   'finally',
+   'yield',
+   'using',
+   'where',
+}
+
+assignment_operators = array<string> { '=', '?=', '??=' }
+
+@Test function FutureKeywordsRejectLocalDeclarations()
+   for _, keyword in reserved_keywords do
+      try
+         exec('local ' .. keyword .. ' = 1')
+      success
+         error(keyword .. ' should be reserved and rejected as a local declaration name')
+      end
+   end
+end
+
+@Test function FutureKeywordsRejectInferredLocalAssignments()
+   for _, keyword in reserved_keywords do
+      for _, op in assignment_operators do
+         try
+            exec(keyword .. ' ' .. op .. ' 1')
+         success
+            error(keyword .. ' should be reserved and rejected as an inferred local assignment with ' .. op)
+         end
+      end
+   end
+end
+
+@Test function FutureKeywordsRemainAvailableAsMemberNames()
+   for _, keyword in reserved_keywords do
+      result = exec("local object = { }; object." .. keyword .. " = '" .. keyword .. "'; return object." .. keyword)
+      assert(result is keyword, keyword .. ' should remain usable as a member name')
+   end
+end
+
+@Test function FutureKeywordsRemainAvailableAsTableFieldNames()
+   for _, keyword in reserved_keywords do
+      result = exec('local object = { ' .. keyword .. " = '" .. keyword .. "' }; return object." .. keyword)
+      assert(result is keyword, keyword .. ' should remain usable as a table field name')
+   end
+end
+
+@Test function ExistingTypeBuiltinRemainsCallable()
+   assert(type(1) is 'number', 'type() should remain callable while type is reserved for declarations')
+   assert(type({}) is 'table', 'type() should still return table for table values')
+end


### PR DESCRIPTION
* Added future syntax keywords to the lexer token set while keeping them usable as member and table field names

* Registered reserved keyword Flute coverage and updated affected tests to avoid reserved local names