### PR TITLE
[HTTP] Converted HTTP string fields to C++ string storage

### DIFF
--- a/.agents/skills/cpp-string-field-conversion/SKILL.md
+++ b/.agents/skills/cpp-string-field-conversion/SKILL.md
@@ -18,7 +18,7 @@ The Config class conversion is the model for this skill:
 
 - TDL field declarations change from `str Field` to `cpp(str) Field`.
 - C++ body members change from `STRING`/`CSTRING` pointer-style fields to `std::string`.
-- Field array entries change from `FDF_STRING` to `FDF_CPPSTRING`.
+- All field array entries change from `FDF_STRING` to `FDF_CPPSTRING` unless there is a good reason for an exception.
 - Field setter/getter callbacks use `std::string_view &Value` instead of `CSTRING Value` or `CSTRING *Value`.
 - Manual `strclone()` and `FreeResource()` ownership disappears for converted string fields.
 - `AC::NewObject` changes to `AC::NewPlacement`, with placement construction of the object body.
@@ -42,8 +42,8 @@ The Config class conversion is the model for this skill:
 
 3. Update C++ helper signatures and call sites:
    - Prefer `std::string_view` for internal helper parameters that read string data.
-   - Use `std::string_view &Value` for `FDF_CPPSTRING` field setters and getters.
-   - For getters, return `ERR::FieldNotSet` when an empty string should preserve the old "null/unset" behaviour.
+   - Use `std::string_view &Value` for `FDF_CPPSTRING` field getters and `const std::string_view &Value` for setters.
+   - For existing getters, return a matching error to the original code if it had an error path for managing "null/unset" behaviour.
    - For setters, assign directly with `Self->Field = Value;` or `Self->Field.assign(Value);`.
    - Replace `if (Self->Field)` and `if ((Value) and (*Value))` with `not Self->Field.empty()` and `not Value.empty()`
      where the old meaning was "has text".
@@ -55,17 +55,17 @@ The Config class conversion is the model for this skill:
    - Keep manual cleanup for raw pointers, handles, buffers, or other resources that are not converted.
 
 5. Fix object lifecycle:
-   - Replace the old new-object action with a placement constructor:
+   - Add a placement constructor if it does not already exist:
 
 ```cpp
-static ERR CLASS_NewPlacement(extClass *Self)
+static ERR CLASSNAME_NewPlacement(extClass *Self)
 {
    new (Self) extClass;
    return ERR::Okay;
 }
 ```
 
-   - Update the action table from `AC::NewObject` to `AC::NewPlacement`.
+   - Add `AC::NewPlacement` to the action table.
    - If an existing `AC::NewObject` performs post-construction allocations, subscriptions, or default initialisation that
      requires normal object context, keep it alongside `AC::NewPlacement`; do not move those operations into placement.
    - In the free action, run any class-specific persistence or release logic first, then call `Self->~extClass();`.

--- a/docs/xml/modules/classes/http.xml
+++ b/docs/xml/modules/classes/http.xml
@@ -175,7 +175,7 @@ http.acActivate()
       <name>ContentType</name>
       <comment>Defines the content-type for <code>PUT</code> and <code>POST</code> methods.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The ContentType should be set prior to sending a <code>PUT</code> or <code>POST</code> request.  If <code>NULL</code>, the default content type for <code>POST</code> methods will be set to <code>application/x-www-form-urlencoded</code>.  For <code>PUT</code> requests the default of <code>application/binary</code> will be applied.</p>
       </description>
@@ -242,7 +242,7 @@ http.acActivate()
       <name>Host</name>
       <comment>The targeted HTTP server is specified here, either by name or IP address.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The HTTP server to target for HTTP requests is defined here.  To change the host post-initialisation, set the <fl>Location</fl>.</p>
       </description>
@@ -275,7 +275,7 @@ http.acActivate()
       <name>InputFile</name>
       <comment>To upload HTTP content from a file, set a file path here.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>HTTP content can be streamed from a source file when a <code>POST</code> command is executed. To do so, set the InputFile field to the file path that contains the source data.  The path is not opened or checked for validity until the <code>POST</code> command is executed by the HTTP object.</p>
 <p>An alternative is to set the <fl>InputObject</fl> for abstracting the data source.</p>
@@ -297,7 +297,7 @@ http.acActivate()
       <name>Location</name>
       <comment>A valid HTTP URI must be specified here.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The URI of the HTTP source must be specified here.  The string must start with <code>http://</code> or <code>https://</code>, followed by the host name, HTTP path and port number if required. The values mentioned will be broken down and stored in the <fl>Host</fl>, <fl>Path</fl> and <fl>Port</fl> fields respectively.  Note that if the port is not defined in the URI, the <fl>Port</fl> field is reset to the default (<code>80</code> for HTTP or <code>443</code> for HTTPS).</p>
 <p>An alternative to setting the Location is to set the <fl>Host</fl>, <fl>Path</fl> and <fl>Port</fl> separately.</p>
@@ -342,7 +342,7 @@ http.acActivate()
       <name>OutputFile</name>
       <comment>To download HTTP content to a file, set a file path here.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>HTTP content can be streamed to a target file during transfer.  To do so, set the OutputFile field to the destination file name that will receive data.  If the file already exists, it will be overwritten unless the <code>RESUME</code> flag has been set in the <fl>Flags</fl> field.</p>
       </description>
