### PR TITLE
[Core] Converted string APIs to C++ string views

### DIFF
--- a/docs/xml/modules/classes/audio.xml
+++ b/docs/xml/modules/classes/audio.xml
@@ -252,11 +252,11 @@
     <method>
       <name>SetVolume</name>
       <comment>Sets the volume for input and output mixers.</comment>
-      <prototype>ERR snd::SetVolume(OBJECTPTR Object, INT Index, CSTRING Name, SVF Flags, INT Channel, DOUBLE Volume)</prototype>
+      <prototype>ERR snd::SetVolume(OBJECTPTR Object, INT Index, const std::string_view &amp; Name, SVF Flags, INT Channel, DOUBLE Volume)</prototype>
       <tiriPrototype>err = SetVolume(Index:num, Name:str, Flags:num, Channel:num, Volume:num)</tiriPrototype>
       <input>
         <param type="INT" name="Index">The index of the mixer that you want to set.</param>
-        <param type="CSTRING" name="Name">If the correct index number is unknown, the name of the mixer may be set here.</param>
+        <param type="const std::string_view &amp;" name="Name">If the correct index number is unknown, the name of the mixer may be set here.</param>
         <param type="SVF" name="Flags" lookup="SVF">Optional flags.</param>
         <param type="INT" name="Channel">A specific channel to modify (e.g. <code>0</code> for left, <code>1</code> for right).  If <code>-1</code>, all channels are affected.</param>
         <param type="DOUBLE" name="Volume">The volume to set for the mixer, from 0 to 1.0.  If <code>-1</code>, the current volume values are retained.</param>

--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -193,10 +193,10 @@
     <method>
       <name>CallFunction</name>
       <comment>Executes any registered function in the currently open document.</comment>
