### PR TITLE
[codex] Upgrade Task string methods

### DIFF
--- a/docs/xml/modules/classes/compression.xml
+++ b/docs/xml/modules/classes/compression.xml
@@ -80,11 +80,11 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>CompressFile</name>
       <comment>Add files to a compression object.</comment>
-      <prototype>ERR cmp::CompressFile(OBJECTPTR Object, CSTRING Location, CSTRING Path)</prototype>
+      <prototype>ERR cmp::CompressFile(OBJECTPTR Object, const std::string_view &amp; Location, const std::string_view &amp; Path)</prototype>
       <tiriPrototype>err = CompressFile(Location:str, Path:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Location">The location of the file(s) to add.</param>
-        <param type="CSTRING" name="Path">The path that is prefixed to the file name when added to the compression object.  May be <code>NULL</code> for no path.</param>
+        <param type="const std::string_view &amp;" name="Location">The location of the file(s) to add.</param>
+        <param type="const std::string_view &amp;" name="Path">The path that is prefixed to the file name when added to the compression object.  May be empty for no path.</param>
       </input>
       <description>
 <p>The CompressFile method is used to add new files and folders to a compression object. The client must supply the <code>Location</code> of the file to compress, as well as the <code>Path</code> that is prefixed to the file name when it is in the compression object.  The <code>Location</code> parameter accepts wildcards, allowing multiple files to be processed in a single function call.</p>
@@ -217,11 +217,11 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>DecompressFile</name>
       <comment>Extracts one or more files from a compression object.</comment>
-      <prototype>ERR cmp::DecompressFile(OBJECTPTR Object, CSTRING Path, CSTRING Dest, INT Flags)</prototype>
+      <prototype>ERR cmp::DecompressFile(OBJECTPTR Object, const std::string_view &amp; Path, const std::string_view &amp; Dest, INT Flags)</prototype>
       <tiriPrototype>err = DecompressFile(Path:str, Dest:str, Flags:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Path">The full path name of the file to extract from the archive.</param>
-        <param type="CSTRING" name="Dest">The destination to extract the file to.</param>
+        <param type="const std::string_view &amp;" name="Path">The full path name of the file to extract from the archive.</param>
+        <param type="const std::string_view &amp;" name="Dest">The destination to extract the file to.</param>
         <param type="INT" name="Flags">Optional flags.  Currently unused.</param>
       </input>
       <description>
@@ -247,10 +247,10 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>DecompressObject</name>
       <comment>Decompresses one file to a target object.</comment>
-      <prototype>ERR cmp::DecompressObject(OBJECTPTR Object, CSTRING Path, OBJECTPTR Object)</prototype>
+      <prototype>ERR cmp::DecompressObject(OBJECTPTR Object, const std::string_view &amp; Path, OBJECTPTR Object)</prototype>
       <tiriPrototype>err = DecompressObject(Path:str, Object:obj)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Path">The location of the source file within the archive.  If a wildcard is used, the first matching file is extracted.</param>
+        <param type="const std::string_view &amp;" name="Path">The location of the source file within the archive.  If a wildcard is used, the first matching file is extracted.</param>
         <param type="OBJECTPTR" name="Object">The target object for the decompressed source data.</param>
       </input>
       <description>
@@ -335,10 +335,10 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>Find</name>
       <comment>Find the first item that matches a given filter.</comment>
-      <prototype>ERR cmp::Find(OBJECTPTR Object, CSTRING Path, INT CaseSensitive, INT Wildcard, struct CompressedItem ** Item)</prototype>
+      <prototype>ERR cmp::Find(OBJECTPTR Object, const std::string_view &amp; Path, INT CaseSensitive, INT Wildcard, struct CompressedItem ** Item)</prototype>
       <tiriPrototype>err, Item:any = Find(Path:str, CaseSensitive:num, Wildcard:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Path">Search for a specific item or items, using wildcards.</param>
+        <param type="const std::string_view &amp;" name="Path">Search for a specific item or items, using wildcards.</param>
         <param type="INT" name="CaseSensitive">Set to <code>true</code> if <code>Path</code> comparisons are case-sensitive.</param>
         <param type="INT" name="Wildcard">Set to <code>true</code> if <code>Path</code> uses wildcards.</param>
         <param type="struct CompressedItem **" name="Item">The discovered item is returned in this parameter, or <code>NULL</code> if the search failed.</param>
@@ -359,10 +359,10 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>RemoveFile</name>
       <comment>Deletes one or more files from a compression object.</comment>
-      <prototype>ERR cmp::RemoveFile(OBJECTPTR Object, CSTRING Path)</prototype>
+      <prototype>ERR cmp::RemoveFile(OBJECTPTR Object, const std::string_view &amp; Path)</prototype>
       <tiriPrototype>err = RemoveFile(Path:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Path">The full path name of the file to delete from the archive.</param>
+        <param type="const std::string_view &amp;" name="Path">The full path name of the file to delete from the archive.</param>
       </input>
       <description>
 <p>This method deletes compressed files from a compression object.  If the file is in a folder then the client must specify the complete path in conjunction with the file name.  Wild cards are accepted if you want to delete multiple files.  A <code>Path</code> setting of <code>*</code> will delete an archive's entire contents, while a more conservative <code>Path</code> of <code>documents/ *</code> would delete all files and directories under the documents path.  Directories can be declared using either the back-slash or the forward-slash characters.</p>
@@ -379,11 +379,11 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
     <method>
       <name>Scan</name>
       <comment>Scan the archive's index of compressed data.</comment>
-      <prototype>ERR cmp::Scan(OBJECTPTR Object, CSTRING Folder, CSTRING Filter, FUNCTION * Callback)</prototype>
+      <prototype>ERR cmp::Scan(OBJECTPTR Object, const std::string_view &amp; Folder, const std::string_view &amp; Filter, FUNCTION * Callback)</prototype>
       <tiriPrototype>err = Scan(Folder:str, Filter:str, Callback:func)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Folder">If defined, only items within the specified folder are returned.  Use an empty string for files in the root folder.</param>
-        <param type="CSTRING" name="Filter">Search for a specific item or items by name, using wildcards.  If <code>NULL</code> or an empty string, all items will be scanned.</param>
+        <param type="const std::string_view &amp;" name="Folder">Only items within the specified folder are returned.  Use an empty string for files in the root folder.</param>
+        <param type="const std::string_view &amp;" name="Filter">Search for a specific item or items by name, using wildcards.  If empty, all items will be scanned.</param>
         <param type="FUNCTION *" name="Callback">This callback function will be called with a pointer to a <st>CompressedItem</st> structure.</param>
       </input>
       <description>

--- a/docs/xml/modules/classes/script.xml
+++ b/docs/xml/modules/classes/script.xml
@@ -226,8 +226,8 @@ SET_FUNCTION_SCRIPT(callback, script, procedure_id);
     <field>
       <name>ErrorMessage</name>
       <comment>A human readable error string may be declared here following a script execution failure.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <access read="R" write="W">Read/Write</access>
+      <type>std::string</type>
     </field>
 
     <field>
@@ -237,16 +237,6 @@ SET_FUNCTION_SCRIPT(callback, script, procedure_id);
       <type lookup="SCF">SCF</type>
       <description>
 <types lookup="SCF"/>
-      </description>
-    </field>
-
-    <field>
-      <name>Language</name>
-      <comment>Indicates the language (locale) that the source script is written in.</comment>
-      <access read="G">Get</access>
-      <type>STRING</type>
-      <description>
-<p>The Language value indicates the language in which the source script was written.  The default setting is <code>ENG</code>, the code for international English.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/task.xml
+++ b/docs/xml/modules/classes/task.xml
@@ -88,10 +88,10 @@
     <method>
       <name>AddArgument</name>
       <comment>Adds a new argument to the Parameters field.</comment>
-      <prototype>ERR task::AddArgument(OBJECTPTR Object, CSTRING Argument)</prototype>
+      <prototype>ERR task::AddArgument(OBJECTPTR Object, const std::string_view &amp; Argument)</prototype>
       <tiriPrototype>err = AddArgument(Argument:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Argument">The new argument string.</param>
+        <param type="const std::string_view &amp;" name="Argument">The new argument string.</param>
       </input>
       <description>
 <p>This method will add a new argument to the end of the <fl>Parameters</fl> field array.  If the string is surrounded by quotes, they will be removed automatically.</p>
@@ -120,11 +120,11 @@
     <method>
       <name>GetEnv</name>
       <comment>Retrieves environment variables for the active process.</comment>
-      <prototype>ERR task::GetEnv(OBJECTPTR Object, CSTRING Name, CSTRING * Value)</prototype>
+      <prototype>ERR task::GetEnv(OBJECTPTR Object, const std::string_view &amp; Name, std::string * Value)</prototype>
       <tiriPrototype>err, Value:str = GetEnv(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the environment variable to retrieve.</param>
-        <param type="CSTRING *" name="Value">The value of the environment variable is returned in this parameter.</param>
+        <param type="const std::string_view &amp;" name="Name">The name of the environment variable to retrieve.</param>
+        <param type="std::string *" name="Value">The value of the environment variable is returned in this parameter.</param>
       </input>
       <description>
 <p>On platforms that support environment variables, GetEnv() returns the value of the environment variable matching the <code>Name</code> string.  If there is no matching variable, <code>ERR::DoesNotExist</code> is returned.</p>
@@ -139,10 +139,11 @@
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
-        <error code="Args">Invalid arguments passed to function</error>
         <error code="NoSupport">The platform does not support environment variables.</error>
         <error code="DoesNotExist">The environment variable is undefined.</error>
+        <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
+      <tags>mutates-input</tags>
     </method>
 
     <method>
@@ -163,14 +164,14 @@
     <method>
       <name>SetEnv</name>
       <comment>Sets environment variables for the active process.</comment>
-      <prototype>ERR task::SetEnv(OBJECTPTR Object, CSTRING Name, CSTRING Value)</prototype>
+      <prototype>ERR task::SetEnv(OBJECTPTR Object, const std::string_view &amp; Name, const std::string_view &amp; Value)</prototype>
       <tiriPrototype>err = SetEnv(Name:str, Value:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the environment variable to set.</param>
-        <param type="CSTRING" name="Value">The value to assign to the environment variable.</param>
+        <param type="const std::string_view &amp;" name="Name">The name of the environment variable to set.</param>
+        <param type="const std::string_view &amp;" name="Value">The value to assign to the environment variable.  If empty, the variable is removed.</param>
       </input>
       <description>
-<p>On platforms that support environment variables, SetEnv() is used for defining values for named variables.  A <code>Name</code> and accompanying <code>Value</code> string are required.  If the <code>Value</code> is <code>NULL</code>, the environment variable is removed if it already exists.</p>
+<p>On platforms that support environment variables, SetEnv() is used for defining values for named variables.  A <code>Name</code> and accompanying <code>Value</code> string are required.  If the <code>Value</code> is empty, the environment variable is removed if it already exists.</p>
 <p>In Windows, it is possible to set registry keys if the string starts with one of the following (in all other cases, the system's environment variables are queried):</p>
 <pre>\HKEY_LOCAL_MACHINE\
 \HKEY_CURRENT_USER\
@@ -181,8 +182,8 @@
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
-        <error code="Args">Invalid arguments passed to function</error>
         <error code="NoSupport">The platform does not support environment variables.</error>
+        <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
     </method>
 

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3374,27 +3374,25 @@ class objScript : public Object {
 
    using create = kt::Create<objScript>;
 
-   std::string Path;         // The location of a script file to be loaded.
-   std::string Procedure;    // Specifies a procedure name to be executed.
-   OBJECTID TargetID;        // Reference to the default container that new script objects will be initialised to.
-   SCF      Flags;           // Optional flags.
-   ERR      Error;           // If a script fails during execution, an error code may be readable here.
-   int      CurrentLine;     // Indicates the current line being executed when in debug mode.
-   int      LineOffset;      // For debugging purposes, this value is added to any message referencing a line number.
+   std::string Path;            // The location of a script file to be loaded.
+   std::string Procedure;       // Specifies a procedure name to be executed.
+   std::string ErrorMessage;    // A human readable error string may be declared here following a script execution failure.
+   OBJECTID TargetID;           // Reference to the default container that new script objects will be initialised to.
+   SCF      Flags;              // Optional flags.
+   ERR      Error;              // If a script fails during execution, an error code may be readable here.
+   int      CurrentLine;        // Indicates the current line being executed when in debug mode.
+   int      LineOffset;         // For debugging purposes, this value is added to any message referencing a line number.
 
 #ifdef PRV_SCRIPT
    int64_t  ProcedureID;          // For callbacks
-   KEYVALUE Vars; // Global parameters
+   KEYVALUE Vars;                 // Global parameters
    kt::vector<std::string> Results;
-   char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
    std::string String;
    std::string WorkingPath;
-   std::string ErrorMessage;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
    int      TotalArgs;            // Total number of ProcArgs
-   char     LanguageDir[32];      // Directory to use for language files
    OBJECTID ScriptOwnerID;
 #endif
 
@@ -3456,6 +3454,11 @@ class objScript : public Object {
       return ERR::Okay;
    }
 
+   inline ERR getErrorMessage(std::string_view &Value) noexcept {
+      Value = this->ErrorMessage;
+      return ERR::Okay;
+   }
+
    inline ERR getTarget(OBJECTID &Value) noexcept {
       Value = this->TargetID;
       return ERR::Okay;
@@ -3482,14 +3485,7 @@ class objScript : public Object {
    }
 
    inline ERR getCacheFile(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[21];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getErrorMessage(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
+      auto field = &this->Class->Dictionary[20];
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       return error;
@@ -3501,13 +3497,6 @@ class objScript : public Object {
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getLanguage(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[20];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3544,6 +3533,11 @@ class objScript : public Object {
       return ERR::Okay;
    }
 
+   inline ERR setErrorMessage(const std::string_view &Value) noexcept {
+      this->ErrorMessage = Value;
+      return ERR::Okay;
+   }
+
    inline ERR setTarget(OBJECTID Value) noexcept {
       this->TargetID = Value;
       return ERR::Okay;
@@ -3561,12 +3555,7 @@ class objScript : public Object {
    }
 
    inline ERR setCacheFile(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[21];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
-   }
-
-   inline ERR setErrorMessage(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
+      auto field = &this->Class->Dictionary[20];
       return field->WriteValue(this, field, 0x00904300, &Value, 1);
    }
 

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3613,10 +3613,10 @@ struct ActionEntry {
 
 namespace task {
 struct Expunge { static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct AddArgument { CSTRING Argument; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct AddArgument { std::string_view Argument; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Quit { static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct GetEnv { CSTRING Name; CSTRING Value; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SetEnv { CSTRING Name; CSTRING Value; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct GetEnv { std::string_view Name; std::string *Value; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SetEnv { std::string_view Name; std::string_view Value; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -3671,20 +3671,19 @@ class objTask : public Object {
    inline ERR expunge() noexcept {
       return(Action(AC(-1), this, nullptr));
    }
-   inline ERR addArgument(CSTRING Argument) noexcept {
+   inline ERR addArgument(const std::string_view & Argument) noexcept {
       struct task::AddArgument args = { Argument };
       return(Action(AC(-2), this, &args));
    }
    inline ERR quit() noexcept {
       return(Action(AC(-3), this, nullptr));
    }
-   inline ERR getEnv(CSTRING Name, CSTRING * Value) noexcept {
-      struct task::GetEnv args = { Name, (CSTRING)0 };
+   inline ERR getEnv(const std::string_view & Name, std::string &Value) noexcept {
+      struct task::GetEnv args = { Name, &Value };
       ERR error = Action(AC(-4), this, &args);
-      if (Value) *Value = args.Value;
       return(error);
    }
-   inline ERR setEnv(CSTRING Name, CSTRING Value) noexcept {
+   inline ERR setEnv(const std::string_view & Name, const std::string_view & Value) noexcept {
       struct task::SetEnv args = { Name, Value };
       return(Action(AC(-5), this, &args));
    }

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -4286,19 +4286,19 @@ class objTime : public Object {
 
 namespace cmp {
 struct CompressBuffer { APTR Input; int InputSize; APTR Output; int OutputSize; int Result; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct CompressFile { CSTRING Location; CSTRING Path; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct CompressFile { std::string_view Location; std::string_view Path; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct DecompressBuffer { APTR Input; APTR Output; int OutputSize; int Result; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct DecompressFile { CSTRING Path; CSTRING Dest; int Flags; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct RemoveFile { CSTRING Path; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct DecompressFile { std::string_view Path; std::string_view Dest; int Flags; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct RemoveFile { std::string_view Path; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct CompressStream { APTR Input; int Length; FUNCTION * Callback; APTR Output; int OutputSize; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct DecompressStream { APTR Input; int Length; FUNCTION * Callback; APTR Output; int OutputSize; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct CompressStreamStart { static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct CompressStreamEnd { FUNCTION * Callback; APTR Output; int OutputSize; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct DecompressStreamEnd { FUNCTION * Callback; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct DecompressStreamStart { static const AC id = AC(-11); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct DecompressObject { CSTRING Path; OBJECTPTR Object; static const AC id = AC(-12); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Scan { CSTRING Folder; CSTRING Filter; FUNCTION * Callback; static const AC id = AC(-13); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Find { CSTRING Path; int CaseSensitive; int Wildcard; struct CompressedItem * Item; static const AC id = AC(-14); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct DecompressObject { std::string_view Path; OBJECTPTR Object; static const AC id = AC(-12); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Scan { std::string_view Folder; std::string_view Filter; FUNCTION * Callback; static const AC id = AC(-13); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Find { std::string_view Path; int CaseSensitive; int Wildcard; struct CompressedItem * Item; static const AC id = AC(-14); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -4328,7 +4328,7 @@ class objCompression : public Object {
       if (Result) *Result = args.Result;
       return(error);
    }
-   inline ERR compressFile(CSTRING Location, CSTRING Path) noexcept {
+   inline ERR compressFile(const std::string_view & Location, const std::string_view & Path) noexcept {
       struct cmp::CompressFile args = { Location, Path };
       return(Action(AC(-2), this, &args));
    }
@@ -4338,11 +4338,11 @@ class objCompression : public Object {
       if (Result) *Result = args.Result;
       return(error);
    }
-   inline ERR decompressFile(CSTRING Path, CSTRING Dest, int Flags) noexcept {
+   inline ERR decompressFile(const std::string_view & Path, const std::string_view & Dest, int Flags) noexcept {
       struct cmp::DecompressFile args = { Path, Dest, Flags };
       return(Action(AC(-4), this, &args));
    }
-   inline ERR removeFile(CSTRING Path) noexcept {
+   inline ERR removeFile(const std::string_view & Path) noexcept {
       struct cmp::RemoveFile args = { Path };
       return(Action(AC(-5), this, &args));
    }
@@ -4368,15 +4368,15 @@ class objCompression : public Object {
    inline ERR decompressStreamStart() noexcept {
       return(Action(AC(-11), this, nullptr));
    }
-   inline ERR decompressObject(CSTRING Path, OBJECTPTR Object) noexcept {
+   inline ERR decompressObject(const std::string_view & Path, OBJECTPTR Object) noexcept {
       struct cmp::DecompressObject args = { Path, Object };
       return(Action(AC(-12), this, &args));
    }
-   inline ERR scan(CSTRING Folder, CSTRING Filter, FUNCTION Callback) noexcept {
+   inline ERR scan(const std::string_view & Folder, const std::string_view & Filter, FUNCTION Callback) noexcept {
       struct cmp::Scan args = { Folder, Filter, &Callback };
       return(Action(AC(-13), this, &args));
    }
-   inline ERR find(CSTRING Path, int CaseSensitive, int Wildcard, struct CompressedItem ** Item) noexcept {
+   inline ERR find(const std::string_view & Path, int CaseSensitive, int Wildcard, struct CompressedItem ** Item) noexcept {
       struct cmp::Find args = { Path, CaseSensitive, Wildcard, (struct CompressedItem *)0 };
       ERR error = Action(AC(-14), this, &args);
       if (Item) *Item = args.Item;

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -316,9 +316,7 @@ mutates-object, creates-resource
 
 static ERR SCRIPT_GetProcedureID(objScript *Self, struct sc::GetProcedureID *Args)
 {
-   kt::Log log;
-
-   if ((not Args) or Args->Procedure.empty()) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Procedure.empty()) return kt::Log().warning(ERR::NullArgs);
    Args->ProcedureID = strihash(Args->Procedure);
    return ERR::Okay;
 }
@@ -347,10 +345,8 @@ static ERR SCRIPT_GetKey(objScript *Self, struct acGetKey *Args)
 
 static ERR SCRIPT_Init(objScript *Self)
 {
-   kt::Log log;
-
    if (not Self->TargetID) { // Define the target if it has not been set already
-      log.detail("Target not set, defaulting to owner #%d.", Self->ownerID());
+      kt::Log().detail("Target not set, defaulting to owner #%d.", Self->ownerID());
       Self->TargetID = Self->ownerID();
    }
 
@@ -366,16 +362,6 @@ static ERR SCRIPT_NewPlacement(objScript *Self)
    new (Self) objScript;
 
    Self->CurrentLine = -1;
-
-   // Assume that the script is in English
-
-   Self->Language[0] = 'e';
-   Self->Language[1] = 'n';
-   Self->Language[2] = 'g';
-   Self->Language[3] = 0;
-
-   strcopy("lang", Self->LanguageDir, sizeof(Self->LanguageDir));
-
    return ERR::Okay;
 }
 
@@ -400,8 +386,7 @@ static ERR SCRIPT_SetKey(objScript *Self, struct acSetKey *Args)
 
    if ((not Args) or (Args->Key.empty())) return ERR::NullArgs;
 
-   kt::Log log;
-   log.trace("%.*s = %.*s", int(Args->Key.size()), Args->Key.data(), int(Args->Value.size()), Args->Value.data());
+   kt::Log().trace("%.*s = %.*s", int(Args->Key.size()), Args->Key.data(), int(Args->Value.size()), Args->Value.data());
 
    auto key_it = Self->Vars.lower_bound(Args->Key);
    if ((key_it != Self->Vars.end()) and (not Self->Vars.key_comp()(Args->Key, key_it->first))) {
@@ -459,41 +444,9 @@ propagated through the call stack.
 -FIELD-
 ErrorMessage: A human readable error string may be declared here following a script execution failure.
 
-*********************************************************************************************************************/
-
-static ERR GET_ErrorMessage(objScript *Self, std::string_view &Value)
-{
-   Value = Self->ErrorMessage;
-   return Self->ErrorMessage.empty() ? ERR::FieldNotSet : ERR::Okay;
-}
-
-static ERR SET_ErrorMessage(objScript *Self, std::string_view &Value)
-{
-   Self->ErrorMessage.assign(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 Flags: Optional flags.
 Lookup: SCF
-
--FIELD-
-Language: Indicates the language (locale) that the source script is written in.
-
-The Language value indicates the language in which the source script was written.  The default setting is `ENG`, the
-code for international English.
-
-*********************************************************************************************************************/
-
-static ERR GET_Language(objScript *Self, std::string_view &Value)
-{
-   Value = std::string_view((const char *)&Self->Language, 3);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 LineOffset: For debugging purposes, this value is added to any message referencing a line number.
@@ -786,18 +739,17 @@ static ERR SET_WorkingPath(objScript *Self, std::string_view &Value)
 #include "class_script_def.c"
 
 static const FieldArray clScriptFields[] = {
-   { "Procedure",   FDF_CPPSTRING|FDF_RW|FDF_PURE },
-   { "Path",        FDF_CPPSTRING|FDF_RI|FDF_PURE, nullptr, SET_Path },
-   { "Target",      FDF_OBJECTID|FDF_RW },
-   { "Flags",       FDF_INTFLAGS|FDF_RI, nullptr, nullptr, &clScriptFlags },
-   { "Error",       FDF_INT|FDF_R },
-   { "CurrentLine", FDF_INT|FDF_R },
-   { "LineOffset",  FDF_INT|FDF_RW },
+   { "Procedure",    FDF_CPPSTRING|FDF_RW|FDF_PURE },
+   { "Path",         FDF_CPPSTRING|FDF_RI|FDF_PURE, nullptr, SET_Path },
+   { "ErrorMessage", FDF_CPPSTRING|FDF_RW|FDF_PURE },
+   { "Target",       FDF_OBJECTID|FDF_RW },
+   { "Flags",        FDF_INTFLAGS|FDF_RI, nullptr, nullptr, &clScriptFlags },
+   { "Error",        FDF_INT|FDF_R },
+   { "CurrentLine",  FDF_INT|FDF_R },
+   { "LineOffset",   FDF_INT|FDF_RW },
    // Virtual Fields
    { "CacheFile",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_CacheFile, SET_CacheFile },
-   { "ErrorMessage", FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_ErrorMessage, SET_ErrorMessage },
    { "WorkingPath",  FDF_CPPSTRING|FDF_RW,                      GET_WorkingPath, SET_WorkingPath },
-   { "Language",     FDF_CPPSTRING|FDF_R|FDF_PURE,              GET_Language },
    { "Results",      FDF_ARRAY|FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_Results, SET_Results },
    { "Src",          FDF_SYNONYM|FDF_CPPSTRING|FDF_RI|FDF_PURE, GET_Path, SET_Path },
    { "Statement",    FDF_CPPSTRING|FDF_RW|FDF_PURE,             GET_String, SET_String },

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -1192,7 +1192,7 @@ This method will add a new argument to the end of the #Parameters field array.  
 they will be removed automatically.
 
 -INPUT-
-cstr Argument: The new argument string.
+cpp(strview) Argument: The new argument string.
 
 -ERRORS-
 Okay
@@ -1205,14 +1205,16 @@ mutates-object, copies-input
 
 static ERR TASK_AddArgument(extTask *Self, struct task::AddArgument *Args)
 {
-   if ((not Args) or (not Args->Argument) or (not *Args->Argument)) return ERR::NullArgs;
+   if ((not Args) or Args->Argument.empty()) return ERR::NullArgs;
 
    auto src = Args->Argument;
-   if ((*src IS '"') or (*src IS '\'')) {
-      auto end = *src++;
-      int len = 0;
-      while ((src[len]) and (src[len] != end)) len++;
-      Self->Parameters.emplace_back(std::string(src, len));
+   if ((src.front() IS '"') or (src.front() IS '\'')) {
+      auto quote = src.front();
+      src.remove_prefix(1);
+      if (auto end = src.find(quote); end != std::string_view::npos) {
+         Self->Parameters.emplace_back(src.substr(0, end));
+      }
+      else Self->Parameters.emplace_back(src);
    }
    else Self->Parameters.emplace_back(Args->Argument);
 
@@ -1310,18 +1312,18 @@ NOTE: If your programming language uses backslash as an escape character, rememb
 `Name` string.
 
 -INPUT-
-cstr Name:  The name of the environment variable to retrieve.
-&cstr Value: The value of the environment variable is returned in this parameter.
+cpp(strview) Name: The name of the environment variable to retrieve.
+^&cpp(str) Value: The value of the environment variable is returned in this parameter.
 
 -ERRORS-
 Okay
-Args
+NullArgs
 DoesNotExist: The environment variable is undefined.
 NoSupport: The platform does not support environment variables.
 -END-
 
 -TAGS-
-pure-query, object-owns-result, null-terminated-result
+pure-query, caller-owns-result
 
 *********************************************************************************************************************/
 
@@ -1329,11 +1331,10 @@ static ERR TASK_GetEnv(extTask *Self, struct task::GetEnv *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Name)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Name.empty() or (not Args->Value)) return log.warning(ERR::NullArgs);
+   Args->Value->clear();
 
 #ifdef _WIN32
-
-   Args->Value = nullptr;
 
    if (glCurrentTask != Self) return ERR::ExecViolation;
 
@@ -1405,7 +1406,6 @@ static ERR TASK_GetEnv(extTask *Self, struct task::GetEnv *Args)
          APTR keyhandle;
          if (not RegOpenKeyExA(key.ID, folder.c_str(), 0, KEY_READ, &keyhandle)) {
             if (enumerate) {
-               Self->Env.clear();
                char value_name[256];
                int8_t buffer[4096];
 
@@ -1416,8 +1416,8 @@ static ERR TASK_GetEnv(extTask *Self, struct task::GetEnv *Args)
                   int data_len = sizeof(buffer);
                   int type;
                   if (RegEnumValueA(keyhandle, index, value_name, &name_len, 0, &type, buffer, &data_len)) break;
-                  if (not Self->Env.empty()) Self->Env += '\t';
-                  Self->Env.append(value_name, name_len);
+                  if (not Args->Value->empty()) Args->Value->push_back('\t');
+                  Args->Value->append(value_name, name_len);
                }
 
                // Enumerate all sub-keys (folders) at this key.  Each sub-key name is
@@ -1427,29 +1427,30 @@ static ERR TASK_GetEnv(extTask *Self, struct task::GetEnv *Args)
                   int name_len = sizeof(value_name);
                   if (RegEnumKeyExA(keyhandle, index, value_name, &name_len, 0, nullptr, nullptr, nullptr)) break;
 
-                  if (not Self->Env.empty()) Self->Env += '\t';
-                  Self->Env.append(value_name, name_len);
-                  Self->Env += '\\';
+                  if (not Args->Value->empty()) Args->Value->push_back('\t');
+                  Args->Value->append(value_name, name_len);
+                  Args->Value->push_back('\\');
                }
 
                winCloseHandle(keyhandle);
-               if (Self->Env.empty()) return ERR::DoesNotExist;
-               Args->Value = Self->Env.c_str();
+               if (Args->Value->empty()) return ERR::DoesNotExist;
                return ERR::Okay;
             }
             else {
                int type;
                int8_t buffer[4096];
                int envlen = sizeof(buffer);
+               bool found = false;
                if (not RegQueryValueExA(keyhandle, name.c_str(), 0, &type, buffer, &envlen)) {
-                  if (not format_value(type, buffer, envlen, Self->Env)) {
-                     log.warning("Unsupported registry type %d for key %s", type, Args->Name);
+                  if (not format_value(type, buffer, envlen, *Args->Value)) {
+                     log.warning("Unsupported registry type %d for key %.*s", type, int(Args->Name.size()),
+                        Args->Name.data());
                   }
-                  else Args->Value = Self->Env.c_str();
+                  else found = true;
                }
                winCloseHandle(keyhandle);
 
-               if (Args->Value) return ERR::Okay;
+               if (found) return ERR::Okay;
                else return ERR::DoesNotExist;
             }
          }
@@ -1457,13 +1458,16 @@ static ERR TASK_GetEnv(extTask *Self, struct task::GetEnv *Args)
       }
    }
 
-   winGetEnv(Args->Name, Self->Env);
-   if (Self->Env.empty()) return ERR::DoesNotExist;
-   Args->Value = Self->Env.c_str();
+   std::string name(Args->Name);
+   winGetEnv(name.c_str(), *Args->Value);
+   if (Args->Value->empty()) return ERR::DoesNotExist;
    return ERR::Okay;
 
 #elif __unix__
-   if ((Args->Value = getenv(Args->Name))) {
+
+   std::string name(Args->Name);
+   if (auto value = getenv(name.c_str())) {
+      Args->Value->assign(value);
       return ERR::Okay;
    }
    else return ERR::DoesNotExist;
@@ -1650,7 +1654,7 @@ static ERR TASK_Quit(extTask *Self)
 SetEnv: Sets environment variables for the active process.
 
 On platforms that support environment variables, SetEnv() is used for defining values for named variables.  A `Name`
-and accompanying `Value` string are required.  If the `Value` is `NULL`, the environment variable is removed if it
+and accompanying `Value` string are required.  If the `Value` is empty, the environment variable is removed if it
 already exists.
 
 In Windows, it is possible to set registry keys if the string starts with one of the following (in all other cases, the
@@ -1668,12 +1672,12 @@ the existing key value is a number such as `DWORD` or `QWORD`, then the Value wi
 key is set.
 
 -INPUT-
-cstr Name:  The name of the environment variable to set.
-cstr Value: The value to assign to the environment variable.
+cpp(strview) Name:  The name of the environment variable to set.
+cpp(strview) Value: The value to assign to the environment variable.  If empty, the variable is removed.
 
 -ERRORS-
 Okay
-Args
+NullArgs
 NoSupport: The platform does not support environment variables.
 -END-
 
@@ -1686,11 +1690,14 @@ static ERR TASK_SetEnv(extTask *Self, struct task::SetEnv *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Name)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Name.empty()) return log.warning(ERR::NullArgs);
+
+   std::string name(Args->Name);
+   std::string value(Args->Value);
 
 #ifdef _WIN32
 
-   if (Args->Name[0] IS '\\') {
+   if (name.starts_with('\\')) {
       int ki, len;
       const struct {
          uint32_t ID;
@@ -1702,11 +1709,11 @@ static ERR TASK_SetEnv(extTask *Self, struct task::SetEnv *Args)
          { HKEY_USERS,          "\\HKEY_USERS\\" }
       };
 
-      log.msg("Registry: %s = %s", Args->Name, Args->Value);
+      log.msg("Registry: %s = %s", name.c_str(), value.c_str());
 
       for (ki=0; ki < std::ssize(keys); ki++) {
-         if (startswith(keys[ki].HKey, Args->Name)) {
-            CSTRING str = Args->Name + strlen(keys[ki].HKey); // str = Kotuku\Something
+         if (startswith(keys[ki].HKey, name)) {
+            CSTRING str = name.c_str() + strlen(keys[ki].HKey); // str = Kotuku\Something
 
             for (len=strlen(str); (len > 0) and (str[len] != '\\'); len--);
 
@@ -1720,23 +1727,23 @@ static ERR TASK_SetEnv(extTask *Self, struct task::SetEnv *Args)
 
                      switch(type) {
                         case REG_DWORD: {
-                           int int32 = strtol(Args->Value, nullptr, 0);
+                           int int32 = strtol(value.c_str(), nullptr, 0);
                            RegSetValueExA(keyhandle, str+len+1, 0, REG_DWORD, &int32, sizeof(int32));
                            break;
                         }
 
                         case REG_QWORD: {
-                           int64_t int64 = strtoll(Args->Value, nullptr, 0);
+                           int64_t int64 = strtoll(value.c_str(), nullptr, 0);
                            RegSetValueExA(keyhandle, str+len+1, 0, REG_QWORD, &int64, sizeof(int64));
                            break;
                         }
 
                         default: {
-                           RegSetValueExA(keyhandle, str+len+1, 0, REG_SZ, Args->Value, strlen(Args->Value)+1);
+                           RegSetValueExA(keyhandle, str+len+1, 0, REG_SZ, value.c_str(), value.size() + 1);
                         }
                      }
                   }
-                  else RegSetValueExA(keyhandle, str+len+1, 0, REG_SZ, Args->Value, strlen(Args->Value)+1);
+                  else RegSetValueExA(keyhandle, str+len+1, 0, REG_SZ, value.c_str(), value.size() + 1);
 
                   winCloseHandle(keyhandle);
                }
@@ -1750,14 +1757,14 @@ static ERR TASK_SetEnv(extTask *Self, struct task::SetEnv *Args)
       return log.warning(ERR::TaskExecutionFailed);
    }
    else {
-      winSetEnv(Args->Name, Args->Value);
+      winSetEnv(name.c_str(), value.empty() ? nullptr : value.c_str());
       return ERR::Okay;
    }
 
 #elif __unix__
 
-   if (Args->Value) setenv(Args->Name, Args->Value, 1);
-   else unsetenv(Args->Name);
+   if (value.empty()) unsetenv(name.c_str());
+   else setenv(name.c_str(), value.c_str(), 1);
    return ERR::Okay;
 
 #else

--- a/src/core/classes/class_task_def.c
+++ b/src/core/classes/class_task_def.c
@@ -13,9 +13,9 @@ static const struct FieldDef clTaskFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maAddArgument[] = { { "Argument", FD_STR }, { 0, 0 } };
-FDEF maGetEnv[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
-FDEF maSetEnv[] = { { "Name", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
+FDEF maAddArgument[] = { { "Argument", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maGetEnv[] = { { "Name", FD_CPP|FD_STR }, { "Value", FD_CPP|FD_STR|FD_MUTABLE|FD_RESULT }, { 0, 0 } };
+FDEF maSetEnv[] = { { "Name", FD_CPP|FD_STR }, { "Value", FD_CPP|FD_STR }, { 0, 0 } };
 
 static const struct MethodEntry clTaskMethods[] = {
    { AC(-1), (APTR)TASK_Expunge, "Expunge", 0, 0 },

--- a/src/core/compression/class_compression.cpp
+++ b/src/core/compression/class_compression.cpp
@@ -593,8 +593,8 @@ to suit the target path.  If the `Path` starts with a forward slash and the sour
 folder will be used in the target path for the compressed files and folders.
 
 -INPUT-
-cstr Location: The location of the file(s) to add.
-cstr Path:     The path that is prefixed to the file name when added to the compression object.  May be `NULL` for no path.
+cpp(strview) Location: The location of the file(s) to add.
+cpp(strview) Path:     The path that is prefixed to the file name when added to the compression object.  May be empty for no path.
 
 -ERRORS-
 Okay: The file was added to the compression object.
@@ -612,7 +612,7 @@ static ERR COMPRESSION_CompressFile(extCompression *Self, struct cmp::CompressFi
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Location) or (!*Args->Location)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Location.empty()) return log.warning(ERR::NullArgs);
    if (!Self->FileIO) return log.warning(ERR::MissingPath);
 
    if ((Self->Flags & CMF::READ_ONLY) != CMF::NIL) return log.warning(ERR::NoPermission);
@@ -628,25 +628,22 @@ static ERR COMPRESSION_CompressFile(extCompression *Self, struct cmp::CompressFi
    std::string src(Args->Location);
    std::string path;
    bool incdir = false;
-   if (!Args->Path) path = "";
+   if (Args->Path.empty()) path = "";
    else { // Accept the path by default but check it for illegal symbols just in case
       if (Args->Path[0] IS '/') { // Special mode: prefix src folder name to the root path
          incdir = true;
-         path.assign(Args->Path + 1);
+         path.assign(Args->Path.data() + 1, Args->Path.size() - 1);
       }
       else path.assign(Args->Path);
 
-      for (int i=0; path[i]; i++) {
-         if (path.find_first_of("*?\":|<>") != std::string::npos) {
-            log.warning("Illegal characters in path: %s", path.c_str());
-            if (Self->OutputID) {
-               std::ostringstream out;
-               out << "Warning - path ignored due to illegal characters: " << path << "\n";
-               print(Self, out.str());
-            }
-            path.clear();
-            break;
+      if (path.find_first_of("*?\":|<>") != std::string::npos) {
+         log.warning("Illegal characters in path: %s", path.c_str());
+         if (Self->OutputID) {
+            std::ostringstream out;
+            out << "Warning - path ignored due to illegal characters: " << path << "\n";
+            print(Self, out.str());
          }
+         path.clear();
       }
    }
 
@@ -1281,9 +1278,9 @@ This method sends feedback at regular intervals during decompression.  For furth
 please refer to the #Feedback field.
 
 -INPUT-
-cstr Path: The full path name of the file to extract from the archive.
-cstr Dest: The destination to extract the file to.
-int Flags: Optional flags.  Currently unused.
+cpp(strview) Path: The full path name of the file to extract from the archive.
+cpp(strview) Dest: The destination to extract the file to.
+int Flags:        Optional flags.  Currently unused.
 
 -ERRORS-
 Okay: The file was successfully extracted.
@@ -1306,27 +1303,21 @@ static ERR COMPRESSION_DecompressFile(extCompression *Self, struct cmp::Decompre
 {
    kt::Log log;
 
-   if (Self->Files.empty()) return ERR::NoData;
-
    // Validate arguments
 
-   if ((!Args) or (!Args->Path)) {
+   if ((not Args) or Args->Path.empty()) {
       if (Self->OutputID) print(Self, "Please supply a Path setting that refers to a compressed file archive.\n");
 
       return log.warning(ERR::NullArgs);
    }
 
-   if (!Args->Dest) {
+   if (Args->Dest.empty()) {
       if (Self->OutputID) print(Self, "Please supply a Destination that refers to a folder for decompression.\n");
 
       return log.warning(ERR::NullArgs);
    }
 
-   if ((!*Args->Path) or (!*Args->Dest)) {
-      if (Self->OutputID) print(Self, "Please supply valid Path and Destination settings.\n");
-
-      return log.warning(ERR::Args);
-   }
+   if (Self->Files.empty()) return ERR::NoData;
 
    if (!Self->FileIO) {
       if (Self->OutputID) print(Self, "Internal error - decompression aborted.\n");
@@ -1349,13 +1340,16 @@ static ERR COMPRESSION_DecompressFile(extCompression *Self, struct cmp::Decompre
 
    // Search for the file(s) in our archive that match the given name and extract them to the destination folder.
 
-   log.branch("%s TO %s, Permissions: $%.8x", Args->Path, Args->Dest, int(Self->Permissions));
+   log.branch("%.*s TO %.*s, Permissions: $%.8x", int(Args->Path.size()), Args->Path.data(),
+      int(Args->Dest.size()), Args->Dest.data(), int(Self->Permissions));
 
    std::string destpath(Args->Dest);
    auto dest_len = destpath.size();
 
    uint16_t pathend = 0;
-   for (uint16_t i=0; Args->Path[i]; i++) if ((Args->Path[i] IS '/') or (Args->Path[i] IS '\\')) pathend = i + 1;
+   for (uint16_t i=0; i < Args->Path.size(); i++) {
+      if ((Args->Path[i] IS '/') or (Args->Path[i] IS '\\')) pathend = i + 1;
+   }
 
    ERR error      = ERR::Okay;
    Self->FileIndex = 0;
@@ -1473,7 +1467,7 @@ static ERR COMPRESSION_DecompressFile(extCompression *Self, struct cmp::Decompre
 
 exit:
    if ((error IS ERR::Okay) and (Self->FileIndex <= 0)) {
-      log.msg("No files matched the path \"%s\".", Args->Path);
+      log.msg("No files matched the path \"%.*s\".", int(Args->Path.size()), Args->Path.data());
       error = ERR::Search;
    }
 
@@ -1494,8 +1488,8 @@ Note that if decompressing to a @File object, the seek position will point to th
 method returns.  Reset the seek position to zero if the decompressed data needs to be read back.
 
 -INPUT-
-cstr Path: The location of the source file within the archive.  If a wildcard is used, the first matching file is extracted.
-obj Object: The target object for the decompressed source data.
+cpp(strview) Path: The location of the source file within the archive.  If a wildcard is used, the first matching file is extracted.
+obj Object:       The target object for the decompressed source data.
 
 -ERRORS-
 Okay
@@ -1514,12 +1508,13 @@ static ERR COMPRESSION_DecompressObject(extCompression *Self, struct cmp::Decomp
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Path) or (!Args->Path[0])) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Path.empty()) return log.warning(ERR::NullArgs);
    if (!Args->Object) return log.warning(ERR::NullArgs);
    if (!Self->FileIO) return log.warning(ERR::MissingPath);
    if (Self->isDerived()) return ERR::NoSupport; // Object belongs to a Compression derived class
 
-   log.branch("%s TO %p, Permissions: $%.8x", Args->Path, Args->Object, int(Self->Permissions));
+   log.branch("%.*s TO %p, Permissions: $%.8x", int(Args->Path.size()), Args->Path.data(), Args->Object,
+      int(Self->Permissions));
 
    Self->FileIndex = 0;
 
@@ -1563,7 +1558,8 @@ static ERR COMPRESSION_DecompressObject(extCompression *Self, struct cmp::Decomp
    }
 
    if (error != ERR::Okay) {
-      log.msg("No files matched the path \"%s\" from %d files.", Args->Path, total_scanned);
+      log.msg("No files matched the path \"%.*s\" from %d files.", int(Args->Path.size()), Args->Path.data(),
+         total_scanned);
       return ERR::Search;
    }
 
@@ -1585,9 +1581,9 @@ values will be discarded on the next call to this method.  If persistent values 
 structure immediately after the call.
 
 -INPUT-
-cstr Path: Search for a specific item or items, using wildcards.
-int CaseSensitive: Set to `true` if `Path` comparisons are case-sensitive.
-int Wildcard: Set to `true` if `Path` uses wildcards.
+cpp(strview) Path: Search for a specific item or items, using wildcards.
+int CaseSensitive:  Set to `true` if `Path` comparisons are case-sensitive.
+int Wildcard:       Set to `true` if `Path` uses wildcards.
 &struct(*CompressedItem) Item: The discovered item is returned in this parameter, or `NULL` if the search failed.
 
 -ERRORS-
@@ -1607,16 +1603,17 @@ static ERR COMPRESSION_Find(extCompression *Self, struct cmp::Find *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Path)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Path.empty()) return log.warning(ERR::NullArgs);
    if (Self->isDerived()) return ERR::NoSupport;
 
-   log.traceBranch("Path: %s, Case: %d, Wildcard: %d", Args->Path, Args->CaseSensitive, Args->Wildcard);
+   log.traceBranch("Path: %.*s, Case: %d, Wildcard: %d", int(Args->Path.size()), Args->Path.data(),
+      Args->CaseSensitive, Args->Wildcard);
    for (auto &item : Self->Files) {
       if (Args->Wildcard) {
          if (!wildcmp(Args->Path, item.Name, Args->CaseSensitive)) continue;
       }
       else if (Args->CaseSensitive) {
-         if (item.Name != Args->Path) continue;
+         if (std::string_view(item.Name) != Args->Path) continue;
       }
       else if (!iequals(item.Name, Args->Path)) continue;
 
@@ -1838,7 +1835,7 @@ Depending on internal optimisation techniques, the compressed file may not shrin
 object is closed or the #Flush() action is called.
 
 -INPUT-
-cstr Path: The full path name of the file to delete from the archive.
+cpp(strview) Path: The full path name of the file to delete from the archive.
 
 -ERRORS-
 Okay: The file was successfully deleted.
@@ -1855,13 +1852,13 @@ static ERR COMPRESSION_RemoveFile(extCompression *Self, struct cmp::RemoveFile *
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Path)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Path.empty()) return log.warning(ERR::NullArgs);
 
    if (Self->isDerived()) return ERR::NoSupport;
 
    // Search for the file(s) in our archive that match the given name and delete them.
 
-   log.msg("%s", Args->Path);
+   log.msg("%.*s", int(Args->Path.size()), Args->Path.data());
 
    for (auto it = Self->Files.begin(); it != Self->Files.end(); ) {
       if (wildcmp(Args->Path, it->Name)) {
@@ -1899,8 +1896,8 @@ The !CompressedItem structure consists of the following fields:
 To search for a single item with a path and name already known, use the #Find() method instead.
 
 -INPUT-
-cstr Folder: If defined, only items within the specified folder are returned.  Use an empty string for files in the root folder.
-cstr Filter: Search for a specific item or items by name, using wildcards.  If `NULL` or an empty string, all items will be scanned.
+cpp(strview) Folder: Only items within the specified folder are returned.  Use an empty string for files in the root folder.
+cpp(strview) Filter: Search for a specific item or items by name, using wildcards.  If empty, all items will be scanned.
 ptr(func) Callback: This callback function will be called with a pointer to a !CompressedItem structure.
 
 -ERRORS-
@@ -1918,46 +1915,38 @@ static ERR COMPRESSION_Scan(extCompression *Self, struct cmp::Scan *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Callback)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (not Args->Callback)) return log.warning(ERR::NullArgs);
 
    if (Self->isDerived()) return ERR::NoSupport;
 
-   log.traceBranch("Folder: \"%s\", Filter: \"%s\"", Args->Folder, Args->Filter);
+   log.traceBranch("Folder: \"%.*s\", Filter: \"%.*s\"", int(Args->Folder.size()), Args->Folder.data(),
+      int(Args->Filter.size()), Args->Filter.data());
 
-   int folder_len = 0;
-   if (Args->Folder) {
-      folder_len = strlen(Args->Folder);
-      if ((folder_len > 0) and (Args->Folder[folder_len-1] IS '/')) folder_len--;
-   }
+   auto folder = Args->Folder;
+   if ((not folder.empty()) and (folder.back() IS '/')) folder.remove_suffix(1);
+   const auto folder_len = folder.size();
 
    ERR error = ERR::Okay;
 
    for (auto &item : Self->Files) {
       log.trace("Item: %s", item.Name);
 
-      if (Args->Folder) {
-         if (std::ssize(item.Name) > folder_len) {
-            if (iequals(Args->Folder, item.Name)) {
-               if ((folder_len > 0) and (item.Name[folder_len] != '/')) continue;
-               if ((item.Name[folder_len] IS '/') and (!item.Name[folder_len+1])) continue;
+      std::string_view item_name(item.Name);
+      if (folder.empty()) {
+         if (item_name.find('/') != std::string_view::npos) continue;
+      }
+      else {
+         if (item_name.size() <= folder_len) continue;
+         if (!iequals(item_name.substr(0, folder_len), folder)) continue;
+         if (item_name[folder_len] != '/') continue;
+         if (item_name.size() <= folder_len + 1) continue;
 
-               // Skip this item if it is within other sub-folders.
+         // Skip this item if it is within other sub-folders.
 
-               int i;
-               for (i=folder_len+1; item.Name[i]; i++) {
-                  if (item.Name[i] IS '/') break;
-               }
-               if (item.Name[i] IS '/') continue;
-            }
-            else continue;
-         }
-         else continue;
+         if (item_name.substr(folder_len + 1).find('/') != std::string_view::npos) continue;
       }
 
-      if ((Args->Filter) and (Args->Filter[0])) {
-         if (wildcmp(Args->Filter, item.Name)) break;
-         else continue;
-      }
+      if ((not Args->Filter.empty()) and (not wildcmp(Args->Filter, item.Name))) continue;
 
       CompressedItem meta;
       zipfile_to_item(item, meta);

--- a/src/core/compression/class_compression_def.c
+++ b/src/core/compression/class_compression_def.c
@@ -52,17 +52,17 @@ static const struct FieldDef clCompressionPermissions[] = {
 };
 
 FDEF maCompressBuffer[] = { { "Input", FD_BUFFER|FD_PTR }, { "InputSize", FD_INT|FD_BUFSIZE }, { "Output", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "OutputSize", FD_INT|FD_BUFSIZE }, { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maCompressFile[] = { { "Location", FD_STR }, { "Path", FD_STR }, { 0, 0 } };
+FDEF maCompressFile[] = { { "Location", FD_CPP|FD_STR }, { "Path", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF maDecompressBuffer[] = { { "Input", FD_BUFFER|FD_PTR }, { "Output", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "OutputSize", FD_INT|FD_BUFSIZE }, { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maDecompressFile[] = { { "Path", FD_STR }, { "Dest", FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
-FDEF maRemoveFile[] = { { "Path", FD_STR }, { 0, 0 } };
+FDEF maDecompressFile[] = { { "Path", FD_CPP|FD_STR }, { "Dest", FD_CPP|FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
+FDEF maRemoveFile[] = { { "Path", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF maCompressStream[] = { { "Input", FD_BUFFER|FD_PTR }, { "Length", FD_INT|FD_BUFSIZE }, { "Callback", FD_FUNCTIONPTR }, { "Output", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "OutputSize", FD_INT|FD_BUFSIZE }, { 0, 0 } };
 FDEF maDecompressStream[] = { { "Input", FD_BUFFER|FD_PTR }, { "Length", FD_INT|FD_BUFSIZE }, { "Callback", FD_FUNCTIONPTR }, { "Output", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "OutputSize", FD_INT|FD_BUFSIZE }, { 0, 0 } };
 FDEF maCompressStreamEnd[] = { { "Callback", FD_FUNCTIONPTR }, { "Output", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "OutputSize", FD_INT|FD_BUFSIZE }, { 0, 0 } };
 FDEF maDecompressStreamEnd[] = { { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maDecompressObject[] = { { "Path", FD_STR }, { "Object", FD_OBJECTPTR }, { 0, 0 } };
-FDEF maScan[] = { { "Folder", FD_STR }, { "Filter", FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maFind[] = { { "Path", FD_STR }, { "CaseSensitive", FD_INT }, { "Wildcard", FD_INT }, { "CompressedItem:Item", FD_PTR|FD_STRUCT|FD_RESULT }, { 0, 0 } };
+FDEF maDecompressObject[] = { { "Path", FD_CPP|FD_STR }, { "Object", FD_OBJECTPTR }, { 0, 0 } };
+FDEF maScan[] = { { "Folder", FD_CPP|FD_STR }, { "Filter", FD_CPP|FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
+FDEF maFind[] = { { "Path", FD_CPP|FD_STR }, { "CaseSensitive", FD_INT }, { "Wildcard", FD_INT }, { "CompressedItem:Item", FD_PTR|FD_STRUCT|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clCompressionMethods[] = {
    { AC(-1), (APTR)COMPRESSION_CompressBuffer, "CompressBuffer", maCompressBuffer, sizeof(struct cmp::CompressBuffer) },

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1434,27 +1434,25 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
   })
 
   klass("Script", { src={ "../classes/class_script.cpp" }, output="../classes/class_script_def.c" }, [[
-    cpp(str) Path        # Location of the script
-    cpp(str) Procedure   # Specifies a procedure name to be executed
-    oid Target           # The object that script objects must be initialised to, e.g. for obj.new()
-    int(SCF) Flags       # Optional flags
-    error Error          # If an error occurred, this field will indicate the error number
-    int CurrentLine      # Current line being executed, or failed line if script execution terminated
-    int LineOffset       # An optional offset to use when reporting line numbers
+    cpp(str) Path         # Location of the script
+    cpp(str) Procedure    # Specifies a procedure name to be executed
+    cpp(str) ErrorMessage # Human readable error string defined on failure
+    oid Target            # The object that script objects must be initialised to, e.g. for obj.new()
+    int(SCF) Flags        # Optional flags
+    error Error           # If an error occurred, this field will indicate the error number
+    int CurrentLine       # Current line being executed, or failed line if script execution terminated
+    int LineOffset        # An optional offset to use when reporting line numbers
   ]],
   [[
    int64_t  ProcedureID;          // For callbacks
-   KEYVALUE Vars; // Global parameters
+   KEYVALUE Vars;                 // Global parameters
    kt::vector<std::string> Results;
-   char     Language[4];          // 3-character language code, null-terminated
    const ScriptArg *ProcArgs;     // Procedure args - applies during Exec
    std::string String;
    std::string WorkingPath;
-   std::string ErrorMessage;
    std::string CacheFile;
    int      ActivationCount;      // Incremented every time the script is activated.
    int      TotalArgs;            // Total number of ProcArgs
-   char     LanguageDir[32];      // Directory to use for language files
    OBJECTID ScriptOwnerID;
   ]])
 

--- a/src/core/tests/test_compression.tiri
+++ b/src/core/tests/test_compression.tiri
@@ -1,11 +1,16 @@
 -- $TIRI
 -- Flute tests for the Compression module
 
+global glScanItems = { }
+global glScanCount = 0
+
 @AfterAll function cleanup()
    mSys.DeleteFile('temp:cmp_test/')
    mSys.DeleteFile('temp:cmp_icons/')
    mSys.DeleteFile('temp:cmp_test_json.zip')
    mSys.DeleteFile('temp:cmp_test_scripts.zip')
+   mSys.DeleteFile('temp:cmp_empty_args.zip')
+   mSys.DeleteFile('temp:cmp_decompress_object.tiri')
    mSys.DeleteFile('temp:scripts.gz')
    mSys.DeleteFile('temp:gui.tiri')
    mSys.DeleteFile('temp:window.tiri')
@@ -14,6 +19,12 @@ end
 global function streamedOutput(CompressedID, Data)
    err, len = glOutFile.acWrite(Data)
    if err != ERR_Okay then return ERR_Write end
+   return ERR_Okay
+end
+
+global function compressionScanCallback(Compression, Item)
+   glScanCount++
+   glScanItems[Item.path] = true
    return ERR_Okay
 end
 
@@ -28,14 +39,19 @@ end
    end
 
    file_count = 0
-   cmp = obj.new('compression', {
-      path     = 'styles:icons/Default.zip',
-      feedback = function(Compression, Info)
-         if Info.progress is 0 then
-            file_count++
+   try
+      cmp = obj.new('compression', {
+         path     = 'styles:icons/Default.zip',
+         feedback = function(Compression, Info)
+            if Info.progress is 0 then
+               file_count++
+            end
          end
-      end
-   })
+      })
+   except e
+      print('Icon archive could not be opened; skipping test: ' .. e.message)
+      return
+   end
 
    if not cmp then return end -- Non-existance of the icon archive means this test is skipped
 
@@ -72,9 +88,86 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+
+@Test(priority=3) function StringViewMethodInputs()
+   cmp = obj.new('compression', { path='temp:cmp_test_json.zip' } )
+
+   glScanItems = { }
+   glScanCount = 0
+
+   err = cmp.mtScan('', '', 'compressionScanCallback')
+   assert(err is ERR_Okay, 'Scan() failed: ' .. mSys.GetErrorMsg(err))
+   assert(glScanCount is 2, 'Root Scan() returned ' .. glScanCount .. ' entries.')
+   assert(glScanItems['gui.tiri'], 'Root Scan() did not return gui.tiri.')
+   assert(glScanItems['window.tiri'], 'Root Scan() did not return window.tiri.')
+
+   glScanItems = { }
+   glScanCount = 0
+
+   err = cmp.mtScan('', 'gui.tiri', 'compressionScanCallback')
+   assert(err is ERR_Okay, 'Filtered Scan() failed: ' .. mSys.GetErrorMsg(err))
+   assert(glScanCount is 1, 'Filtered Scan() returned ' .. glScanCount .. ' entries.')
+   assert(glScanItems['gui.tiri'], 'Filtered Scan() did not return gui.tiri.')
+
+   err, item = cmp.mtFind('gui.tiri', false, false)
+   assert(err is ERR_Okay, 'Find() failed: ' .. mSys.GetErrorMsg(err))
+   assert(item.path is 'gui.tiri', 'Find() returned ' .. tostring(item.path))
+
+   source_file = obj.new('file', { path='scripts:gui.tiri' })
+   source_size = source_file.size
+   source_data = array<byte, source_size>
+   err = mSys.ReadFileToBuffer('scripts:gui.tiri', source_data)
+   assert(err is ERR_Okay, 'Failed to read source data: ' .. mSys.GetErrorMsg(err))
+
+   output = obj.new('file', { path='temp:cmp_decompress_object.tiri', flags=FL_WRITE|FL_NEW })
+   err = cmp.mtDecompressObject('gui.tiri', output)
+   assert(err is ERR_Okay, 'DecompressObject() failed: ' .. mSys.GetErrorMsg(err))
+   output = nil
+   processing.collect()
+
+   output_file = obj.new('file', { path='temp:cmp_decompress_object.tiri' })
+   assert(output_file.size is source_size, f"DecompressObject() wrote {output_file.size} bytes, expected {source_size}.")
+   output_data = array<byte, source_size>
+   err = mSys.ReadFileToBuffer('temp:cmp_decompress_object.tiri', output_data)
+   assert(err is ERR_Okay, 'Failed to read decompressed output: ' .. mSys.GetErrorMsg(err))
+   assert(output_data:getString() is source_data:getString(), 'DecompressObject() output does not match the source.')
+
+   err = cmp.mtRemoveFile('window.tiri')
+   assert(err is ERR_Okay, 'RemoveFile() failed: ' .. mSys.GetErrorMsg(err))
+
+   err, item = cmp.mtFind('window.tiri', false, false)
+   assert(err is ERR_Search, 'Find() should not locate removed file, got ' .. mSys.GetErrorMsg(err))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test(priority=4) function EmptyRequiredStringArguments()
+   cmp = obj.new('compression', { path='temp:cmp_empty_args.zip', flags=FL_NEW } )
+   output = obj.new('file', { path='temp:cmp_decompress_object.tiri', flags=FL_WRITE|FL_NEW })
+
+   err = cmp.mtCompressFile('', '')
+   assert(err is ERR_NullArgs, 'Expected CompressFile() to reject empty Location, got ' .. mSys.GetErrorMsg(err))
+
+   err = cmp.mtDecompressFile('', 'temp:')
+   assert(err is ERR_NullArgs, 'Expected DecompressFile() to reject empty Path, got ' .. mSys.GetErrorMsg(err))
+
+   err = cmp.mtDecompressFile('gui.tiri', '')
+   assert(err is ERR_NullArgs, 'Expected DecompressFile() to reject empty Dest, got ' .. mSys.GetErrorMsg(err))
+
+   err = cmp.mtRemoveFile('')
+   assert(err is ERR_NullArgs, 'Expected RemoveFile() to reject empty Path, got ' .. mSys.GetErrorMsg(err))
+
+   err = cmp.mtDecompressObject('', output)
+   assert(err is ERR_NullArgs, 'Expected DecompressObject() to reject empty Path, got ' .. mSys.GetErrorMsg(err))
+
+   err, item = cmp.mtFind('', false, false)
+   assert(err is ERR_NullArgs, 'Expected Find() to reject empty Path, got ' .. mSys.GetErrorMsg(err))
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Compress an entire folder and then decompress it to a new location.
 
-@Test(priority=3) function CompressFolder()
+@Test(priority=5) function CompressFolder()
    file_count = 0
    global glCompressedFiles = { }
 
@@ -100,7 +193,7 @@ end
    processing.collect() -- Flush the compressed file to disk
 end
 
-@Test(priority=4) function DecompressFolder()
+@Test(priority=6) function DecompressFolder()
    file_count = 0
    cmp = obj.new('compression', {
       path     = 'temp:cmp_test_scripts.zip',
@@ -124,7 +217,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Test streamed compression
 
-@Test(priority=5) function StreamedCompression()
+@Test(priority=7) function StreamedCompression()
    cmp = obj.new('compression' , { } )
    file = obj.new('file', { src='scripts:gui.tiri', flags=FL_READ } )
 
@@ -147,7 +240,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-@Test(priority=6) function ArchiveVolume()
+@Test(priority=8) function ArchiveVolume()
    cmp = obj.new('compression', { path='temp:cmp_test_scripts.zip', archiveName='test' } )
    file = obj.new('file', { path='scripts:gui/button.tiri' } )
    file_size = file.size
@@ -191,7 +284,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Test streamed decompression
 
-@Test(priority=7) function StreamedDecompression()
+@Test(priority=9) function StreamedDecompression()
    cmp = obj.new('compression' , { } )
    file = obj.new('file', { src='temp:scripts.gz', flags=FL_READ } )
 

--- a/src/core/tests/test_misc.tiri
+++ b/src/core/tests/test_misc.tiri
@@ -1,5 +1,10 @@
 -- Core tests not covered by other test files.
 
+@AfterAll function CleanupTaskStringViewEnvironment()
+   task = mSys.CurrentTask()
+   task.mtSetEnv('KOTUKU_TASK_STRING_VIEW_TEST', '')
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Print a list of all actions returned by ActionList()
 
@@ -18,7 +23,52 @@ end
    task = mSys.CurrentTask()
    err, path = task.mtGetEnv('PATH')
    assert(err is ERR_Okay, 'Error reading PATH variable: ' .. mSys.GetErrorMsg(err))
+   assert(#path > 0, 'PATH variable was empty.')
    print('PATH: ' .. path)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function TaskStringViewMethodInputs()
+   task = mSys.CurrentTask()
+
+   err = task.mtSetEnv('KOTUKU_TASK_STRING_VIEW_TEST', 'value')
+   assert(err is ERR_Okay, 'SetEnv() failed: ' .. mSys.GetErrorMsg(err))
+
+   err, value = task.mtGetEnv('KOTUKU_TASK_STRING_VIEW_TEST')
+   assert(err is ERR_Okay, 'GetEnv() failed: ' .. mSys.GetErrorMsg(err))
+   assert(value is 'value', 'GetEnv() returned "' .. value .. '"')
+
+   err = task.mtSetEnv('KOTUKU_TASK_STRING_VIEW_TEST', '')
+   assert(err is ERR_Okay, 'SetEnv() removal failed: ' .. mSys.GetErrorMsg(err))
+
+   err, value = task.mtGetEnv('KOTUKU_TASK_STRING_VIEW_TEST')
+   assert(err is ERR_DoesNotExist, 'GetEnv() should not find removed variable, got ' .. mSys.GetErrorMsg(err))
+
+   new_task = obj.new('task')
+   err = new_task.mtAddArgument('plain')
+   assert(err is ERR_Okay, 'AddArgument() failed: ' .. mSys.GetErrorMsg(err))
+
+   err = new_task.mtAddArgument('"quoted value"')
+   assert(err is ERR_Okay, 'AddArgument() failed for quoted value: ' .. mSys.GetErrorMsg(err))
+   assert(#new_task.parameters is 2, 'Expected 2 task parameters, got ' .. #new_task.parameters)
+   assert(new_task.parameters[0] is 'plain', 'Unexpected first parameter: ' .. new_task.parameters[0])
+   assert(new_task.parameters[1] is 'quoted value', 'Unexpected quoted parameter: ' .. new_task.parameters[1])
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function TaskStringViewNullArgs()
+   task = mSys.CurrentTask()
+
+   err = task.mtAddArgument('')
+   assert(err is ERR_NullArgs, 'Expected AddArgument() to reject an empty argument, got ' .. mSys.GetErrorMsg(err))
+
+   err, value = task.mtGetEnv('')
+   assert(err is ERR_NullArgs, 'Expected GetEnv() to reject an empty name, got ' .. mSys.GetErrorMsg(err))
+
+   err = task.mtSetEnv('', 'value')
+   assert(err is ERR_NullArgs, 'Expected SetEnv() to reject an empty name, got ' .. mSys.GetErrorMsg(err))
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/network/net_iocp.cpp
+++ b/src/network/net_iocp.cpp
@@ -552,17 +552,17 @@ public:
       }
 
       auto task = CurrentTask();
-      CSTRING value;
-      if (task->getEnv(HKEY_PROXY "ProxyEnable", &value) != ERR::Okay) {
+      std::string value;
+      if (task->getEnv(HKEY_PROXY "ProxyEnable", value) != ERR::Okay) {
          log.msg("Host does not have proxies enabled (registry setting: %s)", HKEY_PROXY);
          return ERR::Okay;
       }
 
-      bool enabled = (strtol(value, nullptr, 0) > 0);
+      bool enabled = (strtol(value.c_str(), nullptr, 0) > 0);
 
-      CSTRING servers;
-      if ((task->getEnv(HKEY_PROXY "ProxyServer", &servers) IS ERR::Okay) and servers[0]) {
-         log.msg("Host has defined default proxies: %s", servers);
+      std::string servers;
+      if ((task->getEnv(HKEY_PROXY "ProxyServer", servers) IS ERR::Okay) and (not servers.empty())) {
+         log.msg("Host has defined default proxies: %s", servers.c_str());
 
          auto proxy_entries = parse_proxy_string(servers, enabled);
 
@@ -618,9 +618,8 @@ public:
          }
 
          if (!port_name.empty()) {
-            CSTRING servers;
-            task->getEnv(HKEY_PROXY "ProxyServer", &servers);
-            std::string server_list = servers ? servers : "";
+            std::string server_list;
+            task->getEnv(HKEY_PROXY "ProxyServer", server_list);
 
             const std::string search_pattern = std::format("{}=", port_name);
             if (auto pos = server_list.find(search_pattern); pos != std::string::npos) {

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -479,9 +479,9 @@ global function buildInputParameters(List)
          if param.mutable then fd ..= '|FD_MUTABLE' end
          if param.resultValue then fd ..= '|FD_RESULT' end
          if param.struct then
-            plist ..= "{ \"" .. param.struct .. ":" .. param.name .. "\", " .. fd .. " }, "
+            plist ..= f'{{ "{param.struct}:{param.name}", {fd} }}, '
          else
-            plist ..= "{ \"" .. param.name .. "\", " .. fd .. " }, "
+            plist ..= f'{{ "{param.name}", {fd} }}, '
          end
       end
    end

--- a/tools/idl/include/functions.tiri
+++ b/tools/idl/include/functions.tiri
@@ -967,7 +967,19 @@ global function klass(Name, Options:table, Spec, Private, Custom)
          param_type = param_type:sub(6):trim()
       end
 
+      if Param.resultValue and Param.mutable then
+         param_type ..= ' *'
+      end
+
       return param_type
+   end
+
+   function actionMethodParameterType(Param:table):str
+      if Param.resultValue and Param.mutable then
+         return Param.basicType .. ' &'
+      else
+         return Param.type .. ' '
+      end
    end
 
    if cl.methods then
@@ -1018,7 +1030,12 @@ global function klass(Name, Options:table, Spec, Private, Custom)
          params = ''
          if method.params then
             for param in values(method.params) do
-               struct_params ..= actionMethodStorageType(param) .. ' ' .. pName(param) .. '; '
+               local storage_type = actionMethodStorageType(param)
+               if param.resultValue and param.mutable then
+                  struct_params ..= storage_type .. pName(param) .. '; '
+               else
+                  struct_params ..= storage_type .. ' ' .. pName(param) .. '; '
+               end
 
                if params?? then params ..= ', ' end
 
@@ -1027,10 +1044,13 @@ global function klass(Name, Options:table, Spec, Private, Custom)
                   if v?? then v ..= ', ' end
                   v ..= '&' .. pName(param)
                else
-                  params ..= param.type .. ' ' .. pName(param)
+                  params ..= actionMethodParameterType(param) .. pName(param)
                   if v?? then v ..= ', ' end
 
-                  if param.resultValue then
+                  if param.resultValue and param.mutable then
+                     v ..= '&' .. pName(param)
+                     results = true
+                  elseif param.resultValue then
                      v ..= '(' .. actionMethodStorageType(param) .. ')0'
                      results = true
                   else
@@ -1062,7 +1082,9 @@ global function klass(Name, Options:table, Spec, Private, Custom)
             inline ..= f'      ERR error = Action(AC(-{method.id}), this, {args});\n'
             for p in values(method.params) do
                if p.resultValue then
-                  inline ..= f'      if ({p.name}) *{p.name} = args.{p.name};\n'
+                  if not p.mutable then
+                     inline ..= f'      if ({p.name}) *{p.name} = args.{p.name};\n'
+                  end
                end
             end
             inline ..= '      return(error);\n'


### PR DESCRIPTION
## Summary

- Upgrade Task method string parameters to `std::string_view` in the Core API.
- Switch `Task.GetEnv` result handling to caller-owned `std::string` storage.
- Fix IDL header generation for method parameters using `FD_MUTABLE|FD_RESULT` so generated C++ headers use pointer-backed method structs with reference-based wrappers.

## Impact

This removes the remaining `CSTRING` API shape for the highlighted Task methods and prevents regenerated headers from producing invalid `std::string` value/result initialisation for mutable result parameters.

## Validation

- `cmake --build build/wsl-agents --target core network origo_cmd --parallel`
- `cmake --install build/wsl-agents`
- `build/wsl-agents-install/origo tools/flute.tiri file=src/core/tests/test_misc.tiri --log-warning`
- `ctest --test-dir build/wsl-agents --output-on-failure -L core_misc`
- `git diff --check`