### PR TITLE
[Audio] Convert Audio and Sound fields to std::string with FDF_CPPSTRING glue

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -278,12 +278,12 @@ class extSound : public objSound {
    #endif
    ankerl::unordered_dense::map<std::string, std::string> Tags;
    objFile *File;
-   STRING Path;
+   std::string Path;
    TIMER  StreamTimer;        // Timer to regularly trigger for provisioning streaming data.
    TIMER  PlaybackTimer;      // Timer to trigger when playback ends.
    int   Format;             // The format of the sound data
    int   DataOffset;         // Start of raw audio data within the source file
    int   Note;               // Note to play back (e.g. C, C#, G...)
-   char   NoteString[4];
+   std::string NoteString;
    bool   Active;             // True once the sound is registered with the audio driver or mixer.
 };

--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -1122,17 +1122,18 @@ The default device can always be referenced with a name of `default`.
 
 *********************************************************************************************************************/
 
-static ERR GET_Device(extAudio *Self, CSTRING *Value)
+static ERR GET_Device(extAudio *Self, std::string_view &Value)
 {
-   *Value = Self->Device.c_str();
-   return ERR::Okay;
+   Value = Self->Device;
+   if (not Self->Device.empty()) return ERR::Okay;
+   else return ERR::FieldNotSet;
 }
 
-static ERR SET_Device(extAudio *Self, CSTRING Value)
+static ERR SET_Device(extAudio *Self, std::string_view &Value)
 {
-   if ((!Value) or (!*Value)) Self->Device = "default";
+   if (Value.empty()) Self->Device = "default";
    else {
-      Self->Device = Value;
+      Self->Device.assign(Value);
       std::transform(Self->Device.begin(), Self->Device.end(), Self->Device.begin(), ::tolower);
    }
 
@@ -1460,7 +1461,7 @@ static const FieldArray clAudioFields[] = {
    { "Periods",       FDF_INT|FDF_RI,    nullptr, SET_Periods },
    { "PeriodSize",    FDF_INT|FDF_RI,    nullptr, SET_PeriodSize },
    // VIRTUAL FIELDS
-   { "Device",        FDF_STRING|FDF_RW,  GET_Device, SET_Device },
+   { "Device",        FDF_CPPSTRING|FDF_RW,  GET_Device, SET_Device },
    { "MixerLag",      FDF_DOUBLE|FDF_R,   GET_MixerLag },
    { "MasterVolume",  FDF_DOUBLE|FDF_RW,  GET_MasterVolume, SET_MasterVolume },
    { "Mute",          FDF_INT|FDF_RW,    GET_Mute, SET_Mute },

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -1312,18 +1312,20 @@ and the lowest is 0.  Use either the `S` character or the `#` character for refe
 
 static ERR SOUND_GET_Note(extSound *Self, std::string_view &Value)
 {
+   bool sharp = false;
+
    switch(Self->Note) {
       case NOTE_C:  Self->NoteString = "C"; break;
-      case NOTE_CS: Self->NoteString = "C#"; break;
+      case NOTE_CS: Self->NoteString = "C"; sharp = true; break;
       case NOTE_D:  Self->NoteString = "D"; break;
-      case NOTE_DS: Self->NoteString = "D#"; break;
+      case NOTE_DS: Self->NoteString = "D"; sharp = true; break;
       case NOTE_E:  Self->NoteString = "E"; break;
       case NOTE_F:  Self->NoteString = "F"; break;
-      case NOTE_FS: Self->NoteString = "F#"; break;
+      case NOTE_FS: Self->NoteString = "F"; sharp = true; break;
       case NOTE_G:  Self->NoteString = "G"; break;
-      case NOTE_GS: Self->NoteString = "G#"; break;
+      case NOTE_GS: Self->NoteString = "G"; sharp = true; break;
       case NOTE_A:  Self->NoteString = "A"; break;
-      case NOTE_AS: Self->NoteString = "A#"; break;
+      case NOTE_AS: Self->NoteString = "A"; sharp = true; break;
       case NOTE_B:  Self->NoteString = "B"; break;
       default:      Self->NoteString.clear();
                     Value = Self->NoteString;
@@ -1331,6 +1333,8 @@ static ERR SOUND_GET_Note(extSound *Self, std::string_view &Value)
    }
 
    Self->NoteString += char('5' + Self->Octave);
+   if (sharp) Self->NoteString += '#';
+
    Value = Self->NoteString;
    return ERR::Okay;
 }

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -56,7 +56,7 @@ constexpr int SIZE_RIFF_CHUNK = 12;
 
 static ERR SOUND_GET_Active(extSound *, int *);
 
-static ERR SOUND_SET_Note(extSound *, CSTRING);
+static ERR SOUND_SET_Note(extSound *, std::string_view &);
 
 static const std::array<double, 12> glScale = {
    1.0,         // C
@@ -620,7 +620,7 @@ static ERR SOUND_Free(extSound *Self)
       }
    }
 
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   Self->Path.clear();
    if (Self->File) { FreeResource(Self->File); Self->File = nullptr; }
 
    Self->~extSound();
@@ -693,8 +693,8 @@ static ERR SOUND_Init(extSound *Self)
       else return log.warning(ERR::AccessObject);
    }
 
