### PR TITLE
[Network] Convert NetServer SSL fields to C++ strings

### DIFF
--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -677,22 +677,22 @@ class objNetServer : public objNetSocket {
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
-   template <class T> inline ERR setSSLCertificate(T && Value) noexcept {
+   inline ERR setSSLCertificate(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[0];
-      return field->WriteValue(target, field, 0x08800508, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804508, &Value, 1);
    }
 
-   template <class T> inline ERR setSSLPrivateKey(T && Value) noexcept {
+   inline ERR setSSLPrivateKey(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[3];
-      return field->WriteValue(target, field, 0x08800508, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804508, &Value, 1);
    }
 
-   template <class T> inline ERR setSSLKeyPassword(T && Value) noexcept {
+   inline ERR setSSLKeyPassword(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(target, field, 0x08800508, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804508, &Value, 1);
    }
 
 };
@@ -741,4 +741,3 @@ extern uint32_t LongToHost(uint32_t Value);
 extern ERR SetSSL(objNetSocket *NetSocket, const std::string_view & Command, const std::string_view & Value);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/src/network/class_netserver.cpp
+++ b/src/network/class_netserver.cpp
@@ -121,10 +121,6 @@ static ERR NETSERVER_DisconnectSocket(extNetServer *Self, struct ns::DisconnectS
 
 static ERR NETSERVER_Free(extNetServer *Self)
 {
-   if (Self->SSLCertificate) { FreeResource(Self->SSLCertificate); Self->SSLCertificate = nullptr; }
-   if (Self->SSLKeyPassword) { FreeResource(Self->SSLKeyPassword); Self->SSLKeyPassword = nullptr; }
-   if (Self->SSLPrivateKey)  { FreeResource(Self->SSLPrivateKey); Self->SSLPrivateKey = nullptr; }
-
    #ifndef DISABLE_SSL
       #ifndef _WIN32
          if (Self->ServerSSLContext) {
@@ -164,6 +160,14 @@ static ERR NETSERVER_NewObject(extNetServer *Self)
 
 //********************************************************************************************************************
 
+static ERR NETSERVER_NewPlacement(extNetServer *Self)
+{
+   new (Self) extNetServer;
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
 static ERR NETSERVER_Read(extNetServer *Self, struct acRead *Args)
 {
    // Not allowed - client must read from the ClientSocket.
@@ -189,29 +193,29 @@ NetServer will either self-sign or use a localhost certificate, if available.
 
 *********************************************************************************************************************/
 
-static ERR NETSERVER_SET_SSLCertificate(extNetServer *Self, CSTRING Value)
+static ERR NETSERVER_GET_SSLCertificate(extNetServer *Self, std::string_view &Value)
 {
-   if (Self->SSLCertificate) { FreeResource(Self->SSLCertificate); Self->SSLCertificate = nullptr; }
+   Value = Self->SSLCertificate;
+   return ERR::Okay;
+}
 
-   if ((Value) and (*Value)) {
+static ERR NETSERVER_SET_SSLCertificate(extNetServer *Self, const std::string_view &Value)
+{
+   Self->SSLCertificate.clear();
+
+   if (not Value.empty()) {
       kt::Log log;
 
       LOC type;
       if ((AnalysePath(Value, &type) IS ERR::Okay) and (type IS LOC::FILE)) {
          if (ssl_certificate_format(Value) != SSLCERTFORMAT::NIL) {
-            Self->SSLCertificate = kt::strclone(Value);
+            Self->SSLCertificate.assign(Value);
          }
          else return log.warning(ERR::InvalidData);
       }
       else return log.warning(ERR::FileNotFound);
    }
 
-   return ERR::Okay;
-}
-
-static ERR NETSERVER_GET_SSLCertificate(extNetServer *Self, CSTRING *Value)
-{
-   *Value = Self->SSLCertificate;
    return ERR::Okay;
 }
 
@@ -226,28 +230,28 @@ will either self-sign or use a localhost private key, if available.
 
 *********************************************************************************************************************/
 
-static ERR NETSERVER_SET_SSLPrivateKey(extNetServer *Self, CSTRING Value)
+static ERR NETSERVER_GET_SSLPrivateKey(extNetServer *Self, std::string_view &Value)
 {
-   if (Self->SSLPrivateKey) { FreeResource(Self->SSLPrivateKey); Self->SSLPrivateKey = nullptr; }
+   Value = Self->SSLPrivateKey;
+   return ERR::Okay;
+}
 
-   if ((Value) and (*Value)) {
+static ERR NETSERVER_SET_SSLPrivateKey(extNetServer *Self, const std::string_view &Value)
+{
+   Self->SSLPrivateKey.clear();
+
+   if (not Value.empty()) {
       kt::Log log;
 
       LOC type;
       if ((AnalysePath(Value, &type) IS ERR::Okay) and (type IS LOC::FILE)) {
          if (ssl_private_key_format(Value) != SSLCERTFORMAT::NIL) {
-            Self->SSLPrivateKey = kt::strclone(Value);
+            Self->SSLPrivateKey.assign(Value);
          }
          else return log.warning(ERR::InvalidData);
       }
       else return log.warning(ERR::FileNotFound);
    }
-   return ERR::Okay;
-}
-
-static ERR NETSERVER_GET_SSLPrivateKey(extNetServer *Self, CSTRING *Value)
-{
-   *Value = Self->SSLPrivateKey;
    return ERR::Okay;
 }
 
@@ -261,16 +265,15 @@ not encrypted, this field can be left empty.
 
 *********************************************************************************************************************/
 
-static ERR NETSERVER_SET_SSLKeyPassword(extNetServer *Self, CSTRING Value)
+static ERR NETSERVER_GET_SSLKeyPassword(extNetServer *Self, std::string_view &Value)
 {
-   if (Self->SSLKeyPassword) { FreeResource(Self->SSLKeyPassword); Self->SSLKeyPassword = nullptr; }
-   if ((Value) and (*Value)) Self->SSLKeyPassword = kt::strclone(Value);
+   Value = Self->SSLKeyPassword;
    return ERR::Okay;
 }
 
-static ERR NETSERVER_GET_SSLKeyPassword(extNetServer *Self, CSTRING *Value)
+static ERR NETSERVER_SET_SSLKeyPassword(extNetServer *Self, const std::string_view &Value)
 {
-   *Value = Self->SSLKeyPassword;
+   Self->SSLKeyPassword.assign(Value);
    return ERR::Okay;
 }
 
@@ -612,9 +615,9 @@ static const FieldArray clNetServerFields[] = {
    { "Backlog",        FDF_VIRTUAL|FDF_INT|FDF_RI,    NETSERVER_GET_Backlog, NETSERVER_SET_Backlog },
    { "ClientLimit",    FDF_VIRTUAL|FDF_INT|FDF_RW,    NETSERVER_GET_ClientLimit, NETSERVER_SET_ClientLimit },
    { "SocketLimit",    FDF_VIRTUAL|FDF_INT|FDF_RW,    NETSERVER_GET_SocketLimit, NETSERVER_SET_SocketLimit },
-   { "SSLCertificate", FDF_VIRTUAL|FDF_STRING|FDF_RI, NETSERVER_GET_SSLCertificate, NETSERVER_SET_SSLCertificate },
-   { "SSLPrivateKey",  FDF_VIRTUAL|FDF_STRING|FDF_RI, NETSERVER_GET_SSLPrivateKey, NETSERVER_SET_SSLPrivateKey },
-   { "SSLKeyPassword", FDF_VIRTUAL|FDF_STRING|FDF_RI, NETSERVER_GET_SSLKeyPassword, NETSERVER_SET_SSLKeyPassword },
+   { "SSLCertificate", FDF_VIRTUAL|FDF_CPPSTRING|FDF_RI, NETSERVER_GET_SSLCertificate, NETSERVER_SET_SSLCertificate },
+   { "SSLPrivateKey",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_RI, NETSERVER_GET_SSLPrivateKey, NETSERVER_SET_SSLPrivateKey },
+   { "SSLKeyPassword", FDF_VIRTUAL|FDF_CPPSTRING|FDF_RI, NETSERVER_GET_SSLKeyPassword, NETSERVER_SET_SSLKeyPassword },
    { "Clients",        FDF_VIRTUAL|FDF_OBJECT|FDF_R,  NETSERVER_GET_Clients, nullptr, CLASSID::NETCLIENT },
    END_FIELD
 };

--- a/src/network/netserver_def.c
+++ b/src/network/netserver_def.c
@@ -34,9 +34,9 @@ static const struct MethodEntry clNetServerMethods[] = {
 static const struct ActionArray clNetServerActions[] = {
    { AC::Free, NETSERVER_Free },
    { AC::Init, NETSERVER_Init },
+   { AC::NewPlacement, NETSERVER_NewPlacement },
    { AC::NewObject, NETSERVER_NewObject },
    { AC::Read, NETSERVER_Read },
    { AC::Write, NETSERVER_Write },
    { AC::NIL, nullptr }
 };
-

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -456,7 +456,8 @@ static ERR NETSOCKET_Free(extNetSocket *Self)
 
    free_socket(Self);
 
-   Self->~extNetSocket();
+   if (Self->classID() IS CLASSID::NETSERVER) ((extNetServer *)Self)->~extNetServer();
+   else Self->~extNetSocket();
    return ERR::Okay;
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -168,9 +168,9 @@ class extNetServer : public extNetSocket {
 
    objNetClient *LastClient;   // For linked-list management.
    objNetClient *Clients;      // Lists all clients connected to the NetServer.
-   CSTRING SSLCertificate;     // SSL certificate file to use for SSL listeners.
-   CSTRING SSLPrivateKey;      // Private key file to use for SSL listeners.
-   CSTRING SSLKeyPassword;     // SSL private key password.
+   std::string SSLCertificate; // SSL certificate file to use for SSL listeners.
+   std::string SSLPrivateKey;  // Private key file to use for SSL listeners.
+   std::string SSLKeyPassword; // SSL private key password.
    int    Backlog;             // The maximum number of connections that can be queued against the socket.
    int    ClientLimit;         // The maximum number of client IP addresses that can be connected to the NetServer.
    int    SocketLimit;         // Limits the number of connected sockets per client IP address.
@@ -456,7 +456,7 @@ static std::string glCertPath;
 
    static ERR resolve_ssl_certificate_paths(extNetServer *Self, ssl_certificate_paths &Paths)
    {
-      if ((!Self) or (!Self->SSLCertificate) or (!*Self->SSLCertificate)) return ERR::FieldNotSet;
+      if ((not Self) or Self->SSLCertificate.empty()) return ERR::FieldNotSet;
 
       Paths.Format = ssl_certificate_format(Self->SSLCertificate);
       if (Paths.Format IS SSLCERTFORMAT::NIL) return ERR::InvalidData;
@@ -465,7 +465,7 @@ static std::string glCertPath;
          return error;
       }
 
-      if (Self->SSLPrivateKey) {
+      if (not Self->SSLPrivateKey.empty()) {
          if (ssl_private_key_format(Self->SSLPrivateKey) IS SSLCERTFORMAT::NIL) return ERR::InvalidData;
 
          if (auto error = ResolvePath(Self->SSLPrivateKey, RSF::NIL, &Paths.PrivateKeyPath); error != ERR::Okay) {
@@ -474,7 +474,7 @@ static std::string glCertPath;
          Paths.PrivateKey.emplace(Paths.PrivateKeyPath);
       }
 
-      if (Self->SSLKeyPassword) Paths.Password.emplace(Self->SSLKeyPassword);
+      if (not Self->SSLKeyPassword.empty()) Paths.Password.emplace(Self->SSLKeyPassword);
 
       return ERR::Okay;
    }

--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -367,8 +367,8 @@ static ERR tls_setup_server(extNetServer *Self)
 
    if (auto server_ctx = SSL_CTX_new(TLS_server_method())) {
       // Check if custom certificate is specified
-      if (Self->SSLCertificate and *Self->SSLCertificate) {
-         log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate);
+      if (not Self->SSLCertificate.empty()) {
+         log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate.c_str());
          if ((error = loadCustomCertificateOpenSSL(Self, server_ctx)) IS ERR::Okay) {
             setup_success = true;
             log.msg("Custom SSL server certificate loaded successfully.");

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -69,8 +69,8 @@ static ERR tls_setup_server(extNetServer *Self)
       return ERR::Failed;
    }
 
-   if (Self->SSLCertificate) {
-      log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate);
+   if (not Self->SSLCertificate.empty()) {
+      log.msg("Loading custom SSL server certificate: %s", Self->SSLCertificate.c_str());
 
       ssl_certificate_paths paths;
       if (auto error = resolve_ssl_certificate_paths(Self, paths); error != ERR::Okay) {


### PR DESCRIPTION
## Summary

Converts NetServer SSL certificate-related fields from manually owned C strings to C++ string storage.

## Changes

* Replaces NetServer SSL certificate, private key, and key password storage with `std::string`.
* Updates NetServer field callbacks and field definitions to use `FDF_CPPSTRING` and `std::string_view`.
* Adds NetServer placement construction so embedded C++ strings are constructed before field access.
* Adjusts NetSocket free-time destructor dispatch so NetServer string storage is destroyed through `~extNetServer()`.
* Updates SSL setup paths to use `empty()` checks and `.c_str()` only at C API/logging boundaries.

## Validation

* `git diff --check`
* `cmake --build build/wsl-agents --target network --parallel` from WSL

Flute and ctest were intentionally not run for this mechanical conversion.