### PR TITLE
[Tiri] Added regex string shorthand syntax

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -430,6 +430,25 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          this->ctx.tokens().advance();
          break;
 
+      case TokenKind::RegexString: {
+         SourceSpan span = current.span();
+         GCstr *pattern = current.payload().as_string();
+         this->ctx.tokens().advance();
+
+         Identifier regex_id = Identifier::from_keepstr(this->ctx.lex().keepstr("regex"), span);
+         NameRef regex_ref;
+         regex_ref.identifier = regex_id;
+         ExprNodePtr regex_base = make_identifier_expr(span, regex_ref);
+
+         Identifier new_id = Identifier::from_keepstr(this->ctx.lex().keepstr("new"), span);
+         ExprNodePtr regex_new = make_member_expr(span, std::move(regex_base), new_id, false);
+
+         ExprNodeList args;
+         args.push_back(make_literal_expr(span, LiteralValue::string(pattern)));
+         node = make_call_expr(span, std::move(regex_new), std::move(args), false);
+         break;
+      }
+
       case TokenKind::Identifier:
       case TokenKind::ClassToken:
       case TokenKind::InterfaceToken:

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -426,6 +426,72 @@ err_xesc:
 }
 
 //********************************************************************************************************************
+// Raw string literal parsing for regex shorthand.
+
+static void lex_raw_string(LexState *State, TValue *TV)
+{
+   LexChar delim = State->c;  // Delimiter is '\'' or '"'.
+   lex_next(State);
+
+   while (State->c != delim) {
+      switch (State->c) {
+      case LEX_EOF:
+         lj_lex_error(State, TK_eof, ErrMsg::XSTR);
+         if (State->diagnose_mode) {
+            setstrV(State->L, TV, State->intern_empty_string());
+            return;
+         }
+         continue;
+
+      case '\n':
+      case '\r':
+         lj_lex_error(State, TK_string, ErrMsg::XSTR);
+         if (State->diagnose_mode) {
+            setstrV(State->L, TV, State->intern_empty_string());
+            return;
+         }
+         continue;
+
+      default:
+         lex_savenext(State);
+         break;
+      }
+   }
+
+   lex_next(State);  // Skip trailing delimiter.
+   if (sbuflen(&State->sb) IS 0) setstrV(State->L, TV, State->intern_empty_string());
+   else setstrV(State->L, TV, State->keepstr(std::string_view(State->sb.b, sbuflen(&State->sb))));
+}
+
+static int lex_peek_longstring_sep_from(LexState *State, size_t StartOffset)
+{
+   if (State->peek(StartOffset) != '[') return -1;
+
+   int count = 0;
+   size_t offset = StartOffset + 1;
+   while (State->peek(offset) IS '=') {
+      count++;
+      offset++;
+   }
+
+   return (State->peek(offset) IS '[') ? count : -1;
+}
+
+static int lex_peek_longstring_sep(LexState *State)
+{
+   if (State->c != '[') return -1;
+
+   int count = 0;
+   size_t offset = 0;
+   while (State->peek(offset) IS '=') {
+      count++;
+      offset++;
+   }
+
+   return (State->peek(offset) IS '[') ? count : -1;
+}
+
+//********************************************************************************************************************
 // F-string interpolation support
 
 static LexToken lex_scan(LexState *, TValue *);
@@ -443,6 +509,7 @@ static LexToken lex_scan(LexState *, TValue *);
       case TK_name:
       case TK_number:
       case TK_string:
+      case TK_regex_string:
       case TK_array_typed:
       case TK_defer_typed:
       case TK_pipe:
