### PR TITLE
[Document] Convert string fields to C++ string storage

### DIFF
--- a/.agents/skills/cpp-string-field-conversion/SKILL.md
+++ b/.agents/skills/cpp-string-field-conversion/SKILL.md
@@ -19,7 +19,8 @@ The Config class conversion is the model for this skill:
 - TDL field declarations change from `str Field` to `cpp(str) Field`.
 - C++ body members change from `STRING`/`CSTRING` pointer-style fields to `std::string`.
 - All field array entries change from `FDF_STRING` to `FDF_CPPSTRING` unless there is a good reason for an exception.
-- Field setter/getter callbacks use `std::string_view &Value` instead of `CSTRING Value` or `CSTRING *Value`.
+- Field getter callbacks use `std::string_view &Value` instead of `CSTRING Value`
+- Field setter callbacks use `const std::string_view &Value` instead of `CSTRING *Value`.
 - Manual `strclone()` and `FreeResource()` ownership disappears for converted string fields.
 - `AC::NewObject` changes to `AC::NewPlacement`, with placement construction of the object body.
 - `AC::Free` calls the class destructor after any custom save/release logic has run.

--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -426,8 +426,8 @@
     <field>
       <name>Author</name>
       <comment>The author(s) of the document.</comment>
-      <access read="R">Read</access>
-      <type>STRING</type>
+      <access read="G">Get</access>
+      <type>std::string</type>
       <description>
 <p>If a document declares the names of its author(s) under a head tag, the author string will be readable from this field. This field is always <code>NULL</code> if a document does not declare an author string.</p>
       </description>
@@ -447,8 +447,8 @@
     <field>
       <name>Copyright</name>
       <comment>Copyright information for the document.</comment>
-      <access read="R">Read</access>
-      <type>STRING</type>
+      <access read="G">Get</access>
+      <type>std::string</type>
       <description>
 <p>If a document declares copyright information under a head tag, the copyright string will be readable from this field. This field is always <code>NULL</code> if a document does not declare a copyright string.</p>
       </description>
@@ -457,8 +457,8 @@
     <field>
       <name>Description</name>
       <comment>A description of the document, provided by its author.</comment>
-      <access read="R">Read</access>
-      <type>STRING</type>
+      <access read="G">Get</access>
+      <type>std::string</type>
       <description>
 <p>If the source document includes a description, it will be copied to this field.</p>
       </description>
@@ -521,8 +521,8 @@
     <field>
       <name>Keywords</name>
       <comment>Includes keywords declared by the source document.</comment>
-      <access read="R">Read</access>
-      <type>STRING</type>
+      <access read="G">Get</access>
+      <type>std::string</type>
       <description>
 <p>If a document declares keywords under a head tag, the keywords string will be readable from this field.   This field is always <code>NULL</code> if a document does not declare any keywords.  It is recommended that keywords are separated with spaces or commas.  It should not be assumed that the author of the document has adhered to the accepted standard for keyword separation.</p>
       </description>
@@ -609,8 +609,8 @@
     <field>
       <name>Title</name>
       <comment>The title of the document.</comment>
-      <access read="R">Read</access>
-      <type>STRING</type>
+      <access read="G">Get</access>
+      <type>std::string</type>
       <description>
 <p>If a document declares a title under a head tag, the title string will be readable from this field.   This field is always <code>NULL</code> if a document does not declare a title.</p>
       </description>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3546,10 +3546,10 @@ class objModule : public Object {
       return ERR::Okay;
    }
 
