### PR TITLE
[XQuery] Store string fields in object body

### DIFF
--- a/docs/xml/modules/classes/xquery.xml
+++ b/docs/xml/modules/classes/xquery.xml
@@ -257,8 +257,8 @@ if (query.ok()) {
     <field>
       <name>ErrorMsg</name>
       <comment>A readable description of the last parse or execution error.</comment>
-      <access read="G">Get</access>
-      <type>STRING</type>
+      <access read="R">Read</access>
+      <type>std::string</type>
       <description>
 <p>This field may provide a textual description of the last parse or execution error that occurred.</p>
       </description>
@@ -296,8 +296,8 @@ if (query.ok()) {
     <field>
       <name>Path</name>
       <comment>Base path for resolving relative references.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>Set the Path field to define the base-uri for an XQuery expression.  If left unset, the path will be computed through automated means on-the-fly, which relies  on the working directory or XML document path.</p>
       </description>
@@ -356,9 +356,9 @@ if (query.ok()) {
 
     <field>
       <name>Statement</name>
-      <comment>XQuery data is processed through this field.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <comment>XQuery statements are specified here.</comment>
+      <access read="R" write="S">Read/Set</access>
+      <type>std::string</type>
       <description>
 <p>Set the Statement field with an XPath or XQuery expression for compilation.</p>
 <p>If this field is set after initialisation then <action>Clear</action> will be applied to the object first.  The expression will be compiled on the next execution attempt.</p>

--- a/include/kotuku/modules/xquery.h
+++ b/include/kotuku/modules/xquery.h
@@ -150,6 +150,10 @@ class objXQuery : public Object {
 
    using create = kt::Create<objXQuery>;
 
+   std::string ErrorMsg;    // A readable description of the last parse or execution error.
+   std::string Path;        // Base path for resolving relative references.
+   std::string Statement;   // XQuery statements are specified here.
+
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
@@ -187,16 +191,15 @@ class objXQuery : public Object {
 
    // Customised field setting
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+   inline ERR setPath(const std::string_view &Value) noexcept {
+      this->Path = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setStatement(T && Value) noexcept {
+   inline ERR setStatement(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
    inline ERR setResolveVariable(const FUNCTION Value) noexcept {

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -1061,7 +1061,9 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
       Source.Flags
    );
 
-   if (field.Flags & FD_VIRTUAL); // No offset will be added for virtual fields
+   if (field.Flags & FD_VIRTUAL) { // No offset will be added for fields marked exclusively as virtual
+      field.Offset = 0;
+   }
    else if (field.Flags & FD_RGB) {
       field_size = sizeof(int8_t) * 4;
       field_alignment = alignof(int8_t);

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -229,15 +229,15 @@ static ERR XML_Evaluate(extXML *Self, struct xml::Evaluate *Args)
             return ERR::Okay;
          }
          else {
-            CSTRING str;
-            if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+            std::string_view sv;
+            if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
             FreeResource(xq);
             return error;
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -304,8 +304,8 @@ static ERR XML_Filter(extXML *Self, struct xml::Filter *Args)
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -387,16 +387,16 @@ static ERR XML_Search(extXML *Self, struct xml::Search *Args)
             return ERR::Okay;
          }
          else {
-            CSTRING str;
-            if ((xq->get(FID_ErrorMsg, str) IS ERR::Okay) and (str)) Self->ErrorMsg = str;
+            std::string_view sv;
+            if ((xq->get(FID_ErrorMsg, sv) IS ERR::Okay) and (not sv.empty())) Self->ErrorMsg.assign(sv);
             FreeResource(xq);
             if ((Args->Callback) and (error IS ERR::Search)) return ERR::Okay;
             else return error;
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -624,15 +624,15 @@ static ERR XML_GetKey(extXML *Self, struct acGetKey *Args)
             return ERR::Okay;
          }
          else {
-            CSTRING str;
-            if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+            std::string_view sv;
+            if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
             FreeResource(xq);
             return error;
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -985,16 +985,16 @@ ERR XML_InsertXPath(extXML *Self, struct xml::InsertXPath *Args)
                Self->ErrorMsg = "XPath did not resolve to a valid location.";
             }
             else {
-               CSTRING str;
-               if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+               std::string_view sv;
+               if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
             }
             FreeResource(xq);
             return error;
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -1290,8 +1290,8 @@ static ERR XML_RemoveXPath(extXML *Self, struct xml::RemoveXPath *Args)
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          return error;
       }
@@ -1605,8 +1605,8 @@ static ERR XML_SetKey(extXML *Self, struct acSetKey *Args)
                error = ERR::Search;
             }
             else {
-               CSTRING str;
-               if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+               std::string_view sv;
+               if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
                FreeResource(xq);
             }
             log.warning("Failed to find '%s'", Args->Key);
@@ -1614,8 +1614,8 @@ static ERR XML_SetKey(extXML *Self, struct acSetKey *Args)
          }
       }
       else {
-         CSTRING str;
-         if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+         std::string_view sv;
+         if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
          log.msg("Failed to compile '%s'", Args->Key);
          return error;
@@ -1709,8 +1709,8 @@ static ERR XML_Sort(extXML *Self, struct xml::Sort *Args)
             matching_tag_opt opt;
             auto callback = C_FUNCTION(save_matching_tag, &opt.tag_id);
             if (error = xq->search((objXML *)Self, callback, 0, XEF::NIL); error != ERR::Terminate) {
-               CSTRING str;
-               if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+               std::string_view sv;
+               if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
                FreeResource(xq);
                return log.warning(ERR::Search);
             }
@@ -1720,8 +1720,8 @@ static ERR XML_Sort(extXML *Self, struct xml::Sort *Args)
             branch = &Self->Map[opt.tag_id]->Children;
          }
          else {
-            CSTRING str;
-            if (xq->get(FID_ErrorMsg, str) IS ERR::Okay) Self->ErrorMsg = str;
+            std::string_view sv;
+            if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
             FreeResource(xq);
             return log.warning(error);
          }

--- a/src/xquery/tests/test_func_ext.tiri
+++ b/src/xquery/tests/test_func_ext.tiri
@@ -6,14 +6,14 @@
 -- Verify string casing helpers
 
 @Test function StringCaseFunctions()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><item>Alpha Beta</item><item attr="MixedCase"/></root>'
    })
 
-   local err, uppercaseId = xml.mtSearch('/root/item[upper-case(.) = "ALPHA BETA"]')
+   err, uppercaseId = xml.mtSearch('/root/item[upper-case(.) = "ALPHA BETA"]')
    assert(err is ERR_Okay, "upper-case(.) should transform content to uppercase: " .. mSys.GetErrorMsg(err))
 
-   local err2, attributeId = xml.mtSearch('/root/item[@attr and lower-case(@attr) = "mixedcase"]')
+   err2, attributeId = xml.mtSearch('/root/item[@attr and lower-case(@attr) = "mixedcase"]')
    assert(err2 is ERR_Okay, "lower-case(@attr) should normalise attribute values")
 end
 
@@ -21,14 +21,14 @@ end
 -- Check URI encoding helpers
 
 @Test function UriEncodingFunctions()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><item path="docs/file one" link="a&b?c"/></root>'
    })
 
