### PR TITLE
[Network] Convert proxy fields to C++ strings

### DIFF
--- a/docs/xml/modules/classes/netsocket.xml
+++ b/docs/xml/modules/classes/netsocket.xml
@@ -246,7 +246,7 @@ initially fill the internal write buffer, thereafter it will be called whenever 
     <field>
       <name>Address</name>
       <comment>An IP address or domain name to connect to.</comment>
-      <access read="R" write="S">Read/Set</access>
+      <access read="R" write="I">Read/Init</access>
       <type>std::string</type>
       <description>
 <p>For NetSocket clients, if this field is set with an IP address or domain name prior to initialisation, an attempt to connect to that location will be made when the object is initialised.  Post-initialisation this field cannot be set by the client, however calls to <method>Connect</method> will result in it being updated so that it always reflects the named address of the current connection.</p>

--- a/docs/xml/modules/classes/proxy.xml
+++ b/docs/xml/modules/classes/proxy.xml
@@ -127,8 +127,8 @@ if (proxy.ok()) {
     <field>
       <name>GatewayFilter</name>
       <comment>The IP address of the gateway that the proxy is limited to.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>The GatewayFilter defines the IP address of the gateway that this proxy is limited to. It is intended to limit the results of searches performed by the <method>Find</method> method.</p>
 <p>Gateway matching is not currently implemented.  Records that define this field are skipped by <method>Find</method>.</p>
@@ -148,8 +148,8 @@ if (proxy.ok()) {
     <field>
       <name>NetworkFilter</name>
       <comment>The name of the network that the proxy is limited to.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>The NetworkFilter defines the name of the network that this proxy is limited to. It is intended to limit the results of searches performed by the <method>Find</method> method.</p>
 <p>This filter must not be set if the proxy needs to work on an unnamed network.</p>
@@ -160,8 +160,8 @@ if (proxy.ok()) {
     <field>
       <name>Password</name>
       <comment>The password to use when authenticating against the proxy server.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>If the proxy requires authentication, the user password may be set here to enable an automated authentication process. If the password is not set, a dialog will need to be used to prompt the user for the password before communicating with the proxy.</p>
       </description>
@@ -180,8 +180,8 @@ if (proxy.ok()) {
     <field>
       <name>ProxyName</name>
       <comment>A human readable name for the proxy server entry.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>A proxy can be given a human readable name by setting this field.</p>
       </description>
@@ -201,8 +201,8 @@ if (proxy.ok()) {
     <field>
       <name>Server</name>
       <comment>The destination address of the proxy server - may be an IP address or resolvable domain name.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>The domain name or IP address of the proxy server must be defined here.</p>
       </description>
@@ -221,8 +221,8 @@ if (proxy.ok()) {
     <field>
       <name>Username</name>
       <comment>The username to use when authenticating against the proxy server.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>If the proxy requires authentication, the user name may be set here to enable an automated authentication process. If the username is not set, a dialog will be required to prompt the user for the user name before communicating with the proxy server.</p>
       </description>

--- a/docs/xml/modules/network.xml
+++ b/docs/xml/modules/network.xml
@@ -137,7 +137,7 @@ in SSL mode.</li>
     <description>
 <p>Converts an IPv4 or an IPv6 address in string format to an <st>IPAddress</st> structure.  The <code>String</code> must be of form <code>1.2.3.4</code> (IPv4) or <code>2001:db8::1</code> (IPv6).  IPv6 addresses are automatically detected by the presence of colons.</p>
 <pre>struct IPAddress addr;
-if (!StrToAddress(&quot;127.0.0.1&quot;, &amp;addr)) {
+if (StrToAddress(&quot;127.0.0.1&quot;, &amp;addr) IS ERR::Okay) {
    ...
 }
 </pre>

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -243,17 +243,17 @@ class objProxy : public Object {
 
    using create = kt::Create<objProxy>;
 
-   STRING NetworkFilter;    // The name of the network that the proxy is limited to.
-   STRING GatewayFilter;    // The IP address of the gateway that the proxy is limited to.
-   STRING Username;         // The username to use when authenticating against the proxy server.
-   STRING Password;         // The password to use when authenticating against the proxy server.
-   STRING ProxyName;        // A human readable name for the proxy server entry.
-   STRING Server;           // The destination address of the proxy server - may be an IP address or resolvable domain name.
-   int    Port;             // Defines the ports supported by this proxy.
-   int    ServerPort;       // The port that is used for proxy server communication.
-   int    Enabled;          // All proxies are enabled by default until this field is set to false.
-   int    Record;           // The unique ID of the current proxy record.
-   int    Host;             // If true, the proxy settings are derived from the host operating system's default settings.
+   std::string NetworkFilter;    // The name of the network that the proxy is limited to.
+   std::string GatewayFilter;    // The IP address of the gateway that the proxy is limited to.
+   std::string Username;         // The username to use when authenticating against the proxy server.
+   std::string Password;         // The password to use when authenticating against the proxy server.
+   std::string ProxyName;        // A human readable name for the proxy server entry.
+   std::string Server;           // The destination address of the proxy server - may be an IP address or resolvable domain name.
+   int Port;                     // Defines the ports supported by this proxy.
+   int ServerPort;               // The port that is used for proxy server communication.
+   int Enabled;                  // All proxies are enabled by default until this field is set to false.
+   int Record;                   // The unique ID of the current proxy record.
+   int Host;                     // If true, the proxy settings are derived from the host operating system's default settings.
 
    // Action stubs
 
@@ -274,40 +274,34 @@ class objProxy : public Object {
 
    // Customised field setting
 
-   template <class T> inline ERR setNetworkFilter(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setNetworkFilter(const std::string_view &Value) noexcept {
+      this->NetworkFilter = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setGatewayFilter(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setGatewayFilter(const std::string_view &Value) noexcept {
+      this->GatewayFilter = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setUsername(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setUsername(const std::string_view &Value) noexcept {
+      this->Username = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setPassword(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setPassword(const std::string_view &Value) noexcept {
+      this->Password = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setProxyName(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setProxyName(const std::string_view &Value) noexcept {
+      this->ProxyName = Value;
+      return ERR::Okay;
    }
 
-   template <class T> inline ERR setServer(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[2];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   inline ERR setServer(const std::string_view &Value) noexcept {
+      this->Server = Value;
+      return ERR::Okay;
    }
 
    inline ERR setPort(const int Value) noexcept {
@@ -521,10 +515,10 @@ class objNetSocket : public Object {
       return ERR::Okay;
    }
 
-   inline ERR setAddress(const std::string Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[17];
-      return field->WriteValue(target, field, 0x08800500, to_cstring(Value), 1);
+   inline ERR setAddress(const std::string_view &Value) noexcept {
+      if (this->initialised()) return ERR::NoFieldAccess;
+      this->Address = Value;
+      return ERR::Okay;
    }
 
    inline ERR setState(const NTC Value) noexcept {

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -1005,8 +1005,7 @@ static ERR HTTP_Init(extHTTP *Self)
    if (!Self->ProxyDefined) {
       std::lock_guard<std::mutex> proxy_lock(glProxyMutex);
       if ((glProxy) and (glProxy->find(Self->Port, true) IS ERR::Okay)) {
-         if (glProxy->Server) Self->ProxyServer.assign(glProxy->Server);
-         else Self->ProxyServer.clear();
+         Self->ProxyServer = glProxy->Server;
          Self->ProxyPort   = glProxy->ServerPort; // NB: Default is usually 8080
 
          log.msg("Using preset proxy server '%s:%d'", Self->ProxyServer.c_str(), Self->ProxyPort);

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -38,7 +38,7 @@ static objConfig *glProxyConfig = nullptr;
 static objConfig * get_proxy_config(void)
 {
    std::lock_guard lock(glProxyMutex);
-   if (!glProxyFileChecked) {
+   if (not glProxyFileChecked) {
       kt::SwitchContext ctx(glNetworkModule);
       glProxyConfig = objConfig::create::global({ fl::Path("user:config/network/proxies.cfg") });
       glProxyFileChecked = true;
@@ -64,11 +64,6 @@ public:
    std::string FindPort;
    int FindEnabled = -1;
    bool Find = false;
-
-   void setString(STRING& field, std::string_view value) {
-      if (field) { FreeResource(field); field = nullptr; }
-      if (!value.empty()) { field = kt::strclone(value); }
-   }
 };
 
 static ERR find_proxy(extProxy *);
@@ -114,12 +109,12 @@ static ERR PROXY_DeleteRecord(extProxy *Self)
 {
    kt::Log log;
 
-   if ((Self->GroupName.empty()) or (!Self->Record)) return log.error(ERR::Failed);
+   if ((Self->GroupName.empty()) or (not Self->Record)) return log.error(ERR::Failed);
 
    log.branch();
 
    auto cfg = objConfig::create {fl::Path("user:config/network/proxies.cfg") };
-   if (!cfg.ok()) return log.error(ERR::CreateObject);
+   if (not cfg.ok()) return log.error(ERR::CreateObject);
 
    if (auto error = cfg->deleteGroup(Self->GroupName.c_str()); error != ERR::Okay) return log.warning(error);
    if (auto error = cfg->saveSettings(); error != ERR::Okay) return log.warning(error);
@@ -234,7 +229,7 @@ NoSearchResult: No matching proxy was discovered.
 
 static ERR PROXY_FindNext(extProxy *Self)
 {
-   if (!Self->Find) return ERR::NoSearchResult; // Ensure that Find() was used to initiate a search
+   if (not Self->Find) return ERR::NoSearchResult; // Ensure that Find() was used to initiate a search
 
    return find_proxy(Self);
 }
@@ -257,18 +252,18 @@ static bool matchesPortFilter(const KeysType& keys, const std::string& findPort)
 // Check if proxy matches enabled filter
 
 template<typename KeysType>
-static bool matchesEnabledFilter(const KeysType& keys, int findEnabled) {
+static bool matchesEnabledFilter(const KeysType &Keys, int findEnabled) {
    if (findEnabled IS -1) return true;
 
-   if (keys.contains("Enabled")) {
+   if (Keys.contains("Enabled")) {
       int enabled;
-      return parse_record_id(keys.at("Enabled"), enabled) and (enabled IS findEnabled);
+      return parse_record_id(Keys.at("Enabled"), enabled) and (enabled IS findEnabled);
    }
    return false;
 }
 
 template<typename KeysType>
-static bool matchesDeferredFilter(const KeysType &Keys, CSTRING FieldName)
+static bool matchesDeferredFilter(const KeysType &Keys, std::string_view FieldName)
 {
    auto filter = Keys.find(FieldName);
    return (filter IS Keys.end()) or filter->second.empty();
@@ -283,7 +278,7 @@ static ERR find_proxy(extProxy *Self)
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);
 
    if (auto config = get_proxy_config()) {
-      if (!Self->Find) Self->Find = true; // Start of search
+      if (not Self->Find) Self->Find = true; // Start of search
 
       ConfigGroups *groups;
       if (config->get(FID_Data, groups) != ERR::Okay) return ERR::NoData;
@@ -291,7 +286,7 @@ static ERR find_proxy(extProxy *Self)
       auto group = groups->begin();
 
       // If continuing search, find next record
-      if (!Self->GroupName.empty()) {
+      if (not Self->GroupName.empty()) {
          group = std::find_if(groups->begin(), groups->end(),
             [&](const auto& g) { return g.first IS Self->GroupName; });
          if (group != groups->end()) ++group;
@@ -305,14 +300,14 @@ static ERR find_proxy(extProxy *Self)
 
          const auto& keys = group->second;
          int record;
-         if (!parse_record_id(group->first, record)) continue;
+         if (not parse_record_id(group->first, record)) continue;
 
          // Apply filters
-         if (!matchesPortFilter(keys, Self->FindPort)) continue;
-         if (!matchesEnabledFilter(keys, Self->FindEnabled)) continue;
+         if (not matchesPortFilter(keys, Self->FindPort)) continue;
+         if (not matchesEnabledFilter(keys, Self->FindEnabled)) continue;
 
-         if (!matchesDeferredFilter(keys, "NetworkFilter")) continue;
-         if (!matchesDeferredFilter(keys, "GatewayFilter")) continue;
+         if (not matchesDeferredFilter(keys, "NetworkFilter")) continue;
+         if (not matchesDeferredFilter(keys, "GatewayFilter")) continue;
 
          log.trace("Found matching proxy.");
          Self->GroupName = group->first;
@@ -371,18 +366,18 @@ static ERR PROXY_SaveSettings(extProxy *Self)
 {
    kt::Log log;
 
-   if ((!Self->Server) or (!Self->ServerPort)) return log.error(ERR::FieldNotSet);
+   if ((Self->Server.empty()) or (not Self->ServerPort)) return log.error(ERR::FieldNotSet);
 
    log.branch("Host: %d", Self->Host);
 
    if (Self->Host) {
-      return network_platform().save_host_proxy(Self->Server, Self->ServerPort, Self->Port, Self->Enabled);
+      return network_platform().save_host_proxy(Self->Server.c_str(), Self->ServerPort, Self->Port, Self->Enabled);
    }
 
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);
 
    if (auto config = get_proxy_config()) {
-      if (!Self->GroupName.empty()) config->deleteGroup(Self->GroupName.c_str());
+      if (not Self->GroupName.empty()) config->deleteGroup(Self->GroupName.c_str());
       else { // This is a new proxy
          int id = 0;
          config->read("ID", "Value", id);
@@ -425,16 +420,6 @@ results of searches performed by the #Find() method.
 
 Gateway matching is not currently implemented.  Records that define this field are skipped by #Find().
 
-*********************************************************************************************************************/
-
-static ERR SET_GatewayFilter(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->GatewayFilter, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 Host: If `true`, the proxy settings are derived from the host operating system's default settings.
 
@@ -470,32 +455,12 @@ This filter must not be set if the proxy needs to work on an unnamed network.
 
 Network matching is not currently implemented.  Records that define this field are skipped by #Find().
 
-*********************************************************************************************************************/
-
-static ERR SET_NetworkFilter(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->NetworkFilter, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 Username: The username to use when authenticating against the proxy server.
 
 If the proxy requires authentication, the user name may be set here to enable an automated authentication process. If
 the username is not set, a dialog will be required to prompt the user for the user name before communicating with the
 proxy server.
-
-*********************************************************************************************************************/
-
-static ERR SET_Username(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->Username, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Password: The password to use when authenticating against the proxy server.
@@ -504,45 +469,15 @@ If the proxy requires authentication, the user password may be set here to enabl
 If the password is not set, a dialog will need to be used to prompt the user for the password before communicating with
 the proxy.
 
-*********************************************************************************************************************/
-
-static ERR SET_Password(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->Password, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 ProxyName: A human readable name for the proxy server entry.
 
 A proxy can be given a human readable name by setting this field.
 
-*********************************************************************************************************************/
-
-static ERR SET_ProxyName(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->ProxyName, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 Server: The destination address of the proxy server - may be an IP address or resolvable domain name.
 
 The domain name or IP address of the proxy server must be defined here.
-
-*********************************************************************************************************************/
-
-static ERR SET_Server(extProxy *Self, CSTRING Value)
-{
-   Self->setString(Self->Server, Value ? Value : "");
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 ServerPort: The port that is used for proxy server communication.
@@ -557,8 +492,8 @@ static ERR SET_ServerPort(extProxy *Self, int Value)
       Self->ServerPort = Value;
       return ERR::Okay;
    }
-   kt::Log log;
-   return log.error(ERR::OutOfRange);
+
+   return kt::Log().error(ERR::OutOfRange);
 }
 
 /*********************************************************************************************************************
@@ -609,31 +544,17 @@ static ERR get_record(extProxy *Self)
 
    log.traceBranch("Group: %s", Self->GroupName.c_str());
 
-   if (!parse_record_id(Self->GroupName, Self->Record)) return ERR::Search;
+   if (not parse_record_id(Self->GroupName, Self->Record)) return ERR::Search;
 
    const std::lock_guard<std::recursive_mutex> lock(glProxyMutex);
 
    if (auto config = get_proxy_config()) {
-      std::string str;
-      if (config->read(Self->GroupName, "Server", str) IS ERR::Okay) {
-         Self->setString(Self->Server, str);
-
-         if (config->read(Self->GroupName, "NetworkFilter", str) IS ERR::Okay) {
-            Self->setString(Self->NetworkFilter, str);
-         }
-         if (config->read(Self->GroupName, "GatewayFilter", str) IS ERR::Okay) {
-            Self->setString(Self->GatewayFilter, str);
-         }
-         if (config->read(Self->GroupName, "Username", str) IS ERR::Okay) {
-            Self->setString(Self->Username, str);
-         }
-         if (config->read(Self->GroupName, "Password", str) IS ERR::Okay) {
-            Self->setString(Self->Password, str);
-         }
-         if (config->read(Self->GroupName, "Name", str) IS ERR::Okay) {
-            Self->setString(Self->ProxyName, str);
-         }
-
+      if (config->read(Self->GroupName, "Server", Self->Server) IS ERR::Okay) {
+         config->read(Self->GroupName, "NetworkFilter", Self->NetworkFilter);
+         config->read(Self->GroupName, "GatewayFilter", Self->GatewayFilter);
+         config->read(Self->GroupName, "Username", Self->Username);
+         config->read(Self->GroupName, "Password", Self->Password);
+         config->read(Self->GroupName, "Name", Self->ProxyName);
          config->read(Self->GroupName, "Port", Self->Port);
          config->read(Self->GroupName, "ServerPort", Self->ServerPort);
          config->read(Self->GroupName, "Enabled", Self->Enabled);
@@ -658,12 +579,12 @@ static void clear_values(extProxy *Self)
    Self->Enabled    = 0;
    Self->ServerPort = 0;
    Self->Host       = 0;
-   Self->setString(Self->NetworkFilter, "");
-   Self->setString(Self->GatewayFilter, "");
-   Self->setString(Self->Username, "");
-   Self->setString(Self->Password, "");
-   Self->setString(Self->ProxyName, "");
-   Self->setString(Self->Server, "");
+   Self->NetworkFilter.clear();
+   Self->GatewayFilter.clear();
+   Self->Username.clear();
+   Self->Password.clear();
+   Self->ProxyName.clear();
+   Self->Server.clear();
 }
 
 //********************************************************************************************************************
@@ -688,12 +609,12 @@ static const FieldDef clPorts[] = {
 };
 
 static const FieldArray clProxyFields[] = {
-   { "NetworkFilter", FDF_STRING|FDF_RW, nullptr, SET_NetworkFilter },
-   { "GatewayFilter", FDF_STRING|FDF_RW, nullptr, SET_GatewayFilter },
-   { "Username",      FDF_STRING|FDF_RW, nullptr, SET_Username },
-   { "Password",      FDF_STRING|FDF_RW, nullptr, SET_Password },
-   { "ProxyName",     FDF_STRING|FDF_RW, nullptr, SET_ProxyName },
-   { "Server",        FDF_STRING|FDF_RW, nullptr, SET_Server },
+   { "NetworkFilter", FDF_CPPSTRING|FDF_RW },
+   { "GatewayFilter", FDF_CPPSTRING|FDF_RW },
+   { "Username",      FDF_CPPSTRING|FDF_RW },
+   { "Password",      FDF_CPPSTRING|FDF_RW },
+   { "ProxyName",     FDF_CPPSTRING|FDF_RW },
+   { "Server",        FDF_CPPSTRING|FDF_RW },
    { "Port",          FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SET_Port, &clPorts },
    { "ServerPort",    FDF_INT|FDF_RW, nullptr, SET_ServerPort },
    { "Enabled",       FDF_INT|FDF_RW, nullptr, SET_Enabled },

--- a/src/network/class_proxy.cpp
+++ b/src/network/class_proxy.cpp
@@ -34,13 +34,14 @@ each entry the proxy database.  You may change existing values of any proxy and 
 static std::recursive_mutex glProxyMutex;
 static bool glProxyFileChecked = false;
 static objConfig *glProxyConfig = nullptr;
+static constexpr std::string_view PROXY_CONFIG_PATH = "user:config/network/proxies.cfg";
 
 static objConfig * get_proxy_config(void)
 {
    std::lock_guard lock(glProxyMutex);
    if (not glProxyFileChecked) {
       kt::SwitchContext ctx(glNetworkModule);
-      glProxyConfig = objConfig::create::global({ fl::Path("user:config/network/proxies.cfg") });
+      glProxyConfig = objConfig::create::global({ fl::Path(PROXY_CONFIG_PATH) });
       glProxyFileChecked = true;
    }
 
@@ -68,7 +69,7 @@ public:
 
 static ERR find_proxy(extProxy *);
 
-static bool parse_record_id(const std::string &GroupName, int &Record)
+static bool parse_record_id(std::string_view GroupName, int &Record)
 {
    if (GroupName.empty()) return false;
 
@@ -113,7 +114,7 @@ static ERR PROXY_DeleteRecord(extProxy *Self)
 
    log.branch();
 
-   auto cfg = objConfig::create {fl::Path("user:config/network/proxies.cfg") };
+   auto cfg = objConfig::create {fl::Path(PROXY_CONFIG_PATH) };
    if (not cfg.ok()) return log.error(ERR::CreateObject);
 
    if (auto error = cfg->deleteGroup(Self->GroupName.c_str()); error != ERR::Okay) return log.warning(error);
@@ -236,34 +237,29 @@ static ERR PROXY_FindNext(extProxy *Self)
 
 //********************************************************************************************************************
 
-// Check if proxy matches port filter
+static bool matches_port_filter(const ConfigKeys &Keys, std::string_view FindPort)
+{
+   if (FindPort.empty()) return true;
 
-template<typename KeysType>
-static bool matchesPortFilter(const KeysType& keys, const std::string& findPort) {
-   if (findPort.empty()) return true;
-
-   if (keys.contains("Port")) {
-      const auto& port = keys.at("Port");
-      return (port IS "0") or kt::wildcmp(port, findPort);
+   if (Keys.contains("Port")) {
+      const auto &port = Keys.at("Port");
+      return (port IS "0") or kt::wildcmp(port, FindPort);
    }
    return false;
 }
 
-// Check if proxy matches enabled filter
-
-template<typename KeysType>
-static bool matchesEnabledFilter(const KeysType &Keys, int findEnabled) {
-   if (findEnabled IS -1) return true;
+static bool matches_enabled_filter(const ConfigKeys &Keys, int FindEnabled)
+{
+   if (FindEnabled IS -1) return true;
 
    if (Keys.contains("Enabled")) {
       int enabled;
-      return parse_record_id(Keys.at("Enabled"), enabled) and (enabled IS findEnabled);
+      return parse_record_id(Keys.at("Enabled"), enabled) and (enabled IS FindEnabled);
    }
    return false;
 }
 
-template<typename KeysType>
-static bool matchesDeferredFilter(const KeysType &Keys, std::string_view FieldName)
+static bool matches_deferred_filter(const ConfigKeys &Keys, std::string_view FieldName)
 {
    auto filter = Keys.find(FieldName);
    return (filter IS Keys.end()) or filter->second.empty();
@@ -298,16 +294,16 @@ static ERR find_proxy(extProxy *Self)
       for (; group != groups->end(); ++group) {
          log.trace("Checking group: %s", group->first.c_str());
 
-         const auto& keys = group->second;
+         const auto &keys = group->second;
          int record;
          if (not parse_record_id(group->first, record)) continue;
 
          // Apply filters
-         if (not matchesPortFilter(keys, Self->FindPort)) continue;
-         if (not matchesEnabledFilter(keys, Self->FindEnabled)) continue;
+         if (not matches_port_filter(keys, Self->FindPort)) continue;
+         if (not matches_enabled_filter(keys, Self->FindEnabled)) continue;
 
-         if (not matchesDeferredFilter(keys, "NetworkFilter")) continue;
-         if (not matchesDeferredFilter(keys, "GatewayFilter")) continue;
+         if (not matches_deferred_filter(keys, "NetworkFilter")) continue;
+         if (not matches_deferred_filter(keys, "GatewayFilter")) continue;
 
          log.trace("Found matching proxy.");
          Self->GroupName = group->first;
@@ -325,15 +321,7 @@ static ERR find_proxy(extProxy *Self)
 
 static ERR PROXY_Free(extProxy *Self)
 {
-   clear_values(Self);
    Self->~extProxy();
-   return ERR::Okay;
-}
-
-//********************************************************************************************************************
-
-static ERR PROXY_Init(extProxy *Self)
-{
    return ERR::Okay;
 }
 
@@ -399,7 +387,7 @@ static ERR PROXY_SaveSettings(extProxy *Self)
       config->write(Self->GroupName, "Enabled",       std::to_string(Self->Enabled));
 
       objFile::create file = {
-         fl::Path("user:config/network/proxies.cfg"),
+         fl::Path(PROXY_CONFIG_PATH),
          fl::Permissions(PERMIT::USER_READ|PERMIT::USER_WRITE),
          fl::Flags(FL::NEW|FL::WRITE)
       };
@@ -570,10 +558,6 @@ static ERR get_record(extProxy *Self)
 
 static void clear_values(extProxy *Self)
 {
-   kt::Log log(__FUNCTION__);
-
-   log.trace("");
-
    Self->Record     = 0;
    Self->Port       = 0;
    Self->Enabled    = 0;

--- a/src/network/class_proxy_def.c
+++ b/src/network/class_proxy_def.c
@@ -13,9 +13,7 @@ static const struct ActionArray clProxyActions[] = {
    { AC::Disable, PROXY_Disable },
    { AC::Enable, PROXY_Enable },
    { AC::Free, PROXY_Free },
-   { AC::Init, PROXY_Init },
    { AC::NewPlacement, PROXY_NewPlacement },
    { AC::SaveSettings, PROXY_SaveSettings },
    { AC::NIL, nullptr }
 };
-

--- a/src/network/network.tdl
+++ b/src/network/network.tdl
@@ -86,12 +86,12 @@ typedef int SOCKET_HANDLE;
   })
 
   klass("Proxy", { src="class_proxy.cpp", output="class_proxy_def.c" }, [[
-    str NetworkFilter
-    str GatewayFilter
-    str Username
-    str Password
-    str ProxyName
-    str Server
+    cpp(str) NetworkFilter
+    cpp(str) GatewayFilter
+    cpp(str) Username
+    cpp(str) Password
+    cpp(str) ProxyName
+    cpp(str) Server
     int Port
     int ServerPort
     int Enabled


### PR DESCRIPTION
## Summary
* Converted Proxy string fields to cpp(str)/std::string storage
* Updated Proxy field metadata, HTTP proxy assignment, and related generated network documentation
* Cleaned up Proxy filter helpers and removed redundant lifecycle cleanup hooks

## Validation
* cmake --build build/wsl-agents --target network --parallel
* cmake --build build/wsl-agents --target network http --parallel