### PR TITLE
[Tiri] Reserve future keywords outside contextual names

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -449,17 +449,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
-      case TokenKind::Identifier:
-      case TokenKind::ClassToken:
-      case TokenKind::InterfaceToken:
-      case TokenKind::RecordToken:
-      case TokenKind::ExtendsToken:
-      case TokenKind::ExportToken:
-      case TokenKind::AwaitToken:
-      case TokenKind::FinallyToken:
-      case TokenKind::YieldToken:
-      case TokenKind::UsingToken:
-      case TokenKind::WhereToken: {
+      case TokenKind::Identifier: {
          Identifier id = make_identifier(current);
          NameRef name;
          name.identifier = id;

--- a/src/tiri/tests/test_reserved_keywords.tiri
+++ b/src/tiri/tests/test_reserved_keywords.tiri
@@ -18,6 +18,11 @@ reserved_keywords = array<string> {
 
 assignment_operators = array<string> { '=', '?=', '??=' }
 
+primary_forms = array<string> {
+   '',
+   '()',
+}
+
 @Test function FutureKeywordsRejectLocalDeclarations()
    for _, keyword in reserved_keywords do
       try
@@ -36,6 +41,28 @@ end
          success
             error(keyword .. ' should be reserved and rejected as an inferred local assignment with ' .. op)
          end
+      end
+   end
+end
+
+@Test function FutureKeywordsRejectBarePrimaryReferences()
+   for _, keyword in reserved_keywords do
+      for _, suffix in primary_forms do
+         try
+            exec(keyword .. suffix)
+         success
+            error(keyword .. suffix .. ' should be reserved and rejected as a bare primary expression')
+         end
+      end
+   end
+end
+
+@Test function FutureKeywordsRejectBarePrimaryConditions()
+   for _, keyword in reserved_keywords do
+      try
+         exec('if ' .. keyword .. ' then return 1 end')
+      success
+         error(keyword .. ' should be reserved and rejected as a bare condition expression')
       end
    end
 end


### PR DESCRIPTION
* Restricted primary expression parsing to real identifiers

* [Test] Covered bare future-keyword references and conditions