### PR TITLE
[Font] Harden bitmap font loading and metrics

### DIFF
--- a/docs/xml/modules/classes/font.xml
+++ b/docs/xml/modules/classes/font.xml
@@ -147,7 +147,7 @@
       <name>Face</name>
       <comment>The name of a font face that is to be loaded on initialisation.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The name of an installed font face must be specified here for initialisation.  If this field is undefined then the initialisation process will use the user's preferred face.  A list of available faces can be obtained from the <function module="Font">GetList</function> function.</p>
 <p>For convenience, the face string can also be extended with extra parameters so that the point size and style are defined at the same time.  Extra parameters are delimited with the colon character and must follow a set order defined as <code>face:pointsize:style:colour</code>.</p>
@@ -285,7 +285,7 @@ Charter:120%::255,128,255
       <name>Path</name>
       <comment>The path to a font file.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>This field can be defined prior to initialisation.  It can be used to refer to the exact location of a font data file, in opposition to the normal practice of loading fonts that are installed on the host system.</p>
 <p>This feature is ideal for use when distributing custom fonts with an application.</p>
@@ -307,7 +307,7 @@ Charter:120%::255,128,255
       <name>String</name>
       <comment>The string to use when drawing a Font.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The String field must be defined in order to draw text with a font object.  A string must consist of a valid sequence of UTF-8 characters.  Line feeds are allowed (whenever a line feed is reached, the Draw() action will start printing on the next line).  Drawing will stop when the null termination character is reached.</p>
 <p>If a string contains characters that are not supported by a font, those characters will be printed using a default character from the font.</p>
@@ -318,7 +318,7 @@ Charter:120%::255,128,255
       <name>Style</name>
       <comment>Determines font styling.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The style of a font can be selected by setting the Style field.  This comes into effect only if the font actually supports the specified style as part of its graphics set.  If the style is unsupported, the regular styling of the face will be used on initialisation.</p>
 <p>Bitmap fonts are a special case if a bold or italic style is selected.  In this situation the system can automatically convert the font to that style even if the correct graphics set does not exist.</p>

--- a/docs/xml/modules/font.xml
+++ b/docs/xml/modules/font.xml
@@ -63,6 +63,8 @@
     <result type="ERR">
       <error code="Okay">Fonts were successfully refreshed.</error>
       <error code="AccessObject">Access to the font database was denied, or the object does not exist.</error>
+      <error code="GetField">Failed to read font database entries after scanning.</error>
+      <error code="OpenFile">Failed to open <code>fonts:fonts.cfg</code> for writing.</error>
     </result>
   </function>
 

