### PR TITLE
[Core] Upgrade action string arguments to string views

### DIFF
--- a/docs/xml/modules/classes/config.xml
+++ b/docs/xml/modules/classes/config.xml
@@ -99,10 +99,10 @@ print('The Action class is located at ' .. str)
     <method>
       <name>DeleteGroup</name>
       <comment>Deletes entire groups of configuration data.</comment>
-      <prototype>ERR cfg::DeleteGroup(OBJECTPTR Object, CSTRING Group)</prototype>
+      <prototype>ERR cfg::DeleteGroup(OBJECTPTR Object, const std::string_view &amp; Group)</prototype>
       <tiriPrototype>err = DeleteGroup(Group:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The name of the group that will be deleted.</param>
+        <param type="const std::string_view &amp;" name="Group">The name of the group that will be deleted.</param>
       </input>
       <description>
 <p>This method will delete an entire group of key-values from a config object if a matching group name is provided.</p>
@@ -117,11 +117,11 @@ print('The Action class is located at ' .. str)
     <method>
       <name>DeleteKey</name>
       <comment>Deletes single key entries.</comment>
-      <prototype>ERR cfg::DeleteKey(OBJECTPTR Object, CSTRING Group, CSTRING Key)</prototype>
+      <prototype>ERR cfg::DeleteKey(OBJECTPTR Object, const std::string_view &amp; Group, const std::string_view &amp; Key)</prototype>
       <tiriPrototype>err = DeleteKey(Group:str, Key:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The name of the targeted group.</param>
-        <param type="CSTRING" name="Key">The name of the targeted key.</param>
+        <param type="const std::string_view &amp;" name="Group">The name of the targeted group.</param>
+        <param type="const std::string_view &amp;" name="Key">The name of the targeted key.</param>
       </input>
       <description>
 <p>This method deletes a single key from the Config object.</p>
@@ -177,10 +177,10 @@ print('The Action class is located at ' .. str)
     <method>
       <name>MergeFile</name>
       <comment>Merges a configuration file into existing configuration data.</comment>
-      <prototype>ERR cfg::MergeFile(OBJECTPTR Object, CSTRING Path)</prototype>
+      <prototype>ERR cfg::MergeFile(OBJECTPTR Object, const std::string_view &amp; Path)</prototype>
       <tiriPrototype>err = MergeFile(Path:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Path">The location of the configuration file that you want to merge.</param>
+        <param type="const std::string_view &amp;" name="Path">The location of the configuration file that you want to merge.</param>
       </input>
       <description>
 <p>The MergeFile() method is used to pull configuration data from a file and merge it into the target config object. The path to the configuration file is all that is required.  Existing data in the target will be overwritten by the source in cases where there matching set of group keys.</p>
@@ -196,16 +196,16 @@ print('The Action class is located at ' .. str)
     <method>
       <name>ReadValue</name>
       <comment>Reads a key-value string.</comment>
-      <prototype>ERR cfg::ReadValue(OBJECTPTR Object, CSTRING Group, CSTRING Key, CSTRING * Data)</prototype>
+      <prototype>ERR cfg::ReadValue(OBJECTPTR Object, const std::string_view &amp; Group, const std::string_view &amp; Key, CSTRING * Data)</prototype>
       <tiriPrototype>err, Data:str = ReadValue(Group:str, Key:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The name of a group to examine for a key.  If <code>NULL</code>, all groups are scanned.</param>
-        <param type="CSTRING" name="Key">The name of a key to retrieve (case sensitive).</param>
+        <param type="const std::string_view &amp;" name="Group">The name of a group to examine for a key.  If empty, all groups are scanned.</param>
+        <param type="const std::string_view &amp;" name="Key">The name of a key to retrieve (case sensitive).  If empty, the first key in the group is returned.</param>
         <param type="CSTRING *" name="Data">The key value will be stored in this parameter on returning.</param>
       </input>
       <description>
 <p>This function retrieves key values in their original string format.  On success, the resulting string remains valid only for as long as the client has exclusive access to the config object.  The pointer can also be invalidated if more information is written to the config object.  For this reason, consider copying the result if it will be used extensively.</p>
-<p>If the <code>Group</code> parameter is set to <code>NULL</code>, the scan routine will treat all of the config data as a one dimensional array. If the <code>Key</code> parameter is set to <code>NULL</code> then the first key in the requested group is returned.  If both parameters are <code>NULL</code> then the first known key value will be returned.</p>
+<p>If the <code>Group</code> parameter is empty, the scan routine will treat all of the config data as a one dimensional array. If the <code>Key</code> parameter is empty then the first key in the requested group is returned.  If both parameters are empty then the first known key value will be returned.</p>
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
@@ -218,12 +218,12 @@ print('The Action class is located at ' .. str)
     <method>
       <name>Set</name>
       <comment>Sets keys in existing config groups (aborts if the group does not exist).</comment>
-      <prototype>ERR cfg::Set(OBJECTPTR Object, CSTRING Group, CSTRING Key, CSTRING Data)</prototype>
+      <prototype>ERR cfg::Set(OBJECTPTR Object, const std::string_view &amp; Group, const std::string_view &amp; Key, const std::string_view &amp; Data)</prototype>
       <tiriPrototype>err = Set(Group:str, Key:str, Data:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The name of the group.  Wildcards are supported.</param>
-        <param type="CSTRING" name="Key">The name of the key.</param>
-        <param type="CSTRING" name="Data">The data that will be added to the given group/key.</param>
+        <param type="const std::string_view &amp;" name="Group">The name of the group.  Wildcards are supported.</param>
+        <param type="const std::string_view &amp;" name="Key">The name of the key.</param>
+        <param type="const std::string_view &amp;" name="Data">The data that will be added to the given group/key.</param>
       </input>
       <description>
 <p>This method is identical to <method>WriteValue</method> except it will abort if the name of the referred group does not exist in the config object.  The error code <code>ERR::Search</code> is returned if this is the case.  Please refer to <method>WriteValue</method> for further information on the behaviour of this function.</p>
@@ -239,10 +239,10 @@ print('The Action class is located at ' .. str)
     <method>
       <name>SortByKey</name>
       <comment>Sorts config data using a sequence of sort instructions.</comment>
-      <prototype>ERR cfg::SortByKey(OBJECTPTR Object, CSTRING Key, INT Descending)</prototype>
+      <prototype>ERR cfg::SortByKey(OBJECTPTR Object, const std::string_view &amp; Key, INT Descending)</prototype>
       <tiriPrototype>err = SortByKey(Key:str, Descending:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Key">The name of the key to sort on.</param>
+        <param type="const std::string_view &amp;" name="Key">The name of the key to sort on.</param>
         <param type="INT" name="Descending">Set to true if a descending sort is required.</param>
       </input>
       <description>
@@ -258,12 +258,12 @@ print('The Action class is located at ' .. str)
     <method>
       <name>WriteValue</name>
       <comment>Adds new entries to config objects.</comment>
-      <prototype>ERR cfg::WriteValue(OBJECTPTR Object, CSTRING Group, CSTRING Key, CSTRING Data)</prototype>
+      <prototype>ERR cfg::WriteValue(OBJECTPTR Object, const std::string_view &amp; Group, const std::string_view &amp; Key, const std::string_view &amp; Data)</prototype>
       <tiriPrototype>err = WriteValue(Group:str, Key:str, Data:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The name of the group.</param>
-        <param type="CSTRING" name="Key">The name of the key.</param>
-        <param type="CSTRING" name="Data">The data that will be added to the given group/key.</param>
+        <param type="const std::string_view &amp;" name="Group">The name of the group.</param>
+        <param type="const std::string_view &amp;" name="Key">The name of the key.</param>
+        <param type="const std::string_view &amp;" name="Data">The data that will be added to the given group/key.</param>
       </input>
       <description>
 <p>Use the WriteValue() method to add or update information in a config object.  A <code>Group</code> name, <code>Key</code> name, and <code>Data</code> value are required.  If the <code>Group</code> and <code>Key</code> arguments match an existing entry in the config object, the data of that entry will be replaced with the new Data value.</p>

--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -177,10 +177,10 @@
     <method>
       <name>Copy</name>
       <comment>Copies the data of a file to another location.</comment>
-      <prototype>ERR fl::Copy(OBJECTPTR Object, CSTRING Dest, FUNCTION * Callback)</prototype>
+      <prototype>ERR fl::Copy(OBJECTPTR Object, const std::string_view &amp; Dest, FUNCTION * Callback)</prototype>
       <tiriPrototype>err = Copy(Dest:str, Callback:func)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Dest">The destination file path for the copy operation.</param>
+        <param type="const std::string_view &amp;" name="Dest">The destination file path for the copy operation.</param>
         <param type="FUNCTION *" name="Callback">Optional callback for receiving feedback during the operation.</param>
       </input>
       <description>
@@ -230,10 +230,10 @@
     <method>
       <name>Move</name>
       <comment>Moves a file to a new location.</comment>
-      <prototype>ERR fl::Move(OBJECTPTR Object, CSTRING Dest, FUNCTION * Callback)</prototype>
+      <prototype>ERR fl::Move(OBJECTPTR Object, const std::string_view &amp; Dest, FUNCTION * Callback)</prototype>
       <tiriPrototype>err = Move(Dest:str, Callback:func)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Dest">The desired path for the file.</param>
+        <param type="const std::string_view &amp;" name="Dest">The desired path for the file.</param>
         <param type="FUNCTION *" name="Callback">Optional callback for receiving feedback during the operation.</param>
       </input>
       <description>

--- a/docs/xml/modules/classes/script.xml
+++ b/docs/xml/modules/classes/script.xml
@@ -85,10 +85,10 @@
     <method>
       <name>DebugLog</name>
       <comment>Acquire a debug log from a compiled Script.</comment>
-      <prototype>ERR sc::DebugLog(OBJECTPTR Object, CSTRING Options, CSTRING * Result)</prototype>
+      <prototype>ERR sc::DebugLog(OBJECTPTR Object, const std::string_view &amp; Options, CSTRING * Result)</prototype>
       <tiriPrototype>err, Result:str = DebugLog(Options:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Options">Options to pass to the underlying language.</param>
+        <param type="const std::string_view &amp;" name="Options">Options to pass to the underlying language.</param>
         <param type="CSTRING *" name="Result">Resulting log information.</param>
       </input>
       <description>
@@ -124,10 +124,10 @@
     <method>
       <name>Exec</name>
       <comment>Executes a procedure in the script.</comment>
-      <prototype>ERR sc::Exec(OBJECTPTR Object, CSTRING Procedure, const struct ScriptArg * Args, INT TotalArgs)</prototype>
+      <prototype>ERR sc::Exec(OBJECTPTR Object, const std::string_view &amp; Procedure, const struct ScriptArg * Args, INT TotalArgs)</prototype>
       <tiriPrototype>err = Exec(Procedure:str, Args:any, TotalArgs:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Procedure">The name of the procedure to execute, or NULL for the default entry point.</param>
+        <param type="const std::string_view &amp;" name="Procedure">The name of the procedure to execute, or leave empty for the default entry point.</param>
         <param type="const struct ScriptArg *" name="Args">Optional parameters to pass to the procedure.</param>
         <param type="INT" name="TotalArgs">Total number of <code>Args</code> provided.</param>
       </input>
@@ -168,10 +168,10 @@ struct ScriptArg {
     <method>
       <name>GetProcedureID</name>
       <comment>Converts a procedure name to an ID.</comment>
-      <prototype>ERR sc::GetProcedureID(OBJECTPTR Object, CSTRING Procedure, INT64 * ProcedureID)</prototype>
+      <prototype>ERR sc::GetProcedureID(OBJECTPTR Object, const std::string_view &amp; Procedure, INT64 * ProcedureID)</prototype>
       <tiriPrototype>err, ProcedureID:num = GetProcedureID(Procedure:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Procedure">The name of the procedure.</param>
+        <param type="const std::string_view &amp;" name="Procedure">The name of the procedure.</param>
         <param type="INT64 *" name="ProcedureID">The computed ID will be returned in this parameter.</param>
       </input>
       <description>
@@ -263,8 +263,8 @@ SET_FUNCTION_SCRIPT(callback, script, procedure_id);
     <field>
       <name>Path</name>
       <comment>The location of a script file to be loaded.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <access read="R" write="S">Read/Set</access>
+      <type>std::string</type>
       <description>
 <p>A script file can be loaded by setting the Path to its location.  The path must be defined prior to the initialisation process, or alternatively the client can define the <fl>Statement</fl> field.</p>
 <p>Optional parameters can also be passed to the script via the Path string.  The name of a function is passed first, surrounded by semicolons.  Arguments can be passed to the function by appending them as a CSV list.  The following string illustrates the format used: <code>dir:location;procedure;arg1=val1,arg2,arg3=val2</code></p>
@@ -274,9 +274,9 @@ SET_FUNCTION_SCRIPT(callback, script, procedure_id);
 
     <field>
       <name>Procedure</name>
-      <comment>Specifies a procedure to be executed from within a script.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <comment>Specifies a procedure name to be executed.</comment>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
       <description>
 <p>Sometimes scripts are split into several procedures or functions that can be executed independently from the 'main' area of the script.  If a loaded script contains procedures, the client can set the Procedure field to execute a specific routine whenever the script is activated with the <action>Activate</action> action.</p>
 <p>If this field is not set, the first procedure in the script, or the 'main' procedure (as defined by the script type) is executed by default.</p>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3150,14 +3150,14 @@ class objFile : public Object {
 // Config methods
 
 namespace cfg {
-struct ReadValue { CSTRING Group; CSTRING Key; CSTRING Data; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Set { CSTRING Group; CSTRING Key; CSTRING Data; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct WriteValue { CSTRING Group; CSTRING Key; CSTRING Data; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct DeleteKey { CSTRING Group; CSTRING Key; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct DeleteGroup { CSTRING Group; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ReadValue { std::string_view Group; std::string_view Key; CSTRING Data; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Set { std::string_view Group; std::string_view Key; std::string_view Data; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct WriteValue { std::string_view Group; std::string_view Key; std::string_view Data; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct DeleteKey { std::string_view Group; std::string_view Key; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct DeleteGroup { std::string_view Group; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetGroupFromIndex { int Index; CSTRING Group; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SortByKey { CSTRING Key; int Descending; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct MergeFile { CSTRING Path; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SortByKey { std::string_view Key; int Descending; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct MergeFile { std::string_view Path; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Merge { OBJECTPTR Source; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
@@ -3242,25 +3242,25 @@ class objConfig : public Object {
       struct acSaveToObject args = { Dest, { ClassID } };
       return Action(AC::SaveToObject, this, &args);
    }
-   inline ERR readValue(CSTRING Group, CSTRING Key, CSTRING * Data) noexcept {
+   inline ERR readValue(const std::string_view & Group, const std::string_view & Key, CSTRING * Data) noexcept {
       struct cfg::ReadValue args = { Group, Key, (CSTRING)0 };
       ERR error = Action(AC(-1), this, &args);
       if (Data) *Data = args.Data;
       return(error);
    }
-   inline ERR set(CSTRING Group, CSTRING Key, CSTRING Data) noexcept {
+   inline ERR set(const std::string_view & Group, const std::string_view & Key, const std::string_view & Data) noexcept {
       struct cfg::Set args = { Group, Key, Data };
       return(Action(AC(-2), this, &args));
    }
-   inline ERR writeValue(CSTRING Group, CSTRING Key, CSTRING Data) noexcept {
+   inline ERR writeValue(const std::string_view & Group, const std::string_view & Key, const std::string_view & Data) noexcept {
       struct cfg::WriteValue args = { Group, Key, Data };
       return(Action(AC(-3), this, &args));
    }
-   inline ERR deleteKey(CSTRING Group, CSTRING Key) noexcept {
+   inline ERR deleteKey(const std::string_view & Group, const std::string_view & Key) noexcept {
       struct cfg::DeleteKey args = { Group, Key };
       return(Action(AC(-4), this, &args));
    }
-   inline ERR deleteGroup(CSTRING Group) noexcept {
+   inline ERR deleteGroup(const std::string_view & Group) noexcept {
       struct cfg::DeleteGroup args = { Group };
       return(Action(AC(-5), this, &args));
    }
@@ -3270,11 +3270,11 @@ class objConfig : public Object {
       if (Group) *Group = args.Group;
       return(error);
    }
-   inline ERR sortByKey(CSTRING Key, int Descending) noexcept {
+   inline ERR sortByKey(const std::string_view & Key, int Descending) noexcept {
       struct cfg::SortByKey args = { Key, Descending };
       return(Action(AC(-7), this, &args));
    }
-   inline ERR mergeFile(CSTRING Path) noexcept {
+   inline ERR mergeFile(const std::string_view & Path) noexcept {
       struct cfg::MergeFile args = { Path };
       return(Action(AC(-9), this, &args));
    }
@@ -3359,11 +3359,11 @@ class objConfig : public Object {
 // Script methods
 
 namespace sc {
-struct Exec { CSTRING Procedure; const struct ScriptArg * Args; int TotalArgs; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Exec { std::string_view Procedure; const struct ScriptArg * Args; int TotalArgs; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct DerefProcedure { FUNCTION * Procedure; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Callback { int64_t ProcedureID; const struct ScriptArg * Args; int TotalArgs; ERR Error; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct GetProcedureID { CSTRING Procedure; int64_t ProcedureID; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct DebugLog { CSTRING Options; CSTRING Result; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct GetProcedureID { std::string_view Procedure; int64_t ProcedureID; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct DebugLog { std::string_view Options; CSTRING Result; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -3374,11 +3374,13 @@ class objScript : public Object {
 
    using create = kt::Create<objScript>;
 
-   OBJECTID TargetID;  // Reference to the default container that new script objects will be initialised to.
-   SCF      Flags;     // Optional flags.
-   ERR      Error;     // If a script fails during execution, an error code may be readable here.
-   int      CurrentLine; // Indicates the current line being executed when in debug mode.
-   int      LineOffset; // For debugging purposes, this value is added to any message referencing a line number.
+   std::string Path;         // The location of a script file to be loaded.
+   std::string Procedure;    // Specifies a procedure name to be executed.
+   OBJECTID TargetID;        // Reference to the default container that new script objects will be initialised to.
+   SCF      Flags;           // Optional flags.
+   ERR      Error;           // If a script fails during execution, an error code may be readable here.
+   int      CurrentLine;     // Indicates the current line being executed when in debug mode.
+   int      LineOffset;      // For debugging purposes, this value is added to any message referencing a line number.
 
 #ifdef PRV_SCRIPT
    int64_t  ProcedureID;          // For callbacks
@@ -3386,11 +3388,9 @@ class objScript : public Object {
    kt::vector<std::string> Results;
    char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
-   std::string Path;              // File location of the script
    std::string String;
    std::string WorkingPath;
    std::string ErrorMessage;
-   std::string Procedure;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
    int      TotalArgs;            // Total number of ProcArgs
@@ -3417,7 +3417,7 @@ class objScript : public Object {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }
-   inline ERR exec(CSTRING Procedure, const struct ScriptArg * Args, int TotalArgs) noexcept {
+   inline ERR exec(const std::string_view & Procedure, const struct ScriptArg * Args, int TotalArgs) noexcept {
       struct sc::Exec args = { Procedure, Args, TotalArgs };
       return(Action(AC(-1), this, &args));
    }
@@ -3431,13 +3431,13 @@ class objScript : public Object {
       if (Error) *Error = args.Error;
       return(error);
    }
-   inline ERR getProcedureID(CSTRING Procedure, int64_t * ProcedureID) noexcept {
+   inline ERR getProcedureID(const std::string_view & Procedure, int64_t * ProcedureID) noexcept {
       struct sc::GetProcedureID args = { Procedure, (int64_t)0 };
       ERR error = Action(AC(-4), this, &args);
       if (ProcedureID) *ProcedureID = args.ProcedureID;
       return(error);
    }
-   inline ERR debugLog(CSTRING Options, CSTRING * Result) noexcept {
+   inline ERR debugLog(const std::string_view & Options, CSTRING * Result) noexcept {
       struct sc::DebugLog args = { Options, (CSTRING)0 };
       ERR error = Action(AC(-5), this, &args);
       if (Result) *Result = args.Result;
@@ -3445,6 +3445,16 @@ class objScript : public Object {
    }
 
    // Customised field getting
+
+   inline ERR getPath(std::string_view &Value) noexcept {
+      Value = this->Path;
+      return ERR::Okay;
+   }
+
+   inline ERR getProcedure(std::string_view &Value) noexcept {
+      Value = this->Procedure;
+      return ERR::Okay;
+   }
 
    inline ERR getTarget(OBJECTID &Value) noexcept {
       Value = this->TargetID;
@@ -3472,7 +3482,7 @@ class objScript : public Object {
    }
 
    inline ERR getCacheFile(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[22];
+      auto field = &this->Class->Dictionary[21];
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       return error;
@@ -3495,21 +3505,7 @@ class objScript : public Object {
    }
 
    inline ERR getLanguage(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[21];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getProcedure(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[1];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getPath(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[5];
+      auto field = &this->Class->Dictionary[20];
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       return error;
@@ -3538,6 +3534,16 @@ class objScript : public Object {
 
    // Customised field setting
 
+   inline ERR setPath(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[5];
+      return field->WriteValue(this, field, 0x00904500, &Value, 1);
+   }
+
+   inline ERR setProcedure(const std::string_view &Value) noexcept {
+      this->Procedure = Value;
+      return ERR::Okay;
+   }
+
    inline ERR setTarget(OBJECTID Value) noexcept {
       this->TargetID = Value;
       return ERR::Okay;
@@ -3555,7 +3561,7 @@ class objScript : public Object {
    }
 
    inline ERR setCacheFile(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[22];
+      auto field = &this->Class->Dictionary[21];
       return field->WriteValue(this, field, 0x00904300, &Value, 1);
    }
 
@@ -3567,16 +3573,6 @@ class objScript : public Object {
    inline ERR setWorkingPath(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
       return field->WriteValue(this, field, 0x00804300, &Value, 1);
-   }
-
-   inline ERR setProcedure(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
-   }
-
-   inline ERR setPath(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(this, field, 0x00904500, &Value, 1);
    }
 
    inline ERR setResults(const kt::vector<std::string> *Value) noexcept {

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2843,8 +2843,8 @@ namespace fl {
 struct StartStream { OBJECTID SubscriberID; FL Flags; int Length; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct StopStream { static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Delete { FUNCTION * Callback; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Move { CSTRING Dest; FUNCTION * Callback; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Copy { CSTRING Dest; FUNCTION * Callback; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Move { std::string_view Dest; FUNCTION * Callback; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Copy { std::string_view Dest; FUNCTION * Callback; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SetDate { int Year; int Month; int Day; int Hour; int Minute; int Second; FDT Type; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct ReadLine { STRING Result; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct BufferContent { static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
@@ -2941,11 +2941,11 @@ class objFile : public Object {
       struct fl::Delete args = { &Callback };
       return(Action(AC(-3), this, &args));
    }
-   inline ERR move(CSTRING Dest, FUNCTION Callback) noexcept {
+   inline ERR move(const std::string_view & Dest, FUNCTION Callback) noexcept {
       struct fl::Move args = { Dest, &Callback };
       return(Action(AC(-4), this, &args));
    }
-   inline ERR copy(CSTRING Dest, FUNCTION Callback) noexcept {
+   inline ERR copy(const std::string_view & Dest, FUNCTION Callback) noexcept {
       struct fl::Copy args = { Dest, &Callback };
       return(Action(AC(-5), this, &args));
    }

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -66,7 +66,7 @@ static bool check_for_key(std::string_view);
 static ERR parse_config(extConfig *, std::string_view);
 static ConfigGroup * find_group_wild(extConfig *Self, std::string_view Group);
 static void merge_groups(ConfigGroups &, ConfigGroups &);
-static std::string_view sort_key_value(const ConfigGroup &, CSTRING);
+static std::string_view sort_key_value(const ConfigGroup &, std::string_view);
 static void apply_filters(extConfig *);
 static void apply_key_filter(extConfig *, std::string_view);
 static void apply_group_filter(extConfig *, std::string_view);
@@ -231,8 +231,8 @@ DeleteKey: Deletes single key entries.
 This method deletes a single key from the Config object.
 
 -INPUT-
-cstr Group: The name of the targeted group.
-cstr Key: The name of the targeted key.
+cpp(strview) Group: The name of the targeted group.
+cpp(strview) Key: The name of the targeted key.
 
 -ERRORS-
 Okay
@@ -249,13 +249,14 @@ static ERR CONFIG_DeleteKey(extConfig *Self, struct cfg::DeleteKey *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Group) or (not Args->Key)) return ERR::NullArgs;
+   if ((not Args) or Args->Group.empty() or Args->Key.empty()) return ERR::NullArgs;
 
-   log.msg("Group: %s, Key: %s", Args->Group, Args->Key);
+   log.msg("Group: %.*s, Key: %.*s", int(Args->Group.size()), Args->Group.data(), int(Args->Key.size()),
+      Args->Key.data());
 
    for (auto & [group, keys] : Self->Groups) {
       if (group IS Args->Group) {
-         keys.erase(Args->Key);
+         if (auto it = keys.find(Args->Key); it != keys.end()) keys.erase(it);
          return ERR::Okay;
       }
    }
@@ -271,7 +272,7 @@ DeleteGroup: Deletes entire groups of configuration data.
 This method will delete an entire group of key-values from a config object if a matching group name is provided.
 
 -INPUT-
-cstr Group: The name of the group that will be deleted.
+cpp(strview) Group: The name of the group that will be deleted.
 
 -ERRORS-
 Okay: The group was deleted or does not exist.
@@ -285,7 +286,7 @@ mutates-object, idempotent
 
 static ERR CONFIG_DeleteGroup(extConfig *Self, struct cfg::DeleteGroup *Args)
 {
-   if ((not Args) or (not Args->Group)) return ERR::NullArgs;
+   if ((not Args) or Args->Group.empty()) return ERR::NullArgs;
 
    for (auto it = Self->Groups.begin(); it != Self->Groups.end(); it++) {
       if (it->first IS Args->Group) {
@@ -429,7 +430,7 @@ The path to the configuration file is all that is required.  Existing data in th
 source in cases where there matching set of group keys.
 
 -INPUT-
-cstr Path: The location of the configuration file that you want to merge.
+cpp(strview) Path: The location of the configuration file that you want to merge.
 
 -ERRORS-
 Okay
@@ -446,9 +447,9 @@ static ERR CONFIG_MergeFile(extConfig *Self, struct cfg::MergeFile *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Path)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Path.empty()) return log.warning(ERR::NullArgs);
 
-   log.branch("%s", Args->Path);
+   log.branch("%.*s", int(Args->Path.size()), Args->Path.data());
 
    extConfig::create src = { fl::Path(Args->Path) };
 
@@ -477,13 +478,13 @@ only for as long as the client has exclusive access to the config object.  The p
 if more information is written to the config object.  For this reason, consider copying the result if it will be
 used extensively.
 
-If the `Group` parameter is set to `NULL`, the scan routine will treat all of the config data as a one dimensional array.
-If the `Key` parameter is set to `NULL` then the first key in the requested group is returned.  If both parameters
-are `NULL` then the first known key value will be returned.
+If the `Group` parameter is empty, the scan routine will treat all of the config data as a one dimensional array.
+If the `Key` parameter is empty then the first key in the requested group is returned.  If both parameters are empty
+then the first known key value will be returned.
 
 -INPUT-
-cstr Group: The name of a group to examine for a key.  If `NULL`, all groups are scanned.
-cstr Key: The name of a key to retrieve (case sensitive).
+cpp(strview) Group: The name of a group to examine for a key.  If empty, all groups are scanned.
+cpp(strview) Key: The name of a key to retrieve (case sensitive).  If empty, the first key in the group is returned.
 &cstr Data: The key value will be stored in this parameter on returning.
 
 -ERRORS-
@@ -504,9 +505,9 @@ static ERR CONFIG_ReadValue(extConfig *Self, struct cfg::ReadValue *Args)
    if (not Args) return log.warning(ERR::NullArgs);
 
    for (auto & [group, keys] : Self->Groups) {
-      if ((Args->Group) and (group != Args->Group)) continue;
+      if ((not Args->Group.empty()) and (group != Args->Group)) continue;
 
-      if (not Args->Key) {
+      if (Args->Key.empty()) {
          if (keys.empty()) Args->Data = "";
          else Args->Data = keys.cbegin()->second.c_str();
          return ERR::Okay;
@@ -517,7 +518,8 @@ static ERR CONFIG_ReadValue(extConfig *Self, struct cfg::ReadValue *Args)
       }
    }
 
-   log.trace("Could not find key %s : %s.", Args->Group, Args->Key);
+   log.trace("Could not find key %.*s : %.*s.", int(Args->Group.size()), Args->Group.data(), int(Args->Key.size()),
+      Args->Key.data());
    Args->Data = nullptr;
    return ERR::Search;
 }
@@ -595,9 +597,9 @@ config object.  The error code `ERR::Search` is returned if this is the case.  P
 information on the behaviour of this function.
 
 -INPUT-
-cstr Group: The name of the group.  Wildcards are supported.
-cstr Key:  The name of the key.
-cstr Data: The data that will be added to the given group/key.
+cpp(strview) Group: The name of the group.  Wildcards are supported.
+cpp(strview) Key:  The name of the key.
+cpp(strview) Data: The data that will be added to the given group/key.
 
 -ERRORS-
 Okay
@@ -613,12 +615,13 @@ mutates-object, copies-input
 static ERR CONFIG_Set(extConfig *Self, struct cfg::Set *Args)
 {
    if (not Args) return ERR::NullArgs;
-   if ((not Args->Group) or (not Args->Group[0])) return ERR::NullArgs;
-   if ((not Args->Key) or (not Args->Key[0])) return ERR::NullArgs;
+   if (Args->Group.empty()) return ERR::NullArgs;
+   if (Args->Key.empty()) return ERR::NullArgs;
 
    auto group = find_group_wild(Self, Args->Group);
    if (group) {
-      group->second[Args->Key] = Args->Data;
+      if (auto it = group->second.find(Args->Key); it != group->second.end()) it->second.assign(Args->Data);
+      else group->second.emplace(Args->Key, Args->Data);
       return ERR::Okay;
    }
    else return ERR::Search;
@@ -633,7 +636,7 @@ The SortByKey() method sorts the groups of a config object by key values (the na
 every group).
 
 -INPUT-
-cstr Key: The name of the key to sort on.
+cpp(strview) Key: The name of the key to sort on.
 int Descending: Set to true if a descending sort is required.
 
 -ERRORS-
@@ -648,7 +651,7 @@ mutates-object
 
 static ERR CONFIG_SortByKey(extConfig *Self, struct cfg::SortByKey *Args)
 {
-   if ((not Args) or (not Args->Key)) { // Sort by group name if no args provided.
+   if ((not Args) or Args->Key.empty()) { // Sort by group name if no args or key provided.
       std::sort(Self->Groups.begin(), Self->Groups.end(),
          [](const ConfigGroup &a, const ConfigGroup &b ) {
          return a.first < b.first;
@@ -659,7 +662,7 @@ static ERR CONFIG_SortByKey(extConfig *Self, struct cfg::SortByKey *Args)
 
    kt::Log log;
 
-   log.branch("Key: %s, Descending: %d", Args->Key, Args->Descending);
+   log.branch("Key: %.*s, Descending: %d", int(Args->Key.size()), Args->Key.data(), Args->Descending);
 
    auto descending = Args->Descending;
    std::sort(Self->Groups.begin(), Self->Groups.end(),
@@ -682,9 +685,9 @@ value are required.  If the `Group` and `Key` arguments match an existing entry 
 that entry will be replaced with the new Data value.
 
 -INPUT-
-cstr Group: The name of the group.
-cstr Key:   The name of the key.
-cstr Data:  The data that will be added to the given group/key.
+cpp(strview) Group: The name of the group.
+cpp(strview) Key:   The name of the key.
+cpp(strview) Data:  The data that will be added to the given group/key.
 
 -ERRORS-
 Okay
@@ -702,10 +705,10 @@ static ERR CONFIG_WriteValue(extConfig *Self, struct cfg::WriteValue *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Group) or (not Args->Key)) return log.warning(ERR::NullArgs);
-   if ((not Args->Group[0]) or (not Args->Key[0])) return log.warning(ERR::EmptyString);
+   if ((not Args) or Args->Group.empty() or Args->Key.empty()) return log.warning(ERR::NullArgs);
 
-   log.trace("%s.%s = %s", Args->Group, Args->Key, Args->Data);
+   log.trace("%.*s.%.*s = %.*s", int(Args->Group.size()), Args->Group.data(), int(Args->Key.size()),
+      Args->Key.data(), int(Args->Data.size()), Args->Data.data());
 
    return Self->write(Args->Group, Args->Key, Args->Data);
 }
@@ -888,7 +891,7 @@ static void merge_groups(ConfigGroups &Dest, ConfigGroups &Source)
 
 //********************************************************************************************************************
 
-static std::string_view sort_key_value(const ConfigGroup &Group, CSTRING Key)
+static std::string_view sort_key_value(const ConfigGroup &Group, std::string_view Key)
 {
    if (auto it = Group.second.find(Key); it != Group.second.end()) return it->second;
    else return {};

--- a/src/core/classes/class_config_def.c
+++ b/src/core/classes/class_config_def.c
@@ -8,14 +8,14 @@ static const struct FieldDef clConfigFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maReadValue[] = { { "Group", FD_STR }, { "Key", FD_STR }, { "Data", FD_STR|FD_RESULT }, { 0, 0 } };
-FDEF maSet[] = { { "Group", FD_STR }, { "Key", FD_STR }, { "Data", FD_STR }, { 0, 0 } };
-FDEF maWriteValue[] = { { "Group", FD_STR }, { "Key", FD_STR }, { "Data", FD_STR }, { 0, 0 } };
-FDEF maDeleteKey[] = { { "Group", FD_STR }, { "Key", FD_STR }, { 0, 0 } };
-FDEF maDeleteGroup[] = { { "Group", FD_STR }, { 0, 0 } };
+FDEF maReadValue[] = { { "Group", FD_CPP|FD_STR }, { "Key", FD_CPP|FD_STR }, { "Data", FD_STR|FD_RESULT }, { 0, 0 } };
+FDEF maSet[] = { { "Group", FD_CPP|FD_STR }, { "Key", FD_CPP|FD_STR }, { "Data", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maWriteValue[] = { { "Group", FD_CPP|FD_STR }, { "Key", FD_CPP|FD_STR }, { "Data", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maDeleteKey[] = { { "Group", FD_CPP|FD_STR }, { "Key", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maDeleteGroup[] = { { "Group", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF maGetGroupFromIndex[] = { { "Index", FD_INT }, { "Group", FD_STR|FD_RESULT }, { 0, 0 } };
-FDEF maSortByKey[] = { { "Key", FD_STR }, { "Descending", FD_INT }, { 0, 0 } };
-FDEF maMergeFile[] = { { "Path", FD_STR }, { 0, 0 } };
+FDEF maSortByKey[] = { { "Key", FD_CPP|FD_STR }, { "Descending", FD_INT }, { 0, 0 } };
+FDEF maMergeFile[] = { { "Path", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF maMerge[] = { { "Source", FD_OBJECTPTR }, { 0, 0 } };
 
 static const struct MethodEntry clConfigMethods[] = {

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -419,7 +419,7 @@ copied to the new location.  If an error occurs when copying a sub-folder or fil
 and an error code will be returned.
 
 -INPUT-
-cstr Dest: The destination file path for the copy operation.
+cpp(strview) Dest: The destination file path for the copy operation.
 ptr(func) Callback: Optional callback for receiving feedback during the operation.
 
 -ERRORS-
@@ -878,7 +878,7 @@ destination path then it will be over-written with the new data.
 The #Position field will be reset as a result of calling this method.
 
 -INPUT-
-cstr Dest: The desired path for the file.
+cpp(strview) Dest: The desired path for the file.
 ptr(func) Callback: Optional callback for receiving feedback during the operation.
 
 -ERRORS-
@@ -897,13 +897,13 @@ static ERR FILE_MoveFile(extFile *Self, struct fl::Move *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Dest) or (not Args->Dest[0])) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Dest.empty()) return log.warning(ERR::NullArgs);
    if (Self->Path.empty()) return log.warning(ERR::FieldNotSet);
 
    auto src = std::string_view(Self->Path);
-   auto dest = std::string_view(Args->Dest, strlen(Args->Dest));
+   auto dest = Args->Dest;
 
-   log.msg("%s to %s", src.data(), dest.data());
+   log.msg("%.*s to %.*s", int(src.size()), src.data(), int(dest.size()), dest.data());
 
    if ((dest.ends_with('/')) or (dest.ends_with('\\')) or (dest.ends_with(':'))) {
       // If a trailing slash has been specified, we are moving the file into a folder, rather than to a direct path.
@@ -925,7 +925,7 @@ static ERR FILE_MoveFile(extFile *Self, struct fl::Move *Args)
       if ((error = fs_copy(src, newpath, Args->Callback, true)) IS ERR::Okay) {
          Self->Path.assign(newpath);
       }
-      else log.warning("Failed to move %s to %s", src.data(), newpath.data());
+      else log.warning("Failed to move %.*s to %s", int(src.size()), src.data(), newpath.c_str());
 
       return error;
    }

--- a/src/core/classes/class_file_def.c
+++ b/src/core/classes/class_file_def.c
@@ -22,8 +22,8 @@ static const struct FieldDef clFileFlags[] = {
 
 FDEF maStartStream[] = { { "Subscriber", FD_OBJECTID }, { "Flags", FD_INT }, { "Length", FD_INT }, { 0, 0 } };
 FDEF maDelete[] = { { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maMove[] = { { "Dest", FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maCopy[] = { { "Dest", FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
+FDEF maMove[] = { { "Dest", FD_CPP|FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
+FDEF maCopy[] = { { "Dest", FD_CPP|FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
 FDEF maSetDate[] = { { "Year", FD_INT }, { "Month", FD_INT }, { "Day", FD_INT }, { "Hour", FD_INT }, { "Minute", FD_INT }, { "Second", FD_INT }, { "Type", FD_INT }, { 0, 0 } };
 FDEF maReadLine[] = { { "Result", FD_STR|FD_RESULT }, { 0, 0 } };
 FDEF maNext[] = { { "File", FD_OBJECTPTR|FD_ALLOC|FD_RESULT }, { 0, 0 } };

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -142,7 +142,7 @@ implementation.
 The resulting log information is returned as a string, which needs to be deallocated once no longer required.
 
 -INPUT-
-cstr Options: Options to pass to the underlying language.
+cpp(strview) Options: Options to pass to the underlying language.
 &!cstr Result: Resulting log information.
 
 -ERRORS-
@@ -232,7 +232,7 @@ if the `Int` field is defined then an `FD_INT` `Type` must be used.  Supplementa
 documented in detail in the Kotuku Wiki.
 
 -INPUT-
-cstr Procedure: The name of the procedure to execute, or NULL for the default entry point.
+cpp(strview) Procedure: The name of the procedure to execute, or leave empty for the default entry point.
 cstruct(*ScriptArg) Args: Optional parameters to pass to the procedure.
 int TotalArgs: Total number of `Args` provided.
 
@@ -257,8 +257,7 @@ static ERR SCRIPT_Exec(objScript *Self, struct sc::Exec *Args)
    auto save_id = Self->ProcedureID;
    auto save_name = std::move(Self->Procedure);
    Self->ProcedureID = 0;
-   if (Args->Procedure) Self->Procedure = Args->Procedure;
-   else Self->Procedure.clear();
+   Self->Procedure = Args->Procedure;
 
    const ScriptArg *save_args = Self->ProcArgs;
    Self->ProcArgs  = Args->Args;
@@ -302,7 +301,7 @@ reference, call #DerefProcedure() once access to the procedure is no longer requ
 destroying the script will also dereference all procedures.
 
 -INPUT-
-cstr Procedure:   The name of the procedure.
+cpp(strview) Procedure:   The name of the procedure.
 &large ProcedureID: The computed ID will be returned in this parameter.
 
 -ERRORS-
@@ -319,7 +318,7 @@ static ERR SCRIPT_GetProcedureID(objScript *Self, struct sc::GetProcedureID *Arg
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Procedure) or (not Args->Procedure[0])) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Procedure.empty()) return log.warning(ERR::NullArgs);
    Args->ProcedureID = strihash(Args->Procedure);
    return ERR::Okay;
 }
@@ -623,7 +622,7 @@ static ERR SET_Path(objScript *Self, std::string_view &Value)
 /*********************************************************************************************************************
 
 -FIELD-
-Procedure: Specifies a procedure to be executed from within a script.
+Procedure: Specifies a procedure name to be executed.
 
 Sometimes scripts are split into several procedures or functions that can be executed independently from the 'main'
 area of the script.  If a loaded script contains procedures, the client can set the Procedure field to execute a
@@ -631,22 +630,6 @@ specific routine whenever the script is activated with the #Activate() action.
 
 If this field is not set, the first procedure in the script, or the 'main' procedure (as defined by the script type) is
 executed by default.
-
-*********************************************************************************************************************/
-
-static ERR GET_Procedure(objScript *Self, std::string_view &Value)
-{
-   Value = Self->Procedure;
-   return Self->Procedure.empty() ? ERR::FieldNotSet : ERR::Okay;
-}
-
-static ERR SET_Procedure(objScript *Self, std::string_view &Value)
-{
-   Self->Procedure.assign(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Results: Stores multiple string results for languages that support this feature.
@@ -804,6 +787,8 @@ static ERR SET_WorkingPath(objScript *Self, std::string_view &Value)
 #include "class_script_def.c"
 
 static const FieldArray clScriptFields[] = {
+   { "Procedure",   FDF_CPPSTRING|FDF_RW|FDF_PURE },
+   { "Path",        FDF_CPPSTRING|FDF_RI|FDF_PURE, nullptr, SET_Path },
    { "Target",      FDF_OBJECTID|FDF_RW },
    { "Flags",       FDF_INTFLAGS|FDF_RI, nullptr, nullptr, &clScriptFlags },
    { "Error",       FDF_INT|FDF_R },
@@ -812,11 +797,8 @@ static const FieldArray clScriptFields[] = {
    // Virtual Fields
    { "CacheFile",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_CacheFile, SET_CacheFile },
    { "ErrorMessage", FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_ErrorMessage, SET_ErrorMessage },
-   { "WorkingPath",  FDF_CPPSTRING|FDF_RW,             GET_WorkingPath, SET_WorkingPath },
+   { "WorkingPath",  FDF_CPPSTRING|FDF_RW,                      GET_WorkingPath, SET_WorkingPath },
    { "Language",     FDF_CPPSTRING|FDF_R|FDF_PURE,              GET_Language },
-   { "Location",     FDF_SYNONYM|FDF_CPPSTRING|FDF_RI|FDF_PURE, GET_Path, SET_Path },
-   { "Procedure",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_Procedure, SET_Procedure },
-   { "Path",         FDF_CPPSTRING|FDF_RI|FDF_PURE,             GET_Path, SET_Path },
    { "Results",      FDF_ARRAY|FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_Results, SET_Results },
    { "Src",          FDF_SYNONYM|FDF_CPPSTRING|FDF_RI|FDF_PURE, GET_Path, SET_Path },
    { "Statement",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_String, SET_String },

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -520,7 +520,7 @@ valid existing object).
 static ERR GET_Path(objScript *Self, std::string_view &Value)
 {
    Value = Self->Path;
-   return Self->Path.empty() ? ERR::FieldNotSet : ERR::Okay;
+   return ERR::Okay;
 }
 
 static ERR SET_Path(objScript *Self, std::string_view &Value)
@@ -669,14 +669,13 @@ It is also commonly used for executing scripts that have been embedded into prog
 static ERR GET_String(objScript *Self, std::string_view &Value)
 {
    Value = Self->String;
-   return Self->String.empty() ? ERR::FieldNotSet : ERR::Okay;
+   return ERR::Okay;
 }
 
 static ERR SET_String(objScript *Self, std::string_view &Value)
 {
    Self->Path.clear(); // Path removed when a statement string is being set
    Self->String.assign(check_bom(Value));
-
    return ERR::Okay;
 }
 
@@ -803,8 +802,8 @@ static const FieldArray clScriptFields[] = {
    { "Src",          FDF_SYNONYM|FDF_CPPSTRING|FDF_RI|FDF_PURE, GET_Path, SET_Path },
    { "Statement",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_String, SET_String },
    { "String",       FDF_SYNONYM|FDF_CPPSTRING|FDF_RW|FDF_PURE, GET_String, SET_String },
-   { "TotalArgs",    FDF_INT|FDF_R|FDF_PURE,                    GET_TotalArgs, nullptr },
-   { "Variables",    FDF_POINTER|FDF_SYSTEM|FDF_R|FDF_PURE,     GET_Variables, nullptr },
+   { "TotalArgs",    FDF_INT|FDF_R|FDF_PURE,                    GET_TotalArgs },
+   { "Variables",    FDF_POINTER|FDF_SYSTEM|FDF_R|FDF_PURE,     GET_Variables },
    END_FIELD
 };
 

--- a/src/core/classes/class_script_def.c
+++ b/src/core/classes/class_script_def.c
@@ -7,11 +7,11 @@ static const struct FieldDef clScriptFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maExec[] = { { "Procedure", FD_STR }, { "ScriptArg:Args", FD_PTR|FD_STRUCT }, { "TotalArgs", FD_INT }, { 0, 0 } };
+FDEF maExec[] = { { "Procedure", FD_CPP|FD_STR }, { "ScriptArg:Args", FD_PTR|FD_STRUCT }, { "TotalArgs", FD_INT }, { 0, 0 } };
 FDEF maDerefProcedure[] = { { "Procedure", FD_FUNCTIONPTR }, { 0, 0 } };
 FDEF maCallback[] = { { "ProcedureID", FD_INT64 }, { "ScriptArg:Args", FD_PTR|FD_STRUCT }, { "TotalArgs", FD_INT }, { "Error", FD_INT|FD_ERROR|FD_RESULT }, { 0, 0 } };
-FDEF maGetProcedureID[] = { { "Procedure", FD_STR }, { "ProcedureID", FD_INT64|FD_RESULT }, { 0, 0 } };
-FDEF maDebugLog[] = { { "Options", FD_STR }, { "Result", FD_STR|FD_ALLOC|FD_RESULT }, { 0, 0 } };
+FDEF maGetProcedureID[] = { { "Procedure", FD_CPP|FD_STR }, { "ProcedureID", FD_INT64|FD_RESULT }, { 0, 0 } };
+FDEF maDebugLog[] = { { "Options", FD_CPP|FD_STR }, { "Result", FD_STR|FD_ALLOC|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clScriptMethods[] = {
    { AC(-1), (APTR)SCRIPT_Exec, "Exec", maExec, sizeof(struct sc::Exec) },

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1434,6 +1434,8 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
   })
 
   klass("Script", { src={ "../classes/class_script.cpp" }, output="../classes/class_script_def.c" }, [[
+    cpp(str) Path        # Location of the script
+    cpp(str) Procedure   # Specifies a procedure name to be executed
     oid Target           # The object that script objects must be initialised to, e.g. for obj.new()
     int(SCF) Flags       # Optional flags
     error Error          # If an error occurred, this field will indicate the error number
@@ -1446,11 +1448,9 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
    kt::vector<std::string> Results;
    char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
-   std::string Path;              // File location of the script
    std::string String;
    std::string WorkingPath;
    std::string ErrorMessage;
-   std::string Procedure;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
    int      TotalArgs;            // Total number of ProcArgs

--- a/src/core/tests/test_config.tiri
+++ b/src/core/tests/test_config.tiri
@@ -136,7 +136,7 @@ end
    err = cfg.mtMerge(cfgMerge);
    assert(err is ERR_Okay, 'Merge() returned ' .. mSys.GetErrorMsg(err))
 
-   err, value = cfg.mtReadValue(nil, 'Styles')
+   err, value = cfg.mtReadValue('', 'Styles')
    assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
 
    err, value = cfg.mtReadValue('MergedGroup', 'Hello')
@@ -274,6 +274,61 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function ReadValueEmptySelectors()
+   cfg = new_config()
+
+   err, value = cfg.mtReadValue('', 'Styles')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'Bold,Bold Italic,Italic,Regular', 'Empty group selector returned ' .. tostring(value))
+
+   err, value = cfg.mtReadValue('Clean', '')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'fonts:fixed/clean.fon', 'Empty key selector returned ' .. tostring(value))
+
+   err, value = cfg.mtReadValue('', '')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is 'fonts:fixed/clean.fon', 'Empty selectors returned ' .. tostring(value))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function EmptyRequiredStringArguments()
+   cfg = new_config()
+
+   err = cfg.mtWriteValue('', 'Name', 'Value')
+   assert(err is ERR_NullArgs, 'Expected WriteValue() to reject an empty group, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtWriteValue('Clean', '', 'Value')
+   assert(err is ERR_NullArgs, 'Expected WriteValue() to reject an empty key, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtSet('', 'Name', 'Value')
+   assert(err is ERR_NullArgs, 'Expected Set() to reject an empty group, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtSet('Clean', '', 'Value')
+   assert(err is ERR_NullArgs, 'Expected Set() to reject an empty key, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtDeleteKey('', 'Name')
+   assert(err is ERR_NullArgs, 'Expected DeleteKey() to reject an empty group, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtDeleteKey('Clean', '')
+   assert(err is ERR_NullArgs, 'Expected DeleteKey() to reject an empty key, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtDeleteGroup('')
+   assert(err is ERR_NullArgs, 'Expected DeleteGroup() to reject an empty group, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtMergeFile('')
+   assert(err is ERR_NullArgs, 'Expected MergeFile() to reject an empty path, got ' .. mSys.GetErrorMsg(err))
+
+   err = cfg.mtWriteValue('EmptyValue', 'Name', '')
+   assert(err is ERR_Okay, 'WriteValue() should allow an empty data value, got ' .. mSys.GetErrorMsg(err))
+
+   err, value = cfg.mtReadValue('EmptyValue', 'Name')
+   assert(err is ERR_Okay, 'ReadValue() returned ' .. mSys.GetErrorMsg(err))
+   assert(value is '', 'Expected an empty value, received ' .. tostring(value))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function Sorting()
    cfg = new_config()
 
@@ -286,6 +341,22 @@ end
    assert(groupName is 'Courier Sans', 'Second group is incorrect, returned ' .. groupName)
    err, groupName = cfg.mtGetGroupFromIndex(2)
    assert(groupName is 'Alpha', 'Third group is incorrect, returned ' .. groupName)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function SortingByEmptyKeyUsesGroupName()
+   cfg = new_config()
+
+   err = cfg.mtSortByKey('', false)
+   assert(err is ERR_Okay, 'SortByKey() returned ' .. mSys.GetErrorMsg(err))
+
+   err, groupName = cfg.mtGetGroupFromIndex(0)
+   assert(groupName is 'Alpha', 'First group is incorrect, returned ' .. groupName)
+   err, groupName = cfg.mtGetGroupFromIndex(1)
+   assert(groupName is 'Clean', 'Second group is incorrect, returned ' .. groupName)
+   err, groupName = cfg.mtGetGroupFromIndex(2)
+   assert(groupName is 'Courier Sans', 'Third group is incorrect, returned ' .. groupName)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -803,7 +803,7 @@ ERR RefreshFonts(void)
    scan_fixed_folder(glConfig);
    scan_truetype_folder(glConfig);
 
-   if (auto error = glConfig->sortByKey(nullptr, false); error != ERR::Okay) return error; // Sort by font name.
+   if (auto error = glConfig->sortByKey("", false); error != ERR::Okay) return error; // Sort by font name.
 
    // Create a style list for each font, e.g.
    //

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -20,7 +20,6 @@ struct luaL_Reg {
 
 extern void luaL_openlib(lua_State *, const char *, const luaL_Reg *, int);
 extern void luaL_register(lua_State *, const char *, const luaL_Reg *);
-extern int luaL_getmetafield(lua_State *, int, const char *);
 extern int luaL_typerror(lua_State *, int, const char *);
 extern int luaL_argerror(lua_State *, int, const char *);
 extern const char * luaL_checklstring(lua_State *, int, size_t * = nullptr);

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -21,7 +21,6 @@ struct luaL_Reg {
 extern void luaL_openlib(lua_State *, const char *, const luaL_Reg *, int);
 extern void luaL_register(lua_State *, const char *, const luaL_Reg *);
 extern int luaL_getmetafield(lua_State *, int, const char *);
-extern int luaL_callmeta(lua_State *, int, const char *);
 extern int luaL_typerror(lua_State *, int, const char *);
 extern int luaL_argerror(lua_State *, int, const char *);
 extern const char * luaL_checklstring(lua_State *, int, size_t * = nullptr);

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1044,22 +1044,6 @@ extern int lua_getmetatable(lua_State *L, int idx)
 }
 
 //********************************************************************************************************************
-// Get metatable field by string key
-
-extern int luaL_getmetafield(lua_State *L, int idx, CSTRING field)
-{
-   if (lua_getmetatable(L, idx)) {
-      cTValue *tv = lj_tab_getstr(tabV(L->top - 1), lj_str_newz(L, field));
-      if (tv and !tvisnil(tv)) {
-         copyTV(L, L->top - 1, tv);
-         return 1;
-      }
-      L->top--;
-   }
-   return 0;
-}
-
-//********************************************************************************************************************
 // Get function/userdata/thread environment table
 
 extern void lua_getfenv(lua_State *L, int idx)

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -993,11 +993,11 @@ extern void lua_gettable(lua_State *L, int idx)
 //********************************************************************************************************************
 // Get table field by string key
 
-extern void lua_getfield(lua_State *L, int idx, CSTRING k)
+extern void lua_getfield(lua_State *L, int idx, std::string_view k)
 {
    cTValue *t = index2adr_check(L, idx);
    TValue key;
-   setstrV(L, &key, lj_str_newz(L, k));
+   setstrV(L, &key, lj_str_newsv(L, k));
    cTValue *v = lj_meta_tget(L, t, &key);
    if (v IS nullptr) v = MetaCall::invokeGet(L);
    copyTV(L, L->top, v);
@@ -1396,53 +1396,6 @@ extern int lua_pcall(lua_State *L, int nargs, int nresults, int errfunc)
    status = lj_vm_pcall(L, api_call_base(L, nargs), nresults + 1, ef);
    if (status) hook_restore(g, oldh);
    return status;
-}
-
-//********************************************************************************************************************
-// Prepare C function call with userdata argument
-
-static TValue* cpcall(lua_State *L, lua_CFunction func, void* ud)
-{
-   GCfunc* fn = lj_func_newC(L, 0, getcurrenv(L));
-   TValue* top = L->top;
-   fn->c.f = func;
-   setfuncV(L, top++, fn);
-   setnilV(top++);
-   ud = lj_lightud_intern(L, ud);
-   setrawlightudV(top++, ud);
-   cframe_nres(L->cframe) = 1 + 0;  //  Zero results.
-   L->top = top;
-   return top - 1;  //  Now call the newly allocated C function.
-}
-
-//********************************************************************************************************************
-// Call C function with error handling
-
-extern int lua_cpcall(lua_State *L, lua_CFunction func, void *ud)
-{
-   global_State *g = G(L);
-   uint8_t oldh = hook_save(g);
-   int status;
-   lj_checkapi(L->status IS LUA_OK or L->status IS LUA_ERRERR, "thread called in wrong state %d", L->status);
-   status = lj_vm_cpcall(L, func, ud, cpcall);
-   if (status) hook_restore(g, oldh);
-   return status;
-}
-
-//********************************************************************************************************************
-// Call metamethod function
-
-extern int luaL_callmeta(lua_State *L, int idx, const char *field)
-{
-   if (luaL_getmetafield(L, idx, field)) {
-      TValue* top = L->top--;
-      setnilV(top++);
-      copyTV(L, top++, index2adr(L, idx));
-      L->top = top;
-      lj_vm_call(L, top - 1, 1 + 1);
-      return 1;
-   }
-   return 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -151,7 +151,7 @@ extern int   (lua_pushthread) (lua_State *L);
 enum class AET : uint8_t;
 
 extern void   lua_gettable(lua_State *L, int idx);
-extern void   lua_getfield(lua_State *L, int idx, const char *k);
+extern void   lua_getfield(lua_State *L, int idx, std::string_view k);
 extern void   lua_rawget(lua_State *L, int idx);
 extern void   lua_rawgeti(lua_State *L, int idx, int n);
 extern void   lua_createtable(lua_State *L, int narr, int nrec);
@@ -180,7 +180,6 @@ extern int   (lua_setfenv) (lua_State *L, int idx);
 
 extern void lua_call(lua_State *L, int nargs, int nresults);
 extern int  lua_pcall(lua_State *L, int nargs, int nresults, int errfunc);
-extern int  lua_cpcall(lua_State *L, lua_CFunction func, void *ud);
 extern int  lua_load(lua_State *L, std::string_view, const char *chunk_name);
 extern int  lua_dump(lua_State *L, lua_Writer writer, void *data);
 
@@ -231,7 +230,7 @@ inline void lua_pushliteral(lua_State *L, const char (&S)[N]) {
    lua_pushlstring(L, S, N - 1);
 }
 
-inline void lua_getglobal(lua_State *L, const char *S) {
+inline void lua_getglobal(lua_State *L, std::string_view S) {
    lua_getfield(L, LUA_GLOBALSINDEX, S);
 }
 

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -902,7 +902,7 @@ static ERR run_script(objScript *Self)
    int top;
    bool pcall_failed = false;
    if ((not Self->Procedure.empty()) or (Self->ProcedureID)) {
-      if (not Self->Procedure.empty()) lua_getglobal(prv->Lua, Self->Procedure.c_str());
+      if (not Self->Procedure.empty()) lua_getglobal(prv->Lua, Self->Procedure);
       else lua_rawgeti(prv->Lua, LUA_REGISTRYINDEX, Self->ProcedureID);
 
       if (lua_isfunction(prv->Lua, -1)) {

--- a/src/tiri/tiri_class_methods.cpp
+++ b/src/tiri/tiri_class_methods.cpp
@@ -308,8 +308,8 @@ static void emit_globals_info(prvTiri *Prv, std::ostringstream &Buf, bool Compac
    int count = 0;
    lua_pushnil(Prv->Lua);
    while (lua_next(Prv->Lua, storage_table_idx)) {
-      CSTRING key = lua_tostring(Prv->Lua, -2);
-      int type = lua_type(Prv->Lua, -1);
+      auto key = lua_tostringview(Prv->Lua, -2);
+      auto type = lua_type(Prv->Lua, -1);
 
       std::string value;
 
@@ -318,11 +318,14 @@ static void emit_globals_info(prvTiri *Prv, std::ostringstream &Buf, bool Compac
             case LUA_TBOOLEAN: value = lua_toboolean(Prv->Lua, -1) ? "true" : "false"; break;
             case LUA_TNUMBER:  value = lua_tostring(Prv->Lua, -1); break;
             case LUA_TSTRING: {
-               size_t len;
-               CSTRING str = lua_tolstring(Prv->Lua, -1, &len);
-               std::string_view sv(str, len);
-               if (len > 40) value = "\"" + std::string(sv.substr(0, 40)) + "...\"";
-               else value = "\"" + std::string(sv) + "\"";
+               auto sv = lua_tostringview(Prv->Lua, -1);
+               value.append("\"");
+               if (sv.size() > 40) {
+                  value.append(sv.substr(0, 40));
+                  value.append("...");
+               }
+               else value.append(sv);
+               value.append("\"");
                break;
             }
          }
@@ -425,7 +428,7 @@ static ERR TIRI_DebugLog(objScript *Self, struct sc::DebugLog *Args)
    auto prv = (prvTiri *)Self->DerivedPtr;
    if (not prv->Lua) return log.warning(ERR::NotInitialised);
 
-   log.branch("Options: %s", Args->Options ? Args->Options : "(none)");
+   log.branch("Options: %.*s", int(Args->Options.size()), Args->Options.data());
 
    // Parse options (CSV list)
 
@@ -446,7 +449,7 @@ static ERR TIRI_DebugLog(objScript *Self, struct sc::DebugLog *Args)
       return haystack.find(needle) != std::string_view::npos;
    };
 
-   if (Args->Options) {
+   if (not Args->Options.empty()) {
       const std::string_view options = Args->Options;
 
       if (has_option(options, "all")) {
@@ -712,20 +715,20 @@ static ERR TIRI_GetProcedureID(objScript *Self, struct sc::GetProcedureID *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Procedure) or (not Args->Procedure[0])) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Procedure.empty()) return log.warning(ERR::NullArgs);
 
    auto prv = (prvTiri *)Self->DerivedPtr;
    if (not prv) return log.warning(ERR::ObjectCorrupt);
 
    if ((not prv->Lua) or (not Self->ActivationCount)) {
-      log.warning("Cannot resolve function '%s'.  Script requires activation.", Args->Procedure);
+      log.warning("Cannot resolve function '%.*s'.  Script requires activation.", int(Args->Procedure.size()), Args->Procedure.data());
       return ERR::NotFound;
    }
 
    lua_getglobal(prv->Lua, Args->Procedure);
    if (not lua_isfunction(prv->Lua, -1)) {
       lua_pop(prv->Lua, 1);
-      log.warning("Failed to resolve function name '%s' to an ID.", Args->Procedure);
+      log.warning("Failed to resolve function name '%.*s' to an ID.", int(Args->Procedure.size()), Args->Procedure.data());
       return ERR::NotFound;
    }
 
@@ -735,7 +738,7 @@ static ERR TIRI_GetProcedureID(objScript *Self, struct sc::GetProcedureID *Args)
       return ERR::Okay;
    }
    else {
-      log.warning("Failed to resolve function name '%s' to an ID.", Args->Procedure);
+      log.warning("Failed to resolve function name '%.*s' to an ID.", int(Args->Procedure.size()), Args->Procedure.data());
       return ERR::NotFound;
    }
 }

--- a/tools/idl/include/functions.tiri
+++ b/tools/idl/include/functions.tiri
@@ -954,6 +954,22 @@ global function klass(Name, Options:table, Spec, Private, Custom)
 
    -- Export method definitions for a class
 
+   function actionMethodStorageType(Param:table):str
+      local param_type = Param.basicType
+      local reference = false
+
+      if param_type:endsWith('&') then
+         param_type = param_type:sub(0, -2):trim()
+         reference = true
+      end
+
+      if reference and param_type:startsWith('const ') then
+         param_type = param_type:sub(6):trim()
+      end
+
+      return param_type
+   end
+
    if cl.methods then
       pfx  = cl.methodPrefix
       lpfx = pfx:lower()
@@ -1002,7 +1018,7 @@ global function klass(Name, Options:table, Spec, Private, Custom)
          params = ''
          if method.params then
             for param in values(method.params) do
-               struct_params ..= param.basicType .. ' ' .. pName(param) .. '; '
+               struct_params ..= actionMethodStorageType(param) .. ' ' .. pName(param) .. '; '
 
                if params?? then params ..= ', ' end
 
@@ -1015,7 +1031,7 @@ global function klass(Name, Options:table, Spec, Private, Custom)
                   if v?? then v ..= ', ' end
 
                   if param.resultValue then
-                     v ..= '(' .. param.basicType .. ')0'
+                     v ..= '(' .. actionMethodStorageType(param) .. ')0'
                      results = true
                   else
                      v ..= pName(param)


### PR DESCRIPTION
## Summary

- Converts generated Config, File, and Script method string arguments from C strings to `std::string_view` storage and call paths.
- Updates Script procedure lookup and Lua field access to use length-aware string handling.
- Removes unused Lua compatibility helpers and extends Config tests for empty selector and required string argument behaviour.

## Validation

- `cmake --build build/wsl-agents --target tiri --parallel`