### PR TITLE
[Vector] Converted string fields to C++ storage

### DIFF
--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -943,10 +943,10 @@ class objVectorPattern : public Object {
       return field->WriteValue(target, field, 0x08000318, Value, 1);
    }
 
-   template <class T> inline ERR setTransform(T && Value) noexcept {
+   inline ERR setTransform(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[18];
-      return field->WriteValue(target, field, 0x08800208, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804200, &Value, 1);
    }
 
 };
@@ -2376,10 +2376,10 @@ class objVector : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setSID(T && Value) noexcept {
+   inline ERR setSID(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[21];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setResizeEvent(const FUNCTION Value) noexcept {
@@ -2388,10 +2388,10 @@ class objVector : public Object {
       return field->WriteValue(target, field, FD_FUNCTION, &Value, 1);
    }
 
-   template <class T> inline ERR setStroke(T && Value) noexcept {
+   inline ERR setStroke(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setStrokeColour(const float * Value, int Elements) noexcept {
@@ -2413,10 +2413,10 @@ class objVector : public Object {
       return field->WriteValue(target, field, 0x08000309, Value, 1);
    }
 
-   template <class T> inline ERR setFill(T && Value) noexcept {
+   inline ERR setFill(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setFillColour(const float * Value, int Elements) noexcept {
@@ -2431,10 +2431,10 @@ class objVector : public Object {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setFilter(T && Value) noexcept {
+   inline ERR setFilter(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[3];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setLineJoin(const int Value) noexcept {
@@ -2589,10 +2589,10 @@ class objVectorText : public objVector {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setString(T && Value) noexcept {
+   inline ERR setString(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setAlign(const int Value) noexcept {
@@ -2601,28 +2601,28 @@ class objVectorText : public objVector {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setFace(T && Value) noexcept {
+   inline ERR setFace(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[21];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setFill(T && Value) noexcept {
+   inline ERR setFill(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setFontSize(T && Value) noexcept {
+   inline ERR setFontSize(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[7];
-      return field->WriteValue(target, field, 0x08800328, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setFontStyle(T && Value) noexcept {
+   inline ERR setFontStyle(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(target, field, 0x08800508, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
    inline ERR setDX(const double * Value, int Elements) noexcept {
@@ -2971,10 +2971,10 @@ class objVectorPolygon : public objVector {
       return field->WriteValue(target, field, 0x08001308, Value, Elements);
    }
 
-   template <class T> inline ERR setPoints(T && Value) noexcept {
+   inline ERR setPoints(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(target, field, 0x08800208, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804200, &Value, 1);
    }
 
    inline ERR setX1(const double Value) noexcept {

--- a/src/vector/colourmaps.cpp
+++ b/src/vector/colourmaps.cpp
@@ -1,6 +1,6 @@
 // TODO: These colour maps should be reduced from FRGB to RGB16 to cut resource usage by half.
 
-ankerl::unordered_dense::map<std::string, std::array<FRGB, 256>> glColourMaps = {
+ColourMapTable glColourMaps = {
   { "cmap:rocket", {{
     { 0.01060815, 0.01808215, 0.10018654 },
     { 0.01428972, 0.02048237, 0.10374486 },

--- a/src/vector/filters/filter.cpp
+++ b/src/vector/filters/filter.cpp
@@ -721,7 +721,7 @@ is allocated and must be freed once no longer in use.
 
 *********************************************************************************************************************/
 
-static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, CSTRING *Value)
+static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, std::string_view &Value)
 {
    std::stringstream ss;
 
@@ -735,7 +735,11 @@ static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, CSTRING *Value)
       ss << "/>";
    }
 
-   if ((*Value = strclone(ss.str()))) return ERR::Okay;
+   auto cppstr = ss.str();
+   if (auto str = strclone(cppstr)) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
    else return ERR::AllocMemory;
 }
 
@@ -954,7 +958,7 @@ static const FieldArray clFilterFields[] = {
    { "ColourSpace",    FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorFilterColourSpace },
    { "AspectRatio",    FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorFilterAspectRatio },
    // Virtual fields
-   { "EffectXML",      FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, VECTORFILTER_GET_EffectXML },
+   { "EffectXML",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTORFILTER_GET_EffectXML },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_blur.cpp
+++ b/src/vector/filters/filter_blur.cpp
@@ -456,12 +456,16 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR BLURFX_GET_XMLDef(extBlurFX *Self, STRING *Value)
+static ERR BLURFX_GET_XMLDef(extBlurFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
    stream << "feGaussianBlur stdDeviation=\"" << Self->SX << " " << Self->SY << "\"";
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -471,7 +475,7 @@ static ERR BLURFX_GET_XMLDef(extBlurFX *Self, STRING *Value)
 static const FieldArray clBlurFXFields[] = {
    { "SX",     FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, BLURFX_GET_SX, BLURFX_SET_SX },
    { "SY",     FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, BLURFX_GET_SY, BLURFX_SET_SY },
-   { "XMLDef", FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, BLURFX_GET_XMLDef, nullptr },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, BLURFX_GET_XMLDef, nullptr },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_colourmatrix.cpp
+++ b/src/vector/filters/filter_colourmatrix.cpp
@@ -540,14 +540,18 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR COLOURFX_GET_XMLDef(extColourFX *Self, STRING *Value)
+static ERR COLOURFX_GET_XMLDef(extColourFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
    stream << "feColorMatrix";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -570,7 +574,7 @@ static const FieldDef clMode[] = {
 static const FieldArray clColourFXFields[] = {
    { "Mode",   FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RI,  COLOURFX_GET_Mode, COLOURFX_SET_Mode, &clMode },
    { "Values", FDF_VIRTUAL|FDF_DOUBLE|FDF_ARRAY|FDF_RI, COLOURFX_GET_Values, COLOURFX_SET_Values },
-   { "XMLDef", FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R,  COLOURFX_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,  COLOURFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_composite.cpp
+++ b/src/vector/filters/filter_composite.cpp
@@ -864,10 +864,14 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR COMPOSITEFX_GET_XMLDef(extCompositeFX *Self, STRING *Value)
+static ERR COMPOSITEFX_GET_XMLDef(extCompositeFX *Self, std::string_view &Value)
 {
-   *Value = strclone("feComposite");
-   return ERR::Okay;
+   auto cppstr = std::string("feComposite");
+   if (auto str = strclone(cppstr)) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -907,7 +911,7 @@ static const FieldArray clCompositeFXFields[] = {
    { "K2",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, COMPOSITEFX_GET_K2, COMPOSITEFX_SET_K2 },
    { "K3",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, COMPOSITEFX_GET_K3, COMPOSITEFX_SET_K3 },
    { "K4",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, COMPOSITEFX_GET_K4, COMPOSITEFX_SET_K4 },
-   { "XMLDef",   FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, COMPOSITEFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, COMPOSITEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_convolve.cpp
+++ b/src/vector/filters/filter_convolve.cpp
@@ -835,7 +835,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, STRING *Value)
+static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
@@ -895,7 +895,11 @@ static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, STRING *Value)
 
    if (Self->PreserveAlpha) stream << " preserveAlpha=\"true\"";
 
-   if ((*Value = strclone(stream.str()))) return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
    else return ERR::AllocMemory;
 }
 
@@ -922,7 +926,7 @@ static const FieldArray clConvolveFXFields[] = {
    { "TargetY",       FDF_VIRTUAL|FDF_INT|FDF_RI,              CONVOLVEFX_GET_TargetY, CONVOLVEFX_SET_TargetY },
    { "UnitX",         FDF_VIRTUAL|FDF_DOUBLE|FDF_RI,           CONVOLVEFX_GET_UnitX, CONVOLVEFX_SET_UnitX },
    { "UnitY",         FDF_VIRTUAL|FDF_DOUBLE|FDF_RI,           CONVOLVEFX_GET_UnitY, CONVOLVEFX_SET_UnitY },
-   { "XMLDef",        FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R,  CONVOLVEFX_GET_XMLDef },
+   { "XMLDef",        FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,  CONVOLVEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_displacement.cpp
+++ b/src/vector/filters/filter_displacement.cpp
@@ -233,14 +233,18 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, STRING *Value)
+static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
    stream << "<feDisplacement/>";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -259,7 +263,7 @@ static const FieldArray clDisplacementFXFields[] = {
    { "Scale",     FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, DISPLACEMENTFX_GET_Scale, DISPLACEMENTFX_SET_Scale },
    { "XChannel",  FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, DISPLACEMENTFX_GET_XChannel, DISPLACEMENTFX_SET_XChannel, &clChannel },
    { "YChannel",  FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, DISPLACEMENTFX_GET_YChannel, DISPLACEMENTFX_SET_YChannel, &clChannel },
-   { "XMLDef",    FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, DISPLACEMENTFX_GET_XMLDef },
+   { "XMLDef",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, DISPLACEMENTFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_displacement.cpp
+++ b/src/vector/filters/filter_displacement.cpp
@@ -237,7 +237,7 @@ static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, std::string_view &
 {
    std::stringstream stream;
 
-   stream << "<feDisplacement/>";
+   stream << "feDisplacement";
 
    auto cppstr = stream.str();
    if (auto str = strclone(stream.str())) {

--- a/src/vector/filters/filter_flood.cpp
+++ b/src/vector/filters/filter_flood.cpp
@@ -144,14 +144,18 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, STRING *Value)
+static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
    stream << "<feFlood opacity=\"" << Self->Opacity << "\"/>";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -161,7 +165,7 @@ static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, STRING *Value)
 static const FieldArray clFloodFXFields[] = {
    { "Colour",  FDF_VIRTUAL|FD_FLOAT|FDF_ARRAY|FD_RW,   FLOODFX_GET_Colour, FLOODFX_SET_Colour },
    { "Opacity", FDF_VIRTUAL|FDF_DOUBLE|FDF_RW,          FLOODFX_GET_Opacity, FLOODFX_SET_Opacity },
-   { "XMLDef",  FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, FLOODFX_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, FLOODFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_flood.cpp
+++ b/src/vector/filters/filter_flood.cpp
@@ -148,7 +148,7 @@ static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
-   stream << "<feFlood opacity=\"" << Self->Opacity << "\"/>";
+   stream << "feFlood opacity=\"" << Self->Opacity << "\"";
 
    auto cppstr = stream.str();
    if (auto str = strclone(stream.str())) {

--- a/src/vector/filters/filter_image.cpp
+++ b/src/vector/filters/filter_image.cpp
@@ -141,14 +141,14 @@ Path: Path to an image file supported by the @Picture class.
 
 *********************************************************************************************************************/
 
-static ERR IMAGEFX_GET_Path(extImageFX *Self, CSTRING *Value)
+static ERR IMAGEFX_GET_Path(extImageFX *Self, std::string_view &Value)
 {
-   if (Self->Picture) return Self->Picture->get(FID_Path, *Value);
-   else *Value = nullptr;
+   if (Self->Picture) return Self->Picture->get(FID_Path, Value);
+   else Value = std::string_view{};
    return ERR::Okay;
 }
 
-static ERR IMAGEFX_SET_Path(extImageFX *Self, CSTRING Value)
+static ERR IMAGEFX_SET_Path(extImageFX *Self, const std::string_view &Value)
 {
    if ((Self->Bitmap) or (Self->Picture)) return ERR::Immutable;
 
@@ -188,10 +188,18 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR IMAGEFX_GET_XMLDef(extImageFX *Self, STRING *Value)
+static ERR IMAGEFX_GET_XMLDef(extImageFX *Self, std::string_view &Value)
 {
-   *Value = strclone("feImage");
-   return ERR::Okay;
+   std::stringstream stream;
+
+   stream << "<feImage/>";
+
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -217,8 +225,8 @@ static const FieldDef clResampleMethod[] = {
 
 static const FieldArray clImageFXFields[] = {
    { "Bitmap",         FDF_VIRTUAL|FDF_OBJECT|FDF_R, IMAGEFX_GET_Bitmap, nullptr, CLASSID::BITMAP },
-   { "Path",           FDF_VIRTUAL|FDF_STRING|FDF_RI, IMAGEFX_GET_Path, IMAGEFX_SET_Path },
-   { "XMLDef",         FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, IMAGEFX_GET_XMLDef },
+   { "Path",           FDF_VIRTUAL|FDF_CPPSTRING|FDF_RI, IMAGEFX_GET_Path, IMAGEFX_SET_Path },
+   { "XMLDef",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, IMAGEFX_GET_XMLDef },
    { "AspectRatio",    FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, IMAGEFX_GET_AspectRatio, IMAGEFX_SET_AspectRatio, &clAspectRatio },
    { "ResampleMethod", FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, IMAGEFX_GET_ResampleMethod, IMAGEFX_SET_ResampleMethod, &clResampleMethod },
    END_FIELD

--- a/src/vector/filters/filter_image.cpp
+++ b/src/vector/filters/filter_image.cpp
@@ -192,7 +192,7 @@ static ERR IMAGEFX_GET_XMLDef(extImageFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
-   stream << "<feImage/>";
+   stream << "feImage";
 
    auto cppstr = stream.str();
    if (auto str = strclone(stream.str())) {

--- a/src/vector/filters/filter_lighting.cpp
+++ b/src/vector/filters/filter_lighting.cpp
@@ -994,7 +994,7 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, STRING *Value)
+static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
    std::string type(Self->Type IS LT::DIFFUSE ? "feDiffuseLighting" : "feSpecularLighting");
@@ -1002,8 +1002,13 @@ static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, STRING *Value)
    // TODO
    stream << "<" << type << ">";
    stream << "</" << type << ">";
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -1024,7 +1029,7 @@ static const FieldArray clLightingFXFields[] = {
    { "Type",     FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW,  LIGHTINGFX_GET_Type, LIGHTINGFX_SET_Type, &clLightingType },
    { "UnitX",    FDF_VIRTUAL|FDF_DOUBLE|FDF_RW,          LIGHTINGFX_GET_UnitX, LIGHTINGFX_SET_UnitX },
    { "UnitY",    FDF_VIRTUAL|FDF_DOUBLE|FDF_RW,          LIGHTINGFX_GET_UnitY, LIGHTINGFX_SET_UnitY },
-   { "XMLDef",   FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, LIGHTINGFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, LIGHTINGFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_lighting.cpp
+++ b/src/vector/filters/filter_lighting.cpp
@@ -1000,8 +1000,7 @@ static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, std::string_view &Value)
    std::string type(Self->Type IS LT::DIFFUSE ? "feDiffuseLighting" : "feSpecularLighting");
 
    // TODO
-   stream << "<" << type << ">";
-   stream << "</" << type << ">";
+   stream << type;
 
    auto cppstr = stream.str();
    if (auto str = strclone(stream.str())) {

--- a/src/vector/filters/filter_merge.cpp
+++ b/src/vector/filters/filter_merge.cpp
@@ -145,10 +145,14 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, STRING *Value)
+static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, std::string_view &Value)
 {
-   *Value = strclone("feMerge");
-   return ERR::Okay;
+   auto cppstr = std::string("feMerge");
+   if (auto str = strclone(cppstr)) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -157,7 +161,7 @@ static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, STRING *Value)
 
 static const FieldArray clMergeFXFields[] = {
    { "SourceList", FDF_VIRTUAL|FDF_STRUCT|FDF_ARRAY|FDF_RW, NULL, MERGEFX_SET_SourceList, "MergeSource" },
-   { "XMLDef",     FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, MERGEFX_GET_XMLDef },
+   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, MERGEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_morphology.cpp
+++ b/src/vector/filters/filter_morphology.cpp
@@ -285,7 +285,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, STRING *Value)
+static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
@@ -296,8 +296,12 @@ static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, STRING *Value)
 
    stream << "radius=\"" << Self->RadiusX << " " << Self->RadiusY << "\"";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -314,7 +318,7 @@ static const FieldArray clMorphologyFXFields[] = {
    { "Operator", FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, MORPHOLOGYFX_GET_Operator, MORPHOLOGYFX_SET_Operator, &clMorphologyFXOperator },
    { "RadiusX",  FDF_VIRTUAL|FDF_INT|FDF_RW, MORPHOLOGYFX_GET_RadiusX, MORPHOLOGYFX_SET_RadiusX },
    { "RadiusY",  FDF_VIRTUAL|FDF_INT|FDF_RW, MORPHOLOGYFX_GET_RadiusY, MORPHOLOGYFX_SET_RadiusY },
-   { "XMLDef",   FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, MORPHOLOGYFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, MORPHOLOGYFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_offset.cpp
+++ b/src/vector/filters/filter_offset.cpp
@@ -83,12 +83,17 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, STRING *Value)
+static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
    stream << "feOffset dx=\"" << Self->XOffset << "\" dy=\"" << Self->YOffset << "\"";
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -98,7 +103,7 @@ static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, STRING *Value)
 static const FieldArray clOffsetFXFields[] = {
    { "XOffset", FDF_VIRTUAL|FDF_INT|FDF_RW, OFFSETFX_GET_XOffset, OFFSETFX_SET_XOffset },
    { "YOffset", FDF_VIRTUAL|FDF_INT|FDF_RW, OFFSETFX_GET_YOffset, OFFSETFX_SET_YOffset },
-   { "XMLDef",  FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, OFFSETFX_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, OFFSETFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_remap.cpp
+++ b/src/vector/filters/filter_remap.cpp
@@ -484,7 +484,7 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, STRING *Value)
+static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
@@ -495,8 +495,13 @@ static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, STRING *Value)
    stream << "<feFuncB/>";
    stream << "<feFuncA/>";
    stream << "</feComponentTransfer>";
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -504,7 +509,7 @@ static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, STRING *Value)
 #include "filter_remap_def.c"
 
 static const FieldArray clRemapFXFields[] = {
-   { "XMLDef", FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, REMAPFX_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, REMAPFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_source.cpp
+++ b/src/vector/filters/filter_source.cpp
@@ -266,11 +266,11 @@ Vectors are registered via the @VectorScene.AddDef() method.
 
 *********************************************************************************************************************/
 
-static ERR SOURCEFX_SET_SourceName(extSourceFX *Self, CSTRING Value)
+static ERR SOURCEFX_SET_SourceName(extSourceFX *Self, const std::string_view &Value)
 {
    kt::Log log;
 
-   if ((!Self->Filter) or (!Self->Filter->Scene)) return log.warning(ERR::UndefinedField);
+   if ((not Self->Filter) or (not Self->Filter->Scene)) return log.warning(ERR::UndefinedField);
 
    if (Self->Source) {
       UnsubscribeAction(Self->Source, AC::Free);
@@ -278,7 +278,7 @@ static ERR SOURCEFX_SET_SourceName(extSourceFX *Self, CSTRING Value)
    }
 
    objVector *src;
-   if (Self->Filter->Scene->findDef(Value, (OBJECTPTR *)&src) IS ERR::Okay) {
+   if (Self->Filter->Scene->findDef(Value.data(), (OBJECTPTR *)&src) IS ERR::Okay) {
       if (src->Class->BaseClassID != CLASSID::VECTOR) return log.warning(ERR::WrongClass);
       Self->Source = src;
       SubscribeAction(src, AC::Free, C_FUNCTION(notify_free_source));
@@ -296,10 +296,14 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR SOURCEFX_GET_XMLDef(extSourceFX *Self, STRING *Value)
+static ERR SOURCEFX_GET_XMLDef(extSourceFX *Self, std::string_view &Value)
 {
-   *Value = strclone("feImage");
-   return ERR::Okay;
+   auto cppstr = std::string("feImage");
+   if (auto str = strclone(cppstr)) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -308,9 +312,9 @@ static ERR SOURCEFX_GET_XMLDef(extSourceFX *Self, STRING *Value)
 
 static const FieldArray clSourceFXFields[] = {
    { "AspectRatio", FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW, SOURCEFX_GET_AspectRatio, SOURCEFX_SET_AspectRatio, &clAspectRatio },
-   { "SourceName",  FDF_VIRTUAL|FDF_STRING|FDF_I, nullptr, SOURCEFX_SET_SourceName },
+   { "SourceName",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_I, nullptr, SOURCEFX_SET_SourceName },
    { "Source",      FDF_VIRTUAL|FDF_OBJECT|FDF_R, nullptr, SOURCEFX_SET_Source, CLASSID::VECTOR },
-   { "XMLDef",      FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, SOURCEFX_GET_XMLDef },
+   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, SOURCEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_turbulence.cpp
+++ b/src/vector/filters/filter_turbulence.cpp
@@ -499,14 +499,18 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR TURBULENCEFX_GET_XMLDef(extTurbulenceFX *Self, STRING *Value)
+static ERR TURBULENCEFX_GET_XMLDef(extTurbulenceFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
    stream << "feTurbulence";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -525,7 +529,7 @@ static const FieldArray clTurbulenceFXFields[] = {
    { "Seed",    FDF_VIRTUAL|FDF_INT|FDF_RI,             TURBULENCEFX_GET_Seed,    TURBULENCEFX_SET_Seed },
    { "Stitch",  FDF_VIRTUAL|FDF_INT|FDF_RI,             TURBULENCEFX_GET_Stitch,  TURBULENCEFX_SET_Stitch },
    { "Type",    FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RI,  TURBULENCEFX_GET_Type,    TURBULENCEFX_SET_Type, &clTurbulenceType },
-   { "XMLDef",  FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, TURBULENCEFX_GET_XMLDef,  nullptr },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, TURBULENCEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_wavefunction.cpp
+++ b/src/vector/filters/filter_wavefunction.cpp
@@ -213,21 +213,21 @@ The use of colourmaps and custom stops are mutually exclusive.
 
 *********************************************************************************************************************/
 
-static ERR WAVEFUNCTIONFX_GET_ColourMap(extWaveFunctionFX *Self, CSTRING *Value)
+static ERR WAVEFUNCTIONFX_GET_ColourMap(extWaveFunctionFX *Self, std::string_view &Value)
 {
-   if (Self->ColourMap.empty()) *Value = nullptr;
-   else *Value = Self->ColourMap.c_str();
+   if (Self->ColourMap.empty()) Value = std::string_view{};
+   else Value = Self->ColourMap;
    return ERR::Okay;
 }
 
-static ERR WAVEFUNCTIONFX_SET_ColourMap(extWaveFunctionFX *Self, CSTRING Value)
+static ERR WAVEFUNCTIONFX_SET_ColourMap(extWaveFunctionFX *Self, const std::string_view &Value)
 {
-   if (!Value) return ERR::NoData;
+   if (Value.empty()) return ERR::NoData;
 
-   if (glColourMaps.contains(Value)) {
+   if (auto it = glColourMaps.find(Value); it != glColourMaps.end()) {
       if (Self->Colours) delete Self->Colours;
-      Self->Colours = new (std::nothrow) GradientColours(glColourMaps[Value], 1);
-      if (!Self->Colours) return ERR::AllocMemory;
+      Self->Colours = new (std::nothrow) GradientColours(it->second, 1);
+      if (not Self->Colours) return ERR::AllocMemory;
       Self->ColourMap = Value;
       return ERR::Okay;
    }
@@ -404,14 +404,18 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR WAVEFUNCTIONFX_GET_XMLDef(extWaveFunctionFX *Self, STRING *Value)
+static ERR WAVEFUNCTIONFX_GET_XMLDef(extWaveFunctionFX *Self, std::string_view &Value)
 {
    std::stringstream stream;
 
    stream << "feWaveFunction";
 
-   *Value = strclone(stream.str());
-   return ERR::Okay;
+   auto cppstr = stream.str();
+   if (auto str = strclone(stream.str())) {
+      Value = std::string_view{str, cppstr.size()};
+      return ERR::Okay;
+   }
+   else return ERR::AllocMemory;
 }
 
 //********************************************************************************************************************
@@ -420,14 +424,14 @@ static ERR WAVEFUNCTIONFX_GET_XMLDef(extWaveFunctionFX *Self, STRING *Value)
 
 static const FieldArray clWaveFunctionFXFields[] = {
    { "AspectRatio", FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW,   WAVEFUNCTIONFX_GET_AspectRatio, WAVEFUNCTIONFX_SET_AspectRatio, &clAspectRatio },
-   { "ColourMap",   FDF_VIRTUAL|FDF_STRING|FDF_RW,           WAVEFUNCTIONFX_GET_ColourMap,   WAVEFUNCTIONFX_SET_ColourMap },
+   { "ColourMap",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,        WAVEFUNCTIONFX_GET_ColourMap,   WAVEFUNCTIONFX_SET_ColourMap },
    { "N",           FDF_VIRTUAL|FDF_INT|FDF_RW,              WAVEFUNCTIONFX_GET_N,           WAVEFUNCTIONFX_SET_N },
    { "L",           FDF_VIRTUAL|FDF_INT|FDF_RW,              WAVEFUNCTIONFX_GET_L,           WAVEFUNCTIONFX_SET_L },
    { "M",           FDF_VIRTUAL|FDF_INT|FDF_RW,              WAVEFUNCTIONFX_GET_M,           WAVEFUNCTIONFX_SET_M },
    { "Resolution",  FDF_VIRTUAL|FDF_INT|FDF_RW,              WAVEFUNCTIONFX_GET_Resolution,  WAVEFUNCTIONFX_SET_Resolution },
    { "Scale",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW,           WAVEFUNCTIONFX_GET_Scale,       WAVEFUNCTIONFX_SET_Scale },
    { "Stops",       FDF_VIRTUAL|FDF_ARRAY|FDF_STRUCT|FDF_RW, WAVEFUNCTIONFX_GET_Stops,       WAVEFUNCTIONFX_SET_Stops, "GradientStop" },
-   { "XMLDef",      FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R,  WAVEFUNCTIONFX_GET_XMLDef,      nullptr },
+   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, WAVEFUNCTIONFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient.cpp
+++ b/src/vector/painters/gradient.cpp
@@ -152,10 +152,7 @@ GradientColours::GradientColours(const std::array<FRGB, 256> &Map, double Resolu
 
 static ERR VECTORGRADIENT_Free(extVectorGradient *Self)
 {
-   if (Self->ID) { FreeResource(Self->ID); Self->ID = nullptr; }
    if (Self->Colours) { delete Self->Colours; Self->Colours = nullptr; }
-   Self->Stops.~vector<GradientStop>();
-   Self->ColourMap.~basic_string();
 
    VectorMatrix *next;
    for (auto node=Self->Matrices; node; node=next) {
@@ -164,6 +161,7 @@ static ERR VECTORGRADIENT_Free(extVectorGradient *Self)
    }
    Self->Matrices = nullptr;
 
+   Self->~extVectorGradient();
    return ERR::Okay;
 }
 
@@ -195,8 +193,6 @@ static ERR VECTORGRADIENT_Init(extVectorGradient *Self)
 
 static ERR VECTORGRADIENT_NewObject(extVectorGradient *Self)
 {
-   new (&Self->Stops) std::vector<GradientStop>;
-   new (&Self->ColourMap) std::string;
    Self->SpreadMethod = VSPREAD::PAD;
    Self->Type    = VGT::LINEAR;
    Self->Units   = VUNIT::BOUNDING_BOX;
@@ -208,6 +204,12 @@ static ERR VECTORGRADIENT_NewObject(extVectorGradient *Self)
    Self->X2      = 1.0; // Set for contoured gradients.
    Self->Flags  |= VGF::SCALED_CX|VGF::SCALED_CY|VGF::SCALED_RADIUS;
    Self->Resolution = 1;
+   return ERR::Okay;
+}
+
+static ERR VECTORGRADIENT_NewPlacement(extVectorGradient *Self)
+{
+   new (Self) extVectorGradient;
    return ERR::Okay;
 }
 
@@ -321,21 +323,21 @@ The use of colourmaps and custom stops are mutually exclusive.
 
 *********************************************************************************************************************/
 
-static ERR VECTORGRADIENT_GET_ColourMap(extVectorGradient *Self, CSTRING *Value)
+static ERR VECTORGRADIENT_GET_ColourMap(extVectorGradient *Self, std::string_view &Value)
 {
-   if (!Self->ColourMap.empty()) *Value = Self->ColourMap.c_str();
-   else *Value = nullptr;
+   if (not Self->ColourMap.empty()) Value = Self->ColourMap;
+   else Value = std::string_view{};
    return ERR::Okay;
 }
 
-static ERR VECTORGRADIENT_SET_ColourMap(extVectorGradient *Self, CSTRING Value)
+static ERR VECTORGRADIENT_SET_ColourMap(extVectorGradient *Self, const std::string_view &Value)
 {
-   if (!Value) return ERR::NoData;
+   if (Value.empty()) return ERR::NoData;
 
-   if (glColourMaps.contains(Value)) {
+   if (auto it = glColourMaps.find(Value); it != glColourMaps.end()) {
       if (Self->Colours) delete Self->Colours;
-      Self->Colours = new (std::nothrow) GradientColours(glColourMaps[Value], Self->Resolution);
-      if (!Self->Colours) return ERR::AllocMemory;
+      Self->Colours = new (std::nothrow) GradientColours(it->second, Self->Resolution);
+      if (not Self->Colours) return ERR::AllocMemory;
       Self->ColourMap = Value;
       Self->modified();
       return ERR::Okay;
@@ -449,22 +451,20 @@ existing object name and automatically assigned ID's for identifiers.
 
 *********************************************************************************************************************/
 
-static ERR VECTORGRADIENT_GET_ID(extVectorGradient *Self, STRING *Value)
+static ERR VECTORGRADIENT_GET_ID(extVectorGradient *Self, std::string_view &Value)
 {
-   *Value = Self->ID;
+   Value = Self->ID;
    return ERR::Okay;
 }
 
-static ERR VECTORGRADIENT_SET_ID(extVectorGradient *Self, CSTRING Value)
+static ERR VECTORGRADIENT_SET_ID(extVectorGradient *Self, const std::string_view &Value)
 {
-   if (Self->ID) FreeResource(Self->ID);
-
-   if (Value) {
-      Self->ID = strclone(Value);
+   if (not Value.empty()) {
+      Self->ID = Value;
       Self->NumericID = strhash(Value);
    }
    else {
-      Self->ID = nullptr;
+      Self->ID.clear();
       Self->NumericID = 0;
    }
    return ERR::Okay;
@@ -544,7 +544,7 @@ static ERR VECTORGRADIENT_GET_NumericID(extVectorGradient *Self, int *Value)
 static ERR VECTORGRADIENT_SET_NumericID(extVectorGradient *Self, int Value)
 {
    Self->NumericID = Value;
-   if (Self->ID) { FreeResource(Self->ID); Self->ID = nullptr; }
+   Self->ID.clear();
    return ERR::Okay;
 }
 
@@ -690,15 +690,15 @@ A transform can be applied to the gradient by setting this field with an SVG com
 
 *********************************************************************************************************************/
 
-static ERR VECTORGRADIENT_SET_Transform(extVectorGradient *Self, CSTRING Commands)
+static ERR VECTORGRADIENT_SET_Transform(extVectorGradient *Self, const std::string_view &Commands)
 {
    kt::Log log;
 
-   if (!Commands) return log.warning(ERR::InvalidValue);
+   if (Commands.empty()) return log.warning(ERR::InvalidValue);
 
    Self->modified();
 
-   if (!Self->Matrices) {
+   if (not Self->Matrices) {
       VectorMatrix *matrix;
       if (AllocMemory(sizeof(VectorMatrix), MEM::DATA|MEM::NO_CLEAR, &matrix) IS ERR::Okay) {
          matrix->Vector = nullptr;
@@ -711,13 +711,13 @@ static ERR VECTORGRADIENT_SET_Transform(extVectorGradient *Self, CSTRING Command
          matrix->TranslateY = 0;
 
          Self->Matrices = matrix;
-         return vec::ParseTransform(Self->Matrices, Commands);
+         return vec::ParseTransform(Self->Matrices, Commands.data());
       }
       else return ERR::AllocMemory;
    }
    else {
       vec::ResetMatrix(Self->Matrices);
-      return vec::ParseTransform(Self->Matrices, Commands);
+      return vec::ParseTransform(Self->Matrices, Commands.data());
    }
 }
 
@@ -880,17 +880,17 @@ static const FieldArray clGradientFields[] = {
    { "ColourSpace",  FDF_INT|FDF_RI, nullptr, nullptr, &clVectorGradientColourSpace },
    // Virtual fields
    { "Colour",       FDF_VIRTUAL|FD_FLOAT|FDF_ARRAY|FD_RW, VECTORGRADIENT_GET_Colour, VECTORGRADIENT_SET_Colour },
-   { "ColourMap",    FDF_VIRTUAL|FDF_STRING|FDF_W, VECTORGRADIENT_GET_ColourMap, VECTORGRADIENT_SET_ColourMap },
+   { "ColourMap",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_W, VECTORGRADIENT_GET_ColourMap, VECTORGRADIENT_SET_ColourMap },
    { "CX",           FDF_VIRTUAL|FDF_SYNONYM|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VECTORGRADIENT_GET_CenterX, VECTORGRADIENT_SET_CenterX },
    { "CY",           FDF_VIRTUAL|FDF_SYNONYM|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VECTORGRADIENT_GET_CenterY, VECTORGRADIENT_SET_CenterY },
    { "FX",           FDF_VIRTUAL|FDF_SYNONYM|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VECTORGRADIENT_GET_FocalX, VECTORGRADIENT_SET_FocalX },
    { "FY",           FDF_VIRTUAL|FDF_SYNONYM|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VECTORGRADIENT_GET_FocalY, VECTORGRADIENT_SET_FocalY },
    { "Matrices",     FDF_VIRTUAL|FDF_POINTER|FDF_STRUCT|FDF_RW, VECTORGRADIENT_GET_Matrices, VECTORGRADIENT_SET_Matrices, "VectorMatrix" },
    { "NumericID",    FDF_VIRTUAL|FDF_INT|FDF_RW, VECTORGRADIENT_GET_NumericID, VECTORGRADIENT_SET_NumericID },
-   { "ID",           FDF_VIRTUAL|FDF_STRING|FDF_RW, VECTORGRADIENT_GET_ID, VECTORGRADIENT_SET_ID },
+   { "ID",           FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW, VECTORGRADIENT_GET_ID, VECTORGRADIENT_SET_ID },
    { "Stops",        FDF_VIRTUAL|FDF_ARRAY|FDF_STRUCT|FDF_RW, VECTORGRADIENT_GET_Stops, VECTORGRADIENT_SET_Stops, "GradientStop" },
    { "TotalStops",   FDF_INT|FDF_R, VECTORGRADIENT_GET_TotalStops },
-   { "Transform",    FDF_VIRTUAL|FDF_STRING|FDF_W, nullptr, VECTORGRADIENT_SET_Transform },
+   { "Transform",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_W, nullptr, VECTORGRADIENT_SET_Transform },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient.cpp
+++ b/src/vector/painters/gradient.cpp
@@ -711,13 +711,13 @@ static ERR VECTORGRADIENT_SET_Transform(extVectorGradient *Self, const std::stri
          matrix->TranslateY = 0;
 
          Self->Matrices = matrix;
-         return vec::ParseTransform(Self->Matrices, Commands.data());
+         return vec::ParseTransform(Self->Matrices, Commands);
       }
       else return ERR::AllocMemory;
    }
    else {
       vec::ResetMatrix(Self->Matrices);
-      return vec::ParseTransform(Self->Matrices, Commands.data());
+      return vec::ParseTransform(Self->Matrices, Commands);
    }
 }
 

--- a/src/vector/painters/pattern.cpp
+++ b/src/vector/painters/pattern.cpp
@@ -282,15 +282,15 @@ A transform can be applied to the pattern by setting this field with an SVG comp
 
 *********************************************************************************************************************/
 
-static ERR PATTERN_SET_Transform(extVectorPattern *Self, CSTRING Commands)
+static ERR PATTERN_SET_Transform(extVectorPattern *Self, const std::string_view &Commands)
 {
    kt::Log log;
 
-   if (!Commands) return log.warning(ERR::InvalidValue);
+   if (Commands.empty()) return log.warning(ERR::InvalidValue);
 
    Self->modified();
 
-   if (!Self->Matrices) {
+   if (not Self->Matrices) {
       VectorMatrix *matrix;
       if (AllocMemory(sizeof(VectorMatrix), MEM::DATA|MEM::NO_CLEAR, &matrix) IS ERR::Okay) {
          matrix->Vector = nullptr;
@@ -454,7 +454,7 @@ static const FieldArray clPatternFields[] = {
    //{ "AspectRatio", FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW, PATTERN_GET_AspectRatio, PATTERN_SET_AspectRatio, &clAspectRatio },
    // Virtual fields
    { "Matrices",     FDF_VIRTUAL|FDF_POINTER|FDF_STRUCT|FDF_RW, VECTORPATTERN_GET_Matrices, VECTORPATTERN_SET_Matrices, "VectorMatrix" },
-   { "Transform",    FDF_VIRTUAL|FDF_STRING|FDF_W, nullptr, PATTERN_SET_Transform },
+   { "Transform",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_W, nullptr, PATTERN_SET_Transform },
    END_FIELD
 };
 
@@ -474,4 +474,3 @@ ERR init_pattern(void) // The pattern is a definition type for creating patterns
 
    return clVectorPattern ? ERR::Okay : ERR::AddClass;
 }
-

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -10,6 +10,7 @@ template<class... Args> void DBG_TRANSFORM(Args...) {
 #include <unordered_set>
 #include <sstream>
 #include <set>
+#include <string_view>
 #include <unordered_map>
 #include <mutex>
 #include <stack>
@@ -80,7 +81,26 @@ class extFilterEffect;
 class extVectorViewport;
 class extVectorClip;
 
-extern ankerl::unordered_dense::map<std::string, std::array<FRGB, 256>> glColourMaps;
+struct ColourMapHash {
+   using is_avalanching = void;
+   using is_transparent = void;
+
+   [[nodiscard]] uint64_t operator()(std::string_view Value) const noexcept {
+      return ankerl::unordered_dense::hash<std::string_view>{}(Value);
+   }
+
+   [[nodiscard]] uint64_t operator()(const std::string &Value) const noexcept {
+      return (*this)(std::string_view(Value));
+   }
+
+   [[nodiscard]] uint64_t operator()(CSTRING Value) const noexcept {
+      return (*this)(std::string_view(Value));
+   }
+};
+
+using ColourMapTable = ankerl::unordered_dense::map<std::string, std::array<FRGB, 256>, ColourMapHash, std::equal_to<>>;
+
+extern ColourMapTable glColourMaps;
 extern objConfig *glFontConfig;
 
 class PIXEL_ORDER {
@@ -338,7 +358,7 @@ class extVectorGradient : public objVectorGradient, public SceneDef {
    std::string ColourMap;
    FRGB   Colour;
    RGB8   ColourRGB; // A cached conversion of the FRGB value
-   STRING ID;
+   std::string ID;
    int   NumericID;
    double Angle;
    double Length;
@@ -405,8 +425,8 @@ class extVector : public objVector {
    double StrokeWidth;
    agg::path_storage BasePath;
    agg::trans_affine Transform;   // Final transform.  Accumulated from the Matrix list during path generation.
-   CSTRING FilterString, StrokeString, FillString;
-   STRING SID;
+   std::string FilterString, StrokeString, FillString;
+   std::string SID;
    void   (*GeneratePath)(extVector *, agg::path_storage &);
    agg::rasterizer_scanline_aa<>     *StrokeRaster;
    agg::rasterizer_scanline_aa<>     *FillRaster;

--- a/src/vector/vectors/path.cpp
+++ b/src/vector/vectors/path.cpp
@@ -539,12 +539,12 @@ To terminate a path without joining it to the first coordinate, omit the `Z` fro
 
 *********************************************************************************************************************/
 
-static ERR VECTORPATH_SET_Sequence(extVectorPath *Self, CSTRING Value)
+static ERR VECTORPATH_SET_Sequence(extVectorPath *Self, const std::string_view &Value)
 {
    Self->Commands.clear();
 
    ERR error = ERR::Okay;
-   if (Value) error = read_path(Self->Commands, Value);
+   if (not Value.empty()) error = read_path(Self->Commands, Value);
    reset_path(Self);
    Self->modified();
    return error;
@@ -577,7 +577,7 @@ static ERR VECTORPATH_SET_TotalCommands(extVectorPath *Self, int Value)
 //********************************************************************************************************************
 
 static const FieldArray clPathFields[] = {
-   { "Sequence",      FDF_VIRTUAL|FDF_STRING|FDF_RW, VECTOR_GET_Sequence, VECTORPATH_SET_Sequence },
+   { "Sequence",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW, VECTOR_GET_Sequence, VECTORPATH_SET_Sequence },
    { "TotalCommands", FDF_VIRTUAL|FDF_INT|FDF_RW,   VECTORPATH_GET_TotalCommands, VECTORPATH_SET_TotalCommands },
    { "PathLength",    FDF_VIRTUAL|FDF_INT|FDF_RW,   VECTORPATH_GET_PathLength, VECTORPATH_SET_PathLength },
    { "Commands",      FDF_VIRTUAL|FDF_ARRAY|FDF_STRUCT|FDF_RW, VECTORPATH_GET_Commands, VECTORPATH_SET_Commands, "PathCommand" },

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -317,7 +317,7 @@ a comma.
 
 *********************************************************************************************************************/
 
-static ERR POLY_SET_Points(extVectorPoly *Self, CSTRING Value)
+static ERR POLY_SET_Points(extVectorPoly *Self, const std::string_view &Value)
 {
    if (auto error = read_points(Self, Value); error IS ERR::Okay) {
       reset_path(Self);
@@ -461,7 +461,7 @@ static const FieldArray clPolygonFields[] = {
    { "Closed",      FDF_VIRTUAL|FDF_INT|FD_RW,                 POLY_GET_Closed, POLY_SET_Closed },
    { "PathLength",  FDF_VIRTUAL|FDF_INT|FDF_RW,                POLY_GET_PathLength, POLY_SET_PathLength },
    { "PointsArray", FDF_VIRTUAL|FDF_ARRAY|FDF_POINTER|FDF_RW,   POLY_GET_PointsArray, POLY_SET_PointsArray },
-   { "Points",      FDF_VIRTUAL|FDF_STRING|FDF_W,               nullptr, POLY_SET_Points },
+   { "Points",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,            nullptr, POLY_SET_Points },
    { "TotalPoints", FDF_VIRTUAL|FDF_INT|FDF_R,                 POLY_GET_TotalPoints },
    { "X1",          FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, POLY_GET_X1, POLY_SET_X1 },
    { "Y1",          FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, POLY_GET_Y1, POLY_SET_Y1 },

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -817,19 +817,19 @@ feature is intended for programmed use-cases and is not SVG compliant.
 // Override the existing Vector Fill field - this is required for bitmap fonts as they need a path reset to be
 // triggered when decorative changes occur.
 
-static ERR TEXT_GET_Fill(extVectorText *Self, CSTRING *Value)
+static ERR TEXT_GET_Fill(extVectorText *Self, std::string_view &Value)
 {
-   *Value = Self->FillString;
+   Value = Self->FillString;
    return ERR::Okay;
 }
 
-static ERR TEXT_SET_Fill(extVectorText *Self, CSTRING Value)
+static ERR TEXT_SET_Fill(extVectorText *Self, const std::string_view &Value)
 {
-   if (Self->FillString) { FreeResource(Self->FillString); Self->FillString = nullptr; }
+   Self->FillString.clear();
 
    CSTRING next;
    if (auto error = vec::ReadPainter(Self->Scene, Value, &Self->Fill[0], &next); error IS ERR::Okay) {
-      Self->FillString = strclone(Value);
+      Self->FillString = Value;
 
       if (next) {
          vec::ReadPainter(Self->Scene, next, &Self->Fill[1], nullptr);
@@ -843,7 +843,6 @@ static ERR TEXT_SET_Fill(extVectorText *Self, CSTRING Value)
       return ERR::Okay;
    }
    else return error;
-
 }
 
 /*********************************************************************************************************************
@@ -2060,7 +2059,7 @@ static const FieldArray clTextFields[] = {
    { "String",        FDF_VIRTUAL|FDF_STRING|FDF_RW, TEXT_GET_String, TEXT_SET_String },
    { "Align",         FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW, TEXT_GET_Align, TEXT_SET_Align, &clTextAlign },
    { "Face",          FDF_VIRTUAL|FDF_STRING|FDF_RW, TEXT_GET_Face, TEXT_SET_Face },
-   { "Fill",          FDF_VIRTUAL|FDF_STRING|FDF_RW, TEXT_GET_Fill, TEXT_SET_Fill },
+   { "Fill",          FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW, TEXT_GET_Fill, TEXT_SET_Fill }, // Override
    { "FontSize",      FDF_VIRTUAL|FDF_ALLOC|FDF_STRING|FDF_RW, TEXT_GET_FontSize, TEXT_SET_FontSize },
    { "FontStyle",     FDF_VIRTUAL|FDF_STRING|FDF_RI, TEXT_GET_FontStyle, TEXT_SET_FontStyle },
    { "Descent",       FDF_VIRTUAL|FDF_INT|FDF_R, TEXT_GET_Descent },

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -273,17 +273,10 @@ static ERR VECTOR_Enable(extVector *Self)
 
 static ERR VECTOR_Free(extVector *Self)
 {
-   Self->~extVector();
-
    if (Self->ClipMask)   UnsubscribeAction(Self->ClipMask, AC::Free);
    if (Self->Transition) UnsubscribeAction(Self->Transition, AC::Free);
    if (Self->Morph)      UnsubscribeAction(Self->Morph, AC::Free);
    if (Self->AppendPath) UnsubscribeAction(Self->AppendPath, AC::Free);
-
-   if (Self->SID)          { FreeResource(Self->SID); Self->SID = nullptr; }
-   if (Self->FillString)   { FreeResource(Self->FillString); Self->FillString = nullptr; }
-   if (Self->StrokeString) { FreeResource(Self->StrokeString); Self->StrokeString = nullptr; }
-   if (Self->FilterString) { FreeResource(Self->FilterString); Self->FilterString = nullptr; }
 
    if (Self->Fill[0].GradientTable) { delete Self->Fill[0].GradientTable; Self->Fill[0].GradientTable = nullptr; }
    if (Self->Fill[1].GradientTable) { delete Self->Fill[1].GradientTable; Self->Fill[1].GradientTable = nullptr; }
@@ -354,6 +347,7 @@ static ERR VECTOR_Free(extVector *Self)
    delete Self->KeyboardSubscriptions; Self->KeyboardSubscriptions = nullptr;
    delete Self->FeedbackSubscriptions; Self->FeedbackSubscriptions = nullptr;
 
+   Self->~extVector();
    return ERR::Okay;
 }
 
@@ -515,7 +509,7 @@ static ERR VECTOR_Init(extVector *Self)
 
    // Reapply the filter if it couldn't be set prior to initialisation.
 
-   if ((!Self->Filter) and (Self->FilterString)) {
+   if ((!Self->Filter) and (not Self->FilterString.empty())) {
       Self->setFilter(Self->FilterString);
    }
 
@@ -1361,27 +1355,26 @@ feature is intended for programmed use-cases and is not SVG compliant.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Fill(extVector *Self, CSTRING *Value)
+static ERR VECTOR_GET_Fill(extVector *Self, std::string_view &Value)
 {
-   *Value = Self->FillString;
+   Value = Self->FillString;
    return ERR::Okay;
 }
 
-static ERR VECTOR_SET_Fill(extVector *Self, CSTRING Value)
+static ERR VECTOR_SET_Fill(extVector *Self, const std::string_view &Value)
 {
    // Note that if an internal routine sets DisableFillColour then the colour will be stored but effectively does nothing.
-   if (Self->FillString) { FreeResource(Self->FillString); Self->FillString = nullptr; }
-
+   Self->FillString.clear();
    Self->FGFill = false;
 
-   if (!Value) {
+   if (Value.empty()) {
       Self->Fill[0].reset();
       return ERR::Okay;
    }
 
    CSTRING next;
    if (auto error = vec::ReadPainter(Self->Scene, Value, &Self->Fill[0], &next); error IS ERR::Okay) {
-      Self->FillString = strclone(Value);
+      Self->FillString = Value;
 
       if (next) {
          if (*next IS ';') {
@@ -1452,7 +1445,7 @@ static ERR VECTOR_SET_FillColour(extVector *Self, float *Value, int Elements)
       mark_buffers_for_refresh(Self);
    }
 
-   if (Self->FillString) { FreeResource(Self->FillString); Self->FillString = nullptr; }
+   Self->FillString.clear();
 
    return ERR::Okay;
 }
@@ -1501,39 +1494,38 @@ The Filter value can be in the format `ID` or `url(#SID)` according to client pr
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Filter(extVector *Self, CSTRING *Value)
+static ERR VECTOR_GET_Filter(extVector *Self, std::string_view &Value)
 {
-   *Value = Self->FilterString;
+   Value = Self->FilterString;
    return ERR::Okay;
 }
 
-static ERR VECTOR_SET_Filter(extVector *Self, CSTRING Value)
+static ERR VECTOR_SET_Filter(extVector *Self, const std::string_view &Value)
 {
    kt::Log log;
 
    mark_buffers_for_refresh(Self);
 
-   if ((!Value) or (!Value[0])) {
-      if (Self->FilterString) { FreeResource(Self->FilterString); Self->FilterString = nullptr; }
+   if (Value.empty()) {
+      Self->FilterString.clear();
       Self->Filter = nullptr;
       return ERR::Okay;
    }
 
-   if (!Self->Scene) { // Vector is not yet initialised, so store the filter string for later.
-      if (Self->FilterString) { FreeResource(Self->FilterString); Self->FilterString = nullptr; }
-      Self->FilterString = strclone(Value);
+   if (not Self->Scene) { // Vector is not yet initialised, so store the filter string for later.
+      Self->FilterString = Value;
       return ERR::Okay;
    }
 
+   std::string value(Value);
    OBJECTPTR def = nullptr;
-   if (Self->Scene->findDef(Value, &def) != ERR::Okay) {
-      log.warning("Failed to resolve filter '%s'", Value);
+   if (Self->Scene->findDef(value.c_str(), &def) != ERR::Okay) {
+      log.warning("Failed to resolve filter '%.*s'", int(Value.size()), Value.data());
       return ERR::Search;
    }
 
    if (def->Class->BaseClassID IS CLASSID::VECTORFILTER) {
-      if (Self->FilterString) { FreeResource(Self->FilterString); Self->FilterString = nullptr; }
-      Self->FilterString = strclone(Value);
+      Self->FilterString = Value;
       Self->Filter = (extVectorFilter *)def;
       return ERR::Okay;
    }
@@ -1575,23 +1567,21 @@ circumstances.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_SID(extVector *Self, STRING *Value)
+static ERR VECTOR_GET_SID(extVector *Self, std::string_view &Value)
 {
-   *Value = Self->SID;
+   Value = Self->SID;
    return ERR::Okay;
 }
 
-static ERR VECTOR_SET_SID(extVector *Self, CSTRING Value)
+static ERR VECTOR_SET_SID(extVector *Self, const std::string_view &Value)
 {
-   if (Self->SID) FreeResource(Self->SID);
-
-   if (Value) {
-      Self->SID = strclone(Value);
-      Self->NumericID = strhash(Value);
+   if (Value.empty()) {
+      Self->SID.clear();
+      Self->NumericID = 0;
    }
    else {
-      Self->SID = nullptr;
-      Self->NumericID = 0;
+      Self->SID = Value;
+      Self->NumericID = strhash(Value);
    }
    return ERR::Okay;
 }
@@ -1935,7 +1925,7 @@ static ERR VECTOR_GET_NumericID(extVector *Self, int *Value)
 static ERR VECTOR_SET_NumericID(extVector *Self, int Value)
 {
    Self->NumericID = Value;
-   if (Self->SID) { FreeResource(Self->SID); Self->SID = nullptr; }
+   Self->SID.clear();
    return ERR::Okay;
 }
 
@@ -2115,15 +2105,15 @@ of the previous command).
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Sequence(extVector *Self, STRING *Value)
+static ERR VECTOR_GET_Sequence(extVector *Self, std::string_view &Value)
 {
    kt::Log log;
 
-   if (!Self->GeneratePath) return log.warning(ERR::Mismatch); // Path generation must be supported by the vector.
+   if (not Self->GeneratePath) return log.warning(ERR::Mismatch); // Path generation must be supported by the vector.
 
    gen_vector_tree(Self);
 
-   if (!Self->BasePath.total_vertices()) return ERR::NoData;
+   if (not Self->BasePath.total_vertices()) return ERR::NoData;
 
    std::ostringstream seq;
 
@@ -2191,8 +2181,11 @@ static ERR VECTOR_GET_Sequence(extVector *Self, STRING *Value)
 
    auto out = seq.str();
    if (out.length() > 0) {
-      *Value = strclone(out);
-      return ERR::Okay;
+      if (auto str = strclone(out)) {
+         Value = std::string_view{str, out.length()};
+         return ERR::Okay;
+      }
+      else return ERR::AllocMemory;
    }
    else return ERR::NoData;
 }
@@ -2207,20 +2200,20 @@ the ~ReadPainter() function in the Vector module.  Please refer to it for furthe
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Stroke(extVector *Self, CSTRING *Value)
+static ERR VECTOR_GET_Stroke(extVector *Self, std::string_view &Value)
 {
-   *Value = Self->StrokeString;
+   Value = Self->StrokeString;
    return ERR::Okay;
 }
 
-static ERR VECTOR_SET_Stroke(extVector *Self, STRING Value)
+static ERR VECTOR_SET_Stroke(extVector *Self, const std::string_view &Value)
 {
-   if (Self->StrokeString) { FreeResource(Self->StrokeString); Self->StrokeString = nullptr; }
+   Self->StrokeString.clear();
 
-   if (Value) {
-      Self->StrokeString = strclone(Value);
+   if (not Value.empty()) {
+      Self->StrokeString = Value;
       CSTRING next;
-      vec::ReadPainter(Self->Scene, Value, &Self->Stroke, &next);
+      vec::ReadPainter(Self->Scene, Self->StrokeString, &Self->Stroke, &next);
       if (next) {
          // SVG rules allow for a solid colour fallback to follow the initial painter reference.
          // This typically looks something like 'url(#thing) rgb(values)'
@@ -2547,17 +2540,17 @@ static const FieldArray clVectorFields[] = {
    { "AppendPath",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW,          VECTOR_GET_AppendPath, VECTOR_SET_AppendPath },
    { "MorphFlags",   FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW,        VECTOR_GET_MorphFlags, VECTOR_SET_MorphFlags, &clMorphFlags },
    { "NumericID",    FDF_VIRTUAL|FDF_INT|FDF_RW,             VECTOR_GET_NumericID, VECTOR_SET_NumericID },
-   { "SID",          FDF_VIRTUAL|FDF_STRING|FDF_RW,          VECTOR_GET_SID, VECTOR_SET_SID },
+   { "SID",          FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,       VECTOR_GET_SID, VECTOR_SET_SID },
    { "ResizeEvent",  FDF_VIRTUAL|FDF_FUNCTION|FDF_W,         nullptr, VECTOR_SET_ResizeEvent },
-   { "Sequence",     FDF_VIRTUAL|FDF_STRING|FDF_ALLOC|FDF_R, VECTOR_GET_Sequence },
-   { "Stroke",       FDF_VIRTUAL|FDF_STRING|FDF_RW,          VECTOR_GET_Stroke, VECTOR_SET_Stroke },
+   { "Sequence",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTOR_GET_Sequence },
+   { "Stroke",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,       VECTOR_GET_Stroke, VECTOR_SET_Stroke },
    { "StrokeColour", FDF_VIRTUAL|FD_FLOAT|FDF_ARRAY|FD_RW,   VECTOR_GET_StrokeColour, VECTOR_SET_StrokeColour },
    { "StrokeWidth",  FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VECTOR_GET_StrokeWidth, VECTOR_SET_StrokeWidth },
    { "Transition",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW,          VECTOR_GET_Transition, VECTOR_SET_Transition },
-   { "Fill",         FDF_VIRTUAL|FDF_STRING|FDF_RW,          VECTOR_GET_Fill, VECTOR_SET_Fill },
+   { "Fill",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,       VECTOR_GET_Fill, VECTOR_SET_Fill },
    { "FillColour",   FDF_VIRTUAL|FD_FLOAT|FDF_ARRAY|FDF_RW,  VECTOR_GET_FillColour, VECTOR_SET_FillColour },
    { "FillRule",     FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW,  VECTOR_GET_FillRule, VECTOR_SET_FillRule, &clFillRule },
-   { "Filter",       FDF_VIRTUAL|FDF_STRING|FDF_RW,          VECTOR_GET_Filter, VECTOR_SET_Filter },
+   { "Filter",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,       VECTOR_GET_Filter, VECTOR_SET_Filter },
    { "LineJoin",     FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW,    VECTOR_GET_LineJoin, VECTOR_SET_LineJoin, &clLineJoin },
    { "LineCap",      FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW,    VECTOR_GET_LineCap, VECTOR_SET_LineCap, &clLineCap },
    { "InnerJoin",    FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW,    VECTOR_GET_InnerJoin, VECTOR_SET_InnerJoin, &clInnerJoin },


### PR DESCRIPTION
* Converted Vector field glue and generated accessors to use std::string_view for C++ string fields
* Updated vector filters, painters and shapes to use std::string storage instead of manually owned C strings
* Added placement construction and destructor cleanup for converted Vector classes