@@ -363,7 +363,7 @@ http.acActivate()
       <name>Password</name>
       <comment>The password to use when authenticating access to the server.</comment>
       <access write="S">Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>A password may be preset if authorisation is required against the HTTP server for access to a resource. Note that if authorisation is required and no username and password has been preset, the HTTP object may present a dialog box to the user to request the relevant information.</p>
 <p>A <code>401</code> status code is returned in the event of an authorisation failure.</p>
@@ -374,7 +374,7 @@ http.acActivate()
       <name>Path</name>
       <comment>The HTTP path targeted at the host server.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The path to target at the host server is specified here.  If no path is set, the server root will be targeted.  It is not necessary to set the path if one has been specified in the <fl>Location</fl>.</p>
 <p>If spaces are discovered in the path, they will be converted to the <code>%20</code> HTTP escape code automatically.  No other automatic conversions are operated when setting the Path field.</p>
@@ -405,7 +405,7 @@ http.acActivate()
       <name>ProxyServer</name>
       <comment>Route the HTTP request through the proxy server defined here.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>If a proxy server will receive the HTTP request, set the name or IP address of the server here.  To specify the port that the proxy server uses to receive requests, see the <fl>ProxyPort</fl> field.</p>
       </description>
@@ -415,7 +415,7 @@ http.acActivate()
       <name>Realm</name>
       <comment>Identifies the realm during HTTP authentication.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>During the user authentication process, a realm name may be returned by the HTTP server and this will be reflected here.</p>
       </description>
@@ -478,7 +478,7 @@ http.acActivate()
       <name>UserAgent</name>
       <comment>Specifies the name of the user-agent string that is sent in HTTP requests.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>This field describes the <code>user-agent</code> value that will be sent in HTTP requests.  The default value is <code>Kotuku Client</code>.</p>
       </description>
@@ -488,7 +488,7 @@ http.acActivate()
       <name>Username</name>
       <comment>The username to use when authenticating access to the server.</comment>
       <access write="S">Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>A username can be preset before executing an HTTP method against a secure server zone.  The supplied credentials will only be passed to the HTTP server if it asks for authorisation.  The username provided should be accompanied by a <fl>Password</fl>.</p>
 <p>In the event that a username or password is not supplied, or if the supplied credentials are invalid, the user will be presented with a dialog box and asked to enter the correct username and password.</p>