-   local err, nodeId = xml.mtSearch('/root/item[encode-for-uri(@path) = "docs%2Ffile%20one"]')
+   err, nodeId = xml.mtSearch('/root/item[encode-for-uri(@path) = "docs%2Ffile%20one"]')
    assert(err is ERR_Okay, "encode-for-uri(@path) should percent-encode separators")
 
-   local err2, nodeId2 = xml.mtSearch('/root/item[escape-html-uri(@link) = "a&amp;b%3Fc"]')
+   err2, nodeId2 = xml.mtSearch('/root/item[escape-html-uri(@link) = "a&amp;b%3Fc"]')
    assert(err2 is ERR_Okay, "escape-html-uri(@link) should provide HTML safe output")
 end
 
@@ -36,17 +36,17 @@ end
 -- Validate regular expression helpers
 
 @Test function RegexFunctions()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><code>id123</code><code>ALPHA-001</code><csv>alpha,beta,gamma</csv></root>'
    })
 
-   local err, firstCode = xml.mtSearch('/root/code[matches(., "^id[0-9]+$", "i")]')
+   err, firstCode = xml.mtSearch('/root/code[matches(., "^id[0-9]+$", "i")]')
    assert(err is ERR_Okay, "matches() should support case-insensitive matching")
 
-   local err2, secondCode = xml.mtSearch('/root/code[replace(., "-", "") = "ALPHA001"]')
+   err2, secondCode = xml.mtSearch('/root/code[replace(., "-", "") = "ALPHA001"]')
    assert(err2 is ERR_Okay, "replace() should rewrite substrings")
 