@@ -1027,6 +1094,29 @@ static LexToken lex_scan(LexState *State, TValue *tv)
       // Check for Unicode operators before identifier scanning
       if (LexToken unicode_tok = lex_unicode_operator(State)) {
          return unicode_tok;
+      }
+
+      // Regex string prefix: r"...", r'...', r[[...]] or r[=[...]=].
+      if (State->c IS 'r') {
+         LexChar next = State->peek_next();
+         if (next IS '"' or next IS '\'') {
+            State->mark_token_start();
+            lex_next(State);  // Skip prefix.
+            lj_buf_reset(&State->sb);
+            lex_raw_string(State, tv);
+            if (State->had_lex_error) continue;  // Rescan after error recovery
+            return TK_regex_string;
+         }
+
+         if (next IS '[' and lex_peek_longstring_sep_from(State, 0) >= 0) {
+            State->mark_token_start();
+            lex_next(State);  // Skip prefix.
+            lj_buf_reset(&State->sb);
+            int sep = lex_skipeq(State);
+            lex_longstring(State, tv, sep);
+            if (State->had_lex_error) continue;  // Rescan after error recovery
+            return TK_regex_string;
+         }
       }
 
       // Identifier or numeric literal

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -103,6 +103,7 @@ struct TokenDefinition {
    TOKEN_DEF(number,       "<number>", TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
    TOKEN_DEF(name,         "<name>",   TKF_CAN_END_RANGE_EXPRESSION) \
    TOKEN_DEF(string,       "<string>", TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
+   TOKEN_DEF(regex_string, "<regex_string>", TKF_CAN_END_RANGE_EXPRESSION | TKF_LITERAL) \
    TOKEN_DEF(cadd,         "+=",       TKF_COMPOUND_ASSIGNMENT) \
    TOKEN_DEF(csub,         "-=",       TKF_COMPOUND_ASSIGNMENT) \
    TOKEN_DEF(cmul,         "*=",       TKF_COMPOUND_ASSIGNMENT) \

--- a/src/tiri/jit/src/parser/parse_expr.cpp
+++ b/src/tiri/jit/src/parser/parse_expr.cpp
@@ -69,6 +69,7 @@ static int token_starts_expression(LexToken tok)
    switch (tok) {
       case TK_number:
       case TK_string:
+      case TK_regex_string:
       case TK_nil:
       case TK_true:
       case TK_false:

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -18,6 +18,7 @@ enum class TokenKind : uint16_t {
    Identifier = TK_name,
    Number = TK_number,
    String = TK_string,
+   RegexString = TK_regex_string,
    Nil = TK_nil,
    AsToken = TK_as,
    TrueToken = TK_true,
@@ -155,6 +156,7 @@ enum class TokenKind : uint16_t {
       case TokenKind::Identifier: return "<name>";
       case TokenKind::Number: return "<number>";
       case TokenKind::String: return "<string>";
+      case TokenKind::RegexString: return "<regex_string>";
       case TokenKind::Nil: return "nil";
       case TokenKind::AsToken: return "as";
       case TokenKind::TrueToken: return "true";

--- a/src/tiri/tests/test_regex.tiri
+++ b/src/tiri/tests/test_regex.tiri
@@ -27,6 +27,47 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+@Test function RegexStringShorthand()
+   single_quote = r'\d+'
+   assert(single_quote.pattern is [[\d+]], 'Single-quoted regex shorthand should preserve backslashes')
+   assert(single_quote.test('abc123'), 'Single-quoted regex shorthand should compile a usable regex')
+
+   double_quote = r"\w+"
+   assert(double_quote.pattern is [[\w+]], 'Double-quoted regex shorthand should preserve backslashes')
+   word_match = double_quote.match('word')
+   assert(word_match[0] is 'word', 'Double-quoted regex shorthand should match word characters')
+
+   long_bracket = r[[\s+]]
+   assert(long_bracket.pattern is [[\s+]], 'Long-bracket regex shorthand should preserve content')
+   start_pos, stop_pos = long_bracket.findFirst('ab  cd', 0)
+   assert(start_pos is 2 and stop_pos is 4, 'Long-bracket regex shorthand should find whitespace')
+
+   level_bracket = r[=[\d{2}]=]
+   assert(level_bracket.pattern is [[\d{2}]], 'Levelled long-bracket regex shorthand should preserve content')
+   assert(level_bracket.test('ab12cd'), 'Levelled long-bracket regex shorthand should compile')
+
+   chained_call = r'\d+'.test('abc123')
+   assert(chained_call is true, 'Regex shorthand should support suffix calls')
+
+   local invalid_regex
+   try
+      invalid_regex = r'[unclosed'
+   end
+   assert(invalid_regex is nil, 'Invalid regex shorthand should raise during regex.new()')
+
+   do
+      local r = { 'zero' }
+      assert(r[0] is 'zero', 'Identifier r followed by index syntax should remain unchanged')
+   end
+
+   do
+      local r = function(Value) return Value end
+      assert(r 'text' is 'text', 'Whitespace-separated r string call syntax should remain unchanged')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test function RegexConversion()
    pattern = ltr('[Nn]ame:%s+(.-)')
    expected = "[Nn]ame:[ \\t\\n\\r\\f\\v]+(.*?)"


### PR DESCRIPTION
* Added regex_string token parsing for raw quoted and long-bracket regex literals

* Desugared regex string expressions to regex.new() calls

* [Test] Covered regex shorthand forms and ambiguity regressions