### PR TITLE
[SVG] Converted SVG string fields to C++ storage

### DIFF
--- a/docs/xml/modules/classes/svg.xml
+++ b/docs/xml/modules/classes/svg.xml
@@ -173,7 +173,7 @@
       <name>Colour</name>
       <comment>Defines the default fill to use for <code>currentColor</code> references.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>Set the Colour value to alter the default fill that is used for <code>currentColor</code> references.  Typically a standard RGB painter fill reference should be used for this purpose, e.g. <code>rgb(255,255,255)</code>.  It is however, also acceptable to use URL references to named definitions such as gradients and images.  This will work as long as the named definition is registered in the top-level <class name="VectorScene">VectorScene</class> object.</p>
 <p>

--- a/docs/xml/modules/classes/svg.xml
+++ b/docs/xml/modules/classes/svg.xml
@@ -172,7 +172,7 @@
     <field>
       <name>Colour</name>
       <comment>Defines the default fill to use for <code>currentColor</code> references.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="W">Read/Write</access>
       <type>std::string</type>
       <description>
 <p>Set the Colour value to alter the default fill that is used for <code>currentColor</code> references.  Typically a standard RGB painter fill reference should be used for this purpose, e.g. <code>rgb(255,255,255)</code>.  It is however, also acceptable to use URL references to named definitions such as gradients and images.  This will work as long as the named definition is registered in the top-level <class name="VectorScene">VectorScene</class> object.</p>
@@ -282,7 +282,7 @@
     <field>
       <name>Statement</name>
       <comment>String containing complete SVG document markup.</comment>
-      <access read="R" write="S">Read/Set</access>
+      <access read="R" write="W">Read/Write</access>
       <type>std::string</type>
       <description>
 <p>SVG data can be loaded from a string by specifying it here prior to initialisation.  If the <fl>Path</fl> field has been defined, it will take precedent and the Statement is ignored.</p>
@@ -311,10 +311,10 @@
     <field>
       <name>Title</name>
       <comment>The title of the SVG document.</comment>
-      <access read="R" write="S">Read/Set</access>
+      <access read="R" write="W">Read/Write</access>
       <type>std::string</type>
       <description>
-<p>The title of an SVG document is declared with a title element that can embedded anywhere in the document.  In cases where a title has been specified, it will be possible to read it from this field.  If no title is in the document then <code>NULL</code> will be returned.</p>
+<p>The title of an SVG document is declared with a title element that can embedded anywhere in the document.  In cases where a title has been specified, it will be possible to read it from this field.</p>
       </description>
     </field>
 

--- a/include/kotuku/modules/svg.h
+++ b/include/kotuku/modules/svg.h
@@ -8,6 +8,10 @@
 
 #define MODVERSION_SVG (1)
 
+#ifdef __cplusplus
+#include <string_view>
+#endif
+
 class objSVG;
 
 // SVG flags.
