### PR TITLE
[XML] Converted XML fields to C++ strings

### DIFF
--- a/docs/xml/modules/classes/sound.xml
+++ b/docs/xml/modules/classes/sound.xml
@@ -28,18 +28,18 @@
 <b>Validation and Error Handling:</b> Comprehensive file validation prevents playback of corrupted or unsupported audio data</li>
 </list>
 <p>The following demonstrates advanced Sound class usage including pitch control and event handling:</p>
-<pre>local snd = obj.new('sound', {
+<pre>snd = obj.new('sound', {
    path = 'audio:samples/piano_c4.wav',
    note = 'C6',    -- Play two octaves higher
    volume = 0.8,   -- Reduce volume to 80%
    onStop = function(Sound)
       print('Playback completed')
-      proc.signal()
+      processing.signal()
    end
 })
 
 snd.acActivate()
-proc.sleep()  -- Wait for completion
+processing.sleep()  -- Wait for completion
 </pre></description>
     <source>
       <file>class_sound.cpp</file>

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -646,7 +646,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       <name>DocType</name>
       <comment>Root element name from DOCTYPE declaration</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
     </field>
 
     <field>
@@ -683,7 +683,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       <name>Path</name>
       <comment>Set this field if the XML document originates from a file source.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>XML documents can be loaded from the file system by specifying a file path in this field.  If set post-initialisation, all currently loaded data will be cleared and the file will be parsed automatically.</p>
 <p>The XML class supports <function module="Core">LoadFile</function>, so an XML file can be pre-cached by the program if it is frequently used during a program's life cycle.</p>
@@ -695,7 +695,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       <name>PublicID</name>
       <comment>Public identifier for external DTD</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
     </field>
 
     <field>
@@ -736,7 +736,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       <name>SystemID</name>
       <comment>System identifier for external DTD</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
     </field>
 
     <field>

--- a/docs/xml/modules/document.xml
+++ b/docs/xml/modules/document.xml
@@ -181,6 +181,7 @@
       <const name="BUFFER">FUNCDEF Overrides <code>WRITE</code>.  Indicates a buffer that can be filled with data by the function if paired with <code>RESULT</code>; must be paired with <code>BUFSIZE</code> in second argument.</const>
       <const name="BUFSIZE">FUNCDEF Overrides <code>LOOKUP</code>.  Pair with <code>BUFFER</code> to indicate the byte size of the buffer memory.</const>
       <const name="BYTE">8 bit integer.</const>
+      <const name="CLASS_TYPES">All types that directly contribute to the core definition of a C/C++ type</const>
       <const name="CPP">Use the C++ variant of the indicated type, e.g. <code>ARRAY</code> is a <code>std::vector</code>.</const>
       <const name="CUSTOM"/>
       <const name="DOUBLE">64 bit float.</const>

--- a/include/kotuku/modules/audio.h
+++ b/include/kotuku/modules/audio.h
@@ -280,10 +280,10 @@ class objAudio : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setDevice(T && Value) noexcept {
+   inline ERR setDevice(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setMasterVolume(const double Value) noexcept {
@@ -480,16 +480,16 @@ class objSound : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
-   template <class T> inline ERR setNote(T && Value) noexcept {
+   inline ERR setNote(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[26];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
 };

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2828,7 +2828,7 @@ class objFile : public Object {
       return field->WriteValue(target, field, 0x08000310, Value, 1);
    }
 
-   inline ERR setPath(std::string_view Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
       return field->WriteValue(target, field, 0x00804500, &Value, 1);
@@ -2846,7 +2846,7 @@ class objFile : public Object {
       return field->WriteValue(target, field, FD_INT64, &Value, 1);
    }
 
-   inline ERR setLink(std::string_view Value) noexcept {
+   inline ERR setLink(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[15];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -3008,19 +3008,19 @@ class objConfig : public Object {
 
    // Customised field setting
 
-   inline ERR setPath(std::string_view Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[3];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setKeyFilter(std::string_view Value) noexcept {
+   inline ERR setKeyFilter(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setGroupFilter(std::string_view Value) noexcept {
+   inline ERR setGroupFilter(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[1];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -3144,25 +3144,25 @@ class objScript : public Object {
       return ERR::Okay;
    }
 
-   inline ERR setCacheFile(std::string_view Value) noexcept {
+   inline ERR setCacheFile(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[22];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setErrorMessage(std::string_view Value) noexcept {
+   inline ERR setErrorMessage(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setWorkingPath(std::string_view Value) noexcept {
+   inline ERR setWorkingPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setProcedure(std::string_view Value) noexcept {
+   inline ERR setProcedure(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[1];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -3174,7 +3174,7 @@ class objScript : public Object {
       return field->WriteValue(target, field, 0x08810300, to_cstring(Value), 1);
    }
 
-   inline ERR setPath(std::string_view Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
       return field->WriteValue(target, field, 0x00804500, &Value, 1);
@@ -3186,7 +3186,7 @@ class objScript : public Object {
       return field->WriteValue(target, field, 0x08801300, Value, Elements);
    }
 
-   inline ERR setStatement(std::string_view Value) noexcept {
+   inline ERR setStatement(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[13];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -3799,13 +3799,13 @@ class objCompression : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   inline ERR setArchiveName(std::string_view Value) noexcept {
+   inline ERR setArchiveName(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[0];
       return field->WriteValue(target, field, 0x00804200, &Value, 1);
    }
 
-   inline ERR setPath(std::string_view Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -3817,7 +3817,7 @@ class objCompression : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   inline ERR setPassword(std::string_view Value) noexcept {
+   inline ERR setPassword(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[12];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);

--- a/include/kotuku/modules/display.h
+++ b/include/kotuku/modules/display.h
@@ -1372,10 +1372,10 @@ class objPointer : public Object {
       return ERR::Okay;
    }
 
-   template <class T> inline ERR setButtonOrder(T && Value) noexcept {
+   inline ERR setButtonOrder(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
 };

--- a/include/kotuku/modules/picture.h
+++ b/include/kotuku/modules/picture.h
@@ -134,25 +134,25 @@ class objPicture : public Object {
       return ERR::Okay;
    }
 
-   inline ERR setAuthor(std::string_view Value) noexcept {
+   inline ERR setAuthor(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setCopyright(std::string_view Value) noexcept {
+   inline ERR setCopyright(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[9];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setDescription(std::string_view Value) noexcept {
+   inline ERR setDescription(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setDisclaimer(std::string_view Value) noexcept {
+   inline ERR setDisclaimer(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
@@ -165,19 +165,19 @@ class objPicture : public Object {
       return field->WriteValue(target, field, 0x08000500, Value, 1);
    }
 
-   inline ERR setPath(std::string_view Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
       return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
-   inline ERR setSoftware(std::string_view Value) noexcept {
+   inline ERR setSoftware(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[15];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   inline ERR setTitle(std::string_view Value) noexcept {
+   inline ERR setTitle(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[14];
       return field->WriteValue(target, field, 0x00804300, &Value, 1);

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -214,15 +214,15 @@ class objXML : public Object {
 
    using create = kt::Create<objXML>;
 
-   STRING    Path;    // Set this field if the XML document originates from a file source.
-   STRING    DocType; // Root element name from DOCTYPE declaration
-   STRING    PublicID; // Public identifier for external DTD
-   STRING    SystemID; // System identifier for external DTD
-   OBJECTPTR Source;  // Set this field if the XML data is to be sourced from another object.
-   XMF       Flags;   // Controls XML parsing behaviour and processing options.
-   int       Modified; // A timestamp of when the XML data was last modified.
-   ERR       ParseError; // Private
-   int       LineNo;  // Private
+   std::string Path;       // Set this field if the XML document originates from a file source.
+   std::string DocType;    // Root element name from DOCTYPE declaration
+   std::string PublicID;   // Public identifier for external DTD
+   std::string SystemID;   // System identifier for external DTD
+   OBJECTPTR Source;       // Set this field if the XML data is to be sourced from another object.
+   XMF       Flags;        // Controls XML parsing behaviour and processing options.
+   int       Modified;     // A timestamp of when the XML data was last modified.
+   ERR       ParseError;   // Private
+   int       LineNo;       // Private
    public:
    typedef kt::vector<XTag> TAGS;
    TAGS Tags;
@@ -393,28 +393,28 @@ class objXML : public Object {
 
    // Customised field setting
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setDocType(T && Value) noexcept {
+   inline ERR setDocType(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setPublic(T && Value) noexcept {
+   inline ERR setPublic(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setSystem(T && Value) noexcept {
+   inline ERR setSystem(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setSource(OBJECTPTR Value) noexcept {
@@ -434,10 +434,10 @@ class objXML : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setStatement(T && Value) noexcept {
+   inline ERR setStatement(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[11];
-      return field->WriteValue(target, field, 0x08800320, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804320, &Value, 1);
    }
 
 };

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -698,7 +698,7 @@ struct Object { // Must be 64-bit aligned
 
    // Retrieve a direct pointer to a string field, no-copy operation.  Result will require deallocation by the client if the field is marked with ALLOC.
 
-   [[deprecated]] inline ERR get(FIELD FieldID, CSTRING &Value) {
+   inline ERR get(FIELD FieldID, CSTRING &Value) { // deprecated
       Object *target;
       Value = nullptr;
       if (auto field = FindField(this, FieldID, &target)) {

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -673,7 +673,10 @@ struct Object { // Must be 64-bit aligned
          }
          else if (flags & FD_STRING) {
             if (flags & FD_CPP) {
-               if (field->GetValue) Value.assign(*((std::string_view *)data));
+               if (field->GetValue) {
+                  Value.assign(*((std::string_view *)data));
+                  if (flags & FD_ALLOC) FreeResource(GetMemoryID(((std::string_view *)data)->data()));
+               }
                else Value.assign(*((std::string *)data));
             }
             else {

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -56,7 +56,7 @@ constexpr int SIZE_RIFF_CHUNK = 12;
 
 static ERR SOUND_GET_Active(extSound *, int *);
 
-static ERR SOUND_SET_Note(extSound *, std::string_view &);
+static ERR SOUND_SET_Note(extSound *, const std::string_view &);
 
 static const std::array<double, 12> glScale = {
    1.0,         // C
@@ -1338,7 +1338,7 @@ static ERR SOUND_GET_Note(extSound *Self, std::string_view &Value)
    return ERR::Okay;
 }
 
-static ERR SOUND_SET_Note(extSound *Self, std::string_view &Value)
+static ERR SOUND_SET_Note(extSound *Self, const std::string_view &Value)
 {
    kt::Log log;
 
@@ -1531,7 +1531,7 @@ static ERR SOUND_GET_Path(extSound *Self, std::string_view &Value)
    return ERR::FieldNotSet;
 }
 
-static ERR SOUND_SET_Path(extSound *Self, std::string_view &Value)
+static ERR SOUND_SET_Path(extSound *Self, const std::string_view &Value)
 {
    Self->Path.assign(Value);
    return ERR::Okay;

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -313,7 +313,7 @@ static ERR CONFIG_Free(extConfig *Self)
          auto crc = calc_crc(Self);
 
          if ((not crc) or (crc != Self->CRC)) {
-            log.msg("Auto-saving changes to \"%s\" (CRC: %d : %d)", Self->Path, Self->CRC, crc);
+            log.msg("Auto-saving changes to \"%s\" (CRC: %d : %d)", Self->Path.c_str(), Self->CRC, crc);
 
             objFile::create file = { fl::Path(Self->Path), fl::Flags(FL::WRITE|FL::NEW), fl::Permissions(PERMIT::NIL) };
             Self->saveToObject(*file);

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -2262,7 +2262,7 @@ static ERR GET_Permissions(extFile *Self, PERMIT *Value)
 
    std::string_view path;
    if (GET_ResolvedPath(Self, path) IS ERR::Okay) {
-      int i = path.find_last_of(":/\\");
+      auto i = path.find_last_of(":/\\");
       if ((i != std::string::npos) and (i < path.length()-1) and (path[i+1] IS '.')) Self->Permissions = PERMIT::HIDDEN;
       else Self->Permissions = PERMIT::NIL;
 

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -798,23 +798,20 @@ static ERR GET_WorkingPath(objScript *Self, std::string_view &Value)
          }
       }
 
-      int k;
-      int j = 0;
-      for (k=0; k < int(Self->Path.size()); k++) {
-         if ((Self->Path[k] IS ':') or (Self->Path[k] IS '/') or (Self->Path[k] IS '\\')) j = k+1;
-      }
+      auto j = Self->Path.find_last_of(":/\\");
+      if (j != std::string::npos) j++;
 
       if (path) { // Extract absolute path
          kt::SwitchContext ctx(Self);
          Self->WorkingPath.assign(Self->Path, 0, j);
       }
       else {
-         CSTRING working_path;
-         if ((CurrentTask()->get(FID_Path, working_path) IS ERR::Okay) and (working_path)) {
+         std::string_view working_path;
+         if ((CurrentTask()->get(FID_Path, working_path) IS ERR::Okay) and (not working_path.empty())) {
             // Using ResolvePath() can help to determine relative paths such as "../path/file"
 
-            std::string buf = working_path;
-            if (j > 0) buf.append(Self->Path, 0, j);
+            std::string buf(working_path);
+            if (j != std::string::npos) buf.append(Self->Path, 0, j);
 
             kt::SwitchContext ctx(Self);
             std::string rpath;

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -161,7 +161,6 @@ static ERR compress_file(extCompression *Self, std::string Location, std::string
 
    log.branch("Compressing file \"%s\" to \"%s\"", Location.c_str(), Path.c_str());
 
-   CSTRING symlink = nullptr;
    bool deflateend = false;
    uint32_t dataoffset = 0;
    std::string filename;
@@ -279,9 +278,10 @@ static ERR compress_file(extCompression *Self, std::string Location, std::string
 
    entry.Offset = dataoffset;
 
+   std::string_view symlink;
    if (((Self->Flags & CMF::NO_LINKS) IS CMF::NIL) and ((file->Flags & FL::LINK) != FL::NIL)) {
       if (file->get(FID_Link, symlink) IS ERR::Okay) {
-         log.msg("Note: File \"%s\" is a symbolic link to \"%s\"", filename.c_str(), symlink);
+         log.msg("Note: File \"%s\" is a symbolic link to \"%.*s\"", filename.c_str(), int(symlink.size()), symlink.data());
          entry.Flags |= ZIP_LINK;
       }
    }
@@ -320,16 +320,15 @@ static ERR compress_file(extCompression *Self, std::string Location, std::string
 
    if (entry.Flags & ZIP_LINK) {
       // Compress the symbolic link to the zip file, rather than the data
-      len = strlen(symlink);
-      Self->Zip.next_in   = (Bytef *)symlink;
-      Self->Zip.avail_in  = len;
+      Self->Zip.next_in   = (Bytef *)symlink.data();
+      Self->Zip.avail_in  = symlink.size();
       Self->Zip.next_out  = Self->Output;
       Self->Zip.avail_out = SIZE_COMPRESSION_BUFFER;
       if (deflate(&Self->Zip, Z_NO_FLUSH) != Z_OK) {
          log.warning("Failure during data compression.");
          return ERR::Compression;
       }
-      entry.CRC = GenCRC32(entry.CRC, (APTR)symlink, len);
+      entry.CRC = GenCRC32(entry.CRC, (APTR)symlink.data(), symlink.size());
    }
    else {
       struct acRead read = { .Buffer = Self->Input, .Length = SIZE_COMPRESSION_BUFFER };
@@ -808,4 +807,3 @@ void zipfile_to_item(ZipFile &ZF, CompressedItem &Item)
       Item.Permissions = permissions;
    }
 }
-

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -165,7 +165,7 @@ static ERR compress_file(extCompression *Self, std::string Location, std::string
    uint32_t dataoffset = 0;
    std::string filename;
    std::list<ZipFile>::iterator file_index;
-   int i, len;
+   int i;
 
    int16_t level = Self->CompressionLevel / 10;
    if (level < 0) level = 0;

--- a/src/core/fs_identify.cpp
+++ b/src/core/fs_identify.cpp
@@ -35,7 +35,7 @@ Read
 ERR IdentifyFile(const std::string_view &Path, CLASSID Filter, CLASSID *ClassID, CLASSID *SubClassID)
 {
    kt::Log log(__FUNCTION__);
-   int i, bytes_read;
+   int bytes_read;
    constexpr int HEADER_SIZE = 80;
 
    if ((Path.empty()) or (not ClassID)) return log.warning(ERR::NullArgs);

--- a/src/core/fs_volumes.cpp
+++ b/src/core/fs_volumes.cpp
@@ -127,7 +127,6 @@ ERR SetVolume(const std::string_view &Name, const std::string_view &Path, const 
 {
    kt::Log log(__FUNCTION__);
 
-   if ((&Name IS nullptr) or (&Path IS nullptr)) return log.warning(ERR::NullArgs);
    if ((Name.empty()) or (Path.empty())) return log.warning(ERR::NullArgs);
 
    std::string name;
@@ -153,9 +152,9 @@ ERR SetVolume(const std::string_view &Name, const std::string_view &Path, const 
 
       keys["Path"] = Path;
 
-      if ((&Icon != nullptr) and (not Icon.empty()))     keys["Icon"]   = Icon;
-      if ((&Label != nullptr) and (not Label.empty()))   keys["Label"]  = Label;
-      if ((&Device != nullptr) and (not Device.empty())) keys["Device"] = Device;
+      if (not Icon.empty())   keys["Icon"]   = Icon;
+      if (not Label.empty())  keys["Label"]  = Label;
+      if (not Device.empty()) keys["Device"] = Device;
 
       if ((Flags & VOLUME::HIDDEN) != VOLUME::NIL) keys["Hidden"] = "Yes";
       if ((Flags & VOLUME::SYSTEM) != VOLUME::NIL) keys["System"] = "Yes";

--- a/src/core/fs_volumes.cpp
+++ b/src/core/fs_volumes.cpp
@@ -132,7 +132,7 @@ ERR SetVolume(const std::string_view &Name, const std::string_view &Path, const 
    std::string name;
    name.append(Name, 0, Name.find(':'));
 
-   if ((&Label != nullptr) and (not Label.empty())) log.branch("Name: %.*s (%.*s), Path: %.*s", int(Name.size()), Name.data(), int(Label.size()), Label.data(), int(Path.size()), Path.data());
+   if ((not Label.empty())) log.branch("Name: %.*s (%.*s), Path: %.*s", int(Name.size()), Name.data(), int(Label.size()), Label.data(), int(Path.size()), Path.data());
    else log.branch("Name: %.*s, Path: %.*s", int(Name.size()), Name.data(), int(Path.size()), Path.data());
 
    if (auto lock = std::unique_lock{glmVolumes, 6s}) {

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -673,7 +673,7 @@ ERR SetResourcePath(RP PathType, const std::string_view &Path)
 {
    kt::Log log(__FUNCTION__);
 
-   if ((&Path IS nullptr) or (Path.empty())) return ERR::NullArgs;
+   if (Path.empty()) return ERR::NullArgs;
 
    log.function("Type: %d, Path: %.*s", int(PathType), int(Path.size()), Path.data());
 

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -1386,7 +1386,7 @@ ERR FindObject(const std::string_view &InitialName, CLASSID ClassID, OBJECTID *R
 {
    kt::Log log(__FUNCTION__);
 
-   if ((not Result) or (&InitialName IS nullptr)) return ERR::NullArgs;
+   if (not Result) return ERR::NullArgs;
    if (InitialName.empty()) return log.warning(ERR::EmptyString);
 
    if (auto lock = std::shared_lock{glmObjectLookup, 4s}) {
@@ -1642,11 +1642,11 @@ ERR InitObject(OBJECTPTR Object)
    // This is the only way we can support the automatic loading of sub-classes without causing undue load on CPU and
    // memory resources (loading each sub-class into memory just to check whether or not the data is supported is overkill).
 
-   CSTRING path;
+   std::string_view path;
    if (use_subclass) { // If ERR::UseSubClass was set and the sub-class was not registered, do not call IdentifyFile()
       log.warning("ERR::UseSubClass was used but no suitable sub-class was registered.");
    }
-   else if ((error IS ERR::NoSupport) and (Object->get(FID_Path, path) IS ERR::Okay) and (path)) {
+   else if ((error IS ERR::NoSupport) and (Object->get(FID_Path, path) IS ERR::Okay) and (not path.empty())) {
       CLASSID class_id, subclass_id;
       if (IdentifyFile(path, cl->BaseClassID, &class_id, &subclass_id) IS ERR::Okay) {
          if ((class_id IS Object->classID()) and (subclass_id != CLASSID::NIL)) {
@@ -1665,7 +1665,8 @@ ERR InitObject(OBJECTPTR Object)
             else log.warning("Failed to load module for class #%d.", uint32_t(subclass_id));
          }
       }
-      else log.warning("File '%s' does not belong to class '%s', got $%.8x.", path, Object->className(), uint32_t(class_id));
+      else log.warning("File '%.*s' does not belong to class '%s', got $%.8x.",
+         int(path.size()), path.data(), Object->className(), uint32_t(class_id));
 
       Object->Class = cl;  // Put back the original to retain object integrity
    }
@@ -2052,7 +2053,7 @@ cid: Returns the class ID identified from the class name, or `NULL` if the class
 
 CLASSID ResolveClassName(const std::string_view &ClassName)
 {
-   if ((&ClassName IS nullptr) or (ClassName.empty())) {
+   if (ClassName.empty()) {
       kt::Log log(__FUNCTION__);
       log.warning(ERR::NullArgs);
       return CLASSID::NIL;
@@ -2250,7 +2251,7 @@ ERR SetName(OBJECTPTR Object, const std::string_view &NewName)
 {
    kt::Log log(__FUNCTION__);
 
-   if ((not Object) or (&NewName IS nullptr)) return log.warning(ERR::NullArgs);
+   if (not Object) return log.warning(ERR::NullArgs);
 
    ScopedObjectAccess objlock(Object);
 

--- a/src/json/json.cpp
+++ b/src/json/json.cpp
@@ -71,7 +71,7 @@ static ActionArray clActions[] = {
 };
 
 static ERR extract_item(int &, CSTRING *, objXML::TAGS &, int &);
-static ERR txt_to_json(objXML *, CSTRING);
+static ERR txt_to_json(objXML *, std::string_view);
 
 //********************************************************************************************************************
 
@@ -140,12 +140,12 @@ static void debug_tree(objXML *Self)
 
 //********************************************************************************************************************
 
-static ERR load_file(objXML *Self, CSTRING Path)
+static ERR load_file(objXML *Self, std::string_view Path)
 {
    CacheFile *filecache;
 
-   if ((Self->ParseError = LoadFile(Self->Path, LDF::NIL, &filecache)) IS ERR::Okay) {
-      Self->ParseError = txt_to_json(Self, (CSTRING)filecache->Data);
+   if ((Self->ParseError = LoadFile(Path, LDF::NIL, &filecache)) IS ERR::Okay) { // loaded content is null terminated
+      Self->ParseError = txt_to_json(Self, std::string_view((CSTRING)filecache->Data, size_t(filecache->Size)));
       UnloadFile(filecache);
       return Self->ParseError;
    }
@@ -170,12 +170,13 @@ static ERR next_item(int &Line, CSTRING &Input)
 static ERR JSON_Init(objXML *Self)
 {
    kt::Log log;
-   CSTRING location = nullptr, statement = nullptr;
 
    log.trace("Attempting JSON interpretation of source data.");
 
    // TODO: A back-door to get the Statement string directly from the XML object would be useful
-   if ((Self->get(FID_Statement, statement) IS ERR::Okay) and (statement)) {
+
+   std::string_view statement;
+   if ((Self->get(FID_Statement, statement) IS ERR::Okay) and (not statement.empty())) {
       if ((Self->ParseError = txt_to_json(Self, statement)) != ERR::Okay) {
          log.warning("JSON Parsing Error: %s", GetErrorMsg(Self->ParseError));
       }
@@ -184,24 +185,23 @@ static ERR JSON_Init(objXML *Self)
       debug_tree(Self);
       #endif
 
-      FreeResource(statement);
+      FreeResource(statement.data());
       return Self->ParseError;
    }
 
+   std::string_view location;
    Self->get(FID_Path, location);
-   if ((!location) or ((Self->Flags & XMF::NEW) != XMF::NIL)) {
+   if (location.empty() or ((Self->Flags & XMF::NEW) != XMF::NIL)) {
       // If no location has been specified, assume that the JSON source is being
       // created from scratch (e.g. to save to disk).
 
       return ERR::Okay;
    }
-   else {
-      if ((Self->ParseError = load_file(Self, location)) != ERR::Okay) {
-         log.warning("Parsing Error: %s [File: %s]", GetErrorMsg(Self->ParseError), location);
-         return Self->ParseError;
-      }
-      else return ERR::Okay;
+   else if ((Self->ParseError = load_file(Self, location)) != ERR::Okay) {
+      log.warning("Parsing Error: %s [File: %.*s]", GetErrorMsg(Self->ParseError), int(location.size()), location.data());
+      return Self->ParseError;
    }
+   else return ERR::Okay;
 
    return ERR::NoSupport;
 }
@@ -217,23 +217,21 @@ static ERR JSON_SaveToObject(objXML *Self, struct acSaveToObject *Args)
 
 //********************************************************************************************************************
 
-static ERR txt_to_json(objXML *Self, CSTRING Text)
+static ERR txt_to_json(objXML *Self, std::string_view Text)
 {
    kt::Log log;
 
-   if ((!Self) or (!Text)) return ERR::NullArgs;
+   if ((!Self) or (Text.empty())) return ERR::NullArgs;
 
    log.traceBranch();
 
-   CSTRING str;
+   CSTRING str = Text.data();
    Self->Tags.clear();
    Self->LineNo = 1;
-   for (str=Text; (*str) and (*str != '{'); str++) if (*str IS '\n') Self->LineNo++;
-   if (str[0] != '{') return log.warning(ERR::NoData);
+   for (; (*str) and (*str != '{'); str++) if (*str IS '\n') Self->LineNo++;
+   if (*str != '{') return log.warning(ERR::NoData);
 
    log.trace("Extracting tag information with extract_tag()");
-
-   for (str=Text; (*str) and (*str != '{'); str++) if (*str IS '\n') Self->LineNo++;
    if (*str IS '{') {
       // XML requires the root tag to be numbered with ID 0
       auto &root = Self->Tags.emplace_back(XTag(0, Self->LineNo, { { "item", "" }, { "type", "object" } }));

--- a/src/json/json.cpp
+++ b/src/json/json.cpp
@@ -176,7 +176,7 @@ static ERR JSON_Init(objXML *Self)
    // TODO: A back-door to get the Statement string directly from the XML object would be useful
 
    std::string_view statement;
-   if ((Self->get(FID_Statement, statement) IS ERR::Okay) and (not statement.empty())) {
+   if (Self->get(FID_Statement, statement) IS ERR::Okay) {
       if ((Self->ParseError = txt_to_json(Self, statement)) != ERR::Okay) {
          log.warning("JSON Parsing Error: %s", GetErrorMsg(Self->ParseError));
       }
@@ -216,6 +216,7 @@ static ERR JSON_SaveToObject(objXML *Self, struct acSaveToObject *Args)
 }
 
 //********************************************************************************************************************
+// Parse Text string to JSON.  Assumes that the incoming string is null terminated.
 
 static ERR txt_to_json(objXML *Self, std::string_view Text)
 {
@@ -251,8 +252,6 @@ static ERR txt_to_json(objXML *Self, std::string_view Text)
       log.warning("Missing expected '}' terminator at line %d.", Self->LineNo);
       return ERR::Syntax;
    }
-
-   log.trace("JSON parsing complete.");
 
    return ERR::Okay;
 }

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -81,7 +81,7 @@ static std::atomic<uint32_t> glTagID = 1;
 
 [[nodiscard]] static std::string document_base(extXML *Document)
 {
-   if ((!Document) or (!Document->Path) or (!*Document->Path)) return std::string();
+   if ((!Document) or (Document->Path.empty())) return std::string();
    return xml::uri::normalise_uri_separators(std::string(Document->Path));
 }
 
@@ -143,7 +143,7 @@ static void refresh_base_uris_for_insert(extXML *Document, TAGS &Inserted, XTag 
 }
 
 static ERR add_xml_class(void);
-static ERR SET_Statement(extXML *, CSTRING);
+static ERR SET_Statement(extXML *, const std::string_view &);
 static ERR SET_Source(extXML *, OBJECTPTR);
 
 //********************************************************************************************************************

--- a/src/xml/xml.tdl
+++ b/src/xml/xml.tdl
@@ -107,15 +107,15 @@ module({ name="XML", src="xml.cpp", copyright="Paul Manias © 2001-2026", versio
   })
 
   klass("XML", { src="xml_class.cpp", output="xml_class_def.c" }, [[
-    str Path         # Location of the XML data file
-    str DocType      # Root element name from DOCTYPE declaration
-    str PublicID     # Public identifier for external DTD
-    str SystemID     # System identifier for external DTD
-    obj Source       # Alternative data source to specifying a `Path`
-    int(XMF) Flags   # Optional user flags
-    int Modified     # Modification timestamp
-    error ParseError # Private
-    int LineNo       # Private
+    cpp(str) Path     # Location of the XML data file
+    cpp(str) DocType  # Root element name from DOCTYPE declaration
+    cpp(str) PublicID # Public identifier for external DTD
+    cpp(str) SystemID # System identifier for external DTD
+    obj Source        # Alternative data source to specifying a `Path`
+    int(XMF) Flags    # Optional user flags
+    int Modified      # Modification timestamp
+    error ParseError  # Private
+    int LineNo        # Private
   ]],
   nil,
   [[

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -2028,8 +2028,11 @@ static ERR GET_Statement(extXML *Self, std::string_view &Value)
    kt::Log log;
 
    if (not Self->initialised()) {
-      Value = kt::strclone(Self->Statement);
-      return ERR::Okay;
+      if (CSTRING str = kt::strclone(Self->Statement)) {
+         Value = str;
+         return ERR::Okay;
+      }
+      else return ERR::AllocMemory;
    }
 
    if (Self->Tags.empty()) return ERR::FieldNotSet;

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -107,13 +107,12 @@ The Clear action removes all parsed XML content from the object, including the c
 
 static ERR XML_Clear(extXML *Self)
 {
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
-
+   Self->Path.clear();
    Self->Tags.clear();
    Self->BaseURIMap.clear();
-   if (Self->DocType)  { FreeResource(Self->DocType); Self->DocType = nullptr; }
-   if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
-   if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
+   Self->DocType.clear();
+   Self->PublicID.clear();
+   Self->SystemID.clear();
    Self->Entities.clear();
    Self->ParameterEntities.clear();
    Self->Notations.clear();
@@ -409,10 +408,6 @@ static ERR XML_Search(extXML *Self, struct xml::Search *Args)
 
 static ERR XML_Free(extXML *Self)
 {
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
-   if (Self->DocType) { FreeResource(Self->DocType); Self->DocType = nullptr; }
-   if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
-   if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
    Self->~extXML();
    return ERR::Okay;
 }
@@ -766,12 +761,12 @@ static ERR XML_Init(extXML *Self)
       Self->Statement.clear();
       return Self->ParseError;
    }
-   else if ((Self->Path) or (Self->Source)) {
+   else if ((not Self->Path.empty()) or (Self->Source)) {
       if ((Self->Flags & XMF::NEW) != XMF::NIL) {
          return ERR::Okay;
       }
       else if (parse_source(Self) != ERR::Okay) {
-         log.warning("XML parsing error: %s [File: %s]", GetErrorMsg(Self->ParseError), Self->Path ? Self->Path : "Object");
+         log.warning("XML parsing error: %s [File: %s]", GetErrorMsg(Self->ParseError), not Self->Path.empty() ? Self->Path.c_str() : "Object");
          return Self->ParseError;
       }
       else return ERR::Okay;
@@ -1847,10 +1842,10 @@ DocType: Root element name from DOCTYPE declaration
 
 *********************************************************************************************************************/
 
-static ERR SET_DocType(extXML *Self, CSTRING Value)
+static ERR SET_DocType(extXML *Self, const std::string_view &Value)
 {
-   if (Value) return kt::set_string_field(Value, Self->DocType);
-   else if (Self->DocType) { FreeResource(Self->DocType); Self->DocType = nullptr; }
+   if (not Value.empty()) Self->DocType = Value;
+   else Self->DocType.clear();
    return ERR::Okay;
 }
 
@@ -1864,13 +1859,10 @@ recently received error code.  Issues parsing malformed XPath expressions may al
 
 *********************************************************************************************************************/
 
-static ERR GET_ErrorMsg(extXML *Self, CSTRING *Value)
+static ERR GET_ErrorMsg(extXML *Self, std::string_view &Value)
 {
-   if (not Self->ErrorMsg.empty()) { *Value = Self->ErrorMsg.c_str(); return ERR::Okay; }
-   else {
-      *Value = nullptr;
-      return ERR::Okay;
-   }
+   Value = Self->ErrorMsg;
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -1892,31 +1884,31 @@ establish the base path for relative references in XQuery statements (e.g. for i
 
 *********************************************************************************************************************/
 
-static ERR GET_Path(extXML *Self, STRING *Value)
+static ERR GET_Path(extXML *Self, std::string_view &Value)
 {
-   if (Self->Path) { *Value = Self->Path; return ERR::Okay; }
-   else return ERR::NoData;
+   Value = Self->Path;
+   return ERR::Okay;
 }
 
-static ERR SET_Path(extXML *Self, CSTRING Value)
+static ERR SET_Path(extXML *Self, const std::string_view &Value)
 {
    if (Self->Source) SET_Source(Self, nullptr);
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   if (not Self->Path.empty()) Self->Path.clear();
 
-   if (kt::startswith("string:", Value)) {
+   if (Value.starts_with("string:")) {
       // If the string: path type is used then we can optimise things by setting the following path string as the
       // statement.
 
-      return SET_Statement(Self, Value+7);
+      auto statement = Value;
+      statement.remove_prefix(7);
+      return SET_Statement(Self, statement);
    }
-   else if ((Value) and (*Value)) {
-      if ((Self->Path = kt::strclone(Value))) {
-         if (Self->initialised()) {
-            parse_source(Self);
-            return Self->ParseError;
-         }
+   else if (not Value.empty()) {
+      Self->Path = Value;
+      if (Self->initialised()) {
+         parse_source(Self);
+         return Self->ParseError;
       }
-      else return ERR::AllocMemory;
    }
 
    return ERR::Okay;
@@ -1937,10 +1929,10 @@ PublicID: Public identifier for external DTD
 
 *********************************************************************************************************************/
 
-static ERR SET_PublicID(extXML *Self, CSTRING Value)
+static ERR SET_PublicID(extXML *Self, const std::string_view &Value)
 {
-   if (Value) return kt::set_string_field(Value, Self->PublicID);
-   else if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
+   if (not Value.empty()) Self->PublicID = Value;
+   else Self->PublicID.clear();
    return ERR::Okay;
 }
 
@@ -1951,10 +1943,10 @@ SystemID: System identifier for external DTD
 
 *********************************************************************************************************************/
 
-static ERR SET_SystemID(extXML *Self, CSTRING Value)
+static ERR SET_SystemID(extXML *Self, const std::string_view &Value)
 {
-   if (Value) return kt::set_string_field(Value, Self->SystemID);
-   else if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
+   if (not Value.empty()) Self->SystemID = Value;
+   else Self->SystemID.clear();
    return ERR::Okay;
 }
 
@@ -1996,7 +1988,7 @@ automatically.
 
 static ERR SET_Source(extXML *Self, OBJECTPTR Value)
 {
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   if (not Self->Path.empty()) Self->Path.clear();
    Self->Statement.clear();
 
    if (Value) {
@@ -2031,16 +2023,13 @@ the base path for relative references.
 
 *********************************************************************************************************************/
 
-static ERR GET_Statement(extXML *Self, STRING *Value)
+static ERR GET_Statement(extXML *Self, std::string_view &Value)
 {
    kt::Log log;
 
    if (not Self->initialised()) {
-      if (not Self->Statement.empty()) {
-         *Value = kt::strclone(Self->Statement);
-         return ERR::Okay;
-      }
-      else return ERR::FieldNotSet;
+      Value = Self->Statement;
+      return ERR::Okay;
    }
 
    if (Self->Tags.empty()) return ERR::FieldNotSet;
@@ -2059,17 +2048,18 @@ static ERR GET_Statement(extXML *Self, STRING *Value)
    }
    else return log.warning(ERR::NoData); // NB: If there are tags, tag 0 should always exist, so this indicates a parsing issue
 
-   if ((*Value = kt::strclone(buffer.str()))) {
+   if (CSTRING str = kt::strclone(buffer.str())) {
+      Value = str;
       return ERR::Okay;
    }
    else return ERR::AllocMemory;
 }
 
-static ERR SET_Statement(extXML *Self, CSTRING Value)
+static ERR SET_Statement(extXML *Self, const std::string_view &Value)
 {
    Self->Statement.clear();
 
-   if ((Value) and (*Value)) {
+   if (not Value.empty()) {
       if (Self->initialised()) {
          Self->Tags.clear();
          Self->LineNo = 1;
@@ -2343,20 +2333,20 @@ static ERR XML_ValidateDocument(extXML *Self, void *Args)
 #include "xml_class_def.c"
 
 static const FieldArray clFields[] = {
-   { "Path",         FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "DocType",      FDF_STRING|FDF_RW, nullptr, SET_DocType },
-   { "PublicID",     FDF_STRING|FDF_RW, nullptr, SET_PublicID },
-   { "SystemID",     FDF_STRING|FDF_RW, nullptr, SET_SystemID },
+   { "Path",         FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "DocType",      FDF_CPPSTRING|FDF_RW, nullptr, SET_DocType },
+   { "PublicID",     FDF_CPPSTRING|FDF_RW, nullptr, SET_PublicID },
+   { "SystemID",     FDF_CPPSTRING|FDF_RW, nullptr, SET_SystemID },
    { "Source",       FDF_OBJECT|FDF_RI },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clXMLFlags },
    { "Modified",     FDF_INT|FDF_R },
    { "ParseError",   FDF_INT|FD_PRIVATE|FDF_R },
    { "LineNo",       FDF_INT|FD_PRIVATE|FDF_R },
    // Virtual fields
-   { "ErrorMsg",   FDF_STRING|FDF_R, GET_ErrorMsg },
+   { "ErrorMsg",   FDF_CPPSTRING|FDF_R, GET_ErrorMsg },
    { "ReadOnly",   FDF_INT|FDF_RI, GET_ReadOnly, SET_ReadOnly },
-   { "Src",        FDF_STRING|FDF_SYNONYM|FDF_RW, GET_Path, SET_Path },
-   { "Statement",  FDF_STRING|FDF_ALLOC|FDF_RW, GET_Statement, SET_Statement },
+   { "Src",        FDF_CPPSTRING|FDF_SYNONYM|FDF_RW, GET_Path, SET_Path },
+   { "Statement",  FDF_CPPSTRING|FDF_ALLOC|FDF_RW, GET_Statement, SET_Statement },
    { "Tags",       FDF_ARRAY|FDF_STRUCT|FDF_R, GET_Tags, nullptr, "XTag" },
    END_FIELD
 };

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -2028,7 +2028,7 @@ static ERR GET_Statement(extXML *Self, std::string_view &Value)
    kt::Log log;
 
    if (not Self->initialised()) {
-      Value = Self->Statement;
+      Value = kt::strclone(Self->Statement);
       return ERR::Okay;
    }
 

--- a/src/xml/xml_functions.cpp
+++ b/src/xml/xml_functions.cpp
@@ -41,34 +41,28 @@ static void output_attribvalue(std::string_view String, std::ostringstream &Outp
    }
 }
 
-inline void assign_string(STRING &Target, const std::string_view Value)
+static bool ci_keyword(std::string_view &View, std::string_view Keyword) noexcept
 {
-   if (Target) { FreeResource(Target); Target = nullptr; }
-   if (not Value.empty()) Target = kt::strclone(Value);
-}
+   if (Keyword.empty() or View.size() < Keyword.size()) return false;
 
-static bool ci_keyword(std::string_view &view, std::string_view keyword) noexcept
-{
-   if (keyword.empty() or view.size() < keyword.size()) return false;
-
-   for (size_t i = 0; i < keyword.size(); ++i) {
-      if (to_lower(view[i]) != to_lower(keyword[i])) return false;
+   for (size_t i = 0; i < Keyword.size(); ++i) {
+      if (to_lower(View[i]) != to_lower(Keyword[i])) return false;
    }
 
    // Check that we're not matching a partial name
-   if ((view.size() > keyword.size()) and
-       is_name_char(view[keyword.size()]) and
-       (view[keyword.size()] != '[')) return false;
+   if ((View.size() > Keyword.size()) and
+       is_name_char(View[Keyword.size()]) and
+       (View[Keyword.size()] != '[')) return false;
 
-   view.remove_prefix(keyword.size());
+   View.remove_prefix(Keyword.size());
    return true;
 }
 
-static bool ci_keyword(ParseState &State, std::string_view keyword) noexcept
+static bool ci_keyword(ParseState &State, std::string_view Keyword) noexcept
 {
    auto view = State.cursor;
-   if (ci_keyword(view, keyword)) {
-      State.next(keyword.size());
+   if (ci_keyword(view, Keyword)) {
+      State.next(Keyword.size());
       return true;
    }
    return false;
@@ -285,9 +279,9 @@ static void parse_doctype(extXML *Self, ParseState &State)
    auto type_view = read_name(view);
    if (type_view.empty()) return;
 
-   assign_string(Self->DocType, type_view);
-   if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
-   if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
+   Self->DocType = type_view;
+   Self->PublicID.clear();
+   Self->SystemID.clear();
    Self->Entities.clear();
    Self->ParameterEntities.clear();
    Self->Notations.clear();
@@ -304,19 +298,19 @@ static void parse_doctype(extXML *Self, ParseState &State)
       State.skipWhitespace(Self->LineNo);
       std::string public_id;
       if (read_quoted(Self, State, public_id, entity_stack, parameter_stack)) {
-         if (not standalone) assign_string(Self->PublicID, public_id);
+         if (not standalone) Self->PublicID = public_id;
       }
       State.skipWhitespace(Self->LineNo);
       std::string system_id;
       if (read_quoted(Self, State, system_id, entity_stack, parameter_stack)) {
-         if (not standalone) assign_string(Self->SystemID, system_id);
+         if (not standalone) Self->SystemID = system_id;
       }
    }
    else if (ci_keyword(State, "SYSTEM")) {
       State.skipWhitespace(Self->LineNo);
       std::string system_id;
       if (read_quoted(Self, State, system_id, entity_stack, parameter_stack)) {
-         if (not standalone) assign_string(Self->SystemID, system_id);
+         if (not standalone) Self->SystemID = system_id;
       }
    }
 
@@ -883,9 +877,9 @@ static ERR txt_to_xml(extXML *Self, TAGS &Tags, std::string_view Text)
    kt::Log log(__FUNCTION__);
 
    if (&Tags IS &Self->Tags) {
-      if (Self->DocType)  { FreeResource(Self->DocType); Self->DocType = nullptr; }
-      if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
-      if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
+      Self->DocType.clear();
+      Self->PublicID.clear();
+      Self->SystemID.clear();
       Self->Entities.clear();
       Self->ParameterEntities.clear();
       Self->Notations.clear();
@@ -903,7 +897,7 @@ static ERR txt_to_xml(extXML *Self, TAGS &Tags, std::string_view Text)
 
    ParseState state(Text);
 
-   if (Self->Path) state.CurrentBase = xml::uri::normalise_uri_separators(std::string(Self->Path));
+   if (not Self->Path.empty()) state.CurrentBase = xml::uri::normalise_uri_separators(Self->Path);
    else state.CurrentBase.clear();
 
    state.skipTo('<', Self->LineNo); // Skip any leading whitespace or content

--- a/src/xquery/functions/accessor_support.cpp
+++ b/src/xquery/functions/accessor_support.cpp
@@ -255,8 +255,8 @@ std::optional<std::string> build_base_uri_chain(const XPathContext &Context, XTa
 
    if (not Node) {
       std::string_view path;
-      if ((document) and (document->Path)) path = document->Path;
-      else if ((Context.xml) and (Context.xml->Path)) path = Context.xml->Path;
+      if ((document) and (not document->Path.empty())) path = std::string_view(document->Path);
+      else if ((Context.xml) and (not Context.xml->Path.empty())) path = Context.xml->Path;
       auto base = resolve_document_base_directory(path);
       if (base.has_value()) return xml::uri::normalise_uri_separators(*base);
       return std::nullopt;
@@ -270,8 +270,8 @@ std::optional<std::string> build_base_uri_chain(const XPathContext &Context, XTa
 
    if ((Node->ParentID IS 0) and (!AttributeNode)) { // Root-level node with no attribute
       std::string_view path;
-      if ((document) and (document->Path)) path = document->Path;
-      else if ((Context.xml) and (Context.xml->Path)) path = Context.xml->Path;
+      if ((document) and (not document->Path.empty())) path = std::string_view(document->Path);
+      else if ((Context.xml) and (not Context.xml->Path.empty())) path = Context.xml->Path;
       auto base = resolve_document_base_directory(path);
       if (base.has_value()) return xml::uri::normalise_uri_separators(*base);
    }
@@ -298,7 +298,7 @@ std::optional<std::string> build_base_uri_chain(const XPathContext &Context, XTa
       current = parent;
    }
 
-   std::optional<std::string> base = resolve_document_base_directory((document and document->Path) ? document->Path : std::string_view{});
+   std::optional<std::string> base = resolve_document_base_directory((document and (not document->Path.empty())) ? document->Path : std::string_view{});
 
    for (auto iterator = chain.rbegin(); iterator != chain.rend(); ++iterator) {
       if (base.has_value()) base = xml::uri::resolve_relative_uri(*iterator, *base);
@@ -318,9 +318,7 @@ std::optional<std::string> resolve_document_uri(const XPathContext &Context, XTa
 
    extXML *document = locate_node_document(Context, Node);
    if (not document) return std::nullopt;
-   if (document->Path and document->Path[0]) {
-      return xml::uri::normalise_uri_separators(std::string(document->Path));
-   }
+   if (not document->Path.empty()) return xml::uri::normalise_uri_separators(document->Path);
 
    // Perform a reverse lookup in the XML cache to find the document URI.
 

--- a/src/xquery/functions/func_accessors.cpp
+++ b/src/xquery/functions/func_accessors.cpp
@@ -197,7 +197,7 @@ XPathVal XPathFunctionLibrary::function_static_base_uri(const std::vector<XPathV
    if (not base.has_value()) {
       if (Context.prolog) return XPathVal(Context.prolog->static_base_uri);
       else if (Context.xml) {
-         if (Context.xml->Path) return XPathVal(Context.xml->Path);
+         if (not Context.xml->Path.empty()) return XPathVal(Context.xml->Path);
       }
    }
 

--- a/src/xquery/functions/func_documents.cpp
+++ b/src/xquery/functions/func_documents.cpp
@@ -41,7 +41,7 @@ namespace fs = std::filesystem;
 
 static std::optional<std::string> get_context_directory(const XPathContext &Context)
 {
-   if ((Context.xml) and (Context.xml->Path) and (*Context.xml->Path)) {
+   if ((Context.xml) and (not Context.xml->Path.empty())) {
       std::string resolved;
       if (ResolvePath(Context.xml->Path, RSF::NO_FILE_CHECK, &resolved) IS ERR::Okay) {
          fs::path base_path(resolved);
@@ -49,7 +49,7 @@ static std::optional<std::string> get_context_directory(const XPathContext &Cont
          return base_path.string();
       }
 
-      std::string raw = Context.xml->Path;
+      const std::string &raw = Context.xml->Path;
       size_t slash = raw.find_last_of("/\\");
       if (slash != std::string::npos) return raw.substr(0, slash + 1u);
    }

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -360,7 +360,7 @@ static ERR XQUERY_Evaluate(extXQuery *Self, struct xq::Evaluate *Args)
       kt::ScopedObjectLock lock(xml);
       XTag *root_tag = nullptr;
 
-      if (Self->Path.empty() and (xml->Path)) Self->Path = xml->Path;
+      if (Self->Path.empty() and (not xml->Path.empty())) Self->Path = xml->Path;
       if (Args->Index != 0) {
          root_tag = xml->getTag(Args->Index);
          if (not root_tag) {
@@ -715,7 +715,7 @@ static ERR XQUERY_Search(extXQuery *Self, struct xq::Search *Args)
       kt::ScopedObjectLock lock(xml);
       XTag *root_tag = nullptr;
 
-      if (Self->Path.empty() and (xml->Path)) Self->Path = xml->Path;
+      if (Self->Path.empty() and (not xml->Path.empty())) Self->Path = xml->Path;
       if (Args->Index != 0) {
          root_tag = xml->getTag(Args->Index);
          if (not root_tag) {

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -399,7 +399,7 @@ global function outputClassHeader(Class:table, Private:str, Custom:str)
                   output(f'   inline ERR set{fid_name}({field_type} Value, int Elements) noexcept {{')
                end
             elseif f.flags has FD_STRING and f.flags has FD_CPP then
-                  output(f'   inline ERR set{fid_name}(std::string_view Value) noexcept {{')
+                  output(f'   inline ERR set{fid_name}(const std::string_view &Value) noexcept {{')
             elseif field_type is 'T &&' then
                output(f'   template <class T> inline ERR set{fid_name}({field_type} Value) noexcept {{')
             else
@@ -465,7 +465,7 @@ global function outputClassHeader(Class:table, Private:str, Custom:str)
             if field_type is 'T &&' then
                output(f'   template <class T> inline ERR set{fid_name}({field_type} Value) noexcept {{')
             elseif f.flags has FD_STRING and f.flags has FD_CPP then
-               output(f'   inline ERR set{fid_name}(std::string_view Value) noexcept {{')
+               output(f'   inline ERR set{fid_name}(const std::string_view &Value) noexcept {{')
             else
                output(f'   inline ERR set{fid_name}({field_type} Value) noexcept {{')
             end


### PR DESCRIPTION
* Converted XML class path, doctype and identifier fields to cpp(str) storage

* Updated generated string-view setters to pass C++ string fields directly

* [XQuery] Adjusted XML path handling for std::string storage