-   local err3, csvNode = xml.mtSearch('/root/csv[tokenize(., ",")[2] = "beta" and count(tokenize(., ",")) = 3]')
+   err3, csvNode = xml.mtSearch('/root/csv[tokenize(., ",")[2] = "beta" and count(tokenize(., ",")) = 3]')
    assert(err3 is ERR_Okay, "tokenize() should expose individual fields")
 end
 
@@ -54,45 +54,45 @@ end
 -- Exercise numeric helper functions
 
 @Test function MathFunctions()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><value amount="10" delta="-5"/><value amount="20" delta="5"/><value amount="30" delta="0"/></root>'
    })
 
-   local err, absNode = xml.mtSearch('/root/value[abs(number(@delta)) = 5]')
+   err, absNode = xml.mtSearch('/root/value[abs(number(@delta)) = 5]')
    assert(err is ERR_Okay, "abs() should return absolute numeric value")
 
-   local err2, minNode = xml.mtSearch('/root/value[@amount = min(/root/value/@amount)]')
+   err2, minNode = xml.mtSearch('/root/value[@amount = min(/root/value/@amount)]')
    assert(err2 is ERR_Okay, "min() should locate the smallest attribute value")
 
-   local err3, maxNode = xml.mtSearch('/root/value[@amount = max(/root/value/@amount)]')
+   err3, maxNode = xml.mtSearch('/root/value[@amount = max(/root/value/@amount)]')
    assert(err3 is ERR_Okay, "max() should locate the largest attribute value")
 
-   local err4, avgNode = xml.mtSearch('/root/value[@amount = round(avg(/root/value/@amount))]')
+   err4, avgNode = xml.mtSearch('/root/value[@amount = round(avg(/root/value/@amount))]')
    assert(err4 is ERR_Okay, "avg() should locate the middle item")
 