--- a/include/kotuku/modules/font.h
+++ b/include/kotuku/modules/font.h
@@ -79,10 +79,10 @@ class objFont : public Object {
    double Point;           // The point size of a font.
    double GlyphSpacing;    // Adjusts the amount of spacing between each character.
    objBitmap * Bitmap;     // The destination Bitmap to use when drawing a font.
-   STRING String;          // The string to use when drawing a Font.
-   STRING Path;            // The path to a font file.
-   STRING Style;           // Determines font styling.
-   STRING Face;            // The name of a font face that is to be loaded on initialisation.
+   std::string String;     // The string to use when drawing a Font.
+   std::string Path;       // The path to a font file.
+   std::string Style;      // Determines font styling.
+   std::string Face;       // The name of a font face that is to be loaded on initialisation.
    struct RGB8 Outline;    // Defines the outline colour around a font.
    struct RGB8 Underline;  // Enables font underlining when set.
    struct RGB8 Colour;     // The font colour in RGB8 format.
@@ -131,28 +131,28 @@ class objFont : public Object {
       return ERR::Okay;
    }
 
-   template <class T> inline ERR setString(T && Value) noexcept {
+   inline ERR setString(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[11];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setStyle(T && Value) noexcept {
+   inline ERR setStyle(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[22];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
-   template <class T> inline ERR setFace(T && Value) noexcept {
+   inline ERR setFace(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[25];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
    inline ERR setOutline(const struct RGB8 Value) noexcept {

--- a/include/kotuku/strings.hpp
+++ b/include/kotuku/strings.hpp
@@ -437,6 +437,26 @@ inline int strcopy(T &&Source, std::span<char, N> Dest) noexcept
    return -1;
 }
 
+[[nodiscard]] inline int strisearch(const std::string_view Keyword, const std::string_view String) noexcept
+{
+   if (Keyword.size() > String.size()) return -1;
+   size_t string_pos = 0;
+   while (string_pos < String.size()) {
+      size_t keyword_pos;
+      for (keyword_pos=0; keyword_pos < Keyword.size(); keyword_pos++) {
+         if (string_pos + keyword_pos >= String.size()) break;
+         if (std::toupper(uint8_t(String[string_pos + keyword_pos])) != std::toupper(uint8_t(Keyword[keyword_pos]))) {
+            break;
+         }
+      }
+      if (keyword_pos == Keyword.size()) return int(string_pos);
+      for (++string_pos; (string_pos < String.size()) and ((uint8_t(String[string_pos]) & 0xc0) == 0x80);
+         string_pos++);
+   }
+
+   return -1;
+}
+
 // std::string_view conversion to numeric type.  Returns zero on error.
 // Leading whitespace is not ignored, unlike strtol() and strtod()
 

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -2094,7 +2094,7 @@ static const FieldArray clFields[] = {
    { "Path",          FDF_CPPSTRING|FDF_RW,    GET_Path, SET_Path },
    { "Origin",        FDF_CPPSTRING|FDF_RW,    GET_Path, SET_Origin },
    { "PageWidth",     FDF_UNIT|FDF_INT|FDF_SCALED|FDF_RW, GET_PageWidth, SET_PageWidth },
-   { "Pretext",       FDF_STRING|FDF_W,        nullptr, SET_Pretext },
+   { "Pretext",       FDF_CPPSTRING|FDF_W,     nullptr, SET_Pretext },
    { "Src",           FDF_SYNONYM|FDF_CPPSTRING|FDF_RW, GET_Path, SET_Path },
    { "WorkingPath",   FDF_CPPSTRING|FDF_R,     GET_WorkingPath, nullptr },
    END_FIELD

--- a/src/document/class/fields.cpp
+++ b/src/document/class/fields.cpp
@@ -313,9 +313,9 @@ A Pretext will always survive document unloading and resets.  It can be removed 
 
 *********************************************************************************************************************/
 
-static ERR SET_Pretext(extDocument *Self, CSTRING Value)
+static ERR SET_Pretext(extDocument *Self, const std::string_view &Value)
 {
-   if (!Value) {
+   if (Value.empty()) {
       if (Self->PretextXML) { FreeResource(Self->PretextXML); Self->PretextXML = nullptr; }
       return ERR::Okay;
    }

--- a/src/font/class_font.cpp
+++ b/src/font/class_font.cpp
@@ -109,14 +109,16 @@ static ERR FONT_Init(extFont *Self)
 
    if (Self->Path.empty()) {
       CSTRING path = nullptr;
-      if (fnt::SelectFont(Self->Face, Self->Style, &path, &meta) IS ERR::Okay) {
-         Self->set(FID_Path, path);
+      auto error = fnt::SelectFont(Self->Face, Self->Style, &path, &meta);
+      if (error IS ERR::Okay) {
+         error = Self->set(FID_Path, path);
          FreeResource(path);
+         if (error != ERR::Okay) return error;
       }
       else {
          log.warning("Font \"%s\" (point %.2f, style %s) is not recognised.", Self->Face.c_str(), Self->Point,
             Self->Style.c_str());
-         return ERR::Failed;
+         return error;
       }
    }
 
@@ -338,9 +340,10 @@ static ERR SET_Face(extFont *Self, const std::string_view &Value)
       CSTRING final_name;
       auto i = Value.find(':');
       auto face = Value.substr(0, i);
-      if (fnt::ResolveFamilyName(face, &final_name) IS ERR::Okay) {
+      if (auto error = fnt::ResolveFamilyName(face, &final_name); error IS ERR::Okay) {
          Self->Face.assign(final_name);
       }
+      else return error;
 
       if (i IS std::string::npos) return ERR::Okay;
 
@@ -745,8 +748,8 @@ static ERR draw_bitmap_font(extFont *Self)
    uint8_t *xdata, *data;
    int linewidth, offset, wrapindex, charlen;
    uint32_t unicode, ocolour;
-   int16_t startx, xpos, ex, ey, sx, sy, xinc;
-   int16_t bytewidth, alpha, charwidth;
+   int startx, xpos, ex, ey, sx, sy, xinc;
+   int bytewidth, alpha, charwidth;
    bool draw_line;
    #define CHECK_LINE_CLIP(font,y,bmp) if (((y)-1 < (bmp)->Clip.Bottom) and ((y) + (font)->prvBitmapHeight + 1 > (bmp)->Clip.Top)) draw_line = true; else draw_line = false;
 
@@ -771,6 +774,7 @@ static ERR draw_bitmap_font(extFont *Self)
    }
 
    const char *wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
+   const char *line_start = str.data();
 
    uint32_t colour  = bitmap->getColour(Self->Colour);
    uint32_t ucolour = bitmap->getColour(Self->Underline);
@@ -783,7 +787,7 @@ static ERR draw_bitmap_font(extFont *Self)
 
    if (acLock(bitmap) != ERR::Okay) return log.warning(ERR::Lock);
 
-   int16_t dx = 0, dy = 0;
+   int dx = 0, dy = 0;
    startx = dxcoord;
    CHECK_LINE_CLIP(Self, dycoord, bitmap);
    while (not str.empty()) {
@@ -800,6 +804,7 @@ static ERR draw_bitmap_font(extFont *Self)
          }
 
          wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
+         line_start = str.data();
          startx = dxcoord;
          dycoord += Self->LineSpacing;
          CHECK_LINE_CLIP(Self, dycoord, bitmap);
@@ -822,7 +827,7 @@ static ERR draw_bitmap_font(extFont *Self)
 
          // Wordwrap management
 
-         if (str.data() >= wrapstr) {
+         if ((str.data() >= wrapstr) and (str.data() > line_start)) {
             dxcoord = Self->X;
             dycoord += Self->LineSpacing;
 
@@ -833,6 +838,7 @@ static ERR draw_bitmap_font(extFont *Self)
             if (str.empty()) break;
 
             wrapstr = calc_line_layout(Self, str, &linewidth, &wrapindex, &dxcoord);
+            line_start = str.data();
             CHECK_LINE_CLIP(Self, dycoord, bitmap);
          }
 

--- a/src/font/class_font.cpp
+++ b/src/font/class_font.cpp
@@ -8,41 +8,40 @@ that is distributed with this package.  Please refer to it for further informati
 -CLASS-
 Font: Draws bitmap fonts and manages font meta information.
 
-The Font class is provided for the purpose of bitmap font rendering and querying font meta information.  It supports
-styles such as bold, italic and underlined text, along with extra features such as adjustable spacing and word
-alignment. Fixed-point bitmap fonts are supported through the Windows .fon file format.  Truetype fonts are
-not supported (refer to the @VectorText class for this feature).
+The Font class renders fixed-size bitmap fonts to a @Bitmap and exposes metrics for the selected font face.  It
+supports bold, italic and underlined text, as well as adjustable glyph spacing, line spacing, tab width and alignment.
+Bitmap fonts are loaded from Windows `.fon` files.  Scalable TrueType rendering is provided by @VectorText instead.
 
-Bitmap fonts must be stored in the `fonts:fixed/` directory in order to be recognised.  The process of font
-installation and file management is managed by functions supplied in the Font module.
+Bitmap fonts must be stored in the `fonts:fixed/` directory to be recognised during font database refreshes.  Use the
+Font module's query and refresh functions to inspect or rebuild the installed font list.
 
-The Font class includes full support for the unicode character set through its support for UTF-8.  This gives you the
-added benefit of being able to support international character sets with ease, but you must be careful not to use
-character codes above #127 without being sure that they follow UTF-8 guidelines.  Find out more about UTF-8 at
-this <a href="http://www.cl.cam.ac.uk/~mgk25/unicode.html">web page</a>.
+Font strings are interpreted as UTF-8, allowing Unicode text to be supplied through the #String field.  Do not insert
+arbitrary byte values above `127` unless they are valid UTF-8 sequences.  Invalid or unsupported glyphs fall back to
+the font's default character.
 
-Initialisation of a new font object can be as simple as declaring its #Point size and #Face name.  Font objects can
-be difficult to alter post-initialisation, so all style and graphical selections must be defined on creation.  For
-example, it is not possible to change styling from regular to bold format dynamically.  To support multiple styles
-of the same font, create a font object for every style that requires support.  Basic settings such as colour, the
-font string and text positioning are not affected by these limitations.
+Initialisation of a new Font object can be as simple as declaring its #Point size and #Face name.  Font face, size and
+style selections should be set before initialisation because the loaded bitmap data is cached for that combination.
+To use multiple styles of the same face, create one Font object for each required style.  Runtime drawing properties
+such as colour, #String, #X, #Y and alignment can still be changed between draw operations.
 
-To draw a font string to a Bitmap object, start by setting the #Bitmap and #String fields.  The #X and #Y fields
-determine string positioning and you can also use the #Align field to position a string to the right or center of the
-surface area.
+To draw a string, set #Bitmap and #String, then call #Draw().  The #X and #Y fields set the starting position.  Use
+#Align together with #AlignWidth and #AlignHeight when text needs to be positioned within a larger surface area.
 
-To clarify the terminology used in this documentation, please note the definitions for the following terms:
+This documentation uses the following font terminology:
 
 <list type="bullet">
-<li>'Point' determines the size of a font.  The value is relative only to other point sizes of the same font face, i.e. two faces at the same point size are not necessarily the same height.</li>
-<li>'Height' represents the 'vertical bearing' or point of the font, expressed as a pixel value.  The height does not cover any leading at the top of the font, or the gutter space used for the tails on characters like 'g' and 'y'.</li>
-<li>'Gutter' is the amount of space that a character can descend below the base line.  Characters like 'g' and 'y' are examples of characters that utilise the gutter space.  The gutter is also sometimes known as the 'external leading' or 'descent' of a character.</li>
-<li>'LineSpacing' is the recommended pixel distance between each line that is printed with the font.</li>
-<li>'Glyph' refers to a single font character.</li>
-</>
+<li>`Point` is the requested size of the font.  It is relative to other point sizes of the same face; two faces at the
+same point size are not necessarily the same pixel height.</li>
+<li>`Height` is the vertical bearing of the font expressed in pixels.  It excludes top leading and the gutter used by
+descending glyphs.</li>
+<li>`Gutter` is the space below the baseline used by descending glyphs such as `g` and `y`.  It is also known as the
+external leading or descent.</li>
+<li>`LineSpacing` is the recommended pixel distance from one baseline to the next.</li>
+<li>`Glyph` is a single rendered character image.</li>
+</list>
 
-Please note that in the majority of cases the @VectorText class should be used for drawing strings because the Font
-class is not integrated with the display's vector scene graph.
+Use @VectorText for most display text.  The Font class draws directly to a @Bitmap and is not integrated with the
+display vector scene graph.
 
 -END-
 
@@ -57,11 +56,12 @@ static ERR SET_Style(extFont *, const std::string_view &);
 -ACTION-
 Draw: Draws a font to a Bitmap.
 
-Draws a font to a target Bitmap, starting at the coordinates of #X and #Y, using the characters in the font #String.
+Draws #String to the target #Bitmap, starting at #X and #Y after any configured alignment and baseline adjustments have
+been applied.
 
 -ERRORS-
 Okay
-FieldNotSet: The Bitmap and/or String field has not been set.
+FieldNotSet: The #Bitmap field has not been set.
 -END-
 
 *********************************************************************************************************************/
@@ -241,27 +241,23 @@ static ERR FONT_NewPlacement(extFont *Self)
 -FIELD-
 Align: Sets the position of a font string to an abstract alignment.
 
-Use this field to set the alignment of a font string within its surface area.  This is an abstract means of positioning
-in comparison to setting the #X and #Y fields directly.
+Sets the alignment of the font string within the #AlignWidth and #AlignHeight area.  This is used in addition to the
+#X and #Y drawing coordinates.
 
 -FIELD-
 AlignHeight: The height to use when aligning the font string.
 
-If the `VERTICAL` or `TOP` alignment options are used in the #Align field, the AlignHeight should be set so
-that the alignment of the font string can be correctly calculated.  If the AlignHeight is not defined, the target
-#Bitmap's height will be used when computing alignment.
+Defines the height of the area used for vertical alignment.  If this field is `0`, the target #Bitmap height is used.
 
 -FIELD-
 AlignWidth: The width to use when aligning the font string.
 
-If the `HORIZONTAL` or `RIGHT` alignment options are used in the #Align field, the AlignWidth should be set so
-that the alignment of the font string can be correctly calculated.  If the AlignWidth is not defined, the target
-#Bitmap's width will be used when computing alignment.
+Defines the width of the area used for horizontal alignment.  If this field is `0`, the target #Bitmap width is used.
 
 -FIELD-
 Ascent: The total number of pixels above the baseline.
 
-The Ascent value reflects the total number of pixels above the baseline, including the #Leading value.
+Reflects the total number of pixels above the baseline, including #Leading.
 
 -FIELD-
 Bitmap: The destination Bitmap to use when drawing a font.
@@ -269,8 +265,8 @@ Bitmap: The destination Bitmap to use when drawing a font.
 -FIELD-
 Bold: Set to `true` to enable bold styling.
 
-Setting the Bold field to `true` prior to initialisation will enable bold styling.  This field is provided only for
-convenience - we recommend that you set the Style field for determining font styling where possible.
+Setting this field before initialisation selects the `Bold` style, or `Bold Italic` if #Italic is also set.  Prefer
+#Style when setting an exact style name.
 
 *********************************************************************************************************************/
 
@@ -301,25 +297,21 @@ Colour: The font colour in !RGB8 format.
 -FIELD-
 EndX: Indicates the final horizontal coordinate after completing a draw operation.
 
-The EndX and #EndY fields reflect the final coordinate of the font #String, following the most recent call to
-the #Draw() action.
+Reflects the final horizontal coordinate reached by the most recent #Draw() operation.
 
 -FIELD-
 EndY: Indicates the final vertical coordinate after completing a draw operation.
 
-The #EndX and EndY fields reflect the final coordinate of the font #String, following the most recent call to
-the #Draw() action.
+Reflects the final vertical coordinate reached by the most recent #Draw() operation.
 
 -FIELD-
 Face: The name of a font face that is to be loaded on initialisation.
 
-The name of an installed font face must be specified here for initialisation.  If this field is undefined then the
-initialisation process will use the user's preferred face.  A list of available faces can be obtained from the
-~Font.GetList() function.
+The name of an installed font face must be specified before initialisation unless #Path is set directly.  A list of
+available faces can be obtained from ~Font.GetList().
 
-For convenience, the face string can also be extended with extra parameters so that the point size and style are
-defined at the same time.  Extra parameters are delimited with the colon character and must follow a set order
-defined as `face:pointsize:style:colour`.
+The face string can include optional point size, style and colour values in the form `face:pointsize:style:colour`.
+Omitted middle values may be left empty.
 
 Here are some examples:
 
@@ -329,8 +321,8 @@ Courier:10.6
 Charter:120%::255,128,255
 </pre>
 
-Multiple font faces can be specified in CSV format, e.g. `Sans Serif,Noto Sans`, which allows the closest matching
-font to be selected if the first face is unavailable or unable to match the requested point size.
+Multiple font faces can be specified in CSV format, e.g. `Sans Serif,Noto Sans`.  Names are resolved from left to
+right.
 
 *********************************************************************************************************************/
 
@@ -383,8 +375,8 @@ static ERR SET_Face(extFont *Self, const std::string_view &Value)
 -FIELD-
 FixedWidth: Forces a fixed pixel width to use for all glyphs.
 
-The FixedWidth value imposes a preset pixel width for all glyphs in the font.  It is important to note that if the
-fixed width value is less than the widest glyph, the glyphs will overlap each other.
+Forces all glyphs to advance by the specified pixel width.  If the value is less than the widest glyph, rendered glyphs
+can overlap.
 
 -FIELD-
 Flags:  Optional flags.
@@ -402,29 +394,28 @@ static ERR SET_Flags(extFont *Self, FTF Value)
 -FIELD-
 Gutter: The 'external leading' value, measured in pixels.  Applies to fixed fonts only.
 
-This field reflects the 'external leading' value (also known as the 'gutter'), measured in pixels.
+Reflects the external leading, or descent area, below the baseline.
 
 -FIELD-
 Height: The point size of the font, expressed in pixels.
 
-The point size of the font is expressed in this field as a pixel measurement.  It does not not include the leading value
-(refer to #Ascent if leading is required).
+Reflects the initialised font height in pixels.  It does not include #Leading; use #Ascent when the leading-inclusive
+distance above the baseline is required.
 
 The height is calculated on initialisation and can be read at any time.
 
 -FIELD-
 GlyphSpacing: Adjusts the amount of spacing between each character.
 
-This field adjusts the horizontal spacing between each glyph, technically known as kerning between each font
-character.  The value is expressed as a multiplier of the width of each character, and defaults to `1.0`.
+Adjusts horizontal glyph advance as a multiplier of each glyph's normal width.  The default value is `1.0`.
 
 Using negative values is valid, and can lead to text being printed backwards.
 
 -FIELD-
 Italic: Set to `true` to enable italic styling.
 
-Setting the Italic field to `true` prior to initialisation will enable italic styling.  This field is provided for
-convenience only - we recommend that you set the #Style field for determining font styling where possible.
+Setting this field before initialisation selects the `Italic` style, or `Bold Italic` if #Bold is also set.  Prefer
+#Style when setting an exact style name.
 
 *********************************************************************************************************************/
 
@@ -455,8 +446,7 @@ Leading: 'Internal leading' measured in pixels.  Applies to fixed fonts only.
 -FIELD-
 LineCount: The total number of lines in a font string.
 
-This field indicates the number of lines that are present in a #font's String field.  If word wrapping is enabled,
-this will be taken into account in the resulting figure.
+Returns the number of lines in #String.  If #WrapEdge is set, wrapped lines are included in the count.
 
 *********************************************************************************************************************/
 
@@ -472,19 +462,17 @@ static ERR GET_LineCount(extFont *Self, int *Value)
 -FIELD-
 LineSpacing: The amount of spacing between each line.
 
-This field defines the amount of space between each line that is printed with a font object.  It is set automatically
-during initialisation to reflect the recommended distance between each line.   The client can increase or decrease
-this value to make finer adjustments to the line spacing.  If negative, the text will be printed in a reverse vertical
-direction with each new line.
+Defines the vertical distance from one line baseline to the next.  It is initialised from the selected font and can be
+increased or decreased to adjust line spacing.  If negative, later lines are drawn upward.
 
-If set prior to initialisation, the value will be added to the font's normal line-spacing instead of over-riding it.
+If set before initialisation, the value is added to the font's normal line spacing instead of replacing it.
 For instance, setting the LineSpacing to 2 will result in an extra 2 pixels being added to the font's spacing.
 
 -FIELD-
 Path: The path to a font file.
 
-This field can be defined prior to initialisation.  It can be used to refer to the exact location of a font data file,
-in opposition to the normal practice of loading fonts that are installed on the host system.
+Defines the exact font file to load before initialisation.  This bypasses normal face-name resolution through the font
+database.
 
 This feature is ideal for use when distributing custom fonts with an application.
 
@@ -504,15 +492,13 @@ static ERR SET_Path(extFont *Self, const std::string_view &Value)
 -FIELD-
 MaxHeight: The maximum possible pixel height per character.
 
-This field reflects the maximum possible pixel height per character, covering the entire character set at the current
-point size.
+Reflects the maximum bitmap height for the selected font at the current point size.
 
 -FIELD-
 Opacity: Determines the level of translucency applied to a font.
 
-This field determines the translucency level of a font graphic.  The default setting is 100%, which means that the font
-will not be translucent.  Any other value set here will alter the impact of a font's graphic over the destination
-#Bitmap.  High values will retain the boldness of the font, while low values can render it close to invisible.
+Determines the translucency level of the font fill colour.  The default setting is `100`, meaning fully opaque.
+Lower values blend the glyphs with the destination #Bitmap.
 
 Please note that the use of translucency will always have an impact on the time it normally takes to draw a font.
 
@@ -537,14 +523,13 @@ static ERR SET_Opacity(extFont *Self, double Value)
 -FIELD-
 Outline: Defines the outline colour around a font.
 
-An outline can be drawn around a font by setting the Outline field to an !RGB8 colour.  The outline can be turned off by
-writing this field with a `NULL` value or setting the alpha component to zero.  Outlining is currently supported for
-bitmap fonts only.
+Draws a one-pixel outline around bitmap glyphs when set to an !RGB8 colour with a non-zero alpha component.  Set the
+field to `NULL` or use an alpha value of zero to disable outlining.
 
 -FIELD-
 Point: The point size of a font.
 
-The point size defines the size of a font in point units, at a ratio of 1:72 DPI.
+Defines the requested font size in points.
 
 When setting the point size of a bitmap font, the system will try and find the closest matching value for the requested
 point size.  For instance, if you request a fixed font at point 11 and the closest size is point 8, the system will
@@ -570,9 +555,8 @@ static ERR SET_Point(extFont *Self, double Value)
 -FIELD-
 String: The string to use when drawing a Font.
 
-The String field must be defined in order to draw text with a font object.  A string must consist of a valid sequence
-of UTF-8 characters.  Line feeds are allowed (whenever a line feed is reached, the Draw() action will start printing on
-the next line).  Drawing will stop when the null termination character is reached.
+The String field must be defined to draw text with a Font object.  It must contain valid UTF-8.  Line feed characters
+start a new line during #Draw().
 
 If a string contains characters that are not supported by a font, those characters will be printed using a default
 character from the font.
@@ -606,9 +590,8 @@ static ERR SET_String(extFont *Self, const std::string_view &Value)
 -FIELD-
 Style: Determines font styling.
 
-The style of a font can be selected by setting the Style field.  This comes into effect only if the font actually
-supports the specified style as part of its graphics set.  If the style is unsupported, the regular styling of the
-face will be used on initialisation.
+Selects the preferred style for initialisation.  If the selected face does not provide that style, regular styling or
+the first registered style is used.
 
 Bitmap fonts are a special case if a bold or italic style is selected.  In this situation the system can automatically
 convert the font to that style even if the correct graphics set does not exist.
@@ -629,21 +612,21 @@ static ERR SET_Style(extFont *Self, const std::string_view &Value)
 -FIELD-
 TabSize: Defines the tab size to use when drawing and manipulating a font string.
 
-The TabSize value controls the interval between tabs, measured in characters.
+Controls the tab interval, measured in character columns.
 
-The default tab size is 8 and the TabSize only comes into effect when tab characters are used in the font #String.
+The default tab size is `8`.  This field only affects tab characters in #String.
 
 -FIELD-
 Underline: Enables font underlining when set.
 
-To underline a font string, set the Underline field to the colour that should be used to draw the underline.
-Underlining can be turned off by writing this field with a `NULL` value or setting the alpha component to zero.
+Draws an underline using the supplied !RGB8 colour.  Set the field to `NULL` or use an alpha value of zero to disable
+underlining.
 
 -FIELD-
 Width: Returns the pixel width of a string.
 
-Read this virtual field to obtain the pixel width of a font string.  You must have already set a string in the font for
-this to work, or a width of zero will be returned.
+Returns the pixel width of #String using the current font metrics and wrapping settings.  If #String is empty, the
+result is `0`.
 
 *********************************************************************************************************************/
 
@@ -670,27 +653,24 @@ static ERR GET_Width(extFont *Self, int *Value)
 -FIELD-
 WrapEdge: Enables word wrapping at a given boundary.
 
-Word wrapping is enabled by setting the WrapEdge field to a value greater than zero.  Wrapping occurs whenever the
-right-most edge of any word in the font string extends past the coordinate indicated by the WrapEdge.
+Enables word wrapping when set to a value greater than zero.  Wrapping occurs when a word extends beyond this X
+coordinate.
 
 -FIELD-
 X: The starting horizontal position when drawing the font string.
 
-When drawing font strings, the X and #Y fields define the position that the string will be drawn to in the target
-surface.  The default coordinates are `(0, 0)`.
+Defines the starting horizontal coordinate for #Draw().  The default coordinate is `0`.
 
 -FIELD-
 Y: The starting vertical position when drawing the font string.
 
-When drawing font strings, the #X and Y fields define the position that the string will be drawn to in the target
-surface.  The default coordinates are `(0, 0)`.
+Defines the starting vertical coordinate for #Draw().  The default coordinate is `0`.
 
 -FIELD-
 YOffset: Additional offset value that is added to vertically aligned fonts.
 
-Fonts that are aligned vertically (either in the center or bottom edge of the drawing area) will have a vertical offset
-value.  Reading that value from this field and adding it to the Y field will give you an accurate reading of where
-the string will be drawn.
+Returns the vertical offset applied by `VERTICAL` or `BOTTOM` alignment.  Add this value to #Y to determine the
+aligned drawing baseline.
 -END-
 
 *********************************************************************************************************************/

--- a/src/font/class_font.cpp
+++ b/src/font/class_font.cpp
@@ -50,7 +50,7 @@ class is not integrated with the display's vector scene graph.
 
 static BitmapCache * check_bitmap_cache(extFont *, FTF);
 static ERR SET_Point(extFont *Self, double);
-static ERR SET_Style(extFont *, CSTRING);
+static ERR SET_Style(extFont *, const std::string_view &);
 
 /*********************************************************************************************************************
 
@@ -90,7 +90,6 @@ static ERR FONT_Free(extFont *Self)
       }
    }
 
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
    Self->~extFont();
    return ERR::Okay;
 }
@@ -104,25 +103,26 @@ static ERR FONT_Init(extFont *Self)
    FTF style;
    FMETA meta = FMETA::NIL;
 
-   if ((!Self->prvFace[0]) and (!Self->Path)) return log.warning(ERR::FieldNotSet);
+   if ((Self->Face.empty()) and (Self->Path.empty())) return log.warning(ERR::FieldNotSet);
 
    if (!Self->Point) Self->Point = global_point_size();
 
-   if (!Self->Path) {
+   if (Self->Path.empty()) {
       CSTRING path = nullptr;
-      if (fnt::SelectFont(Self->prvFace, Self->prvStyle, &path, &meta) IS ERR::Okay) {
+      if (fnt::SelectFont(Self->Face, Self->Style, &path, &meta) IS ERR::Okay) {
          Self->set(FID_Path, path);
          FreeResource(path);
       }
       else {
-         log.warning("Font \"%s\" (point %.2f, style %s) is not recognised.", Self->prvFace, Self->Point, Self->prvStyle);
+         log.warning("Font \"%s\" (point %.2f, style %s) is not recognised.", Self->Face.c_str(), Self->Point,
+            Self->Style.c_str());
          return ERR::Failed;
       }
    }
 
    // Check the bitmap cache to see if we have already loaded this font
 
-   style = font_style_flags(Self->prvStyle);
+   style = font_style_flags(Self->Style);
 
    CACHE_LOCK lock(glCacheMutex);
 
@@ -147,7 +147,7 @@ static ERR FONT_Init(extFont *Self)
 
             winfnt_header_fields header;
             if (file->read(&header, sizeof(header)) IS ERR::Okay) {
-               if (auto error = validate_winfnt_header(header, nullptr); error != ERR::Okay) {
+               if (auto error = validate_winfnt_header(header, ""); error != ERR::Okay) {
                   return log.warning(error);
                }
 
@@ -170,7 +170,7 @@ static ERR FONT_Init(extFont *Self)
          Self->Point = face.nominal_point_size;
          cache = check_bitmap_cache(Self, style);
          if (!cache) { // Load the font into the cache
-            auto it = glBitmapCache.emplace(glBitmapCache.end(), face, Self->prvStyle, Self->Path, *file, fonts[wfi]);
+            auto it = glBitmapCache.emplace(glBitmapCache.end(), face, Self->Style, Self->Path, *file, fonts[wfi]);
 
             if (it->Result IS ERR::Okay) cache = &(*it);
             else {
@@ -184,7 +184,7 @@ static ERR FONT_Init(extFont *Self)
    }
 
    if (cache) {
-      Self->prvData     = cache->mData;
+      Self->prvData     = cache->mData.data();
       Self->Ascent      = cache->Header.ascent;
       Self->Point       = cache->Header.nominal_point_size;
       Self->Height      = cache->Header.ascent - cache->Header.internal_leading + cache->Header.external_leading;
@@ -213,9 +213,10 @@ static ERR FONT_Init(extFont *Self)
 
    // Remove the location string to reduce resource usage
 
-   if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
+   Self->Path.clear();
 
-   log.detail("Family: %s, Style: %s, Point: %.2f, Height: %d", Self->prvFace, Self->prvStyle, Self->Point, Self->Height);
+   log.detail("Family: %s, Style: %s, Point: %.2f, Height: %d", Self->Face.c_str(), Self->Style.c_str(),
+      Self->Point, Self->Height);
    return ERR::Okay;
 }
 
@@ -227,11 +228,9 @@ static ERR FONT_NewPlacement(extFont *Self)
    Self->TabSize         = 8;
    Self->prvDefaultChar  = '.';
    Self->prvLineCountCR  = 1;
-   Self->Style           = Self->prvStyle;
-   Self->Face            = Self->prvFace;
    Self->Colour.Alpha    = 255;
    Self->GlyphSpacing    = 1.0;
-   strcopy("Regular", Self->prvStyle, sizeof(Self->prvStyle));
+   Self->Style           = "Regular";
    return ERR::Okay;
 }
 
@@ -276,7 +275,7 @@ convenience - we recommend that you set the Style field for determining font sty
 static ERR GET_Bold(extFont *Self, int *Value)
 {
    if ((Self->Flags & FTF::BOLD) != FTF::NIL) *Value = TRUE;
-   else if (kt::strisearch("bold", Self->prvStyle) != -1) *Value = TRUE;
+   else if (kt::strisearch("bold", Self->Style) != -1) *Value = TRUE;
    else *Value = FALSE;
    return ERR::Okay;
 }
@@ -284,7 +283,7 @@ static ERR GET_Bold(extFont *Self, int *Value)
 static ERR SET_Bold(extFont *Self, int Value)
 {
    const bool bold = Value != FALSE;
-   const bool italic = ((Self->Flags & FTF::ITALIC) != FTF::NIL) or (kt::strisearch("italic", Self->prvStyle) != -1);
+   const bool italic = ((Self->Flags & FTF::ITALIC) != FTF::NIL) or (kt::strisearch("italic", Self->Style) != -1);
 
    if (bold and italic) return SET_Style(Self, "Bold Italic");
    else if (bold) return SET_Style(Self, "Bold");
@@ -333,46 +332,45 @@ font to be selected if the first face is unavailable or unable to match the requ
 
 *********************************************************************************************************************/
 
-static ERR SET_Face(extFont *Self, STRING Value)
+static ERR SET_Face(extFont *Self, const std::string_view &Value)
 {
-   if ((Value) and (Value[0])) {
+   if (not Value.empty()) {
       CSTRING final_name;
-      int i;
-      for (i=0; Value[i] and Value[i] != ':'; i++);
-
-      std::string face(Value, i);
+      auto i = Value.find(':');
+      auto face = Value.substr(0, i);
       if (fnt::ResolveFamilyName(face, &final_name) IS ERR::Okay) {
-         strcopy(final_name, Self->prvFace, std::ssize(Self->prvFace));
+         Self->Face.assign(final_name);
       }
 
-      if (!Value[i]) return ERR::Okay;
+      if (i IS std::string::npos) return ERR::Okay;
 
       // Extract the point size
 
-      Value += i + 1;
-      if ((*Value) and (*Value != ':')) {
-         double pt = strtod(Value, &Value);
-         SET_Point(Self, pt);
+      auto point = Value.substr(i + 1);
+      i = point.find(':');
+      auto point_value = point.substr(0, i);
+      if (not point_value.empty()) {
+         double pt = 0;
+         auto result = std::from_chars(point_value.data(), point_value.data() + point_value.size(), pt);
+         if (result.ec IS std::errc()) SET_Point(Self, pt);
       }
 
-      while ((*Value) and (*Value != ':')) Value++;
-      if (!*Value) return ERR::Okay;
+      if (i IS std::string::npos) return ERR::Okay;
 
       // Extract the style string
 
-      Value++;
-      char style[sizeof(Self->prvStyle)];
-      for (i=0; (Value[i]) and (Value[i] != ':') and (i < int(sizeof(style))-1); i++) style[i] = Value[i];
-      style[i] = 0;
-      SET_Style(Self, style);
+      auto style = point.substr(i + 1);
+      i = style.find(':');
 
-      if (Value[i] != ':') return ERR::Okay;
+      SET_Style(Self, style.substr(0, i));
+
+      if (i IS std::string::npos) return ERR::Okay;
 
       // Extract the colour string
 
-      Self->set(FID_Colour, Value + i + 1);
+      Self->set(FID_Colour, style.substr(i + 1));
    }
-   else Self->prvFace[0] = 0;
+   else Self->Face.clear();
 
    return ERR::Okay;
 }
@@ -430,7 +428,7 @@ convenience only - we recommend that you set the #Style field for determining fo
 static ERR GET_Italic(extFont *Self, int *Value)
 {
    if ((Self->Flags & FTF::ITALIC) != FTF::NIL) *Value = TRUE;
-   else if (kt::strisearch("italic", Self->prvStyle) != -1) *Value = TRUE;
+   else if (kt::strisearch("italic", Self->Style) != -1) *Value = TRUE;
    else *Value = FALSE;
    return ERR::Okay;
 }
@@ -438,7 +436,7 @@ static ERR GET_Italic(extFont *Self, int *Value)
 static ERR SET_Italic(extFont *Self, int Value)
 {
    const bool italic = Value != FALSE;
-   const bool bold = ((Self->Flags & FTF::BOLD) != FTF::NIL) or (kt::strisearch("bold", Self->prvStyle) != -1);
+   const bool bold = ((Self->Flags & FTF::BOLD) != FTF::NIL) or (kt::strisearch("bold", Self->Style) != -1);
 
    if (bold and italic) return SET_Style(Self, "Bold Italic");
    else if (bold) return SET_Style(Self, "Bold");
@@ -489,11 +487,10 @@ This feature is ideal for use when distributing custom fonts with an application
 
 *********************************************************************************************************************/
 
-static ERR SET_Path(extFont *Self, CSTRING Value)
+static ERR SET_Path(extFont *Self, const std::string_view &Value)
 {
    if (!Self->initialised()) {
-      if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
-      if (Value) Self->Path = strclone(Value);
+      Self->Path.assign(Value);
       return ERR::Okay;
    }
    else return ERR::Failed;
@@ -579,25 +576,24 @@ character from the font.
 
 *********************************************************************************************************************/
 
-static ERR SET_String(extFont *Self, CSTRING Value)
+static ERR SET_String(extFont *Self, const std::string_view &Value)
 {
-   if ((Value) and (Self->String) and (std::string_view(Value) IS Self->String)) return ERR::Okay;
+   if (Self->String.size() IS Value.size()) {
+      if (std::string_view(Self->String) IS Value) return ERR::Okay;
+   }
 
-   Self->prvLineCount = 0;
-   Self->prvStrWidth  = 0; // Reset the string width for GET_Width
+   Self->prvLineCount   = 0;
+   Self->prvStrWidth    = 0; // Reset the string width for GET_Width
    Self->prvLineCountCR = 1; // Line count (carriage returns only)
 
-   if ((Value) and (*Value)) {
-      int i;
-      for (i=0; Value[i]; i++) if (Value[i] IS '\n') Self->prvLineCountCR++;
+   if (not Value.empty()) {
+      for (auto ch : Value) {
+         if (ch IS '\n') Self->prvLineCountCR++;
+      }
 
-      Self->prvBuffer.assign(Value);
-      Self->String = (STRING)Self->prvBuffer.c_str();
+      Self->String.assign(Value);
    }
-   else {
-      Self->prvBuffer.clear();
-      Self->String = nullptr;
-   }
+   else Self->String.clear();
 
    return ERR::Okay;
 }
@@ -618,10 +614,10 @@ Conventional font styles are `Bold`, `Bold Italic`, `Italic` and `Regular` (the 
 
 *********************************************************************************************************************/
 
-static ERR SET_Style(extFont *Self, CSTRING Value)
+static ERR SET_Style(extFont *Self, const std::string_view &Value)
 {
-   if ((!Value) or (!Value[0])) strcopy("Regular", Self->prvStyle, sizeof(Self->prvStyle));
-   else strcopy(Value, Self->prvStyle, sizeof(Self->prvStyle));
+   if (Value.empty()) Self->Style = "Regular";
+   else Self->Style.assign(Value);
    return ERR::Okay;
 }
 
@@ -650,7 +646,7 @@ this to work, or a width of zero will be returned.
 
 static ERR GET_Width(extFont *Self, int *Value)
 {
-   if (!Self->String) {
+   if (Self->String.empty()) {
       *Value = 0;
       return ERR::Okay;
    }
@@ -757,10 +753,10 @@ static ERR draw_bitmap_font(extFont *Self)
    // Validate settings for fixed font type
 
    if (not (bitmap = Self->Bitmap)) return log.warning(ERR::FieldNotSet);
-   if (Self->prvBuffer.empty()) return ERR::Okay;
+   if (Self->String.empty()) return ERR::Okay;
 
    ERR error = ERR::Okay;
-   auto str = std::string_view(Self->prvBuffer);
+   auto str = std::string_view(Self->String);
    int dxcoord = Self->X;
    int dycoord = Self->Y;
 
@@ -1046,10 +1042,10 @@ static const FieldArray clFontFields[] = {
    { "Point",        FDF_DOUBLE|FDF_RW, GET_Point, SET_Point },
    { "GlyphSpacing", FDF_DOUBLE|FDF_RW },
    { "Bitmap",       FDF_OBJECT|FDF_RW, nullptr, nullptr, CLASSID::BITMAP },
-   { "String",       FDF_STRING|FDF_RW, nullptr, SET_String },
-   { "Path",         FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "Style",        FDF_STRING|FDF_RI, nullptr, SET_Style },
-   { "Face",         FDF_STRING|FDF_RI, nullptr, SET_Face },
+   { "String",       FDF_CPPSTRING|FDF_RW, nullptr, SET_String },
+   { "Path",         FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "Style",        FDF_CPPSTRING|FDF_RI, nullptr, SET_Style },
+   { "Face",         FDF_CPPSTRING|FDF_RI, nullptr, SET_Face },
    { "Outline",      FDF_RGB|FDF_RW },
    { "Underline",    FDF_RGB|FDF_RW },
    { "Colour",       FDF_RGB|FDF_RW },
@@ -1074,7 +1070,7 @@ static const FieldArray clFontFields[] = {
    { "Bold",         FDF_VIRTUAL|FDF_INT|FDF_RW, GET_Bold, SET_Bold },
    { "Italic",       FDF_VIRTUAL|FDF_INT|FDF_RW, GET_Italic, SET_Italic },
    { "LineCount",    FDF_VIRTUAL|FDF_INT|FDF_R, GET_LineCount },
-   { "Location",     FDF_VIRTUAL|FDF_STRING|FDF_SYNONYM|FDF_RW, nullptr, SET_Path },
+   { "Location",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_SYNONYM|FDF_RW, nullptr, SET_Path },
    { "Opacity",      FDF_VIRTUAL|FDF_DOUBLE|FDF_RW, GET_Opacity, SET_Opacity },
    { "Width",        FDF_VIRTUAL|FDF_INT|FDF_R, GET_Width },
    { "YOffset",      FDF_VIRTUAL|FDF_INT|FDF_R, GET_YOffset },

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -182,9 +182,12 @@ constexpr T tab_advance(T Num, T Alignment) {
 
 static double glDefaultPoint = 10;
 static bool glPointSet = false;
+static std::mutex glPointMutex;
 
 static double global_point_size(void)
 {
+   const std::lock_guard<std::mutex> lock(glPointMutex);
+
    if (not glPointSet) {
       kt::Log log(__FUNCTION__);
       OBJECTID style_id;
@@ -192,13 +195,13 @@ static double global_point_size(void)
          kt::ScopedObjectLock<objXML> style(style_id, 3000);
          if (style.granted()) {
             char pointsize[20];
-            glPointSet = true;
             if (acGetKey(style.obj, "/interface/@fontsize", pointsize, sizeof(pointsize)) IS ERR::Okay) {
                glDefaultPoint = strtod(pointsize, nullptr);
                if (glDefaultPoint < 6) glDefaultPoint = 6;
                else if (glDefaultPoint > 80) glDefaultPoint = 80;
                log.msg("Global font size is %.1f.", glDefaultPoint);
             }
+            glPointSet = true;
          }
       }
       else log.warning("glStyle XML object is not available");
@@ -261,7 +264,7 @@ static void string_size(extFont *Font, std::string_view String, int Chars, int W
          if (ch IS ' ') x += Font->prvChar[' '].Advance * Font->GlyphSpacing;
          else if (ch IS '\t') {
             tabwidth = (Font->prvChar[' '].Advance * Font->GlyphSpacing) * Font->TabSize;
-            if (tabwidth) x += tab_advance<int>(x, tabwidth);
+            if (tabwidth) x = tab_advance<int>(x, tabwidth);
          }
          else if (ch IS '\n') {
             if (lastword > longest) longest = lastword;
@@ -350,19 +353,35 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
    argModule->get(FID_Root, modFont);
 
+   auto cleanup = [] {
+      if (glFTLibrary) { FT_Done_FreeType(glFTLibrary); glFTLibrary = nullptr; }
+      if (glConfig)    { FreeResource(glConfig);        glConfig    = nullptr; }
+      if (clFont)      { FreeResource(clFont);          clFont      = nullptr; }
+      if (modDisplay)  { FreeResource(modDisplay);      modDisplay  = nullptr; }
+   };
+
    if (objModule::load("display", &modDisplay, &DisplayBase) != ERR::Okay) return ERR::LoadModule;
 
-   if (FT_Init_FreeType(&glFTLibrary)) return log.warning(ERR::LoadModule);
+   if (FT_Init_FreeType(&glFTLibrary)) {
+      cleanup();
+      return log.warning(ERR::LoadModule);
+   }
 
    LOC type;
    bool refresh = (AnalysePath("fonts:fonts.cfg", &type) != ERR::Okay) or (type != LOC::FILE);
 
    if ((glConfig = objConfig::create::global(fl::Name("cfgSystemFonts"), fl::Path("fonts:fonts.cfg")))) {
-      if (refresh) fnt::RefreshFonts();
+      if (refresh) {
+         if (auto error = fnt::RefreshFonts(); error != ERR::Okay) {
+            cleanup();
+            return error;
+         }
+      }
 
       ConfigGroups *groups;
       if (not ((glConfig->get(FID_Data, groups) IS ERR::Okay) and (not groups->empty()))) {
          log.error("Failed to build a database of valid fonts.");
+         cleanup();
          return ERR::Failed;
       }
 
@@ -372,10 +391,16 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
    }
    else {
       log.error("Failed to load or prepare the font configuration file.");
+      cleanup();
       return ERR::Failed;
    }
 
-   return add_font_class();
+   if (auto error = add_font_class(); error != ERR::Okay) {
+      cleanup();
+      return error;
+   }
+
+   return ERR::Okay;
 }
 
 static ERR MODOpen(OBJECTPTR Module)
@@ -418,6 +443,8 @@ int: The pixel width of the character will be returned.
 
 int CharWidth(objFont *Font, uint32_t Char)
 {
+   if (not Font) return 0;
+
    auto font = (extFont *)Font;
    if (Font->FixedWidth > 0) return Font->FixedWidth;
    else if ((Char < 256) and (font->prvChar)) return font->prvChar[Char].Advance;
@@ -459,9 +486,17 @@ ERR GetList(FontList **Result)
    ConfigGroups *groups;
    if (glConfig->get(FID_Data, groups) IS ERR::Okay) {
       for (auto & [group, keys] : groups[0]) {
-         size += sizeof(FontList) + keys["Name"].size() + 1 + keys["Styles"].size() + 1 + (keys["Points"].size()*4) + 1;
+         size += sizeof(FontList) + keys["Name"].size() + 1 + keys["Styles"].size() + 1;
          if (keys.contains("Alias")) size += keys["Alias"].size() + 1;
          if (keys.contains("Axes")) size += keys["Axes"].size() + 1;
+
+         if (auto point_it = keys.find("Points"); (point_it != keys.end()) and (not point_it->second.empty())) {
+            size_t point_count = 1;
+            for (auto ch : point_it->second) {
+               if (ch IS ',') point_count++;
+            }
+            size += sizeof(int) - 1 + ((point_count + 1) * sizeof(int));
+         }
       }
 
       FontList *list, *last_list = nullptr;
@@ -517,6 +552,9 @@ ERR GetList(FontList **Result)
                if (keys.contains("Points")) {
                   auto fontpoints = std::string_view(keys["Points"]);
                   if (not fontpoints.empty()) {
+                     auto align = (uintptr_t)buffer % sizeof(int);
+                     if (align) buffer += sizeof(int) - align;
+
                      list->Points = (int *)buffer;
                      std::size_t i = 0;
                      for (int16_t j=0; i != std::string::npos; j++) {
@@ -643,7 +681,9 @@ ERR SelectFont(const std::string_view &Name, const std::string_view &Style, CSTR
 
    log.branch("%.*s:%.*s", int(Name.size()), Name.data(), int(Style.size()), Style.data());
 
-   if (Name.empty()) return log.warning(ERR::NullArgs);
+   if (Name.empty() or (not Path)) return log.warning(ERR::NullArgs);
+
+   *Path = nullptr;
 
    kt::ScopedObjectLock<objConfig> config(glConfig, 5000);
    if (not config.granted()) return log.warning(ERR::AccessObject);
@@ -665,12 +705,18 @@ ERR SelectFont(const std::string_view &Name, const std::string_view &Style, CSTR
       return meta;
    };
 
-   auto get_font_path = [](ConfigKeys &Keys, const std::string &Style) {
-      if (Keys.contains(Style)) return strclone(Keys[Style]);
-      else if (not iequals("Regular", Style)) {
-         if (Keys.contains("Regular")) return strclone(Keys["Regular"]);
+   auto get_font_path = [](ConfigKeys &Keys, const std::string &Style, CSTRING *Path) {
+      if (Keys.contains(Style)) {
+         if ((*Path = strclone(Keys[Style]))) return ERR::Okay;
+         else return ERR::AllocMemory;
       }
-      return STRING(nullptr);
+      else if (not iequals("Regular", Style)) {
+         if (Keys.contains("Regular")) {
+            if ((*Path = strclone(Keys["Regular"]))) return ERR::Okay;
+            else return ERR::AllocMemory;
+         }
+      }
+      return ERR::Search;
    };
 
    std::string style_name(Style);
@@ -679,10 +725,12 @@ ERR SelectFont(const std::string_view &Name, const std::string_view &Style, CSTR
    for (auto & [group, keys] : groups[0]) {
       if (not iequals(Name, keys["Name"])) continue;
 
-      if ((*Path = get_font_path(keys, style_name))) {
+      auto error = get_font_path(keys, style_name, Path);
+      if (error IS ERR::Okay) {
          if (Meta) *Meta = get_meta(keys);
          return ERR::Okay;
       }
+      else if (error != ERR::Search) return error;
 
       log.traceWarning("Requested style '%s' not available, choosing first style.", style_name.c_str());
 
@@ -692,7 +740,7 @@ ERR SelectFont(const std::string_view &Name, const std::string_view &Style, CSTR
       std::string first_style = styles.substr(0, end);
 
       if (keys.contains(first_style)) {
-         *Path = strclone(keys[first_style]);
+         if (not (*Path = strclone(keys[first_style]))) return ERR::AllocMemory;
          if (Meta) *Meta = get_meta(keys);
          return ERR::Okay;
       }
@@ -716,6 +764,8 @@ information.  The `fonts:fonts.cfg` file will be re-written on completion to ref
 -ERRORS-
 Okay: Fonts were successfully refreshed.
 AccessObject: Access to the font database was denied, or the object does not exist.
+GetField: Failed to read font database entries after scanning.
+OpenFile: Failed to open `fonts:fonts.cfg` for writing.
 -END-
 
 *********************************************************************************************************************/
@@ -729,12 +779,12 @@ ERR RefreshFonts(void)
    kt::ScopedObjectLock<objConfig> config(glConfig, 3000);
    if (not config.granted()) return log.warning(ERR::AccessObject);
 
-   acClear(glConfig); // Clear out existing font information
+   if (auto error = acClear(glConfig); error != ERR::Okay) return error; // Clear out existing font information
 
    scan_fixed_folder(glConfig);
    scan_truetype_folder(glConfig);
 
-   glConfig->sortByKey(nullptr, false); // Sort the font names into alphabetical order
+   if (auto error = glConfig->sortByKey(nullptr, false); error != ERR::Okay) return error; // Sort by font name.
 
    // Create a style list for each font, e.g.
    //
@@ -761,13 +811,13 @@ ERR RefreshFonts(void)
          keys["Styles"] = style_list.str();
       }
    }
+   else return log.warning(ERR::GetField);
 
    // Save the font configuration file
 
    objFile::create file = { fl::Path("fonts:fonts.cfg"), fl::Flags(FL::NEW|FL::WRITE) };
-   if (file.ok()) glConfig->saveToObject(*file);
-
-   return ERR::Okay;
+   if (file.ok()) return glConfig->saveToObject(*file);
+   else return log.warning(ERR::OpenFile);
 }
 
 /*********************************************************************************************************************
@@ -792,6 +842,10 @@ NullArgs:
 AccessObject: Access to the font database was denied, or the object does not exist.
 GetField:
 Search: It was not possible to resolve the String to a known font family.
+
+-TAGS-
+volatile-result
+
 -END-
 
 *********************************************************************************************************************/

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -11,11 +11,13 @@ the FreeType home page at www.freetype.org.
 -MODULE-
 Font: Provides font management functionality and hosts the Font class.
 
-The Font module is responsible for managing the font database and provides support for client queries.  Fixed size
-bitmap fonts are supported via the Windows .fon file format, while Truetype fonts are support for scalable fonts.
+The Font module maintains the system font database and provides query functions for resolving font family names,
+styles, file paths and metadata.  Fixed-size bitmap fonts are recognised through the Windows `.fon` format, while
+TrueType fonts are scanned as scalable font resources.
 
-Bitmap fonts can be opened and drawn by the @Font class.  Drawing Truetype fonts is not supported by the Font module,
-but is instead provided by the #Vector module and @VectorText class.
+Bitmap fonts can be opened and drawn directly by the @Font class.  Scalable TrueType rendering is handled by the
+Vector module and @VectorText class; the Font module supplies the database information that allows those fonts to be
+selected.
 
 For a thorough introduction to typesetting history and terminology as it applies to computing, we recommend visiting
 Google Fonts Knowledge page: https://fonts.google.com/knowledge
@@ -427,17 +429,21 @@ namespace fnt {
 -FUNCTION-
 CharWidth: Returns the width of a character.
 
-This function will return the pixel width of a bitmap font character.  The character is specified as a unicode value
-in the Char parameter.
+Returns the pixel width of a bitmap font character.  `Char` is interpreted as a Unicode character value.  Bitmap fonts
+provide a maximum of 256 glyph slots; unsupported characters fall back to the font's default character.
 
-The font's GlyphSpacing value is not used in calculating the character width.
+The font's #GlyphSpacing value is not included in the returned width.  If `Font` is `NULL` or has no character table,
+the result is `0`.
 
 -INPUT-
 obj(Font) Font: The font to use for calculating the character width.
-uint Char: A unicode character.
+uint Char: A Unicode character value.
 
 -RESULT-
-int: The pixel width of the character will be returned.
+int: The pixel width of the character, or `0` if it cannot be measured.
+
+-TAGS-
+pure-query
 
 *********************************************************************************************************************/
 
@@ -456,8 +462,8 @@ int CharWidth(objFont *Font, uint32_t Char)
 -FUNCTION-
 GetList: Returns a list of all available system fonts.
 
-This function returns a linked list of all available system fonts.  The list must be terminated once it is no longer
-required.
+Returns a linked list of available system fonts.  The returned list is allocated as a single resource and must be
+released with `FreeResource()` when it is no longer required.
 
 -INPUT-
 &!struct(FontList) Result: The font list is returned here.
@@ -466,6 +472,11 @@ required.
 Okay
 NullArgs
 AccessObject: Access to the font database was denied, or the object does not exist.
+AllocMemory
+NoData
+
+-TAGS-
+caller-owns-result, creates-resource, blocking
 
 *********************************************************************************************************************/
 
@@ -585,19 +596,21 @@ ERR GetList(FontList **Result)
 -FUNCTION-
 StringWidth: Returns the pixel width of any given string in relation to a font's settings.
 
-This function calculates the pixel width of any string in relation to a font's object definition.  The routine takes
-into account any line feeds that might be specified in the String, so if the String contains 8 lines, then the width
-of the longest line will be returned.
+Calculates the pixel width of `String` using the supplied Font object's current metrics and spacing settings.  Line
+feeds are handled by measuring each line independently and returning the width of the longest line.
 
-Word wrapping will not be taken into account, even if it has been enabled in the font object.
+Word wrapping is not applied, even if #WrapEdge has been set on the Font object.
 
 -INPUT-
 obj(Font) Font: An initialised font object.
 cpp(strview) String: The string to be calculated.
-int Chars: The number of characters (not bytes, so consider UTF-8 serialisation) to be used in calculating the string length, or -1 to use the entire string.
+int Chars: The maximum number of characters to measure, or `-1` to measure the entire string.
 
 -RESULT-
-int: The pixel width of the string is returned - this will be zero if there was an error or the string is empty.
+int: The pixel width of the string, or `0` if `Font` is `NULL`, uninitialised or `String` is empty.
+
+-TAGS-
+pure-query
 
 *********************************************************************************************************************/
 
@@ -655,14 +668,15 @@ int StringWidth(objFont *Font, const std::string_view &String, int Chars)
 -FUNCTION-
 SelectFont: Searches for a 'best fitting' font file, based on family name and style.
 
-This function resolves a font family Name and Style to a font file path.  It works on a best efforts basis; the Name
-must exist but the Style is a non-mandatory preference.
+Resolves a font family `Name` and preferred `Style` to a font file path.  The family name must exist in the font
+database.  If the requested style is unavailable, the function falls back to the face's regular style or first
+registered style.
 
-The resulting Path must be freed once it is no longer required.
+The returned `Path` is allocated and must be released with `FreeResource()` when it is no longer required.
 
 -INPUT-
 cpp(strview) Name:  The name of a font face to search for (case insensitive).
-cpp(strview) Style: The required style, e.g. Bold or Italic.  Using camel-case for each word is compulsory.
+cpp(strview) Style: The preferred style, e.g. `Bold` or `Italic`.
 &!cstr Path: The location of the best-matching font file is returned in this parameter.
 &int(FMETA) Meta: Optional, returns additional meta information about the font file.
 
@@ -670,7 +684,11 @@ cpp(strview) Style: The required style, e.g. Bold or Italic.  Using camel-case f
 Okay
 NullArgs
 AccessObject: Access to the font database was denied, or the object does not exist.
+AllocMemory
 Search: Unable to find a suitable font.
+
+-TAGS-
+caller-owns-result, creates-resource, blocking, case-insensitive
 -END-
 
 *********************************************************************************************************************/
@@ -756,16 +774,19 @@ ERR SelectFont(const std::string_view &Name, const std::string_view &Style, CSTR
 -FUNCTION-
 RefreshFonts: Refreshes the system font list with up-to-date font information.
 
-This function scans the `fonts:` volume and refreshes the font database.
+Scans the `fonts:` volume and rebuilds the font database.
 
-Refreshing fonts can take an extensive amount of time as each font file needs to be completely analysed for
-information.  The `fonts:fonts.cfg` file will be re-written on completion to reflect current font settings.
+Refreshing fonts can take an extensive amount of time because each font file must be analysed for family, style,
+metric and metadata information.  The `fonts:fonts.cfg` file is rewritten on completion.
 
 -ERRORS-
-Okay: Fonts were successfully refreshed.
+Okay
 AccessObject: Access to the font database was denied, or the object does not exist.
 GetField: Failed to read font database entries after scanning.
 OpenFile: Failed to open `fonts:fonts.cfg` for writing.
+
+-TAGS-
+blocking
 -END-
 
 *********************************************************************************************************************/
@@ -825,26 +846,28 @@ ERR RefreshFonts(void)
 -FUNCTION-
 ResolveFamilyName: Convert a CSV family string to a single family name.
 
-Use ResolveFamilyName() to convert complex CSV family strings to a single family name.  The provided String will be
-parsed in sequence, with priority given from left to right.  If a single asterisk is used to terminate the list, it is
-guaranteed that the system default will be returned if no valid match is made.
+Converts a CSV family string to one resolved family name.  `String` is parsed from left to right, with each family name
+or wildcard tested against the font database in order.  If a single asterisk is used to terminate the list, the system
+default is returned when no earlier name matches.
 
-It is valid for individual names to utilise the common wildcards `?` and `*` to make a match.  E.g. `Times New *`
-would be able to match to `Times New Roman` if available.
+Individual names may use the common wildcards `?` and `*`; for example, `Times New *` can match `Times New Roman` if
+it is available.
+
+The returned `Result` is borrowed storage.  Copy it immediately if it needs to survive a later font database refresh.
 
 -INPUT-
 cpp(strview) String: A CSV family string to resolve.
-&cstr Result: The nominated family name is returned in this parameter.
+&cstr Result: The resolved family name is returned in this parameter.
 
 -ERRORS-
-Okay:
-NullArgs:
+Okay
+NullArgs
 AccessObject: Access to the font database was denied, or the object does not exist.
-GetField:
+GetField
 Search: It was not possible to resolve the String to a known font family.
 
 -TAGS-
-volatile-result
+volatile-result, null-terminated-result, blocking, case-insensitive
 
 -END-
 

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -85,7 +85,6 @@ static FT_Library glFTLibrary = nullptr;
 class extFont : public objFont {
    public:
    uint8_t *prvData;
-   std::string prvBuffer;
    struct FontCharacter *prvChar;
    class BitmapCache *BmpCache;
    int prvLineCount;
@@ -93,8 +92,6 @@ class extFont : public objFont {
    int16_t prvBitmapHeight;
    int16_t prvLineCountCR;
    char prvEscape[2];
-   char prvFace[32];
-   char prvStyle[20];
    uint8_t prvDefaultChar;
 };
 
@@ -105,7 +102,7 @@ class extFont : public objFont {
 static ERR add_font_class(void);
 static void scan_truetype_folder(objConfig *);
 static void scan_fixed_folder(objConfig *);
-static ERR analyse_bmp_font(CSTRING, winfnt_header_fields *, std::string &, std::vector<uint16_t> &);
+static ERR analyse_bmp_font(std::string_view, winfnt_header_fields *, std::string &, std::vector<uint16_t> &);
 static void string_size(extFont *, std::string_view, int, int, int *, int *);
 
 //********************************************************************************************************************
@@ -214,9 +211,9 @@ static double global_point_size(void)
 
 inline void calc_lines(extFont *Self)
 {
-   if (not Self->prvBuffer.empty()) {
+   if (not Self->String.empty()) {
       if (Self->WrapEdge > 0) {
-         string_size(Self, Self->prvBuffer, -1, Self->WrapEdge - Self->X, nullptr, &Self->prvLineCount);
+         string_size(Self, Self->String, -1, Self->WrapEdge - Self->X, nullptr, &Self->prvLineCount);
       }
       else Self->prvLineCount = Self->prvLineCountCR;
    }
@@ -1034,8 +1031,8 @@ static void scan_fixed_folder(objConfig *Config)
          winfnt_header_fields header;
          std::vector<uint16_t> points;
          std::string facename;
-         if (analyse_bmp_font(src, &header, facename, points) IS ERR::Okay) {
-            log.detail("Detected font file \"%s\", name: %s", src, facename.c_str());
+         if (analyse_bmp_font(location, &header, facename, points) IS ERR::Okay) {
+            log.detail("Detected font file \"%.*s\", name: %s", int(location.size()), location.data(), facename.c_str());
 
             if (facename.empty()) continue;
             std::string group(facename);
@@ -1074,15 +1071,15 @@ static void scan_fixed_folder(objConfig *Config)
 
             // Add the style with a link to the font file location
 
-            if (style IS FTF::BOLD) Config->write(gs, "Bold", src);
-            else if (style IS FTF::ITALIC) Config->write(gs, "Italic", src);
-            else if (style IS (FTF::BOLD|FTF::ITALIC)) Config->write(gs, "Bold Italic", src);
+            if (style IS FTF::BOLD) Config->write(gs, "Bold", location);
+            else if (style IS FTF::ITALIC) Config->write(gs, "Italic", location);
+            else if (style IS (FTF::BOLD|FTF::ITALIC)) Config->write(gs, "Bold Italic", location);
             else {
                // Font is regular, which also means we can convert it to bold/italic with some code
-               Config->write(gs, "Regular", src);
-               Config->write(gs, "Bold", src);
-               Config->write(gs, "Bold Italic", src);
-               Config->write(gs, "Italic", src);
+               Config->write(gs, "Regular", location);
+               Config->write(gs, "Bold", location);
+               Config->write(gs, "Bold Italic", location);
+               Config->write(gs, "Italic", location);
             }
 
             std::ostringstream out;
@@ -1095,7 +1092,7 @@ static void scan_fixed_folder(objConfig *Config)
 
             Config->write(gs, "Points", out.str());
          }
-         else log.warning("Failed to analyse %s", src);
+         else log.warning("Failed to analyse %.*s", int(location.size()), location.data());
       }
    }
    else log.warning("Failed to scan directory fonts:fixed/");
@@ -1103,18 +1100,18 @@ static void scan_fixed_folder(objConfig *Config)
 
 //********************************************************************************************************************
 
-static ERR analyse_bmp_font(CSTRING Path, winfnt_header_fields *Header, std::string &FaceName, std::vector<uint16_t> &Points)
+static ERR analyse_bmp_font(std::string_view Path, winfnt_header_fields *Header, std::string &FaceName, std::vector<uint16_t> &Points)
 {
    kt::Log log(__FUNCTION__);
    char face[50];
 
-   if ((not Path) or (not Header)) return ERR::NullArgs;
+   if ((Path.empty()) or (not Header)) return ERR::NullArgs;
 
    objFile::create file = { fl::Path(Path), fl::Flags(FL::READ) };
    if (file.ok()) {
       std::vector<winFont> fonts;
       if (auto error = read_winfont_entries(*file, fonts); error IS ERR::NoData) {
-         log.warning("There are no fonts in file \"%s\"", Path);
+         log.warning("There are no fonts in file \"%.*s\"", int(Path.size()), Path.data());
          return ERR::Failed;
       }
       else if (error != ERR::Okay) return error;

--- a/src/font/font.tdl
+++ b/src/font/font.tdl
@@ -50,10 +50,10 @@ module({ name="Font", copyright="Paul Manias © 1998-2026", version=1.0, timesta
    double Point           # The Point/Height of the font (arbitrary size, non-exact)
    double GlyphSpacing    # Amount of spacing between characters (additional to normal horizontal spacing)
    obj(Bitmap) Bitmap     # Pointer to destination @Bitmap
-   str   String           # String for drawing etc
-   str   Path             # The location of the font file as derived from the name of the face.
-   str   Style            # The font style (Regular, Bold, Italic, Condensed, Light etc)
-   str   Face             # The face of the font
+   cpp(str) String        # String for drawing etc
+   cpp(str) Path          # The location of the font file as derived from the name of the face.
+   cpp(str) Style         # The font style (Regular, Bold, Italic, Condensed, Light etc)
+   cpp(str) Face          # The face of the font
    struct(RGB8) Outline   # Outline colour
    struct(RGB8) Underline # Underline colour
    struct(RGB8) Colour    # Fill colour

--- a/src/font/font_bitmap.cpp
+++ b/src/font/font_bitmap.cpp
@@ -191,7 +191,10 @@ public:
 
       // Read character information from the file
 
-      File->seek(WinFont.Offset + 118, SEEK::START);
+      if (File->seek(WinFont.Offset + 118, SEEK::START) != ERR::Okay) {
+         Result = log.warning(ERR::Read);
+         return;
+      }
 
       clearmem(Chars, sizeof(Chars));
       if (Face.version IS 0x300) {
@@ -200,8 +203,18 @@ public:
             uint16_t width;
             uint32_t offset;
 
-            if (fl::ReadLE(File, &width) != ERR::Okay) break;
-            if (fl::ReadLE(File, &offset) != ERR::Okay) break;
+            if (fl::ReadLE(File, &width) != ERR::Okay) {
+               Result = log.warning(ERR::Read);
+               return;
+            }
+            if (fl::ReadLE(File, &offset) != ERR::Okay) {
+               Result = log.warning(ERR::Read);
+               return;
+            }
+            if ((width > 0x7fff) or (offset < Face.bits_offset)) {
+               Result = log.warning(ERR::InvalidData);
+               return;
+            }
 
             Chars[j].Width   = width;
             Chars[j].Advance = Chars[j].Width;
@@ -213,8 +226,19 @@ public:
          int j = Face.first_char;
          for (int i=0; i < Face.last_char - Face.first_char + 1; i++) {
             uint16_t width, offset;
-            if (fl::ReadLE(File, &width) != ERR::Okay) break;
-            if (fl::ReadLE(File, &offset) != ERR::Okay) break;
+            if (fl::ReadLE(File, &width) != ERR::Okay) {
+               Result = log.warning(ERR::Read);
+               return;
+            }
+            if (fl::ReadLE(File, &offset) != ERR::Okay) {
+               Result = log.warning(ERR::Read);
+               return;
+            }
+            if ((width > 0x7fff) or (uint32_t(offset) < Face.bits_offset)) {
+               Result = log.warning(ERR::InvalidData);
+               return;
+            }
+
             Chars[j].Width   = width;
             Chars[j].Advance = Chars[j].Width;
             Chars[j].Offset  = offset - Face.bits_offset;
@@ -222,14 +246,40 @@ public:
          }
       }
 
-      int size = Face.file_size - Face.bits_offset;
+      if (Face.bits_offset >= Face.file_size) {
+         Result = log.warning(ERR::InvalidData);
+         return;
+      }
+
+      uint32_t data_size = Face.file_size - Face.bits_offset;
+      if (data_size > 0x7fffffff) {
+         Result = log.warning(ERR::InvalidData);
+         return;
+      }
+
+      int size = int(data_size);
 
       if (size > 0) {
          mData.resize(size);
          int result;
-         File->seek(WinFont.Offset + Face.bits_offset, SEEK::START);
+         if (File->seek(WinFont.Offset + Face.bits_offset, SEEK::START) != ERR::Okay) {
+            Result = log.warning(ERR::Read);
+            return;
+         }
 
          if ((File->read(mData.data(), size, &result) IS ERR::Okay) and (result IS size)) {
+            for (int16_t i=0; i < 256; i++) {
+               if (!Chars[i].Width) continue;
+
+               uint32_t bytewidth = uint32_t((Chars[i].Width+7)>>3);
+               uint32_t char_size = bytewidth * Header.pixel_height;
+
+               if ((Chars[i].Offset >= data_size) or (char_size > data_size - Chars[i].Offset)) {
+                  Result = log.warning(ERR::InvalidData);
+                  return;
+               }
+            }
+
             // Convert the graphics format for wide characters from column-first format to row-first format.
 
             for (int16_t i=0; i < 256; i++) {
@@ -253,9 +303,15 @@ public:
                }
             }
          }
-         else Result = log.warning(ERR::Read);
+         else {
+            Result = log.warning(ERR::Read);
+            return;
+         }
       }
-      else Result = log.warning(ERR::AllocMemory);
+      else {
+         Result = log.warning(ERR::AllocMemory);
+         return;
+      }
 
       if (((StyleFlags & FTF::BOLD) != FTF::NIL) and (Header.weight < 600)) {
          log.msg("Converting base font graphics data to bold.");
@@ -280,7 +336,7 @@ public:
                   for (int y=0; y < Header.pixel_height; y++) {
                      for (int xb=0; xb < oldwidth; xb++) {
                         buffer[pos+xb] |= gfx[xb]|(gfx[xb]>>1);
-                        if ((xb < newwidth) and (gfx[xb] & 0x01)) buffer[pos+xb+1] |= 0x80;
+                        if ((xb + 1 < newwidth) and (gfx[xb] & 0x01)) buffer[pos+xb+1] |= 0x80;
                      }
 
                      pos += newwidth;
@@ -294,7 +350,10 @@ public:
 
             mData = std::move(buffer);
          }
-         else Result = log.warning(ERR::AllocMemory);
+         else {
+            Result = log.warning(ERR::AllocMemory);
+            return;
+         }
       }
 
       if (((StyleFlags & FTF::ITALIC) != FTF::NIL) and (!Header.italic)) {
@@ -340,12 +399,17 @@ public:
 
             mData = std::move(buffer);
          }
-         else Result = log.warning(ERR::AllocMemory);
+         else {
+            Result = log.warning(ERR::AllocMemory);
+            return;
+         }
       }
    }
 
    uint8_t * get_outline()
    {
+      CACHE_LOCK lock(glCacheMutex);
+
       if (not mOutline.empty()) return mOutline.data();
 
       int size = 0;

--- a/src/font/font_bitmap.cpp
+++ b/src/font/font_bitmap.cpp
@@ -1,7 +1,6 @@
 
-/******************************************************************************
-** Win32 font structures
-*/
+//********************************************************************************************************************
+// Win32 font structures
 
 struct winFont {
    int Offset, Size;
@@ -31,61 +30,64 @@ PACK(struct winfnt_header_fields {
    uint16_t ascent;                 // The amount of pixels above the base-line
    uint16_t internal_leading;       // top leading pixels
    uint16_t external_leading;       // gutter
-   int8_t  italic;                 // TRUE if font is italic
-   int8_t  underline;              // TRUE if font is underlined
-   int8_t  strike_out;             // TRUE if font is striked-out
+   int8_t   italic;                 // TRUE if font is italic
+   int8_t   underline;              // TRUE if font is underlined
+   int8_t   strike_out;             // TRUE if font is striked-out
    uint16_t weight;                 // Indicates font boldness
-   int8_t  charset;
+   int8_t   charset;
    uint16_t pixel_width;
    uint16_t pixel_height;
-   int8_t  pitch_and_family;
+   int8_t   pitch_and_family;
    uint16_t avg_width;
    uint16_t max_width;
-   uint8_t first_char;
-   uint8_t last_char;
-   uint8_t default_char;
-   uint8_t break_char;
+   uint8_t  first_char;
+   uint8_t  last_char;
+   uint8_t  default_char;
+   uint8_t  break_char;
    uint16_t bytes_per_row;
    uint32_t device_offset;
    uint32_t face_name_offset;
    uint32_t bits_pointer;
    uint32_t bits_offset;
-   int8_t  reserved;
+   int8_t   reserved;
    uint32_t flags;
    uint16_t A_space;
    uint16_t B_space;
    uint16_t C_space;
    uint16_t color_table_offset;
-   int8_t  reservedend[4];
+   int8_t   reservedend[4];
 });
 
 #define ID_WINMZ  0x5A4D
 #define ID_WINNE  0x454E
 
-//*****************************************************************************
+//********************************************************************************************************************
 
-static ERR validate_winfnt_header(const winfnt_header_fields &Header, CSTRING Path)
+static ERR validate_winfnt_header(const winfnt_header_fields &Header, std::string_view Path)
 {
    kt::Log log(__FUNCTION__);
 
    // NOTE: 0x100 indicates the Microsoft vector font format, which we do not support.
 
    if ((Header.version != 0x200) and (Header.version != 0x300)) {
-      if (Path) {
-         log.warning("Font \"%s\" is written in unsupported version %d / $%x.", Path, Header.version, Header.version);
+      if (not Path.empty()) {
+         log.warning("Font \"%.*s\" is written in unsupported version %d / $%x.", int(Path.size()), Path.data(),
+            Header.version, Header.version);
       }
       return ERR::NoSupport;
    }
 
    if (Header.file_type & 1) {
-      if (Path) log.warning("Font \"%s\" is in the non-supported vector font format.", Path);
+      if (not Path.empty()) {
+         log.warning("Font \"%.*s\" is in the non-supported vector font format.", int(Path.size()), Path.data());
+      }
       return ERR::NoSupport;
    }
 
    return ERR::Okay;
 }
 
-//*****************************************************************************
+//********************************************************************************************************************
 // Reads the Windows .fon resource table and returns each embedded bitmap font entry.
 
 static ERR read_winfont_entries(objFile *File, std::vector<winFont> &Fonts)
@@ -148,9 +150,9 @@ static ERR read_winfont_entries(objFile *File, std::vector<winFont> &Fonts)
    return ERR::Okay;
 }
 
-//*****************************************************************************
+//********************************************************************************************************************
 
-static FTF font_style_flags(CSTRING Style)
+static FTF font_style_flags(const std::string_view Style)
 {
    if (iequals("Bold", Style)) return FTF::BOLD;
    else if (iequals("Italic", Style)) return FTF::ITALIC;
@@ -158,15 +160,15 @@ static FTF font_style_flags(CSTRING Style)
    else return FTF::NIL;
 }
 
-//*****************************************************************************
+//********************************************************************************************************************
 // Structure definition for cached bitmap fonts.
 
 class BitmapCache {
 private:
-   uint8_t *mOutline;
+   std::vector<uint8_t> mOutline;
 
 public:
-   uint8_t *mData;
+   std::vector<uint8_t> mData;
    winfnt_header_fields Header;
    FontCharacter Chars[256];
    std::string Path;
@@ -174,77 +176,76 @@ public:
    FTF StyleFlags;
    ERR Result;
 
-   BitmapCache(winfnt_header_fields &pFace, CSTRING pStyle, CSTRING pPath, objFile *pFile, winFont &pWinFont) {
+   BitmapCache(const winfnt_header_fields &Face, std::string_view RequestedStyle, std::string_view SourcePath,
+      objFile *File, const winFont &WinFont) :
+      Header(Face),
+      Path(SourcePath),
+      OpenCount(0),
+      StyleFlags(font_style_flags(RequestedStyle)),
+      Result(ERR::Okay)
+   {
       kt::Log log(__FUNCTION__);
 
-      log.branch("Caching font %s : %d : %s", pPath, pFace.nominal_point_size, pStyle);
-
-      mData     = nullptr;
-      mOutline  = nullptr;
-      OpenCount = 0;
-      Result    = ERR::Okay;
-      Header    = pFace;
-
-      StyleFlags = font_style_flags(pStyle);
-
-      Path = pPath;
+      log.branch("Caching font %.*s : %d : %.*s", int(SourcePath.size()), SourcePath.data(),
+         Face.nominal_point_size, int(RequestedStyle.size()), RequestedStyle.data());
 
       // Read character information from the file
 
-      pFile->seek(pWinFont.Offset + 118, SEEK::START);
+      File->seek(WinFont.Offset + 118, SEEK::START);
 
       clearmem(Chars, sizeof(Chars));
-      if (pFace.version IS 0x300) {
-         int j = pFace.first_char;
-         for (int i=0; i < pFace.last_char - pFace.first_char + 1; i++) {
+      if (Face.version IS 0x300) {
+         int j = Face.first_char;
+         for (int i=0; i < Face.last_char - Face.first_char + 1; i++) {
             uint16_t width;
             uint32_t offset;
 
-            if (fl::ReadLE(pFile, &width) != ERR::Okay) break;
-            if (fl::ReadLE(pFile, &offset) != ERR::Okay) break;
+            if (fl::ReadLE(File, &width) != ERR::Okay) break;
+            if (fl::ReadLE(File, &offset) != ERR::Okay) break;
 
             Chars[j].Width   = width;
             Chars[j].Advance = Chars[j].Width;
-            Chars[j].Offset  = offset - pFace.bits_offset;
+            Chars[j].Offset  = offset - Face.bits_offset;
             j++;
          }
       }
       else {
-         int j = pFace.first_char;
-         for (int i=0; i < pFace.last_char - pFace.first_char + 1; i++) {
+         int j = Face.first_char;
+         for (int i=0; i < Face.last_char - Face.first_char + 1; i++) {
             uint16_t width, offset;
-            if (fl::ReadLE(pFile, &width) != ERR::Okay) break;
-            if (fl::ReadLE(pFile, &offset) != ERR::Okay) break;
+            if (fl::ReadLE(File, &width) != ERR::Okay) break;
+            if (fl::ReadLE(File, &offset) != ERR::Okay) break;
             Chars[j].Width   = width;
             Chars[j].Advance = Chars[j].Width;
-            Chars[j].Offset  = offset - pFace.bits_offset;
+            Chars[j].Offset  = offset - Face.bits_offset;
             j++;
          }
       }
 
-      int size = pFace.file_size - pFace.bits_offset;
+      int size = Face.file_size - Face.bits_offset;
 
-      if (AllocMemory(size, MEM::UNTRACKED, &mData) IS ERR::Okay) {
+      if (size > 0) {
+         mData.resize(size);
          int result;
-         pFile->seek(pWinFont.Offset + pFace.bits_offset, SEEK::START);
+         File->seek(WinFont.Offset + Face.bits_offset, SEEK::START);
 
-         if ((pFile->read(mData, size, &result) IS ERR::Okay) and (result IS size)) {
+         if ((File->read(mData.data(), size, &result) IS ERR::Okay) and (result IS size)) {
             // Convert the graphics format for wide characters from column-first format to row-first format.
 
             for (int16_t i=0; i < 256; i++) {
                if (!Chars[i].Width) continue;
 
-               int sz = ((Chars[i].Width+7)>>3) * pFace.pixel_height;
+               int sz = ((Chars[i].Width+7)>>3) * Face.pixel_height;
                if (Chars[i].Width > 8) {
                   auto buffer = std::make_unique<uint8_t[]>(sz);
                   clearmem(buffer.get(), sz);
 
-                  uint8_t *gfx = mData + Chars[i].Offset;
+                  uint8_t *gfx = mData.data() + Chars[i].Offset;
                   int bytewidth = (Chars[i].Width + 7)>>3;
                   int pos = 0;
-                  for (int k=0; k < pFace.pixel_height; k++) {
+                  for (int k=0; k < Face.pixel_height; k++) {
                      for (int j=0; j < bytewidth; j++) {
-                        buffer[pos++] = gfx[k + (j * pFace.pixel_height)];
+                        buffer[pos++] = gfx[k + (j * Face.pixel_height)];
                      }
                   }
 
@@ -264,12 +265,12 @@ public:
             if (Chars[i].Width) size += Header.pixel_height * ((Chars[i].Width+8)>>3);
          }
 
-         uint8_t *buffer;
-         if (AllocMemory(size, MEM::UNTRACKED, &buffer) IS ERR::Okay) {
+         if (size > 0) {
+            std::vector<uint8_t> buffer(size);
             int pos = 0;
             for (int i=0; i < 256; i++) {
                if (Chars[i].Width) {
-                  uint8_t *gfx = mData + Chars[i].Offset;
+                  uint8_t *gfx = mData.data() + Chars[i].Offset;
                   Chars[i].Offset = pos;
 
                   // Copy character graphic to the buffer and embolden it
@@ -291,8 +292,7 @@ public:
                }
             }
 
-            FreeResource(mData);
-            mData = buffer;
+            mData = std::move(buffer);
          }
          else Result = log.warning(ERR::AllocMemory);
       }
@@ -307,18 +307,18 @@ public:
             if (Chars[i].Width) size += Header.pixel_height * ((Chars[i].Width+7+extra)>>3);
          }
 
-         uint8_t *buffer;
-         if (AllocMemory(size, MEM::UNTRACKED, &buffer) IS ERR::Okay) {
+         if (size > 0) {
+            std::vector<uint8_t> buffer(size);
             int pos = 0;
             for (int i=0; i < 256; i++) {
                if (Chars[i].Width) {
-                  uint8_t *gfx = mData + Chars[i].Offset;
+                  uint8_t *gfx = mData.data() + Chars[i].Offset;
                   Chars[i].Offset = pos;
 
                   int oldwidth = (Chars[i].Width+7)>>3;
                   int newwidth = (Chars[i].Width+7+extra)>>3;
                   int italic = Header.pixel_height;
-                  uint8_t *dest = buffer + pos;
+                  uint8_t *dest = buffer.data() + pos;
                   for (int y=0; y < Header.pixel_height; y++) {
                      int dx = italic>>2;
                      for (int sx=0; sx < Chars[i].Width; sx++) {
@@ -338,8 +338,7 @@ public:
                }
             }
 
-            FreeResource(mData);
-            mData = buffer;
+            mData = std::move(buffer);
          }
          else Result = log.warning(ERR::AllocMemory);
       }
@@ -347,26 +346,27 @@ public:
 
    uint8_t * get_outline()
    {
-      if (mOutline) return mOutline;
+      if (not mOutline.empty()) return mOutline.data();
 
       int size = 0;
       for (int16_t i=0; i < 256; i++) {
          if (Chars[i].Width) size += (Header.pixel_height+2) * ((Chars[i].Width+9)>>3);
       }
 
-      uint8_t *buffer;
-      if (AllocMemory(size, MEM::UNTRACKED, &buffer) != ERR::Okay) return nullptr;
+      if (size <= 0) return nullptr;
+
+      std::vector<uint8_t> buffer(size);
 
       int pos = 0;
       for (int16_t i=0; i < 256; i++) {
          if (Chars[i].Width) {
-            auto gfx = mData + Chars[i].Offset;
+            auto gfx = mData.data() + Chars[i].Offset;
             Chars[i].OutlineOffset = pos;
 
             int oldwidth = (Chars[i].Width+7)>>3;
             int newwidth = (Chars[i].Width+9)>>3;
 
-            auto dest = buffer + pos;
+            auto dest = buffer.data() + pos;
 
             dest += newwidth; // Start ahead of line 0
             for (int sy=0; sy < Header.pixel_height; sy++) {
@@ -389,8 +389,8 @@ public:
          }
       }
 
-      mOutline = buffer;
-      return mOutline;
+      mOutline = std::move(buffer);
+      return mOutline.data();
    }
 
    ~BitmapCache() {
@@ -398,8 +398,6 @@ public:
          kt::Log log(__FUNCTION__);
          log.warning("Removing \"%s : %d : $%.8x\" with an open count of %d", Path.c_str(), Header.nominal_point_size, int(StyleFlags), OpenCount);
       }
-      if (mData) { FreeResource(mData); mData = nullptr; }
-      if (mOutline) { FreeResource(mOutline); mOutline = nullptr; }
    }
 };
 
@@ -416,10 +414,11 @@ static BitmapCache * check_bitmap_cache(extFont *Self, FTF Style)
    for (auto & cache : glBitmapCache) {
       if (cache.Result != ERR::Okay) continue;
 
-      if (iequals(cache.Path.c_str(), Self->Path)) {
+      if (iequals(cache.Path, Self->Path)) {
          if (cache.StyleFlags IS Style) {
             if (Self->Point IS cache.Header.nominal_point_size) {
-               log.trace("Exists in cache (count %d) %s : %s", cache.OpenCount, cache.Path.c_str(), Self->prvStyle);
+               log.trace("Exists in cache (count %d) %s : %s", cache.OpenCount, cache.Path.c_str(),
+                  Self->Style.c_str());
                return &cache;
             }
             else log.trace("Failed point check %.2f / %d", Self->Point, cache.Header.nominal_point_size);

--- a/src/font/font_structs.h
+++ b/src/font/font_structs.h
@@ -4,8 +4,8 @@
 struct FontCharacter {
    int16_t  Width;
    int16_t  Advance;
-   uint16_t Offset;
-   uint16_t OutlineOffset;
+   uint32_t Offset;
+   uint32_t OutlineOffset;
 };
 
 typedef const std::lock_guard<std::recursive_mutex> CACHE_LOCK;

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -776,10 +776,10 @@ static ERR TEXT_SET_Font(extVectorText *Self, OBJECTPTR Value)
    if (Value->baseClassID() IS CLASSID::FONT) {
       auto other = (objFont *)Value;
 
-      Self->txFamily = other->Face ? other->Face : "Noto Sans";
-      Self->txFontSize = std::trunc(other->Point * (96.0 / 72.0));
+      Self->txFamily         = other->Face.empty() ? "Noto Sans" : other->Face;
+      Self->txFontSize       = std::trunc(other->Point * (96.0 / 72.0));
       Self->txScaledFontSize = false;
-      Self->txFontStyle = other->Style ? other->Style : "Regular";
+      Self->txFontStyle      = other->Style.empty() ? "Regular" : other->Style;
 
       if (Self->initialised()) return reset_font(Self);
       else return ERR::Okay;
@@ -787,10 +787,10 @@ static ERR TEXT_SET_Font(extVectorText *Self, OBJECTPTR Value)
    else if (Value->classID() IS CLASSID::VECTORTEXT) {
       auto other = (extVectorText *)Value;
 
-      Self->txFamily = other->txFamily;
-      Self->txFontSize = other->txFontSize;
+      Self->txFamily         = other->txFamily;
+      Self->txFontSize       = other->txFontSize;
       Self->txScaledFontSize = false;
-      Self->txFontStyle = other->txFontStyle;
+      Self->txFontStyle      = other->txFontStyle;
 
       if (Self->initialised()) return reset_font(Self);
       else return ERR::Okay;


### PR DESCRIPTION
## Summary

This PR hardens the Font module after a bug sweep of bitmap font loading and font metrics paths.

It updates bitmap `.fon` parsing to reject invalid offsets, truncated glyph tables and malformed bitmap data before cache transformations run. It also fixes point-list allocation in `GetList()`, propagates font selection and refresh errors, makes shared default point-size caching thread-safe, and avoids blank-line wrapping for over-wide first glyphs.

Generated font XML documentation is included for the updated `RefreshFonts()` error contract.

## Validation

- `git diff --check -- src/font/class_font.cpp src/font/font.cpp src/font/font_bitmap.cpp src/font/font_structs.h`
- style scan for forbidden `static_cast`, `&&`, `||`, `==`, tabs, and C++ throws
- `wsl -d Kotuku -- bash -lc "cd /mnt/e/kotuku && cmake --build build/wsl-agents --target font --parallel"`

The WSL Font target build passed. The only compiler output was the pre-existing unused `src` warning in `scan_fixed_folder()`.