@@ -40,13 +44,14 @@ class objSVG : public Object {
 
    using create = kt::Create<objSVG>;
 
-   OBJECTPTR Target;    // Destination container for the generated SVG scene graph elements.
-   STRING    Path;      // File system path to the source SVG document.
-   STRING    Title;     // The title of the SVG document.
-   STRING    Statement; // String containing complete SVG document markup.
-   int       Frame;     // Constrains rendering to a specific frame number for frame-based display systems.
-   SVF       Flags;     // Configuration flags that modify SVG processing behaviour.
-   int       FrameRate; // Controls the maximum frame rate for SVG animation playback.
+   OBJECTPTR Target;         // Destination container for the generated SVG scene graph elements.
+   std::string Path;         // File system path to the source SVG document.
+   std::string Title;        // The title of the SVG document.
+   std::string Statement;    // String containing complete SVG document markup.
+   std::string Colour;       // Defines the default fill to use for currentColor references.
+   int       Frame;          // Constrains rendering to a specific frame number for frame-based display systems.
+   SVF       Flags;          // Configuration flags that modify SVG processing behaviour.
+   int       FrameRate;      // Controls the maximum frame rate for SVG animation playback.
 
    // Action stubs
 
@@ -82,22 +87,28 @@ class objSVG : public Object {
       return field->WriteValue(target, field, 0x08000501, Value, 1);
    }
 
-   template <class T> inline ERR setPath(T && Value) noexcept {
+   inline ERR setPath(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setTitle(T && Value) noexcept {
+   inline ERR setTitle(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[12];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
    }
 
-   template <class T> inline ERR setStatement(T && Value) noexcept {
+   inline ERR setStatement(const std::string_view &Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+      return field->WriteValue(target, field, 0x00804300, &Value, 1);
+   }
+
+   inline ERR setColour(const std::string_view &Value) noexcept {
+      auto target = this;
+      auto field = &this->Class->Dictionary[4];
+      return field->WriteValue(target, field, 0x00804308, &Value, 1);
    }
 
    inline ERR setFrame(const int Value) noexcept {
@@ -114,12 +125,6 @@ class objSVG : public Object {
       auto target = this;
       auto field = &this->Class->Dictionary[0];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
-   }
-
-   template <class T> inline ERR setColour(T && Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[4];
-      return field->WriteValue(target, field, 0x08800308, to_cstring(Value), 1);
    }
 
    inline ERR setFrameCallback(const FUNCTION Value) noexcept {

--- a/include/kotuku/modules/svg.h
+++ b/include/kotuku/modules/svg.h
@@ -94,21 +94,18 @@ class objSVG : public Object {
    }
 
    inline ERR setTitle(const std::string_view &Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[12];
-      return field->WriteValue(target, field, 0x00804300, &Value, 1);
+      this->Title = Value;
+      return ERR::Okay;
    }
 
    inline ERR setStatement(const std::string_view &Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(target, field, 0x00804300, &Value, 1);
+      this->Statement = Value;
+      return ERR::Okay;
    }
 
    inline ERR setColour(const std::string_view &Value) noexcept {
-      auto target = this;
-      auto field = &this->Class->Dictionary[4];
-      return field->WriteValue(target, field, 0x00804308, &Value, 1);
+      this->Colour = Value;
+      return ERR::Okay;
    }
 
    inline ERR setFrame(const int Value) noexcept {

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -134,9 +134,6 @@ static ERR SVG_Free(extSVG *Self)
       Self->Target = nullptr;
    }
 
-   if (Self->Path)      { FreeResource(Self->Path);      Self->Path = nullptr; }
-   if (Self->Title)     { FreeResource(Self->Title);     Self->Title = nullptr; }
-   if (Self->Statement) { FreeResource(Self->Statement); Self->Statement = nullptr; }
    if (Self->XML)       { FreeResource(Self->XML);       Self->XML = nullptr; }
 
    if (!Self->Resources.empty()) {
@@ -179,10 +176,22 @@ static ERR SVG_Init(extSVG *Self)
       else return ERR::NewObject;
    }
 
-   if (Self->Path) return parse_svg(Self, Self->Path, nullptr);
-   else if (Self->Statement) return parse_svg(Self, nullptr, Self->Statement);
+   if (not Self->Path.empty()) return parse_svg(Self, Self->Path.c_str(), nullptr);
+   else if (not Self->Statement.empty()) return parse_svg(Self, nullptr, Self->Statement.c_str());
 
    return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+static ERR SVF_NewObject(extSVG *Self)
+{
+   #ifdef __ANDROID__
+      Self->FrameRate = 30; // Choose a lower frame rate for Android devices, so as to minimise power consumption.
+   #else
+      Self->FrameRate = 60;
+   #endif
+   Self->Colour = "rgb(0,0,0)"; // Default colour, used for 'currentColor' references
 }
 
 //********************************************************************************************************************
@@ -190,11 +199,6 @@ static ERR SVG_Init(extSVG *Self)
 static ERR SVG_NewPlacement(extSVG *Self)
 {
    new (Self) extSVG;
-   #ifdef __ANDROID__
-      Self->FrameRate = 30; // Choose a lower frame rate for Android devices, so as to minimise power consumption.
-   #else
-      Self->FrameRate = 60;
-   #endif
    return ERR::Okay;
 }
 
@@ -455,23 +459,6 @@ registered in the top-level @VectorScene object.
 <li>Named colours: Standard SVG colour names</li>
 <li>URL references: `url(#gradientId)` for complex paint definitions</li>
 </list>
-*********************************************************************************************************************/
-
-static ERR GET_Colour(extSVG *Self, CSTRING *Value)
-{
-   *Value = Self->Colour.c_str();
-   return ERR::Okay;
-}
-
-static ERR SET_Colour(extSVG *Self, CSTRING Value)
-{
-   if ((Value) and (*Value)) {
-      Self->Colour.assign(Value);
-   }
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Flags: Configuration flags that modify SVG processing behaviour.
@@ -578,20 +565,16 @@ When both #Path and #Statement are specified, the Path field takes precedence an
 
 *********************************************************************************************************************/
 
-static ERR GET_Path(extSVG *Self, STRING *Value)
+static ERR GET_Path(extSVG *Self, std::string_view &Value)
 {
-   *Value = Self->Path;
+   Value = Self->Path;
    return ERR::Okay;
 }
 
-static ERR SET_Path(extSVG *Self, CSTRING Value)
+static ERR SET_Path(extSVG *Self, const std::string_view &Value)
 {
-   if (Self->Path)   { FreeResource(Self->Path); Self->Path = nullptr; }
    Self->Folder.clear();
-
-   if ((Value) and (*Value)) {
-      if (!(Self->Path = strclone(Value))) return ERR::AllocMemory;
-   }
+   Self->Path = Value;
    return ERR::Okay;
 }
 
@@ -624,20 +607,6 @@ defined, it will take precedent and the Statement is ignored.
 
 For incremental data parsing after initialisation, consider using the #DataFeed() action instead, which supports
 progressive document construction from data streams.
-
-*********************************************************************************************************************/
-
-static ERR SET_Statement(extSVG *Self, CSTRING Value)
-{
-   if (Self->Statement) { FreeResource(Self->Statement); Self->Statement = nullptr; }
-
-   if ((Value) and (*Value)) {
-      if (!(Self->Statement = strclone(Value))) return ERR::AllocMemory;
-   }
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Target: Destination container for the generated SVG scene graph elements.
@@ -693,19 +662,7 @@ static ERR SET_Target(extSVG *Self, OBJECTPTR Value)
 Title: The title of the SVG document.
 
 The title of an SVG document is declared with a title element that can embedded anywhere in the document.  In cases
-where a title has been specified, it will be possible to read it from this field.  If no title is in the document then
-`NULL` will be returned.
-
-*********************************************************************************************************************/
-
-static ERR SET_Title(extSVG *Self, CSTRING Value)
-{
-   if (Self->Title) { FreeResource(Self->Title); Self->Title = nullptr; }
-   if (Value) Self->Title = strclone(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
+where a title has been specified, it will be possible to read it from this field.
 
 -FIELD-
 Viewport: Reference to the primary @VectorViewport containing the SVG document content.
@@ -741,16 +698,16 @@ static ERR GET_Viewport(extSVG *Self, OBJECTPTR *Value)
 
 static const FieldArray clSVGFields[] = {
    { "Target",    FDF_OBJECT|FDF_RI, nullptr, SET_Target },
-   { "Path",      FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "Title",     FDF_STRING|FDF_RW, nullptr, SET_Title },
-   { "Statement", FDF_STRING|FDF_RW, nullptr, SET_Statement },
+   { "Path",      FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "Title",     FDF_CPPSTRING|FDF_RW },
+   { "Statement", FDF_CPPSTRING|FDF_RW },
+   { "Colour",    FDF_CPPSTRING|FDF_RW },
    { "Frame",     FDF_INT|FDF_RW, nullptr, nullptr },
    { "Flags",     FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clSVGFlags },
    { "FrameRate", FDF_INT|FDF_RW, nullptr, SET_FrameRate },
    // Virtual Fields
-   { "Colour",        FDF_VIRTUAL|FDF_STRING|FDF_RW, GET_Colour, SET_Colour },
    { "FrameCallback", FDF_VIRTUAL|FDF_FUNCTION|FDF_RW, GET_FrameCallback, SET_FrameCallback },
-   { "Src",           FDF_VIRTUAL|FDF_SYNONYM|FDF_STRING|FDF_RW, GET_Path, SET_Path },
+   { "Src",           FDF_VIRTUAL|FDF_SYNONYM|FDF_CPPSTRING|FDF_RW, GET_Path, SET_Path },
    { "Scene",         FDF_VIRTUAL|FDF_OBJECT|FDF_R, GET_Scene, nullptr },
    { "Viewport",      FDF_VIRTUAL|FDF_OBJECT|FDF_R, GET_Viewport, nullptr },
    END_FIELD

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -184,7 +184,7 @@ static ERR SVG_Init(extSVG *Self)
 
 //********************************************************************************************************************
 
-static ERR SVF_NewObject(extSVG *Self)
+static ERR SVG_NewObject(extSVG *Self)
 {
    #ifdef __ANDROID__
       Self->FrameRate = 30; // Choose a lower frame rate for Android devices, so as to minimise power consumption.
@@ -192,6 +192,7 @@ static ERR SVF_NewObject(extSVG *Self)
       Self->FrameRate = 60;
    #endif
    Self->Colour = "rgb(0,0,0)"; // Default colour, used for 'currentColor' references
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************

--- a/src/svg/class_svg_def.c
+++ b/src/svg/class_svg_def.c
@@ -22,6 +22,7 @@ static const struct ActionArray clSVGActions[] = {
    { AC::Deactivate, SVG_Deactivate },
    { AC::Free, SVG_Free },
    { AC::Init, SVG_Init },
+   { AC::NewObject, SVG_NewObject },
    { AC::NewPlacement, SVG_NewPlacement },
    { AC::SaveImage, SVG_SaveImage },
    { AC::SaveToObject, SVG_SaveToObject },

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -1897,11 +1897,11 @@ ERR svgState::process_tag(XTag &Tag, XTag &ParentTag, OBJECTPTR Parent, objVecto
       case SVF_pattern:          proc_pattern(Tag); break;
 
       case SVF_title:
-         if (Self->Title) { FreeResource(Self->Title); Self->Title = nullptr; }
+         Self->Title.clear();
          if (!Tag.Children.empty()) {
             if (auto buffer = Tag.getContent(); !buffer.empty()) {
                kt::ltrim(buffer);
-               Self->Title = strclone(buffer);
+               Self->Title.assign(buffer);
             }
          }
          break;

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -91,7 +91,6 @@ class extSVG : public objSVG {
    objXML *XML;
    objVectorScene *Scene;
    std::string Folder;
-   std::string Colour = "rgb(0,0,0)"; // Default colour, used for 'currentColor' references
    class objVectorViewport *Viewport; // First viewport (the <svg> tag) to be created on parsing the SVG document.
    std::list<std::variant<anim_transform, anim_motion, anim_value>> Animations; // NB: Pointer stability is a container requirement
    ankerl::unordered_dense::map<OBJECTID, svgAnimState> Animatrix; // For animated transforms, a vector may have one matrix only.

--- a/src/svg/svg.tdl
+++ b/src/svg/svg.tdl
@@ -1,6 +1,8 @@
 --$TIRI:Include
 
 module({ name="SVG", copyright="Paul Manias © 2010-2026", version=1.0, timestamp=20240611, src="svg.cpp" }, function()
+  cpp_include('<string_view>')
+
   flags("SVF", { comment="SVG flags." },
     "AUTOSCALE: In auto-resize mode, vector dimensions are scaled to the width and height of the vector page.  The @VectorScene.PageWidth and @VectorScene.PageHeight must be set for this.",
     "ALPHA: Generate an alpha channel in the rendered image.",
@@ -12,12 +14,13 @@ module({ name="SVG", copyright="Paul Manias © 2010-2026", version=1.0, timestam
   })
 
   klass("SVG", { src="class_svg.cpp", output="class_svg_def.c" }, [[
-    obj Target      # Refers to the target of the generated SVG scene.
-    str Path        # A path referring to an SVG file.
-    str Title       # Automatically defined if the title element is used in the SVG source document.
-    str Statement   # A string containing SVG data.
-    int Frame       # Draw the SVG only when this frame number is a match to the target surface frame number.
-    int(SVF) Flags  # Optional flags.
-    int FrameRate   # Maximum frame rate to use for animation.
+    obj Target         # Refers to the target of the generated SVG scene.
+    cpp(str) Path      # A path referring to an SVG file.
+    cpp(str) Title     # Automatically defined if the title element is used in the SVG source document.
+    cpp(str) Statement # A string containing SVG data.
+    cpp(str) Colour    # Defines the default fill to use for `currentColor` references.
+    int Frame          # Draw the SVG only when this frame number is a match to the target surface frame number.
+    int(SVF) Flags     # Optional flags.
+    int FrameRate      # Maximum frame rate to use for animation.
   ]])
 end)

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -205,13 +205,12 @@ static std::vector<Transition> process_transition_stops(extSVG *Self, const objX
 static CSTRING folder(extSVG *Self)
 {
    if (!Self->Folder.empty()) return Self->Folder.c_str();
-   if (!Self->Path) return nullptr;
+   if (Self->Path.empty()) return nullptr;
 
    // Setting a path of "my/house/is/red.svg" results in "my/house/is/"
 
    if (ResolvePath(Self->Path, RSF::NO_FILE_CHECK, &Self->Folder) IS ERR::Okay) {
-      auto last = Self->Folder.find_last_of("/\\");
-      if (last != std::string::npos) {
+      if (auto last = Self->Folder.find_last_of("/\\"); last != std::string::npos) {
          Self->Folder.resize(last + 1);
          return Self->Folder.c_str();
       }


### PR DESCRIPTION
* Converted Path, Title, Statement and Colour fields to cpp(str) storage
* Updated SVG parsing code to use std::string storage for source paths and titles
* [Doc] Regenerated SVG field documentation for the Colour type