-   CSTRING path;
-   if (((Self->Flags & SDF::NEW) != SDF::NIL) or (Self->get(FID_Path, path) != ERR::Okay) or (!path)) {
+   auto path = Self->get<std::string_view>(FID_Path);
+   if (((Self->Flags & SDF::NEW) != SDF::NIL) or (path.empty())) {
       // If the sample is new or no path has been specified, create an audio sample from scratch (e.g. to record
       // audio to disk).
 
@@ -797,9 +797,9 @@ static ERR SOUND_Init(extSound *Self)
       else return log.warning(ERR::AccessObject);
    }
 
-   auto path = Self->get<STRING>(FID_Path);
+   auto path = Self->get<std::string_view>(FID_Path);
 
-   if (((Self->Flags & SDF::NEW) != SDF::NIL) or (!path)) {
+   if (((Self->Flags & SDF::NEW) != SDF::NIL) or (path.empty())) {
       log.msg("Sample created as new (without sample data).");
 
       // If the sample is new or no path has been specified, create an audio sample from scratch (e.g. to
@@ -1310,82 +1310,43 @@ and the lowest is 0.  Use either the `S` character or the `#` character for refe
 
 *********************************************************************************************************************/
 
-static ERR SOUND_GET_Note(extSound *Self, CSTRING *Value)
+static ERR SOUND_GET_Note(extSound *Self, std::string_view &Value)
 {
    switch(Self->Note) {
-      case NOTE_C:  Self->NoteString[0] = 'C';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_CS: Self->NoteString[0] = 'C';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = '#';
-                    Self->NoteString[3] = 0;
-                    break;
-      case NOTE_D:  Self->NoteString[0] = 'D';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_DS: Self->NoteString[0] = 'D';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = '#';
-                    Self->NoteString[3] = 0;
-                    break;
-      case NOTE_E:  Self->NoteString[0] = 'E';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_F:  Self->NoteString[0] = 'F';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_FS: Self->NoteString[0] = 'F';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = '#';
-                    Self->NoteString[3] = 0;
-                    break;
-      case NOTE_G:  Self->NoteString[0] = 'G';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_GS: Self->NoteString[0] = 'G';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = '#';
-                    Self->NoteString[3] = 0;
-                    break;
-      case NOTE_A:  Self->NoteString[0] = 'A';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      case NOTE_AS: Self->NoteString[0] = 'A';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = '#';
-                    Self->NoteString[3] = 0;
-                    break;
-      case NOTE_B:  Self->NoteString[0] = 'B';
-                    Self->NoteString[1] = '5' + Self->Octave;
-                    Self->NoteString[2] = 0;
-                    break;
-      default:      Self->NoteString[0] = 0;
+      case NOTE_C:  Self->NoteString = "C"; break;
+      case NOTE_CS: Self->NoteString = "C#"; break;
+      case NOTE_D:  Self->NoteString = "D"; break;
+      case NOTE_DS: Self->NoteString = "D#"; break;
+      case NOTE_E:  Self->NoteString = "E"; break;
+      case NOTE_F:  Self->NoteString = "F"; break;
+      case NOTE_FS: Self->NoteString = "F#"; break;
+      case NOTE_G:  Self->NoteString = "G"; break;
+      case NOTE_GS: Self->NoteString = "G#"; break;
+      case NOTE_A:  Self->NoteString = "A"; break;
+      case NOTE_AS: Self->NoteString = "A#"; break;
+      case NOTE_B:  Self->NoteString = "B"; break;
+      default:      Self->NoteString.clear();
+                    Value = Self->NoteString;
+                    return ERR::FieldNotSet;
    }
-   *Value = Self->NoteString;
 
+   Self->NoteString += char('5' + Self->Octave);
+   Value = Self->NoteString;
    return ERR::Okay;
 }
 
-static ERR SOUND_SET_Note(extSound *Self, CSTRING Value)
+static ERR SOUND_SET_Note(extSound *Self, std::string_view &Value)
 {
    kt::Log log;
 
-   if (!*Value) return ERR::Okay;
+   if (Value.empty()) return ERR::Okay;
 
    int i, note;
-   for (i=0; (Value[i]) and (i < 3); i++) Self->NoteString[i] = Value[i];
-   Self->NoteString[i] = 0;
+   Self->NoteString.assign(Value);
 
-   CSTRING str = Value;
-   if (((*Value >= '0') and (*Value <= '9')) or (*Value IS '-')) {
-      note = strtol(Value, nullptr, 0);
+   const char *str = Value.data();
+   if (((*str >= '0') and (*str <= '9')) or (*str IS '-')) {
+      note = strtol(str, nullptr, 0);
    }
    else {
       note = 0;
@@ -1560,26 +1521,16 @@ with the `SDF::NEW` flag, it is not necessary to define a file source.
 
 *********************************************************************************************************************/
 
-static ERR SOUND_GET_Path(extSound *Self, STRING *Value)
+static ERR SOUND_GET_Path(extSound *Self, std::string_view &Value)
 {
-   if ((*Value = Self->Path)) return ERR::Okay;
-   else return ERR::FieldNotSet;
+   Value = Self->Path;
+   if (not Self->Path.empty()) return ERR::Okay;
+   return ERR::FieldNotSet;
 }
 
-static ERR SOUND_SET_Path(extSound *Self, CSTRING Value)
+static ERR SOUND_SET_Path(extSound *Self, std::string_view &Value)
 {
-   kt::Log log;
-
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
-
-   if ((Value) and (*Value)) {
-      int i = strlen(Value);
-      if (AllocMemory(i+1, MEM::STRING|MEM::NO_CLEAR, (void **)&Self->Path) IS ERR::Okay) {
-         for (i=0; Value[i]; i++) Self->Path[i] = Value[i];
-         Self->Path[i] = 0;
-      }
-      else return log.warning(ERR::AllocMemory);
-   }
+   Self->Path.assign(Value);
    return ERR::Okay;
 }
 
@@ -1798,9 +1749,9 @@ static const FieldArray clFields[] = {
    { "Duration", FDF_DOUBLE|FDF_R,         SOUND_GET_Duration },
    { "Header",   FDF_BYTE|FDF_ARRAY|FDF_R, SOUND_GET_Header },
    { "OnStop",   FDF_FUNCTIONPTR|FDF_RW,   SOUND_GET_OnStop, SOUND_SET_OnStop },
-   { "Path",     FDF_STRING|FDF_RI,        SOUND_GET_Path, SOUND_SET_Path },
-   { "Src",      FDF_SYNONYM|FDF_STRING|FDF_RI, SOUND_GET_Path, SOUND_SET_Path },
-   { "Note",     FDF_STRING|FDF_RW, SOUND_GET_Note, SOUND_SET_Note },
+   { "Path",     FDF_CPPSTRING|FDF_RI,        SOUND_GET_Path, SOUND_SET_Path },
+   { "Src",      FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, SOUND_GET_Path, SOUND_SET_Path },
+   { "Note",     FDF_CPPSTRING|FDF_RW, SOUND_GET_Note, SOUND_SET_Note },
    END_FIELD
 };
 


### PR DESCRIPTION
### Motivation

- Modernise string field storage and field glue for the Audio and Sound classes by replacing manual `STRING`/`CSTRING` ownership with `std::string` body members and `std::string_view` field callbacks. 
- Remove manual allocation/freeing and pointer-style bookkeeping to reduce memory-management complexity and follow the `cpp(str)` / `FDF_CPPSTRING` pattern used across the codebase. 
- Ensure the Sound base-class field API remains compatible for consumers (e.g. MP3) by updating virtual field glue signatures rather than changing MP3 internals. 

### Description

- Replaced `extSound` pointer-style `Path` and `NoteString` members with `std::string` in `src/audio/audio.h`. 
- Converted `Audio.Device` field glue from `FDF_STRING` to `FDF_CPPSTRING` and changed its callbacks to `static ERR GET_Device(extAudio*, std::string_view&)` and `static ERR SET_Device(extAudio*, std::string_view&)` in `src/audio/class_audio.cpp`. 
- Converted Sound virtual fields `Path`, `Src` and `Note` to `FDF_CPPSTRING` and updated corresponding getters/setters signatures to use `std::string_view &` in `src/audio/class_sound.cpp`. 
- Replaced manual `AllocMemory`/`FreeResource` string handling for `Path` and manual char-array manipulation for `Note` with `std::string::assign`, `std::string::clear` and updated parsing/formatting logic to use `std::string`/`std::string_view`. 

### Testing

- Attempted a targeted build `cmake --build build/agents --config Debug --target audio mp3 --parallel`, which failed because those specific targets are not present in the build tree. (expected failure). 
- Performed a full Debug build with `cmake --build build/agents --config Debug --parallel`, which completed successfully. 
- No automated unit or Flute tests (`ctest`/`flute`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a157ae56f0c832eb9bdd128eeda9d23)