### PR TITLE
[Core] Converted Config class fields and Groups to value-type storage

### DIFF
--- a/docs/xml/modules/classes/config.xml
+++ b/docs/xml/modules/classes/config.xml
@@ -259,7 +259,6 @@ print('The Action class is located at ' .. str)
       </input>
       <description>
 <p>Use the WriteValue() method to add or update information in a config object.  A <code>Group</code> name, <code>Key</code> name, and <code>Data</code> value are required.  If the <code>Group</code> and <code>Key</code> arguments match an existing entry in the config object, the data of that entry will be replaced with the new Data value.</p>
-<p>The <code>Group</code> string may refer to an index if the hash <code>#</code> character is used to precede a target index number.</p>
       </description>
       <result>
         <error code="Okay">Operation successful.</error>

--- a/docs/xml/modules/classes/config.xml
+++ b/docs/xml/modules/classes/config.xml
@@ -296,7 +296,7 @@ print('The Action class is located at ' .. str)
       <name>GroupFilter</name>
       <comment>Set this field to enable group filtering.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>When dealing with large configuration files, filtering out unrelated data may be useful.  By setting the GroupFilter field, it is possible to filter out entire groups that don't match the criteria.</p>
 <p>Group filters are created in CSV format, i.e. <code>GroupA, GroupB, GroupC, ...</code>.</p>
@@ -309,7 +309,7 @@ print('The Action class is located at ' .. str)
       <name>KeyFilter</name>
       <comment>Set this field to enable key filtering.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>When dealing with large configuration files it may be useful to filter out groups of key-values that are not needed. The KeyFilter field allows simple filters to be defined that will perform this task for you.  It is recommended that it is set prior to parsing new data for best performance, but can be set or changed at any time to apply a new filter.</p>
 <p>Key filters are created in the format <code>[Key] = [Data1], [Data2], ...</code>.  For example:</p>
