### PR TITLE
[Network] Guard Windows SSL encrypted input buffer growth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ local/
 build/
 out/
 CLAUDE.local.md
+AGENTS.local.md
 src/link/kotuku.manifest
 src/link/resource.rc
 data/ssl/localhost.p12

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -4,12 +4,14 @@
 set (MOD "audio")
 set (INC_MOD_AUDIO TRUE PARENT_SCOPE)
 
+if (NOT WIN32)
    CHECK_C_SOURCE_COMPILES ("
 #include <alsa/asoundlib.h>
 int main() {
    return 0;
 }"
    ALSA_INSTALLED)
+endif ()
 
 idl_gen ("${MOD}.tdl" NAME ${MOD}_defs
    OUTPUT "${INCLUDE_OUTPUT}/modules/${MOD}.h"

--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -66,6 +66,7 @@ if (BUILD_DEFS) # Customised idl_c() equivalent, this is for defining the output
    register_generated_header_target (display_defs)
 endif ()
 
+if (NOT WIN32)
    CHECK_C_SOURCE_COMPILES ("
 #include <X11/Xlib.h>
 #include <X11/extensions/Xxf86dga.h>
@@ -73,6 +74,7 @@ int main() {
    return 0;
 }"
    XDGA_INSTALLED)
+endif ()
 
 add_library (${MOD})
 

--- a/src/network/win32/ssl_wrapper.cpp
+++ b/src/network/win32/ssl_wrapper.cpp
@@ -151,6 +151,7 @@ public:
    size_t capacity() const { return data_.size(); }
    bool empty() const { return used_ == 0; }
    size_t available() const { return data_.size() - used_; }
+   bool can_append(size_t Bytes) const { return Bytes <= SSL_IO_BUFFER_SIZE - used_; }
 
    void reserve(size_t new_cap) {
       if (new_cap <= SSL_IO_BUFFER_SIZE and new_cap > data_.size()) {
@@ -535,6 +536,7 @@ void ssl_consume_pending_output(SSL_HANDLE SSL, size_t Bytes)
 SSL_ERROR_CODE ssl_queue_encrypted_input(SSL_HANDLE SSL, const void *Buffer, int Length)
 {
    if ((!SSL) or (!Buffer) or (Length <= 0)) return SSL_ERROR_ARGS;
+   if (!SSL->recv_buffer.can_append(size_t(Length))) return SSL_ERROR_BUFFER_OVERFLOW;
 
    std::span<const unsigned char> buffer_span((const unsigned char *)Buffer, size_t(Length));
    return SSL->recv_buffer.append(buffer_span) ? SSL_OK : SSL_ERROR_MEMORY;
@@ -553,6 +555,13 @@ int ssl_last_security_status(SSL_HANDLE SSL)
 size_t ssl_encrypted_input_size(SSL_HANDLE SSL)
 {
    return SSL ? SSL->recv_buffer.size() : 0;
+}
+
+//********************************************************************************************************************
+
+size_t ssl_encrypted_input_limit(SSL_HANDLE SSL)
+{
+   return SSL ? SSL_IO_BUFFER_SIZE : 0;
 }
 
 //********************************************************************************************************************

--- a/src/network/win32/ssl_wrapper.h
+++ b/src/network/win32/ssl_wrapper.h
@@ -11,14 +11,15 @@ typedef struct ssl_context * SSL_HANDLE;
 
 // Error codes
 typedef enum {
-    SSL_OK = 0,
-    SSL_ERROR_ARGS = -1,
-    SSL_ERROR_FAILED = -2,
-    SSL_ERROR_MEMORY = -3,
-    SSL_ERROR_WOULD_BLOCK = -4,
-    SSL_ERROR_DISCONNECTED = -5,
-    SSL_NEED_DATA = -6, // Indicates more data needed to complete operation
-    SSL_ERROR_CONNECTING = -7
+   SSL_OK = 0,
+   SSL_ERROR_ARGS = -1,
+   SSL_ERROR_FAILED = -2,
+   SSL_ERROR_MEMORY = -3,
+   SSL_ERROR_WOULD_BLOCK = -4,
+   SSL_ERROR_DISCONNECTED = -5,
+   SSL_NEED_DATA = -6, // Indicates more data needed to complete operation
+   SSL_ERROR_CONNECTING = -7,
+   SSL_ERROR_BUFFER_OVERFLOW = -8
 } SSL_ERROR_CODE;
 
 void ssl_cleanup();
@@ -43,6 +44,7 @@ SSL_ERROR_CODE ssl_write(SSL_HANDLE, const void* buffer, size_t buffer_size, siz
 uint32_t ssl_last_win32_error(SSL_HANDLE);
 int ssl_last_security_status(SSL_HANDLE);
 size_t ssl_encrypted_input_size(SSL_HANDLE);
+size_t ssl_encrypted_input_limit(SSL_HANDLE);
 bool ssl_get_verify_result(SSL_HANDLE);
 SSL_ERROR_CODE ssl_load_server_certificate(SSL_HANDLE, const std::string &, std::optional<const std::string> &,
    std::optional<const std::string> &);

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -175,14 +175,28 @@ template <class T> ERR tls_receive_encrypted(T *Self)
    if ((error IS ERR::Okay) and (bytes_received > 0)) {
       if (auto ssl_error = ssl_queue_encrypted_input(Self->TLS.Handle, buffer.data(), int(bytes_received));
           ssl_error != SSL_OK) {
-         kt::Log(__FUNCTION__).warning("Failed to queue encrypted SSL input: %d", ssl_error);
+         if (ssl_error IS SSL_ERROR_BUFFER_OVERFLOW) {
+            kt::Log(__FUNCTION__).warning(
+               "Encrypted SSL input buffer full while receiving %d bytes: queued=%d, limit=%d",
+               int(bytes_received), int(ssl_encrypted_input_size(Self->TLS.Handle)),
+               int(ssl_encrypted_input_limit(Self->TLS.Handle)));
+            return ERR::BufferOverflow;
+         }
+
+         kt::Log(__FUNCTION__).warning(
+            "Failed to queue encrypted SSL input: %d (incoming=%d, queued=%d, limit=%d)",
+            ssl_error, int(bytes_received), int(ssl_encrypted_input_size(Self->TLS.Handle)),
+            int(ssl_encrypted_input_limit(Self->TLS.Handle)));
          return ERR::Failed;
       }
 
       auto prepare_error = ssl_prepare_read(Self->TLS.Handle);
       if ((prepare_error != SSL_OK) and (prepare_error != SSL_ERROR_WOULD_BLOCK)) {
          if (prepare_error IS SSL_ERROR_DISCONNECTED) return ERR::Disconnected;
-         kt::Log(__FUNCTION__).warning("Failed to decrypt SSL input: %d", prepare_error);
+         kt::Log(__FUNCTION__).warning(
+            "Failed to decrypt SSL input: %d (queued=%d, security-status=0x%08x)",
+            prepare_error, int(ssl_encrypted_input_size(Self->TLS.Handle)),
+            unsigned(ssl_last_security_status(Self->TLS.Handle)));
          return ERR::Failed;
       }
    }


### PR DESCRIPTION
* Report buffer overflow when encrypted SSL input cannot fit in the pending receive buffer

* Improve Windows SSL receive diagnostics with queued input and security status details

* [Build] Skip Unix-only capability probes when configuring Windows builds