### PR TITLE
[Core] Updated action marshaling for string views and mutable buffers

### DIFF
--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -113,10 +113,10 @@
     <action>
       <name>GetKey</name>
       <comment>Retrieves global variables and URI parameters.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -147,11 +147,11 @@
     <action>
       <name>SetKey</name>
       <comment>Set a global key-value in the document.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -104,10 +104,10 @@
     <action>
       <name>Rename</name>
       <comment>Changes the name of a file.</comment>
-      <prototype>ERR acRename(*Object, CSTRING Name)</prototype>
+      <prototype>ERR acRename(*Object, std::string_view Name)</prototype>
       <tiriPrototype>err = Object.acRename(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The new name for the object.</param>
+        <param type="STRVIEW" name="Name">The new name for the object.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/http.xml
+++ b/docs/xml/modules/classes/http.xml
@@ -103,10 +103,10 @@ http.acActivate()
     <action>
       <name>GetKey</name>
       <comment>Entries in the HTTP response header can be read as key-values.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -115,11 +115,11 @@ http.acActivate()
     <action>
       <name>SetKey</name>
       <comment>Options for the HTTP header can be set as key-values.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/script.xml
+++ b/docs/xml/modules/classes/script.xml
@@ -32,10 +32,10 @@
     <action>
       <name>GetKey</name>
       <comment>Script parameters can be retrieved through this action.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -51,11 +51,11 @@
     <action>
       <name>SetKey</name>
       <comment>Script parameters can be set through this action.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/sound.xml
+++ b/docs/xml/modules/classes/sound.xml
@@ -78,10 +78,10 @@ processing.sleep()  -- Wait for completion
     <action>
       <name>GetKey</name>
       <comment>Retrieve custom key values.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -142,11 +142,11 @@ processing.sleep()  -- Wait for completion
     <action>
       <name>SetKey</name>
       <comment>Define custom tags that will be saved with the sample data.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/task.xml
+++ b/docs/xml/modules/classes/task.xml
@@ -48,10 +48,10 @@
     <action>
       <name>GetKey</name>
       <comment>Retrieves custom key values.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -60,11 +60,11 @@
     <action>
       <name>SetKey</name>
       <comment>Variable fields are supported for the general storage of program variables.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
     </action>
 

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -72,10 +72,10 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <action>
       <name>GetKey</name>
       <comment>Deprecated.  Use the Evaluate() method instead.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -105,11 +105,11 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <action>
       <name>SetKey</name>
       <comment>Sets attributes and content in the XML tree using XPaths.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
       <description>
 <p>Use SetKey to add tag attributes and content using XPaths.  The XPath is specified in the <code>Key</code> parameter and the data is specified in the <code>Value</code> parameter.  Setting the Value to <code>NULL</code> will remove the attribute or existing content, while an empty string will keep an attribute but eliminate any associated data.</p>

--- a/docs/xml/modules/classes/xquery.xml
+++ b/docs/xml/modules/classes/xquery.xml
@@ -94,10 +94,10 @@ if (query.ok()) {
     <action>
       <name>GetKey</name>
       <comment>Read XQuery variable values.</comment>
-      <prototype>ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)</prototype>
+      <prototype>ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)</prototype>
       <tiriPrototype>err = Object.acGetKey(Key:str, Value:str, Size:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of a key value.</param>
+        <param type="STRVIEW" name="Key">The name of a key value.</param>
         <param type="STRING" name="Value">Pointer to a buffer space large enough to hold the retrieved value.</param>
         <param type="INT" name="Size">Indicates the byte size of the Buffer.</param>
       </input>
@@ -125,11 +125,11 @@ if (query.ok()) {
     <action>
       <name>SetKey</name>
       <comment>Set XQuery variable values.</comment>
-      <prototype>ERR acSetKey(*Object, CSTRING Key, CSTRING Value)</prototype>
+      <prototype>ERR acSetKey(*Object, std::string_view Key, std::string_view Value)</prototype>
       <tiriPrototype>err = Object.acSetKey(Key:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the target key.</param>
-        <param type="CSTRING" name="Value">The string value to associate with Key.</param>
+        <param type="STRVIEW" name="Key">The name of the target key.</param>
+        <param type="STRVIEW" name="Value">The string value to associate with Key.</param>
       </input>
       <description>
 <p>Use SetKey to store key-value pairs that can be referenced in XQuery expressions using the variable syntax <code>$variableName</code>.</p>

--- a/include/kotuku/modules/audio.h
+++ b/include/kotuku/modules/audio.h
@@ -406,7 +406,7 @@ class objSound : public Object {
    inline ERR deactivate() noexcept { return Action(AC::Deactivate, this, nullptr); }
    inline ERR disable() noexcept { return Action(AC::Disable, this, nullptr); }
    inline ERR enable() noexcept { return Action(AC::Enable, this, nullptr); }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -441,7 +441,7 @@ class objSound : public Object {
    inline ERR seekStart(double Offset) noexcept { return seek(Offset, SEEK::START); }
    inline ERR seekEnd(double Offset) noexcept { return seek(Offset, SEEK::END); }
    inline ERR seekCurrent(double Offset) noexcept { return seek(Offset, SEEK::CURRENT); }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2896,7 +2896,7 @@ class objFile : public Object {
       struct acRead read = { (int8_t *)Buffer, bytes };
       return Action(AC::Read, this, &read);
    }
-   inline ERR rename(CSTRING Name) noexcept {
+   inline ERR rename(std::string_view Name) noexcept {
       struct acRename args = { Name };
       return Action(AC::Rename, this, &args);
    }
@@ -3410,7 +3410,7 @@ class objScript : public Object {
       struct acDataFeed args = { Object, Datatype, Buffer, Size };
       return Action(AC::DataFeed, this, &args);
    }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -3418,7 +3418,7 @@ class objScript : public Object {
    }
    inline ERR init() noexcept { return InitObject(this); }
    inline ERR reset() noexcept { return Action(AC::Reset, this, nullptr); }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }
@@ -3655,14 +3655,14 @@ class objTask : public Object {
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
       return error;
    }
    inline ERR init() noexcept { return InitObject(this); }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -152,7 +152,7 @@ class objDocument : public Object {
    }
    inline ERR enable() noexcept { return Action(AC::Enable, this, nullptr); }
    inline ERR focus() noexcept { return Action(AC::Focus, this, nullptr); }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -164,7 +164,7 @@ class objDocument : public Object {
       struct acSaveToObject args = { Dest, { ClassID } };
       return Action(AC::SaveToObject, this, &args);
    }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/modules/http.h
+++ b/include/kotuku/modules/http.h
@@ -173,14 +173,14 @@ class objHTTP : public Object {
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
    inline ERR deactivate() noexcept { return Action(AC::Deactivate, this, nullptr); }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
       return error;
    }
    inline ERR init() noexcept { return InitObject(this); }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -257,7 +257,7 @@ class objXML : public Object {
       struct acDataFeed args = { Object, Datatype, Buffer, Size };
       return Action(AC::DataFeed, this, &args);
    }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -269,7 +269,7 @@ class objXML : public Object {
       struct acSaveToObject args = { Dest, { ClassID } };
       return Action(AC::SaveToObject, this, &args);
    }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/modules/xquery.h
+++ b/include/kotuku/modules/xquery.h
@@ -159,7 +159,7 @@ class objXQuery : public Object {
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
    inline ERR clear() noexcept { return Action(AC::Clear, this, nullptr); }
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -167,7 +167,7 @@ class objXQuery : public Object {
    }
    inline ERR init() noexcept { return InitObject(this); }
    inline ERR reset() noexcept { return Action(AC::Reset, this, nullptr); }
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -1023,7 +1023,7 @@ inline void SharedObjectAccess::release() {
 struct acClipboard     { static const AC id = AC::Clipboard; CLIPMODE Mode; };
 struct acCopyData      { static const AC id = AC::CopyData; OBJECTPTR Dest; };
 struct acDataFeed      { static const AC id = AC::DataFeed; OBJECTPTR Object; DATA Datatype; const void *Buffer; int Size; };
-struct acDragDrop      { static const AC id = AC::DragDrop; OBJECTPTR Source; int Item; CSTRING Datatype; };
+struct acDragDrop      { static const AC id = AC::DragDrop; OBJECTPTR Source; int Item; std::string_view Datatype; };
 struct acDraw          { static const AC id = AC::Draw; int X; int Y; int Width; int Height; };
 struct acGetKey        { static const AC id = AC::GetKey; std::string_view Key; STRING Value; int Size; };
 struct acMove          { static const AC id = AC::Move; double DeltaX; double DeltaY; double DeltaZ; };
@@ -1072,7 +1072,7 @@ inline ERR acClipboard(OBJECTPTR Object, CLIPMODE Mode) {
    return Action(AC::Clipboard, Object, &args);
 }
 
-inline ERR acDragDrop(OBJECTPTR Object, OBJECTPTR Source, int Item, CSTRING Datatype) {
+inline ERR acDragDrop(OBJECTPTR Object, OBJECTPTR Source, int Item, std::string_view Datatype) {
    struct acDragDrop args = { Source, Item, Datatype };
    return Action(AC::DragDrop, Object, &args);
 }

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -1025,7 +1025,7 @@ struct acCopyData      { static const AC id = AC::CopyData; OBJECTPTR Dest; };
 struct acDataFeed      { static const AC id = AC::DataFeed; OBJECTPTR Object; DATA Datatype; const void *Buffer; int Size; };
 struct acDragDrop      { static const AC id = AC::DragDrop; OBJECTPTR Source; int Item; CSTRING Datatype; };
 struct acDraw          { static const AC id = AC::Draw; int X; int Y; int Width; int Height; };
-struct acGetKey        { static const AC id = AC::GetKey; CSTRING Key; STRING Value; int Size; };
+struct acGetKey        { static const AC id = AC::GetKey; std::string_view Key; STRING Value; int Size; };
 struct acMove          { static const AC id = AC::Move; double DeltaX; double DeltaY; double DeltaZ; };
 struct acMoveToPoint   { static const AC id = AC::MoveToPoint; double X; double Y; double Z; MTF Flags; };
 struct acNewChild      { static const AC id = AC::NewChild; OBJECTPTR Object; };
@@ -1033,12 +1033,12 @@ struct acNewOwner      { static const AC id = AC::NewOwner; OBJECTPTR NewOwner; 
 struct acRead          { static const AC id = AC::Read; APTR Buffer; int Length; int Result; };
 struct acRedimension   { static const AC id = AC::Redimension; double X; double Y; double Z; double Width; double Height; double Depth; };
 struct acRedo          { static const AC id = AC::Redo; int Steps; };
-struct acRename        { static const AC id = AC::Rename; CSTRING Name; };
+struct acRename        { static const AC id = AC::Rename; std::string_view Name; };
 struct acResize        { static const AC id = AC::Resize; double Width; double Height; double Depth; };
 struct acSaveImage     { static const AC id = AC::SaveImage; OBJECTPTR Dest; union { CLASSID ClassID; CLASSID Class; }; };
 struct acSaveToObject  { static const AC id = AC::SaveToObject; OBJECTPTR Dest; union { CLASSID ClassID; CLASSID Class; }; };
 struct acSeek          { static const AC id = AC::Seek; double Offset; SEEK Position; };
-struct acSetKey        { static const AC id = AC::SetKey; CSTRING Key; CSTRING Value; };
+struct acSetKey        { static const AC id = AC::SetKey; std::string_view Key; std::string_view Value; };
 struct acUndo          { static const AC id = AC::Undo; int Steps; };
 struct acWrite         { static const AC id = AC::Write; CPTR Buffer; int Length; int Result; };
 
@@ -1087,7 +1087,7 @@ inline ERR acDataFeed(OBJECTPTR Object, OBJECTPTR Sender, DATA Datatype, const v
    return Action(AC::DataFeed, Object, &args);
 }
 
-inline ERR acGetKey(OBJECTPTR Object, CSTRING Key, STRING Value, int Size) {
+inline ERR acGetKey(OBJECTPTR Object, std::string_view Key, STRING Value, int Size) {
    struct acGetKey args = { Key, Value, Size };
    ERR error = Action(AC::GetKey, Object, &args);
    if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -1121,7 +1121,7 @@ inline ERR acRedimension(OBJECTPTR Object, double X, double Y, double Z, double 
    return Action(AC::Redimension, Object, &args);
 }
 
-inline ERR acRename(OBJECTPTR Object, CSTRING Name) {
+inline ERR acRename(OBJECTPTR Object, std::string_view Name) {
    struct acRename args = { Name };
    return Action(AC::Rename, Object, &args);
 }
@@ -1186,7 +1186,7 @@ template <class T> inline ERR acSeekCurrent(OBJECTPTR Object, T Offset) {
    return acSeek(Object, Offset, SEEK::CURRENT);
 }
 
-inline ERR acSetKey(OBJECTPTR Object, CSTRING Key, CSTRING Value) {
+inline ERR acSetKey(OBJECTPTR Object, std::string_view Key, std::string_view Value) {
    struct acSetKey args = { Key, Value };
    return Action(AC::SetKey, Object, &args);
 }

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -646,7 +646,7 @@ The following custom key values are formally recognised and may be defined autom
 
 static ERR SOUND_GetKey(extSound *Self, struct acGetKey *Args)
 {
-   if ((!Args) or (!Args->Key)) return ERR::NullArgs;
+   if (!Args) return ERR::NullArgs;
 
    std::string name(Args->Key);
    if (Self->Tags.contains(name)) {
@@ -1103,7 +1103,7 @@ SetKey: Define custom tags that will be saved with the sample data.
 
 static ERR SOUND_SetKey(extSound *Self, struct acSetKey *Args)
 {
-   if ((!Args) or (!Args->Key) or (!Args->Key[0])) return ERR::NullArgs;
+   if ((!Args) or (Args->Key.empty())) return ERR::NullArgs;
 
    Self->Tags[std::string(Args->Key)] = Args->Value;
    return ERR::Okay;

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -1225,12 +1225,12 @@ static ERR FILE_Rename(extFile *Self, struct acRename *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Name) or (not Args->Name[0])) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Name.empty())) return log.warning(ERR::NullArgs);
    if (Self->Path.empty()) return log.warning(ERR::FieldNotSet);
 
-   log.branch("%s to %s", Self->Path.c_str(), Args->Name);
+   log.branch("%s to %.*s", Self->Path.c_str(), int(Args->Name.size()), Args->Name.data());
 
-   auto name = std::string_view(Args->Name, strlen(Args->Name));
+   auto name = Args->Name;
 
    if ((Self->isFolder) or ((Self->Flags & FL::FOLDER) != FL::NIL)) {
       if (Self->Path.ends_with(':')) { // Renaming a volume

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -332,7 +332,7 @@ GetKey: Script parameters can be retrieved through this action.
 
 static ERR SCRIPT_GetKey(objScript *Self, struct acGetKey *Args)
 {
-   if ((!Args) or (!Args->Value) or (!Args->Key)) return ERR::NullArgs;
+   if ((!Args) or (!Args->Value)) return ERR::NullArgs;
    if (Args->Size < 2) return ERR::Args;
 
    if (auto it = Self->Vars.find(Args->Key); it != Self->Vars.end()) {
@@ -400,13 +400,17 @@ static ERR SCRIPT_SetKey(objScript *Self, struct acSetKey *Args)
 {
    // It is acceptable to set zero-length string values (this has its uses in some scripts).
 
-   if ((!Args) or (!Args->Key) or (!Args->Value)) return ERR::NullArgs;
-   if (!Args->Key[0]) return ERR::NullArgs;
+   if ((!Args) or (Args->Key.empty())) return ERR::NullArgs;
 
    kt::Log log;
-   log.trace("%s = %s", Args->Key, Args->Value);
+   log.trace("%.*s = %.*s", int(Args->Key.size()), Args->Key.data(), int(Args->Value.size()), Args->Value.data());
 
-   Self->Vars[Args->Key] = Args->Value;
+   auto key_it = Self->Vars.lower_bound(Args->Key);
+   if ((key_it != Self->Vars.end()) and (not Self->Vars.key_comp()(Args->Key, key_it->first))) {
+      key_it->second.assign(Args->Value);
+   }
+   else Self->Vars.emplace_hint(key_it, std::string(Args->Key), std::string(Args->Value));
+
    return ERR::Okay;
 }
 

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -1486,8 +1486,7 @@ static ERR TASK_GetKey(extTask *Self, struct acGetKey *Args)
 
    if ((!Args) or (!Args->Value) or (Args->Size <= 0)) return log.warning(ERR::NullArgs);
 
-   auto it = Self->Fields.find(Args->Key);
-   if (it != Self->Fields.end()) {
+   if (auto it = Self->Fields.find(Args->Key); it != Self->Fields.end()) {
       for (j=0; (it->second[j]) and (j < Args->Size-1); j++) Args->Value[j] = it->second[j];
       Args->Value[j++] = 0;
 
@@ -1495,7 +1494,7 @@ static ERR TASK_GetKey(extTask *Self, struct acGetKey *Args)
       else return ERR::Okay;
    }
 
-   log.warning("The variable \"%s\" does not exist.", Args->Key);
+   log.warning("The variable \"%.*s\" does not exist.", int(Args->Key.size()), Args->Key.data());
 
    return ERR::Okay;
 }
@@ -1784,7 +1783,7 @@ SetKey: Variable fields are supported for the general storage of program variabl
 
 static ERR TASK_SetKey(extTask *Self, struct acSetKey *Args)
 {
-   if ((!Args) or (!Args->Key) or (!Args->Value)) return ERR::NullArgs;
+   if (!Args) return ERR::NullArgs;
 
    Self->Fields[Args->Key] = Args->Value;
    return ERR::Okay;

--- a/src/core/data_actionlist.cpp
+++ b/src/core/data_actionlist.cpp
@@ -6,9 +6,9 @@
 FDEF argsClipboard[]     = { { "Mode", FD_INT }, { 0, 0 } };
 FDEF argsCopyData[]      = { { "Dest", FD_OBJECTPTR  }, { 0, 0 } };
 FDEF argsDataFeed[]      = { { "Object", FD_OBJECTPTR }, { "Datatype", FD_INT }, { "Buffer", FD_PTR }, { "Size", FD_INT|FD_PTRSIZE }, { 0, 0 } };
-FDEF argsDragDrop[]      = { { "Source", FD_OBJECTPTR }, { "Item", FD_INT }, { "Datatype", FD_STR }, { 0, 0 } };
+FDEF argsDragDrop[]      = { { "Source", FD_OBJECTPTR }, { "Item", FD_INT }, { "Datatype", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF argsDraw[]          = { { "X", FD_INT }, { "Y", FD_INT }, { "Width", FD_INT }, { "Height", FD_INT }, { 0, 0 } };
-FDEF argsGetKey[]        = { { "Field", FD_STR }, { "Buffer",  FD_PTRBUFFER|FD_MUTABLE }, { "Size", FD_INT|FD_BUFSIZE }, { 0, 0 } };
+FDEF argsGetKey[]        = { { "Field", FD_CPP|FD_STR }, { "Buffer",  FD_PTRBUFFER|FD_MUTABLE }, { "Size", FD_INT|FD_BUFSIZE }, { 0, 0 } };
 FDEF argsMove[]          = { { "DeltaX", FD_DOUBLE }, { "DeltaY", FD_DOUBLE }, { "DeltaZ", FD_DOUBLE }, { 0, 0 } };
 FDEF argsMoveToPoint[]   = { { "X", FD_DOUBLE }, { "Y", FD_DOUBLE }, { "Z", FD_DOUBLE }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF argsNewChild[]      = { { "NewChild", FD_OBJECTPTR }, { 0, 0 } };
@@ -16,12 +16,12 @@ FDEF argsNewOwner[]      = { { "NewOwner", FD_OBJECTPTR }, { 0, 0 } };
 FDEF argsRead[]          = { { "Buffer", FD_PTRBUFFER|FD_MUTABLE }, { "Length", FD_INT|FD_BUFSIZE }, { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
 FDEF argsRedimension[]   = { { "X", FD_DOUBLE }, { "Y", FD_DOUBLE }, { "Z", FD_DOUBLE }, { "Width", FD_DOUBLE }, { "Height", FD_DOUBLE }, { "Depth", FD_DOUBLE }, { 0, 0 } };
 FDEF argsRedo[]          = { { "Steps", FD_INT }, { 0, 0 } };
-FDEF argsRename[]        = { { "Name", FD_STR }, { 0, 0 } };
+FDEF argsRename[]        = { { "Name", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF argsResize[]        = { { "Width", FD_DOUBLE }, { "Height", FD_DOUBLE }, { "Depth", FD_DOUBLE }, { 0, 0 } };
 FDEF argsSaveImage[]     = { { "Dest", FD_OBJECTPTR }, { "Class", FD_INT }, { 0, 0 } };
 FDEF argsSaveToObject[]  = { { "Dest", FD_OBJECTPTR }, { "Class", FD_INT }, { 0, 0 } };
 FDEF argsSeek[]          = { { "Offset", FD_DOUBLE }, { "Position", FD_INT }, { 0, 0 } };
-FDEF argsSetKey[]        = { { "Field", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
+FDEF argsSetKey[]        = { { "Field", FD_CPP|FD_STR }, { "Value", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF argsUndo[]          = { { "Steps", FD_INT }, { 0, 0 } };
 FDEF argsWrite[]         = { { "Buffer", FD_PTR|FD_BUFFER }, { "Length", FD_INT|FD_BUFSIZE }, { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -283,16 +283,30 @@ struct CaseInsensitiveMap {
 };
 
 struct CaseInsensitiveHash {
-   std::size_t operator()(const std::string& s) const noexcept {
-      std::string lower = s;
-      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-      return std::hash<std::string>{}(lower);
+   using is_transparent = void;
+
+   std::size_t operator()(std::string_view Value) const noexcept {
+      std::size_t hash = 5381;
+      for (auto ch : Value) {
+         hash = ((hash << 5) + hash) + std::tolower(uint8_t(ch));
+      }
+      return hash;
    }
 };
 
 struct CaseInsensitiveEqual {
-   bool operator()(const std::string& lhs, const std::string& rhs) const noexcept {
-      return ::strcasecmp(lhs.c_str(), rhs.c_str()) == 0;
+   using is_transparent = void;
+
+   bool operator()(std::string_view Lhs, std::string_view Rhs) const noexcept {
+      if (Lhs.size() != Rhs.size()) return false;
+
+      for (size_t i=0; i < Lhs.size(); i++) {
+         auto lhs = std::tolower(uint8_t(Lhs[i]));
+         auto rhs = std::tolower(uint8_t(Rhs[i]));
+         if (lhs != rhs) return false;
+      }
+
+      return true;
    }
 };
 

--- a/src/core/internal.cpp
+++ b/src/core/internal.cpp
@@ -173,8 +173,9 @@ copy_args: Serialise argument structures into sendable messages.
 This function searches an argument structure for pointer and string types.  If it encounters them, it attempts to
 convert them to a format that can be passed to other memory spaces.
 
-A PTR|RESULT followed by a PTRSIZE indicates that the user has to supply a buffer to the function.  It is assumed that
-the function will fill the buffer with data, which means that a result set has to be returned to the caller.  Example:
+A PTR|RESULT or PTR|MUTABLE followed by a PTRSIZE indicates that the user has to supply a buffer to the function.  It
+is assumed that the function will fill the buffer with data, so the caller's initial buffer content is not serialised.
+Example:
 
 <pre>
 Read(Bytes (FD_INT), Buffer (FD_PTRRESULT), BufferSize (FD_PTRSIZE), &BytesRead (FD_INTRESULT));
@@ -210,13 +211,17 @@ ERR copy_args(const FunctionField *Args, int ArgsSize, int8_t *Parameters, std::
 
       if (Args[i].Type & FD_STR) {
          if (Args[i].Type & FD_CPP) {
-            if (std::string *str = ((std::string **)(Parameters + pos))[0]) size += str->length() + 1;
+            auto view = (std::string_view *)(Parameters + pos);
+            size += view->length() + 1;
+            pos += sizeof(std::string_view);
          }
-         else if (auto str = ((STRING *)(Parameters + pos))[0]) size += strlen(str) + 1;
-         pos += sizeof(APTR);
+         else {
+            if (auto str = ((STRING *)(Parameters + pos))[0]) size += strlen(str) + 1;
+            pos += sizeof(APTR);
+         }
       }
       else if (Args[i].Type & FD_PTR) {
-         if (Args[i].Type & FD_RESULT); // Result will be stored in the parameter buffer.
+         if ((Args[i].Type & FD_RESULT) and (not (Args[i+1].Type & FD_PTRSIZE))); // Stored in parameter buffer.
          else if (Args[i].Type & (FD_INT|FD_PTRSIZE)) { // Pointer to int.
             pos += sizeof(int);
          }
@@ -248,13 +253,12 @@ ERR copy_args(const FunctionField *Args, int ArgsSize, int8_t *Parameters, std::
       if (Args[i].Type & FD_STR) {
          if (Args[i].Type & FD_CPP) {
             auto insert = (STRING)(Buffer.data() + Buffer.size());
-            if (std::string *str = ((std::string **)(Parameters + pos))[0]) {
-               Buffer.resize(Buffer.size() + str->length() + 1);
-               ((STRING *)param)[0] = insert;
-               copymem(str->c_str(), insert, str->length() + 1);
-            }
-            else ((STRING *)param)[0] = nullptr;
-            pos += sizeof(APTR);
+            auto view = (std::string_view *)(Parameters + pos);
+            Buffer.resize(Buffer.size() + view->length() + 1);
+            ((std::string_view *)param)[0] = std::string_view(insert, view->length());
+            if (not view->empty()) copymem(view->data(), insert, view->length());
+            insert[view->length()] = 0;
+            pos += sizeof(std::string_view);
          }
          else {
             auto insert = (STRING)(Buffer.data() + Buffer.size());
@@ -283,16 +287,19 @@ ERR copy_args(const FunctionField *Args, int ArgsSize, int8_t *Parameters, std::
          }
          else if (Args[i+1].Type & FD_PTRSIZE) { // Pointer to a buffer
             if (int memsize = ((int *)(Parameters + pos + sizeof(APTR)))[0]; memsize > 0) {
-               if (Args[i].Type & FD_RESULT) { // 'Receive' buffer
+               if (Args[i].Type & (FD_RESULT|FD_MUTABLE)) { // 'Receive' buffer
+                  auto insert = Buffer.data() + Buffer.size();
+                  ((APTR *)param)[0] = insert;
                   Buffer.resize(Buffer.size() + memsize);
                }
                else { // 'Send' buffer
-                  if (int8_t *src = ((int8_t **)param)[0]) { // Get the data source pointer
+                  if (int8_t *src = ((int8_t **)(Parameters + pos))[0]) {
                      auto insert = Buffer.data() + Buffer.size();
                      ((APTR *)param)[0] = insert;
                      Buffer.resize(Buffer.size() + memsize);
                      copymem(src, insert, memsize);
                   }
+                  else ((APTR *)param)[0] = nullptr;
                }
             }
             else ((APTR *)param)[0] = nullptr;

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -694,14 +694,14 @@ key-value will be given the same name as that specified in the widget's element.
 
 static ERR DOCUMENT_GetKey(extDocument *Self, struct acGetKey *Args)
 {
-   if ((not Args) or (not Args->Value) or (not Args->Key) or (Args->Size < 2)) return ERR::Args;
+   if ((not Args) or (not Args->Value) or (Args->Size < 2)) return ERR::Args;
 
-   if (Self->Vars.contains(Args->Key)) {
-      strcopy(Self->Vars[Args->Key], Args->Value, Args->Size);
+   if (auto key_it = Self->Vars.find(Args->Key); key_it != Self->Vars.end()) {
+      strcopy(key_it->second, Args->Value, Args->Size);
       return ERR::Okay;
    }
-   else if (Self->Params.contains(Args->Key)) {
-      strcopy(Self->Params[Args->Key], Args->Value, Args->Size);
+   else if (auto key_it = Self->Params.find(Args->Key); key_it != Self->Params.end()) {
+      strcopy(key_it->second, Args->Value, Args->Size);
       return ERR::Okay;
    }
 
@@ -2005,10 +2005,13 @@ static ERR DOCUMENT_SetKey(extDocument *Self, struct acSetKey *Args)
 {
    // Note: Zero-length parameter values are permitted.
 
-   if ((not Args) or (not Args->Key)) return ERR::NullArgs;
-   if (not Args->Key[0]) return ERR::Args;
+   if ((not Args) or (Args->Key.empty())) return ERR::NullArgs;
 
-   Self->Vars[Args->Key] = Args->Value;
+   auto key_it = Self->Vars.lower_bound(Args->Key);
+   if ((key_it != Self->Vars.end()) and (not Self->Vars.key_comp()(Args->Key, key_it->first))) {
+      key_it->second.assign(Args->Value);
+   }
+   else Self->Vars.emplace_hint(key_it, std::string(Args->Key), std::string(Args->Value));
 
    return ERR::Okay;
 }

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -269,25 +269,24 @@ static void close_debug_socket_file()
 }
 #endif
 
-static bool valid_http_header_name(CSTRING Key)
+static bool valid_http_header_name(std::string_view Key)
 {
-   if ((!Key) or (!*Key)) return false;
+   if (Key.empty()) return false;
 
    constexpr CSTRING separators = "()<>@,;:\\\"/[]?={}";
-   for (auto key = (const uint8_t *)Key; *key; key++) {
-      if ((*key <= 0x20) or (*key >= 0x7f)) return false;
-      if (std::strchr(separators, *key)) return false;
+   for (auto ch : Key) {
+      auto key = uint8_t(ch);
+      if ((key <= 0x20) or (key >= 0x7f)) return false;
+      if (std::strchr(separators, key)) return false;
    }
 
    return true;
 }
 
-static bool valid_http_header_value(CSTRING Value)
+static bool valid_http_header_value(std::string_view Value)
 {
-   if (!Value) return false;
-
-   for (auto value = (const uint8_t *)Value; *value; value++) {
-      if ((*value IS '\r') or (*value IS '\n')) return false;
+   for (auto ch : Value) {
+      if ((ch IS '\r') or (ch IS '\n')) return false;
    }
 
    return true;
@@ -296,15 +295,31 @@ static bool valid_http_header_value(CSTRING Value)
 extern "C" uint8_t glAuthScript[];
 static int glAuthScriptLength;
 
+struct http_header_hash {
+   using is_transparent = void;
+
+   std::size_t operator()(std::string_view Value) const noexcept {
+      return std::hash<std::string_view>{}(Value);
+   }
+};
+
+struct http_header_equal {
+   using is_transparent = void;
+
+   bool operator()(std::string_view Lhs, std::string_view Rhs) const noexcept {
+      return Lhs IS Rhs;
+   }
+};
+
 class extHTTP : public objHTTP {
    public:
    FUNCTION Incoming;
    FUNCTION Outgoing;
    FUNCTION AuthCallback;
    FUNCTION StateChanged;
-   ankerl::unordered_dense::map<std::string, std::string> ResponseHeaders;
+   ankerl::unordered_dense::map<std::string, std::string, http_header_hash, http_header_equal> ResponseHeaders;
    kt::vector<std::string> ResponseKeys;
-   ankerl::unordered_dense::map<std::string, std::string> Headers;
+   ankerl::unordered_dense::map<std::string, std::string, http_header_hash, http_header_equal> Headers;
    std::string Response;   // Response header buffer
    std::string URI;        // Temporary string, used only when the user reads the URI
    std::string Username;
@@ -984,13 +999,13 @@ static ERR HTTP_GetKey(extHTTP *Self, struct acGetKey *Args)
 {
    if (!Args) return ERR::NullArgs;
 
-   if (Self->ResponseHeaders.contains(Args->Key)) {
-      kt::strcopy(Self->ResponseHeaders[Args->Key], Args->Value, Args->Size);
+   if (auto key_it = Self->ResponseHeaders.find(Args->Key); key_it != Self->ResponseHeaders.end()) {
+      kt::strcopy(key_it->second, Args->Value, Args->Size);
       return ERR::Okay;
    }
 
-   if (Self->Headers.contains(Args->Key)) {
-      kt::strcopy(Self->Headers[Args->Key], Args->Value, Args->Size);
+   if (auto key_it = Self->Headers.find(Args->Key); key_it != Self->Headers.end()) {
+      kt::strcopy(key_it->second, Args->Value, Args->Size);
       return ERR::Okay;
    }
 

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -62,6 +62,15 @@ inline void luaL_argcheck(lua_State *L, bool Cond, int NumArg, const char *Extra
    if (not Cond) luaL_argerror(L, NumArg, ExtraMsg);
 }
 
+inline bool luaL_checkstring(lua_State *L, int N, std::string_view &SV) {
+   size_t len;
+   if (auto str = luaL_checklstring(L, N, &len)) {
+      SV = std::string_view{str, len};
+      return true;
+   }
+   else return false;
+}
+
 inline const char * luaL_checkstring(lua_State *L, int N) { return luaL_checklstring(L, N, nullptr); }
 inline const char * luaL_optstring(lua_State *L, int N, const char *D) { return luaL_optlstring(L, N, D, nullptr); }
 inline int luaL_checkint(lua_State *L, int N) { return int(luaL_checkinteger(L, N)); }

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -215,10 +215,7 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
                else if (args[i+1].Type & FD_INT64) ((int64_t *)(argbuffer + j))[0] = len;
             }
          }
-         else if (type IS LUA_TNUMBER) {
-            luaL_argerror(Lua, n, "Cannot use a number as a buffer pointer.");
-            return ERR::WrongType;
-         }
+         else if (type IS LUA_TNUMBER) luaL_argerror(Lua, n, "Cannot use a number as a buffer pointer.");
          else {
             //log.trace("Arg: %s, Value: Buffer", args[i].Name);
             ((APTR *)(argbuffer + j))[0] = lua_touserdata(Lua, n);
@@ -228,28 +225,36 @@ ERR build_args(lua_State *Lua, const FunctionField *args, int ArgsSize, int8_t *
       else if (args[i].Type & FD_STR) {
          j = ALIGN64(j);
          if (args[i].Type & FD_MUTABLE) {
-            if (type != LUA_TSTRING) {
-               luaL_argerror(Lua, n, "Mutable buffer required.");
-               return ERR::WrongType;
-            }
+            if (type != LUA_TSTRING) luaL_argerror(Lua, n, "Mutable buffer required.");
             auto string = strV(Lua->base + n - 1);
             if (not check_mutable_string_arg(Lua, n, string)) return ERR::WrongType;
             ((CSTRING *)(argbuffer + j))[0] = strdatawr(string);
+            j += sizeof(CSTRING);
          }
          else if ((type IS LUA_TSTRING) or (type IS LUA_TNUMBER)) {
-            ((CSTRING *)(argbuffer + j))[0] = lua_tostring(Lua, n);
+            if (args[i].Type & FD_CPP) {
+               ((std::string_view *)(argbuffer + j))[0] = lua_tostringview(Lua, n);
+               j += sizeof(std::string_view);
+            }
+            else {
+               ((CSTRING *)(argbuffer + j))[0] = lua_tostring(Lua, n);
+               j += sizeof(CSTRING);
+            }
          }
          else if (type <= 0) {
-            ((CSTRING *)(argbuffer + j))[0] = nullptr;
-         }
-         else if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
-            luaL_error(Lua, ERR::InvalidType, "Arg #%d (%s) requires a string and not untyped pointer.", i, args[i].Name);
+            if (args[i].Type & FD_CPP) {
+               ((std::string_view *)(argbuffer + j))[0] = std::string_view{};
+               j += sizeof(std::string_view);
+            }
+            else {
+               ((CSTRING *)(argbuffer + j))[0] = nullptr;
+               j += sizeof(CSTRING);
+            }
          }
          else luaL_error(Lua, ERR::InvalidType, "Arg #%d (%s) requires a string, got %s '%s'.", i, args[i].Name, lua_typename(Lua, type), lua_tostring(Lua, n));
 
          //log.trace("Arg: %s, Value: %s", args[i].Name, ((STRING *)(argbuffer + j))[0]);
 
-         j += sizeof(STRING);
       }
       else if (args[i].Type & FD_PTR) {
          j = ALIGN64(j);

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -263,7 +263,8 @@ static int object_get(lua_State *Lua)
 {
    kt::Log log("obj.get");
 
-   if (auto fieldname = luaL_checkstring(Lua, 1)) {
+   std::string_view fieldname;
+   if (luaL_checkstring(Lua, 1, fieldname)) {
       auto def = object_context(Lua);
 
       auto obj = access_object(def);
@@ -273,9 +274,10 @@ static int object_get(lua_State *Lua)
       }
 
       OBJECTPTR target;
-      if (fieldname[0] IS '$') { // Get field as a string, good for CSV arrays, flags and lookups
+      if (fieldname.starts_with('$')) { // Get field as a string, good for CSV arrays, flags and lookups
+         fieldname.remove_prefix(1);
          std::string buffer;
-         if (obj->get(fieldhash(fieldname+1), buffer) IS ERR::Okay) lua_pushlstring(Lua, buffer.c_str(), buffer.size());
+         if (obj->get(fieldhash(fieldname), buffer) IS ERR::Okay) lua_pushlstring(Lua, buffer.c_str(), buffer.size());
          else lua_pushvalue(Lua, 2); // Push the client's default value
          release_object(def);
          return 1;
@@ -311,7 +313,7 @@ static int object_get(lua_State *Lua)
          }
 
          release_object(def);
-         if (!result) lua_pushvalue(Lua, 2); // An error occurred if no result.  Push the client's default value
+         if (not result) lua_pushvalue(Lua, 2); // An error occurred if no result.  Push the client's default value
          return 1;
       }
       else { // Revert to getKey() if the class supports it failed
@@ -336,7 +338,8 @@ static int object_get(lua_State *Lua)
 
 static int object_getkey(lua_State *Lua)
 {
-   if (auto fieldname = luaL_checkstring(Lua, 1)) {
+   std::string_view fieldname;
+   if (luaL_checkstring(Lua, 1, fieldname)) {
       auto def = object_context(Lua);
       ERR error;
       if (auto obj = access_object(def)) {
@@ -365,8 +368,8 @@ static int object_set(lua_State *Lua)
 {
    auto def = object_context(Lua);
 
-   CSTRING fieldname;
-   if (!(fieldname = luaL_checkstring(Lua, 1))) return 0;
+   std::string_view fieldname;
+   if (not luaL_checkstring(Lua, 1, fieldname)) return 0;
 
    if (auto obj = access_object(def)) {
       int type = lua_type(Lua, 2);
@@ -395,7 +398,8 @@ static int object_set(lua_State *Lua)
 static int object_setkey(lua_State *Lua)
 {
    auto def = object_context(Lua);
-   if (auto fieldname = luaL_checkstring(Lua, 1)) {
+   std::string_view fieldname;
+   if (luaL_checkstring(Lua, 1, fieldname)) {
       auto value = luaL_optstring(Lua, 2, nullptr);
       if (auto obj = access_object(def)) {
          ERR error = acSetKey(obj, fieldname, value);

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -624,7 +624,7 @@ static ERR XML_GetKey(extXML *Self, struct acGetKey *Args)
    kt::Log log;
 
    if (not Args) return log.warning(ERR::NullArgs);
-   if ((not Args->Key) or (not Args->Value) or (Args->Size < 1)) return log.warning(ERR::NullArgs);
+   if ((not Args->Value) or (Args->Size < 1)) return log.warning(ERR::NullArgs);
    if (not Self->initialised()) return log.warning(ERR::NotInitialised);
 
    Args->Value[0] = 0;
@@ -1618,7 +1618,7 @@ static ERR XML_SetKey(extXML *Self, struct acSetKey *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Key)) return log.warning(ERR::NullArgs);
+   if (not Args) return log.warning(ERR::NullArgs);
    if (Self->ReadOnly) return log.warning(ERR::ReadOnly);
 
    objXQuery *xq;
@@ -1666,7 +1666,7 @@ static ERR XML_SetKey(extXML *Self, struct acSetKey *Args)
                if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
                FreeResource(xq);
             }
-            log.warning("Failed to find '%s'", Args->Key);
+            log.warning("Failed to find '%.*s'", int(Args->Key.size()), Args->Key.data());
             return error;
          }
       }
@@ -1674,7 +1674,7 @@ static ERR XML_SetKey(extXML *Self, struct acSetKey *Args)
          std::string_view sv;
          if (xq->get(FID_ErrorMsg, sv) IS ERR::Okay) Self->ErrorMsg.assign(sv);
          FreeResource(xq);
-         log.msg("Failed to compile '%s'", Args->Key);
+         log.msg("Failed to compile '%.*s'", int(Args->Key.size()), Args->Key.data());
          return error;
       }
    }

--- a/src/xquery/xquery.h
+++ b/src/xquery/xquery.h
@@ -952,9 +952,19 @@ class XPathParser {
 
 //*********************************************************************************************************************
 
+struct fi_hash {
+   using is_transparent = void;
+   [[nodiscard]] size_t operator()(std::string_view Value) const noexcept { return std::hash<std::string_view>{}(Value); }
+};
+
+struct fi_equal {
+   using is_transparent = void;
+   [[nodiscard]] bool operator()(const std::string_view &Lhs, const std::string_view &Rhs) const noexcept { return Lhs IS Rhs; }
+};
+
 class extXQuery : public objXQuery {
 public:
-   ankerl::unordered_dense::map<std::string, std::string> Variables; // XPath variable references
+   ankerl::unordered_dense::map<std::string, std::string, fi_hash, fi_equal> Variables; // XPath variable references
    ankerl::unordered_dense::map<std::string, FUNCTION> RegisteredFunctions;
    FUNCTION Callback;
    FUNCTION ResolveVariable;

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -780,14 +780,8 @@ static ERR XQUERY_SetKey(extXQuery *Self, struct acSetKey *Args)
 
    log.trace("Setting variable '%.*s' = '%.*s'", int(Args->Key.size()), Args->Key.data(), int(Args->Value.size()), Args->Value.data());
 
-   if (not Args->Value.empty()) {
-      Self->Variables[Args->Key] = Args->Value;
-   }
-   else { // Remove existing variable when Value is empty
-      if (auto it = Self->Variables.find(Args->Key); it != Self->Variables.end()) Self->Variables.erase(it);
-      else Self->Variables[Args->Key] = "";
-   }
-
+   Self->Variables[Args->Key] = Args->Value;
+   Self->ListVariables.clear();
    return ERR::Okay;
 }
 

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -412,7 +412,7 @@ GetKey: Read XQuery variable values.
 
 static ERR XQUERY_GetKey(extXQuery *Self, struct acGetKey *Args)
 {
-   if ((not Args) or (not Args->Value) or (not Args->Key)) return ERR::NullArgs;
+   if ((not Args) or (not Args->Value) or (Args->Key.empty())) return ERR::NullArgs;
    if (Args->Size < 2) return ERR::Args;
 
    if (auto it = Self->Variables.find(Args->Key); it != Self->Variables.end()) {
@@ -765,10 +765,6 @@ SetKey: Set XQuery variable values.
 Use SetKey to store key-value pairs that can be referenced in XQuery expressions using the variable syntax
 `$variableName`.
 
--INPUT-
-cstr Key: The name of the variable (case sensitive).
-cstr Value: The string value to store or NULL to remove an existing key.
-
 -ERRORS-
 Okay:
 NullArgs: The `Key` parameter was not specified.
@@ -780,16 +776,16 @@ static ERR XQUERY_SetKey(extXQuery *Self, struct acSetKey *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Key)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Key.empty())) return log.warning(ERR::NullArgs);
 
-   log.trace("Setting variable '%s' = '%s'", Args->Key, Args->Value ? Args->Value : "");
+   log.trace("Setting variable '%.*s' = '%.*s'", int(Args->Key.size()), Args->Key.data(), int(Args->Value.size()), Args->Value.data());
 
-   if (Args->Value) {
+   if (not Args->Value.empty()) {
       Self->Variables[Args->Key] = Args->Value;
    }
-   else {
-      // Remove variable if Value is null
-      Self->Variables.erase(Args->Key);
+   else { // Remove existing variable when Value is empty
+      if (auto it = Self->Variables.find(Args->Key); it != Self->Variables.end()) Self->Variables.erase(it);
+      else Self->Variables[Args->Key] = "";
    }
 
    return ERR::Okay;

--- a/tools/idl/include/actions.tiri
+++ b/tools/idl/include/actions.tiri
@@ -37,7 +37,7 @@ global glActionStubs = {
       return Action(AC::CopyData, this, &args);
    }]],
    DragDrop = [[
-   inline ERR dragDrop(OBJECTPTR Source, int Item, CSTRING Datatype) noexcept {
+   inline ERR dragDrop(OBJECTPTR Source, int Item, std::string_view Datatype) noexcept {
       struct acDragDrop args = { .Source = Source, .Item = Item, .Datatype = Datatype };
       return Action(AC::DragDrop, this, &args);
    }]],
@@ -95,7 +95,7 @@ global glActionStubs = {
       return Action(AC::Redimension, this, &args);
    }]],
    Rename = [[
-   inline ERR rename(CSTRING Name) noexcept {
+   inline ERR rename(std::string_view Name) noexcept {
       struct acRename args = { Name };
       return Action(AC::Rename, this, &args);
    }]],
@@ -110,7 +110,7 @@ global glActionStubs = {
       return Action(AC::Undo, this, &args);
    }]],
    GetKey = [[
-   inline ERR getKey(CSTRING Key, STRING Value, int Size) noexcept {
+   inline ERR getKey(std::string_view Key, STRING Value, int Size) noexcept {
       struct acGetKey args = { Key, Value, Size };
       auto error = Action(AC::GetKey, this, &args);
       if ((error != ERR::Okay) and (Value)) Value[0] = 0;
@@ -140,21 +140,6 @@ global glActionStubs = {
    inline ERR seekEnd(double Offset) noexcept { return seek(Offset, SEEK::END); }
    inline ERR seekCurrent(double Offset) noexcept { return seek(Offset, SEEK::CURRENT); }
    ]],
-   SetKeys = [[
-   inline ERR setKeys(CSTRING tags, ...) noexcept {
-      struct acSetKey args;
-      va_list list;
-      va_start(list, tags);
-      while ((args.Field = va_arg(list, STRING)) != TAGEND) {
-         args.Value = va_arg(list, STRING);
-         if (Action(AC::SetKey, this, &args) != ERR::Okay) {
-            va_end(list);
-            return ERR::Failed;
-         }
-      }
-      va_end(list);
-      return ERR::Okay;
-   }]],
    Write = [[
    inline ERR write(CPTR Buffer, int Size, int *Result = nullptr) noexcept {
       struct acWrite write = { (int8_t *)Buffer, Size };
@@ -189,7 +174,7 @@ global glActionStubs = {
       return Action(AC::SelectArea, this, &area);
    }]],
    SetKey = [[
-   inline ERR acSetKey(CSTRING FieldName, CSTRING Value) noexcept {
+   inline ERR acSetKey(std::string_view FieldName, std::string_view Value) noexcept {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }]],

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -123,12 +123,12 @@ setAction('Disable', {
 
 setAction('DragDrop', {
    comment   = 'Manages drag and drop from one object to another.',
-   prototype = 'ERR acDragDrop(*Object, OBJECTID Source, INT Item, DATA Datatype)',
-   tiriPrototype = 'err = Object.acDragDrop(Source:obj, Item:num, Datatype:DATA)',
+   prototype = 'ERR acDragDrop(*Object, OBJECTID Source, INT Item, STRVIEW Datatype)',
+   tiriPrototype = 'err = Object.acDragDrop(Source:obj, Item:num, Datatype:str)',
    params    = {
       { name='Source', type='OBJECTID', comment='Refers to the object containing the source data.' },
       { name='Item', type='INT', comment='An item ID, relevant to the source object.' },
-      { name='Datatype', type='DATA', lookup='DATA', comment='The type of data represented by the source item.' }
+      { name='Datatype', type='STRVIEW', comment='The types of data represented by the source item.' }
    }
 })
 
@@ -174,10 +174,10 @@ setAction('Free', {
 
 setAction('GetKey', {
    comment   = 'Retrieves custom key values that are not defined by an object\'s structure.',
-   prototype = 'ERR acGetKey(*Object, CSTRING Key, STRING Value, INT Size)',
+   prototype = 'ERR acGetKey(*Object, std::string_view Key, STRING Value, INT Size)',
    tiriPrototype = 'err = Object.acGetKey(Key:str, Value:str, Size:num)',
    params    = {
-      { name='Key', type='CSTRING', comment='The name of a key value.' },
+      { name='Key', type='STRVIEW', comment='The name of a key value.' },
       { name='Value', type='STRING', comment='Pointer to a buffer space large enough to hold the retrieved value.' },
       { name='Size', type='INT', comment='Indicates the byte size of the Buffer.' }
    }
@@ -311,10 +311,10 @@ setAction('Refresh', {
 
 setAction('Rename', {
    comment   = 'Renames an object.',
-   prototype = 'ERR acRename(*Object, CSTRING Name)',
+   prototype = 'ERR acRename(*Object, std::string_view Name)',
    tiriPrototype = 'err = Object.acRename(Name:str)',
    params    = {
-      { name='Name', type='CSTRING', comment='The new name for the object.' }
+      { name='Name', type='STRVIEW', comment='The new name for the object.' }
    }
 })
 
@@ -377,11 +377,11 @@ setAction('SetField', {
 
 setAction('SetKey', {
    comment   = 'Sets custom key values that are not defined by an object\'s structure.',
-   prototype = 'ERR acSetKey(*Object, CSTRING Key, CSTRING Value)',
+   prototype = 'ERR acSetKey(*Object, std::string_view Key, std::string_view Value)',
    tiriPrototype = 'err = Object.acSetKey(Key:str, Value:str)',
    params    = {
-      { name='Key', type='CSTRING', comment='The name of the target key.' },
-      { name='Value', type='CSTRING', comment='The string value to associate with Key.' }
+      { name='Key', type='STRVIEW', comment='The name of the target key.' },
+      { name='Value', type='STRVIEW', comment='The string value to associate with Key.' }
    }
 })
 


### PR DESCRIPTION
* Switched string action arguments and generated helpers to std::string_view metadata

* Treated mutable pointer buffers as output buffers during action argument copying

* Updated affected action call sites and case-insensitive lookup helpers