### PR TITLE
[Core] Updated Script string field handling

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3169,12 +3169,6 @@ class objScript : public Object {
       return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setName(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(target, field, 0x08810300, to_cstring(Value), 1);
-   }
-
    inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -542,6 +542,7 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
       int i;
       if (not Value.empty()) {
          auto len = Value.find(';');
+         if (len IS std::string_view::npos) len = Value.size();
 
          if (Value.substr(0, len).starts_with("STRING:")) {
             auto statement = Value.substr(7);

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -491,9 +491,9 @@ code for international English.
 
 *********************************************************************************************************************/
 
-static ERR GET_Language(objScript *Self, STRING *Value)
+static ERR GET_Language(objScript *Self, std::string_view &Value)
 {
-   *Value = Self->Language;
+   Value = std::string_view((const char *)&Self->Language, 3);
    return ERR::Okay;
 }
 
@@ -539,9 +539,9 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
       Self->String.clear();
       Self->WorkingPath.clear();
 
-      int i, len;
+      int i;
       if (not Value.empty()) {
-         for (len=0; (len < int(Value.size())) and (Value[len] != ';'); len++);
+         auto len = Value.find(';');
 
          if (Value.substr(0, len).starts_with("STRING:")) {
             auto statement = Value.substr(7);
@@ -620,18 +620,6 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
    }
 
    return ERR::Okay;
-}
-
-//********************************************************************************************************************
-
-static ERR SET_Name(objScript *Self, CSTRING Name)
-{
-   if (Name) {
-      SetName(Self, Name);
-      struct acSetKey args("Name", Name);
-      return SCRIPT_SetKey(Self, &args);
-   }
-   else return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -858,10 +846,9 @@ static const FieldArray clScriptFields[] = {
    { "CacheFile",    FDF_CPPSTRING|FDF_RW,           GET_CacheFile, SET_CacheFile },
    { "ErrorMessage", FDF_CPPSTRING|FDF_RW,           GET_ErrorMessage, SET_ErrorMessage },
    { "WorkingPath",  FDF_CPPSTRING|FDF_RW,           GET_WorkingPath, SET_WorkingPath },
-   { "Language",     FDF_STRING|FDF_R,               GET_Language, nullptr },
+   { "Language",     FDF_CPPSTRING|FDF_R,            GET_Language },
    { "Location",     FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path },
    { "Procedure",    FDF_CPPSTRING|FDF_RW,           GET_Procedure, SET_Procedure },
-   { "Name",         FDF_STRING|FDF_SYSTEM|FDF_RW,   nullptr, SET_Name },
    { "Path",         FDF_CPPSTRING|FDF_RI,           GET_Path, SET_Path },
    { "Results",      FDF_ARRAY|FDF_POINTER|FDF_STRING|FDF_RW, GET_Results, SET_Results },
    { "Src",          FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path },


### PR DESCRIPTION
## Summary

Updates Script field handling so the `Language` field uses C++ string view access and removes the Script `Name` field setter path from the generated/public field surface.

## Impact

This keeps Script string field access aligned with the newer C++ string field conventions and removes an obsolete mutable `Name` field hook.

## Validation

Not run. The preceding request was commit-only, so no build or test pass was performed for this PR.