--- a/include/kotuku/modules/http.h
+++ b/include/kotuku/modules/http.h
@@ -150,11 +150,11 @@ class objHTTP : public Object {
    int64_t  Index;           // Indicates the total bytes received during content transfer.
    int64_t  ContentLength;   // The byte length of incoming or outgoing content.
    int64_t  Size;            // Set this field to define the length of a data transfer when issuing a POST command.
-   STRING   Host;            // The targeted HTTP server is specified here, either by name or IP address.
-   STRING   Path;            // The HTTP path targeted at the host server.
-   STRING   OutputFile;      // To download HTTP content to a file, set a file path here.
-   STRING   InputFile;       // To upload HTTP content from a file, set a file path here.
-   STRING   UserAgent;       // Specifies the name of the user-agent string that is sent in HTTP requests.
+   std::string Host;         // The targeted HTTP server is specified here, either by name or IP address.
+   std::string Path;         // The HTTP path targeted at the host server.
+   std::string OutputFile;   // To download HTTP content to a file, set a file path here.
+   std::string InputFile;    // To upload HTTP content from a file, set a file path here.
+   std::string UserAgent;    // Specifies the name of the user-agent string that is sent in HTTP requests.
    OBJECTID InputObjectID;   // Allows data to be sent from an object on execution of a POST command.
    OBJECTID OutputObjectID;  // Incoming data can be sent to the object referenced in this field.
    HTM      Method;          // The HTTP instruction to execute (defaults to GET).
@@ -165,7 +165,7 @@ class objHTTP : public Object {
    ERR      Error;           // The error code received for the most recently executed HTTP command.
    DATA     Datatype;        // The default datatype format to use when passing data to a target object.
    HGS      CurrentState;    // Indicates the current state of an HTTP object during its interaction with an HTTP server.
-   STRING   ProxyServer;     // Route the HTTP request through the proxy server defined here.
+   std::string ProxyServer;  // Route the HTTP request through the proxy server defined here.
    int      ProxyPort;       // The port to use when communicating with a proxy server.
    int      BufferSize;      // Indicates the preferred buffer size for data operations.
 
@@ -239,34 +239,34 @@ class objHTTP : public Object {
       return ERR::Okay;
    }
 
-   template <class T> inline ERR setHost(T && Value) noexcept {
+   inline ERR setHost(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[25];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setOutputFile(T && Value) noexcept {
+   inline ERR setOutputFile(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[15];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setInputFile(T && Value) noexcept {
+   inline ERR setInputFile(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[16];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setUserAgent(T && Value) noexcept {
+   inline ERR setUserAgent(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setInputObject(OBJECTID Value) noexcept {
@@ -321,10 +321,10 @@ class objHTTP : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setProxyServer(T && Value) noexcept {
+   inline ERR setProxyServer(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[20];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setProxyPort(const int Value) noexcept {
@@ -344,10 +344,10 @@ class objHTTP : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setContentType(T && Value) noexcept {
+   inline ERR setContentType(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[21];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804308, &Value, 1);
    }
 
    inline ERR setIncoming(FUNCTION Value) noexcept {
@@ -356,10 +356,10 @@ class objHTTP : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setLocation(T && Value) noexcept {
+   inline ERR setLocation(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[34];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804308, &Value, 1);
    }
 
    inline ERR setOutgoing(FUNCTION Value) noexcept {
@@ -368,10 +368,10 @@ class objHTTP : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setRealm(T && Value) noexcept {
+   inline ERR setRealm(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804308, &Value, 1);
    }
 
    inline ERR setStateChanged(FUNCTION Value) noexcept {
@@ -380,17 +380,16 @@ class objHTTP : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setUsername(T && Value) noexcept {
+   inline ERR setUsername(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[37];
-      return field->WriteValue(target, field, 0x08800208, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804208, &Value, 1);
    }
 
-   template <class T> inline ERR setPassword(T && Value) noexcept {
+   inline ERR setPassword(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[17];
-      return field->WriteValue(target, field, 0x08800208, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804208, &Value, 1);
    }
 
 };
-

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -195,29 +195,27 @@ static bool is_valid_url_char(char Char, bool AllowReserved = false) {
 //********************************************************************************************************************
 // Enhanced URL encoding with validation
 
-static std::string encode_url_path(const char* Input)
+static std::string encode_url_path(std::string_view Input)
 {
-   if (!Input) return std::string();
-
    std::string result;
-   result.reserve(strlen(Input) * 3); // Worst case: every char becomes %XX
+   result.reserve(Input.size() * 3); // Worst case: every char becomes %XX
 
-   for (const char* p = Input; *p; p++) {
-      if (is_valid_url_char(*p, true)) {
-         result += *p;
+   for (const char ch : Input) {
+      if (is_valid_url_char(ch, true)) {
+         result += ch;
       }
-      else if (*p IS ' ') {
+      else if (ch IS ' ') {
          result += "%20";
       }
-      else if ((unsigned char)(*p) < 32 or (unsigned char)(*p) > 126) {
+      else if ((unsigned char)(ch) < 32 or (unsigned char)(ch) > 126) {
          // Encode control characters and non-ASCII
          char encoded[4];
-         snprintf(encoded, sizeof(encoded), "%%%02X", (unsigned char)(*p));
+         snprintf(encoded, sizeof(encoded), "%%%02X", (unsigned char)(ch));
          result += encoded;
       }
       else { // Other characters that need encoding
          char encoded[4];
-         snprintf(encoded, sizeof(encoded), "%%%02X", (unsigned char)(*p));
+         snprintf(encoded, sizeof(encoded), "%%%02X", (unsigned char)(ch));
          result += encoded;
       }
    }
@@ -417,8 +415,8 @@ static void writehex(HASH, HASHHEX);
 static void digest_calc_ha1(extHTTP *, HASHHEX);
 static void digest_calc_response(extHTTP *, std::string, CSTRING, HASHHEX, HASHHEX, HASHHEX);
 static void set_http_method(extHTTP *, CSTRING, std::ostringstream &);
-static ERR  SET_Path(extHTTP *, CSTRING);
-static ERR  SET_Location(extHTTP *, CSTRING);
+static ERR  SET_Path(extHTTP *, const std::string_view &);
+static ERR  SET_Location(extHTTP *, const std::string_view &);
 static ERR  http_timeout(extHTTP *, int64_t, int64_t);
 static void socket_feedback(objNetSocket *, NTC, APTR);
 static ERR  socket_incoming(objNetSocket *);
@@ -536,7 +534,8 @@ static ERR HTTP_Activate(extHTTP *Self)
 
    if (!Self->initialised()) return log.warning(ERR::NotInitialised);
 
-   log.branch("Host: %s, Port: %d, Path: %s, Proxy: %s, SSL: %d", Self->Host, Self->Port, Self->Path, Self->ProxyServer, ((Self->Flags & HTF::SSL) != HTF::NIL) ? 1 : 0);
+   log.branch("Host: %s, Port: %d, Path: %s, Proxy: %s, SSL: %d", Self->Host.c_str(), Self->Port,
+      Self->Path.c_str(), Self->ProxyServer.c_str(), ((Self->Flags & HTF::SSL) != HTF::NIL) ? 1 : 0);
 
    if (Self->TimeoutManager) { UpdateTimer(Self->TimeoutManager, 0); Self->TimeoutManager = 0; }
 
@@ -575,7 +574,7 @@ static ERR HTTP_Activate(extHTTP *Self)
 
    std::ostringstream cmd;
 
-   if ((Self->ProxyServer) and ((Self->Flags & HTF::SSL) != HTF::NIL) and (!Self->Socket)) {
+   if ((not Self->ProxyServer.empty()) and ((Self->Flags & HTF::SSL) != HTF::NIL) and (!Self->Socket)) {
       // SSL tunnelling is required.  Send a CONNECT request to the proxy and
       // then we will follow this up with the actual HTTP requests.
 
@@ -583,7 +582,7 @@ static ERR HTTP_Activate(extHTTP *Self)
 
       cmd << "CONNECT " << Self->Host << ":" << Self->Port << " HTTP/1.1" << CRLF;
       cmd << "Host: " << Self->Host << CRLF;
-      cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
+      cmd << "User-Agent: " << (Self->UserAgent.empty() ? "Kotuku Client" : Self->UserAgent.c_str()) << CRLF;
       cmd << "Proxy-Connection: keep-alive" << CRLF;
       cmd << "Connection: keep-alive" << CRLF;
 
@@ -641,10 +640,10 @@ static ERR HTTP_Activate(extHTTP *Self)
          }
       }
       else if (Self->Method IS HTM::OPTIONS) {
-         if ((!Self->Path) or ((Self->Path[0] IS '*') and (!Self->Path[1]))) {
+         if (Self->Path.empty() or (Self->Path IS "*")) {
             cmd << "OPTIONS * HTTP/1.1" << CRLF;
             cmd << "Host: " << Self->Host << CRLF;
-            cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
+            cmd << "User-Agent: " << (Self->UserAgent.empty() ? "Kotuku Client" : Self->UserAgent.c_str()) << CRLF;
          }
          else set_http_method(Self, "OPTIONS", cmd);
       }
@@ -672,7 +671,7 @@ static ERR HTTP_Activate(extHTTP *Self)
                // the developer should set ContentLength to -1.
 
             }
-            else if (Self->InputFile) {
+            else if (not Self->InputFile.empty()) {
                if (Self->MultipleInput) {
                   log.trace("Multiple input files detected.");
                   Self->InputPos = 0;
@@ -867,7 +866,9 @@ static ERR HTTP_Activate(extHTTP *Self)
 
    if (acWrite(Self->Socket, cstr.c_str(), cstr.length()) IS ERR::Okay) {
       if (Self->Socket->State IS NTC::DISCONNECTED) {
-         if (auto result = Self->Socket->connect(Self->ProxyServer ? Self->ProxyServer : Self->Host, Self->ProxyServer ? Self->ProxyPort : Self->Port, 5.0); result IS ERR::Okay) {
+         CSTRING server_host = Self->ProxyServer.empty() ? Self->Host.c_str() : Self->ProxyServer.c_str();
+         const int server_port = Self->ProxyServer.empty() ? Self->Port : Self->ProxyPort;
+         if (auto result = Self->Socket->connect(server_host, server_port, 5.0); result IS ERR::Okay) {
             Self->Connecting = true;
 
             if (Self->TimeoutManager) UpdateTimer(Self->TimeoutManager, Self->ConnectTimeout);
@@ -964,13 +965,6 @@ static ERR HTTP_Free(extHTTP *Self)
 
    if (Self->flInput)     { FreeResource(Self->flInput);     Self->flInput = nullptr; }
    if (Self->flOutput)    { FreeResource(Self->flOutput);    Self->flOutput = nullptr; }
-   if (Self->Path)        { FreeResource(Self->Path);        Self->Path = nullptr; }
-   if (Self->InputFile)   { FreeResource(Self->InputFile);   Self->InputFile = nullptr; }
-   if (Self->OutputFile)  { FreeResource(Self->OutputFile);  Self->OutputFile = nullptr; }
-   if (Self->Host)        { FreeResource(Self->Host);        Self->Host = nullptr; }
-   if (Self->UserAgent)   { FreeResource(Self->UserAgent);   Self->UserAgent = nullptr; }
-   if (Self->ProxyServer) { FreeResource(Self->ProxyServer); Self->ProxyServer = nullptr; }
-
    if (!Self->Password.empty()) {
       secure_clear_memory(const_cast<char*>(Self->Password.data()), Self->Password.size());
    }
@@ -1011,11 +1005,11 @@ static ERR HTTP_Init(extHTTP *Self)
    if (!Self->ProxyDefined) {
       std::lock_guard<std::mutex> proxy_lock(glProxyMutex);
       if ((glProxy) and (glProxy->find(Self->Port, true) IS ERR::Okay)) {
-         if (Self->ProxyServer) FreeResource(Self->ProxyServer);
-         Self->ProxyServer = kt::strclone(glProxy->Server);
+         if (glProxy->Server) Self->ProxyServer.assign(glProxy->Server);
+         else Self->ProxyServer.clear();
          Self->ProxyPort   = glProxy->ServerPort; // NB: Default is usually 8080
 
-         log.msg("Using preset proxy server '%s:%d'", Self->ProxyServer, Self->ProxyPort);
+         log.msg("Using preset proxy server '%s:%d'", Self->ProxyServer.c_str(), Self->ProxyPort);
       }
    }
    else log.msg("Proxy pre-defined by user.");
@@ -1089,11 +1083,11 @@ static const FieldArray clFields[] = {
    { "Index",          FDF_INT64|FDF_RW }, // Writeable only because we update it using SetField()
    { "ContentLength",  FDF_INT64|FDF_RW },
    { "Size",           FDF_INT64|FDF_RW },
-   { "Host",           FDF_STRING|FDF_RI, nullptr, SET_Host },
-   { "Path",           FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "OutputFile",     FDF_STRING|FDF_RW, nullptr, SET_OutputFile },
-   { "InputFile",      FDF_STRING|FDF_RW, nullptr, SET_InputFile },
-   { "UserAgent",      FDF_STRING|FDF_RW, GET_UserAgent, SET_UserAgent },
+   { "Host",           FDF_CPPSTRING|FDF_RI, nullptr, SET_Host },
+   { "Path",           FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "OutputFile",     FDF_CPPSTRING|FDF_RW, nullptr, SET_OutputFile },
+   { "InputFile",      FDF_CPPSTRING|FDF_RW, nullptr, SET_InputFile },
+   { "UserAgent",      FDF_CPPSTRING|FDF_RW, GET_UserAgent, SET_UserAgent },
    { "InputObject",    FDF_OBJECTID|FDF_RW },
    { "OutputObject",   FDF_OBJECTID|FDF_RW },
    { "Method",         FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SET_Method, &clHTTPMethod },
@@ -1104,23 +1098,23 @@ static const FieldArray clFields[] = {
    { "Error",          FDF_ERROR|FDF_RW },
    { "Datatype",       FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clHTTPDatatype },
    { "CurrentState",   FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SET_CurrentState, &clHTTPCurrentState },
-   { "ProxyServer",    FDF_STRING|FDF_RW, nullptr, SET_ProxyServer },
+   { "ProxyServer",    FDF_CPPSTRING|FDF_RW, nullptr, SET_ProxyServer },
    { "ProxyPort",      FDF_INT|FDF_RW },
    { "BufferSize",     FDF_INT|FDF_RW, nullptr, SET_BufferSize },
    // Virtual fields
    { "AuthCallback",   FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_AuthCallback, SET_AuthCallback },
-   { "ContentType",    FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_ContentType, SET_ContentType },
+   { "ContentType",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_ContentType, SET_ContentType },
    { "Incoming",       FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_Incoming, SET_Incoming },
-   { "Location",       FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_Location, SET_Location },
+   { "Location",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_Location, SET_Location },
    { "Outgoing",       FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_Outgoing, SET_Outgoing },
-   { "Realm",          FDF_VIRTUAL|FDF_STRING|FDF_RW,        GET_Realm, SET_Realm },
+   { "Realm",          FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_Realm, SET_Realm },
    { "RecvBuffer",     FDF_VIRTUAL|FDF_ARRAY|FDF_BYTE|FDF_R, GET_RecvBuffer },
    { "ResponseKeys",   FDF_VIRTUAL|FDF_ARRAY|FDF_STRING|FDF_ALLOC|FDF_R, GET_ResponseKeys },
-   { "Src",            FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FD_PRIVATE|FDF_RW, GET_Location, SET_Location }, // Deprecated by URL
-   { "URL",            FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FDF_RW, GET_Location, SET_Location },
+   { "Src",            FDF_VIRTUAL|FDF_CPPSTRING|FDF_SYNONYM|FD_PRIVATE|FDF_RW, GET_Location, SET_Location }, // Deprecated by URL
+   { "URL",            FDF_VIRTUAL|FDF_CPPSTRING|FDF_SYNONYM|FDF_RW, GET_Location, SET_Location },
    { "StateChanged",   FDF_VIRTUAL|FDF_FUNCTIONPTR|FDF_RW,   GET_StateChanged, SET_StateChanged },
-   { "Username",       FDF_VIRTUAL|FDF_STRING|FDF_W,         nullptr, SET_Username },
-   { "Password",       FDF_VIRTUAL|FDF_STRING|FDF_W,         nullptr, SET_Password },
+   { "Username",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,      nullptr, SET_Username },
+   { "Password",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,      nullptr, SET_Password },
    END_FIELD
 };
 

--- a/src/http/http.tdl
+++ b/src/http/http.tdl
@@ -113,11 +113,11 @@ module({ name="HTTP", copyright="Paul Manias © 2005-2026", version=1.0, timesta
    large Index            # Current read/write index, relative to content length so always starts from zero
    large ContentLength    # Content length as reported in the content length response field, -1 if streamed or unknown
    large Size             # Content size to use when sending data
-   str Host               # Host / Domain
-   str Path               # Path for file retrieval
-   str OutputFile         # Target file for downloaded content
-   str InputFile          # Source file for uploads
-   str UserAgent          # User agent to pass in the HTTP headers
+   cpp(str) Host          # Host / Domain
+   cpp(str) Path          # Path for file retrieval
+   cpp(str) OutputFile    # Target file for downloaded content
+   cpp(str) InputFile     # Source file for uploads
+   cpp(str) UserAgent     # User agent to pass in the HTTP headers
    oid InputObject        # An object to send HTTP content
    oid OutputObject       # An object to receive HTTP content
    int(HTM) Method        # HTTP Request: GET, HEAD, POST, PUT..
@@ -128,7 +128,7 @@ module({ name="HTTP", copyright="Paul Manias © 2005-2026", version=1.0, timesta
    error Error            # Result of the operation
    int(DATA) Datatype     # Datatype to use when sending HTTP data to a target object
    int(HGS) CurrentState  # Current state of the http get operation
-   str ProxyServer        # If using a proxy server, this is the name or IP address of the server
+   cpp(str) ProxyServer   # If using a proxy server, this is the name or IP address of the server
    int ProxyPort          # The port of the proxy server
    int BufferSize         # Preferred buffer size for things like outgoing operations (sending data)
   ]])

--- a/src/http/http_fields.cpp
+++ b/src/http/http_fields.cpp
@@ -76,16 +76,15 @@ The ContentType should be set prior to sending a `PUT` or `POST` request.  If `N
 
 *********************************************************************************************************************/
 
-static ERR GET_ContentType(extHTTP *Self, STRING *Value)
+static ERR GET_ContentType(extHTTP *Self, std::string_view &Value)
 {
-   *Value = Self->ContentType.data();
+   Value = Self->ContentType;
    return ERR::Okay;
 }
 
-static ERR SET_ContentType(extHTTP *Self, CSTRING Value)
+static ERR SET_ContentType(extHTTP *Self, const std::string_view &Value)
 {
-   if (Value) Self->ContentType.assign(Value);
-   else Self->ContentType.clear();
+   Self->ContentType.assign(Value);
    return ERR::Okay;
 }
 
@@ -192,10 +191,9 @@ The HTTP server to target for HTTP requests is defined here.  To change the host
 
 *********************************************************************************************************************/
 
-static ERR SET_Host(extHTTP *Self, CSTRING Value)
+static ERR SET_Host(extHTTP *Self, const std::string_view &Value)
 {
-   if (Self->Host) { FreeResource(Self->Host); Self->Host = nullptr; }
-   Self->Host = kt::strclone(Value);
+   Self->Host.assign(Value);
    return ERR::Okay;
 }
 
@@ -259,18 +257,17 @@ Multiple files can be specified in the InputFile field by separating each file p
 
 *********************************************************************************************************************/
 
-static ERR SET_InputFile(extHTTP *Self, CSTRING Value)
+static ERR SET_InputFile(extHTTP *Self, const std::string_view &Value)
 {
    kt::Log log;
 
-   log.trace("InputFile: %.80s", Value);
+   log.trace("InputFile: %.*s", int(std::min<size_t>(Value.size(), 80)), Value.data());
 
-   if (Self->InputFile) { FreeResource(Self->InputFile);  Self->InputFile = nullptr; }
-
+   Self->InputFile.clear();
    Self->MultipleInput = false;
    Self->InputPos = 0;
-   if ((Value) and (*Value)) {
-      Self->InputFile = kt::strclone(Value);
+   if (not Value.empty()) {
+      Self->InputFile.assign(Value);
 
       // Check if the path contains multiple inputs, separated by the pipe symbol.
 
@@ -312,7 +309,7 @@ An alternative to setting the Location is to set the #Host, #Path and #Port sepa
 
 *********************************************************************************************************************/
 
-static ERR GET_Location(extHTTP *Self, STRING *Value)
+static ERR GET_Location(extHTTP *Self, std::string_view &Value)
 {
    Self->AuthRetries = 0; // Reset the retry counter
 
@@ -327,49 +324,54 @@ static ERR GET_Location(extHTTP *Self, STRING *Value)
    else str << "http://" << Self->Host << ':' << Self->Port << '/' << Self->Path;
 
    Self->URI = str.str();
-   *Value = Self->URI.data();
+   Value = Self->URI;
    return ERR::Okay;
 }
 
-static ERR SET_Location(extHTTP *Self, CSTRING Value)
+static ERR SET_Location(extHTTP *Self, const std::string_view &Value)
 {
    kt::Log log;
 
-   if ((!Value) or (!*Value)) return ERR::InvalidValue;
+   if (Value.empty()) return ERR::InvalidValue;
 
-   CSTRING str = Value;
+   auto uri = Value;
    int new_port = 80;
    bool new_ssl = false;
 
-   if (kt::startswith("http://", str)) str += 7;
-   else if (kt::startswith("https://", str)) {
-      str += 8;
+   if (uri.starts_with("http://")) uri.remove_prefix(7);
+   else if (uri.starts_with("https://")) {
+      uri.remove_prefix(8);
       new_port = 443;
       new_ssl = true;
    }
    else return ERR::InvalidValue;
 
-   CSTRING host = str;
-   int len;
-   for (len=0; (str[len]) and (str[len] != ':') and (str[len] != '/'); len++);
-   if (!len) return ERR::InvalidValue;
+   auto host_len = uri.find_first_of(":/");
+   if (host_len IS std::string_view::npos) host_len = uri.size();
+   if (!host_len) return ERR::InvalidValue;
 
-   str += len;
+   auto host = uri.substr(0, host_len);
+   auto path = uri.substr(host_len);
 
-   if (*str IS ':') {
-      str++;
+   if ((!path.empty()) and (path.front() IS ':')) {
+      path.remove_prefix(1);
 
-      char *port_end = nullptr;
-      long port_long = strtol(str, &port_end, 10);
-      if ((port_end IS str) or (port_long <= 0) or (port_long > MAX_PORT_NUMBER)) return ERR::InvalidValue;
-      if ((*port_end) and (*port_end != '/')) return ERR::InvalidValue;
+      auto port_end = path.find('/');
+      auto port_text = path.substr(0, port_end);
+      if (port_text.empty()) return ERR::InvalidValue;
 
-      new_port = int(port_long);
+      int port_value = 0;
+      auto [ ptr, error ] = std::from_chars(port_text.data(), port_text.data() + port_text.size(), port_value);
+      if ((error != std::errc()) or (ptr != port_text.data() + port_text.size()) or
+            (port_value <= 0) or (port_value > MAX_PORT_NUMBER)) {
+         return ERR::InvalidValue;
+      }
+
+      new_port = port_value;
       if (new_port IS 443) new_ssl = true;
-      str = port_end;
-   }
 
-   while ((*str) and (*str != '/')) str++;
+      path = (port_end IS std::string_view::npos) ? std::string_view() : path.substr(port_end);
+   }
 
    if (Self->initialised()) {
       if (Self->TimeoutManager) { UpdateTimer(Self->TimeoutManager, 0); Self->TimeoutManager = 0; }
@@ -382,25 +384,19 @@ static ERR SET_Location(extHTTP *Self, CSTRING Value)
          Self->Socket = nullptr;
       }
 
-      log.msg("%s", Value);
+      log.msg("%.*s", int(Value.size()), Value.data());
    }
 
    Self->Port = new_port;
    if (new_ssl) Self->Flags |= HTF::SSL;
    else Self->Flags &= ~HTF::SSL;
 
-   if (Self->Host) { FreeResource(Self->Host); Self->Host = nullptr; }
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   Self->Host.assign(host);
+   Self->Path.clear();
 
-   if (AllocMemory(len+1, MEM::STRING|MEM::NO_CLEAR, &Self->Host) != ERR::Okay) {
-      return ERR::AllocMemory;
-   }
-
-   kt::copymem(host, Self->Host, len);
-   Self->Host[len] = 0;
-
-   if (*str) { // Parse absolute path
-      return SET_Path(Self, str+1);
+   if (not path.empty()) { // Parse absolute path
+      path.remove_prefix(1);
+      return SET_Path(Self, path);
    }
 
    return ERR::Okay;
@@ -480,10 +476,9 @@ been set in the #Flags field.
 
 *********************************************************************************************************************/
 
-static ERR SET_OutputFile(extHTTP *Self, CSTRING Value)
+static ERR SET_OutputFile(extHTTP *Self, const std::string_view &Value)
 {
-   if (Self->OutputFile) { FreeResource(Self->OutputFile); Self->OutputFile = nullptr; }
-   Self->OutputFile = kt::strclone(Value);
+   Self->OutputFile.assign(Value);
    return ERR::Okay;
 }
 
@@ -509,10 +504,8 @@ A `401` status code is returned in the event of an authorisation failure.
 
 *********************************************************************************************************************/
 
-static ERR SET_Password(extHTTP *Self, CSTRING Value)
+static ERR SET_Password(extHTTP *Self, const std::string_view &Value)
 {
-   if (!Value) return ERR::InvalidValue;
-
    Self->Password.assign(Value);
    Self->PasswordPreset = true;
    return ERR::Okay;
@@ -531,42 +524,40 @@ automatic conversions are operated when setting the Path field.
 
 *********************************************************************************************************************/
 
-static ERR SET_Path(extHTTP *Self, CSTRING Value)
+static ERR SET_Path(extHTTP *Self, const std::string_view &Value)
 {
    Self->AuthRetries = 0; // Reset the retry counter
 
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   Self->Path.clear();
 
-   if (!Value) return ERR::Okay;
+   if (Value.empty()) return ERR::Okay;
 
-   while (*Value IS '/') Value++; // Skip '/' prefix
+   auto path = Value;
+   while ((not path.empty()) and (path.front() IS '/')) path.remove_prefix(1); // Skip '/' prefix
 
-   std::string encoded_path = encode_url_path(Value);
+   std::string encoded_path = encode_url_path(path);
 
-   if (AllocMemory(encoded_path.length() + 1, MEM::STRING|MEM::NO_CLEAR, &Self->Path) IS ERR::Okay) {
-      kt::strcopy(encoded_path, Self->Path, encoded_path.length() + 1);
+   Self->Path.assign(encoded_path);
 
-      // Check if this path has been authenticated against the server yet by comparing it to AuthPath.  We need to
-      // do this if a PUT instruction is executed against the path and we're not authenticated yet.
+   // Check if this path has been authenticated against the server yet by comparing it to AuthPath.  We need to
+   // do this if a PUT instruction is executed against the path and we're not authenticated yet.
 
-      auto pview = std::string_view(Self->Path, encoded_path.length());
-      auto folder_len = pview.find_last_of('/');
-      if (folder_len IS std::string::npos) folder_len = 0;
+   auto pview = std::string_view(Self->Path.data(), Self->Path.size());
+   auto folder_len = pview.find_last_of('/');
+   if (folder_len IS std::string::npos) folder_len = 0;
 
-      Self->SecurePath = true;
-      if (!Self->AuthPath.empty()) {
-         if (Self->AuthPath.size() IS folder_len) {
-            pview.remove_suffix(pview.size() - folder_len);
-            if (pview IS Self->AuthPath) { // No change to the current path
-               Self->SecurePath = false;
-            }
+   Self->SecurePath = true;
+   if (!Self->AuthPath.empty()) {
+      if (Self->AuthPath.size() IS folder_len) {
+         pview.remove_suffix(pview.size() - folder_len);
+         if (pview IS Self->AuthPath) { // No change to the current path
+            Self->SecurePath = false;
          }
       }
-
-      Self->AuthPath.assign(Self->Path, folder_len);
-      return ERR::Okay;
    }
-   else return ERR::AllocMemory;
+
+   Self->AuthPath.assign(Self->Path, 0, folder_len);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -590,10 +581,9 @@ that the proxy server uses to receive requests, see the #ProxyPort field.
 
 *********************************************************************************************************************/
 
-static ERR SET_ProxyServer(extHTTP *Self, CSTRING Value)
+static ERR SET_ProxyServer(extHTTP *Self, const std::string_view &Value)
 {
-   if (Self->ProxyServer) { FreeResource(Self->ProxyServer); Self->ProxyServer = nullptr; }
-   if ((Value) and (Value[0])) Self->ProxyServer = kt::strclone(Value);
+   Self->ProxyServer.assign(Value);
    Self->ProxyDefined = true;
    return ERR::Okay;
 }
@@ -608,17 +598,15 @@ here.
 
 *********************************************************************************************************************/
 
-static ERR GET_Realm(extHTTP *Self, CSTRING *Value)
+static ERR GET_Realm(extHTTP *Self, std::string_view &Value)
 {
-   if (Self->Realm.empty()) *Value = nullptr;
-   else *Value = Self->Realm.c_str();
+   Value = Self->Realm;
    return ERR::Okay;
 }
 
-static ERR SET_Realm(extHTTP *Self, CSTRING Value)
+static ERR SET_Realm(extHTTP *Self,  const std::string_view &Value)
 {
-   if (Value) Self->Realm.assign(Value);
-   else Self->Realm.clear();
+   Self->Realm.assign(Value);
    return ERR::Okay;
 }
 
@@ -740,17 +728,16 @@ This field describes the `user-agent` value that will be sent in HTTP requests. 
 
 *********************************************************************************************************************/
 
-static ERR GET_UserAgent(extHTTP *Self, CSTRING *Value)
+static ERR GET_UserAgent(extHTTP *Self, std::string_view &Value)
 {
-   if (Self->UserAgent) *Value = Self->UserAgent;
-   else *Value = "Kotuku Client";
+   if (Self->UserAgent.empty()) Value = "Kotuku Client";
+   else Value = std::string_view(Self->UserAgent.data(), Self->UserAgent.size());
    return ERR::Okay;
 }
 
-static ERR SET_UserAgent(extHTTP *Self, CSTRING Value)
+static ERR SET_UserAgent(extHTTP *Self,  const std::string_view &Value)
 {
-   if (Self->UserAgent) { FreeResource(Self->UserAgent); Self->UserAgent = nullptr; }
-   Self->UserAgent = kt::strclone(Value);
+   Self->UserAgent.assign(Value);
    return ERR::Okay;
 }
 
@@ -769,10 +756,8 @@ presented with a dialog box and asked to enter the correct username and password
 
 *********************************************************************************************************************/
 
-static ERR SET_Username(extHTTP *Self, CSTRING Value)
+static ERR SET_Username(extHTTP *Self, const std::string_view &Value)
 {
-   if (!Value) return ERR::InvalidValue;
-
    Self->Username.assign(Value);
    return ERR::Okay;
 }

--- a/src/http/http_functions.cpp
+++ b/src/http/http_functions.cpp
@@ -530,22 +530,22 @@ static ERR check_incoming_end(extHTTP *Self)
 
 static void set_http_method(extHTTP *Self, CSTRING Method, std::ostringstream &Cmd)
 {
-   if ((Self->ProxyServer) and ((Self->Flags & HTF::SSL) IS HTF::NIL)) {
+   if ((not Self->ProxyServer.empty()) and ((Self->Flags & HTF::SSL) IS HTF::NIL)) {
       // Normal proxy request without SSL tunneling
       Cmd << Method << " " << ((Self->Port IS 443) ? "https" : "http") << "://" << Self->Host << ":" <<
-         Self->Port << "/" << (Self->Path ? Self->Path : "") << " HTTP/1.1" << CRLF;
+         Self->Port << "/" << Self->Path << " HTTP/1.1" << CRLF;
    }
-   else Cmd << Method << " /" << (Self->Path ? Self->Path : (STRING)"") << " HTTP/1.1" << CRLF;
+   else Cmd << Method << " /" << Self->Path << " HTTP/1.1" << CRLF;
 
    Cmd << "Host: " << Self->Host << CRLF;
-   Cmd << "User-Agent: " << (Self->UserAgent ? Self->UserAgent : "Kotuku Client") << CRLF;
+   Cmd << "User-Agent: " << (Self->UserAgent.empty() ? "Kotuku Client" : Self->UserAgent.c_str()) << CRLF;
 }
 
 //********************************************************************************************************************
 
   static ERR parse_file(extHTTP *Self, std::string &Buffer)
   {
-     const char *file = Self->InputFile;
+     auto file = Self->InputFile.c_str();
      auto pos = Self->InputPos;
      while (char ch = file[pos]) {
         if (ch IS '"') {

--- a/src/http/http_incoming.cpp
+++ b/src/http/http_incoming.cpp
@@ -726,7 +726,7 @@ static ERR parse_response(extHTTP *Self, std::string_view Response)
    if (error IS std::errc()) Self->Status = HTS(code);
    else Self->Status = HTS::NIL;
 
-   if (Self->ProxyServer) Self->ContentLength = -1; // Some proxy servers (Squid) strip out information like 'transfer-encoding' yet pass all the requested content anyway :-/
+   if (not Self->ProxyServer.empty()) Self->ContentLength = -1; // Some proxy servers (Squid) strip out information like 'transfer-encoding' yet pass all the requested content anyway :-/
    else Self->ContentLength = 0;
    Self->Chunked = false;
 
@@ -812,7 +812,7 @@ static ERR output_incoming_data(extHTTP *Self, APTR Buffer, int Length)
 
    Self->setIndex(Self->Index + Length); // Use Set() so that field subscribers can track progress with field monitoring
 
-   if ((!Self->flOutput) and (Self->OutputFile)) {
+   if ((!Self->flOutput) and (not Self->OutputFile.empty())) {
       FL flags;
       LOC type;
 


### PR DESCRIPTION
* Replaced HTTP string field declarations and generated accessors with cpp(str), FDF_CPPSTRING and std::string_view field handlers
* Updated URL, path, proxy and user-agent handling to work with std::string-backed storage
* [AI] Refined C++ string field conversion guidance for setter/getter signatures and placement construction