-   local xmlRound = obj.new("xml", {
+   xmlRound = obj.new("xml", {
       statement = '<root><case id="tie-low" value="0.5"/><case id="tie-high" value="1.5"/><case id="tie-upper" value="2.5"/><case id="negative" value="-1.5"/><case id="precision" value="123.455"/><case id="precision-even" value="123.445"/><case id="neg-precision" value="1250"/></root>'
    })
 
-   local errTieLow, tieLowId = xmlRound.mtSearch('/root/case[@id = "tie-low" and round-half-to-even(number(@value)) = 0]')
+   errTieLow, tieLowId = xmlRound.mtSearch('/root/case[@id = "tie-low" and round-half-to-even(number(@value)) = 0]')
    assert(errTieLow is ERR_Okay, 'round-half-to-even() should round 0.5 to the even integer 0')
 
-   local errTieHigh, tieHighId = xmlRound.mtSearch('/root/case[@id = "tie-high" and round-half-to-even(number(@value)) = 2]')
+   errTieHigh, tieHighId = xmlRound.mtSearch('/root/case[@id = "tie-high" and round-half-to-even(number(@value)) = 2]')
    assert(errTieHigh is ERR_Okay, 'round-half-to-even() should round 1.5 up to the even integer 2')
 
-   local errTieUpper, tieUpperId = xmlRound.mtSearch('/root/case[@id = "tie-upper" and round-half-to-even(number(@value)) = 2]')
+   errTieUpper, tieUpperId = xmlRound.mtSearch('/root/case[@id = "tie-upper" and round-half-to-even(number(@value)) = 2]')
    assert(errTieUpper is ERR_Okay, 'round-half-to-even() should round 2.5 down to the even integer 2')
 
-   local errNegative, negativeId = xmlRound.mtSearch('/root/case[@id = "negative" and round-half-to-even(number(@value)) = -2]')
+   errNegative, negativeId = xmlRound.mtSearch('/root/case[@id = "negative" and round-half-to-even(number(@value)) = -2]')
    assert(errNegative is ERR_Okay, 'round-half-to-even() should honour even rounding for negative ties')
 
-   local errPrecision, precisionId = xmlRound.mtSearch('/root/case[@id = "precision" and round-half-to-even(number(@value), 2) = 123.46]')
+   errPrecision, precisionId = xmlRound.mtSearch('/root/case[@id = "precision" and round-half-to-even(number(@value), 2) = 123.46]')
    assert(errPrecision is ERR_Okay, 'round-half-to-even() should round fractional precision ties upward when the preceding digit is odd')
 
-   local errPrecisionEven, precisionEvenId = xmlRound.mtSearch('/root/case[@id = "precision-even" and round-half-to-even(number(@value), 2) = 123.44]')
+   errPrecisionEven, precisionEvenId = xmlRound.mtSearch('/root/case[@id = "precision-even" and round-half-to-even(number(@value), 2) = 123.44]')
    assert(errPrecisionEven is ERR_Okay, 'round-half-to-even() should leave even fractional digits unchanged when exactly halfway')
 
-   local errNegPrecision, negPrecisionId = xmlRound.mtSearch('/root/case[@id = "neg-precision" and round-half-to-even(number(@value), -2) = 1200]')
+   errNegPrecision, negPrecisionId = xmlRound.mtSearch('/root/case[@id = "neg-precision" and round-half-to-even(number(@value), -2) = 1200]')
    assert(errNegPrecision is ERR_Okay, 'round-half-to-even() should support negative precision arguments')
 end
 
@@ -100,17 +100,17 @@ end
 -- Ensure trace() produces pass-through results while emitting diagnostics
 
 @Test function TraceFunction()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><item id="a">Alpha</item><item id="b">Beta</item></root>'
    })
 
-   local err, nodeId = xml.mtSearch('/root/item[trace(@id, "ids") = "a"]')
+   err, nodeId = xml.mtSearch('/root/item[trace(@id, "ids") = "a"]')
    assert(err is ERR_Okay, 'trace() should preserve attribute values during predicates: ' .. mSys.GetErrorMsg(err))
    assert(nodeId != nil, 'trace() predicate should locate the first matching item')
 
-   local err2, contentId = xml.mtSearch('/root/item[trace(., "content") = "Beta"]')
+   err2, contentId = xml.mtSearch('/root/item[trace(., "content") = "Beta"]')
    assert(err2 is ERR_Okay, 'trace() should expose node string values: ' .. mSys.GetErrorMsg(err2))
-   local _, attrValue = xml.mtGetAttrib(contentId, 'id')
+   _, attrValue = xml.mtGetAttrib(contentId, 'id')
    assert(attrValue is 'b', 'trace() should return the original node-set without modification')
 end
 
@@ -118,14 +118,14 @@ end
 -- Verify error() reports diagnostics and halts XPath evaluation
 
 @Test function ErrorFunction()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><item code="A">Alpha</item></root>'
    })
 
