### PR TITLE
[Display] Convert Pointer ButtonOrder to std::string and FDF_CPPSTRING

### DIFF
--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -23,10 +23,10 @@ this shared object, usually via ~Display.AccessPointer(), when reading pointer s
 using namespace display;
 #endif
 
-static ERR GET_ButtonOrder(extPointer *, CSTRING *);
+static ERR GET_ButtonOrder(extPointer *, std::string_view *);
 static ERR GET_ButtonState(extPointer *, int *);
 
-static ERR SET_ButtonOrder(extPointer *, CSTRING);
+static ERR SET_ButtonOrder(extPointer *, std::string_view &);
 static ERR SET_MaxSpeed(extPointer *, int);
 static ERR PTR_SET_X(extPointer *, double);
 static ERR PTR_SET_Y(extPointer *, double);
@@ -825,52 +825,54 @@ Changes to this field will have an immediate impact on the pointing device's beh
 
 *********************************************************************************************************************/
 
-static ERR GET_ButtonOrder(extPointer *Self, CSTRING *Value)
+static ERR GET_ButtonOrder(extPointer *Self, std::string_view *Value)
 {
+   if (Self->ButtonOrder.empty()) return ERR::FieldNotSet;
    *Value = Self->ButtonOrder;
    return ERR::Okay;
 }
 