@@ -326,7 +326,7 @@ Name = Kōtuku
       <name>Path</name>
       <comment>Set this field to the location of the source configuration file.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
     </field>
 
     <field>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2891,17 +2891,17 @@ class objConfig : public Object {
 
    using create = kt::Create<objConfig>;
 
-   STRING Path;         // Set this field to the location of the source configuration file.
-   STRING KeyFilter;    // Set this field to enable key filtering.
-   STRING GroupFilter;  // Set this field to enable group filtering.
-   CNF    Flags;        // Optional flags may be set here.
+   std::string Path;         // Set this field to the location of the source configuration file.
+   std::string KeyFilter;    // Set this field to enable key filtering.
+   std::string GroupFilter;  // Set this field to enable group filtering.
+   CNF Flags;                // Optional flags may be set here.
    public:
-   ConfigGroups *Groups;
+   ConfigGroups Groups;
 
    // For C++ only, these read variants avoid method calls for speed, but apply identical logic.
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, double &pValue) {
-      for (auto& [group, keys] : Groups[0]) {
+      for (auto& [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = strtod(keys.cbegin()->second.c_str(), nullptr);
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = strtod(it->second.c_str(), nullptr);
@@ -2912,7 +2912,7 @@ class objConfig : public Object {
    }
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, int &pValue) {
-      for (auto& [group, keys] : Groups[0]) {
+      for (auto& [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = strtol(keys.cbegin()->second.c_str(), nullptr, 0);
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = strtol(it->second.c_str(), nullptr, 0);
@@ -2923,7 +2923,7 @@ class objConfig : public Object {
    }
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, std::string &pValue) {
-      for (auto & [group, keys] : Groups[0]) {
+      for (auto & [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = keys.cbegin()->second;
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = it->second;
@@ -2934,8 +2934,7 @@ class objConfig : public Object {
    }
 
    inline ERR write(std::string_view Group, std::string_view Key, std::string_view Value) {
-      ConfigGroups &groups = *Groups;
-      for (auto& [group, keys] : groups) {
+      for (auto& [group, keys] : Groups) {
          if (!group.compare(Group)) {
             if (auto it = keys.find(Key); it != keys.end()) {
                it->second.assign(Value);
@@ -2945,7 +2944,7 @@ class objConfig : public Object {
          }
       }
 
-      auto &new_group = Groups->emplace_back();
+      auto &new_group = Groups.emplace_back();
       new_group.first.assign(Group);
       new_group.second.emplace(Key, Value);
       return ERR::Okay;
@@ -3008,22 +3007,22 @@ class objConfig : public Object {
 
    // Customised field setting
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(std::string_view Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[3];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setKeyFilter(T && Value) noexcept {
+   inline ERR setKeyFilter(std::string_view Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setGroupFilter(T && Value) noexcept {
+   inline ERR setGroupFilter(std::string_view Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setFlags(const CNF Value) noexcept {

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -671,9 +671,20 @@ struct Object { // Must be 64-bit aligned
             auto written = snprintf(buffer, sizeof(buffer), "%f", *((double *)data));
             Value.assign(buffer, written);
          }
-         else if (flags & (FD_POINTER|FD_STRING)) {
-            Value.assign(*((CSTRING *)data));
-            if (flags & FD_ALLOC) FreeResource(GetMemoryID(*((CSTRING *)data)));
+         else if (flags & FD_STRING) {
+            if (flags & FD_CPP) {
+               if (field->GetValue) Value.assign(*((std::string_view *)data));
+               else Value.assign(*((std::string *)data));
+            }
+            else {
+               if (auto str = *((CSTRING *)data)) Value.assign(str);
+               else Value.clear();
+               if (flags & FD_ALLOC) FreeResource(GetMemoryID(*((CSTRING *)data)));
+            }
+         }
+         else if (flags & FD_POINTER) {
+            if (auto str = *((CSTRING *)data)) Value.assign(str);
+            else Value.clear();
          }
          else return ERR::UnrecognisedFieldType;
 
@@ -724,20 +735,34 @@ struct Object { // Must be 64-bit aligned
       if (auto field = FindField(this, FieldID, &target)) {
          if (not field->readable()) return ERR::NoFieldAccess;
 
-         int8_t field_value[sizeof(std::string_view)];
-         int array_size;
-         auto fv = get_field_value(target, *field, field_value, array_size);
-         if (fv.first != ERR::Okay) return fv.first;
-
          if (field->Flags & FD_STRING) {
-            if (field->Flags & FD_CPP) Value = *((std::string_view *)fv.second);
+            if (field->Flags & FD_CPP) {
+               if (field->GetValue) {
+                  SetObjectContext(target, field, AC::NIL);
+                  auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+                  auto error = get_field(target, Value);
+                  RestoreObjectContext();
+                  return error;
+               }
+               else Value = *((std::string *)(((int8_t *)target) + field->Offset));
+            }
             else {
+               int8_t field_value[sizeof(std::string_view)];
+               int array_size;
+               auto fv = get_field_value(target, *field, field_value, array_size);
+               if (fv.first != ERR::Okay) return fv.first;
+
                CSTRING val = *((CSTRING *)fv.second);
                Value = val ? std::string_view(val) : std::string_view{};
             }
             return ERR::Okay;
          }
          else if ((field->Flags & FD_INT) and (field->Flags & FD_LOOKUP)) {
+            int8_t field_value[sizeof(std::string_view)];
+            int array_size;
+            auto fv = get_field_value(target, *field, field_value, array_size);
+            if (fv.first != ERR::Okay) return fv.first;
+
             // Reading a lookup field as a string is permissible, we just return the string registered in the lookup table
             if (auto lookup = (FieldDef *)field->Arg) {
                int value = ((int *)fv.second)[0];

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -64,7 +64,7 @@ static ERR CONFIG_SaveSettings(extConfig *);
 
 static bool check_for_key(std::string_view);
 static ERR parse_config(extConfig *, std::string_view);
-static ConfigKeys * find_group_wild(extConfig *Self, std::string_view Group);
+static ConfigGroup * find_group_wild(extConfig *Self, std::string_view Group);
 static void merge_groups(ConfigGroups &, ConfigGroups &);
 static std::string_view sort_key_value(const ConfigGroup &, CSTRING);
 static void apply_filters(extConfig *);
@@ -147,8 +147,7 @@ static uint32_t calc_crc(extConfig *Self)
 }
 
 //********************************************************************************************************************
-// Open a file with read only and exclusive flags, then read all of the data into a buffer.  Terminate the buffer,
-// then free the file.
+// Parse source file(s) into the Config object.
 //
 // Note that multiple files can be specified by separating each file path with a pipe.  This allows you to merge
 // many configuration files into one object.
@@ -159,11 +158,9 @@ static ERR parse_file(extConfig *Self, std::string_view Path)
    std::string_view paths(Path);
 
    while ((not paths.empty()) and (error IS ERR::Okay)) {
-      // Find the next separator
-      auto sep = paths.find_first_of(";|");
+      auto sep = paths.find_first_of(";|"); // Find the next separator
       auto current_path = (sep != std::string_view::npos) ? paths.substr(0, sep) : paths;
 
-      // Create a null-terminated copy for fl::Path
       objFile::create file = { fl::Path(current_path), fl::Flags(FL::READ|FL::APPROXIMATE) };
 
       if (file.ok()) {
@@ -548,7 +545,7 @@ static ERR CONFIG_SaveToObject(extConfig *Self, struct acSaveToObject *Args)
 {
    kt::Log log;
 
-   if (not Args) return log.warning(ERR::NullArgs);
+   if ((not Args) or (not Args->Dest)) return log.warning(ERR::NullArgs);
 
    log.branch("Saving %d groups to object #%d.", (int)Self->Groups.size(), Args->Dest->UID);
 
@@ -599,7 +596,10 @@ static ERR CONFIG_Set(extConfig *Self, struct cfg::Set *Args)
    if ((not Args->Key) or (not Args->Key[0])) return ERR::NullArgs;
 
    auto group = find_group_wild(Self, Args->Group);
-   if (group) return Self->writeValue(Args->Group, Args->Key, Args->Data);
+   if (group) {
+      group->second[Args->Key] = Args->Data;
+      return ERR::Okay;
+   }
    else return ERR::Search;
 }
 
@@ -680,19 +680,7 @@ static ERR CONFIG_WriteValue(extConfig *Self, struct cfg::WriteValue *Args)
 
    log.trace("%s.%s = %s", Args->Group, Args->Key, Args->Data);
 
-   // Check if the named group already exists
-
-   for (auto & [group, keys] : Self->Groups) {
-      if (group IS Args->Group) {
-         keys[Args->Key] = Args->Data;
-         return ERR::Okay;
-      }
-   }
-
-   auto &new_group = Self->Groups.emplace_back();
-   new_group.first.assign(Args->Group);
-   new_group.second[Args->Key].assign(Args->Data);
-   return ERR::Okay;
+   return Self->write(Args->Group, Args->Key, Args->Data);
 }
 
 /*********************************************************************************************************************
@@ -1094,12 +1082,12 @@ static void apply_group_filter(extConfig *Self, std::string_view Filter)
 //********************************************************************************************************************
 // Returns the key-values for a group, given a group name.  Supports wild-cards.
 
-static ConfigKeys * find_group_wild(extConfig *Self, std::string_view Group)
+static ConfigGroup * find_group_wild(extConfig *Self, std::string_view Group)
 {
    if (Group.empty()) return nullptr;
 
-   for (auto & [group, keys] : Self->Groups) {
-      if (wildcmp(Group, group)) return &keys;
+   for (auto &group : Self->Groups) {
+      if (wildcmp(Group, group.first)) return &group;
    }
 
    return nullptr;

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -57,28 +57,17 @@ class FilterConfig {
    std::vector<std::string> values;
 };
 
-static ERR GET_KeyFilter(extConfig *, std::string_view &);
-static ERR GET_GroupFilter(extConfig *, std::string_view &);
-static ERR GET_TotalGroups(extConfig *, int *);
 
 static ERR CONFIG_SaveSettings(extConfig *);
-
-static const FieldDef clFlags[] = {
-   { "AutoSave",    CNF::AUTO_SAVE },
-   { "StripQuotes", CNF::STRIP_QUOTES },
-   { "New",         CNF::NEW },
-   { nullptr, 0 }
-};
-
-constexpr int CF_MATCHED  = 1;
-constexpr int CF_FAILED   = 0;
-constexpr int CF_KEY_FAIL = -1;
 
 //********************************************************************************************************************
 
 static bool check_for_key(std::string_view);
 static ERR parse_config(extConfig *, std::string_view);
 static ConfigKeys * find_group_wild(extConfig *Self, std::string_view Group);
+static void merge_groups(ConfigGroups &, ConfigGroups &);
+static std::string_view sort_key_value(const ConfigGroup &, CSTRING);
+static void apply_filters(extConfig *);
 static void apply_key_filter(extConfig *, std::string_view);
 static void apply_group_filter(extConfig *, std::string_view);
 static class FilterConfig parse_filter(std::string_view, bool);
@@ -229,8 +218,7 @@ static ERR CONFIG_DataFeed(extConfig *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::TEXT) {
       auto buf = (Args->Size > 0) ? std::string_view((CSTRING)Args->Buffer, Args->Size) : std::string_view((CSTRING)Args->Buffer);
       if (auto error = parse_config(Self, buf); error IS ERR::Okay) {
-         if (not Self->GroupFilter.empty()) apply_group_filter(Self, Self->GroupFilter);
-         if (not Self->KeyFilter.empty()) apply_key_filter(Self, Self->KeyFilter);
+         apply_filters(Self);
       }
       else return error;
    }
@@ -384,8 +372,7 @@ static ERR CONFIG_Init(extConfig *Self)
    if (not Self->Path.empty()) {
       error = parse_file(Self, Self->Path);
       if (error IS ERR::Okay) {
-         if (not Self->GroupFilter.empty()) apply_group_filter(Self, Self->GroupFilter);
-         if (not Self->KeyFilter.empty()) apply_key_filter(Self, Self->KeyFilter);
+         apply_filters(Self);
       }
    }
 
@@ -534,7 +521,7 @@ static ERR CONFIG_SaveSettings(extConfig *Self)
    kt::Log log;
    log.branch();
 
-   uint32_t crc = calc_crc(Self);
+   auto crc = calc_crc(Self);
    if (((Self->Flags & CNF::AUTO_SAVE) != CNF::NIL) and (crc IS Self->CRC)) return ERR::Okay;
 
    if (not Self->Path.empty()) {
@@ -561,7 +548,9 @@ static ERR CONFIG_SaveToObject(extConfig *Self, struct acSaveToObject *Args)
 {
    kt::Log log;
 
-   log.msg("Saving %d groups to object #%d.", (int)Self->Groups.size(), Args->Dest->UID);
+   if (not Args) return log.warning(ERR::NullArgs);
+
+   log.branch("Saving %d groups to object #%d.", (int)Self->Groups.size(), Args->Dest->UID);
 
    std::string buffer;
    buffer.reserve(256);
@@ -648,18 +637,13 @@ static ERR CONFIG_SortByKey(extConfig *Self, struct cfg::SortByKey *Args)
 
    log.branch("Key: %s, Descending: %d", Args->Key, Args->Descending);
 
-   if (Args->Descending) {
-      std::sort(Self->Groups.begin(), Self->Groups.end(),
-         [Args](ConfigGroup &a, ConfigGroup &b) {
-         return a.second[Args->Key] > b.second[Args->Key];
-      });
-   }
-   else {
-      std::sort(Self->Groups.begin(), Self->Groups.end(),
-         [Args](ConfigGroup &a, ConfigGroup &b) {
-         return a.second[Args->Key] < b.second[Args->Key];
-      });
-   }
+   auto descending = Args->Descending;
+   std::sort(Self->Groups.begin(), Self->Groups.end(),
+      [Args, descending](const ConfigGroup &A, const ConfigGroup &B) {
+      auto a_value = sort_key_value(A, Args->Key);
+      auto b_value = sort_key_value(B, Args->Key);
+      return descending ? (a_value > b_value) : (a_value < b_value);
+   });
 
    return ERR::Okay;
 }
@@ -672,8 +656,6 @@ WriteValue: Adds new entries to config objects.
 Use the WriteValue() method to add or update information in a config object.  A `Group` name, `Key` name, and `Data`
 value are required.  If the `Group` and `Key` arguments match an existing entry in the config object, the data of
 that entry will be replaced with the new Data value.
-
-The `Group` string may refer to an index if the hash `#` character is used to precede a target index number.
 
 -INPUT-
 cstr Group: The name of the group.
@@ -865,7 +847,7 @@ static bool check_for_key(std::string_view Data)
 
 //********************************************************************************************************************
 
-void merge_groups(ConfigGroups &Dest, ConfigGroups &Source)
+static void merge_groups(ConfigGroups &Dest, ConfigGroups &Source)
 {
    for (auto & [src_group, src_keys] : Source) {
       bool processed = false;
@@ -887,6 +869,22 @@ void merge_groups(ConfigGroups &Dest, ConfigGroups &Source)
          new_group.second = src_keys;
       }
    }
+}
+
+//********************************************************************************************************************
+
+static std::string_view sort_key_value(const ConfigGroup &Group, CSTRING Key)
+{
+   if (auto it = Group.second.find(Key); it != Group.second.end()) return it->second;
+   else return {};
+}
+
+//********************************************************************************************************************
+
+static void apply_filters(extConfig *Self)
+{
+   if (not Self->GroupFilter.empty()) apply_group_filter(Self, Self->GroupFilter);
+   if (not Self->KeyFilter.empty()) apply_key_filter(Self, Self->KeyFilter);
 }
 
 //********************************************************************************************************************
@@ -1115,7 +1113,7 @@ static const FieldArray clFields[] = {
    { "Path",        FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
    { "KeyFilter",   FDF_CPPSTRING|FDF_RW, GET_KeyFilter, SET_KeyFilter },
    { "GroupFilter", FDF_CPPSTRING|FDF_RW, GET_GroupFilter, SET_GroupFilter },
-   { "Flags",       FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clFlags },
+   { "Flags",       FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clConfigFlags },
    // Virtual fields
    { "Data",        FDF_POINTER|FDF_R, GET_Data },
    { "TotalGroups", FDF_INT|FDF_R, GET_TotalGroups },

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -57,8 +57,8 @@ class FilterConfig {
    std::vector<std::string> values;
 };
 
-static ERR GET_KeyFilter(extConfig *, CSTRING *);
-static ERR GET_GroupFilter(extConfig *, CSTRING *);
+static ERR GET_KeyFilter(extConfig *, std::string_view &);
+static ERR GET_GroupFilter(extConfig *, std::string_view &);
 static ERR GET_TotalGroups(extConfig *, int *);
 
 static ERR CONFIG_SaveSettings(extConfig *);
@@ -78,7 +78,7 @@ constexpr int CF_KEY_FAIL = -1;
 
 static bool check_for_key(std::string_view);
 static ERR parse_config(extConfig *, std::string_view);
-static ConfigKeys * find_group_wild(extConfig *Self, CSTRING Group);
+static ConfigKeys * find_group_wild(extConfig *Self, std::string_view Group);
 static void apply_key_filter(extConfig *, std::string_view);
 static void apply_group_filter(extConfig *, std::string_view);
 static class FilterConfig parse_filter(std::string_view, bool);
@@ -136,7 +136,7 @@ static std::string_view next_group(std::string_view Data, std::string &GroupName
 
 static std::pair<std::string, KEYVALUE> * find_group(extConfig *Self, std::string_view GroupName)
 {
-   for (auto &group : *Self->Groups) {
+   for (auto &group : Self->Groups) {
       if (group.first IS GroupName) return &group;
    }
    return nullptr;
@@ -147,7 +147,7 @@ static std::pair<std::string, KEYVALUE> * find_group(extConfig *Self, std::strin
 static uint32_t calc_crc(extConfig *Self)
 {
    uint32_t crc = 0;
-   for (auto & [group, keys] : Self->Groups[0]) {
+   for (auto & [group, keys] : Self->Groups) {
       crc = GenCRC32(crc, (APTR)group.c_str(), group.size());
       for (auto & [k, v] : keys) {
          crc = GenCRC32(crc, (APTR)k.c_str(), k.size());
@@ -164,12 +164,12 @@ static uint32_t calc_crc(extConfig *Self)
 // Note that multiple files can be specified by separating each file path with a pipe.  This allows you to merge
 // many configuration files into one object.
 
-static ERR parse_file(extConfig *Self, CSTRING Path)
+static ERR parse_file(extConfig *Self, std::string_view Path)
 {
    ERR error = ERR::Okay;
    std::string_view paths(Path);
 
-   while (!paths.empty() and (error IS ERR::Okay)) {
+   while ((not paths.empty()) and (error IS ERR::Okay)) {
       // Find the next separator
       auto sep = paths.find_first_of(";|");
       auto current_path = (sep != std::string_view::npos) ? paths.substr(0, sep) : paths;
@@ -205,9 +205,9 @@ Clear: Clears all configuration data.
 
 static ERR CONFIG_Clear(extConfig *Self)
 {
-   if (Self->Groups) { Self->Groups->clear(); }
-   if (Self->KeyFilter) { FreeResource(Self->KeyFilter); Self->KeyFilter = nullptr; }
-   if (Self->GroupFilter) { FreeResource(Self->GroupFilter); Self->GroupFilter = nullptr; }
+   Self->Groups.clear();
+   Self->KeyFilter.clear();
+   Self->GroupFilter.clear();
    return ERR::Okay;
 }
 
@@ -229,8 +229,8 @@ static ERR CONFIG_DataFeed(extConfig *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::TEXT) {
       auto buf = (Args->Size > 0) ? std::string_view((CSTRING)Args->Buffer, Args->Size) : std::string_view((CSTRING)Args->Buffer);
       if (auto error = parse_config(Self, buf); error IS ERR::Okay) {
-         if (Self->GroupFilter) apply_group_filter(Self, Self->GroupFilter);
-         if (Self->KeyFilter) apply_key_filter(Self, Self->KeyFilter);
+         if (not Self->GroupFilter.empty()) apply_group_filter(Self, Self->GroupFilter);
+         if (not Self->KeyFilter.empty()) apply_key_filter(Self, Self->KeyFilter);
       }
       else return error;
    }
@@ -265,7 +265,7 @@ static ERR CONFIG_DeleteKey(extConfig *Self, struct cfg::DeleteKey *Args)
 
    log.msg("Group: %s, Key: %s", Args->Group, Args->Key);
 
-   for (auto & [group, keys] : Self->Groups[0]) {
+   for (auto & [group, keys] : Self->Groups) {
       if (group IS Args->Group) {
          keys.erase(Args->Key);
          return ERR::Okay;
@@ -296,9 +296,9 @@ static ERR CONFIG_DeleteGroup(extConfig *Self, struct cfg::DeleteGroup *Args)
 {
    if ((not Args) or (not Args->Group)) return ERR::NullArgs;
 
-   for (auto it = Self->Groups->begin(); it != Self->Groups->end(); it++) {
+   for (auto it = Self->Groups.begin(); it != Self->Groups.end(); it++) {
       if (it->first IS Args->Group) {
-         Self->Groups->erase(it);
+         Self->Groups.erase(it);
          return ERR::Okay;
       }
    }
@@ -324,7 +324,7 @@ static ERR CONFIG_Free(extConfig *Self)
    kt::Log log;
 
    if ((Self->Flags & CNF::AUTO_SAVE) != CNF::NIL) {
-      if (Self->Path) {
+      if (not Self->Path.empty()) {
          auto crc = calc_crc(Self);
 
          if ((not crc) or (crc != Self->CRC)) {
@@ -333,14 +333,10 @@ static ERR CONFIG_Free(extConfig *Self)
             objFile::create file = { fl::Path(Self->Path), fl::Flags(FL::WRITE|FL::NEW), fl::Permissions(PERMIT::NIL) };
             Self->saveToObject(*file);
          }
-         else log.msg("Not auto-saving data (CRC unchanged).");
       }
    }
 
-   if (Self->Groups) { delete Self->Groups; Self->Groups = nullptr; }
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = 0; }
-   if (Self->KeyFilter) { FreeResource(Self->KeyFilter); Self->KeyFilter = 0; }
-   if (Self->GroupFilter) { FreeResource(Self->GroupFilter); Self->GroupFilter = 0; }
+   Self->~extConfig();
    return ERR::Okay;
 }
 
@@ -369,8 +365,8 @@ static ERR CONFIG_GetGroupFromIndex(extConfig *Self, struct cfg::GetGroupFromInd
 
    if ((not Args) or (Args->Index < 0)) return log.warning(ERR::Args);
 
-   if ((Args->Index >= 0) and (Args->Index < (int)Self->Groups->size())) {
-      Args->Group = Self->Groups[0][Args->Index].first.c_str();
+   if ((Args->Index >= 0) and (Args->Index < (int)Self->Groups.size())) {
+      Args->Group = Self->Groups[Args->Index].first.c_str();
       return ERR::Okay;
    }
    else return log.warning(ERR::OutOfRange);
@@ -385,11 +381,11 @@ static ERR CONFIG_Init(extConfig *Self)
    if ((Self->Flags & CNF::NEW) != CNF::NIL) return ERR::Okay; // Do not load any data even if the path is defined.
 
    ERR error = ERR::Okay;
-   if (Self->Path) {
+   if (not Self->Path.empty()) {
       error = parse_file(Self, Self->Path);
       if (error IS ERR::Okay) {
-         if (Self->GroupFilter) apply_group_filter(Self, Self->GroupFilter);
-         if (Self->KeyFilter) apply_key_filter(Self, Self->KeyFilter);
+         if (not Self->GroupFilter.empty()) apply_group_filter(Self, Self->GroupFilter);
+         if (not Self->KeyFilter.empty()) apply_key_filter(Self, Self->KeyFilter);
       }
    }
 
@@ -423,7 +419,7 @@ static ERR CONFIG_Merge(extConfig *Self, struct cfg::Merge *Args)
    if (Args->Source->classID() != CLASSID::CONFIG) return ERR::Args;
 
    auto src = (extConfig *)Args->Source;
-   merge_groups(Self->Groups[0], src->Groups[0]);
+   merge_groups(Self->Groups, src->Groups);
    return ERR::Okay;
 }
 
@@ -458,7 +454,7 @@ static ERR CONFIG_MergeFile(extConfig *Self, struct cfg::MergeFile *Args)
    extConfig::create src = { fl::Path(Args->Path) };
 
    if (src.ok()) {
-      merge_groups(Self->Groups[0], src->Groups[0]);
+      merge_groups(Self->Groups, src->Groups);
       return ERR::Okay;
    }
    else return ERR::File;
@@ -466,9 +462,9 @@ static ERR CONFIG_MergeFile(extConfig *Self, struct cfg::MergeFile *Args)
 
 //********************************************************************************************************************
 
-static ERR CONFIG_NewObject(extConfig *Self)
+static ERR CONFIG_NewPlacement(extConfig *Self)
 {
-   if (not (Self->Groups = new (std::nothrow) ConfigGroups)) return ERR::Memory;
+   new (Self) extConfig;
    return ERR::Okay;
 }
 
@@ -505,7 +501,7 @@ static ERR CONFIG_ReadValue(extConfig *Self, struct cfg::ReadValue *Args)
 
    if (not Args) return log.warning(ERR::NullArgs);
 
-   for (auto & [group, keys] : Self->Groups[0]) {
+   for (auto & [group, keys] : Self->Groups) {
       if ((Args->Group) and (group != Args->Group)) continue;
 
       if (not Args->Key) {
@@ -541,7 +537,7 @@ static ERR CONFIG_SaveSettings(extConfig *Self)
    uint32_t crc = calc_crc(Self);
    if (((Self->Flags & CNF::AUTO_SAVE) != CNF::NIL) and (crc IS Self->CRC)) return ERR::Okay;
 
-   if (Self->Path) {
+   if (not Self->Path.empty()) {
       objFile::create file = {
          fl::Path(Self->Path), fl::Flags(FL::WRITE|FL::NEW), fl::Permissions(PERMIT::NIL)
       };
@@ -565,13 +561,12 @@ static ERR CONFIG_SaveToObject(extConfig *Self, struct acSaveToObject *Args)
 {
    kt::Log log;
 
-   log.msg("Saving %d groups to object #%d.", (int)Self->Groups->size(), Args->Dest->UID);
+   log.msg("Saving %d groups to object #%d.", (int)Self->Groups.size(), Args->Dest->UID);
 
    std::string buffer;
    buffer.reserve(256);
 
-   ConfigGroups &groups = Self->Groups[0];
-   for (auto & [group, keys] : groups) {
+   for (auto & [group, keys] : Self->Groups) {
       buffer.clear();
       buffer += "\n[" + group + "]\n";
       acWrite(Args->Dest, buffer.c_str(), buffer.size(), nullptr);
@@ -641,7 +636,7 @@ NoData
 static ERR CONFIG_SortByKey(extConfig *Self, struct cfg::SortByKey *Args)
 {
    if ((not Args) or (not Args->Key)) { // Sort by group name if no args provided.
-      std::sort(Self->Groups->begin(), Self->Groups->end(),
+      std::sort(Self->Groups.begin(), Self->Groups.end(),
          [](const ConfigGroup &a, const ConfigGroup &b ) {
          return a.first < b.first;
       });
@@ -654,13 +649,13 @@ static ERR CONFIG_SortByKey(extConfig *Self, struct cfg::SortByKey *Args)
    log.branch("Key: %s, Descending: %d", Args->Key, Args->Descending);
 
    if (Args->Descending) {
-      std::sort(Self->Groups->begin(), Self->Groups->end(),
+      std::sort(Self->Groups.begin(), Self->Groups.end(),
          [Args](ConfigGroup &a, ConfigGroup &b) {
          return a.second[Args->Key] > b.second[Args->Key];
       });
    }
    else {
-      std::sort(Self->Groups->begin(), Self->Groups->end(),
+      std::sort(Self->Groups.begin(), Self->Groups.end(),
          [Args](ConfigGroup &a, ConfigGroup &b) {
          return a.second[Args->Key] < b.second[Args->Key];
       });
@@ -705,15 +700,14 @@ static ERR CONFIG_WriteValue(extConfig *Self, struct cfg::WriteValue *Args)
 
    // Check if the named group already exists
 
-   ConfigGroups &groups = *Self->Groups;
-   for (auto & [group, keys] : groups) {
+   for (auto & [group, keys] : Self->Groups) {
       if (group IS Args->Group) {
          keys[Args->Key] = Args->Data;
          return ERR::Okay;
       }
    }
 
-   auto &new_group = Self->Groups->emplace_back();
+   auto &new_group = Self->Groups.emplace_back();
    new_group.first.assign(Args->Group);
    new_group.second[Args->Key].assign(Args->Data);
    return ERR::Okay;
@@ -731,7 +725,7 @@ by system code that is included with the standard framework.
 
 static ERR GET_Data(extConfig *Self, ConfigGroups **Value)
 {
-   *Value = Self->Groups;
+   *Value = &Self->Groups;
    return ERR::Okay;
 }
 
@@ -761,28 +755,19 @@ To create a filter based on group names, refer to the #GroupFilter field.
 
 *********************************************************************************************************************/
 
-static ERR GET_KeyFilter(extConfig *Self, CSTRING *Value)
+static ERR GET_KeyFilter(extConfig *Self, std::string_view &Value)
 {
-   if (Self->KeyFilter) {
-      *Value = Self->KeyFilter;
+   if (not Self->KeyFilter.empty()) {
+      Value = Self->KeyFilter;
       return ERR::Okay;
    }
-   else {
-      *Value = nullptr;
-      return ERR::FieldNotSet;
-   }
+   else return ERR::FieldNotSet;
 }
 
-static ERR SET_KeyFilter(extConfig *Self, CSTRING Value)
+static ERR SET_KeyFilter(extConfig *Self, std::string_view &Value)
 {
-   if (Self->KeyFilter) { FreeResource(Self->KeyFilter); Self->KeyFilter = nullptr; }
-
-   if ((Value) and (*Value)) {
-      if (not (Self->KeyFilter = strclone(Value))) return ERR::AllocMemory;
-   }
-
+   Self->KeyFilter = Value;
    if (Self->initialised()) apply_key_filter(Self, Self->KeyFilter);
-
    return ERR::Okay;
 }
 
@@ -803,28 +788,19 @@ To create a filter based on key names, refer to the #KeyFilter field.
 
 *********************************************************************************************************************/
 
-static ERR GET_GroupFilter(extConfig *Self, CSTRING *Value)
+static ERR GET_GroupFilter(extConfig *Self, std::string_view &Value)
 {
-   if (Self->GroupFilter) {
-      *Value = Self->GroupFilter;
+   if (not Self->GroupFilter.empty()) {
+      Value = Self->GroupFilter;
       return ERR::Okay;
    }
-   else {
-      *Value = nullptr;
-      return ERR::FieldNotSet;
-   }
+   else return ERR::FieldNotSet;
 }
 
-static ERR SET_GroupFilter(extConfig *Self, CSTRING Value)
+static ERR SET_GroupFilter(extConfig *Self, std::string_view &Value)
 {
-   if (Self->GroupFilter) { FreeResource(Self->GroupFilter); Self->GroupFilter = nullptr; }
-
-   if ((Value) and (*Value)) {
-      if (not (Self->GroupFilter = strclone(Value))) return ERR::AllocMemory;
-   }
-
+   Self->GroupFilter.assign(Value);
    if (Self->initialised()) apply_group_filter(Self, Self->GroupFilter);
-
    return ERR::Okay;
 }
 
@@ -834,14 +810,9 @@ Path: Set this field to the location of the source configuration file.
 
 *********************************************************************************************************************/
 
-static ERR SET_Path(extConfig *Self, CSTRING Value)
+static ERR SET_Path(extConfig *Self, std::string_view &Value)
 {
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
-
-   if ((Value) and (*Value)) {
-      if (not (Self->Path = strclone(Value))) return ERR::AllocMemory;
-   }
-
+   Self->Path.assign(Value);
    return ERR::Okay;
 }
 
@@ -853,7 +824,7 @@ TotalGroups: Returns the total number of groups in a config object.
 
 static ERR GET_TotalGroups(extConfig *Self, int *Value)
 {
-   *Value = Self->Groups->size();
+   *Value = Self->Groups.size();
    return ERR::Okay;
 }
 
@@ -868,7 +839,7 @@ TotalKeys: The total number of key values loaded into the config object.
 static ERR GET_TotalKeys(extConfig *Self, int *Value)
 {
    int total = 0;
-   for (const auto & [group, keys] : Self->Groups[0]) {
+   for (const auto & [group, keys] : Self->Groups) {
       total += keys.size();
    }
    *Value = total;
@@ -1010,7 +981,7 @@ static ERR parse_config(extConfig *Self, std::string_view Buffer)
       }
 
       std::pair<std::string, KEYVALUE> *current_group = nullptr;
-      while (!data.empty() and (data.front() != '[')) { // Keep processing keys until either a new group or EOF is reached
+      while ((not data.empty()) and (data.front() != '[')) { // Keep processing keys until either a new group or EOF is reached
          if (check_for_key(data)) {
             // Find the '=' separator
             auto eq_pos = data.find('=');
@@ -1049,7 +1020,7 @@ static ERR parse_config(extConfig *Self, std::string_view Buffer)
             if (not current_group) { // Check if a matching group already exists before creating a new one
                current_group = find_group(Self, group_name);
                if (not current_group) {
-                  current_group = &Self->Groups->emplace_back();
+                  current_group = &Self->Groups.emplace_back();
                   current_group->first = group_name;
                }
             }
@@ -1076,7 +1047,7 @@ static void apply_key_filter(extConfig *Self, std::string_view Filter)
    FilterConfig f = parse_filter(Filter, true);
    if (not f.valid) return;
 
-   for (auto group = Self->Groups->begin(); group != Self->Groups->end(); ) {
+   for (auto group = Self->Groups.begin(); group != Self->Groups.end(); ) {
       bool matched = (f.reverse) ? true : false;
       for (auto & [k, v] : group->second) {
          if (iequals(f.name, k)) {
@@ -1090,7 +1061,7 @@ static void apply_key_filter(extConfig *Self, std::string_view Filter)
          }
       }
 
-      if (not matched) group = Self->Groups->erase(group);
+      if (not matched) group = Self->Groups.erase(group);
       else group++;
    }
 }
@@ -1108,7 +1079,7 @@ static void apply_group_filter(extConfig *Self, std::string_view Filter)
    FilterConfig f = parse_filter(Filter, false);
    if (not f.valid) return;
 
-   for (auto group = Self->Groups->begin(); group != Self->Groups->end(); ) {
+   for (auto group = Self->Groups.begin(); group != Self->Groups.end(); ) {
       bool matched = f.reverse ? true : false;
       for (auto const &cmp : f.values) {
          if (cmp IS group->first) {
@@ -1117,7 +1088,7 @@ static void apply_group_filter(extConfig *Self, std::string_view Filter)
          }
       }
 
-      if (not matched) group = Self->Groups->erase(group);
+      if (not matched) group = Self->Groups.erase(group);
       else group++;
    }
 }
@@ -1125,11 +1096,11 @@ static void apply_group_filter(extConfig *Self, std::string_view Filter)
 //********************************************************************************************************************
 // Returns the key-values for a group, given a group name.  Supports wild-cards.
 
-static ConfigKeys * find_group_wild(extConfig *Self, CSTRING Group)
+static ConfigKeys * find_group_wild(extConfig *Self, std::string_view Group)
 {
-   if ((not Group) or (not *Group)) return nullptr;
+   if (Group.empty()) return nullptr;
 
-   for (auto & [group, keys] : Self->Groups[0]) {
+   for (auto & [group, keys] : Self->Groups) {
       if (wildcmp(Group, group)) return &keys;
    }
 
@@ -1141,9 +1112,9 @@ static ConfigKeys * find_group_wild(extConfig *Self, CSTRING Group)
 #include "class_config_def.c"
 
 static const FieldArray clFields[] = {
-   { "Path",        FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "KeyFilter",   FDF_STRING|FDF_RW, GET_KeyFilter, SET_KeyFilter },
-   { "GroupFilter", FDF_STRING|FDF_RW, GET_GroupFilter, SET_GroupFilter },
+   { "Path",        FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "KeyFilter",   FDF_CPPSTRING|FDF_RW, GET_KeyFilter, SET_KeyFilter },
+   { "GroupFilter", FDF_CPPSTRING|FDF_RW, GET_GroupFilter, SET_GroupFilter },
    { "Flags",       FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clFlags },
    // Virtual fields
    { "Data",        FDF_POINTER|FDF_R, GET_Data },

--- a/src/core/classes/class_config_def.c
+++ b/src/core/classes/class_config_def.c
@@ -37,7 +37,7 @@ static const struct ActionArray clConfigActions[] = {
    { AC::Flush, CONFIG_Flush },
    { AC::Free, CONFIG_Free },
    { AC::Init, CONFIG_Init },
-   { AC::NewObject, CONFIG_NewObject },
+   { AC::NewPlacement, CONFIG_NewPlacement },
    { AC::SaveSettings, CONFIG_SaveSettings },
    { AC::SaveToObject, CONFIG_SaveToObject },
    { AC::NIL, nullptr }

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1135,7 +1135,6 @@ void   scan_classes(void);
 
 ERR  writeval_default(OBJECTPTR, Field *, int, const void *, int);
 ERR  check_paths(std::string_view, PERMIT);
-void merge_groups(ConfigGroups &, ConfigGroups &);
 extern "C" ERR validate_process(int);
 
 #ifdef _WIN32

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1367,7 +1367,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
     cpp(str) Path          # The location pointer
     cpp(str) KeyFilter     # Enables key filtering, removing any unwanted keys on load.
     cpp(str) GroupFilter   # Enables group filtering, removing any unwanted groups on load.
-    int(CNF) Flags         # Not currently in use
+    int(CNF) Flags         # Optional flags
   ]],
   nil,
   [[

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1364,19 +1364,19 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
   })
 
   klass("Config", { src="../classes/class_config.cpp", output="../classes/class_config_def.c" }, [[
-    str Path          # The location pointer
-    str KeyFilter     # Enables key filtering, removing any unwanted keys on load.
-    str GroupFilter   # Enables group filtering, removing any unwanted groups on load.
-    int(CNF) Flags    # Not currently in use
+    cpp(str) Path          # The location pointer
+    cpp(str) KeyFilter     # Enables key filtering, removing any unwanted keys on load.
+    cpp(str) GroupFilter   # Enables group filtering, removing any unwanted groups on load.
+    int(CNF) Flags         # Not currently in use
   ]],
   nil,
   [[
-   ConfigGroups *Groups;
+   ConfigGroups Groups;
 
    // For C++ only, these read variants avoid method calls for speed, but apply identical logic.
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, double &pValue) {
-      for (auto& [group, keys] : Groups[0]) {
+      for (auto& [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = strtod(keys.cbegin()->second.c_str(), nullptr);
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = strtod(it->second.c_str(), nullptr);
@@ -1387,7 +1387,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
    }
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, int &pValue) {
-      for (auto& [group, keys] : Groups[0]) {
+      for (auto& [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = strtol(keys.cbegin()->second.c_str(), nullptr, 0);
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = strtol(it->second.c_str(), nullptr, 0);
@@ -1398,7 +1398,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
    }
 
    inline ERR read(std::string_view pGroup, std::string_view pKey, std::string &pValue) {
-      for (auto & [group, keys] : Groups[0]) {
+      for (auto & [group, keys] : Groups) {
          if ((!pGroup.empty()) and (group.compare(pGroup))) continue;
          if (pKey.empty()) pValue = keys.cbegin()->second;
          else if (auto it = keys.find(pKey); it != keys.end()) pValue = it->second;
@@ -1409,8 +1409,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
    }
 
    inline ERR write(std::string_view Group, std::string_view Key, std::string_view Value) {
-      ConfigGroups &groups = *Groups;
-      for (auto& [group, keys] : groups) {
+      for (auto& [group, keys] : Groups) {
          if (!group.compare(Group)) {
             if (auto it = keys.find(Key); it != keys.end()) {
                it->second.assign(Value);
@@ -1420,7 +1419,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
          }
       }
 
-      auto &new_group = Groups->emplace_back();
+      auto &new_group = Groups.emplace_back();
       new_group.first.assign(Group);
       new_group.second.emplace(Key, Value);
       return ERR::Okay;

--- a/src/core/tests/test_config.tiri
+++ b/src/core/tests/test_config.tiri
@@ -104,7 +104,8 @@ end
    cfg = new_config()
 
    cfgMerge = obj.new('config', { })
-   err = cfg.acDataFeed(nil, DATA_TEXT, glMerge, 0)
+   err = cfgMerge.acDataFeed(nil, DATA_TEXT, glMerge, 0)
+   assert(err is ERR_Okay, 'DataFeed() returned ' .. mSys.GetErrorMsg(err))
 
    err = cfg.mtMerge(cfgMerge);
    assert(err is ERR_Okay, 'Merge() returned ' .. mSys.GetErrorMsg(err))
@@ -164,6 +165,17 @@ end
    assert(groupName is 'Courier Sans', 'Second group is incorrect, returned ' .. groupName)
    err, groupName = cfg.mtGetGroupFromIndex(2)
    assert(groupName is 'Alpha', 'Third group is incorrect, returned ' .. groupName)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function SortingMissingKeyDoesNotAddKeys()
+   cfg = new_config()
+
+   before_count = cfg.totalKeys
+   err = cfg.mtSortByKey('Missing', false)
+   assert(err is ERR_Okay, 'SortByKey() returned ' .. mSys.GetErrorMsg(err))
+   assert(cfg.totalKeys is before_count, 'SortByKey() inserted missing key entries')
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/core/tests/test_config.tiri
+++ b/src/core/tests/test_config.tiri
@@ -30,6 +30,9 @@ glMerge = 'Ignore this\r\n[MergedGroup]\r\nHello=World\r\n'
 
 @AfterAll function cleanup()
    mSys.DeleteFile('temp:test-write.cfg')
+   mSys.DeleteFile('temp:test-source.cfg')
+   mSys.DeleteFile('temp:test-merge-file.cfg')
+   mSys.DeleteFile('temp:test-save-settings.cfg')
 end
 
 function new_config()
@@ -37,6 +40,15 @@ function new_config()
    err = cfg.acDataFeed(nil, DATA_TEXT, glLegalData, 0)
    assert(err is ERR_Okay, 'DataFeed() returned ' .. mSys.GetErrorMsg(err))
    return cfg
+end
+
+function write_temp_file(Path, Content)
+   file = obj.new('file', { path=Path, flags=FL_NEW|FL_WRITE })
+   err, written = file.acWrite(Content, #Content)
+   assert(err is ERR_Okay, 'Write() returned ' .. mSys.GetErrorMsg(err))
+   assert(written is #Content, 'Wrote ' .. tostring(written) .. ' bytes, expected ' .. tostring(#Content))
+   file = nil
+   processing.collect()
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -75,6 +87,20 @@ end
    success
       error('ReadValue() returned successfully with: ' .. mSys.GetErrorMsg(err) .. ', ' .. tostring(value))
    end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function ClearAndTotals()
+   cfg = new_config()
+
+   assert(cfg.totalGroups is 3, 'Expected 3 groups, got ' .. tostring(cfg.totalGroups))
+   assert(cfg.totalKeys is 14, 'Expected 14 keys, got ' .. tostring(cfg.totalKeys))
+
+   err = cfg.acClear()
+   assert(err is ERR_Okay, 'Clear() returned ' .. mSys.GetErrorMsg(err))
+   assert(cfg.totalGroups is 0, 'Expected Clear() to remove all groups')
+   assert(cfg.totalKeys is 0, 'Expected Clear() to remove all keys')
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -120,6 +146,21 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function MergeFile()
+   cfg = new_config()
+
+   write_temp_file('temp:test-merge-file.cfg', glMerge)
+
+   err = cfg.mtMergeFile('temp:test-merge-file.cfg')
+   assert(err is ERR_Okay, 'MergeFile() returned ' .. mSys.GetErrorMsg(err))
+
+   err, value = cfg.mtReadValue('MergedGroup', 'Hello')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'World', 'Expected World, received ' .. tostring(value))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function WriteValues()
    cfg = new_config()
 
@@ -139,6 +180,84 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+
+@Test function SetExactGroup()
+   cfg = new_config()
+   before_count = cfg.totalGroups
+
+   err = cfg.mtSet('Clean', 'Name', 'Clean Updated')
+   assert(err is ERR_Okay, 'Set() returned ' .. mSys.GetErrorMsg(err))
+
+   err, value = cfg.mtReadValue('Clean', 'Name')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'Clean Updated', 'Expected Set() to update Clean.Name, received ' .. tostring(value))
+
+   err = cfg.mtSet('Missing', 'Name', 'Nope')
+   assert(err is ERR_Search, 'Expected Set() to return ERR_Search for a missing group')
+   assert(cfg.totalGroups is before_count, 'Set() created a missing group')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function SetWildcardUpdatesMatchedGroup()
+   cfg = new_config()
+   before_count = cfg.totalGroups
+
+   err = cfg.mtSet('Courier*', 'New', 'Value')
+   assert(err is ERR_Okay, 'Set() returned ' .. mSys.GetErrorMsg(err))
+   assert(cfg.totalGroups is before_count, 'Set() created a literal wildcard group')
+
+   err, value = cfg.mtReadValue('Courier Sans', 'New')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'Value', 'Expected wildcard Set() to update Courier Sans, received ' .. tostring(value))
+
+   err = cfg.mtSet('Missing*', 'New', 'Value')
+   assert(err is ERR_Search, 'Expected Set() to return ERR_Search for a missing wildcard group')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function FileLoadFlags()
+   write_temp_file('temp:test-source.cfg', [[
+[Quoted]
+Name = "Visible"
+Plain = Value
+]])
+
+   cfg = obj.new('config', { path='temp:test-source.cfg', flags=CNF_STRIP_QUOTES })
+   err, value = cfg.mtReadValue('Quoted', 'Name')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'Visible', 'Expected STRIP_QUOTES to remove quotes, received ' .. tostring(value))
+
+   cfg = obj.new('config', { path='temp:test-source.cfg', flags=CNF_NEW })
+   assert(cfg.totalGroups is 0, 'Expected CNF_NEW to skip loading file data')
+
+   cfg = obj.new('config', { path='temp:missing-config-file.cfg', flags=CNF_OPTIONAL_FILES })
+   assert(cfg.totalGroups is 0, 'Expected optional missing file to produce an empty config')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function FlushSavesSettings()
+   cfg = obj.new('config', { path='temp:test-save-settings.cfg', flags=CNF_NEW })
+
+   err = cfg.mtWriteValue('Saved', 'Name', 'Persisted')
+   assert(err is ERR_Okay, 'WriteValue() returned ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.acFlush()
+   assert(err is ERR_Okay, 'Flush() returned ' .. mSys.GetErrorMsg(err))
+
+   cfg = nil
+   processing.collect()
+
+   cfg = obj.new('config', { path='temp:test-save-settings.cfg' })
+   err, value = cfg.mtReadValue('Saved', 'Name')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'Persisted', 'Expected saved value, received ' .. tostring(value))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 -- Test case sensitivity
 
 @Test function ReadValues()


### PR DESCRIPTION
* Path, KeyFilter, and GroupFilter changed from heap-allocated STRING to embedded std::string; manual strclone()/FreeResource() calls removed throughout
* Groups changed from ConfigGroups * (heap pointer) to ConfigGroups (inline value); all Groups[0] dereferences and -> operator calls replaced with direct member access
* CONFIG_NewObject replaced with CONFIG_NewPlacement using placement-new to correctly initialise the embedded std::string and ConfigGroups members
* CONFIG_Free simplified to call Self->~extConfig() instead of individually destroying each member
* Field table updated to FDF_CPPSTRING for Path, KeyFilter, and GroupFilter; getter/setter signatures updated to std::string_view &
* parse_file() and find_group_wild() parameter types upgraded from CSTRING to std::string_view
* GET_Data returns &Self->Groups (pointer to embedded value) instead of the former raw pointer
* [Doc] config.xml updated to reflect std::string types for Path, KeyFilter, and GroupFilter
* core.tdl updated from str to cpp(str) for Path, KeyFilter, and GroupFilter field declarations