### PR TITLE
[Font] Windows .fon refactor, field setter fixes, and robustness improvements

### DIFF
--- a/src/font/class_font.cpp
+++ b/src/font/class_font.cpp
@@ -102,7 +102,6 @@ static ERR FONT_Init(extFont *Self)
    kt::Log log;
    int diff;
    FTF style;
-   ERR error;
    FMETA meta = FMETA::NIL;
 
    if ((!Self->prvFace[0]) and (!Self->Path)) return log.warning(ERR::FieldNotSet);
@@ -137,107 +136,52 @@ static ERR FONT_Init(extFont *Self)
    else {
       objFile::create file = { fl::Path(Self->Path), fl::Flags(FL::READ|FL::APPROXIMATE) };
       if (file.ok()) {
-         // Check if the file is a Windows Bitmap Font
+         std::vector<winFont> fonts;
+         if (auto error = read_winfont_entries(*file, fonts); error IS ERR::NoData) return log.warning(error);
+         else if (error != ERR::Okay) return error;
 
-         winmz_header_fields mz_header;
-         file->read(&mz_header, sizeof(mz_header));
+         // Scan the list of available fonts to find the closest point size for our font
 
-         if (mz_header.magic IS ID_WINMZ) {
-            file->seek(mz_header.lfanew, SEEK::START);
+         int abs = 0x7fff;
+         int wfi = 0;
+         winfnt_header_fields face;
+         for (int i=0; i < int(fonts.size()); i++) {
+            file->seekStart(fonts[i].Offset);
 
-            winne_header_fields ne_header;
-            if ((file->read(&ne_header, sizeof(ne_header)) IS ERR::Okay) and (ne_header.magic IS ID_WINNE)) {
-               uint32_t res_offset = mz_header.lfanew + ne_header.resource_tab_offset;
-               file->seek(res_offset, SEEK::START);
-
-               // Count the number of fonts in the file
-
-               int16_t size_shift = 0;
-               uint16_t font_count = 0;
-               int font_offset = 0;
-               fl::ReadLE(*file, &size_shift);
-
-               int16_t type_id;
-               for ((error = fl::ReadLE(*file, &type_id)); (error IS ERR::Okay) and (type_id); error = fl::ReadLE(*file, &type_id)) {
-                  int16_t count = 0;
-                  fl::ReadLE(*file, &count);
-
-                  if ((uint16_t)type_id IS 0x8008) {
-                     font_count  = count;
-                     file->get(FID_Position, font_offset);
-                     font_offset += 4;
-                     break;
-                  }
-
-                  file->seek(4 + (count * 12), SEEK::CURRENT);
+            winfnt_header_fields header;
+            if (file->read(&header, sizeof(header)) IS ERR::Okay) {
+               if (auto error = validate_winfnt_header(header, nullptr); error != ERR::Okay) {
+                  return log.warning(error);
                }
 
-               if ((!font_count) or (!font_offset)) { // There are no fonts in the file
-                  return log.warning(ERR::NoData);
+               if (header.pixel_width <= 0) header.pixel_width = header.pixel_height;
+
+               if ((diff = Self->Point - header.nominal_point_size) < 0) diff = -diff;
+
+               if (diff < abs) {
+                  face = header;
+                  abs  = diff;
+                  wfi  = i;
                }
+            }
+            else return log.warning(ERR::Read);
+         }
 
-               file->seek(font_offset, SEEK::START);
+         // Check the bitmap cache again to ensure that the discovered font is not already loaded.  This is important
+         // if the cached font wasn't originally found due to variation in point size.
 
-               // Scan the list of available fonts to find the closest point size for our font
+         Self->Point = face.nominal_point_size;
+         cache = check_bitmap_cache(Self, style);
+         if (!cache) { // Load the font into the cache
+            auto it = glBitmapCache.emplace(glBitmapCache.end(), face, Self->prvStyle, Self->Path, *file, fonts[wfi]);
 
-               auto fonts = std::make_unique<winFont[]>(font_count);
-
-               for (int i=0; i < font_count; i++) {
-                  uint16_t offset, size;
-                  fl::ReadLE(*file, &offset);
-                  fl::ReadLE(*file, &size);
-                  fonts[i].Offset = offset<<size_shift;
-                  fonts[i].Size   = size<<size_shift;
-                  file->seek(8, SEEK::CURRENT);
-               }
-
-               int abs = 0x7fff;
-               int wfi = 0;
-               winfnt_header_fields face;
-               for (int i=0; i < font_count; i++) {
-                  file->seek((double)fonts[i].Offset, SEEK::START);
-
-                  winfnt_header_fields header;
-                  if (file->read(&header, sizeof(header)) IS ERR::Okay) {
-                     if ((header.version != 0x200) and (header.version != 0x300)) {
-                        // Font is written in an unsupported version
-                        return log.warning(ERR::NoSupport);
-                     }
-
-                     if (header.file_type & 1) { // Font is in the non-supported vector font format."
-                        return log.warning(ERR::NoSupport);
-                     }
-
-                     if (header.pixel_width <= 0) header.pixel_width = header.pixel_height;
-
-                     if ((diff = Self->Point - header.nominal_point_size) < 0) diff = -diff;
-
-                     if (diff < abs) {
-                        face = header;
-                        abs  = diff;
-                        wfi  = i;
-                     }
-                  }
-                  else return log.warning(ERR::Read);
-               }
-
-               // Check the bitmap cache again to ensure that the discovered font is not already loaded.  This is important
-               // if the cached font wasn't originally found due to variation in point size.
-
-               Self->Point = face.nominal_point_size;
-               cache = check_bitmap_cache(Self, style);
-               if (!cache) { // Load the font into the cache
-                  auto it = glBitmapCache.emplace(glBitmapCache.end(), face, Self->prvStyle, Self->Path, *file, fonts[wfi]);
-
-                  if (it->Result IS ERR::Okay) cache = &(*it);
-                  else {
-                     ERR error = it->Result;
-                     glBitmapCache.erase(it);
-                     return error;
-                  }
-               }
-            } // File is not a windows fixed font
-         } // File is not a windows fixed font
+            if (it->Result IS ERR::Okay) cache = &(*it);
+            else {
+               ERR error = it->Result;
+               glBitmapCache.erase(it);
+               return error;
+            }
+         }
       }
       else return log.warning(ERR::OpenFile);
    }
@@ -775,7 +719,7 @@ static ERR draw_bitmap_font(extFont *Self)
    RGB8 rgb;
    static const uint8_t table[] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
    uint8_t *xdata, *data;
-   int linewidth, offset, charclip, wrapindex, charlen;
+   int linewidth, offset, wrapindex, charlen;
    uint32_t unicode, ocolour;
    int16_t startx, xpos, ex, ey, sx, sy, xinc;
    int16_t bytewidth, alpha, charwidth;
@@ -822,8 +766,6 @@ static ERR draw_bitmap_font(extFont *Self)
       ocolour = bitmap->getColour(Self->Outline);
    }
    else ocolour = 0;
-
-   charclip = Self->WrapEdge - 8; //(Self->prvChar['.'].Advance<<2); //8
 
    if (acLock(bitmap) != ERR::Okay) return log.warning(ERR::Lock);
 

--- a/src/font/class_font.cpp
+++ b/src/font/class_font.cpp
@@ -122,10 +122,7 @@ static ERR FONT_Init(extFont *Self)
 
    // Check the bitmap cache to see if we have already loaded this font
 
-   if (iequals("Bold", Self->prvStyle)) style = FTF::BOLD;
-   else if (iequals("Italic", Self->prvStyle)) style = FTF::ITALIC;
-   else if (iequals("Bold Italic", Self->prvStyle)) style = FTF::BOLD|FTF::ITALIC;
-   else style = FTF::NIL;
+   style = font_style_flags(Self->prvStyle);
 
    CACHE_LOCK lock(glCacheMutex);
 
@@ -286,14 +283,13 @@ static ERR GET_Bold(extFont *Self, int *Value)
 
 static ERR SET_Bold(extFont *Self, int Value)
 {
-   if (Self->initialised()) {
-      // If the font is initialised, setting the bold style is implicit
-      return SET_Style(Self, "Bold");
-   }
-   else if ((Self->Flags & FTF::ITALIC) != FTF::NIL) {
-      return SET_Style(Self, "Bold Italic");
-   }
-   else return SET_Style(Self, "Bold");
+   const bool bold = Value != FALSE;
+   const bool italic = ((Self->Flags & FTF::ITALIC) != FTF::NIL) or (kt::strisearch("italic", Self->prvStyle) != -1);
+
+   if (bold and italic) return SET_Style(Self, "Bold Italic");
+   else if (bold) return SET_Style(Self, "Bold");
+   else if (italic) return SET_Style(Self, "Italic");
+   else return SET_Style(Self, "Regular");
 }
 
 /*********************************************************************************************************************
@@ -341,36 +337,40 @@ static ERR SET_Face(extFont *Self, STRING Value)
 {
    if ((Value) and (Value[0])) {
       CSTRING final_name;
-      if (fnt::ResolveFamilyName(Value, &final_name) IS ERR::Okay) {
+      int i;
+      for (i=0; Value[i] and Value[i] != ':'; i++);
+
+      std::string face(Value, i);
+      if (fnt::ResolveFamilyName(face, &final_name) IS ERR::Okay) {
          strcopy(final_name, Self->prvFace, std::ssize(Self->prvFace));
       }
 
-      int i, j;
-      for (i=0; Value[i] and Value[i] != ':'; i++);
       if (!Value[i]) return ERR::Okay;
 
       // Extract the point size
 
-      Value += i;
-      double pt = strtod(Value, &Value);
-      SET_Point(Self, pt);
+      Value += i + 1;
+      if ((*Value) and (*Value != ':')) {
+         double pt = strtod(Value, &Value);
+         SET_Point(Self, pt);
+      }
 
-      i = 0;
       while ((*Value) and (*Value != ':')) Value++;
       if (!*Value) return ERR::Okay;
 
       // Extract the style string
 
-      i++;
-      for (j=0; (Value[i]) and (Value[i] != ':') and (j < std::ssize(Self->prvStyle)-1); j++) Self->prvStyle[j] = Value[i++];
-      Self->prvStyle[j] = 0;
+      Value++;
+      char style[sizeof(Self->prvStyle)];
+      for (i=0; (Value[i]) and (Value[i] != ':') and (i < int(sizeof(style))-1); i++) style[i] = Value[i];
+      style[i] = 0;
+      SET_Style(Self, style);
 
       if (Value[i] != ':') return ERR::Okay;
 
       // Extract the colour string
 
-      i++;
-      Self->set(FID_Colour, Value + i);
+      Self->set(FID_Colour, Value + i + 1);
    }
    else Self->prvFace[0] = 0;
 
@@ -437,14 +437,13 @@ static ERR GET_Italic(extFont *Self, int *Value)
 
 static ERR SET_Italic(extFont *Self, int Value)
 {
-   if (Self->initialised()) {
-      // If the font is initialised, setting the italic style is implicit
-      return SET_Style(Self, "Italic");
-   }
-   else if ((Self->Flags & FTF::BOLD) != FTF::NIL) {
-      return SET_Style(Self, "Bold Italic");
-   }
-   else return SET_Style(Self, "Italic");
+   const bool italic = Value != FALSE;
+   const bool bold = ((Self->Flags & FTF::BOLD) != FTF::NIL) or (kt::strisearch("bold", Self->prvStyle) != -1);
+
+   if (bold and italic) return SET_Style(Self, "Bold Italic");
+   else if (bold) return SET_Style(Self, "Bold");
+   else if (italic) return SET_Style(Self, "Italic");
+   else return SET_Style(Self, "Regular");
 }
 
 /*********************************************************************************************************************
@@ -595,6 +594,10 @@ static ERR SET_String(extFont *Self, CSTRING Value)
       Self->prvBuffer.assign(Value);
       Self->String = (STRING)Self->prvBuffer.c_str();
    }
+   else {
+      Self->prvBuffer.clear();
+      Self->String = nullptr;
+   }
 
    return ERR::Okay;
 }
@@ -712,6 +715,31 @@ static ERR GET_YOffset(extFont *Self, int *Value)
 
 //********************************************************************************************************************
 
+static const char * calc_line_layout(extFont *Self, std::string_view String, int *LineWidth, int *WrapIndex,
+   int *XCoord)
+{
+   if (String.empty()) {
+      *LineWidth = 0;
+      *WrapIndex = 0;
+   }
+   else {
+      int wrap = (Self->WrapEdge > 0) ? (Self->WrapEdge - Self->X) : 0;
+      string_size(Self, String, FSS_LINE, wrap, LineWidth, WrapIndex);
+   }
+
+   if ((Self->Align & (ALIGN::HORIZONTAL|ALIGN::RIGHT)) != ALIGN::NIL) {
+      if ((Self->Align & ALIGN::HORIZONTAL) != ALIGN::NIL) {
+         *XCoord = Self->X + ((Self->AlignWidth - *LineWidth)>>1);
+      }
+      else *XCoord = Self->X + Self->AlignWidth - *LineWidth;
+   }
+   else *XCoord = Self->X;
+
+   return String.data() + *WrapIndex;
+}
+
+//********************************************************************************************************************
+
 static ERR draw_bitmap_font(extFont *Self)
 {
    kt::Log log(__FUNCTION__);
@@ -746,17 +774,7 @@ static ERR draw_bitmap_font(extFont *Self)
       dycoord -= (Self->Ascent - Self->Leading); // - 1;
    }
 
-   string_size(Self, str, FSS_LINE, (Self->WrapEdge > 0) ? (Self->WrapEdge - Self->X) : 0, &linewidth, &wrapindex);
-   const char *wrapstr = str.data() + wrapindex;
-
-   // If horizontal centering is required, calculate the correct horizontal starting coordinate.
-
-   if ((Self->Align & (ALIGN::HORIZONTAL|ALIGN::RIGHT)) != ALIGN::NIL) {
-      if ((Self->Align & ALIGN::HORIZONTAL) != ALIGN::NIL) {
-         dxcoord = Self->X + ((Self->AlignWidth - linewidth)>>1);
-      }
-      else dxcoord = Self->X + Self->AlignWidth - linewidth;
-   }
+   const char *wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
 
    uint32_t colour  = bitmap->getColour(Self->Colour);
    uint32_t ucolour = bitmap->getColour(Self->Underline);
@@ -785,22 +803,7 @@ static ERR draw_bitmap_font(extFont *Self)
             str.remove_prefix(1);
          }
 
-         if (str.empty()) {
-            linewidth = 0;
-            wrapindex = 0;
-         }
-         else {
-            string_size(Self, str, FSS_LINE, (Self->WrapEdge > 0) ? (Self->WrapEdge - Self->X) : 0,
-               &linewidth, &wrapindex);
-         }
-         wrapstr = str.data() + wrapindex;
-
-         if ((Self->Align & (ALIGN::HORIZONTAL|ALIGN::RIGHT)) != ALIGN::NIL) {
-            if ((Self->Align & ALIGN::HORIZONTAL) != ALIGN::NIL) dxcoord = Self->X + ((Self->AlignWidth - linewidth)>>1);
-            else dxcoord = Self->X + Self->AlignWidth - linewidth;
-         }
-         else dxcoord = Self->X;
-
+         wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
          startx = dxcoord;
          dycoord += Self->LineSpacing;
          CHECK_LINE_CLIP(Self, dycoord, bitmap);
@@ -833,13 +836,7 @@ static ERR draw_bitmap_font(extFont *Self)
             }
             if (str.empty()) break;
 
-            string_size(Self, str, FSS_LINE, Self->WrapEdge - dxcoord, &linewidth, &wrapindex);
-            wrapstr = str.data() + wrapindex;
-
-            if ((Self->Align & (ALIGN::HORIZONTAL|ALIGN::RIGHT)) != ALIGN::NIL) {
-               if ((Self->Align & ALIGN::HORIZONTAL) != ALIGN::NIL) dxcoord = Self->X + ((Self->AlignWidth - linewidth)>>1);
-               else dxcoord = Self->X + Self->AlignWidth - linewidth;
-            }
+            wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
             CHECK_LINE_CLIP(Self, dycoord, bitmap);
          }
 
@@ -1045,14 +1042,6 @@ static ERR draw_bitmap_font(extFont *Self)
 
 #include "class_font_def.c"
 
-static const FieldDef AlignFlags[] = {
-   { "Right",      ALIGN::RIGHT      }, { "Left",     ALIGN::LEFT },
-   { "Bottom",     ALIGN::BOTTOM     }, { "Top",      ALIGN::TOP },
-   { "Horizontal", ALIGN::HORIZONTAL }, { "Vertical", ALIGN::VERTICAL },
-   { "Center",     ALIGN::CENTER     }, { "Middle",   ALIGN::MIDDLE },
-   { nullptr, 0 }
-};
-
 static const FieldArray clFontFields[] = {
    { "Point",        FDF_DOUBLE|FDF_RW, GET_Point, SET_Point },
    { "GlyphSpacing", FDF_DOUBLE|FDF_RW },
@@ -1075,7 +1064,7 @@ static const FieldArray clFontFields[] = {
    { "Height",       FDF_INT|FDF_RI },
    { "Leading",      FDF_INT|FDF_R },
    { "MaxHeight",    FDF_INT|FDF_RI },
-   { "Align",        FDF_INTFLAGS|FDF_RW, nullptr, nullptr, AlignFlags },
+   { "Align",        FDF_INTFLAGS|FDF_RW, nullptr, nullptr, clFontAlign },
    { "AlignWidth",   FDF_INT|FDF_RW },
    { "AlignHeight",  FDF_INT|FDF_RW },
    { "Ascent",       FDF_INT|FDF_R },

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -29,10 +29,8 @@ Google Fonts Knowledge page: https://fonts.google.com/knowledge
 //#define DEBUG
 
 #include <ft2build.h>
-#include FT_SIZES_H
 #include FT_FREETYPE_H
 #include FT_MULTIPLE_MASTERS_H
-#include FT_ADVANCES_H
 #include FT_SFNT_NAMES_H
 
 #undef FT_INT64  // Avoid Freetype clash
@@ -43,9 +41,6 @@ Google Fonts Knowledge page: https://fonts.google.com/knowledge
 #include <kotuku/modules/display.h>
 
 #include <sstream>
-#include <array>
-#include <math.h>
-#include <wchar.h>
 #include <kotuku/strings.hpp>
 #include "../link/unicode.h"
 
@@ -1084,111 +1079,49 @@ static void scan_fixed_folder(objConfig *Config)
 static ERR analyse_bmp_font(CSTRING Path, winfnt_header_fields *Header, std::string &FaceName, std::vector<uint16_t> &Points)
 {
    kt::Log log(__FUNCTION__);
-   winmz_header_fields mz_header;
-   winne_header_fields ne_header;
-   int i, res_offset, font_offset;
-   uint16_t size_shift, font_count, count;
    char face[50];
 
    if ((not Path) or (not Header)) return ERR::NullArgs;
 
    objFile::create file = { fl::Path(Path), fl::Flags(FL::READ) };
    if (file.ok()) {
-      file->read(&mz_header, sizeof(mz_header));
-
-      if (mz_header.magic IS ID_WINMZ) {
-         file->seekStart(mz_header.lfanew);
-
-         if ((file->read(&ne_header, sizeof(ne_header)) IS ERR::Okay) and (ne_header.magic IS ID_WINNE)) {
-            res_offset = mz_header.lfanew + ne_header.resource_tab_offset;
-            file->seekStart(res_offset);
-
-            font_count  = 0;
-            font_offset = 0;
-            size_shift  = 0;
-            fl::ReadLE(*file, &size_shift);
-
-            uint16_t type_id = 0;
-            for (fl::ReadLE(*file, &type_id); type_id; fl::ReadLE(*file, &type_id)) {
-               if (fl::ReadLE(*file, &count) IS ERR::Okay) {
-                  if (type_id IS 0x8008) {
-                     font_count  = count;
-                     file->get(FID_Position, font_offset);
-                     font_offset = font_offset + 4;
-                     break;
-                  }
-
-                  file->seekCurrent(4 + count * 12);
-               }
-            }
-
-            if ((not font_count) or (not font_offset)) {
-               log.warning("There are no fonts in file \"%s\"", Path);
-               return ERR::Failed;
-            }
-
-            file->seekStart(font_offset);
-
-            {
-               auto fonts = std::make_unique<winFont[]>(font_count);
-
-               // Get the offset and size of each font entry
-
-               for (int i=0; i < font_count; i++) {
-                  uint16_t offset = 0, size = 0;
-                  fl::ReadLE(*file, &offset);
-                  fl::ReadLE(*file, &size);
-                  fonts[i].Offset = offset<<size_shift;
-                  fonts[i].Size   = size<<size_shift;
-                  file->seekCurrent(8);
-               }
-
-               // Read font point sizes
-
-               for (i=0; i < font_count; i++) {
-                  file->seekStart(fonts[i].Offset);
-                  if (file->read(Header, sizeof(winfnt_header_fields)) IS ERR::Okay) {
-                     Points.push_back(Header->nominal_point_size);
-                  }
-               }
-
-               // Go to the first font in the file and read the font header
-
-               file->seekStart(fonts[0].Offset);
-
-               if (file->read(Header, sizeof(winfnt_header_fields)) != ERR::Okay) {
-                  return ERR::Read;
-               }
-
-                // NOTE: 0x100 indicates the Microsoft vector font format, which we do not support.
-
-               if ((Header->version != 0x200) and (Header->version != 0x300)) {
-                  log.warning("Font \"%s\" is written in unsupported version %d / $%x.", Path, Header->version, Header->version);
-                  return ERR::NoSupport;
-               }
-
-               if (Header->file_type & 1) {
-                  log.warning("Font \"%s\" is in the non-supported vector font format.", Path);
-                  return ERR::NoSupport;
-               }
-
-               // Extract the name of the font
-
-               file->seekStart(fonts[0].Offset + Header->face_name_offset);
-
-               for (i=0; (size_t)i < sizeof(face)-1; i++) {
-                  ERR result = file->read(face+i, 1);
-                  if ((result != ERR::Okay) or (not face[i])) break;
-               }
-               face[i] = 0;
-               FaceName = face;
-            }
-
-            return ERR::Okay;
-         }
-         else return ERR::NoSupport;
+      std::vector<winFont> fonts;
+      if (auto error = read_winfont_entries(*file, fonts); error IS ERR::NoData) {
+         log.warning("There are no fonts in file \"%s\"", Path);
+         return ERR::Failed;
       }
-      else return ERR::NoSupport;
+      else if (error != ERR::Okay) return error;
+
+      // Read font point sizes
+
+      for (auto &font : fonts) {
+         file->seekStart(font.Offset);
+         if (file->read(Header, sizeof(winfnt_header_fields)) IS ERR::Okay) {
+            Points.push_back(Header->nominal_point_size);
+         }
+      }
+
+      // Go to the first font in the file and read the font header
+
+      file->seekStart(fonts[0].Offset);
+
+      if (file->read(Header, sizeof(winfnt_header_fields)) != ERR::Okay) return ERR::Read;
+
+      if (auto error = validate_winfnt_header(*Header, Path); error != ERR::Okay) return error;
+
+      // Extract the name of the font
+
+      file->seekStart(fonts[0].Offset + Header->face_name_offset);
+
+      int i;
+      for (i=0; (size_t)i < sizeof(face)-1; i++) {
+         ERR result = file->read(face+i, 1);
+         if ((result != ERR::Okay) or (not face[i])) break;
+      }
+      face[i] = 0;
+      FaceName = face;
+
+      return ERR::Okay;
    }
    else return ERR::File;
 }

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -818,33 +818,59 @@ ERR ResolveFamilyName(const std::string_view &String, CSTRING *Result)
       kt::ltrim(name, "'\"");
       kt::rtrim(name, "'\"");
 
-restart:
-      if ((name[0] IS '*') and (not name[1])) {
-         // Default family requested - use the first font declaring a "Default" key
+      if (name.empty()) continue;
+
+      std::vector<std::string> visited_aliases;
+
+      for (;;) {
+         if ((name[0] IS '*') and (not name[1])) {
+            // Default family requested - use the first font declaring a "Default" key
+            for (auto & [group, keys] : groups[0]) {
+               if (keys.contains("Default")) {
+                  *Result = keys["Name"].c_str();
+                  return ERR::Okay;
+               }
+            }
+
+            *Result = "Noto Sans";
+            return ERR::Okay;
+         }
+
+         bool alias_restart = false;
+         bool alias_loop = false;
+
          for (auto & [group, keys] : groups[0]) {
-            if (keys.contains("Default")) {
+            if (kt::wildcmp(name, keys["Name"])) {
+               if (auto it = keys.find("Alias"); it != keys.end()) {
+                  const std::string &alias = it->second;
+                  if (not alias.empty()) {
+                     for (auto &visited : visited_aliases) {
+                        if (iequals(visited, keys["Name"])) {
+                           alias_loop = true;
+                           break;
+                        }
+                     }
+
+                     if (alias_loop) break;
+
+                     visited_aliases.push_back(keys["Name"]);
+                     name = alias;
+                     alias_restart = true;
+                     break;
+                  }
+               }
+
                *Result = keys["Name"].c_str();
                return ERR::Okay;
             }
          }
 
-         *Result = "Noto Sans";
-         return ERR::Okay;
-      }
-
-      for (auto & [group, keys] : groups[0]) {
-         if (kt::wildcmp(name, keys["Name"])) {
-            if (auto it = keys.find("Alias"); it != keys.end()) {
-               const std::string &alias = it->second;
-               if (not alias.empty()) {
-                  name = alias;
-                  goto restart;
-               }
-            }
-
-            *Result = keys["Name"].c_str();
-            return ERR::Okay;
+         if (alias_loop) {
+            log.warning("Detected a cyclic alias while resolving family \"%.*s\"", int(String.size()), String.data());
+            break;
          }
+         else if (alias_restart) continue;
+         else break;
       }
    }
 
@@ -998,6 +1024,8 @@ static void scan_fixed_folder(objConfig *Config)
 
    DirInfo *dir;
    if (OpenDir("fonts:fixed/", RDF::FILE, &dir) IS ERR::Okay) {
+      LocalResource free_dir(dir);
+
       while (ScanDir(dir) IS ERR::Okay) {
          std::string location("fonts:fixed/");
          location.append(dir->Info->Name);
@@ -1069,7 +1097,6 @@ static void scan_fixed_folder(objConfig *Config)
          }
          else log.warning("Failed to analyse %s", src);
       }
-      FreeResource(dir);
    }
    else log.warning("Failed to scan directory fonts:fixed/");
 }

--- a/src/font/font_bitmap.cpp
+++ b/src/font/font_bitmap.cpp
@@ -149,6 +149,16 @@ static ERR read_winfont_entries(objFile *File, std::vector<winFont> &Fonts)
 }
 
 //*****************************************************************************
+
+static FTF font_style_flags(CSTRING Style)
+{
+   if (iequals("Bold", Style)) return FTF::BOLD;
+   else if (iequals("Italic", Style)) return FTF::ITALIC;
+   else if (iequals("Bold Italic", Style)) return FTF::BOLD|FTF::ITALIC;
+   else return FTF::NIL;
+}
+
+//*****************************************************************************
 // Structure definition for cached bitmap fonts.
 
 class BitmapCache {
@@ -175,10 +185,7 @@ public:
       Result    = ERR::Okay;
       Header    = pFace;
 
-      if (iequals("Bold", pStyle)) StyleFlags = FTF::BOLD;
-      else if (iequals("Italic", pStyle)) StyleFlags = FTF::ITALIC;
-      else if (iequals("Bold Italic", pStyle)) StyleFlags = FTF::BOLD|FTF::ITALIC;
-      else StyleFlags = FTF::NIL;
+      StyleFlags = font_style_flags(pStyle);
 
       Path = pPath;
 

--- a/src/font/font_bitmap.cpp
+++ b/src/font/font_bitmap.cpp
@@ -4,7 +4,7 @@
 */
 
 struct winFont {
-   int Offset, Size, Point;
+   int Offset, Size;
 };
 
 struct winmz_header_fields {
@@ -61,6 +61,92 @@ PACK(struct winfnt_header_fields {
 
 #define ID_WINMZ  0x5A4D
 #define ID_WINNE  0x454E
+
+//*****************************************************************************
+
+static ERR validate_winfnt_header(const winfnt_header_fields &Header, CSTRING Path)
+{
+   kt::Log log(__FUNCTION__);
+
+   // NOTE: 0x100 indicates the Microsoft vector font format, which we do not support.
+
+   if ((Header.version != 0x200) and (Header.version != 0x300)) {
+      if (Path) {
+         log.warning("Font \"%s\" is written in unsupported version %d / $%x.", Path, Header.version, Header.version);
+      }
+      return ERR::NoSupport;
+   }
+
+   if (Header.file_type & 1) {
+      if (Path) log.warning("Font \"%s\" is in the non-supported vector font format.", Path);
+      return ERR::NoSupport;
+   }
+
+   return ERR::Okay;
+}
+
+//*****************************************************************************
+// Reads the Windows .fon resource table and returns each embedded bitmap font entry.
+
+static ERR read_winfont_entries(objFile *File, std::vector<winFont> &Fonts)
+{
+   if (not File) return ERR::NullArgs;
+
+   Fonts.clear();
+
+   winmz_header_fields mz_header;
+   if (File->read(&mz_header, sizeof(mz_header)) != ERR::Okay) return ERR::Read;
+   if (mz_header.magic != ID_WINMZ) return ERR::NoSupport;
+
+   File->seekStart(mz_header.lfanew);
+
+   winne_header_fields ne_header;
+   if ((File->read(&ne_header, sizeof(ne_header)) != ERR::Okay) or (ne_header.magic != ID_WINNE)) {
+      return ERR::NoSupport;
+   }
+
+   File->seekStart(mz_header.lfanew + ne_header.resource_tab_offset);
+
+   uint16_t size_shift = 0;
+   if (fl::ReadLE(File, &size_shift) != ERR::Okay) return ERR::Read;
+
+   uint16_t font_count = 0;
+   int font_offset = 0;
+   uint16_t type_id = 0;
+   ERR error = fl::ReadLE(File, &type_id);
+
+   while ((error IS ERR::Okay) and (type_id)) {
+      uint16_t count = 0;
+      if (fl::ReadLE(File, &count) != ERR::Okay) return ERR::Read;
+
+      if (type_id IS 0x8008) {
+         font_count = count;
+         File->get(FID_Position, font_offset);
+         font_offset += 4;
+         break;
+      }
+
+      File->seekCurrent(4 + count * 12);
+      error = fl::ReadLE(File, &type_id);
+   }
+
+   if (error != ERR::Okay) return error;
+   if ((not font_count) or (not font_offset)) return ERR::NoData;
+
+   File->seekStart(font_offset);
+   Fonts.resize(font_count);
+
+   for (int i=0; i < int(font_count); i++) {
+      uint16_t offset = 0, size = 0;
+      if (fl::ReadLE(File, &offset) != ERR::Okay) return ERR::Read;
+      if (fl::ReadLE(File, &size) != ERR::Okay) return ERR::Read;
+      Fonts[i].Offset = offset<<size_shift;
+      Fonts[i].Size   = size<<size_shift;
+      File->seekCurrent(8);
+   }
+
+   return ERR::Okay;
+}
 
 //*****************************************************************************
 // Structure definition for cached bitmap fonts.

--- a/src/font/font_structs.h
+++ b/src/font/font_structs.h
@@ -1,9 +1,6 @@
 
 #include <mutex>
 
-#define FT_DOWNSIZE  6
-#define FIXED_DPI 96 // FreeType measurements are based on this DPI.
-
 struct FontCharacter {
    int16_t  Width;
    int16_t  Advance;
@@ -11,21 +8,5 @@ struct FontCharacter {
    uint16_t OutlineOffset;
 };
 
-class font_cache { // Represents a font face.  Stored in glCache
-public:
-   std::string Path; // Path to the font source
-   FT_Face Face;     // Truetype font face
-   int    Usage;    // Counter for usage of the typeface
-
-   font_cache(std::string pPath, FT_Face pFace) : Path(pPath), Face(pFace), Usage(0) { }
-
-   ~font_cache() {
-      kt::Log log;
-      kt::SwitchContext ctx(modFont);
-      FT_Done_Face(Face);
-      log.trace("Terminated cache entry for '%s'", Path.c_str());
-   }
-};
-
 typedef const std::lock_guard<std::recursive_mutex> CACHE_LOCK;
-static std::recursive_mutex glCacheMutex; // Protects access to glCache for multi-threading support
+static std::recursive_mutex glCacheMutex; // Protects access to glBitmapCache for multi-threading support

--- a/src/font/tests/font_tests.tiri
+++ b/src/font/tests/font_tests.tiri
@@ -19,3 +19,25 @@ end
    assert(err is ERR_Okay, "ResolveFamilyName() returned error " .. mSys.GetErrorMsg(err))
    assert(name is "Noto Sans", "Expected ResolveFamilyName() to return 'Noto Sans' as the default font")
 end
+
+@Test function FontFieldSetters()
+   local font = obj.new('font')
+   defer font.free() end
+
+   font.face = 'Noto Sans:12:Bold Italic:#ff0000'
+   assert(font.face is 'Noto Sans', 'Face parsing did not isolate the family name')
+   assert(font.point is 12, 'Face parsing did not isolate the point size')
+   assert(font.style is 'Bold Italic', 'Face parsing did not isolate the style')
+
+   font.bold = false
+   assert(font.style is 'Italic', 'Clearing Bold should preserve Italic')
+
+   font.italic = false
+   assert(font.style is 'Regular', 'Clearing Italic should restore Regular')
+
+   font.string = 'abc'
+   assert(font.string is 'abc', 'String field did not store the assigned value')
+
+   font.string = nil
+   assert(font.string is nil, 'Clearing String should remove the previous value')
+end


### PR DESCRIPTION
## Summary

* Extracted `read_winfont_entries()` and `validate_winfnt_header()` helpers to consolidate duplicated Windows `.fon` MZ/NE resource-table parsing that existed in both `FONT_Init()` and `analyse_bmp_font()`
* Fixed `SET_Bold` and `SET_Italic` to inspect both `Flags` and `prvStyle` when determining the complementary style, correcting incorrect style transitions on uninitialised fonts
* Fixed off-by-one in `SET_Face` face-string parser (`face:point:style:colour`) that caused the `:` separator to be included in each extracted segment
* `SET_String` now correctly clears `Self->String` to `nullptr` when passed a null value
* `ResolveFamilyName()` replaced `goto`-based alias restart loop with a bounded loop that detects and breaks cyclic aliases
* `scan_fixed_folder()` switched to `LocalResource` RAII for the directory handle
* Extracted `calc_line_layout()` helper to eliminate three copies of the line-width and alignment calculation in `draw_bitmap_font()`
* Added `font_style_flags()` helper and removed duplicate inline style mapping
* Added `FontFieldSetters` Flute test covering face-string parsing, bold/italic setters, and string field clearing

## Test plan

- [ ] Build the `font` module and confirm no compilation errors
- [ ] Run existing Flute font tests: `build/agents-install/origo tools/flute.tiri file=src/font/tests/font_tests.tiri --log-warning`
- [ ] Verify `FontFieldSetters` test passes (face parsing, bold/italic/style round-trips, string nil clear)
- [ ] Smoke-test a bitmap font render to confirm `draw_bitmap_font()` line layout is unchanged
- [ ] Verify `ResolveFamilyName()` still resolves aliased and default (`*`) families correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)