### PR TITLE
[Core] Added string_view support for field access

### DIFF
--- a/include/kotuku/main.h
+++ b/include/kotuku/main.h
@@ -485,85 +485,64 @@ class objNetClient;
 namespace fl {
    using namespace kt;
 
-[[nodiscard]] constexpr FieldValue Path(CSTRING Value) { return FieldValue(FID_Path, Value); }
-inline FieldValue Path(const std::string &Value) { return FieldValue(FID_Path, Value.c_str()); }
+[[nodiscard]] inline FieldValue Path(std::string_view Value) { return FieldValue(FID_Path, Value); }
+[[nodiscard]] inline FieldValue Location(std::string_view Value) { return FieldValue(FID_Location, Value); }
+[[nodiscard]] inline FieldValue Args(std::string_view Value) { return FieldValue(FID_Args, Value); }
+[[nodiscard]] inline FieldValue Fill(std::string_view Value) { return FieldValue(FID_Fill, Value); }
+[[nodiscard]] inline FieldValue Statement(std::string_view Value) { return FieldValue(FID_Statement, Value); }
+[[nodiscard]] inline FieldValue Stroke(std::string_view Value) { return FieldValue(FID_Stroke, Value); }
+[[nodiscard]] inline FieldValue String(std::string_view Value) { return FieldValue(FID_String, Value); }
+[[nodiscard]] inline FieldValue Name(std::string_view Value) { return FieldValue(FID_Name, Value); }
+[[nodiscard]] inline FieldValue Allow(std::string_view Value) { return FieldValue(FID_Allow, Value); }
+[[nodiscard]] inline FieldValue Style(std::string_view Value) { return FieldValue(FID_Style, Value); }
+[[nodiscard]] inline FieldValue Face(std::string_view Value) { return FieldValue(FID_Face, Value); }
+[[nodiscard]] inline FieldValue FileExtension(std::string_view Value) { return FieldValue(FID_FileExtension, Value); }
+[[nodiscard]] inline FieldValue FileDescription(std::string_view Value) { return FieldValue(FID_FileDescription, Value); }
+[[nodiscard]] inline FieldValue FileHeader(std::string_view Value) { return FieldValue(FID_FileHeader, Value); }
+[[nodiscard]] inline FieldValue ArchiveName(std::string_view Value) { return FieldValue(FID_ArchiveName, Value); }
+[[nodiscard]] inline FieldValue Volume(std::string_view Value) { return FieldValue(FID_Volume, Value); }
+[[nodiscard]] inline FieldValue DPMS(std::string_view Value) { return FieldValue(FID_DPMS, Value); }
+[[nodiscard]] inline FieldValue Icon(std::string_view Value) { return FieldValue(FID_Icon, Value); }
+[[nodiscard]] inline FieldValue Procedure(std::string_view Value) { return FieldValue(FID_Procedure, Value); }
+[[nodiscard]] inline FieldValue ButtonOrder(std::string_view Value) { return FieldValue(FID_ButtonOrder, Value); }
+[[nodiscard]] inline FieldValue Points(std::string_view Value) { return FieldValue(FID_Points, Value); }
+[[nodiscard]] inline FieldValue Pretext(std::string_view Value) { return FieldValue(FID_Pretext, Value); }
+[[nodiscard]] inline FieldValue Point(std::string_view Value) { return FieldValue(FID_Point, Value); }
 
-[[nodiscard]] constexpr FieldValue Location(CSTRING Value) { return FieldValue(FID_Location, Value); }
-inline FieldValue Location(const std::string &Value) { return FieldValue(FID_Location, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Args(CSTRING Value) { return FieldValue(FID_Args, Value); }
-inline FieldValue Args(const std::string &Value) { return FieldValue(FID_Args, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Fill(CSTRING Value) { return FieldValue(FID_Fill, Value); }
-inline FieldValue Fill(const std::string &Value) { return FieldValue(FID_Fill, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Statement(CSTRING Value) { return FieldValue(FID_Statement, Value); }
-inline FieldValue Statement(const std::string &Value) { return FieldValue(FID_Statement, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Stroke(CSTRING Value) { return FieldValue(FID_Stroke, Value); }
-inline FieldValue Stroke(const std::string &Value) { return FieldValue(FID_Stroke, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue String(CSTRING Value) { return FieldValue(FID_String, Value); }
-inline FieldValue String(const std::string &Value) { return FieldValue(FID_String, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Name(CSTRING Value) { return FieldValue(FID_Name, Value); }
-inline FieldValue Name(const std::string &Value) { return FieldValue(FID_Name, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Allow(CSTRING Value) { return FieldValue(FID_Allow, Value); }
-inline FieldValue Allow(const std::string &Value) { return FieldValue(FID_Allow, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Style(CSTRING Value) { return FieldValue(FID_Style, Value); }
-inline FieldValue Style(const std::string &Value) { return FieldValue(FID_Style, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Face(CSTRING Value) { return FieldValue(FID_Face, Value); }
-inline FieldValue Face(const std::string &Value) { return FieldValue(FID_Face, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue FileExtension(CSTRING Value) { return FieldValue(FID_FileExtension, Value); }
-inline FieldValue FileExtension(const std::string &Value) { return FieldValue(FID_FileExtension, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue FileDescription(CSTRING Value) { return FieldValue(FID_FileDescription, Value); }
-inline FieldValue FileDescription(const std::string &Value) { return FieldValue(FID_FileDescription, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue FileHeader(CSTRING Value) { return FieldValue(FID_FileHeader, Value); }
-inline FieldValue FileHeader(const std::string &Value) { return FieldValue(FID_FileHeader, Value.c_str()); }
+// Handlers to prevent failure on receipt of a nullptr value
+[[nodiscard]] inline FieldValue Path(CSTRING Value) { return FieldValue(FID_Path, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Location(CSTRING Value) { return FieldValue(FID_Location, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Args(CSTRING Value) { return FieldValue(FID_Args, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Fill(CSTRING Value) { return FieldValue(FID_Fill, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Statement(CSTRING Value) { return FieldValue(FID_Statement, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Stroke(CSTRING Value) { return FieldValue(FID_Stroke, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue String(CSTRING Value) { return FieldValue(FID_String, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Name(CSTRING Value) { return FieldValue(FID_Name, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Allow(CSTRING Value) { return FieldValue(FID_Allow, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Style(CSTRING Value) { return FieldValue(FID_Style, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Face(CSTRING Value) { return FieldValue(FID_Face, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue FileExtension(CSTRING Value) { return FieldValue(FID_FileExtension, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue FileDescription(CSTRING Value) { return FieldValue(FID_FileDescription, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue FileHeader(CSTRING Value) { return FieldValue(FID_FileHeader, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue ArchiveName(CSTRING Value) { return FieldValue(FID_ArchiveName, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Volume(CSTRING Value) { return FieldValue(FID_Volume, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue DPMS(CSTRING Value) { return FieldValue(FID_DPMS, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Icon(CSTRING Value) { return FieldValue(FID_Icon, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Procedure(CSTRING Value) { return FieldValue(FID_Procedure, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue ButtonOrder(CSTRING Value) { return FieldValue(FID_ButtonOrder, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Points(CSTRING Value) { return FieldValue(FID_Points, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Pretext(CSTRING Value) { return FieldValue(FID_Pretext, Value ? std::string_view(Value) : std::string_view()); }
+[[nodiscard]] inline FieldValue Point(CSTRING Value) { return FieldValue(FID_Point, Value ? std::string_view(Value) : std::string_view()); }
 
 [[nodiscard]] constexpr FieldValue FontSize(double Value) { return FieldValue(FID_FontSize, Value); }
 [[nodiscard]] constexpr FieldValue FontSize(int Value) { return FieldValue(FID_FontSize, Value); }
-[[nodiscard]] constexpr FieldValue FontSize(CSTRING Value) { return FieldValue(FID_FontSize, Value); }
-inline FieldValue FontSize(const std::string &Value) { return FieldValue(FID_FontSize, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue ArchiveName(CSTRING Value) { return FieldValue(FID_ArchiveName, Value); }
-inline FieldValue ArchiveName(const std::string &Value) { return FieldValue(FID_ArchiveName, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Volume(CSTRING Value) { return FieldValue(FID_Volume, Value); }
-inline FieldValue Volume(const std::string &Value) { return FieldValue(FID_Volume, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue DPMS(CSTRING Value) { return FieldValue(FID_DPMS, Value); }
-inline FieldValue DPMS(const std::string &Value) { return FieldValue(FID_DPMS, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Icon(CSTRING Value) { return FieldValue(FID_Icon, Value); }
-inline FieldValue Icon(const std::string &Value) { return FieldValue(FID_Icon, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Procedure(CSTRING Value) { return FieldValue(FID_Procedure, Value); }
-inline FieldValue Procedure(const std::string &Value) { return FieldValue(FID_Procedure, Value.c_str()); }
+inline FieldValue FontSize(std::string_view Value) { return FieldValue(FID_FontSize, Value); }
 
 [[nodiscard]] constexpr FieldValue ReadOnly(int Value) { return FieldValue(FID_ReadOnly, Value); }
 [[nodiscard]] constexpr FieldValue ReadOnly(bool Value) { return FieldValue(FID_ReadOnly, (Value ? 1 : 0)); }
 
-[[nodiscard]] constexpr FieldValue ButtonOrder(CSTRING Value) { return FieldValue(FID_ButtonOrder, Value); }
-inline FieldValue ButtonOrder(const std::string &Value) { return FieldValue(FID_ButtonOrder, Value.c_str()); }
-
 [[nodiscard]] constexpr FieldValue Point(double Value) { return FieldValue(FID_Point, Value); }
 [[nodiscard]] constexpr FieldValue Point(int Value) { return FieldValue(FID_Point, Value); }
-[[nodiscard]] constexpr FieldValue Point(CSTRING Value) { return FieldValue(FID_Point, Value); }
-inline FieldValue Point(const std::string &Value) { return FieldValue(FID_Point, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Points(CSTRING Value) { return FieldValue(FID_Points, Value); }
-inline FieldValue Points(const std::string &Value) { return FieldValue(FID_Points, Value.c_str()); }
-
-[[nodiscard]] constexpr FieldValue Pretext(CSTRING Value) { return FieldValue(FID_Pretext, Value); }
-inline FieldValue Pretext(const std::string &Value) { return FieldValue(FID_Pretext, Value.c_str()); }
-
 [[nodiscard]] constexpr FieldValue Acceleration(double Value) { return FieldValue(FID_Acceleration, Value); }
 [[nodiscard]] constexpr FieldValue Actions(CPTR Value) { return FieldValue(FID_Actions, Value); }
 [[nodiscard]] constexpr FieldValue AmtColours(int Value) { return FieldValue(FID_AmtColours, Value); }

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2827,10 +2827,10 @@ class objFile : public Object {
       return field->WriteValue(target, field, 0x08000310, Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(std::string_view Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
    inline ERR setPermissions(const int Value) noexcept {
@@ -2845,10 +2845,10 @@ class objFile : public Object {
       return field->WriteValue(target, field, FD_INT64, &Value, 1);
    }
 
-   template <class T> inline ERR setLink(T && Value) noexcept {
+   inline ERR setLink(std::string_view Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[15];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setUser(const int Value) noexcept {

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -28,6 +28,7 @@
 #define FDF_UNIT       FD_UNIT
 #define FDF_SYNONYM    FD_SYNONYM
 
+#define FDF_CPPSTRING   (FD_CPP|FD_STRING)
 #define FDF_STRVIEW     (FD_CPP|FD_STRING)
 #define FDF_UNSIGNED    FD_UNSIGNED
 #define FDF_FUNCTION    FD_FUNCTION           // sizeof(FUNCTION) - use FDF_FUNCTIONPTR for sizeof(APTR)
@@ -82,6 +83,7 @@ struct FieldValue {
    uint32_t FieldID;
    int Type;
    union {
+      std::string_view CPPString;
       CSTRING String;
       APTR    Pointer;
       CPTR    CPointer;
@@ -92,7 +94,7 @@ struct FieldValue {
    };
 
    //std::string not included as not compatible with constexpr
-   constexpr FieldValue(uint32_t pFID, CSTRING pValue)  : FieldID(pFID), Type(FD_STRING), String(pValue) { };
+   constexpr FieldValue(uint32_t pFID, std::string_view pValue)  : FieldID(pFID), Type(FD_STRING|FD_CPP), CPPString(pValue) { };
    constexpr FieldValue(uint32_t pFID, int pValue)      : FieldID(pFID), Type(FD_INT), Int(pValue) { };
    constexpr FieldValue(uint32_t pFID, int64_t pValue)  : FieldID(pFID), Type(FD_INT64), Int64(pValue) { };
    constexpr FieldValue(uint32_t pFID, size_t pValue)   : FieldID(pFID), Type(FD_INT64), Int64(pValue) { };
@@ -369,8 +371,8 @@ struct Object { // Must be 64-bit aligned
    template <class T> ERR set(FIELD FieldID, const T *Data, size_t Elements, int Type = FIELD_TYPECHECK<T>()) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!(field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if (not (field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_ARRAY|Type, Data, Elements);
       }
@@ -380,8 +382,8 @@ struct Object { // Must be 64-bit aligned
    template <class T, std::size_t SIZE> ERR set(FIELD FieldID, const std::array<T, SIZE> &Value, int Type = FIELD_TYPECHECK<T>()) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!(field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if (not (field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
 
          return field->WriteValue(target, field, FD_ARRAY|Type, Value.data(), SIZE);
@@ -392,8 +394,8 @@ struct Object { // Must be 64-bit aligned
    template <class T> ERR set(FIELD FieldID, const std::vector<T> &Value, int Type = FIELD_TYPECHECK<T>()) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!(field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if (not (field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
 
          return field->WriteValue(target, field, FD_ARRAY|Type, const_cast<T *>(Value.data()), std::ssize(Value));
@@ -404,8 +406,8 @@ struct Object { // Must be 64-bit aligned
    template <class T> ERR set(FIELD FieldID, const kt::vector<T> &Value, int Type = FIELD_TYPECHECK<T>()) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!(field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if (not (field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
 
          if (field->Flags & FD_CPP) return field->WriteValue(target, field, FD_ARRAY|Type, &Value, std::ssize(Value));
@@ -417,8 +419,8 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const FRGB &Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!(field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if (not (field->Flags & FD_ARRAY)) return ERR::FieldTypeMismatch;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_ARRAY|FD_FLOAT, &Value, 4);
       }
@@ -435,7 +437,7 @@ struct Object { // Must be 64-bit aligned
    template <class T> ERR set(FIELD FieldID, const T Value) requires std::integral<T> || std::floating_point<T> {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FIELD_TYPECHECK<T>(), &Value, 1);
       }
@@ -445,7 +447,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const FUNCTION *Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_FUNCTION, Value, 1);
       }
@@ -455,7 +457,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const char *Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_STRING, Value, 1);
       }
@@ -465,7 +467,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const unsigned char *Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_STRING, Value, 1);
       }
@@ -475,7 +477,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, std::string_view Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_CPP|FD_STRING, &Value, 1);
       }
@@ -485,7 +487,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const std::string &Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          auto sv = std::string_view(Value);
          return field->WriteValue(target, field, FD_CPP|FD_STRING, &sv, 1);
@@ -496,7 +498,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const Unit *Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_UNIT, Value, 1);
       }
@@ -512,7 +514,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR set(FIELD FieldID, const void *Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
+         if ((not field->writeable()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          if ((field->Flags & FD_INIT) and (target->initialised()) and (CurrentContext() != target)) return ERR::NoFieldAccess;
          return field->WriteValue(target, field, FD_POINTER, Value, 1);
       }
@@ -555,7 +557,7 @@ struct Object { // Must be 64-bit aligned
       Value = 0;
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!field->readable()) return ERR::NoFieldAccess;
+         if (not field->readable()) return ERR::NoFieldAccess;
 
          ScopedObjectAccess objlock(target);
 
@@ -563,7 +565,7 @@ struct Object { // Must be 64-bit aligned
 
          if (flags & FD_UNIT) return get_unit<T>(target, *field, Value);
 
-         int8_t field_value[8];
+         int8_t field_value[sizeof(std::string_view)];
          int array_size;
          auto fv = get_field_value(target, *field, field_value, array_size);
 
@@ -582,7 +584,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR get(FIELD FieldID, std::string &Value) { // Retrieve field as a string, supports type conversion.
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!field->readable()) return ERR::NoFieldAccess;
+         if (not field->readable()) return ERR::NoFieldAccess;
 
          auto flags = field->Flags;
          if (flags & FD_UNIT) {
@@ -596,7 +598,7 @@ struct Object { // Must be 64-bit aligned
             else return error;
          }
 
-         int8_t field_value[8];
+         int8_t field_value[sizeof(std::string_view)];
          int array_size = -1;
          auto fv = get_field_value(target, *field, field_value, array_size);
          APTR data = fv.second;
@@ -625,7 +627,7 @@ struct Object { // Must be 64-bit aligned
                for (int i=0; i < array_size; i++) Value.append(std::to_string(*array++)).push_back(',');
             }
 
-            if (!Value.empty()) Value.pop_back(); // Remove trailing comma
+            if (not Value.empty()) Value.pop_back(); // Remove trailing comma
             return ERR::Okay;
          }
 
@@ -655,7 +657,7 @@ struct Object { // Must be 64-bit aligned
                      }
                      lookup++;
                   }
-                  if (!Value.empty()) Value.pop_back(); // Remove trailing pipe
+                  if (not Value.empty()) Value.pop_back(); // Remove trailing pipe
                   return ERR::Okay;
                }
             }
@@ -682,13 +684,13 @@ struct Object { // Must be 64-bit aligned
 
    // Retrieve a direct pointer to a string field, no-copy operation.  Result will require deallocation by the client if the field is marked with ALLOC.
 
-   inline ERR get(FIELD FieldID, CSTRING &Value) {
+   [[deprecated]] inline ERR get(FIELD FieldID, CSTRING &Value) {
       Object *target;
       Value = nullptr;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!field->readable()) return ERR::NoFieldAccess;
+         if (not field->readable()) return ERR::NoFieldAccess;
 
-         int8_t field_value[8];
+         int8_t field_value[sizeof(std::string_view)];
          int array_size;
          auto fv = get_field_value(target, *field, field_value, array_size);
          if (fv.first != ERR::Okay) return fv.first;
@@ -716,13 +718,51 @@ struct Object { // Must be 64-bit aligned
       else return ERR::UnsupportedField;
    }
 
+   inline ERR get(FIELD FieldID, std::string_view &Value) {
+      Object *target;
+      Value = std::string_view();
+      if (auto field = FindField(this, FieldID, &target)) {
+         if (not field->readable()) return ERR::NoFieldAccess;
+
+         int8_t field_value[sizeof(std::string_view)];
+         int array_size;
+         auto fv = get_field_value(target, *field, field_value, array_size);
+         if (fv.first != ERR::Okay) return fv.first;
+
+         if (field->Flags & FD_STRING) {
+            if (field->Flags & FD_CPP) Value = *((std::string_view *)fv.second);
+            else {
+               CSTRING val = *((CSTRING *)fv.second);
+               Value = val ? std::string_view(val) : std::string_view{};
+            }
+            return ERR::Okay;
+         }
+         else if ((field->Flags & FD_INT) and (field->Flags & FD_LOOKUP)) {
+            // Reading a lookup field as a string is permissible, we just return the string registered in the lookup table
+            if (auto lookup = (FieldDef *)field->Arg) {
+               int value = ((int *)fv.second)[0];
+               while (lookup->Name) {
+                  if (value IS lookup->Value) {
+                     Value = std::string_view(lookup->Name);
+                     return ERR::Okay;
+                  }
+                  lookup++;
+               }
+            }
+            return ERR::Okay;
+         }
+         else return ERR::FieldTypeMismatch;
+      }
+      else return ERR::UnsupportedField;
+   }
+
    template <class T> ERR get(FIELD FieldID, T &Value) requires pcPointer<T> {
       Object *target;
       Value = nullptr;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!field->readable()) return ERR::NoFieldAccess;
+         if (not field->readable()) return ERR::NoFieldAccess;
 
-         int8_t field_value[8];
+         int8_t field_value[sizeof(std::string_view)];
          int array_size;
          auto fv = get_field_value(target, *field, field_value, array_size);
          if (fv.first != ERR::Okay) return fv.first;
@@ -739,7 +779,7 @@ struct Object { // Must be 64-bit aligned
    inline ERR get(FIELD FieldID, Unit &Value) {
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
-         if (!field->readable()) return ERR::NoFieldAccess;
+         if (not field->readable()) return ERR::NoFieldAccess;
 
          if (field->Flags & FD_UNIT) {
             SetObjectContext(target, field, AC::NIL);
@@ -772,9 +812,9 @@ struct Object { // Must be 64-bit aligned
       Object *target;
       Result = nullptr;
       if (auto field = FindField(this, FieldID, &target)) {
-         if ((!field->readable()) or (!(field->Flags & FD_ARRAY))) return ERR::NoFieldAccess;
+         if ((not field->readable()) or (not (field->Flags & FD_ARRAY))) return ERR::NoFieldAccess;
 
-         if ((TypeCheck) and (!(field->Flags & FIELD_TYPECHECK<T>()))) return ERR::FieldTypeMismatch;
+         if ((TypeCheck) and (not (field->Flags & FIELD_TYPECHECK<T>()))) return ERR::FieldTypeMismatch;
 
          ScopedObjectAccess objlock(target);
 
@@ -818,7 +858,7 @@ struct Object { // Must be 64-bit aligned
       for (auto &f : Fields) {
          OBJECTPTR target;
          if (auto field = FindField(this, f.FieldID, &target)) {
-            if ((!(field->Flags & (FD_INIT|FD_WRITE))) and (ctx != target)) {
+            if ((not (field->Flags & (FD_INIT|FD_WRITE))) and (ctx != target)) {
                log.warning("%s.%s is immutable.", className(), field->Name);
             }
             else if ((field->Flags & FD_INIT) and (target->initialised()) and (ctx != target)) {
@@ -828,7 +868,10 @@ struct Object { // Must be 64-bit aligned
                if (target != this) target->lock();
 
                ERR error;
-               if (f.Type & (FD_POINTER|FD_STRING|FD_ARRAY|FD_FUNCTION|FD_UNIT)) {
+               if ((f.Type & FD_STRING) and (f.Type & FD_CPP)) {
+                  error = field->WriteValue(target, field, f.Type, &f.CPPString, 0);
+               }
+               else if (f.Type & (FD_POINTER|FD_STRING|FD_ARRAY|FD_FUNCTION|FD_UNIT)) {
                   error = field->WriteValue(target, field, f.Type, f.Pointer, 0);
                }
                else if (f.Type & (FD_DOUBLE|FD_FLOAT)) {
@@ -941,14 +984,17 @@ class Create {
             for (auto &f : Fields) {
                OBJECTPTR target;
                if (auto field = FindField(obj, f.FieldID, &target)) {
-                  if (!(field->Flags & (FD_WRITE|FD_INIT))) {
+                  if (not (field->Flags & (FD_WRITE|FD_INIT))) {
                      error = log.warning(ERR::NoFieldAccess);
                      return;
                   }
                   else {
                      target->lock();
 
-                     if (f.Type & (FD_POINTER|FD_STRING|FD_ARRAY|FD_FUNCTION|FD_UNIT)) {
+                     if ((f.Type & FD_STRING) and (f.Type & FD_CPP)) {
+                        error = field->WriteValue(target, field, f.Type, &f.CPPString, 0);
+                     }
+                     else if (f.Type & (FD_POINTER|FD_STRING|FD_ARRAY|FD_FUNCTION|FD_UNIT)) {
                         error = field->WriteValue(target, field, f.Type, f.Pointer, 0);
                      }
                      else if (f.Type & (FD_DOUBLE|FD_FLOAT)) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,6 +19,18 @@ set (FUNCTIONS  # Full paths are required for add_custom_command() dependencies 
    "${CMAKE_CURRENT_SOURCE_DIR}/fs_resolution.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/fs_volumes.cpp")
 
+set (CORE_CLASSES
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_config.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_file.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_metaclass.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_module.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_script.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_storagedevice.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_task.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_thread.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_time.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/compression/class_compression.cpp")
+
 SET (CORE_DEFS
    "${CMAKE_CURRENT_SOURCE_DIR}/compression/class_compressed_stream_def.c"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_config_def.c"
@@ -68,6 +80,7 @@ if (BUILD_DEFS)
          "${CMAKE_CURRENT_SOURCE_DIR}/defs/fields.tdl"
          "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/idl/common.tdl"
          ${FUNCTIONS}
+         ${CORE_CLASSES}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMENT "Producing definition files for the Core library"
       VERBATIM)

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -175,8 +175,7 @@ static ERR parse_file(extConfig *Self, CSTRING Path)
       auto current_path = (sep != std::string_view::npos) ? paths.substr(0, sep) : paths;
 
       // Create a null-terminated copy for fl::Path
-      std::string path_str(current_path);
-      objFile::create file = { fl::Path(path_str), fl::Flags(FL::READ|FL::APPROXIMATE) };
+      objFile::create file = { fl::Path(current_path), fl::Flags(FL::READ|FL::APPROXIMATE) };
 
       if (file.ok()) {
          auto filesize = file->get<int>(FID_Size);

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -150,10 +150,10 @@ extern void path_monitor(HOSTHANDLE, OBJECTPTR);
 static ERR FILE_Init(extFile *);
 static ERR FILE_Watch(extFile *, struct fl::Watch *);
 
-static ERR SET_Path(extFile *, CSTRING);
+static ERR SET_Path(extFile *, std::string_view &);
 static ERR SET_Size(extFile *, int64_t);
 
-static ERR GET_ResolvedPath(extFile *, CSTRING *);
+static ERR GET_ResolvedPath(extFile *, std::string_view &);
 
 static ERR set_permissions(extFile *, PERMIT);
 
@@ -177,8 +177,8 @@ static ERR FILE_Activate(extFile *Self)
    int openflags = 0;
    if ((Self->Flags & FL::NEW) != FL::NIL) openflags |= O_CREAT|O_TRUNC;
 
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) != ERR::Okay) return ERR::ResolvePath;
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) != ERR::Okay) return ERR::ResolvePath;
 
 #ifdef __unix__
    int secureflags = S_IRUSR|S_IWUSR|convert_permissions(Self->Permissions);
@@ -197,18 +197,18 @@ static ERR FILE_Activate(extFile *Self)
 #endif
 
    if ((Self->Flags & (FL::READ|FL::WRITE)) IS (FL::READ|FL::WRITE)) {
-      log.msg("Open \"%s\" [RW]", path);
+      log.msg("Open \"%.*s\" [RW]", int(path.size()), path.data());
       openflags |= O_RDWR;
    }
    else if ((Self->Flags & FL::READ) != FL::NIL) {
-      log.msg("Open \"%s\" [R]", path);
+      log.msg("Open \"%.*s\" [R]", int(path.size()), path.data());
       openflags |= O_RDONLY;
    }
    else if ((Self->Flags & FL::WRITE) != FL::NIL) {
-      log.msg("Open \"%s\" [W|%s]", path, ((Self->Flags & FL::NEW) != FL::NIL) ? "New" : "Existing");
+      log.msg("Open \"%.*s\" [W|%s]", int(path.size()), path.data(), ((Self->Flags & FL::NEW) != FL::NIL) ? "New" : "Existing");
       openflags |= O_RDWR;
    }
-   else log.msg("Open \"%s\" [-]", path);
+   else log.msg("Open \"%.*s\" [-]", int(path.size()), path.data());
 
    #ifdef __unix__
       // Set O_NONBLOCK to stop the task from being halted in the event that we accidentally try to open a pipe like a
@@ -221,22 +221,22 @@ static ERR FILE_Activate(extFile *Self)
       if ((Self->Flags & FL::NEW) != FL::NIL) {
          // Make sure that we'll be able to recreate the file from new if it already exists and is marked read-only.
 
-         chmod(path, S_IRUSR|S_IWUSR);
+         chmod(path.data(), S_IRUSR|S_IWUSR);
       }
    #endif
 
-   if ((Self->Handle = open(path, openflags|WIN32OPEN|O_LARGEFILE, secureflags)) IS -1) {
+   if ((Self->Handle = open(path.data(), openflags|WIN32OPEN|O_LARGEFILE, secureflags)) IS -1) {
       int err = errno;
 
       if ((Self->Flags & FL::NEW) != FL::NIL) {
          // Attempt to create the necessary directories that might be required for this new file.
 
          if (check_paths(path, Self->Permissions) IS ERR::Okay) {
-            Self->Handle = open(path, openflags|WIN32OPEN|O_LARGEFILE, secureflags);
+            Self->Handle = open(path.data(), openflags|WIN32OPEN|O_LARGEFILE, secureflags);
          }
 
          if (Self->Handle IS -1) {
-            log.warning("New file error \"%s\"", path);
+            log.warning("New file error \"%.*s\"", int(path.size()), path.data());
             if (err IS EACCES) return log.warning(ERR::NoPermission);
             else if (err IS ENAMETOOLONG) return log.warning(ERR::BufferOverflow);
             else return ERR::CreateFile;
@@ -247,7 +247,7 @@ static ERR FILE_Activate(extFile *Self)
          log.warning("Reverting to read-only access for this read-only file.");
          openflags = O_RDONLY;
          Self->Flags &= ~FL::WRITE;
-         Self->Handle = open(path, openflags|WIN32OPEN|O_LARGEFILE, secureflags);
+         Self->Handle = open(path.data(), openflags|WIN32OPEN|O_LARGEFILE, secureflags);
       }
       else if ((Self->Flags & FL::LINK) != FL::NIL) {
          // The file is a broken symbolic link (i.e. refers to a file that no longer exists).  Even
@@ -263,7 +263,7 @@ static ERR FILE_Activate(extFile *Self)
             case EINVAL: return log.warning(ERR::Args);
             case ENOENT: return log.warning(ERR::FileNotFound);
             default:
-               log.warning("Could not open \"%s\", error: %s", path, strerror(errno));
+               log.warning("Could not open \"%.*s\", error: %s", int(path.size()), path.data(), strerror(errno));
                return ERR::SystemCall;
          }
       }
@@ -486,8 +486,8 @@ static ERR FILE_Delete(extFile *Self, struct fl::Delete *Args)
 
       // Delete the folder and its contents
 
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          std::string buffer(path);
 
          #ifdef __unix__
@@ -514,8 +514,8 @@ static ERR FILE_Delete(extFile *Self, struct fl::Delete *Args)
    else {
       log.branch("Delete File: %s", Self->Path.c_str());
 
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          std::string buffer(path);
          if (buffer.ends_with('/') or buffer.ends_with('\\')) buffer.pop_back();
 
@@ -762,7 +762,8 @@ retrydir:
          // Then return ERR::UseSubClass to have support delegated to the correct File sub-class.
          Self->Flags |= FL::VIRTUAL;
          if (not iequals(Self->Path, Self->prvResolvedPath)) {
-            SET_Path(Self, Self->prvResolvedPath.c_str());
+            auto sv = std::string_view(Self->prvResolvedPath);
+            SET_Path(Self, sv);
          }
          log.trace("ResolvePath() reports virtual volume, will delegate to sub-class...");
          return ERR::UseSubClass;
@@ -1358,9 +1359,9 @@ static ERR FILE_SetDate(extFile *Self, struct fl::SetDate *Args)
    log.msg("%d/%d/%d %.2d:%.2d:%.2d", Args->Day, Args->Month, Args->Year, Args->Hour, Args->Minute, Args->Second);
 
    #ifdef _WIN32
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
-         auto result = winSetFileTime(path, Self->isFolder,
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
+         auto result = winSetFileTime(path.data(), Self->isFolder,
             Args->Year, Args->Month, Args->Day, Args->Hour, Args->Minute, Args->Second);
 
          if (result) {
@@ -1373,8 +1374,8 @@ static ERR FILE_SetDate(extFile *Self, struct fl::SetDate *Args)
 
    #elif __unix__
 
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          struct tm time;
          time.tm_year  = Args->Year - 1900;
          time.tm_mon   = Args->Month - 1;
@@ -1391,7 +1392,7 @@ static ERR FILE_SetDate(extFile *Self, struct fl::SetDate *Args)
             filetime[0].tv_usec = 0;
             filetime[1] = filetime[0];
 
-            if (utimes(path, filetime) != -1) {
+            if (utimes(path.data(), filetime) != -1) {
                Self->Flags |= FL::RESET_DATE;
                return ERR::Okay;
             }
@@ -1551,9 +1552,9 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
    }
 #endif
 
-   CSTRING resolve;
+   std::string_view resolve;
    ERR error;
-   if ((error = GET_ResolvedPath(Self, &resolve)) IS ERR::Okay) {
+   if ((error = GET_ResolvedPath(Self, resolve)) IS ERR::Okay) {
       auto vd = get_fs(resolve);
 
       if (vd.WatchPath) {
@@ -1741,11 +1742,11 @@ static ERR GET_Created(extFile *Self, DateTime **Value)
       else return log.warning(ERR::SystemCall);
    }
    else {
-      CSTRING path;
+      std::string_view path;
       ERR error;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          char buffer[512];
-         int len = strcopy(path, buffer, sizeof(buffer));
+         int len = strcopy(path.data(), buffer, std::min(sizeof(buffer), path.length()));
          if ((buffer[len-1] IS '/') or (buffer[len-1] IS '\\')) buffer[len-1] = 0;
 
          struct stat64 stats;
@@ -1819,11 +1820,11 @@ static ERR GET_Date(extFile *Self, DateTime **Value)
       return error;
    }
    else {
-      CSTRING path;
+      std::string_view path;
       ERR error;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          char buffer[512];
-         int len = strcopy(path, buffer, sizeof(buffer));
+         int len = strcopy(path.data(), buffer, std::min(sizeof(buffer), path.length()));
          if ((buffer[len-1] IS '/') or (buffer[len-1] IS '\\')) buffer[len-1] = 0;
 
          struct stat64 stats;
@@ -1860,9 +1861,9 @@ ERR SET_Date(extFile *Self, DateTime *Date)
    if (not Date) return log.warning(ERR::NullArgs);
 
 #ifdef _WIN32
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
-      if (winSetFileTime(path, Self->isFolder, Date->Year, Date->Month, Date->Day, Date->Hour, Date->Minute, Date->Second)) {
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
+      if (winSetFileTime(path.data(), Self->isFolder, Date->Year, Date->Month, Date->Day, Date->Hour, Date->Minute, Date->Second)) {
          Self->Flags |= FL::RESET_DATE;
          return ERR::Okay;
       }
@@ -1872,10 +1873,10 @@ ERR SET_Date(extFile *Self, DateTime *Date)
 
 #elif __unix__
 
-   CSTRING path;
+   std::string_view path;
    time_t datetime;
    struct utimbuf utm;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
       struct tm time;
       time.tm_year  = Date->Year - 1900;
       time.tm_mon   = Date->Month - 1;
@@ -1891,7 +1892,7 @@ ERR SET_Date(extFile *Self, DateTime *Date)
          utm.modtime = datetime;
          utm.actime  = datetime;
 
-         if (utime(path, &utm) != -1) {
+         if (utime(path.data(), &utm) != -1) {
             Self->Flags |= FL::RESET_DATE;
             return ERR::Okay;
          }
@@ -1998,10 +1999,10 @@ The resulting string is returned in the format `icons:category/name` and will re
 
 *********************************************************************************************************************/
 
-static ERR GET_Icon(extFile *Self, CSTRING *Value)
+static ERR GET_Icon(extFile *Self, std::string_view &Value)
 {
    if (not Self->prvIcon.empty()) {
-      *Value = Self->prvIcon.c_str();
+      Value = Self->prvIcon;
       return ERR::Okay;
    }
 
@@ -2009,7 +2010,7 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
 
    if (Self->Path.empty()) {
       Self->prvIcon = "icons:filetypes/empty";
-      *Value = Self->prvIcon.c_str();
+      Value = Self->prvIcon;
       return ERR::Okay;
    }
 
@@ -2019,7 +2020,7 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
       std::string icon("icons:folders/folder");
 
       if (auto lock = std::shared_lock{glmVolumes, 2s}) {
-         std::string_view volume(Self->Path.c_str(), Self->Path.size()-1);
+         std::string_view volume(Self->Path.data(), Self->Path.data() + Self->Path.size() - 1);
 
          if (auto vol = glVolumes.find(volume); vol != glVolumes.end()) {
             if (auto stored_icon = vol->second.find("Icon"); stored_icon != vol->second.end()) {
@@ -2029,7 +2030,7 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
       }
 
       Self->prvIcon = icon;
-      *Value = Self->prvIcon.c_str();
+      Value = Self->prvIcon;
       return ERR::Okay;
    }
 
@@ -2042,8 +2043,8 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
          if (auto tags = info.getTags(); tags) {
             if (auto icon = tags->find("Icon"); icon != tags->end()) {
                Self->prvIcon = icon->second;
-               *Value = Self->prvIcon.c_str();
-               if (*Value) return ERR::Okay;
+               Value = Self->prvIcon;
+               if (not Value.empty()) return ERR::Okay;
             }
          }
       }
@@ -2051,7 +2052,7 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
       if ((info.Flags & RDF::FOLDER) != RDF::NIL) {
          if (link) Self->prvIcon = "icons:folders/folder_shortcut";
          else Self->prvIcon = "icons:folders/folder";
-         *Value = Self->prvIcon.c_str();
+         Value = Self->prvIcon;
          return ERR::Okay;
       }
    }
@@ -2059,7 +2060,7 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
    if ((Self->Path.ends_with('/')) or (Self->Path.ends_with('\\'))) {
       if (link) Self->prvIcon = "icons:folders/folder_shortcut";
       else Self->prvIcon = "icons:folders/folder";
-      *Value = Self->prvIcon.c_str();
+      Value = Self->prvIcon;
       return ERR::Okay;
    }
 
@@ -2094,14 +2095,14 @@ static ERR GET_Icon(extFile *Self, CSTRING *Value)
    if (icon.empty()) {
       if (link) Self->prvIcon = "icons:filetypes/empty_shortcut";
       else Self->prvIcon = "icons:filetypes/empty";
-      *Value = Self->prvIcon.c_str();
+      Value = Self->prvIcon;
       return ERR::Okay;
    }
 
    if (not kt::startswith("icons:", icon)) Self->prvIcon = "icons:" + icon;
    else Self->prvIcon = icon;
 
-   *Value = Self->prvIcon.c_str();
+   Value = Self->prvIcon;
    return ERR::Okay;
 }
 
@@ -2115,29 +2116,28 @@ folder containing the link will need to be taken into consideration when calcula
 
 *********************************************************************************************************************/
 
-static ERR GET_Link(extFile *Self, STRING *Value)
+static ERR GET_Link(extFile *Self, std::string_view &Value)
 {
 #ifdef __unix__
    kt::Log log;
-   std::string path;
 
    if (not Self->prvLink.empty()) { // The link has already been read previously, just re-use it
-      *Value = Self->prvLink.data();
+      Value = Self->prvLink;
       return ERR::Okay;
    }
 
-   *Value = nullptr;
    if ((Self->Flags & FL::LINK) != FL::NIL) {
+      std::string path;
       if (ResolvePath(Self->Path, RSF::NIL, &path) IS ERR::Okay) {
          if (path.ends_with('/')) path.pop_back();
          int i;
          char buffer[512];
          if (((i = readlink(path.c_str(), buffer, sizeof(buffer)-1)) > 0) and ((size_t)i < sizeof(buffer)-1)) {
             Self->prvLink.assign(buffer, 0, i);
-            *Value = Self->prvLink.data();
+            Value = Self->prvLink;
          }
 
-         if (*Value) return ERR::Okay;
+         if (not Value.empty()) return ERR::Okay;
          else return ERR::SystemCall;
       }
       else return ERR::ResolvePath;
@@ -2149,7 +2149,7 @@ static ERR GET_Link(extFile *Self, STRING *Value)
 #endif
 }
 
-static ERR SET_Link(extFile *Self, STRING Value)
+static ERR SET_Link(extFile *Self, std::string_view &Value)
 {
 #ifdef __unix__
    //symlink().
@@ -2175,21 +2175,19 @@ to traverse the folder hierarchy.
 
 Access to `std*` handles is achieved by using the path strings `std:in`, `std:out` and `std:err`.
 
+-TAGS-
+null-terminated-result
+
 *********************************************************************************************************************/
 
-static ERR GET_Path(extFile *Self, CSTRING *Value)
+static ERR GET_Path(extFile *Self, std::string_view &Value)
 {
-   if (not Self->Path.empty()) {
-      *Value = Self->Path.c_str();
-      return ERR::Okay;
-   }
-   else {
-      *Value = nullptr;
-      return ERR::FieldNotSet;
-   }
+   Value = Self->Path;
+   if (not Self->Path.empty()) return ERR::Okay;
+   else return ERR::FieldNotSet;
 }
 
-static ERR SET_Path(extFile *Self, CSTRING Value)
+static ERR SET_Path(extFile *Self, std::string_view &Value)
 {
    kt::Log log;
 
@@ -2206,23 +2204,21 @@ static ERR SET_Path(extFile *Self, CSTRING Value)
       Self->Handle = -1;
    }
 
-   if ((Value) and (*Value)) {
-      std::string_view val;
-      if (kt::startswith("string:", Value)) {
-         int len;
-         for (len=0; (Value[len]) and (Value[len] != '|'); len++);
+   if (not Value.empty()) {
+      if (Value.starts_with("string:")) {
+         int len = Value.find('|', 7);
          Self->Path.assign(Value, 0, len);
       }
       else {
          // If the path is set to ':' then this is the equivalent of asking for a folder list of all volumes in
          // the system.  No further initialisation is necessary in such a case.
 
-         val = std::string_view(Value, strlen(Value));
-         if (val IS ":") {
+         if (Value IS ":") {
             Self->Path.assign(":");
             Self->isFolder = true;
          }
          else {
+            auto val = Value;
             while (val.starts_with(':')) val.remove_prefix(1);
             auto sep = val.find('|');
             if (sep != std::string::npos) val = val.substr(0, sep);
@@ -2264,11 +2260,10 @@ static ERR GET_Permissions(extFile *Self, PERMIT *Value)
    // Always read permissions straight off the disk rather than returning an internal field, because some other
    // process could always have changed the permission flags.
 
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
-      int i = strlen(path);
-      while ((i >= 0) and (path[i] != '/') and (path[i] != ':') and (path[i] != '\\')) i--;
-      if (path[i+1] IS '.') Self->Permissions = PERMIT::HIDDEN;
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
+      int i = path.find_last_of(":/\\");
+      if ((i != std::string::npos) and (i < path.length()-1) and (path[i+1] IS '.')) Self->Permissions = PERMIT::HIDDEN;
       else Self->Permissions = PERMIT::NIL;
 
       if (Self->Handle != -1) {
@@ -2280,7 +2275,7 @@ static ERR GET_Permissions(extFile *Self, PERMIT *Value)
       }
       else if (Self->Stream) {
          struct stat64 info;
-         if (stat64(path, &info) != -1) Self->Permissions |= convert_fs_permissions(info.st_mode);
+         if (stat64(path.data(), &info) != -1) Self->Permissions |= convert_fs_permissions(info.st_mode);
          else return convert_errno(errno, ERR::SystemCall);
       }
 
@@ -2291,9 +2286,9 @@ static ERR GET_Permissions(extFile *Self, PERMIT *Value)
 
 #elif _WIN32
 
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
-      winGetAttrib(path, (int *)(Value)); // Supports PERMIT::HIDDEN/ARCHIVE/OFFLINE/READ/WRITE
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
+      winGetAttrib(path.data(), (int *)(Value)); // Supports PERMIT::HIDDEN/ARCHIVE/OFFLINE/READ/WRITE
       return ERR::Okay;
    }
    else return ERR::ResolvePath;
@@ -2352,8 +2347,8 @@ static ERR set_permissions(extFile *Self, PERMIT Permissions)
    else if (Self->Stream) {
       // File represents a folder
 
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          int flags = 0;
          if ((Permissions & PERMIT::READ) != PERMIT::NIL)  flags |= S_IRUSR;
          if ((Permissions & PERMIT::WRITE) != PERMIT::NIL) flags |= S_IWUSR;
@@ -2370,7 +2365,7 @@ static ERR set_permissions(extFile *Self, PERMIT Permissions)
          if ((Permissions & PERMIT::GROUPID) != PERMIT::NIL) flags |= S_ISGID;
          if ((Permissions & PERMIT::USERID) != PERMIT::NIL)  flags |= S_ISUID;
 
-         if (chmod(path, flags) != -1) {
+         if (chmod(path.data(), flags) != -1) {
             Self->Permissions = Permissions;
             return ERR::Okay;
          }
@@ -2384,10 +2379,10 @@ static ERR set_permissions(extFile *Self, PERMIT Permissions)
 
    log.branch("$%.8x", int(Permissions));
 
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
       ERR error;
-      if (winSetAttrib(path, int(Permissions))) error = log.warning(ERR::SystemCall);
+      if (winSetAttrib(path.data(), int(Permissions))) error = log.warning(ERR::SystemCall);
       else error = ERR::Okay;
       return error;
    }
@@ -2431,7 +2426,7 @@ to the host platform.  Please refer to the ~ResolvePath() function for further i
 
 *********************************************************************************************************************/
 
-static ERR GET_ResolvedPath(extFile *Self, CSTRING *Value)
+static ERR GET_ResolvedPath(extFile *Self, std::string_view &Value)
 {
    if (Self->Path.empty()) return ERR::FieldNotSet;
 
@@ -2440,7 +2435,7 @@ static ERR GET_ResolvedPath(extFile *Self, CSTRING *Value)
       if (ResolvePath(Self->Path, flags, &Self->prvResolvedPath) != ERR::Okay) return ERR::ResolvePath;
    }
 
-   *Value = Self->prvResolvedPath.c_str();
+   Value = Self->prvResolvedPath; // Guarantees that the path is null-terminated
    return ERR::Okay;
 }
 
@@ -2475,10 +2470,10 @@ static ERR GET_Size(extFile *Self, int64_t *Size)
       return ERR::Okay;
    }
 
-   CSTRING path;
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+   std::string_view path;
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
       struct stat64 stats;
-      if (not stat64(path, &stats)) {
+      if (not stat64(path.data(), &stats)) {
          *Size = stats.st_size;
          log.trace("The file size is %" PF64, (long long)*Size);
          return ERR::Okay;
@@ -2510,10 +2505,10 @@ static ERR SET_Size(extFile *Self, int64_t Size)
    }
 
 #ifdef _WIN32
-   CSTRING path;
+   std::string_view path;
 
-   if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
-      if (winSetEOF(path, Size)) {
+   if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
+      if (winSetEOF(path.data(), Size)) {
          acSeek(Self, 0.0, SEEK::END);
          Self->Size = Size;
          if (Self->Position > Self->Size) acSeekStart(Self, Size);
@@ -2545,14 +2540,13 @@ static ERR SET_Size(extFile *Self, int64_t Size)
       log.warning("%" PF64 " bytes, ftruncate: %s", (long long)Size, strerror(errno));
 
       if (Size > Self->Size) {
-         CSTRING path;
+         std::string_view path;
 
          // Seek past the file boundary and write a single byte to expand the file.  Yes, it's legal and works.
 
-         ERR error;
-         if ((error = GET_ResolvedPath(Self, &path)) IS ERR::Okay) {
+         if (auto error = GET_ResolvedPath(Self, path); error IS ERR::Okay) {
             struct statfs fstat;
-            if (statfs(path, &fstat) != -1) {
+            if (statfs(path.data(), &fstat) != -1) {
                if (Size < (int64_t)fstat.f_bavail * (int64_t)fstat.f_bsize) {
                   log.msg("Attempting to use the write-past-boundary method.");
 
@@ -2622,10 +2616,10 @@ static ERR GET_Timestamp(extFile *Self, int64_t *Value)
       else return convert_errno(errno, ERR::SystemCall);
    }
    else {
-      CSTRING path;
-      if (GET_ResolvedPath(Self, &path) IS ERR::Okay) {
+      std::string_view path;
+      if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
          struct stat64 stats;
-         if (not stat64(path, &stats)) {
+         if (not stat64(path.data(), &stats)) {
             if (auto local = localtime(&stats.st_mtime)) {
                DateTime datetime = {
                   .Year   = int16_t(1900 + local->tm_year),
@@ -2731,19 +2725,19 @@ static const FieldArray FileFields[] = {
    // Virtual fields
    { "Date",         FDF_POINTER|FDF_STRUCT|FDF_RW, GET_Date, SET_Date, "DateTime" },
    { "Created",      FDF_POINTER|FDF_STRUCT|FDF_RW, GET_Created, nullptr, "DateTime" },
-   { "Handle",       FDF_INT64|FDF_R,     GET_Handle },
-   { "Icon",         FDF_STRING|FDF_R,    GET_Icon },
-   { "Path",         FDF_STRING|FDF_RI,   GET_Path, SET_Path },
-   { "Permissions",  FDF_INTFLAGS|FDF_RW, GET_Permissions, SET_Permissions, &PermissionFlags },
-   { "ResolvedPath", FDF_STRING|FDF_R,    GET_ResolvedPath },
-   { "Size",         FDF_INT64|FDF_RW,    GET_Size, SET_Size },
-   { "Timestamp",    FDF_INT64|FDF_R,     GET_Timestamp },
-   { "Link",         FDF_STRING|FDF_RW,   GET_Link, SET_Link },
-   { "User",         FDF_INT|FDF_RW,      GET_User, SET_User },
-   { "Group",        FDF_INT|FDF_RW,      GET_Group, SET_Group },
+   { "Handle",       FDF_INT64|FDF_R,      GET_Handle },
+   { "Icon",         FDF_CPPSTRING|FDF_R,  GET_Icon },
+   { "Path",         FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path },
+   { "Permissions",  FDF_INTFLAGS|FDF_RW,  GET_Permissions, SET_Permissions, &PermissionFlags },
+   { "ResolvedPath", FDF_CPPSTRING|FDF_R,  GET_ResolvedPath },
+   { "Size",         FDF_INT64|FDF_RW,     GET_Size, SET_Size },
+   { "Timestamp",    FDF_INT64|FDF_R,      GET_Timestamp },
+   { "Link",         FDF_CPPSTRING|FDF_RW, GET_Link, SET_Link },
+   { "User",         FDF_INT|FDF_RW,       GET_User, SET_User },
+   { "Group",        FDF_INT|FDF_RW,       GET_Group, SET_Group },
    // Synonyms
-   { "Src",       FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FDF_RI, GET_Path, SET_Path },
-   { "Location",  FDF_VIRTUAL|FDF_SYSTEM|FDF_SYNONYM|FDF_STRING|FDF_RI, GET_Path, SET_Path }, // Deprecated
+   { "Src",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_SYNONYM|FDF_RI, GET_Path, SET_Path },
+   { "Location",  FDF_VIRTUAL|FDF_SYSTEM|FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path }, // Deprecated
    { "TimeStamp", FDF_VIRTUAL|FDF_SYSTEM|FDF_SYNONYM|FDF_INT64|FDF_R,   GET_Timestamp }, // Deprecated
    END_FIELD
 };

--- a/src/core/lib_fields_write.cpp
+++ b/src/core/lib_fields_write.cpp
@@ -28,7 +28,7 @@ static ERR writeval_large(OBJECTPTR, Field *, int, CPTR , int);
 static ERR writeval_double(OBJECTPTR, Field *, int, CPTR , int);
 static ERR writeval_function(OBJECTPTR, Field *, int, CPTR , int);
 static ERR writeval_ptr(OBJECTPTR, Field *, int, CPTR , int);
-static ERR writeval_strview(OBJECTPTR, Field *, int, CPTR , int);
+static ERR writeval_cppstr(OBJECTPTR, Field *, int, CPTR , int);
 
 static ERR setval_large(OBJECTPTR, Field *, int Flags, CPTR , int);
 static ERR setval_pointer(OBJECTPTR, Field *, int Flags, CPTR , int);
@@ -194,6 +194,7 @@ ERR writeval_default(OBJECTPTR Object, Field *Field, int flags, CPTR Data, int E
       else if (Field->Flags & FD_INT64)    error = writeval_large(Object, Field, flags, Data, 0);
       else if (Field->Flags & (FD_DOUBLE|FD_FLOAT)) error = writeval_double(Object, Field, flags, Data, 0);
       else if (Field->Flags & FD_FUNCTION) error = writeval_function(Object, Field, flags, Data, 0);
+      else if ((Field->Flags & FD_STRING) and (Field->Flags & FD_CPP)) error = writeval_cppstr(Object, Field, flags, Data, 0);
       else if (Field->Flags & (FD_POINTER|FD_STRING)) error = writeval_ptr(Object, Field, flags, Data, 0);
       else log.warning("Unrecognised field flags $%.8x.", Field->Flags);
 
@@ -209,6 +210,7 @@ ERR writeval_default(OBJECTPTR Object, Field *Field, int flags, CPTR Data, int E
       else if (Field->Flags & FD_FUNCTION) return setval_function(Object, Field, flags, Data, 0);
       else if (Field->Flags & FD_INT)      return setval_long(Object, Field, flags, Data, 0);
       else if (Field->Flags & (FD_DOUBLE|FD_FLOAT))   return setval_double(Object, Field, flags, Data, 0);
+      else if ((Field->Flags & FD_STRING) and (Field->Flags & FD_CPP)) return setval_strview(Object, Field, flags, Data, 0);
       else if (Field->Flags & (FD_POINTER|FD_STRING)) return setval_pointer(Object, Field, flags, Data, 0);
       else if (Field->Flags & FD_INT64)    return setval_large(Object, Field, flags, Data, 0);
       else return ERR::FieldTypeMismatch;
@@ -445,10 +447,15 @@ static ERR writeval_function(OBJECTPTR Object, Field *Field, int Flags, CPTR Dat
 
 static ERR writeval_ptr(OBJECTPTR Object, Field *Field, int Flags, CPTR Data, int Elements)
 {
-   auto offset = (APTR *)((int8_t *)Object + Field->Offset);
    if (Flags & (FD_POINTER|FD_STRING)) {
-      if (Flags & FD_CPP) *offset = (APTR)((std::string_view *)Data)->data();
-      else *offset = (APTR)Data;
+      if (Flags & FD_CPP) {
+         auto offset = (CSTRING *)((int8_t *)Object + Field->Offset);
+         *offset = ((std::string_view *)Data)->data();
+      }
+      else {
+         auto offset = (APTR *)((int8_t *)Object + Field->Offset);
+         *offset = (APTR)Data;
+      }
    }
    else return ERR::SetValueNotPointer;
    return ERR::Okay;
@@ -456,8 +463,8 @@ static ERR writeval_ptr(OBJECTPTR Object, Field *Field, int Flags, CPTR Data, in
 
 static ERR writeval_cppstr(OBJECTPTR Object, Field *Field, int Flags, CPTR Data, int Elements)
 {
-   auto offset = (std::string *)((int8_t *)Object + Field->Offset);
    if (Flags & (FD_POINTER|FD_STRING)) {
+      auto offset = (std::string *)((int8_t *)Object + Field->Offset);
       if (Flags & FD_CPP) offset->assign(*((std::string_view *)Data));
       else if (Data) offset->assign(CSTRING(Data));
       else offset->clear();
@@ -652,9 +659,9 @@ static ERR setval_pointer(OBJECTPTR Object, Field *Field, int Flags, CPTR Data, 
    FieldContext ctx(Object, Field);
 
    if (Flags & (FD_POINTER|FD_STRING)) {
-      if (Flags & FD_CPP) {
-         std::string str(field_string_view(Flags, Data));
-         return ((ERR (*)(APTR, CPTR))(Field->SetValue))(Object, str.c_str());
+      if (Flags & FD_CPP) { // Target is CSTRING, incoming std::string_view must be a reference to a null-terminated string.
+         auto sv = (std::string_view *)Data;
+         return ((ERR (*)(APTR, CPTR))(Field->SetValue))(Object, sv->empty() ? nullptr : sv->data());
       }
       else return ((ERR (*)(APTR, CPTR))(Field->SetValue))(Object, Data);
    }
@@ -675,8 +682,11 @@ static ERR setval_strview(OBJECTPTR Object, Field *Field, int Flags, CPTR Data, 
    FieldContext ctx(Object, Field);
 
    if (Flags & (FD_POINTER|FD_STRING)) {
-      if (Flags & FD_CPP) return ((ERR (*)(APTR, std::string_view))(Field->SetValue))(Object, *((std::string_view *)Data));
-      else return ((ERR (*)(APTR, std::string_view))(Field->SetValue))(Object, Data ? std::string_view(CSTRING(Data)) : std::string_view());
+      if (Flags & FD_CPP) return ((ERR (*)(APTR, std::string_view &))(Field->SetValue))(Object, *((std::string_view *)Data));
+      else {
+         std::string_view sv = Data ? std::string_view(CSTRING(Data)) : std::string_view{};
+         return ((ERR (*)(APTR, std::string_view &))(Field->SetValue))(Object, sv);
+      }
    }
    else if (Flags & FD_INT) {
       return ((ERR (*)(APTR, std::string_view))(Field->SetValue))(Object, std::to_string(*((int *)Data)));

--- a/src/font/tests/font_tests.tiri
+++ b/src/font/tests/font_tests.tiri
@@ -21,8 +21,7 @@ end
 end
 
 @Test function FontFieldSetters()
-   local font = obj.new('font')
-   defer font.free() end
+   font <close> = obj.new('font')
 
    font.face = 'Noto Sans:12:Bold Italic:#ff0000'
    assert(font.face is 'Noto Sans', 'Face parsing did not isolate the family name')

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -677,7 +677,7 @@ static ERR HTTP_Activate(extHTTP *Self)
                   log.trace("Multiple input files detected.");
                   Self->InputPos = 0;
                   parse_file(Self, cmd);
-                  Self->flInput = objFile::create::local(fl::Path(cmd.str().c_str()), fl::Flags(FL::READ));
+                  Self->flInput = objFile::create::local(fl::Path(cmd.str()), fl::Flags(FL::READ));
                }
                else Self->flInput = objFile::create::local(fl::Path(Self->InputFile), fl::Flags(FL::READ));
 

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -140,15 +140,6 @@ static inline std::string_view lua_checkstringview(lua_State *L, int idx)
    else return std::string_view{};
 }
 
-// This version doesn't raise an error if the argument is not a string.
-
-static inline std::string_view lua_tostringview(lua_State *L, int idx)
-{
-   size_t len = 0;
-   if (auto s = lua_tolstring(L, idx, &len)) return std::string_view{s, len};
-   else return std::string_view{};
-}
-
 //********************************************************************************************************************
 // Standard hash computation, but stops when it encounters a character outside of A-Za-z0-9 range
 // Note that struct name hashes are case sensitive.

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -100,6 +100,7 @@ static constexpr uint32_t OJH_unsubscribe = simple_hash("unsubscribe");
 [[nodiscard]] static ERR object_set_function(lua_State *, OBJECTPTR, Field *, int);
 [[nodiscard]] static ERR object_set_object(lua_State *, OBJECTPTR, Field *, int);
 [[nodiscard]] static ERR object_set_ptr(lua_State *, OBJECTPTR, Field *, int);
+[[nodiscard]] static ERR object_set_cppstring(lua_State *, OBJECTPTR, Field *, int);
 [[nodiscard]] static ERR object_set_double(lua_State *, OBJECTPTR, Field *, int);
 [[nodiscard]] static ERR object_set_lookup(lua_State *, OBJECTPTR, Field *, int);
 [[nodiscard]] static ERR object_set_oid(lua_State *, OBJECTPTR, Field *, int);
@@ -383,6 +384,9 @@ WRITE_TABLE * get_write_table(objMetaClass *Class)
          }
          else if (field.Flags & FD_FUNCTION) {
             jmp.push_back(obj_write(hash, object_set_function, &field));
+         }
+         else if (field.Flags & FD_STRING) {
+            jmp.push_back(obj_write(hash, object_set_cppstring, &field));
          }
          else if (field.Flags & FD_POINTER) {
             if (field.Flags & (FD_OBJECT|FD_LOCAL)) {

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -239,6 +239,12 @@ inline const char *lua_tostring(lua_State *L, int I) {
    return lua_tolstring(L, I, nullptr);
 }
 
+inline std::string_view lua_tostringview(lua_State *L, int I) {
+   size_t len = 0;
+   if (auto s = lua_tolstring(L, I, &len)) return std::string_view{s, len};
+   else return std::string_view{};
+}
+
 // compatibility macros and inline functions
 
 #define lua_open()   luaL_newstate()

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1147,7 +1147,7 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_imported_file(std::st
    this->ctx.push_import(Path);
 
    // Read the file contents using Kotuku File API
-   objFile::create file = { fl::Path(Path.c_str()), fl::Flags(FL::READ) };
+   objFile::create file = { fl::Path(Path), fl::Flags(FL::READ) };
    if (not file.ok()) {
       this->ctx.pop_import();
       return this->fail<std::unique_ptr<BlockStmt>>(ParserErrorCode::UnexpectedToken, ImportToken,

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -144,6 +144,22 @@ static ERR object_set_ptr(lua_State *Lua, OBJECTPTR Object, Field *Field, int Va
    else return ERR::SetValueNotPointer;
 }
 
+static ERR object_set_cppstring(lua_State *Lua, OBJECTPTR Object, Field *Field, int ValueIndex)
+{
+   auto type = lua_type(Lua, ValueIndex);
+
+   if (type IS LUA_TSTRING) {
+      return Object->set(Field->FieldID, lua_tostringview(Lua, ValueIndex));
+   }
+   else if (type IS LUA_TNUMBER) {
+      return Object->set(Field->FieldID, lua_tonumber(Lua, ValueIndex));
+   }
+   else if (type IS LUA_TNIL) {
+      return Object->set(Field->FieldID, std::string_view());
+   }
+   else return ERR::SetValueNotString;
+}
+
 static ERR object_set_double(lua_State *Lua, OBJECTPTR Object, Field *Field, int ValueIndex)
 {
    switch(lua_type(Lua, ValueIndex)) {
@@ -339,7 +355,12 @@ static int object_set(lua_State *Lua)
 
       ERR error;
       if (type IS LUA_TNUMBER) error = obj->set(fh, luaL_checknumber(Lua, 2));
-      else error = obj->set(fh, luaL_optstring(Lua, 2, nullptr));
+      else {
+         size_t len;
+         auto str = luaL_optlstring(Lua, 2, nullptr, &len);
+         std::string_view sv(str ? str : "", len);
+         error = obj->set(fh, sv);
+      }
 
       release_object(def);
       lua_pushinteger(Lua, int(error));
@@ -387,6 +408,9 @@ static ERR set_object_field(lua_State *Lua, OBJECTPTR Object, uint32_t FieldHash
             return object_set_object(Lua, target, field, ValueIndex);
          }
          else return object_set_ptr(Lua, target, field, ValueIndex);
+      }
+      else if ((field->Flags & FD_STRING) and (field->Flags & FD_CPP)) { // std::string target
+         return object_set_cppstring(Lua, target, field, ValueIndex);
       }
       else if (field->Flags & (FD_DOUBLE|FD_FLOAT)) {
          return object_set_double(Lua, target, field, ValueIndex);
@@ -510,10 +534,11 @@ static int object_get_string(lua_State *Lua, const obj_read &Handle, GCobject *D
    ERR error;
    if (auto obj = access_object(Def)) {
       auto field = (Field *)(Handle.Data);
-      CSTRING result;
+      std::string_view result;
       if ((error = obj->get(field->FieldID, result)) IS ERR::Okay) {
-         lua_pushstring(Lua, result);
-         if (field->Flags & FD_ALLOC) FreeResource(result);
+         if (result.empty()) lua_pushnil(Lua);
+         else lua_pushlstring(Lua, result.data(), result.size());
+         if (field->Flags & FD_ALLOC) FreeResource(result.data());
       }
       release_object(Def);
    }

--- a/src/xquery/tests/test_core.tiri
+++ b/src/xquery/tests/test_core.tiri
@@ -2,7 +2,7 @@
 
    include 'xml'
    include 'xquery'
-   
+
 function contains(table, element)
    for value in values(table) do
       if value is element then return true end
@@ -416,7 +416,7 @@ end
 
    err = xq.mtEvaluate(empty_xml)
    assert(err is ERR_Okay, 'Second evaluation should succeed: ' .. mSys.GetErrorMsg(err))
-   assert(xq.resultString is '', 'Empty re-evaluation must clear the previous string result')
+   assert(xq.resultString is nil, 'Empty re-evaluation must clear the previous string result')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/xquery/tests/test_prolog.tiri
+++ b/src/xquery/tests/test_prolog.tiri
@@ -53,7 +53,7 @@ end
 @Test function BoundarySpaceStripRemoval()
    xq = obj.new('xquery', { statement = 'string(<a>   </a>)' })
    assert(xq.acActivate() is ERR_Okay, f'Query execution failed: {xq.errorMsg}')
-   assert(xq.resultString is '', f'Boundary-space strip should remove whitespace-only text, got {tostring(xq.resultString)}')
+   assert(xq.resultString is nil, f'Boundary-space strip should remove whitespace-only text, got {tostring(xq.resultString)}')
 end
 
 @Test function BoundarySpaceStripComputedText()
@@ -65,7 +65,7 @@ end
 @Test function ConstructionStripComputedWhitespace()
    xq = obj.new('xquery', { statement = [[declare construction strip; string(<a>{"   "}</a>)]] })
    assert(xq.acActivate() is ERR_Okay, 'Query execution failed: ' .. tostring(xq.errorMsg))
-   assert(xq.resultString is '', 'Construction strip should remove whitespace-only computed text nodes, got ' .. tostring(xq.resultString))
+   assert(xq.resultString is nil, 'Construction strip should remove whitespace-only computed text nodes, got ' .. tostring(xq.resultString))
 end
 
 @Test function ConstructionPreserveComputedWhitespace()

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -464,6 +464,8 @@ global function outputClassHeader(Class:table, Private:str, Custom:str)
          else
             if field_type is 'T &&' then
                output(f'   template <class T> inline ERR set{fid_name}({field_type} Value) noexcept {{')
+            elseif f.flags has FD_STRING and f.flags has FD_CPP then
+               output(f'   inline ERR set{fid_name}(std::string_view Value) noexcept {{')
             else
                output(f'   inline ERR set{fid_name}({field_type} Value) noexcept {{')
             end


### PR DESCRIPTION
## Summary

This updates core field handling to support `std::string_view` for CPP string fields and preserves explicit string lengths through object and Tiri access paths.

## Details

* Added `std::string_view` FieldValue helpers and object get/set handling for CPP string fields.
* Updated File string fields and Tiri bindings to preserve string lengths during field access.
* Added Core class sources to IDL definition dependencies.
* Fixed remaining Unix POSIX path calls in `class_file.cpp` to pass null-terminated path data to `stat64()` and `statfs()`.

## Validation

* `cmake --build build/agents --config Debug --target core --parallel`
* `git diff --check -- src/core/classes/class_file.cpp`

Note: local validation used the existing Windows Debug build, so the Unix-only branches were reviewed by inspection rather than compiled locally.