### PR TITLE
[Tiri] Restored trace abort stack state before JIT retries

### DIFF
--- a/src/tiri/jit/src/lj_opt_loop.cpp
+++ b/src/tiri/jit/src/lj_opt_loop.cpp
@@ -75,12 +75,16 @@
 #define lj_opt_loop_c
 #define LUA_CORE
 
+#include <kotuku/main.h>
+
 #include "lj_obj.h"
 #include "lj_err.h"
 #include "lj_buf.h"
+#include "lj_frame.h"
 #include "lj_ir.h"
 #include "lj_jit.h"
 #include "lj_iropt.h"
+#include "lj_state.h"
 #include "lj_trace.h"
 #include "lj_snap.h"
 #include "lj_vm.h"
@@ -409,19 +413,22 @@ static TValue* cploop_opt(lua_State* L, lua_CFunction dummy, void* ud)
 // Loop optimization.
 int lj_opt_loop(jit_State* J)
 {
+   lua_State* L = J->L;
    IRRef nins = J->cur.nins;
    SnapNo nsnap = J->cur.nsnap;
    MSize nsnapmap = J->cur.nsnapmap;
    LoopState lps;
+   ptrdiff_t base_before = savestack(L, L->base);
+   ptrdiff_t top_before = savestack(L, L->top);
+   int32_t cframe_nres_before = L->cframe ? cframe_nres(cframe_raw(L->cframe)) : 0;
    int errcode;
    lps.J = J;
    lps.subst = nullptr;
    lps.sizesubst = 0;
-   errcode = lj_vm_cpcall(J->L, nullptr, &lps, cploop_opt);
+   errcode = lj_vm_cpcall(L, nullptr, &lps, cploop_opt);
    lj_mem_freevec(J2G(J), lps.subst, lps.sizesubst, IRRef1);
    if (LJ_UNLIKELY(errcode)) {
-      lua_State* L = J->L;
-      if (errcode == LUA_ERRRUN and tvisnumber(L->top - 1)) {  // Trace error?
+      if (errcode IS LUA_ERRRUN and tvisnumber(L->top - 1)) {  // Trace error?
          int32_t e = numberVint(L->top - 1);
          switch ((TraceError)e) {
          case LJ_TRERR_TYPEINS:  //  Type instability.
@@ -429,7 +436,28 @@ int lj_opt_loop(jit_State* J)
             // Unrolling via recording fixes many cases, e.g. a flipped boolean.
             if (--J->instunroll < 0)  //  But do not unroll forever.
                break;
-            L->top--;  //  Remove error object.
+            {
+               TValue* expected_base = restorestack(L, base_before);
+               TValue* expected_top = restorestack(L, top_before);
+#ifdef LUA_USE_ASSERT
+               if (not (L->base IS expected_base)) {
+                  kt::Log(__FUNCTION__).msg(
+                     "Recoverable loop optimisation trace error changed stack base.  Error: %d, Base: %p -> %p",
+                     e, expected_base, L->base);
+                  lj_assertJ(L->base IS expected_base, "recoverable loop optimisation trace error changed stack base");
+               }
+#endif
+               L->top--;  //  Remove error object.
+               if (not (L->top IS expected_top)) {
+#ifdef LUA_USE_ASSERT
+                  kt::Log(__FUNCTION__).msg(
+                     "Recoverable loop optimisation trace error changed stack top.  Error: %d, Top: %p -> %p",
+                     e, expected_top, L->top);
+#endif
+                  L->top = expected_top;
+               }
+               if (L->cframe) cframe_nres(cframe_raw(L->cframe)) = cframe_nres_before;
+            }
             loop_undo(J, nins, nsnap, nsnapmap);
             return 1;  //  Loop optimization failed, continue recording.
          default:

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -1,4 +1,6 @@
 // Trace management.
+//
+// Copyright © 2025-2026 Paul Manias
 // Copyright (C) 2005-2022 Mike Pall. See Copyright Notice in luajit.h
 
 #define lj_trace_c
@@ -31,6 +33,85 @@
 #include "lj_prng.h"
 #include "../../defs.h"
 
+struct TraceAbortStackState {
+   jit_State *jit;
+   ptrdiff_t base_before;
+   ptrdiff_t top_before;
+   ptrdiff_t top_after;
+   int32_t cframe_nres_before;
+   int32_t error;
+   bool cframe_saved;
+   bool top_changed;
+};
+
+static thread_local TraceAbortStackState glTraceAbortStack;
+
+//********************************************************************************************************************
+// Trace aborts normalise L->top to curr_top() before pushing the trace error object.  Retry paths that continue
+// recording must restore the pre-abort logical top, otherwise lj_trace_ins() sees a stack mutation after retry.
+
+static void trace_abort_stack_snapshot(jit_State *J, TraceError Error, TValue *SafeTop)
+{
+   lua_State *L = J->L;
+
+   // Store stack positions as offsets because error unwinding and VM events may resize the stack before retry.
+   glTraceAbortStack.jit = J;
+   glTraceAbortStack.base_before = savestack(L, L->base);
+   glTraceAbortStack.top_before = savestack(L, L->top);
+   glTraceAbortStack.top_after = savestack(L, SafeTop);
+   glTraceAbortStack.cframe_nres_before = L->cframe ? cframe_nres(cframe_raw(L->cframe)) : 0;
+   glTraceAbortStack.error = int32_t(Error);
+   glTraceAbortStack.cframe_saved = L->cframe != nullptr;
+   glTraceAbortStack.top_changed = not (L->top IS SafeTop);
+
+#ifdef LUA_USE_ASSERT
+   if (glTraceAbortStack.top_changed) {
+      kt::Log(__FUNCTION__).msg("Trace abort normalised stack top.  Error: %d, State: %d, Base: %p, Top: %p -> %p",
+         glTraceAbortStack.error, int32_t(J->state), restorestack(L, glTraceAbortStack.base_before),
+         restorestack(L, glTraceAbortStack.top_before), restorestack(L, glTraceAbortStack.top_after));
+   }
+#endif
+}
+
+//********************************************************************************************************************
+// Restore the logical stack state that existed before lj_trace_err() normalised L->top.  This is only used when
+// trace_abort() is about to retry recording or assembly; non-retry aborts leave normal unwinding to own the stack.
+
+static void trace_abort_restore_retry_stack(jit_State *J, CSTRING Path)
+{
+#ifndef LUA_USE_ASSERT
+   UNUSED(Path);
+#endif
+
+   if (glTraceAbortStack.jit IS J) {
+      lua_State *L = J->L;
+      TValue *base_before = restorestack(L, glTraceAbortStack.base_before);
+      TValue *top_before = restorestack(L, glTraceAbortStack.top_before);
+
+#ifdef LUA_USE_ASSERT
+      if (not (L->base IS base_before)) {
+         kt::Log(__FUNCTION__).msg(
+            "Trace abort retry with changed stack base.  Path: %s, Error: %d, Base: %p -> %p",
+            Path, glTraceAbortStack.error, base_before, L->base);
+         lj_assertJ(L->base IS base_before, "trace abort retry changed stack base");
+      }
+
+      if (not (L->top IS top_before)) {
+         kt::Log(__FUNCTION__).msg(
+            "Trace abort retry restored stack top.  Path: %s, Error: %d, Top: %p -> %p",
+            Path, glTraceAbortStack.error, L->top, top_before);
+      }
+#endif
+
+      L->top = top_before;
+      // lj_trace_err() writes cframe_nres to match the normalised top.  Put it back before retrying the recorder.
+      if (L->cframe and glTraceAbortStack.cframe_saved) {
+         cframe_nres(cframe_raw(L->cframe)) = glTraceAbortStack.cframe_nres_before;
+      }
+      glTraceAbortStack.jit = nullptr;
+   }
+}
+
 //********************************************************************************************************************
 // Synchronous abort of the JIT tracing process, with error message.
 
@@ -52,6 +133,7 @@ void lj_trace_err(jit_State *J, TraceError e)
    // Prefer the interpreter's view of the current frame to avoid clobbering live locals.
    TValue *safe_top = curr_top(J->L);
    if (safe_top < J->L->base) safe_top = J->L->base;
+   trace_abort_stack_snapshot(J, e, safe_top);
    J->L->top = safe_top;
    if (J->L->cframe) cframe_nres(cframe_raw(J->L->cframe)) = -int32_t(savestack(J->L, safe_top));
 
@@ -75,6 +157,7 @@ void lj_trace_err_info(jit_State *J, TraceError e)
    // Prefer the interpreter's view of the current frame to avoid clobbering live locals.
    TValue *safe_top = curr_top(J->L);
    if (safe_top < J->L->base) safe_top = J->L->base;
+   trace_abort_stack_snapshot(J, e, safe_top);
    J->L->top = safe_top;
    if (J->L->cframe) cframe_nres(cframe_raw(J->L->cframe)) = -int32_t(savestack(J->L, safe_top));
 
@@ -622,6 +705,7 @@ static int trace_abort(jit_State *J)
 
    if (e IS LJ_TRERR_MCODELM) {
       L->top--;  //  Remove error object
+      trace_abort_restore_retry_stack(J, "mcode-limit");
       J->state = TraceState::ASM;
       return 1;  //  Retry ASM with new MCode area.
    }
@@ -669,7 +753,10 @@ static int trace_abort(jit_State *J)
    }
 
    L->top--;  //  Remove error object
-   if (e IS LJ_TRERR_DOWNREC) return trace_downrec(J);
+   if (e IS LJ_TRERR_DOWNREC) {
+      trace_abort_restore_retry_stack(J, "down-recursion");
+      return trace_downrec(J);
+   }
    else if (e IS LJ_TRERR_MCODEAL) lj_trace_flushall(L);
    return 0;
 }


### PR DESCRIPTION
## Summary
- Restores the pre-abort Lua stack top and C frame result marker before recoverable trace retry paths resume recording.
- Applies the same stack restoration discipline to recoverable loop optimiser aborts.
- Keeps the trace recorder stack mutation assertion useful while repairing known normalisation paths.

## Root Cause
Trace abort helpers normalise `L->top` to `curr_top()` before pushing a trace error. Recoverable retry paths such as down-recursion, mcode-limit retry, and loop optimiser `TYPEINS`/`GFAIL` handling could resume recording after removing only the error object, leaving `L->top` and `cframe_nres` at the normalised frame top instead of the pre-abort logical top.

## Validation
- `cmake --build build/agents --config Debug --target tiri origo_cmd --parallel`
- `cmake --install build/agents --config Debug`
- `build\agents-install\origo src\tiri\tests\repro_trace_stack_top.tiri --log-api`
- `ctest --build-config Debug --test-dir build/agents --output-on-failure -R "^tiri_stress$"`
- `ctest --build-config Debug --test-dir build/agents --output-on-failure -R "^tiri_unit_tests$"`
- 10 standalone repro process runs passed after the final restore adjustment.
- 10 registered `tiri_stress` CTest runs passed after the final restore adjustment.