### PR TITLE
[Core] Handled object names as C++ string fields

### DIFF
--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -245,7 +245,7 @@ struct Object { // Must be 64-bit aligned
    std::atomic_char SleepQueue;  // For the use of LockObject() only
    std::atomic_uint8_t RefCount; // Reference counting - object cannot be freed until this reaches 0.  NB: This is not a locking mechanism!
    OBJECTID UID;                 // Unique object identifier
-   std::atomic<uint32_t> Flags;  // Object flags
+   std::atomic<uint32_t> Flags;  // Object NF flags
    std::atomic_int ThreadID;     // Managed by locking functions.  Atomic due to volatility.
    char Name[MAX_NAME_LEN];      // The name of the object.  NOTE: This value can be adjusted to ensure that the struct is always 8-bit aligned.
 

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -30,11 +30,11 @@ Further discussion on classes and their technical aspects can be found in the Ko
 
 static ERR OBJECT_GetClass(OBJECTPTR, extMetaClass **);
 static ERR OBJECT_GetClassID(OBJECTPTR, CLASSID *);
-static ERR OBJECT_GetName(OBJECTPTR, STRING *);
+static ERR OBJECT_GetName(OBJECTPTR, std::string_view &);
 static ERR OBJECT_GetOwner(OBJECTPTR, OBJECTID *);
 static ERR OBJECT_GetID(OBJECTPTR, OBJECTID *);
 static ERR OBJECT_SetOwner(OBJECTPTR, OBJECTID);
-static ERR OBJECT_SetName(OBJECTPTR, CSTRING);
+static ERR OBJECT_SetName(OBJECTPTR, const std::string_view &);
 
 static void field_setup(extMetaClass *);
 static void sort_class_fields(extMetaClass *, std::vector<Field> &);
@@ -947,7 +947,7 @@ static void field_setup(extMetaClass *Class)
             .FieldID    = FID_Name,
             .Offset     = 0,
             .Index      = 0,
-            .Flags      = FDF_STRING|FDF_RW|FDF_SYSTEM
+            .Flags      = FDF_CPPSTRING|FDF_RW|FDF_SYSTEM
          });
       }
 
@@ -1098,17 +1098,30 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
    if (field.Flags & FD_VIRTUAL) { // No offset will be added for fields marked exclusively as virtual
       field.Offset = 0;
    }
+   else if (field.Flags & FD_ARRAY) {
+      field_size = sizeof(APTR);
+      field_alignment = alignof(APTR);
+      field_type = "pointer";
+   }
    else if (field.Flags & FD_RGB) {
       field_size = sizeof(int8_t) * 4;
       field_alignment = alignof(int8_t);
       field_type = "RGB";
    }