-   local err = xml.mtSearch('/root/item[error("err:TEST0001", "Forced failure", @code)]')
+   err = xml.mtSearch('/root/item[error("err:TEST0001", "Forced failure", @code)]')
    assert(err != ERR_Okay, 'error() should signal a failing predicate evaluation')
 
-   local message = xml.errorMsg ?? ''
+   message = xml.errorMsg ?? ''
    assert(message is 'XPath error err:TEST0001: Forced failure [A]',
       'error() should populate the XML error message with detail, got ' .. message)
 end
@@ -134,17 +134,17 @@ end
 -- Validate date and time helper functions
 
 @Test function DateTimeFunctions()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><item id="a"/></root>'
    })
 
-   local errDate, dateNode = xml.mtSearch('/root/item[matches(current-date(), "^[0-9]{4}-[0-9]{2}-[0-9]{2}$")]')
+   errDate, dateNode = xml.mtSearch('/root/item[matches(current-date(), "^[0-9]{4}-[0-9]{2}-[0-9]{2}$")]')
    assert(errDate is ERR_Okay, 'current-date() should yield an ISO8601 date string: ' .. mSys.GetErrorMsg(errDate))
 
-   local errTime, timeNode = xml.mtSearch('/root/item[matches(current-time(), "^[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")]')
+   errTime, timeNode = xml.mtSearch('/root/item[matches(current-time(), "^[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")]')
    assert(errTime is ERR_Okay, 'current-time() should yield an ISO8601 time with Z suffix: ' .. mSys.GetErrorMsg(errTime))
 
-   local errDateTime, dateTimeNode = xml.mtSearch('/root/item[matches(current-dateTime(), "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")]')
+   errDateTime, dateTimeNode = xml.mtSearch('/root/item[matches(current-dateTime(), "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")]')
    assert(errDateTime is ERR_Okay, 'current-dateTime() should yield a combined timestamp: ' .. mSys.GetErrorMsg(errDateTime))
 end
 
@@ -152,31 +152,31 @@ end
 -- Check value comparison operators (eq, ne, lt, le, gt, ge)
 
 @Test function ValueComparisonOperators()