-   template <class T> inline ERR setName(T && Value) noexcept {
+   inline ERR setName(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
 };

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -117,11 +117,11 @@ class objDocument : public Object {
 
    using create = kt::Create<objDocument>;
 
-   STRING   Description;            // A description of the document, provided by its author.
-   STRING   Title;                  // The title of the document.
-   STRING   Author;                 // The author(s) of the document.
-   STRING   Copyright;              // Copyright information for the document.
-   STRING   Keywords;               // Includes keywords declared by the source document.
+   std::string Description;         // A description of the document, provided by its author.
+   std::string Title;               // The title of the document.
+   std::string Author;              // The author(s) of the document.
+   std::string Copyright;           // Copyright information for the document.
+   std::string Keywords;            // Includes keywords declared by the source document.
    objVectorViewport * Viewport;    // A client-specific viewport that will host the document graphics.
    objVectorViewport * Focus;       // Refers to the object that will be monitored for user focusing.
    objVectorViewport * View;        // The viewing area of the document.
@@ -268,16 +268,16 @@ class objDocument : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setOrigin(T && Value) noexcept {
+   inline ERR setOrigin(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[3];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setPageWidth(const int Value) noexcept {

--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -1129,7 +1129,7 @@ static ERR GET_Device(extAudio *Self, std::string_view &Value)
    else return ERR::FieldNotSet;
 }
 
-static ERR SET_Device(extAudio *Self, std::string_view &Value)
+static ERR SET_Device(extAudio *Self, const std::string_view &Value)
 {
    if (Value.empty()) Self->Device = "default";
    else {

--- a/src/core/classes/class_module.cpp
+++ b/src/core/classes/class_module.cpp
@@ -93,11 +93,11 @@ static void free_module(MODHANDLE handle);
 
 //********************************************************************************************************************
 
-static ERR GET_Defs(extModule *, CSTRING *);
-static ERR GET_Name(extModule *, CSTRING *);
+static ERR GET_Defs(extModule *, std::string_view &);
+static ERR GET_Name(extModule *, std::string_view &);
 
 static ERR SET_Header(extModule *, struct ModHeader *);
-static ERR SET_Name(extModule *, CSTRING);
+static ERR SET_Name(extModule *, const std::string_view &);
 
 static const FieldDef clFlags[] = {
    { "LinkLibrary", MOF::LINK_LIBRARY },
@@ -112,8 +112,8 @@ static const FieldArray glModuleFields[] = {
    { "Header",       FDF_POINTER|FDF_STRUCT|FDF_RI, nullptr, SET_Header, "ModHeader" }, // For creating virtual modules only
    { "Flags",        FDF_INT|FDF_RI, nullptr, nullptr, &clFlags },
    // Virtual fields
-   { "Defs",         FDF_STRING|FDF_R, GET_Defs },
-   { "Name",         FDF_STRING|FDF_RI, GET_Name, SET_Name },
+   { "Defs",         FDF_CPPSTRING|FDF_R, GET_Defs },
+   { "Name",         FDF_CPPSTRING|FDF_RI, GET_Name, SET_Name },
    END_FIELD
 };
 
@@ -590,10 +590,10 @@ Returns the IDL definition string that was compiled from the module's TDL file. 
 
 **********************************************************************************************************************/
 
-static ERR GET_Defs(extModule *Self, CSTRING *Value)
+static ERR GET_Defs(extModule *Self, std::string_view &Value)
 {
-   if ((Self->Root) and (Self->Root->Header)) *Value = Self->Root->Header->Definitions;
-   else *Value = nullptr;
+   if ((Self->Root) and (Self->Root->Header)) Value = Self->Root->Header->Definitions;
+   else Value = std::string{};
    return ERR::Okay;
 }
 
@@ -657,15 +657,15 @@ may use a `.dll` extension.
 
 **********************************************************************************************************************/
 
-static ERR GET_Name(extModule *Self, CSTRING *Value)
+static ERR GET_Name(extModule *Self, std::string_view &Value)
 {
-   *Value = Self->Name.c_str();
+   Value = Self->Name;
    return ERR::Okay;
 }
 
-static ERR SET_Name(extModule *Self, CSTRING Name)
+static ERR SET_Name(extModule *Self, const std::string_view &Name)
 {
-   if (!Name) return ERR::Okay;
+   if (Name.empty()) return ERR::Okay;
 
    Self->Name.assign(Name);
    std::transform(Self->Name.begin(), Self->Name.end(), Self->Name.begin(),

--- a/src/core/classes/class_module.cpp
+++ b/src/core/classes/class_module.cpp
@@ -593,7 +593,7 @@ Returns the IDL definition string that was compiled from the module's TDL file. 
 static ERR GET_Defs(extModule *Self, std::string_view &Value)
 {
    if ((Self->Root) and (Self->Root->Header)) Value = Self->Root->Header->Definitions;
-   else Value = std::string{};
+   else Value = std::string_view{};
    return ERR::Okay;
 }
 

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -2074,11 +2074,11 @@ static ERR DOCUMENT_ShowIndex(extDocument *Self, doc::ShowIndex *Args)
 #include "document_def.c"
 
 static const FieldArray clFields[] = {
-   { "Description",  FDF_STRING|FDF_R },
-   { "Title",        FDF_STRING|FDF_R },
-   { "Author",       FDF_STRING|FDF_R },
-   { "Copyright",    FDF_STRING|FDF_R },
-   { "Keywords",     FDF_STRING|FDF_R },
+   { "Description",  FDF_CPPSTRING|FDF_R },
+   { "Title",        FDF_CPPSTRING|FDF_R },
+   { "Author",       FDF_CPPSTRING|FDF_R },
+   { "Copyright",    FDF_CPPSTRING|FDF_R },
+   { "Keywords",     FDF_CPPSTRING|FDF_R },
    { "Viewport",     FDF_OBJECT|FDF_RW, nullptr, SET_Viewport, CLASSID::VECTORVIEWPORT },
    { "Focus",        FDF_OBJECT|FDF_RI, nullptr, nullptr, CLASSID::VECTORVIEWPORT },
    { "View",         FDF_OBJECT|FDF_R, nullptr, nullptr, CLASSID::VECTORVIEWPORT },
@@ -2091,11 +2091,11 @@ static const FieldArray clFields[] = {
    // Virtual fields
    { "ClientScript",  FDF_OBJECT|FDF_I,        nullptr, SET_ClientScript },
    { "EventCallback", FDF_FUNCTIONPTR|FDF_RW,  GET_EventCallback, SET_EventCallback },
-   { "Path",          FDF_STRING|FDF_RW,       GET_Path, SET_Path },
-   { "Origin",        FDF_STRING|FDF_RW,       GET_Path, SET_Origin },
+   { "Path",          FDF_CPPSTRING|FDF_RW,    GET_Path, SET_Path },
+   { "Origin",        FDF_CPPSTRING|FDF_RW,    GET_Path, SET_Origin },
    { "PageWidth",     FDF_UNIT|FDF_INT|FDF_SCALED|FDF_RW, GET_PageWidth, SET_PageWidth },
    { "Pretext",       FDF_STRING|FDF_W,        nullptr, SET_Pretext },
-   { "Src",           FDF_SYNONYM|FDF_STRING|FDF_RW, GET_Path, SET_Path },
-   { "WorkingPath",   FDF_STRING|FDF_R,        GET_WorkingPath, nullptr },
+   { "Src",           FDF_SYNONYM|FDF_CPPSTRING|FDF_RW, GET_Path, SET_Path },
+   { "WorkingPath",   FDF_CPPSTRING|FDF_R,     GET_WorkingPath, nullptr },
    END_FIELD
 };

--- a/src/document/class/fields.cpp
+++ b/src/document/class/fields.cpp
@@ -155,23 +155,23 @@ Other means of opening a document include loading the data manually and passing 
 
 *********************************************************************************************************************/
 
-static ERR GET_Path(extDocument *Self, CSTRING *Value)
+static ERR GET_Path(extDocument *Self, std::string_view &Value)
 {
-   *Value = Self->Path.c_str();
+   Value = Self->Path;
    return ERR::Okay;
 }
 
-static ERR SET_Path(extDocument *Self, CSTRING Value)
+static ERR SET_Path(extDocument *Self, const std::string_view &Value)
 {
    kt::Log log;
 
-   if ((!Value) or (!*Value)) return ERR::NoData;
+   if (Value.empty()) return ERR::NoData;
    if (Self->PathGuard) return log.warning(ERR::Recursion);
 
    Self->PathGuard = true;
 
    Self->Error = ERR::Okay;
-   auto value = std::string_view(Value);
+   auto value = Value;
 
    std::string newpath;
    if ((value[0] IS '#') or (value[0] IS '?')) {
@@ -243,10 +243,9 @@ changed without causing a load operation.
 
 *********************************************************************************************************************/
 
-static ERR SET_Origin(extDocument *Self, CSTRING Value)
+static ERR SET_Origin(extDocument *Self, const std::string_view &Value)
 {
-   Self->Path.clear();
-   if ((Value) and (*Value)) Self->Path.assign(Value);
+   Self->Path.assign(Value);
    return ERR::Okay;
 }
 
@@ -396,7 +395,7 @@ The client can manually change the working path by setting the #Origin field wit
 
 *********************************************************************************************************************/
 
-static ERR GET_WorkingPath(extDocument *Self, CSTRING *Value)
+static ERR GET_WorkingPath(extDocument *Self, std::string_view &Value)
 {
    kt::Log log;
 
@@ -410,38 +409,30 @@ static ERR GET_WorkingPath(extDocument *Self, CSTRING *Value)
    // Determine if an absolute path has been indicated
 
    bool path = false;
-   if (Self->Path[0] IS '/') path = true;
+   if (Self->Path.starts_with('/')) path = true;
    else {
-     for (int j=0; (Self->Path[j]) and (Self->Path[j] != '/') and (Self->Path[j] != '\\'); j++) {
-         if (Self->Path[j] IS ':') {
-            path = true;
-            break;
-         }
-      }
+      int j = Self->Path.find_first_of(":/\\");
+      if ((j != std::string::npos) and (Self->Path[j] IS ':')) path = true;
    }
 
-   int j = 0;
-   for (int k=0; Self->Path[k]; k++) {
-      if ((Self->Path[k] IS ':') or (Self->Path[k] IS '/') or (Self->Path[k] IS '\\')) j = k+1;
-   }
+   int last_sep = Self->Path.find_last_of(":/\\");
+   if (last_sep != std::string::npos) last_sep++;
 
    kt::SwitchContext context(Self);
 
-   CSTRING task_path;
+   std::string_view task_path;
    if (path) { // Extract absolute path
-      Self->WorkingPath.assign(Self->Path, 0, j);
+      Self->WorkingPath.assign(Self->Path, 0, last_sep);
    }
-   else if ((CurrentTask()->get(FID_Path, task_path) IS ERR::Okay) and (task_path)) {
-      std::string buf(task_path);
-
+   else if (CurrentTask()->get(FID_Path, task_path); not task_path.empty()) {
       // Using ResolvePath() can help to determine relative paths such as "../path/file"
 
-      if (j > 0) buf += Self->Path.substr(0, j);
-
+      std::string buf(task_path);
+      if (last_sep > 0) buf += Self->Path.substr(0, last_sep);
       ResolvePath(buf, RSF::APPROXIMATE, &Self->WorkingPath);
    }
-   else { *Value = nullptr; return ERR::NoData; }
+   else return ERR::NoData;
 
-   *Value = Self->WorkingPath.c_str();
+   Value = Self->WorkingPath;
    return ERR::Okay;
 }

--- a/src/document/defs/document.tdl
+++ b/src/document/defs/document.tdl
@@ -72,11 +72,11 @@ module({ name="Document", copyright="Paul Manias © 2005-2026", version=1.0, tim
   })
 
   klass("Document", { src={ "../class/document_class.cpp", "../class/fields.cpp" }, output="../class/document_def.c" }, [[
-    str Description      # A description assigned by the author of the document
-    str Title            # The title of the document
-    str Author           # The author of the document
-    str Copyright        # Copyright information for the document
-    str Keywords         # Keywords for the document
+    cpp(str) Description # A description assigned by the author of the document
+    cpp(str) Title       # The title of the document
+    cpp(str) Author      # The author of the document
+    cpp(str) Copyright   # Copyright information for the document
+    cpp(str) Keywords    # Keywords for the document
     obj(VectorViewport) Viewport  # The viewport that will host the document
     obj(VectorViewport) Focus     # Monitor this viewport for focus events
     obj(VectorViewport) View      # An internally created viewport that hosts the Page

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -166,7 +166,7 @@ static ERR  unload_doc(extDocument *, ULD = ULD::NIL);
 static bool valid_objectid(extDocument *, OBJECTID);
 static bool view_area(extDocument *, double, double, double, double);
 
-static ERR GET_WorkingPath(extDocument *, CSTRING *);
+static ERR GET_WorkingPath(extDocument *, std::string_view &);
 
 #ifdef DBG_STREAM
 static void print_stream(RSTREAM &);

--- a/src/document/functions.cpp
+++ b/src/document/functions.cpp
@@ -449,12 +449,12 @@ static ERR unload_doc(extDocument *Self, ULD Flags)
 
    if (Self->terminating()) Self->Vars.clear();
 
-   if (Self->SVG)         { FreeResource(Self->SVG);         Self->SVG = nullptr; }
-   if (Self->Keywords)    { FreeResource(Self->Keywords);    Self->Keywords = nullptr; }
-   if (Self->Author)      { FreeResource(Self->Author);      Self->Author = nullptr; }
-   if (Self->Copyright)   { FreeResource(Self->Copyright);   Self->Copyright = nullptr; }
-   if (Self->Description) { FreeResource(Self->Description); Self->Description = nullptr; }
-   if (Self->Title)       { FreeResource(Self->Title);       Self->Title = nullptr; }
+   if (Self->SVG) { FreeResource(Self->SVG); Self->SVG = nullptr; }
+   Self->Keywords.clear();
+   Self->Author.clear();
+   Self->Copyright.clear();
+   Self->Description.clear();
+   Self->Title.clear();
 
    // Free templates only if they have been modified (no longer at the default settings)
    // or if the document is being destroyed.

--- a/src/document/parsing.cpp
+++ b/src/document/parsing.cpp
@@ -2055,37 +2055,21 @@ void parser::tag_head(const tag_view &Tag)
    // The head contains information about the document
 
    for (auto &scan : Tag.Children) {
-      // Anything allocated here needs to be freed in unload_doc()
       std::string_view name = scan.name();
       if ("title" IS name) {
-         if (scan.hasContent()) {
-            if (Self->Title) FreeResource(Self->Title);
-            Self->Title = kt::strclone(scan.Children[0].Attribs[0].Value);
-         }
+         if (scan.hasContent()) Self->Title.assign(scan.Children[0].Attribs[0].Value);
       }
       else if ("author" IS name) {
-         if (scan.hasContent()) {
-            if (Self->Author) FreeResource(Self->Author);
-            Self->Author = kt::strclone(scan.Children[0].Attribs[0].Value);
-         }
+         if (scan.hasContent()) Self->Author.assign(scan.Children[0].Attribs[0].Value);
       }
       else if ("copyright" IS name) {
-         if (scan.hasContent()) {
-            if (Self->Copyright) FreeResource(Self->Copyright);
-            Self->Copyright = kt::strclone(scan.Children[0].Attribs[0].Value);
-         }
+         if (scan.hasContent()) Self->Copyright.assign(scan.Children[0].Attribs[0].Value);
       }
       else if ("keywords" IS name) {
-         if (scan.hasContent()) {
-            if (Self->Keywords) FreeResource(Self->Keywords);
-            Self->Keywords = kt::strclone(scan.Children[0].Attribs[0].Value);
-         }
+         if (scan.hasContent()) Self->Keywords.assign(scan.Children[0].Attribs[0].Value);
       }
       else if ("description" IS name) {
-         if (scan.hasContent()) {
-            if (Self->Description) FreeResource(Self->Description);
-            Self->Description = kt::strclone(scan.Children[0].Attribs[0].Value);
-         }
+         if (scan.hasContent()) Self->Description.assign(scan.Children[0].Attribs[0].Value);
       }
       else log_hint(&scan, "doc.unknown-head-tag", "Unknown head tag '{}'.", name);
    }

--- a/src/document/parsing_xquery.cpp
+++ b/src/document/parsing_xquery.cpp
@@ -272,11 +272,11 @@ static XPathValue xq_meta_to_map(const extDocument *Self)
    XPathValue result(XPVT::Map);
    result.map_storage = std::make_shared<XPathMapStorage>();
 
-   if (Self->Title)       xq_map_append_string(result.map_storage, "title", Self->Title);
-   if (Self->Author)      xq_map_append_string(result.map_storage, "author", Self->Author);
-   if (Self->Description) xq_map_append_string(result.map_storage, "description", Self->Description);
-   if (Self->Copyright)   xq_map_append_string(result.map_storage, "copyright", Self->Copyright);
-   if (Self->Keywords)    xq_map_append_string(result.map_storage, "keywords", Self->Keywords);
+   if (not Self->Title.empty())       xq_map_append_string(result.map_storage, "title", Self->Title);
+   if (not Self->Author.empty())      xq_map_append_string(result.map_storage, "author", Self->Author);
+   if (not Self->Description.empty()) xq_map_append_string(result.map_storage, "description", Self->Description);
+   if (not Self->Copyright.empty())   xq_map_append_string(result.map_storage, "copyright", Self->Copyright);
+   if (not Self->Keywords.empty())    xq_map_append_string(result.map_storage, "keywords", Self->Keywords);
    if (not Self->Path.empty()) xq_map_append_string(result.map_storage, "path", Self->Path);
    xq_map_append_number(result.map_storage, "line-no", double(Self->Segments.size()));
 


### PR DESCRIPTION
## Summary
* Converted Document metadata fields to cpp(str) / std::string storage
* Updated Document path-related field glue to FDF_CPPSTRING
* Removed manual allocation/release handling for converted metadata strings
* Updated generated Document API documentation

## Validation
* cmake --build build/agents --config Debug --target document --parallel
* cmake --install build/agents --config Debug

Flute, ctest, and integration tests were intentionally not run for this string field conversion.