-   else if ((field.Flags & FD_STRING) and (field.Flags & FD_CPP)) {
-      field_size = sizeof(std::string);
-      field_alignment = alignof(std::string);
-      field_type = "std::string";
+   else if (field.Flags & FD_STRING) {
+      if (field.Flags & FD_CPP) {
+         field_size = sizeof(std::string);
+         field_alignment = alignof(std::string);
+         field_type = "std::string";
+      }
+      else {
+         log.warning("C-style string fields are deprecated");
+         field_size = sizeof(APTR);
+         field_alignment = alignof(APTR);
+         field_type = "pointer";
+      }
    }
-   else if (field.Flags & (FD_POINTER|FD_ARRAY)) {
+   else if (field.Flags & FD_POINTER) {
       field_size = sizeof(APTR);
       field_alignment = alignof(APTR);
       field_type = "pointer";
@@ -1210,16 +1223,15 @@ static ERR OBJECT_SetOwner(OBJECTPTR Self, OBJECTID OwnerID)
    else return log.warning(ERR::NullArgs);
 }
 
-static ERR OBJECT_GetName(OBJECTPTR Self, STRING *Name)
+static ERR OBJECT_GetName(OBJECTPTR Self, std::string_view &Name)
 {
-   *Name = Self->Name;
+   Name = Self->Name;
    return ERR::Okay;
 }
 
-static ERR OBJECT_SetName(OBJECTPTR Self, CSTRING Name)
+static ERR OBJECT_SetName(OBJECTPTR Self, const std::string_view &Name)
 {
-   if (!Name) return SetName(Self, "");
-   else return SetName(Self, Name);
+   return SetName(Self, Name);
 }
 
 //********************************************************************************************************************

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -1098,15 +1098,15 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
    if (field.Flags & FD_VIRTUAL) { // No offset will be added for fields marked exclusively as virtual
       field.Offset = 0;
    }
-   else if (field.Flags & FD_ARRAY) {
-      field_size = sizeof(APTR);
-      field_alignment = alignof(APTR);
-      field_type = "pointer";
-   }
    else if (field.Flags & FD_RGB) {
       field_size = sizeof(int8_t) * 4;
       field_alignment = alignof(int8_t);
       field_type = "RGB";
+   }
+   else if (field.Flags & FD_ARRAY) {
+      field_size = sizeof(APTR);
+      field_alignment = alignof(APTR);
+      field_type = "pointer";
    }
    else if (field.Flags & FD_STRING) {
       if (field.Flags & FD_CPP) {
@@ -1131,16 +1131,6 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
       field_alignment = alignof(int);
       field_type = "integer";
    }
-   else if (field.Flags & FD_BYTE) {
-      field_size = sizeof(int8_t);
-      field_alignment = alignof(int8_t);
-      field_type = "byte";
-   }
-   else if (field.Flags & FD_FUNCTION) {
-      field_size = sizeof(FUNCTION);
-      field_alignment = alignof(FUNCTION);
-      field_type = "function";
-   }
    else if (field.Flags & FD_DOUBLE) {
       field_size = sizeof(double);
       field_alignment = alignof(double);
@@ -1150,6 +1140,16 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
       field_size = sizeof(int64_t);
       field_alignment = alignof(int64_t);
       field_type = "64-bit integer";
+   }
+   else if (field.Flags & FD_FUNCTION) {
+      field_size = sizeof(FUNCTION);
+      field_alignment = alignof(FUNCTION);
+      field_type = "function";
+   }
+   else if (field.Flags & FD_BYTE) {
+      field_size = sizeof(int8_t);
+      field_alignment = alignof(int8_t);
+      field_type = "byte";
    }
    else log.warning("%s field \"%s\"/%d has an invalid flag setting.", Class->ClassName.c_str(), field.Name, field.FieldID);
 

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -334,8 +334,9 @@ int fcmd_include(lua_State *Lua)
 // Loads a Tiri language file from any location and executes it.  Any return values from the script will be returned
 // as-is.  Any error that occurs will be thrown with a descriptive string.
 //
-// If the Path is preceded by "./" then the path of the script that called this function is prepended to the location.
-// If a path is not available for the running script, the current working directory will be prepended as a fallback.
+// If the Path is preceded by "./" or "../" then the path of the script that called this function is prepended to
+// the location.  If a path is not available for the running script, the current working directory will be prepended
+// as a fallback.
 
 int fcmd_loadfile(lua_State *Lua)
 {
@@ -352,6 +353,10 @@ int fcmd_loadfile(lua_State *Lua)
       bool inject_working_path = false;
       if (path.starts_with("./")) {
          path.remove_prefix(2);
+         inject_working_path = true;
+      }
+      else if (path.starts_with("../")) {
+         // Maintain the prefix to access the parent folder - ResolvePath() takes care of it.
          inject_working_path = true;
       }
       std::string src(path);

--- a/src/xquery/xquery.tdl
+++ b/src/xquery/xquery.tdl
@@ -5,7 +5,7 @@ module({ name='XQuery', src='xquery.cpp', copyright='Paul Manias © 2025-2026', 
   cpp_include('<functional>', '<optional>', '<sstream>', '<kotuku/strings.hpp>', '<string_view>', '<vector>')
 
   restrict(function()
-    loadFile('./../xml/constants.tdl')
+    loadFile('../xml/constants.tdl')
   end)
 
   -- Shared enumerations for parser and evaluator state, including map/array node kinds.


### PR DESCRIPTION
* Registered MetaClass Name as a C++ string field

* Corrected metaclass field sizing for arrays and deprecated C-style strings

* [Tiri] Resolved parent-relative loadFile() paths without stripping the prefix

* [XQuery] Updated the constants import to use the parent-relative path form