-   local xml = obj.new("xml", {
+   xml = obj.new("xml", {
       statement = '<root><value amount="10"/><value amount="20"/><value amount="30"/></root>'
    })
 
-   local errEq, eqId = xml.mtSearch('/root/value[@amount eq 20]')
+   errEq, eqId = xml.mtSearch('/root/value[@amount eq 20]')
    assert(errEq is ERR_Okay, 'eq should match the exact attribute value: ' .. mSys.GetErrorMsg(errEq))
 
-   local errNe, neId = xml.mtSearch('/root/value[@amount ne 20][@amount = 10]')
+   errNe, neId = xml.mtSearch('/root/value[@amount ne 20][@amount = 10]')
    assert(errNe is ERR_Okay and neId != nil, 'ne should exclude the middle value while leaving the first entry')
 
-   local errLt, ltId = xml.mtSearch('/root/value[@amount lt 15]')
+   errLt, ltId = xml.mtSearch('/root/value[@amount lt 15]')
    assert(errLt is ERR_Okay, 'lt should identify nodes smaller than the threshold: ' .. mSys.GetErrorMsg(errLt))
-   local _, ltAmount = xml.mtGetAttrib(ltId, 'amount')
+   _, ltAmount = xml.mtGetAttrib(ltId, 'amount')
    assert(ltAmount is '10', 'lt should select the smallest amount')
 
-   local errLe, leId = xml.mtSearch('/root/value[@amount le 20][@amount = 20]')
+   errLe, leId = xml.mtSearch('/root/value[@amount le 20][@amount = 20]')
    assert(errLe is ERR_Okay, 'le should include boundary values: ' .. mSys.GetErrorMsg(errLe))
 
-   local errGt, gtId = xml.mtSearch('/root/value[@amount gt 20]')
+   errGt, gtId = xml.mtSearch('/root/value[@amount gt 20]')
    assert(errGt is ERR_Okay, 'gt should locate the largest entry: ' .. mSys.GetErrorMsg(errGt))
-   local _, gtAmount = xml.mtGetAttrib(gtId, 'amount')
+   _, gtAmount = xml.mtGetAttrib(gtId, 'amount')
    assert(gtAmount is '30', 'gt should select the highest amount')
 
-   local errGe, geId = xml.mtSearch('/root/value[@amount ge 30]')
+   errGe, geId = xml.mtSearch('/root/value[@amount ge 30]')
    assert(errGe is ERR_Okay, 'ge should accept values equal to the boundary: ' .. mSys.GetErrorMsg(errGe))
-   local _, geAmount = xml.mtGetAttrib(geId, 'amount')
+   _, geAmount = xml.mtGetAttrib(geId, 'amount')
    assert(geAmount is '30', 'ge should return the maximum amount when equal to the comparison value')
 end

--- a/src/xquery/xquery.h
+++ b/src/xquery/xquery.h
@@ -958,8 +958,6 @@ public:
    ankerl::unordered_dense::map<std::string, FUNCTION> RegisteredFunctions;
    FUNCTION Callback;
    FUNCTION ResolveVariable;
-   std::string Statement;
-   std::string ErrorMsg;
    CompiledXQuery ParseResult; // Result of parsing the query.
    std::shared_ptr<XQueryModuleCache> ModuleCache; // Strong reference; ParseResult.module_cache is weak to break cycles
    XPathVal Result; // Result of the last execution.
@@ -967,7 +965,6 @@ public:
    kt::vector<std::string> ListVariables; // List of variable names.
    kt::vector<std::string> ListFunctions; // List of function names.
    std::string ResultString; // Cached string representation of the result.
-   std::string Path; // Base path for resolving relative URIs.
    size_t MemUsage; // Total bytes allocated during the most recent evaluation or compilation.
    extXML *XML; // During query execution, the context XML document.
    bool StaleBuild = true; // If true, the compiled query needs to be rebuilt.

--- a/src/xquery/xquery.tdl
+++ b/src/xquery/xquery.tdl
@@ -5,11 +5,11 @@ module({ name='XQuery', src='xquery.cpp', copyright='Paul Manias © 2025-2026', 
   cpp_include('<functional>', '<optional>', '<sstream>', '<kotuku/strings.hpp>', '<string_view>', '<vector>')
 
   restrict(function()
-    loadFile('sdk:src/xml/constants.tdl')
+    loadFile('./../xml/constants.tdl')
   end)
 
   -- Shared enumerations for parser and evaluator state, including map/array node kinds.
-  loadFile('sdk:src/xquery/constants.tdl')
+  loadFile('./constants.tdl')
 
   flags("XEF", { comment="Options for XQuery evaluation flags." },
     "LIMIT_SCOPE: For tag specific queries, limit the scope to the specified element.")
@@ -26,6 +26,9 @@ module({ name='XQuery', src='xquery.cpp', copyright='Paul Manias © 2025-2026', 
     output     = 'xquery_class_def.cpp',
     references = { 'XQF', 'XPVT', 'XEF' },
     comment    = 'Provides an interface for XQuery evaluation and execution.' }, [[
+    cpp(str) ErrorMsg  # A readable description of the last parse or execution error.
+    cpp(str) Path      # Base path for resolving relative references.
+    cpp(str) Statement # XQuery statements are specified here.
   ]])
 
   c_insert([[

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -790,17 +790,6 @@ ErrorMsg: A readable description of the last parse or execution error.
 
 This field may provide a textual description of the last parse or execution error that occurred.
 
-*********************************************************************************************************************/
-
-static ERR GET_ErrorMsg(extXQuery *Self, std::string_view &Value)
-{
-   if (not Self->ErrorMsg.empty()) Value = Self->ErrorMsg;
-   else Value = std::string_view();
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 FeatureFlags: Flags indicating the features of a compiled XQuery expression.
 
@@ -879,33 +868,6 @@ Path: Base path for resolving relative references.
 
 Set the Path field to define the base-uri for an XQuery expression.  If left unset, the path will be computed through
 automated means on-the-fly, which relies  on the working directory or XML document path.
-
-*********************************************************************************************************************/
-
-static ERR GET_Path(extXQuery *Self, std::string_view &Value)
-{
-   if (not Self->initialised()) {
-      if (not Self->Path.empty()) Value = Self->Path;
-      else return ERR::FieldNotSet;
-   }
-   else Value = Self->Path;
-
-   return ERR::Okay;
-}
-
-static ERR SET_Path(extXQuery *Self, const std::string_view &Value)
-{
-   if (not Value.empty()) {
-      Self->Path = Value;
-      return ERR::Okay;
-   }
-   else {
-      Self->Path.clear();
-      return ERR::Okay;
-   }
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 ResolveVariable: Callback function for resolving unknown variables.
@@ -1027,7 +989,7 @@ static ERR GET_ResultType(extXQuery *Self, XPVT &Value)
 /*********************************************************************************************************************
 
 -FIELD-
-Statement: XQuery data is processed through this field.
+Statement: XQuery statements are specified here.
 
 Set the Statement field with an XPath or XQuery expression for compilation.
 
@@ -1040,17 +1002,6 @@ the base path for relative references.
 -END-
 
 *********************************************************************************************************************/
-
-static ERR GET_Statement(extXQuery *Self, std::string_view &Value)
-{
-   if (not Self->initialised()) {
-      if (not Self->Statement.empty()) Value = Self->Statement;
-      else return ERR::FieldNotSet;
-   }
-   else Value = Self->Statement;
-
-   return ERR::Okay;
-}
 
 static ERR SET_Statement(extXQuery *Self, const std::string_view &Value)
 {
@@ -1120,12 +1071,12 @@ static ERR GET_Variables(extXQuery *Self, kt::vector<std::string> **Value)
 #include "xquery_class_def.cpp"
 
 static const FieldArray clFields[] = {
-   { "ErrorMsg",        FDF_VIRTUAL|FDF_CPPSTRING|FDF_R,      GET_ErrorMsg },
+   { "ErrorMsg",        FDF_CPPSTRING|FDF_R },
+   { "Path",            FDF_CPPSTRING|FDF_RW },
+   { "Statement",       FDF_CPPSTRING|FDF_RW, nullptr, SET_Statement },
    { "MemoryUsage",     FDF_VIRTUAL|FDF_INT64|FDF_R,          GET_MemoryUsage },
-   { "Path",            FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_Path, SET_Path },
    { "Result",          FDF_VIRTUAL|FDF_PTR|FDF_STRUCT|FDF_R, GET_Result, nullptr, "XPathValue" },
    { "ResultString",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_R,      GET_ResultString },
-   { "Statement",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_Statement, SET_Statement },
    { "FeatureFlags",    FDF_VIRTUAL|FDF_INTFLAGS|FDF_R,       GET_FeatureFlags, nullptr, &clXQueryXQF },
    { "ResultType",      FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_R, GET_ResultType, nullptr, &clXQueryXPVT },
    { "ResolveVariable", FDF_VIRTUAL|FDF_FUNCTION|FDF_RW,      GET_ResolveVariable, SET_ResolveVariable },


### PR DESCRIPTION
## Summary

This PR moves the XQuery `ErrorMsg`, `Path`, and `Statement` fields to generated `cpp(str)` object-body storage, removing the custom virtual string field handlers where direct storage is sufficient.

It also updates XML callers to retrieve XQuery error messages through `std::string_view`, keeping caller-side error propagation compatible with the new field representation.

A small Core metaclass fix is included so fields marked exclusively as virtual receive an explicit zero offset instead of inheriting offset state.

## Validation

- `git diff --cached --check` passed before commit
- WSL build and Flute tests were not run during the commit-only workflow