-static ERR SET_ButtonOrder(extPointer *Self, CSTRING Value)
+static ERR SET_ButtonOrder(extPointer *Self, std::string_view &Value)
 {
    kt::Log log;
 
-   log.msg("%s", Value);
+   log.msg("%.*s", int(Value.size()), Value.data());
 
-   if (!Value) return ERR::Okay;
+   if (Value.empty()) return ERR::Okay;
 
-   // Assign the buttons
+   // Assign the buttons.
+   Self->ButtonOrder.assign(Value);
 
-   for (int i=0; (Value[i]) and ((size_t)i < sizeof(Self->ButtonOrder)-1); i++) Self->ButtonOrder[i] = Value[i];
-   Self->ButtonOrder[sizeof(Self->ButtonOrder)-1] = 0;
+   // Eliminate any invalid buttons.
 
-   // Eliminate any invalid buttons
-
-   for (int i=0; Self->ButtonOrder[i]; i++) {
+   for (size_t i=0; i < Self->ButtonOrder.size(); i++) {
       if (((Self->ButtonOrder[i] >= '1') and (Self->ButtonOrder[i] <= '9')) or
           ((Self->ButtonOrder[i] >= 'A') and (Self->ButtonOrder[i] <= 'Z'))) {
       }
       else Self->ButtonOrder[i] = ' ';
    }
 
-   // Reduce the length of the button list if there are gaps
+   // Reduce the length of the button list if there are gaps.
 
-   int j = 0;
-   for (int i=0; Self->ButtonOrder[i]; i++) {
+   size_t j = 0;
+   for (size_t i=0; i < Self->ButtonOrder.size(); i++) {
       if (Self->ButtonOrder[i] != ' ') {
          Self->ButtonOrder[j++] = Self->ButtonOrder[i];
       }
    }
 
-   while ((size_t)j < sizeof(Self->ButtonOrder)) Self->ButtonOrder[j++] = 0; // Clear any left-over bytes
+   Self->ButtonOrder.resize(j);
 
-   // Convert the button indexes into their relevant flags
+   // Convert the button indexes into their relevant flags.
 
-   for (int i=0; (size_t)i < sizeof(Self->ButtonOrder); i++) {
-      if ((Self->ButtonOrder[i] >= '1') and (Self->ButtonOrder[i] <= '9')) j = Self->ButtonOrder[i] - '1';
-      else if ((Self->ButtonOrder[i] >= 'A') and (Self->ButtonOrder[i] <= 'Z')) j = Self->ButtonOrder[i] - 'A' + 9;
-      else j = 0;
-      Self->ButtonOrderFlags[i] = 1<<j;
+   int button_index = 0;
+   for (size_t i=0; i < std::size(Self->ButtonOrderFlags); i++) {
+      char button = (i < Self->ButtonOrder.size()) ? Self->ButtonOrder[i] : 0;
+
+      if ((button >= '1') and (button <= '9')) button_index = button - '1';
+      else if ((button >= 'A') and (button <= 'Z')) button_index = button - 'A' + 9;
+      else button_index = 0;
+      Self->ButtonOrderFlags[i] = 1<<button_index;
    }
 
    return ERR::Okay;
@@ -1333,7 +1335,7 @@ static const FieldArray clPointerFields[] = {
    { "ClickSlop",    FDF_INT|FDF_RW },
    // Virtual Fields
    { "ButtonState",  FDF_INT|FDF_R, GET_ButtonState },
-   { "ButtonOrder",  FDF_STRING|FDF_RW, GET_ButtonOrder, SET_ButtonOrder },
+   { "ButtonOrder",  FDF_CPPSTRING|FDF_RW, GET_ButtonOrder, SET_ButtonOrder },
    END_FIELD
 };
 

--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -23,7 +23,7 @@ this shared object, usually via ~Display.AccessPointer(), when reading pointer s
 using namespace display;
 #endif
 
-static ERR GET_ButtonOrder(extPointer *, std::string_view *);
+static ERR GET_ButtonOrder(extPointer *, std::string_view &);
 static ERR GET_ButtonState(extPointer *, int *);
 
 static ERR SET_ButtonOrder(extPointer *, std::string_view &);
@@ -825,10 +825,10 @@ Changes to this field will have an immediate impact on the pointing device's beh
 
 *********************************************************************************************************************/
 
-static ERR GET_ButtonOrder(extPointer *Self, std::string_view *Value)
+static ERR GET_ButtonOrder(extPointer *Self, std::string_view &Value)
 {
    if (Self->ButtonOrder.empty()) return ERR::FieldNotSet;
-   *Value = Self->ButtonOrder;
+   Value = Self->ButtonOrder;
    return ERR::Okay;
 }
 
@@ -837,8 +837,6 @@ static ERR SET_ButtonOrder(extPointer *Self, std::string_view &Value)
    kt::Log log;
 
    log.msg("%.*s", int(Value.size()), Value.data());
-
-   if (Value.empty()) return ERR::Okay;
 
    // Assign the buttons.
    Self->ButtonOrder.assign(Value);

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -307,7 +307,7 @@ class extPointer : public objPointer {
    OBJECTID BufferObject;
    char     DragData[8];          // Data preferences for current drag & drop item
    char     Device[32];
-   char     ButtonOrder[12];      // The order of the first 11 buttons can be changed here
+   std::string ButtonOrder;       // The order of the first 11 buttons can be changed here
    int16_t     ButtonOrderFlags[12]; // Button order represented as JD flags
    int8_t     PostComposite;        // Enable post-composite drawing (default)
    uint8_t    prvOverCursorID;


### PR DESCRIPTION
### Motivation
- Remove manual C-string ownership and adapt the Pointer class to modern C++ string storage for safer, clearer handling of the ButtonOrder field.
- Ensure runtime field glue and metadata reflect the new in-place string storage so IDL-generated tooling and field callbacks remain consistent.

### Description
- Replaced `extPointer::ButtonOrder` fixed `char[12]` with `std::string` in `src/display/defs.h` to hold the button-order text in-place.
- Updated getter/setter callbacks in `src/display/class_pointer.cpp` to use `std::string_view` (`GET_ButtonOrder` now returns `ERR::FieldNotSet` when empty and `SET_ButtonOrder` accepts a `std::string_view &`), and adapted logging and assignment to use `std::string` APIs.
- Preserved existing sanitisation and flag-mapping behaviour while adapting loops and resizing to `std::string` semantics, and changed field metadata from `FDF_STRING` to `FDF_CPPSTRING` for `ButtonOrder`.

### Testing
- Verified build configuration is Debug by inspecting `build/agents/CMakeCache.txt` (`CMAKE_BUILD_TYPE:STRING=Debug`).
- Performed a full build with `cmake --build build/agents --config Debug --parallel` which completed successfully.
- Attempted a targeted module build with `cmake --build build/agents --config Debug --target display --parallel` which failed because that target is not present in the current build graph.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a157eb858fc832eaaff4ce46a7d44aa)