### PR TITLE
[Core] Store script results as C++ string arrays

### DIFF
--- a/docs/xml/modules/classes/script.xml
+++ b/docs/xml/modules/classes/script.xml
@@ -288,7 +288,7 @@ SET_FUNCTION_SCRIPT(callback, script, procedure_id);
       <name>Results</name>
       <comment>Stores multiple string results for languages that support this feature.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING []</type>
+      <type>kt::vector&lt;std::string&gt;</type>
       <description>
 <p>If a scripting language supports the return of multiple results, this field may reflect those result values after the execution of any procedure.</p>
 <p>For maximum compatibility in type conversion, the results are stored as an array of strings.</p>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3070,7 +3070,7 @@ class objScript : public Object {
 #ifdef PRV_SCRIPT
    int64_t  ProcedureID;          // For callbacks
    KEYVALUE Vars; // Global parameters
-   STRING   *Results;
+   kt::vector<std::string> Results;
    char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
    std::string Path;              // File location of the script
@@ -3080,7 +3080,6 @@ class objScript : public Object {
    std::string Procedure;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
-   int      ResultsTotal;
    int      TotalArgs;            // Total number of ProcArgs
    char     LanguageDir[32];      // Directory to use for language files
    OBJECTID ScriptOwnerID;
@@ -3180,10 +3179,10 @@ class objScript : public Object {
       return field->WriteValue(target, field, 0x00804500, &Value, 1);
    }
 
-   inline ERR setResults(STRING * Value, int Elements) noexcept {
+   inline ERR setResults(const kt::vector<std::string> *Value) noexcept {
       auto target = this;
       auto field = &this->Class->Dictionary[16];
-      return field->WriteValue(target, field, 0x08801300, Value, Elements);
+      return field->WriteValue(target, field, 0x00805300, Value, int(Value->size()));
    }
 
    inline ERR setStatement(const std::string_view &Value) noexcept {

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -38,8 +38,6 @@
 #define FDF_OBJECT      (FD_POINTER|FD_OBJECT)   // Field refers to another object
 #define FDF_OBJECTID    (FD_INT|FD_OBJECT)      // Field refers to another object by ID
 #define FDF_LOCAL       (FD_POINTER|FD_LOCAL)    // Field refers to a local object
-#define FDF_STRING      (FD_POINTER|FD_STRING)   // Field points to a string.  NB: Ideally want to remove the FD_POINTER as it should be redundant
-#define FDF_STR         FDF_STRING
 #define FDF_SCALED      FD_SCALED
 #define FDF_FLAGS       FD_FLAGS                // Field contains flags
 #define FDF_ALLOC       FD_ALLOC                // Field is a dynamic allocation - either a memory block or object

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -24,12 +24,7 @@ Terminating the script will not remove objects that are outside its resource hie
 #define PRV_SCRIPT
 #include "../defs.h"
 #include <kotuku/main.h>
-
-static ERR GET_Results(objScript *, STRING **, int *);
-
-static ERR SET_Procedure(objScript *, std::string_view &);
-static ERR SET_Results(objScript *, CSTRING *, int);
-static ERR SET_String(objScript *, std::string_view &);
+#include <kotuku/vector.hpp>
 
 inline std::string_view check_bom(std::string_view Value)
 {
@@ -285,7 +280,6 @@ static ERR SCRIPT_Exec(objScript *Self, struct sc::Exec *Args)
 
 static ERR SCRIPT_Free(objScript *Self)
 {
-   if (Self->Results)     { FreeResource(Self->Results);     Self->Results = nullptr; }
    Self->~objScript();
    return ERR::Okay;
 }
@@ -545,8 +539,8 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
          if (len IS std::string_view::npos) len = Value.size();
 
          if (Value.substr(0, len).starts_with("STRING:")) {
-            auto statement = Value.substr(7);
-            return SET_String(Self, statement);
+            Self->String.assign(check_bom(Value.substr(7)));
+            return ERR::Okay;
          }
 
          Self->Path.assign(Value, 0, len);
@@ -566,7 +560,7 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
                   std::string buffer;
                   buffer.append(value, start, end - start);
                   std::string_view procedure(buffer);
-                  SET_Procedure(Self, procedure);
+                  Self->Procedure.assign(procedure);
                }
 
                // Process optional parameters
@@ -661,49 +655,18 @@ For maximum compatibility in type conversion, the results are stored as an array
 
 *********************************************************************************************************************/
 
-static ERR GET_Results(objScript *Self, STRING **Value, int *Elements)
+static ERR GET_Results(objScript *Self, kt::vector<std::string> **Value, int *Elements)
 {
-   if (Self->Results) {
-      *Value = Self->Results;
-      *Elements = Self->ResultsTotal;
-      return ERR::Okay;
-   }
-   else {
-      *Value = nullptr;
-      *Elements = 0;
-      return ERR::FieldNotSet;
-   }
+   *Value = &Self->Results;
+   *Elements = Self->Results.size();
+   return ERR::Okay;
 }
 
-static ERR SET_Results(objScript *Self, CSTRING *Value, int Elements)
+static ERR SET_Results(objScript *Self, const kt::vector<std::string> *Value, int Elements)
 {
-   kt::Log log;
-
-   if (Self->Results) { FreeResource(Self->Results); Self->Results = 0; }
-
-   Self->ResultsTotal = 0;
-
-   if (Value) {
-      int len = 0;
-      for (int i=0; i < Elements; i++) {
-         if (!Value[i]) return log.warning(ERR::SetValueNotString);
-         len += strlen(Value[i]) + 1;
-      }
-      Self->ResultsTotal = Elements;
-
-      if (AllocMemory((sizeof(CSTRING) * (Elements+1)) + len, MEM::STRING|MEM::NO_CLEAR, (APTR *)&Self->Results, nullptr) IS ERR::Okay) {
-         STRING str = (STRING)(Self->Results + Elements + 1);
-         int i;
-         for (i=0; Value[i]; i++) {
-            Self->Results[i] = str;
-            str += strcopy(Value[i], str) + 1;
-         }
-         Self->Results[i] = nullptr;
-         return ERR::Okay;
-      }
-      else return ERR::AllocMemory;
-   }
-   else return ERR::Okay;
+   if (Value) Self->Results = *Value;
+   else Self->Results.clear();
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -844,19 +807,19 @@ static const FieldArray clScriptFields[] = {
    { "CurrentLine", FDF_INT|FDF_R },
    { "LineOffset",  FDF_INT|FDF_RW },
    // Virtual Fields
-   { "CacheFile",    FDF_CPPSTRING|FDF_RW,           GET_CacheFile, SET_CacheFile },
-   { "ErrorMessage", FDF_CPPSTRING|FDF_RW,           GET_ErrorMessage, SET_ErrorMessage },
-   { "WorkingPath",  FDF_CPPSTRING|FDF_RW,           GET_WorkingPath, SET_WorkingPath },
-   { "Language",     FDF_CPPSTRING|FDF_R,            GET_Language },
+   { "CacheFile",    FDF_CPPSTRING|FDF_RW,             GET_CacheFile, SET_CacheFile },
+   { "ErrorMessage", FDF_CPPSTRING|FDF_RW,             GET_ErrorMessage, SET_ErrorMessage },
+   { "WorkingPath",  FDF_CPPSTRING|FDF_RW,             GET_WorkingPath, SET_WorkingPath },
+   { "Language",     FDF_CPPSTRING|FDF_R,              GET_Language },
    { "Location",     FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path },
-   { "Procedure",    FDF_CPPSTRING|FDF_RW,           GET_Procedure, SET_Procedure },
-   { "Path",         FDF_CPPSTRING|FDF_RI,           GET_Path, SET_Path },
-   { "Results",      FDF_ARRAY|FDF_POINTER|FDF_STRING|FDF_RW, GET_Results, SET_Results },
+   { "Procedure",    FDF_CPPSTRING|FDF_RW,             GET_Procedure, SET_Procedure },
+   { "Path",         FDF_CPPSTRING|FDF_RI,             GET_Path, SET_Path },
+   { "Results",      FDF_ARRAY|FDF_CPPSTRING|FDF_RW,   GET_Results, SET_Results },
    { "Src",          FDF_SYNONYM|FDF_CPPSTRING|FDF_RI, GET_Path, SET_Path },
-   { "Statement",    FDF_CPPSTRING|FDF_RW,           GET_String, SET_String },
+   { "Statement",    FDF_CPPSTRING|FDF_RW,             GET_String, SET_String },
    { "String",       FDF_SYNONYM|FDF_CPPSTRING|FDF_RW, GET_String, SET_String },
-   { "TotalArgs",    FDF_INT|FDF_R,                  GET_TotalArgs, nullptr },
-   { "Variables",    FDF_POINTER|FDF_SYSTEM|FDF_R,   GET_Variables, nullptr },
+   { "TotalArgs",    FDF_INT|FDF_R,                    GET_TotalArgs, nullptr },
+   { "Variables",    FDF_POINTER|FDF_SYSTEM|FDF_R,     GET_Variables, nullptr },
    END_FIELD
 };
 

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1444,7 +1444,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
   [[
    int64_t  ProcedureID;          // For callbacks
    KEYVALUE Vars; // Global parameters
-   STRING   *Results;
+   kt::vector<std::string> Results;
    char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
    std::string Path;              // File location of the script
@@ -1454,7 +1454,6 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
    std::string Procedure;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
-   int      ResultsTotal;
    int      TotalArgs;            // Total number of ProcArgs
    char     LanguageDir[32];      // Directory to use for language files
    OBJECTID ScriptOwnerID;

--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -209,10 +209,10 @@ extern "C" FFR CALL_FEEDBACK(FUNCTION *Callback, FileFeedback *Feedback)
       }), error) != ERR::Okay) error = ERR::Function;
 
       if (error IS ERR::Okay) {
-         CSTRING *results;
+         kt::vector<std::string> *results;
          int size;
          if ((Callback->Context->get(FID_Results, results, size) IS ERR::Okay) and (size > 0)) {
-            return FFR(strtol(results[0], nullptr, 0));
+            return FFR(strtol((*results)[0].c_str(), nullptr, 0));
          }
          else return FFR::OKAY;
       }

--- a/src/document/parsing.cpp
+++ b/src/document/parsing.cpp
@@ -1472,10 +1472,10 @@ void parser::tag_call(const tag_view &Tag)
 
    // Check for a result and print it
 
-   CSTRING *results;
-   int size;
-   if ((script->get(FID_Results, results, size) IS ERR::Okay) and (size > 0)) {
-      auto xmlinc = objXML::create::global(fl::Statement(results[0]), fl::Flags(XMF::PARSE_HTML|XMF::STRIP_HEADERS));
+   kt::vector<std::string> *results;
+   if ((script->get(FID_Results, results) IS ERR::Okay) and (results->size() > 0)) {
+      auto xmlinc = objXML::create::global(fl::Statement((*results)[0].c_str()),
+         fl::Flags(XMF::PARSE_HTML|XMF::STRIP_HEADERS));
       if (xmlinc) {
          auto old_xml = change_xml(xmlinc);
          parse_tags(xmlinc->Tags);
@@ -1487,7 +1487,6 @@ void parser::tag_call(const tag_view &Tag)
       }
       else log_error(&Tag, ERR::Syntax, "doc.call-result-xml-parse-failed",
          "<call/> returned content that could not be parsed as XML/RIPL.");
-      FreeResource(results);
    }
 }
 
@@ -2713,10 +2712,11 @@ void parser::tag_script(const tag_view &Tag)
 
    // Any results returned from the script are processed as XML
 
-   CSTRING *results;
+   kt::vector<std::string> *results;
    int size;
    if ((script->get(FID_Results, results, size) IS ERR::Okay) and (size > 0)) {
-      auto xmlinc = objXML::create::global(fl::Statement(results[0]), fl::Flags(XMF::PARSE_HTML|XMF::STRIP_HEADERS));
+      auto xmlinc = objXML::create::global(fl::Statement((*results)[0].c_str()),
+         fl::Flags(XMF::PARSE_HTML|XMF::STRIP_HEADERS));
       if (xmlinc) {
          auto old_xml = change_xml(xmlinc);
          parse_tags(xmlinc->Tags);

--- a/src/document/ui.cpp
+++ b/src/document/ui.cpp
@@ -423,10 +423,10 @@ static void error_dialog(const std::string Title, const std::string Message)
       acSetKey(dialog, "message", Message.c_str());
 
       if ((InitObject(dialog) IS ERR::Okay) and (acActivate(dialog) IS ERR::Okay)) {
-         CSTRING *results;
+         kt::vector<std::string> *results;
          int size;
          if ((dialog->get(FID_Results, results, size) IS ERR::Okay) and (size > 0)) {
-            new_dialog_id = strtol(results[0], nullptr, 0);
+            new_dialog_id = strtol((*results)[0].c_str(), nullptr, 0);
          }
       }
    }

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -2162,10 +2162,10 @@ static void error_dialog(CSTRING Title, CSTRING Message, ERR Error)
       else acSetKey(dialog, "message", Message);
 
       if ((InitObject(dialog) IS ERR::Okay) and (acActivate(dialog) IS ERR::Okay)) {
-         CSTRING *results;
+         kt::vector<std::string> *results;
          int size;
          if ((dialog->get(FID_Results, results, size) IS ERR::Okay) and (size > 0)) {
-            dialog_id = strtol(results[0], nullptr, 0);
+            dialog_id = strtol((*results)[0].c_str(), nullptr, 0);
          }
       }
    }

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -1041,11 +1041,15 @@ static ERR run_script(objScript *Self)
    if (not pcall_failed) { // If the procedure returned results, copy them to the Results field of the Script.
       int results = lua_gettop(prv->Lua) - top + 1;
 
+      ERR error = ERR::Okay;
       if (results > 0) {
          kt::vector<std::string> array;
          array.resize(results);
          for (int i=0; i < results; i++) {
-            array[i] = lua_tostringview(prv->Lua, -results+i);
+            size_t size;
+            auto str = lua_tolstring(prv->Lua, -results+i, &size);
+            if (str) array[i] = std::string_view(str, size);
+            else Self->Error = error = ERR::LimitedSuccess;
          }
          Self->set(FID_Results, array);
          lua_pop(prv->Lua, results);  // pop returned values
@@ -1058,7 +1062,7 @@ static ERR run_script(objScript *Self)
          ProcessMessages(PMF::NIL, 0);
       }
 
-      return ERR::Okay;
+      return error;
    }
    else {
       // LuaJIT catches C++ exceptions, but we would prefer that crashes occur normally so that they can be traced in

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -1042,19 +1042,12 @@ static ERR run_script(objScript *Self)
       int results = lua_gettop(prv->Lua) - top + 1;
 
       if (results > 0) {
-         std::vector<CSTRING> array;
-         array.resize(results+1);
-
-         // NB: The Results field will take a clone of the Lua strings, so this sub-routine is safe to pass
-         // on Lua's temporary string results.
-
-         int i;
-         for (i=0; i < results; i++) {
-            array[i] = lua_tostring(prv->Lua, -results+i);
-            log.trace("Result: %d/%d: %s", i, results, array[i]);
+         kt::vector<std::string> array;
+         array.resize(results);
+         for (int i=0; i < results; i++) {
+            array[i] = lua_tostringview(prv->Lua, -results+i);
          }
-         array[i] = nullptr;
-         Self->set(FID_Results, array.data(), i);
+         Self->set(FID_Results, array);
          lua_pop(prv->Lua, results);  // pop returned values
       }
 


### PR DESCRIPTION
* Converted Script.Results storage to kt::vector<std::string> and updated generated field glue

* [Tiri] Returned procedure values through the C++ array field path

* [Document] Updated script result consumers to read kt::vector string results