-      <prototype>ERR doc::CallFunction(OBJECTPTR Object, CSTRING Function, struct ScriptArg * Args, INT TotalArgs)</prototype>
+      <prototype>ERR doc::CallFunction(OBJECTPTR Object, const std::string_view &amp; Function, struct ScriptArg * Args, INT TotalArgs)</prototype>
       <tiriPrototype>err = CallFunction(Function:str, Args:any, TotalArgs:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Function">The name of the function that will be called.</param>
+        <param type="STRVIEW" name="Function">The name of the function that will be called.</param>
         <param type="struct ScriptArg *" name="Args">Pointer to an optional list of parameters to pass to the procedure.</param>
         <param type="INT" name="TotalArgs">The total number of entries in the <code>Args</code> array.</param>
       </input>
@@ -214,10 +214,10 @@
     <method>
       <name>Edit</name>
       <comment>Activates a user editing section within a document.</comment>
-      <prototype>ERR doc::Edit(OBJECTPTR Object, CSTRING Name, INT Flags)</prototype>
+      <prototype>ERR doc::Edit(OBJECTPTR Object, const std::string_view &amp; Name, INT Flags)</prototype>
       <tiriPrototype>err = Edit(Name:str, Flags:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the edit cell that will be activated.</param>
+        <param type="STRVIEW" name="Name">The name of the edit cell that will be activated.  If empty, the current edit cell is deactivated.</param>
         <param type="INT" name="Flags">Optional flags.</param>
       </input>
       <description>
@@ -235,10 +235,10 @@
     <method>
       <name>FindIndex</name>
       <comment>Searches the document stream for an index, returning the start and end points if found.</comment>
-      <prototype>ERR doc::FindIndex(OBJECTPTR Object, CSTRING Name, INT * Start, INT * End)</prototype>
+      <prototype>ERR doc::FindIndex(OBJECTPTR Object, const std::string_view &amp; Name, INT * Start, INT * End)</prototype>
       <tiriPrototype>err, Start:num, End:num = FindIndex(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the index to search for.</param>
+        <param type="STRVIEW" name="Name">The name of the index to search for.</param>
         <param type="INT *" name="Start">The byte position of the index is returned in this parameter.</param>
         <param type="INT *" name="End">The byte position at which the index ends is returned in this parameter.</param>
       </input>
@@ -257,10 +257,10 @@
     <method>
       <name>HideIndex</name>
       <comment>Hides the content held within a named index.</comment>
-      <prototype>ERR doc::HideIndex(OBJECTPTR Object, CSTRING Name)</prototype>
+      <prototype>ERR doc::HideIndex(OBJECTPTR Object, const std::string_view &amp; Name)</prototype>
       <tiriPrototype>err = HideIndex(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the index.</param>
+        <param type="STRVIEW" name="Name">The name of the index.</param>
       </input>
       <description>
 <p>The HideIndex() and <method>ShowIndex</method> methods allow the display of document content to be controlled at code level.  To control content visibility, start by encapsulating the content in the source document with an <code>&lt;index&gt;</code> tag and ensure that it is named.  Then make calls to HideIndex() and <method>ShowIndex</method> with the index name to manipulate visibility.</p>
@@ -277,10 +277,10 @@
     <method>
       <name>InsertText</name>
       <comment>Inserts new content into a loaded document (raw text format).</comment>
-      <prototype>ERR doc::InsertText(OBJECTPTR Object, CSTRING Text, INT Index, INT Char, INT Preformat)</prototype>
+      <prototype>ERR doc::InsertText(OBJECTPTR Object, const std::string_view &amp; Text, INT Index, INT Char, INT Preformat)</prototype>
       <tiriPrototype>err = InsertText(Text:str, Index:num, Char:num, Preformat:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Text">A UTF-8 text string.</param>
+        <param type="STRVIEW" name="Text">A UTF-8 text string.</param>
         <param type="INT" name="Index">Reference to a <code>TEXT</code> control code that will receive the content.  If <code>-1</code>, the text will be inserted at the end of the document stream.</param>
         <param type="INT" name="Char">A character offset within the <code>TEXT</code> control code that will be injected with content.  If <code>-1</code>, the text will be injected at the end of the target string.</param>
         <param type="INT" name="Preformat">If <code>true</code>, the text will be treated as pre-formatted (all whitespace, including consecutive whitespace will be recognised).</param>
@@ -302,10 +302,10 @@
     <method>
       <name>InsertXML</name>
       <comment>Inserts new content into a loaded document (XML format).</comment>
-      <prototype>ERR doc::InsertXML(OBJECTPTR Object, CSTRING XML, INT Index)</prototype>
+      <prototype>ERR doc::InsertXML(OBJECTPTR Object, const std::string_view &amp; XML, INT Index)</prototype>
       <tiriPrototype>err = InsertXML(XML:str, Index:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="XML">An XML string in RIPL format.</param>
+        <param type="STRVIEW" name="XML">An XML string in RIPL format.</param>
         <param type="INT" name="Index">The byte position at which to insert the new content.</param>
       </input>
       <description>
@@ -392,11 +392,11 @@
     <method>
       <name>SelectLink</name>
       <comment>Selects links in the document.</comment>
-      <prototype>ERR doc::SelectLink(OBJECTPTR Object, INT Index, CSTRING Name)</prototype>
+      <prototype>ERR doc::SelectLink(OBJECTPTR Object, INT Index, const std::string_view &amp; Name)</prototype>
       <tiriPrototype>err = SelectLink(Index:num, Name:str)</tiriPrototype>
       <input>
         <param type="INT" name="Index">Index to a link (links are in the order in which they are created in the document, zero being the first link).  Ignored if the <code>Name</code> parameter is set.</param>
-        <param type="CSTRING" name="Name">The name of the link to select (set to <code>NULL</code> if an <code>Index</code> is defined).</param>
+        <param type="STRVIEW" name="Name">The name of the link to select.  Leave empty if an <code>Index</code> is defined.</param>
       </input>
       <description>
 <p>This method will select a link in the document.  Selecting a link will mean that the link in question will take on a different appearance (e.g. if a text link, the text will change colour).  If the user presses the enter key when a hyperlink is selected, that link will be activated.</p>
@@ -414,10 +414,10 @@
     <method>
       <name>ShowIndex</name>
       <comment>Shows the content held within a named index.</comment>
-      <prototype>ERR doc::ShowIndex(OBJECTPTR Object, CSTRING Name)</prototype>
+      <prototype>ERR doc::ShowIndex(OBJECTPTR Object, const std::string_view &amp; Name)</prototype>
       <tiriPrototype>err = ShowIndex(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the index.</param>
+        <param type="STRVIEW" name="Name">The name of the index.</param>
       </input>
       <description>
 <p>The <method>HideIndex</method> and ShowIndex() methods allow the display of document content to be controlled at code level.  To control content visibility, start by encapsulating the content in the source document with an <code>&lt;index&gt;</code> tag and ensure that it is named.  Then make calls to <method>HideIndex</method> and ShowIndex() with the index name to manipulate visibility.</p>

--- a/docs/xml/modules/classes/task.xml
+++ b/docs/xml/modules/classes/task.xml
@@ -284,7 +284,7 @@
       <name>LaunchPath</name>
       <comment>Launched executables will start in the path specified here.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>Use the LaunchPath field to specify the folder that a launched executable will start in when the task object is activated.  This will override all other path options, such as the <code>RESET_PATH</code> flag.</p>
       </description>
@@ -294,7 +294,7 @@
       <name>Location</name>
       <comment>Location of an executable file to launch.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>When a task object is activated, the Location field will be checked for a valid filename.  If the path is valid, the executable code will be loaded from this source.  The source must be in an executable format recognised by the native platform.</p>
 <p>Leading spaces will be ignored by the string parser.  The Location string can be enclosed with quotes, in which case only the quoted portion of the string will be used as the source path.</p>
@@ -305,7 +305,7 @@
       <name>Name</name>
       <comment>Name of the task.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>This field specifies the name of the task or program that has been initialised. It is up to the developer of the program to set the Name which will appear in this field.  If there is no name for the task then the system may assign a randomly generated name.</p>
       </description>
@@ -350,7 +350,7 @@ end
       <name>Path</name>
       <comment>The current working folder of the active process.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The Path specifies the 'working folder' that determines where files are loaded from when an absolute path is not otherwise specified for file access.  Initially the working folder is usually set to the folder of the parent process, such as that of a terminal shell.</p>
 <p>The working folder can be changed at any time by updating the Path with a new folder location.  If changing to the new folder fails for any reason, the working folder will remain unchanged and the path value will not be updated.</p>
@@ -384,7 +384,7 @@ end
       <name>ProcessPath</name>
       <comment>The path of the executable that is associated with the task.</comment>
       <access read="G">Get</access>
-      <type>STRING</type>
+      <type>std::string</type>
       <description>
 <p>The ProcessPath is set to the path of the executable file that is associated with the task (not including the executable file name).  This value is managed internally and cannot be altered.</p>
 <p>In Microsoft Windows it is not always possible to determine the origins of an executable, in which case the ProcessPath is set to the working folder in use at the time the process was launched.</p>

--- a/include/kotuku/modules/audio.h
+++ b/include/kotuku/modules/audio.h
@@ -168,7 +168,7 @@ struct RemoveSample { int Handle; static const AC id = AC(-4); ERR call(OBJECTPT
 struct SetSampleLength { int Sample; int64_t Length; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct AddStream { FUNCTION Callback; FUNCTION OnStop; SFM SampleFormat; int SampleLength; int PlayOffset; struct AudioLoop * Loop; int LoopSize; int Result; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Beep { int Pitch; int Duration; int Volume; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SetVolume { int Index; CSTRING Name; SVF Flags; int Channel; double Volume; static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SetVolume { int Index; std::string_view Name; SVF Flags; int Channel; double Volume; static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -231,7 +231,7 @@ class objAudio : public Object {
       struct snd::Beep args = { Pitch, Duration, Volume };
       return(Action(AC(-7), this, &args));
    }
-   inline ERR setVolume(int Index, CSTRING Name, SVF Flags, int Channel, double Volume) noexcept {
+   inline ERR setVolume(int Index, const std::string_view & Name, SVF Flags, int Channel, double Volume) noexcept {
       struct snd::SetVolume args = { Index, Name, Flags, Channel, Volume };
       return(Action(AC(-8), this, &args));
    }

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3627,10 +3627,15 @@ class objTask : public Object {
 
    using create = kt::Create<objTask>;
 
-   double TimeOut;    // Limits the amount of time to wait for a launched process to return.
-   TSF    Flags;      // Optional flags.
-   int    ReturnCode; // The task's return code can be retrieved following execution.
-   int    ProcessID;  // Reflects the process ID when an executable is launched.
+   std::string LaunchPath;    // Launched executables will start in the path specified here.
+   std::string Name;          // Name of the task.
+   std::string Location;      // Location of an executable file to launch.
+   std::string Path;          // The current working folder of the active process.
+   std::string ProcessPath;   // The path of the executable that is associated with the task.
+   double TimeOut;            // Limits the amount of time to wait for a launched process to return.
+   TSF    Flags;              // Optional flags.
+   int    ReturnCode;         // The task's return code can be retrieved following execution.
+   int    ProcessID;          // Reflects the process ID when an executable is launched.
 
    // Action stubs
 
@@ -3689,6 +3694,41 @@ class objTask : public Object {
    }
 
    // Customised field getting
+
+   inline ERR getLaunchPath(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[12];
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
+
+   inline ERR getName(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[15];
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
+
+   inline ERR getLocation(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[17];
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
+
+   inline ERR getPath(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[9];
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
+
+   inline ERR getProcessPath(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[10];
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
 
    inline ERR getTimeOut(double &Value) noexcept {
       Value = this->TimeOut;
@@ -3755,44 +3795,9 @@ class objTask : public Object {
       return error;
    }
 
-   inline ERR getLaunchPath(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[12];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getLocation(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getName(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[15];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
    inline ERR getOutputCallback(FUNCTION * &Value) noexcept {
       auto field = &this->Class->Dictionary[3];
       auto get_field = (ERR (*)(APTR, FUNCTION * &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getPath(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
-   }
-
-   inline ERR getProcessPath(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[10];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       return error;
    }
@@ -3807,6 +3812,26 @@ class objTask : public Object {
 
 
    // Customised field setting
+
+   inline ERR setLaunchPath(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[12];
+      return field->WriteValue(this, field, 0x00904300, &Value, 1);
+   }
+
+   inline ERR setName(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[15];
+      return field->WriteValue(this, field, 0x00904300, &Value, 1);
+   }
+
+   inline ERR setLocation(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[17];
+      return field->WriteValue(this, field, 0x00904300, &Value, 1);
+   }
+
+   inline ERR setPath(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[9];
+      return field->WriteValue(this, field, 0x00904300, &Value, 1);
+   }
 
    inline ERR setTimeOut(const double Value) noexcept {
       this->TimeOut = Value;
@@ -3860,29 +3885,9 @@ class objTask : public Object {
       return field->WriteValue(this, field, FD_FUNCTION, &Value, 1);
    }
 
-   inline ERR setLaunchPath(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[12];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
-   }
-
-   inline ERR setLocation(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
-   }
-
-   inline ERR setName(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[15];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
-   }
-
    inline ERR setOutputCallback(const FUNCTION Value) noexcept {
       auto field = &this->Class->Dictionary[3];
       return field->WriteValue(this, field, FD_FUNCTION, &Value, 1);
-   }
-
-   inline ERR setPath(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(this, field, 0x00904300, &Value, 1);
    }
 
    inline ERR setPriority(const int Value) noexcept {

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -94,18 +94,18 @@ DEFINE_ENUM_FLAG_OPERATORS(FSO)
 // Document methods
 
 namespace doc {
-struct FeedParser { CSTRING String; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SelectLink { int Index; CSTRING Name; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct FindIndex { CSTRING Name; int Start; int End; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct InsertXML { CSTRING XML; int Index; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct FeedParser { std::string_view String; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SelectLink { int Index; std::string_view Name; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct FindIndex { std::string_view Name; int Start; int End; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct InsertXML { std::string_view XML; int Index; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct RemoveContent { int Start; int End; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct InsertText { CSTRING Text; int Index; int Char; int Preformat; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct CallFunction { CSTRING Function; struct ScriptArg * Args; int TotalArgs; static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct InsertText { std::string_view Text; int Index; int Char; int Preformat; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct CallFunction { std::string_view Function; struct ScriptArg * Args; int TotalArgs; static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct AddListener { DRT Trigger; FUNCTION * Function; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct RemoveListener { int Trigger; FUNCTION * Function; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ShowIndex { CSTRING Name; static const AC id = AC(-11); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct HideIndex { CSTRING Name; static const AC id = AC(-12); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Edit { CSTRING Name; int Flags; static const AC id = AC(-13); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ShowIndex { std::string_view Name; static const AC id = AC(-11); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct HideIndex { std::string_view Name; static const AC id = AC(-12); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Edit { std::string_view Name; int Flags; static const AC id = AC(-13); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct ReadContent { DATA Format; int Start; int End; STRING Result; static const AC id = AC(-14); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
@@ -168,22 +168,22 @@ class objDocument : public Object {
       struct acSetKey args = { FieldName, Value };
       return Action(AC::SetKey, this, &args);
    }
-   inline ERR feedParser(CSTRING String) noexcept {
+   inline ERR feedParser(const std::string_view & String) noexcept {
       struct doc::FeedParser args = { String };
       return(Action(AC(-1), this, &args));
    }
-   inline ERR selectLink(int Index, CSTRING Name) noexcept {
+   inline ERR selectLink(int Index, const std::string_view & Name) noexcept {
       struct doc::SelectLink args = { Index, Name };
       return(Action(AC(-2), this, &args));
    }
-   inline ERR findIndex(CSTRING Name, int * Start, int * End) noexcept {
+   inline ERR findIndex(const std::string_view & Name, int * Start, int * End) noexcept {
       struct doc::FindIndex args = { Name, (int)0, (int)0 };
       ERR error = Action(AC(-4), this, &args);
       if (Start) *Start = args.Start;
       if (End) *End = args.End;
       return(error);
    }
-   inline ERR insertXML(CSTRING XML, int Index) noexcept {
+   inline ERR insertXML(const std::string_view & XML, int Index) noexcept {
       struct doc::InsertXML args = { XML, Index };
       return(Action(AC(-5), this, &args));
    }
@@ -191,11 +191,11 @@ class objDocument : public Object {
       struct doc::RemoveContent args = { Start, End };
       return(Action(AC(-6), this, &args));
    }
-   inline ERR insertText(CSTRING Text, int Index, int Char, int Preformat) noexcept {
+   inline ERR insertText(const std::string_view & Text, int Index, int Char, int Preformat) noexcept {
       struct doc::InsertText args = { Text, Index, Char, Preformat };
       return(Action(AC(-7), this, &args));
    }
-   inline ERR callFunction(CSTRING Function, struct ScriptArg * Args, int TotalArgs) noexcept {
+   inline ERR callFunction(const std::string_view & Function, struct ScriptArg * Args, int TotalArgs) noexcept {
       struct doc::CallFunction args = { Function, Args, TotalArgs };
       return(Action(AC(-8), this, &args));
    }
@@ -207,15 +207,15 @@ class objDocument : public Object {
       struct doc::RemoveListener args = { Trigger, &Function };
       return(Action(AC(-10), this, &args));
    }
-   inline ERR showIndex(CSTRING Name) noexcept {
+   inline ERR showIndex(const std::string_view & Name) noexcept {
       struct doc::ShowIndex args = { Name };
       return(Action(AC(-11), this, &args));
    }
-   inline ERR hideIndex(CSTRING Name) noexcept {
+   inline ERR hideIndex(const std::string_view & Name) noexcept {
       struct doc::HideIndex args = { Name };
       return(Action(AC(-12), this, &args));
    }
-   inline ERR edit(CSTRING Name, int Flags) noexcept {
+   inline ERR edit(const std::string_view & Name, int Flags) noexcept {
       struct doc::Edit args = { Name, Flags };
       return(Action(AC(-13), this, &args));
    }
@@ -415,4 +415,3 @@ constexpr FieldValue EventMask(DEF Value) { return FieldValue(FID_EventMask, int
 constexpr FieldValue Flags(DCF Value) { return FieldValue(FID_Flags, int(Value)); }
 
 }
-

--- a/src/audio/audio_def.c
+++ b/src/audio/audio_def.c
@@ -18,7 +18,7 @@ FDEF maRemoveSample[] = { { "Handle", FD_INT }, { 0, 0 } };
 FDEF maSetSampleLength[] = { { "Sample", FD_INT }, { "Length", FD_INT64 }, { 0, 0 } };
 FDEF maAddStream[] = { { "Callback", FD_FUNCTION }, { "OnStop", FD_FUNCTION }, { "SampleFormat", FD_INT }, { "SampleLength", FD_INT }, { "PlayOffset", FD_INT }, { "AudioLoop:Loop", FD_PTR|FD_STRUCT }, { "LoopSize", FD_INT|FD_BUFSIZE }, { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
 FDEF maBeep[] = { { "Pitch", FD_INT }, { "Duration", FD_INT }, { "Volume", FD_INT }, { 0, 0 } };
-FDEF maSetVolume[] = { { "Index", FD_INT }, { "Name", FD_STR }, { "Flags", FD_INT }, { "Channel", FD_INT }, { "Volume", FD_DOUBLE }, { 0, 0 } };
+FDEF maSetVolume[] = { { "Index", FD_INT }, { "Name", FD_CPP|FD_STR }, { "Flags", FD_INT }, { "Channel", FD_INT }, { "Volume", FD_DOUBLE }, { 0, 0 } };
 
 static const struct MethodEntry clAudioMethods[] = {
    { AC(-1), (APTR)AUDIO_OpenChannels, "OpenChannels", maOpenChannels, sizeof(struct snd::OpenChannels) },

--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -899,7 +899,7 @@ Optional flags may be set as follows:
 
 -INPUT-
 int Index: The index of the mixer that you want to set.
-cstr Name: If the correct index number is unknown, the name of the mixer may be set here.
+cpp(strview) Name: If the correct index number is unknown, the name of the mixer may be set here.
 int(SVF) Flags: Optional flags.
 int Channel: A specific channel to modify (e.g. `0` for left, `1` for right).  If `-1`, all channels are affected.
 double Volume: The volume to set for the mixer, from 0 to 1.0.  If `-1`, the current volume values are retained.
@@ -936,7 +936,7 @@ static ERR AUDIO_SetVolume(extAudio *Self, struct snd::SetVolume *Args)
 
    // Determine what mixer we are going to adjust
 
-   if (Args->Name) {
+   if (not Args->Name.empty()) {
       for (index=0; index < std::ssize(Self->Volumes); index++) {
          if (iequals(Args->Name, Self->Volumes[index].Name)) break;
       }
@@ -1053,7 +1053,7 @@ static ERR AUDIO_SetVolume(extAudio *Self, struct snd::SetVolume *Args)
 
    // Determine what mixer we are going to adjust
 
-   if (Args->Name) {
+   if (not Args->Name.empty()) {
       for (index=0; index < (int)Self->Volumes.size(); index++) {
          if (iequals(Args->Name, Self->Volumes[index].Name)) break;
       }

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -374,7 +374,7 @@ static ERR FILE_BufferContent(extFile *Self)
       }
    }
 
-   log.msg("File content now buffered in a %" PF64 " byte memory block.", (long long)Self->Size);
+   log.msg("File content now buffered in a %" PF64 " byte memory block.", (int64_t)Self->Size);
 
    close(Self->Handle);
    Self->Handle = -1;
@@ -1200,11 +1200,15 @@ static ERR FILE_ReadLine(extFile *Self, struct fl::ReadLine *Args)
 
          if (line_offset + CHUNK >= output.size()) {
             lseek64(Self->Handle, Self->Position, SEEK_SET); // Reset the file position back to normal
+            output.clear();
             return log.warning(ERR::BufferOverflow);
          }
       }
 
-      if (not line_offset) return ERR::NoData;
+      if (not line_offset) {
+         output.clear();
+         return ERR::NoData;
+      }
 
       Self->Position += line_offset;
       if (output[line_offset] IS '\n') {
@@ -1326,9 +1330,8 @@ static ERR FILE_Seek(extFile *Self, struct acSeek *Args)
 
    if (Self->Handle IS -1) return log.warning(ERR::ObjectCorrupt);
 
-   int64_t ret;
-   if ((ret = lseek64(Self->Handle, Self->Position, SEEK_SET)) != Self->Position) {
-      log.warning("Failed to Seek to new position of %" PF64 " (return %" PF64 ").", (long long)Self->Position, (long long)ret);
+   if (auto ret = lseek64(Self->Handle, Self->Position, SEEK_SET); ret != Self->Position) {
+      log.warning("Failed to Seek to new position of %" PF64 " (return %" PF64 ").", (int64_t)Self->Position, (int64_t)ret);
       Self->Position = oldpos;
       return ERR::SystemCall;
    }
@@ -2507,7 +2510,7 @@ static ERR GET_Size(extFile *Self, int64_t *Size)
       struct stat64 stats;
       if (not stat64(path.data(), &stats)) {
          *Size = stats.st_size;
-         log.trace("The file size is %" PF64, (long long)*Size);
+         log.trace("The file size is %" PF64, (int64_t)*Size);
          return ERR::Okay;
       }
       else return convert_errno(errno, ERR::SystemCall);
@@ -2547,7 +2550,7 @@ static ERR SET_Size(extFile *Self, int64_t Size)
          return ERR::Okay;
       }
       else {
-         log.warning("Failed to set file size to %" PF64, (long long)Size);
+         log.warning("Failed to set file size to %" PF64, (int64_t)Size);
          return ERR::SystemCall;
       }
    }
@@ -2569,7 +2572,7 @@ static ERR SET_Size(extFile *Self, int64_t Size)
       // Some filesystem drivers do not support truncation for the purpose of
       // enlarging files.  In this case, we have to write to the end of the file.
 
-      log.warning("%" PF64 " bytes, ftruncate: %s", (long long)Size, strerror(errno));
+      log.warning("%" PF64 " bytes, ftruncate: %s", (int64_t)Size, strerror(errno));
 
       if (Size > Self->Size) {
          std::string_view path;

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -374,7 +374,7 @@ static ERR FILE_BufferContent(extFile *Self)
       }
    }
 
-   log.msg("File content now buffered in a %" PF64 " byte memory block.", (int64_t)Self->Size);
+   log.msg("File content now buffered in a %" PF64 " byte memory block.", (long long)Self->Size);
 
    close(Self->Handle);
    Self->Handle = -1;
@@ -1331,7 +1331,7 @@ static ERR FILE_Seek(extFile *Self, struct acSeek *Args)
    if (Self->Handle IS -1) return log.warning(ERR::ObjectCorrupt);
 
    if (auto ret = lseek64(Self->Handle, Self->Position, SEEK_SET); ret != Self->Position) {
-      log.warning("Failed to Seek to new position of %" PF64 " (return %" PF64 ").", (int64_t)Self->Position, (int64_t)ret);
+      log.warning("Failed to Seek to new position of %" PF64 " (return %" PF64 ").", (long long)Self->Position, (long long)ret);
       Self->Position = oldpos;
       return ERR::SystemCall;
    }
@@ -2510,7 +2510,7 @@ static ERR GET_Size(extFile *Self, int64_t *Size)
       struct stat64 stats;
       if (not stat64(path.data(), &stats)) {
          *Size = stats.st_size;
-         log.trace("The file size is %" PF64, (int64_t)*Size);
+         log.trace("The file size is %" PF64, (long long)*Size);
          return ERR::Okay;
       }
       else return convert_errno(errno, ERR::SystemCall);
@@ -2550,7 +2550,7 @@ static ERR SET_Size(extFile *Self, int64_t Size)
          return ERR::Okay;
       }
       else {
-         log.warning("Failed to set file size to %" PF64, (int64_t)Size);
+         log.warning("Failed to set file size to %" PF64, (long long)Size);
          return ERR::SystemCall;
       }
    }
@@ -2572,7 +2572,7 @@ static ERR SET_Size(extFile *Self, int64_t Size)
       // Some filesystem drivers do not support truncation for the purpose of
       // enlarging files.  In this case, we have to write to the end of the file.
 
-      log.warning("%" PF64 " bytes, ftruncate: %s", (int64_t)Size, strerror(errno));
+      log.warning("%" PF64 " bytes, ftruncate: %s", (long long)Size, strerror(errno));
 
       if (Size > Self->Size) {
          std::string_view path;

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -112,8 +112,6 @@ extern "C" DLLCALL int WINAPI RegEnumKeyExA(APTR hKey, int dwIndex, STRING lpNam
 static MSGID glProcessBreak = MSGID::NIL;
 #endif
 
-static ERR GET_LaunchPath(extTask *, std::string_view &);
-
 static ERR TASK_Activate(extTask *);
 static ERR TASK_Free(extTask *);
 static ERR TASK_GetEnv(extTask *, struct task::GetEnv *);
@@ -909,8 +907,7 @@ static ERR TASK_Activate(extTask *Self)
       return quoted;
    };
 
-   std::string_view path;
-   GET_LaunchPath(Self, path);
+   std::string_view path = Self->LaunchPath;
    requested_shell = ((Self->Flags & TSF::SHELL) != TSF::NIL) ? 1 : 0;
 
    std::ostringstream buffer;
@@ -2132,22 +2129,6 @@ LaunchPath: Launched executables will start in the path specified here.
 Use the LaunchPath field to specify the folder that a launched executable will start in when the task object is
 activated.  This will override all other path options, such as the `RESET_PATH` flag.
 
-*********************************************************************************************************************/
-
-static ERR GET_LaunchPath(extTask *Self, std::string_view &Value)
-{
-   Value = Self->LaunchPath;
-   return ERR::Okay;
-}
-
-static ERR SET_LaunchPath(extTask *Self, const std::string_view &Value)
-{
-   Self->LaunchPath.assign(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
 -FIELD-
 Location: Location of an executable file to launch.
 
@@ -2192,22 +2173,6 @@ Name: Name of the task.
 This field specifies the name of the task or program that has been initialised. It is up to the developer of the
 program to set the Name which will appear in this field.  If there is no name for the task then the system may
 assign a randomly generated name.
-
-*********************************************************************************************************************/
-
-static ERR GET_Name(extTask *Self, std::string_view &Value)
-{
-   Value = Self->Name;
-   return ERR::Okay;
-}
-
-static ERR SET_Name(extTask *Self, const std::string_view &Value)
-{
-   Self->Name.assign(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Parameters: Command line arguments (list format).
@@ -2275,12 +2240,6 @@ truncated.
 
 *********************************************************************************************************************/
 
-static ERR GET_Path(extTask *Self, std::string_view &Value)
-{
-   Value = Self->Path;
-   return ERR::Okay;
-}
-
 static ERR SET_Path(extTask *Self, const std::string_view &Value)
 {
    std::string new_path;
@@ -2334,16 +2293,6 @@ executable file name).  This value is managed internally and cannot be altered.
 
 In Microsoft Windows it is not always possible to determine the origins of an executable, in which case the
 ProcessPath is set to the working folder in use at the time the process was launched.
-
-*********************************************************************************************************************/
-
-static ERR GET_ProcessPath(extTask *Self, std::string_view &Value)
-{
-   Value = Self->ProcessPath;
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Priority: The task priority in relation to other tasks is be defined here.
@@ -2485,6 +2434,11 @@ process to return.  The time out is defined in seconds.
 *********************************************************************************************************************/
 
 static const FieldArray clFields[] = {
+   { "LaunchPath",      FDF_CPPSTRING|FDF_RW },
+   { "Name",            FDF_CPPSTRING|FDF_RW },
+   { "Location",        FDF_CPPSTRING|FDF_RW, nullptr, SET_Location },
+   { "Path",            FDF_CPPSTRING|FDF_RW, nullptr, SET_Path },
+   { "ProcessPath",     FDF_CPPSTRING|FDF_R },
    { "TimeOut",         FDF_DOUBLE|FDF_RW },
    { "Flags",           FDF_INTFLAGS|FDF_RI, nullptr, nullptr, &clFlags },
    { "ReturnCode",      FDF_INT|FDF_RW, GET_ReturnCode, SET_ReturnCode },
@@ -2497,12 +2451,7 @@ static const FieldArray clFields[] = {
    { "ErrorCallback",  FDF_FUNCTION|FDF_RI|FDF_PURE,    GET_ErrorCallback,   SET_ErrorCallback }, // STDERR
    { "ExitCallback",   FDF_FUNCTION|FDF_RW|FDF_PURE,    GET_ExitCallback,    SET_ExitCallback },
    { "InputCallback",  FDF_FUNCTION|FDF_RW|FDF_PURE,    GET_InputCallback,   SET_InputCallback }, // STDIN
-   { "LaunchPath",     FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_LaunchPath,      SET_LaunchPath },
-   { "Location",       FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_Location,        SET_Location },
-   { "Name",           FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_Name,            SET_Name },
    { "OutputCallback", FDF_FUNCTION|FDF_RI|FDF_PURE,    GET_OutputCallback,  SET_OutputCallback }, // STDOUT
-   { "Path",           FDF_CPPSTRING|FDF_RW|FDF_PURE,   GET_Path,            SET_Path },
-   { "ProcessPath",    FDF_CPPSTRING|FDF_R|FDF_PURE,    GET_ProcessPath },
    { "Priority",       FDF_INT|FDF_RW,         GET_Priority, SET_Priority },
    // Synonyms
    { "Src",            FDF_SYNONYM|FDF_CPPSTRING|FDF_RW|FDF_PURE, GET_Location, SET_Location },

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -472,11 +472,6 @@ class extTask : public objTask {
    kt::vector<std::string> Parameters; // Arguments (string array)
    uint64_t AffinityMask;  // CPU affinity mask for process/thread binding
    MEMORYID MessageMID;
-   std::string LaunchPath;
-   std::string Path;
-   std::string ProcessPath;
-   std::string Location;      // Where to load the task from (string)
-   std::string Name;          // Name of the task, if specified (string)
    bool     ReturnCodeSet;    // TRUE if the ReturnCode has been set
    bool     QuitCalled;       // TRUE if TASK_Quit has been called before
    FUNCTION ErrorCallback;

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1498,6 +1498,11 @@ inline ERR Call(const FUNCTION &Function, ERR &Result) noexcept {
   })
 
   klass("Task", { src="../classes/class_task.cpp", output="../classes/class_task_def.c" }, [[
+    cpp(str) LaunchPath
+    cpp(str) Name
+    cpp(str) Location
+    cpp(str) Path
+    cpp(str) ProcessPath
     double TimeOut
     int(TSF) Flags
     int ReturnCode

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -254,7 +254,7 @@ formatted - please refer to the @Script class' Exec method for more information 
 parameters.
 
 -INPUT-
-cstr Function:  The name of the function that will be called.
+cpp(strview) Function: The name of the function that will be called.
 struct(*ScriptArg) Args: Pointer to an optional list of parameters to pass to the procedure.
 int TotalArgs: The total number of entries in the `Args` array.
 
@@ -271,7 +271,7 @@ static ERR DOCUMENT_CallFunction(extDocument *Self, doc::CallFunction *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Function)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Function.empty())) return log.warning(ERR::NullArgs);
 
    // Function is in the format 'function()' or 'script.function()'
 
@@ -501,7 +501,7 @@ If the editable section is associated with an `OnEnter` trigger, the trigger wil
 invoked.
 
 -INPUT-
-cstr Name: The name of the edit cell that will be activated.
+cpp(strview) Name: The name of the edit cell that will be activated.  If empty, the current edit cell is deactivated.
 int Flags: Optional flags.
 
 -ERRORS-
@@ -519,7 +519,7 @@ static ERR DOCUMENT_Edit(extDocument *Self, doc::Edit *Args)
 {
    if (not Args) return ERR::NullArgs;
 
-   if (not Args->Name) {
+   if (Args->Name.empty()) {
       if ((not Self->CursorIndex.valid()) or (not Self->ActiveEditDef)) return ERR::Okay;
       deactivate_edit(Self, true);
       return ERR::Okay;
@@ -550,7 +550,7 @@ FeedParser: Private. Inserts content into a document during the parsing stage.
 Private
 
 -INPUT-
-cstr String: Content to insert
+cpp(strview) String: Content to insert
 
 -ERRORS-
 Okay
@@ -565,7 +565,7 @@ static ERR DOCUMENT_FeedParser(extDocument *Self, doc::FeedParser *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->String)) return ERR::NullArgs;
+   if ((not Args) or (Args->String.empty())) return ERR::NullArgs;
 
    if (not Self->Processing) return log.warning(ERR::Failed);
 
@@ -591,7 +591,7 @@ will be returned as byte indexes in the document stream.  The starting byte will
 the end byte will refer to an `SCODE::INDEX_END` code.
 
 -INPUT-
-cstr Name:  The name of the index to search for.
+cpp(strview) Name: The name of the index to search for.
 &int Start: The byte position of the index is returned in this parameter.
 &int End:   The byte position at which the index ends is returned in this parameter.
 
@@ -609,9 +609,9 @@ static ERR DOCUMENT_FindIndex(extDocument *Self, doc::FindIndex *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Name)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Name.empty())) return log.warning(ERR::NullArgs);
 
-   log.trace("Name: %s", Args->Name);
+   log.trace("Name: %.*s", int(Args->Name.size()), Args->Name.data());
 
    auto name_hash = strihash(Args->Name);
    for (INDEX i=0; i < INDEX(Self->Stream.size()); i++) {
@@ -636,7 +636,7 @@ static ERR DOCUMENT_FindIndex(extDocument *Self, doc::FindIndex *Args)
       }
    }
 
-   log.detail("Failed to find index '%s'", Args->Name);
+   log.detail("Failed to find index '%.*s'", int(Args->Name.size()), Args->Name.data());
    return ERR::Search;
 }
 
@@ -721,7 +721,7 @@ it is named.  Then make calls to HideIndex() and #ShowIndex() with the index nam
 The document layout is automatically updated and pushed to the display when this method is called.
 
 -INPUT-
-cstr Name: The name of the index.
+cpp(strview) Name: The name of the index.
 
 -ERRORS-
 Okay
@@ -739,9 +739,9 @@ static ERR DOCUMENT_HideIndex(extDocument *Self, doc::HideIndex *Args)
    kt::Log log(__FUNCTION__);
    int tab;
 
-   if ((not Args) or (not Args->Name)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Name.empty())) return log.warning(ERR::NullArgs);
 
-   log.msg("Index: %s", Args->Name);
+   log.msg("Index: %.*s", int(Args->Name.size()), Args->Name.data());
 
    auto &stream = Self->Stream;
    auto name_hash = strihash(Args->Name);
@@ -923,7 +923,7 @@ The document view will not be automatically redrawn by this method.  This must b
 to the document are complete.
 
 -INPUT-
-cstr XML: An XML string in RIPL format.
+cpp(strview) XML: An XML string in RIPL format.
 int Index: The byte position at which to insert the new content.
 
 -ERRORS-
@@ -943,7 +943,7 @@ static ERR DOCUMENT_InsertXML(extDocument *Self, doc::InsertXML *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->XML)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->XML.empty())) return log.warning(ERR::NullArgs);
    if ((Args->Index < -1) or (Args->Index > int(Self->Stream.size()))) return log.warning(ERR::OutOfRange);
 
    if (Self->Stream.data.empty()) return ERR::NoData;
@@ -958,7 +958,7 @@ static ERR DOCUMENT_InsertXML(extDocument *Self, doc::InsertXML *Args)
       Self->invalidate_text_width_cache();
 
       ERR error = insert_xml(Self, &Self->Stream, *xml, xml->Tags, (Args->Index IS -1) ? Self->Stream.size() : Args->Index, STYLE::NIL);
-      if (error != ERR::Okay) log.warning("Insert failed for: %s", Args->XML);
+      if (error != ERR::Okay) log.warning("Insert failed for: %.*s", int(Args->XML.size()), Args->XML.data());
 
       return error;
    }
@@ -980,7 +980,7 @@ The document view will not be automatically redrawn by this method.  This must b
 to the document are complete.
 
 -INPUT-
-cstr Text: A UTF-8 text string.
+cpp(strview) Text: A UTF-8 text string.
 int Index: Reference to a `TEXT` control code that will receive the content.  If `-1`, the text will be inserted at the end of the document stream.
 int Char: A character offset within the `TEXT` control code that will be injected with content.  If `-1`, the text will be injected at the end of the target string.
 int Preformat: If `true`, the text will be treated as pre-formatted (all whitespace, including consecutive whitespace will be recognised).
@@ -1001,7 +1001,7 @@ static ERR DOCUMENT_InsertText(extDocument *Self, doc::InsertText *Args)
 {
    kt::Log log(__FUNCTION__);
 
-   if ((not Args) or (not Args->Text)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Text.empty())) return log.warning(ERR::NullArgs);
    if ((Args->Index < -1) or (Args->Index > std::ssize(Self->Stream))) return log.warning(ERR::OutOfRange);
 
    log.traceBranch("Index: %d, Preformat: %d", Args->Index, Args->Preformat);
@@ -1950,7 +1950,7 @@ selectable links due to the nature of their functionality.
 
 -INPUT-
 int Index: Index to a link (links are in the order in which they are created in the document, zero being the first link).  Ignored if the `Name` parameter is set.
-cstr Name: The name of the link to select (set to `NULL` if an `Index` is defined).
+cpp(strview) Name: The name of the link to select.  Leave empty if an `Index` is defined.
 
 -ERRORS-
 Okay
@@ -1969,7 +1969,7 @@ static ERR DOCUMENT_SelectLink(extDocument *Self, doc::SelectLink *Args)
 
    if (not Args) return log.warning(ERR::NullArgs);
 
-   if ((Args->Name) and (Args->Name[0])) {
+   if (not Args->Name.empty()) {
 /*
       LONG i;
       for (i=0; i < Self->Tabs.size(); i++) {
@@ -2028,7 +2028,7 @@ it is named.  Then make calls to #HideIndex() and ShowIndex() with the index nam
 The document layout is automatically updated and pushed to the display when this method is called.
 
 -INPUT-
-cstr Name: The name of the index.
+cpp(strview) Name: The name of the index.
 
 -ERRORS-
 Okay
@@ -2045,9 +2045,9 @@ static ERR DOCUMENT_ShowIndex(extDocument *Self, doc::ShowIndex *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Name)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Name.empty())) return log.warning(ERR::NullArgs);
 
-   log.branch("Index: %s", Args->Name);
+   log.branch("Index: %.*s", int(Args->Name.size()), Args->Name.data());
 
    auto &stream = Self->Stream;
    auto name_hash = strihash(Args->Name);

--- a/src/document/class/document_def.c
+++ b/src/document/class/document_def.c
@@ -22,18 +22,18 @@ static const struct FieldDef clDocumentFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maFeedParser[] = { { "String", FD_STR }, { 0, 0 } };
-FDEF maSelectLink[] = { { "Index", FD_INT }, { "Name", FD_STR }, { 0, 0 } };
-FDEF maFindIndex[] = { { "Name", FD_STR }, { "Start", FD_INT|FD_RESULT }, { "End", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maInsertXML[] = { { "XML", FD_STR }, { "Index", FD_INT }, { 0, 0 } };
+FDEF maFeedParser[] = { { "String", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maSelectLink[] = { { "Index", FD_INT }, { "Name", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maFindIndex[] = { { "Name", FD_CPP|FD_STR }, { "Start", FD_INT|FD_RESULT }, { "End", FD_INT|FD_RESULT }, { 0, 0 } };
+FDEF maInsertXML[] = { { "XML", FD_CPP|FD_STR }, { "Index", FD_INT }, { 0, 0 } };
 FDEF maRemoveContent[] = { { "Start", FD_INT }, { "End", FD_INT }, { 0, 0 } };
-FDEF maInsertText[] = { { "Text", FD_STR }, { "Index", FD_INT }, { "Char", FD_INT }, { "Preformat", FD_INT }, { 0, 0 } };
-FDEF maCallFunction[] = { { "Function", FD_STR }, { "ScriptArg:Args", FD_PTR|FD_STRUCT }, { "TotalArgs", FD_INT }, { 0, 0 } };
+FDEF maInsertText[] = { { "Text", FD_CPP|FD_STR }, { "Index", FD_INT }, { "Char", FD_INT }, { "Preformat", FD_INT }, { 0, 0 } };
+FDEF maCallFunction[] = { { "Function", FD_CPP|FD_STR }, { "ScriptArg:Args", FD_PTR|FD_STRUCT }, { "TotalArgs", FD_INT }, { 0, 0 } };
 FDEF maAddListener[] = { { "Trigger", FD_INT }, { "Function", FD_FUNCTIONPTR }, { 0, 0 } };
 FDEF maRemoveListener[] = { { "Trigger", FD_INT }, { "Function", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maShowIndex[] = { { "Name", FD_STR }, { 0, 0 } };
-FDEF maHideIndex[] = { { "Name", FD_STR }, { 0, 0 } };
-FDEF maEdit[] = { { "Name", FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
+FDEF maShowIndex[] = { { "Name", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maHideIndex[] = { { "Name", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maEdit[] = { { "Name", FD_CPP|FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maReadContent[] = { { "Format", FD_INT }, { "Start", FD_INT }, { "End", FD_INT }, { "Result", FD_STR|FD_ALLOC|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clDocumentMethods[] = {
@@ -72,4 +72,3 @@ static const struct ActionArray clDocumentActions[] = {
    { AC::SetKey, DOCUMENT_SetKey },
    { AC::NIL, nullptr }
 };
-

--- a/src/document/tests/test_stream.tiri
+++ b/src/document/tests/test_stream.tiri
@@ -473,3 +473,65 @@ end
    root_name = xpath(xml, 'name(/extract/*[1])')
    assert(root_name is 'stream', 'Clamped XML output must start with <stream>, got ' .. tostring(root_name))
 end
+
+@Test function StringViewMethodInputs()
+   scene = obj.new('VectorScene', { pageWidth=1024, pageHeight=768 })
+   vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   doc = vp.new('document', { viewport=vp })
+   check doc.acDataFeed(nil, DATA_XML,
+      '<body/><page><index name="string_view_index">Indexed text</index><p><a href="links.rpl">Link text</a></p></page>')
+
+   err, start_index, end_index = doc.mtFindIndex('string_view_index')
+   assert(err is ERR_Okay, 'FindIndex() should accept a normal Tiri string, got ' .. err)
+   assert(start_index >= 0 and end_index > start_index, 'FindIndex() returned an invalid range')
+
+   err = doc.mtHideIndex('string_view_index')
+   assert(err is ERR_Okay, 'HideIndex() should accept a normal Tiri string, got ' .. err)
+
+   err = doc.mtShowIndex('string_view_index')
+   assert(err is ERR_Okay, 'ShowIndex() should accept a normal Tiri string, got ' .. err)
+
+   err = doc.mtSelectLink(-1, '')
+   assert(err is ERR_OutOfRange, 'SelectLink() should treat an empty name as index selection, got ' .. err)
+
+   err = doc.mtEdit('', 0)
+   assert(err is ERR_Okay, 'Edit() should treat an empty name as a deactivate request, got ' .. err)
+
+   err_xml, xml_str = doc.mtReadContent(DATA_XML, 0, 0x7fffffff)
+   assert(err_xml is ERR_Okay, 'ReadContent(DATA_XML) failed while locating text stream index, got ' .. err_xml)
+   xml = parseXML(xml_str)
+   text_index = tonumber(xpath(xml, 'string((/extract/stream//text/@stream-index)[1])'))
+   assert(text_index != nil, 'Expected to locate a text stream index')
+
+   err = doc.mtInsertText('Inserted ', text_index, -1, false)
+   assert(err is ERR_Okay, 'InsertText() should accept a normal Tiri string, got ' .. err)
+
+   err_text, text = doc.mtReadContent(DATA_TEXT, 0, 0x7fffffff)
+   assert(err_text is ERR_Okay, 'ReadContent(DATA_TEXT) failed after InsertText(), got ' .. err_text)
+   assert(text:find('Inserted'), 'Inserted text was not present in the document text output')
+end
+
+@Test function StringViewRequiredInputErrors()
+   scene = obj.new('VectorScene', { pageWidth=1024, pageHeight=768 })
+   vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   doc = vp.new('document', { viewport=vp })
+   check doc.acDataFeed(nil, DATA_XML, '<body/><page><p>Content</p></page>')
+
+   err_find, _, _ = doc.mtFindIndex('')
+   assert(err_find is ERR_NullArgs, 'FindIndex() should reject an empty name, got ' .. err_find)
+
+   err_insert_xml = doc.mtInsertXML('', -1)
+   assert(err_insert_xml is ERR_NullArgs, 'InsertXML() should reject empty XML, got ' .. err_insert_xml)
+
+   err_insert_text = doc.mtInsertText('', -1, -1, false)
+   assert(err_insert_text is ERR_NullArgs, 'InsertText() should reject empty text, got ' .. err_insert_text)
+
+   err_call = doc.mtCallFunction('', nil, 0)
+   assert(err_call is ERR_NullArgs, 'CallFunction() should reject an empty function name, got ' .. err_call)
+
+   err_show = doc.mtShowIndex('')
+   assert(err_show is ERR_NullArgs, 'ShowIndex() should reject an empty name, got ' .. err_show)
+
+   err_hide = doc.mtHideIndex('')
+   assert(err_hide is ERR_NullArgs, 'HideIndex() should reject an empty name, got ' .. err_hide)
+end


### PR DESCRIPTION
* [Document] Updated string method inputs to use cpp(strview) metadata and std::string_view handlers
* [Audio] Converted SetVolume mixer names to std::string_view inputs
* [Task] Moved string fields into generated C++ string storage
* [Test] Added Document stream coverage for normal string inputs and required empty-input errors