### PR TITLE
Upgrade method parameters to string_view APIs across Vector, Display, Network, SVG, and XQuery modules

### DIFF
--- a/docs/xml/modules/classes/clipboard.xml
+++ b/docs/xml/modules/classes/clipboard.xml
@@ -66,11 +66,11 @@
     <method>
       <name>AddFile</name>
       <comment>Adds a file reference to the clipboard.</comment>
-      <prototype>ERR clip::AddFile(OBJECTPTR Object, CLIPTYPE Datatype, CSTRING Path, CEF Flags)</prototype>
+      <prototype>ERR clip::AddFile(OBJECTPTR Object, CLIPTYPE Datatype, const std::string_view &amp; Path, CEF Flags)</prototype>
       <tiriPrototype>err = AddFile(Datatype:num, Path:str, Flags:num)</tiriPrototype>
       <input>
         <param type="CLIPTYPE" name="Datatype" lookup="CLIPTYPE">Identifies the type of data represented by the file.</param>
-        <param type="CSTRING" name="Path">Path of the file to add.</param>
+        <param type="const std::string_view &amp;" name="Path">Path of the file to add.</param>
         <param type="CEF" name="Flags" lookup="CEF">Optional flags.</param>
       </input>
       <description>
@@ -118,10 +118,10 @@
     <method>
       <name>AddText</name>
       <comment>Adds a block of text to the clipboard.</comment>
-      <prototype>ERR clip::AddText(OBJECTPTR Object, CSTRING String)</prototype>
+      <prototype>ERR clip::AddText(OBJECTPTR Object, const std::string_view &amp; String)</prototype>
       <tiriPrototype>err = AddText(String:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="String">UTF-8 text to add to the clipboard.</param>
+        <param type="const std::string_view &amp;" name="String">UTF-8 text to add to the clipboard.</param>
       </input>
       <description>
 <p>Use AddText() to place plain UTF-8 text on the clipboard.  Empty strings are ignored and return <code>ERR::Okay</code>.</p>

--- a/docs/xml/modules/classes/display.xml
+++ b/docs/xml/modules/classes/display.xml
@@ -366,10 +366,10 @@
     <method>
       <name>SetMonitor</name>
       <comment>Changes the default monitor settings.</comment>
-      <prototype>ERR gfx::SetMonitor(OBJECTPTR Object, CSTRING Name, INT MinH, INT MaxH, INT MinV, INT MaxV, MON Flags)</prototype>
+      <prototype>ERR gfx::SetMonitor(OBJECTPTR Object, const std::string_view &amp; Name, INT MinH, INT MaxH, INT MinV, INT MaxV, MON Flags)</prototype>
       <tiriPrototype>err = SetMonitor(Name:str, MinH:num, MaxH:num, MinV:num, MaxV:num, Flags:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the display.</param>
+        <param type="const std::string_view &amp;" name="Name">The name of the display.</param>
         <param type="INT" name="MinH">The minimum horizontal scan rate.  Usually set to 31.</param>
         <param type="INT" name="MaxH">The maximum horizontal scan rate.</param>
         <param type="INT" name="MinV">The minimum vertical scan rate.  Usually set to 50.</param>

--- a/docs/xml/modules/classes/netlookup.xml
+++ b/docs/xml/modules/classes/netlookup.xml
@@ -143,7 +143,7 @@
       <access read="G" write="S">Get/Set</access>
       <type>FUNCTION</type>
       <description>
-<p>The function referenced here will receive the results of the most recently resolved name or address.  The C++ prototype is <code>Function(*NetLookup, ERR Error, const std::string &amp;HostName, const std::vector&lt;IPAddress&gt; &amp;Addresses)</code>.</p>
+<p>The function referenced here will receive the results of the most recently resolved name or address.  The C++ prototype is <code>Function(*NetLookup, ERR Error, std::string_view HostName, const std::vector&lt;IPAddress&gt; &amp;Addresses)</code>.</p>
 <p>The Tiri prototype is as follows, with results readable from the <fl>HostName</fl> and <fl>Addresses</fl> fields: <code>function(NetLookup, Error)</code>.</p>
       </description>
       <tags>object-owns-result, callback-held</tags>

--- a/docs/xml/modules/classes/netlookup.xml
+++ b/docs/xml/modules/classes/netlookup.xml
@@ -37,10 +37,10 @@
     <method>
       <name>BlockingResolveAddress</name>
       <comment>Resolves an IP address to a host name.</comment>
-      <prototype>ERR nl::BlockingResolveAddress(OBJECTPTR Object, CSTRING Address)</prototype>
+      <prototype>ERR nl::BlockingResolveAddress(OBJECTPTR Object, const std::string_view &amp; Address)</prototype>
       <tiriPrototype>err = BlockingResolveAddress(Address:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Address">IP address to be resolved, e.g. 123.111.94.82.</param>
+        <param type="const std::string_view &amp;" name="Address">IP address to be resolved, e.g. 123.111.94.82.</param>
       </input>
       <description>
 <p>BlockingResolveAddress() performs an IP address resolution, converting an address to an official host name and list of IP addresses.  The resolution process requires contact with a DNS server and this will cause the routine to block until a response is received.</p>
@@ -62,10 +62,10 @@
     <method>
       <name>BlockingResolveName</name>
       <comment>Resolves a domain name to an official host name and a list of IP addresses.</comment>
-      <prototype>ERR nl::BlockingResolveName(OBJECTPTR Object, CSTRING HostName)</prototype>
+      <prototype>ERR nl::BlockingResolveName(OBJECTPTR Object, const std::string_view &amp; HostName)</prototype>
       <tiriPrototype>err = BlockingResolveName(HostName:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="HostName">The host name to be resolved.</param>
+        <param type="const std::string_view &amp;" name="HostName">The host name to be resolved.</param>
       </input>
       <description>
 <p>BlockingResolveName() performs a domain name resolution, converting a domain name to its official host name and IP addresses.  The resolution process requires contact with a DNS server and the function will block until a response is received or a timeout occurs.</p>
@@ -86,10 +86,10 @@
     <method>
       <name>ResolveAddress</name>
       <comment>Resolves an IP address to a host name.</comment>
-      <prototype>ERR nl::ResolveAddress(OBJECTPTR Object, CSTRING Address)</prototype>
+      <prototype>ERR nl::ResolveAddress(OBJECTPTR Object, const std::string_view &amp; Address)</prototype>
       <tiriPrototype>err = ResolveAddress(Address:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Address">IP address to be resolved, e.g. "123.111.94.82".</param>
+        <param type="const std::string_view &amp;" name="Address">IP address to be resolved, e.g. "123.111.94.82".</param>
       </input>
       <description>
 <p>ResolveAddress() performs a IP address resolution, converting an address to an official host name and list of IP addresses.  The resolution process involves contacting a DNS server.  To prevent delays, asynchronous communication is used so that the function can return immediately.  The <fl>Callback</fl> function will be called on completion of the process.</p>
@@ -107,10 +107,10 @@
     <method>
       <name>ResolveName</name>
       <comment>Resolves a domain name to an official host name and a list of IP addresses.</comment>
-      <prototype>ERR nl::ResolveName(OBJECTPTR Object, CSTRING HostName)</prototype>
+      <prototype>ERR nl::ResolveName(OBJECTPTR Object, const std::string_view &amp; HostName)</prototype>
       <tiriPrototype>err = ResolveName(HostName:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="HostName">The host name to be resolved.</param>
+        <param type="const std::string_view &amp;" name="HostName">The host name to be resolved.</param>
       </input>
       <description>
 <p>ResolveName() performs a domain name resolution, converting a domain name to an official host name and IP addresses. The resolution process involves contacting a DNS server.  To prevent delays, asynchronous communication is used so that the function can return immediately.  The <fl>Callback</fl> function will be called on completion of the process.</p>

--- a/docs/xml/modules/classes/netsocket.xml
+++ b/docs/xml/modules/classes/netsocket.xml
@@ -108,10 +108,10 @@ initially fill the internal write buffer, thereafter it will be called whenever 
     <method>
       <name>Connect</name>
       <comment>Connects a NetSocket to an address.</comment>
-      <prototype>ERR ns::Connect(OBJECTPTR Object, CSTRING Address, INT Port, DOUBLE Timeout)</prototype>
+      <prototype>ERR ns::Connect(OBJECTPTR Object, const std::string_view &amp; Address, INT Port, DOUBLE Timeout)</prototype>
       <tiriPrototype>err = Connect(Address:str, Port:num, Timeout:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Address">String containing either a domain name (e.g. <code>www.google.com</code>) or an IP address (e.g. <code>123.123.123.123</code>)</param>
+        <param type="const std::string_view &amp;" name="Address">String containing either a domain name (e.g. <code>www.google.com</code>) or an IP address (e.g. <code>123.123.123.123</code>)</param>
         <param type="INT" name="Port">Remote port to connect to.</param>
         <param type="DOUBLE" name="Timeout">Connection timeout in seconds (0 = no timeout).</param>
       </input>
@@ -154,10 +154,10 @@ initially fill the internal write buffer, thereafter it will be called whenever 
     <method>
       <name>JoinMulticastGroup</name>
       <comment>Join a multicast group for receiving multicast packets (UDP only).</comment>
-      <prototype>ERR ns::JoinMulticastGroup(OBJECTPTR Object, CSTRING Group)</prototype>
+      <prototype>ERR ns::JoinMulticastGroup(OBJECTPTR Object, const std::string_view &amp; Group)</prototype>
       <tiriPrototype>err = JoinMulticastGroup(Group:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The multicast group address to join (e.g. <code>224.1.1.1</code>).</param>
+        <param type="const std::string_view &amp;" name="Group">The multicast group address to join (e.g. <code>224.1.1.1</code>).</param>
       </input>
       <description>
 <p>This method joins a multicast group, allowing the socket to receive packets sent to the specified multicast address. This is only available for UDP sockets.</p>
@@ -175,10 +175,10 @@ initially fill the internal write buffer, thereafter it will be called whenever 
     <method>
       <name>LeaveMulticastGroup</name>
       <comment>Leave a multicast group (UDP only).</comment>
-      <prototype>ERR ns::LeaveMulticastGroup(OBJECTPTR Object, CSTRING Group)</prototype>
+      <prototype>ERR ns::LeaveMulticastGroup(OBJECTPTR Object, const std::string_view &amp; Group)</prototype>
       <tiriPrototype>err = LeaveMulticastGroup(Group:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Group">The multicast group address to leave.</param>
+        <param type="const std::string_view &amp;" name="Group">The multicast group address to leave.</param>
       </input>
       <description>
 <p>This method leaves a previously joined multicast group, stopping the reception of packets sent to the specified multicast address.</p>

--- a/docs/xml/modules/classes/svg.xml
+++ b/docs/xml/modules/classes/svg.xml
@@ -131,10 +131,10 @@
     <method>
       <name>ParseSymbol</name>
       <comment>Instantiates an SVG symbol definition within a target viewport.</comment>
-      <prototype>ERR svg::ParseSymbol(OBJECTPTR Object, CSTRING ID, objVectorViewport * Viewport)</prototype>
+      <prototype>ERR svg::ParseSymbol(OBJECTPTR Object, const std::string_view &amp; ID, objVectorViewport * Viewport)</prototype>
       <tiriPrototype>err = ParseSymbol(ID:str, Viewport:obj)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="ID">Name of the symbol to parse.</param>
+        <param type="const std::string_view &amp;" name="ID">Name of the symbol to parse.</param>
         <param type="objVectorViewport *" name="Viewport">The target viewport.</param>
       </input>
       <description>

--- a/docs/xml/modules/classes/vectorscene.xml
+++ b/docs/xml/modules/classes/vectorscene.xml
@@ -91,10 +91,10 @@
     <method>
       <name>AddDef</name>
       <comment>Registers a named definition object within a scene graph.</comment>
-      <prototype>ERR sc::AddDef(OBJECTPTR Object, CSTRING Name, OBJECTPTR Def)</prototype>
+      <prototype>ERR sc::AddDef(OBJECTPTR Object, const std::string_view &amp; Name, OBJECTPTR Def)</prototype>
       <tiriPrototype>err = AddDef(Name:str, Def:obj)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The unique name to associate with the definition.</param>
+        <param type="const std::string_view &amp;" name="Name">The unique name to associate with the definition.</param>
         <param type="OBJECTPTR" name="Def">Reference to the definition object.</param>
       </input>
       <description>
@@ -129,10 +129,10 @@
     <method>
       <name>FindDef</name>
       <comment>Search for a vector definition by name.</comment>
-      <prototype>ERR sc::FindDef(OBJECTPTR Object, CSTRING Name, OBJECTPTR * Def)</prototype>
+      <prototype>ERR sc::FindDef(OBJECTPTR Object, const std::string_view &amp; Name, OBJECTPTR * Def)</prototype>
       <tiriPrototype>err, Def:obj = FindDef(Name:str)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the definition.</param>
+        <param type="const std::string_view &amp;" name="Name">The name of the definition.</param>
         <param type="OBJECTPTR *" name="Def">A pointer to the definition object is returned here if discovered.</param>
       </input>
       <description>

--- a/docs/xml/modules/classes/xquery.xml
+++ b/docs/xml/modules/classes/xquery.xml
@@ -167,12 +167,12 @@ if (query.ok()) {
     <method>
       <name>InspectFunctions</name>
       <comment>Returns information about compiled XQuery functions.</comment>
-      <prototype>ERR xq::InspectFunctions(OBJECTPTR Object, CSTRING Name, XIF ResultFlags, CSTRING * Result)</prototype>
+      <prototype>ERR xq::InspectFunctions(OBJECTPTR Object, const std::string_view &amp; Name, XIF ResultFlags, std::string * Result)</prototype>
       <tiriPrototype>err, Result:str = InspectFunctions(Name:str, ResultFlags:num)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="Name">The name of the function or functions to inspect (supports wildcards).</param>
+        <param type="const std::string_view &amp;" name="Name">The name of the function or functions to inspect (supports wildcards).</param>
         <param type="XIF" name="ResultFlags" lookup="XIF">Bitmask controlling the returned information.</param>
-        <param type="CSTRING *" name="Result">Receives a serialised XML document describing the function(s).</param>
+        <param type="std::string *" name="Result">Receives a serialised XML document describing the function(s).</param>
       </input>
       <description>
 <p>Use InspectFunctions to retrieve metadata about user-defined or standard XQuery functions available in the compiled XQuery object.  The function name can include wildcards to match multiple functions.</p>
@@ -199,16 +199,16 @@ if (query.ok()) {
         <error code="Okay">Operation successful.</error>
         <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
-      <tags>mutates-object, caller-owns-result, null-terminated-result</tags>
+      <tags>mutates-object, caller-owns-result, null-terminated-result, mutates-input</tags>
     </method>
 
     <method>
       <name>RegisterFunction</name>
       <comment>Register a custom XQuery function.</comment>
-      <prototype>ERR xq::RegisterFunction(OBJECTPTR Object, CSTRING FunctionName, FUNCTION * Callback)</prototype>
+      <prototype>ERR xq::RegisterFunction(OBJECTPTR Object, const std::string_view &amp; FunctionName, FUNCTION * Callback)</prototype>
       <tiriPrototype>err = RegisterFunction(FunctionName:str, Callback:func)</tiriPrototype>
       <input>
-        <param type="CSTRING" name="FunctionName">The name of the function to register (e.g., "custom-function").</param>
+        <param type="const std::string_view &amp;" name="FunctionName">The name of the function to register (e.g., "custom-function").</param>
         <param type="FUNCTION *" name="Callback">The callback function to register for FunctionName.</param>
       </input>
       <description>

--- a/include/kotuku/modules/display.h
+++ b/include/kotuku/modules/display.h
@@ -1048,7 +1048,7 @@ struct SetDisplay { int X; int Y; int Width; int Height; int InsideWidth; int In
 struct SizeHints { int MinWidth; int MinHeight; int MaxWidth; int MaxHeight; int EnforceAspect; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SetGamma { double Red; double Green; double Blue; GMF Flags; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SetGammaLinear { double Red; double Green; double Blue; GMF Flags; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SetMonitor { CSTRING Name; int MinH; int MaxH; int MinV; int MaxV; MON Flags; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SetMonitor { std::string_view Name; int MinH; int MaxH; int MinV; int MaxV; MON Flags; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Minimise { static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct CheckXWindow { static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetFrame { int Left; int Top; int Right; int Bottom; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
@@ -1155,7 +1155,7 @@ class objDisplay : public Object {
       struct gfx::SetGammaLinear args = { Red, Green, Blue, Flags };
       return(Action(AC(-6), this, &args));
    }
-   inline ERR setMonitor(CSTRING Name, int MinH, int MaxH, int MinV, int MaxV, MON Flags) noexcept {
+   inline ERR setMonitor(const std::string_view & Name, int MinH, int MaxH, int MinV, int MaxV, MON Flags) noexcept {
       struct gfx::SetMonitor args = { Name, MinH, MaxH, MinV, MaxV, Flags };
       return(Action(AC(-7), this, &args));
    }
@@ -1465,10 +1465,10 @@ class objDisplay : public Object {
 // Clipboard methods
 
 namespace clip {
-struct AddFile { CLIPTYPE Datatype; CSTRING Path; CEF Flags; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct AddFile { CLIPTYPE Datatype; std::string_view Path; CEF Flags; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct AddObjects { CLIPTYPE Datatype; OBJECTID * Objects; CEF Flags; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetFiles { CLIPTYPE Filter; int Index; CLIPTYPE Datatype; CSTRING * Files; CEF Flags; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct AddText { CSTRING String; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct AddText { std::string_view String; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Remove { CLIPTYPE Datatype; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
@@ -1494,7 +1494,7 @@ class objClipboard : public Object {
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR init() noexcept { return InitObject(this); }
-   inline ERR addFile(CLIPTYPE Datatype, CSTRING Path, CEF Flags) noexcept {
+   inline ERR addFile(CLIPTYPE Datatype, const std::string_view & Path, CEF Flags) noexcept {
       struct clip::AddFile args = { Datatype, Path, Flags };
       return(Action(AC(-1), this, &args));
    }
@@ -1510,7 +1510,7 @@ class objClipboard : public Object {
       if (Flags) *Flags = args.Flags;
       return(error);
    }
-   inline ERR addText(CSTRING String) noexcept {
+   inline ERR addText(const std::string_view & String) noexcept {
       struct clip::AddText args = { String };
       return(Action(AC(-4), this, &args));
    }

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -447,10 +447,10 @@ class objProxy : public Object {
 // NetLookup methods
 
 namespace nl {
-struct ResolveName { CSTRING HostName; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ResolveAddress { CSTRING Address; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct BlockingResolveName { CSTRING HostName; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct BlockingResolveAddress { CSTRING Address; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ResolveName { std::string_view HostName; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ResolveAddress { std::string_view Address; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct BlockingResolveName { std::string_view HostName; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct BlockingResolveAddress { std::string_view Address; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -467,19 +467,19 @@ class objNetLookup : public Object {
    // Action stubs
 
    inline ERR init() noexcept { return InitObject(this); }
-   inline ERR resolveName(CSTRING HostName) noexcept {
+   inline ERR resolveName(const std::string_view & HostName) noexcept {
       struct nl::ResolveName args = { HostName };
       return(Action(AC(-1), this, &args));
    }
-   inline ERR resolveAddress(CSTRING Address) noexcept {
+   inline ERR resolveAddress(const std::string_view & Address) noexcept {
       struct nl::ResolveAddress args = { Address };
       return(Action(AC(-2), this, &args));
    }
-   inline ERR blockingResolveName(CSTRING HostName) noexcept {
+   inline ERR blockingResolveName(const std::string_view & HostName) noexcept {
       struct nl::BlockingResolveName args = { HostName };
       return(Action(AC(-3), this, &args));
    }
-   inline ERR blockingResolveAddress(CSTRING Address) noexcept {
+   inline ERR blockingResolveAddress(const std::string_view & Address) noexcept {
       struct nl::BlockingResolveAddress args = { Address };
       return(Action(AC(-4), this, &args));
    }
@@ -544,12 +544,12 @@ class objNetLookup : public Object {
 // NetSocket methods
 
 namespace ns {
-struct Connect { CSTRING Address; int Port; double Timeout; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Connect { std::string_view Address; int Port; double Timeout; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetLocalIPAddress { struct IPAddress * Address; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SendTo { struct IPAddress * Dest; APTR Data; int Length; int BytesSent; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct RecvFrom { struct IPAddress * Source; APTR Buffer; int BufferSize; int BytesRead; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct JoinMulticastGroup { CSTRING Group; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct LeaveMulticastGroup { CSTRING Group; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct JoinMulticastGroup { std::string_view Group; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct LeaveMulticastGroup { std::string_view Group; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -617,7 +617,7 @@ class objNetSocket : public Object {
          return error;
       }
    }
-   inline ERR connect(CSTRING Address, int Port, double Timeout) noexcept {
+   inline ERR connect(const std::string_view & Address, int Port, double Timeout) noexcept {
       struct ns::Connect args = { Address, Port, Timeout };
       return(Action(AC(-1), this, &args));
    }
@@ -637,11 +637,11 @@ class objNetSocket : public Object {
       if (BytesRead) *BytesRead = args.BytesRead;
       return(error);
    }
-   inline ERR joinMulticastGroup(CSTRING Group) noexcept {
+   inline ERR joinMulticastGroup(const std::string_view & Group) noexcept {
       struct ns::JoinMulticastGroup args = { Group };
       return(Action(AC(-5), this, &args));
    }
-   inline ERR leaveMulticastGroup(CSTRING Group) noexcept {
+   inline ERR leaveMulticastGroup(const std::string_view & Group) noexcept {
       struct ns::LeaveMulticastGroup args = { Group };
       return(Action(AC(-6), this, &args));
    }

--- a/include/kotuku/modules/svg.h
+++ b/include/kotuku/modules/svg.h
@@ -33,7 +33,7 @@ DEFINE_ENUM_FLAG_OPERATORS(SVF)
 
 namespace svg {
 struct Render { objBitmap * Bitmap; int X; int Y; int Width; int Height; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ParseSymbol { CSTRING ID; objVectorViewport * Viewport; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ParseSymbol { std::string_view ID; objVectorViewport * Viewport; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -74,7 +74,7 @@ class objSVG : public Object {
       struct svg::Render args = { Bitmap, X, Y, Width, Height };
       return(Action(AC(-1), this, &args));
    }
-   inline ERR parseSymbol(CSTRING ID, objVectorViewport * Viewport) noexcept {
+   inline ERR parseSymbol(const std::string_view & ID, objVectorViewport * Viewport) noexcept {
       struct svg::ParseSymbol args = { ID, Viewport };
       return(Action(AC(-2), this, &args));
    }

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -690,9 +690,9 @@ class objVectorTransition : public Object {
 // VectorScene methods
 
 namespace sc {
-struct AddDef { CSTRING Name; OBJECTPTR Def; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct AddDef { std::string_view Name; OBJECTPTR Def; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SearchByID { int ID; OBJECTPTR Result; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct FindDef { CSTRING Name; OBJECTPTR Def; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct FindDef { std::string_view Name; OBJECTPTR Def; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Debug { static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
@@ -737,7 +737,7 @@ class objVectorScene : public Object {
       struct acResize args = { Width, Height, Depth };
       return Action(AC::Resize, this, &args);
    }
-   inline ERR addDef(CSTRING Name, OBJECTPTR Def) noexcept {
+   inline ERR addDef(const std::string_view & Name, OBJECTPTR Def) noexcept {
       struct sc::AddDef args = { Name, Def };
       return(Action(AC(-1), this, &args));
    }
@@ -747,7 +747,7 @@ class objVectorScene : public Object {
       if (Result) *Result = args.Result;
       return(error);
    }
-   inline ERR findDef(CSTRING Name, OBJECTPTR * Def) noexcept {
+   inline ERR findDef(const std::string_view & Name, OBJECTPTR * Def) noexcept {
       struct sc::FindDef args = { Name, (OBJECTPTR)0 };
       ERR error = Action(AC(-3), this, &args);
       if (Def) *Def = args.Def;
@@ -5646,4 +5646,3 @@ template <kt::NumericOrScale T> FieldValue RoundX(T Value) { return FieldValue(F
 template <kt::NumericOrScale T> FieldValue RoundY(T Value) { return FieldValue(FID_RoundY, Value); }
 
 }
-

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -5646,3 +5646,4 @@ template <kt::NumericOrScale T> FieldValue RoundX(T Value) { return FieldValue(F
 template <kt::NumericOrScale T> FieldValue RoundY(T Value) { return FieldValue(FID_RoundY, Value); }
 
 }
+

--- a/include/kotuku/modules/xquery.h
+++ b/include/kotuku/modules/xquery.h
@@ -138,8 +138,8 @@ DEFINE_ENUM_FLAG_OPERATORS(XEF)
 namespace xq {
 struct Evaluate { objXML * XML; int Index; XEF Flags; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Search { objXML * XML; FUNCTION * Callback; int Index; XEF Flags; static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct RegisterFunction { CSTRING FunctionName; FUNCTION * Callback; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct InspectFunctions { CSTRING Name; XIF ResultFlags; CSTRING Result; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct RegisterFunction { std::string_view FunctionName; FUNCTION * Callback; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct InspectFunctions { std::string_view Name; XIF ResultFlags; std::string *Result; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -179,14 +179,13 @@ class objXQuery : public Object {
       struct xq::Search args = { XML, &Callback, Index, Flags };
       return(Action(AC(-2), this, &args));
    }
-   inline ERR registerFunction(CSTRING FunctionName, FUNCTION Callback) noexcept {
+   inline ERR registerFunction(const std::string_view & FunctionName, FUNCTION Callback) noexcept {
       struct xq::RegisterFunction args = { FunctionName, &Callback };
       return(Action(AC(-3), this, &args));
    }
-   inline ERR inspectFunctions(CSTRING Name, XIF ResultFlags, CSTRING * Result) noexcept {
-      struct xq::InspectFunctions args = { Name, ResultFlags, (CSTRING)0 };
+   inline ERR inspectFunctions(const std::string_view & Name, XIF ResultFlags, std::string &Result) noexcept {
+      struct xq::InspectFunctions args = { Name, ResultFlags, &Result };
       ERR error = Action(AC(-4), this, &args);
-      if (Result) *Result = args.Result;
       return(error);
    }
 

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -62,27 +62,27 @@ static int glLastClipID = -1;
 
 static std::string get_datatype(CLIPTYPE);
 static ERR add_clip(CLIPTYPE, const std::vector<ClipItem> &, CEF = CEF::NIL);
-static ERR add_clip(CSTRING);
+static ERR add_clip(std::string_view);
 static ERR CLIPBOARD_AddObjects(objClipboard *, struct clip::AddObjects *);
 
 #ifdef _WIN32
-static std::u16string utf8_to_utf16(CSTRING String, int Length, bool SurrogatePairs)
+static std::u16string utf8_to_utf16(std::string_view String, bool SurrogatePairs)
 {
    std::u16string result;
-   if (!String) return result;
+   if (String.empty()) return result;
 
-   auto str = String;
+   auto str = String.data();
    int chars, bytes = 0;
-   for (chars=0; (bytes < Length) and (str[bytes]); chars++) {
-      for (++bytes; (bytes < Length) and ((str[bytes] & 0xc0) IS 0x80); bytes++);
+   for (chars=0; bytes < std::ssize(String); chars++) {
+      for (++bytes; (bytes < std::ssize(String)) and ((str[bytes] & 0xc0) IS 0x80); bytes++);
    }
 
    result.reserve(size_t(chars));
 
    int pos = 0;
-   while (pos < bytes) {
+   while (pos < std::ssize(String)) {
       int len = UTF8CharLength(str);
-      if ((len IS 0) or (pos + len > bytes)) break;
+      if ((len IS 0) or (pos + len > std::ssize(String))) break;
 
       uint32_t codepoint;
       if (SurrogatePairs and (len IS 1)) codepoint = *str;
@@ -180,7 +180,7 @@ static ERR add_file_to_host(objClipboard *Self, const std::vector<ClipItem> &Ite
    for (auto &item : Items) {
       std::string path;
       if (ResolvePath(item.Path, RSF::NIL, &path) IS ERR::Okay) {
-         list << utf8_to_utf16(path.c_str(), 0x7fffffff, true) << char16_t(0);
+         list << utf8_to_utf16(path, true) << char16_t(0);
       }
    }
    list << char16_t(0); // An extra null byte is required to terminate the list for Windows HDROP
@@ -196,7 +196,7 @@ static ERR add_file_to_host(objClipboard *Self, const std::vector<ClipItem> &Ite
 
 //********************************************************************************************************************
 
-static ERR add_text_to_host(objClipboard *Self, CSTRING String, int Length = 0x7fffffff)
+static ERR add_text_to_host(objClipboard *Self, std::string_view String)
 {
    kt::Log log(__FUNCTION__);
 
@@ -205,7 +205,7 @@ static ERR add_text_to_host(objClipboard *Self, CSTRING String, int Length = 0x7
 #ifdef _WIN32
    // Copy text to the Windows clipboard.  This requires a conversion from UTF-8 to UTF-16.
 
-   auto utf16 = utf8_to_utf16(String, Length, false);
+   auto utf16 = utf8_to_utf16(String, false);
    utf16.push_back(0);
 
    auto error = (ERR)winAddClip(int(CLIPTYPE::TEXT), utf16.data(), utf16.size() * sizeof(char16_t), false);
@@ -238,7 +238,7 @@ Optional flags that may be passed to this method are as follows:
 
 -INPUT-
 int(CLIPTYPE) Datatype: Identifies the type of data represented by the file.
-cstr Path: Path of the file to add.
+cpp(strview) Path: Path of the file to add.
 int(CEF) Flags: Optional flags.
 
 -ERRORS-
@@ -257,11 +257,12 @@ static ERR CLIPBOARD_AddFile(objClipboard *Self, struct clip::AddFile *Args)
    kt::Log log;
 
    if (!Args) return log.warning(ERR::NullArgs);
-   if ((!Args->Path) or (!Args->Path[0])) return log.warning(ERR::MissingPath);
+   if (Args->Path.empty()) return log.warning(ERR::MissingPath);
 
-   log.branch("Path: %s", Args->Path);
+   std::string path(Args->Path);
+   log.branch("Path: %s", path.c_str());
 
-   std::vector<ClipItem> items = { std::string(Args->Path) };
+   std::vector<ClipItem> items = { path };
    if (add_file_to_host(Self, items, ((Args->Flags & CEF::DELETE) != CEF::NIL) ? true : false) IS ERR::Okay) {
       if (glHistoryLimit <= 1) return ERR::Okay;
    }
@@ -361,7 +362,7 @@ On Windows, the text is also published to the host clipboard when supported.  If
 host clipboard accepts the text, no local cache file is created.
 
 -INPUT-
-cstr String: UTF-8 text to add to the clipboard.
+cpp(strview) String: UTF-8 text to add to the clipboard.
 
 -ERRORS-
 Okay
@@ -378,8 +379,8 @@ static ERR CLIPBOARD_AddText(objClipboard *Self, struct clip::AddText *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->String)) return log.warning(ERR::NullArgs);
-   if (!Args->String[0]) return ERR::Okay;
+   if (!Args) return log.warning(ERR::NullArgs);
+   if (Args->String.empty()) return ERR::Okay;
 
    if (add_text_to_host(Self, Args->String) IS ERR::Okay) {
       if (glHistoryLimit <= 1) return ERR::Okay;
@@ -445,7 +446,7 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
       log.msg("Copying text to the clipboard.");
 
       if (!Args->Buffer) return log.warning(ERR::NullArgs);
-      if (auto error = add_text_to_host(Self, (CSTRING)Args->Buffer, Args->Size);
+      if (auto error = add_text_to_host(Self, std::string_view((CSTRING)Args->Buffer, size_t(Args->Size)));
             (error != ERR::Okay) and (error != ERR::NoSupport)) {
          return log.warning(error);
       }
@@ -772,7 +773,7 @@ static ERR add_clip(CLIPTYPE Datatype, const std::vector<ClipItem> &Items, CEF F
 
 //********************************************************************************************************************
 
-static ERR add_clip(CSTRING String)
+static ERR add_clip(std::string_view String)
 {
    kt::Log log(__FUNCTION__);
    log.branch();
@@ -781,7 +782,7 @@ static ERR add_clip(CSTRING String)
    if (auto error = add_clip(CLIPTYPE::TEXT, items); error IS ERR::Okay) {
       kt::Create<objFile> file = { fl::Path(items[0].Path), fl::Flags(FL::WRITE|FL::NEW), fl::Permissions(PERMIT::READ|PERMIT::WRITE) };
       if (file.ok()) {
-         if (auto error = file->write(String, strlen(String), 0); error != ERR::Okay) return log.warning(error);
+         if (auto error = file->write(String.data(), int(String.size()), 0); error != ERR::Okay) return log.warning(error);
          return ERR::Okay;
       }
       else return log.warning(ERR::CreateFile);
@@ -907,7 +908,7 @@ extern "C" void report_windows_clip_utf16(uint16_t *String)
       }
    }
 
-   add_clip(buffer.str().c_str());
+   add_clip(buffer.str());
    glLastClipID = winCurrentClipboardID();
 }
 

--- a/src/display/class_clipboard_def.c
+++ b/src/display/class_clipboard_def.c
@@ -7,10 +7,10 @@ static const struct FieldDef clClipboardFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maAddFile[] = { { "Datatype", FD_INT }, { "Path", FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
+FDEF maAddFile[] = { { "Datatype", FD_INT }, { "Path", FD_CPP|FD_STR }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maAddObjects[] = { { "Datatype", FD_INT }, { "Objects", FD_PTR }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maGetFiles[] = { { "Filter", FD_INT }, { "Index", FD_INT }, { "Datatype", FD_INT|FD_RESULT }, { "Files", FD_ARRAY|FD_STR|FD_ALLOC|FD_RESULT }, { "Flags", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maAddText[] = { { "String", FD_STR }, { 0, 0 } };
+FDEF maAddText[] = { { "String", FD_CPP|FD_STR }, { 0, 0 } };
 FDEF maRemove[] = { { "Datatype", FD_INT }, { 0, 0 } };
 
 static const struct MethodEntry clClipboardMethods[] = {

--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -1822,7 +1822,7 @@ This method does not work on hosted platforms.  All parameters passed to this me
 if it should not be changed).
 
 -INPUT-
-cstr Name: The name of the display.
+cpp(strview) Name: The name of the display.
 int MinH: The minimum horizontal scan rate.  Usually set to 31.
 int MaxH: The maximum horizontal scan rate.
 int MinV: The minimum vertical scan rate.  Usually set to 50.
@@ -1856,13 +1856,14 @@ static ERR DISPLAY_SetMonitor(extDisplay *Self, gfx::SetMonitor *Args)
       return ERR::NoPermission;
    }
 
-   log.branch("%s", Args->Name);
+   std::string name(Args->Name);
+   log.branch("%s", name.c_str());
 
    glSixBitDisplay = ((Args->Flags & MON::BIT_6) != MON::NIL);
    if (glSixBitDisplay) Self->Flags |= SCR::BIT_6;
    else Self->Flags &= ~SCR::BIT_6;
 
-   if (Args->Name) StrCopy(Args->Name, Self->Display, sizeof(Self->Display));
+   if (not Args->Name.empty()) StrCopy(name.c_str(), Self->Display, sizeof(Self->Display));
 
    // Get the current monitor record, then set the new scan rates against it.
 

--- a/src/display/class_display_def.c
+++ b/src/display/class_display_def.c
@@ -49,7 +49,7 @@ FDEF maSetDisplay[] = { { "X", FD_INT }, { "Y", FD_INT }, { "Width", FD_INT }, {
 FDEF maSizeHints[] = { { "MinWidth", FD_INT }, { "MinHeight", FD_INT }, { "MaxWidth", FD_INT }, { "MaxHeight", FD_INT }, { "EnforceAspect", FD_INT }, { 0, 0 } };
 FDEF maSetGamma[] = { { "Red", FD_DOUBLE }, { "Green", FD_DOUBLE }, { "Blue", FD_DOUBLE }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maSetGammaLinear[] = { { "Red", FD_DOUBLE }, { "Green", FD_DOUBLE }, { "Blue", FD_DOUBLE }, { "Flags", FD_INT }, { 0, 0 } };
-FDEF maSetMonitor[] = { { "Name", FD_STR }, { "MinH", FD_INT }, { "MaxH", FD_INT }, { "MinV", FD_INT }, { "MaxV", FD_INT }, { "Flags", FD_INT }, { 0, 0 } };
+FDEF maSetMonitor[] = { { "Name", FD_CPP|FD_STR }, { "MinH", FD_INT }, { "MaxH", FD_INT }, { "MinV", FD_INT }, { "MaxV", FD_INT }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maGetFrame[] = { { "Left", FD_INT|FD_RESULT }, { "Top", FD_INT|FD_RESULT }, { "Right", FD_INT|FD_RESULT }, { "Bottom", FD_INT|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clDisplayMethods[] = {

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -330,7 +330,7 @@ static ERR DOCUMENT_Clipboard(extDocument *Self, struct acClipboard *Args)
 
          objClipboard::create clipboard = { };
          if (clipboard.ok()) {
-            if (auto error = clipboard->addText(buffer.c_str()); error IS ERR::Okay) {
+            if (auto error = clipboard->addText(buffer); error IS ERR::Okay) {
                // Delete the highlighted document if the CUT mode was used
                if (Args->Mode IS CLIPMODE::CUT) {
                   //delete_selection(Self);

--- a/src/document/parsing_xquery.cpp
+++ b/src/document/parsing_xquery.cpp
@@ -788,14 +788,14 @@ static ERR xq_prepare_query(parser *Parser, std::string_view Expression, XQEval 
    }
 
    query->setResolveVariable(C_FUNCTION(xq_resolve_runtime_scope, Parser));
-   query->registerFunction(XQ_OBJECT_EXISTS_FUNCTION.data(), C_FUNCTION(xq_document_object_exists, Parser));
-   query->registerFunction(XQ_OBJECT_ID_FUNCTION.data(), C_FUNCTION(xq_document_object_id, Parser));
-   query->registerFunction(XQ_SELF_ID_FUNCTION.data(), C_FUNCTION(xq_document_self_id, Parser));
-   query->registerFunction(XQ_UID_FUNCTION.data(), C_FUNCTION(xq_document_uid, Parser));
-   query->registerFunction(XQ_PLATFORM_FUNCTION.data(), C_FUNCTION(xq_document_platform, Parser));
-   query->registerFunction(XQ_FIELD_FUNCTION.data(), C_FUNCTION(xq_document_field, Parser));
-   query->registerFunction(XQ_KEY_FUNCTION.data(), C_FUNCTION(xq_document_key, Parser));
-   query->registerFunction(XQ_TEMPLATE_CONTENT_FUNCTION.data(), C_FUNCTION(xq_document_template_content, Parser));
+   query->registerFunction(XQ_OBJECT_EXISTS_FUNCTION, C_FUNCTION(xq_document_object_exists, Parser));
+   query->registerFunction(XQ_OBJECT_ID_FUNCTION, C_FUNCTION(xq_document_object_id, Parser));
+   query->registerFunction(XQ_SELF_ID_FUNCTION, C_FUNCTION(xq_document_self_id, Parser));
+   query->registerFunction(XQ_UID_FUNCTION, C_FUNCTION(xq_document_uid, Parser));
+   query->registerFunction(XQ_PLATFORM_FUNCTION, C_FUNCTION(xq_document_platform, Parser));
+   query->registerFunction(XQ_FIELD_FUNCTION, C_FUNCTION(xq_document_field, Parser));
+   query->registerFunction(XQ_KEY_FUNCTION, C_FUNCTION(xq_document_key, Parser));
+   query->registerFunction(XQ_TEMPLATE_CONTENT_FUNCTION, C_FUNCTION(xq_document_template_content, Parser));
 
    if (query->setStatement(eval_expression) != ERR::Okay) {
       Self->Error = ERR::SetField;

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -882,7 +882,8 @@ static ERR HTTP_Activate(extHTTP *Self)
 
    if (acWrite(Self->Socket, cstr.c_str(), cstr.length()) IS ERR::Okay) {
       if (Self->Socket->State IS NTC::DISCONNECTED) {
-         CSTRING server_host = Self->ProxyServer.empty() ? Self->Host.c_str() : Self->ProxyServer.c_str();
+         const auto server_host = Self->ProxyServer.empty() ? std::string_view(Self->Host) :
+            std::string_view(Self->ProxyServer);
          const int server_port = Self->ProxyServer.empty() ? Self->Port : Self->ProxyPort;
          if (auto result = Self->Socket->connect(server_host, server_port, 5.0); result IS ERR::Okay) {
             Self->Connecting = true;

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -57,9 +57,9 @@ struct resolve_buffer {
    }
 };
 
-static ERR resolve_address(CSTRING, const IPAddress *, DNSEntry &);
-static ERR resolve_name(CSTRING, DNSEntry &);
-static ERR cache_host(HOSTMAP &, CSTRING, const HostLookupResult &, DNSEntry &);
+static ERR resolve_address(std::string_view, const IPAddress *, DNSEntry &);
+static ERR resolve_name(std::string_view, DNSEntry &);
+static ERR cache_host(HOSTMAP &, std::string_view, const HostLookupResult &, DNSEntry &);
 
 static std::vector<IPAddress> glNoAddresses;
 
@@ -148,7 +148,7 @@ a response is received.
 The results can be read from the #HostName field or received via the #Callback function.
 
 -INPUT-
-cstr Address: IP address to be resolved, e.g. 123.111.94.82.
+cpp(strview) Address: IP address to be resolved, e.g. 123.111.94.82.
 
 -ERRORS-
 Okay: The IP address was resolved successfully.
@@ -169,12 +169,12 @@ static ERR NETLOOKUP_BlockingResolveAddress(extNetLookup *Self, struct nl::Block
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Address)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Address.empty()) return log.warning(ERR::NullArgs);
 
-   log.branch("Address: %s", Args->Address);
+   log.branch("Address: %.*s", int(Args->Address.size()), Args->Address.data());
 
    IPAddress ip;
-   if (net::StrToAddress(std::string_view(Args->Address), &ip) IS ERR::Okay) {
+   if (net::StrToAddress(Args->Address, &ip) IS ERR::Okay) {
       DNSEntry info;
       if (auto error = resolve_address(Args->Address, &ip, info); error IS ERR::Okay) {
          Self->Info = info;
@@ -201,7 +201,7 @@ response is received or a timeout occurs.
 The results can be read from the #Addresses field or received via the #Callback function.
 
 -INPUT-
-cstr HostName: The host name to be resolved.
+cpp(strview) HostName: The host name to be resolved.
 
 -ERRORS-
 Okay
@@ -217,13 +217,13 @@ blocking, mutates-object, callback-inlines
 
 *********************************************************************************************************************/
 
-static ERR NETLOOKUP_BlockingResolveName(extNetLookup *Self, struct nl::ResolveName *Args)
+static ERR NETLOOKUP_BlockingResolveName(extNetLookup *Self, struct nl::BlockingResolveName *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->HostName)) return log.error(ERR::NullArgs);
+   if ((not Args) or Args->HostName.empty()) return log.error(ERR::NullArgs);
 
-   log.branch("Host: %s", Args->HostName);
+   log.branch("Host: %.*s", int(Args->HostName.size()), Args->HostName.data());
 
    DNSEntry info;
    if (auto error = resolve_name(Args->HostName, info); error IS ERR::Okay) {
@@ -232,7 +232,8 @@ static ERR NETLOOKUP_BlockingResolveName(extNetLookup *Self, struct nl::ResolveN
       return ERR::Okay;
    }
    else {
-      resolve_callback(Self, error, Args->HostName);
+      std::string host_name(Args->HostName);
+      resolve_callback(Self, error, host_name);
       return error;
    }
 }
@@ -290,7 +291,7 @@ process.
 If synchronous (blocking) operation is desired then use the #BlockingResolveAddress() method.
 
 -INPUT-
-cstr Address: IP address to be resolved, e.g. "123.111.94.82".
+cpp(strview) Address: IP address to be resolved, e.g. "123.111.94.82".
 
 -ERRORS-
 Okay: The IP address was resolved successfully.
@@ -307,17 +308,18 @@ static ERR NETLOOKUP_ResolveAddress(extNetLookup *Self, struct nl::ResolveAddres
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Address)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Address.empty()) return log.warning(ERR::NullArgs);
    if (Self->Callback.Type IS CALL::NIL) return log.warning(ERR::FieldNotSet);
 
-   log.branch("Address: %s", Args->Address);
+   log.branch("Address: %.*s", int(Args->Address.size()), Args->Address.data());
 
    if ((Self->Flags & NLF::NO_CACHE) IS NLF::NIL) { // Use the cache if available.
       bool found = false;
       DNSEntry cached;
+      std::string address(Args->Address);
       {
          std::shared_lock<std::shared_mutex> lock(glAddressesMutex);
-         auto it = glAddresses.find(Args->Address);
+         auto it = glAddresses.find(address);
          if (it != glAddresses.end()) {
             cached = it->second;
             found = true;
@@ -326,7 +328,7 @@ static ERR NETLOOKUP_ResolveAddress(extNetLookup *Self, struct nl::ResolveAddres
 
       if (found) {
          Self->Info = cached;
-         log.trace("Cache hit for address %s", Args->Address);
+         log.trace("Cache hit for address %s", address.c_str());
          resolve_callback(Self, ERR::Okay, Self->Info.HostName, Self->Info.Addresses);
          return ERR::Okay;
       }
@@ -338,7 +340,7 @@ static ERR NETLOOKUP_ResolveAddress(extNetLookup *Self, struct nl::ResolveAddres
 
       Self->Threads.emplace_back(std::make_unique<std::jthread>(std::jthread([](resolve_buffer rb) {
          DNSEntry dummy;
-         rb.Error = resolve_address(rb.Address.c_str(), &rb.IP, dummy);
+         rb.Error = resolve_address(rb.Address, &rb.IP, dummy);
          auto ser = rb.serialise();
          if (auto error = SendMessage(glResolveAddrMsgID, MSF::NIL, ser.data(), ser.size()); error != ERR::Okay) {
             kt::Log(__FUNCTION__).warning("Failed to queue address resolution result: %s", GetErrorMsg(error));
@@ -362,7 +364,7 @@ that the function can return immediately.  The #Callback function will be called
 If synchronous (blocking) operation is desired then use the #BlockingResolveName() method.
 
 -INPUT-
-cstr HostName: The host name to be resolved.
+cpp(strview) HostName: The host name to be resolved.
 
 -ERRORS-
 Okay
@@ -377,16 +379,17 @@ static ERR NETLOOKUP_ResolveName(extNetLookup *Self, struct nl::ResolveName *Arg
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->HostName)) return log.error(ERR::NullArgs);
+   if ((not Args) or Args->HostName.empty()) return log.error(ERR::NullArgs);
 
-   log.branch("Host: %s", Args->HostName);
+   log.branch("Host: %.*s", int(Args->HostName.size()), Args->HostName.data());
 
    if ((Self->Flags & NLF::NO_CACHE) IS NLF::NIL) { // Use the cache if available.
       bool found = false;
       DNSEntry cached;
+      std::string host_name(Args->HostName);
       {
          std::shared_lock<std::shared_mutex> lock(glHostsMutex);
-         auto it = glHosts.find(Args->HostName);
+         auto it = glHosts.find(host_name);
          if (it != glHosts.end()) {
             cached = it->second;
             found = true;
@@ -404,7 +407,7 @@ static ERR NETLOOKUP_ResolveName(extNetLookup *Self, struct nl::ResolveName *Arg
    resolve_buffer rb(Self->UID, Args->HostName);
    Self->Threads.emplace_back(std::make_unique<std::jthread>(std::jthread([](resolve_buffer rb) {
       DNSEntry dummy;
-      rb.Error = resolve_name(rb.Address.c_str(), dummy);
+      rb.Error = resolve_name(rb.Address, dummy);
       auto ser = rb.serialise();
       if (auto error = SendMessage(glResolveNameMsgID, MSF::NIL, ser.data(), ser.size()); error != ERR::Okay) {
          kt::Log(__FUNCTION__).warning("Failed to queue name resolution result: %s", GetErrorMsg(error));
@@ -499,11 +502,11 @@ static ERR GET_HostName(extNetLookup *Self, std::string_view &Value)
 
 //********************************************************************************************************************
 
-static ERR cache_host(HOSTMAP &Store, CSTRING Key, const HostLookupResult &Result, DNSEntry &Cache)
+static ERR cache_host(HOSTMAP &Store, std::string_view Key, const HostLookupResult &Result, DNSEntry &Cache)
 {
-   if (not Key) {
+   if (Key.empty()) {
       if (Result.HostName.empty()) return ERR::Args;
-      Key = Result.HostName.c_str();
+      Key = Result.HostName;
    }
 
    DNSEntry cache;
@@ -514,7 +517,7 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, const HostLookupResult &Resul
    {
       std::shared_mutex &cache_mutex = (&Store IS &glHosts) ? glHostsMutex : glAddressesMutex;
       std::unique_lock<std::shared_mutex> lock(cache_mutex);
-      auto &entry = Store[Key];
+      auto &entry = Store[std::string(Key)];
       entry = std::move(cache);
       Cache = entry;
    }
@@ -523,28 +526,30 @@ static ERR cache_host(HOSTMAP &Store, CSTRING Key, const HostLookupResult &Resul
 
 //********************************************************************************************************************
 
-static ERR resolve_address(CSTRING Address, const IPAddress *IP, DNSEntry &Info)
+static ERR resolve_address(std::string_view Address, const IPAddress *IP, DNSEntry &Info)
 {
+   std::string address(Address);
    {
       std::shared_lock<std::shared_mutex> lock(glAddressesMutex);
-      if (auto it = glAddresses.find(Address); it != glAddresses.end()) {
+      if (auto it = glAddresses.find(address); it != glAddresses.end()) {
          Info = it->second;
          return ERR::Okay;
       }
    }
 
    HostLookupResult result;
-   if (auto error = network_platform().resolve_address(Address, *IP, result); error != ERR::Okay) return error;
-   return cache_host(glAddresses, Address, result, Info);
+   if (auto error = network_platform().resolve_address(address.c_str(), *IP, result); error != ERR::Okay) return error;
+   return cache_host(glAddresses, address, result, Info);
 }
 
-static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
+static ERR resolve_name(std::string_view HostName, DNSEntry &Info)
 {
    // Use the cache if available.
 
+   std::string host_name(HostName);
    {
       std::shared_lock<std::shared_mutex> lock(glHostsMutex);
-      auto it = glHosts.find(HostName);
+      auto it = glHosts.find(host_name);
       if (it != glHosts.end()) {
          Info = it->second;
          return ERR::Okay;
@@ -552,11 +557,11 @@ static ERR resolve_name(CSTRING HostName, DNSEntry &Info)
    }
 
    kt::Log log(__FUNCTION__);
-   log.detail("Resolving hostname: %s", HostName);
+   log.detail("Resolving hostname: %s", host_name.c_str());
 
    HostLookupResult result;
-   if (auto error = network_platform().resolve_name(HostName, result); error != ERR::Okay) return error;
-   return cache_host(glHosts, HostName, result, Info);
+   if (auto error = network_platform().resolve_name(host_name.c_str(), result); error != ERR::Okay) return error;
+   return cache_host(glHosts, host_name, result, Info);
 }
 
 //********************************************************************************************************************

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -63,7 +63,7 @@ static ERR cache_host(HOSTMAP &, std::string_view, const HostLookupResult &, DNS
 
 static std::vector<IPAddress> glNoAddresses;
 
-static void resolve_callback(extNetLookup *, ERR, const std::string & = "", std::vector<IPAddress> & = glNoAddresses);
+static void resolve_callback(extNetLookup *, ERR, std::string_view, std::vector<IPAddress> & = glNoAddresses);
 
 //********************************************************************************************************************
 // Used for receiving asynchronous execution results (sent as a message).
@@ -93,7 +93,7 @@ static ERR resolve_name_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Mes
          nl->Info = cached;
          resolve_callback(*nl, ERR::Okay, nl->Info.HostName, nl->Info.Addresses);
       }
-      else resolve_callback(*nl, ERR::Failed);
+      else resolve_callback(*nl, ERR::Failed, "");
    }
    return ERR::Okay;
 }
@@ -124,7 +124,7 @@ static ERR resolve_addr_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Mes
          nl->Info = cached;
          resolve_callback(*nl, ERR::Okay, nl->Info.HostName, nl->Info.Addresses);
       }
-      else resolve_callback(*nl, ERR::Failed);
+      else resolve_callback(*nl, ERR::Failed, "");
    }
    return ERR::Okay;
 }
@@ -182,7 +182,7 @@ static ERR NETLOOKUP_BlockingResolveAddress(extNetLookup *Self, struct nl::Block
          return ERR::Okay;
       }
       else {
-         resolve_callback(Self, error);
+         resolve_callback(Self, error, "");
          return error;
       }
    }
@@ -232,8 +232,7 @@ static ERR NETLOOKUP_BlockingResolveName(extNetLookup *Self, struct nl::Blocking
       return ERR::Okay;
    }
    else {
-      std::string host_name(Args->HostName);
-      resolve_callback(Self, error, host_name);
+      resolve_callback(Self, error, Args->HostName);
       return error;
    }
 }
@@ -445,8 +444,7 @@ static ERR GET_Addresses(extNetLookup *Self, int8_t **Value, int *Elements)
 Callback: This function will be called on the completion of any name or address resolution.
 
 The function referenced here will receive the results of the most recently resolved name or address.  The C++
-prototype is
-`Function(*NetLookup, ERR Error, const std::string &amp;HostName, const std::vector&lt;IPAddress&gt; &amp;Addresses)`.
+prototype is `Function(*NetLookup, ERR Error, std::string_view HostName, const std::vector&lt;IPAddress&gt; &amp;Addresses)`.
 
 The Tiri prototype is as follows, with results readable from the #HostName and #Addresses fields:
 `function(NetLookup, Error)`.
@@ -566,14 +564,16 @@ static ERR resolve_name(std::string_view HostName, DNSEntry &Info)
 
 //********************************************************************************************************************
 
-static void resolve_callback(extNetLookup *Self, ERR Error, const std::string &HostName, std::vector<IPAddress> &Addresses)
+static void resolve_callback(extNetLookup *Self, ERR Error, std::string_view HostName,
+   std::vector<IPAddress> &Addresses)
 {
    kt::Log log(__FUNCTION__);
-   log.traceBranch("Host: %s", HostName.c_str());
+   log.traceBranch("Host: %.*s", int(HostName.size()), HostName.data());
 
    if (Self->Callback.isC()) {
       kt::SwitchContext context(Self->Callback.Context);
-      auto routine = (ERR (*)(extNetLookup *, ERR, const std::string &, const std::vector<IPAddress> &, APTR))(Self->Callback.Routine);
+      auto routine = (ERR (*)(extNetLookup *, ERR, std::string_view, const std::vector<IPAddress> &, APTR))(
+         Self->Callback.Routine);
       routine(Self, Error, HostName, Addresses, Self->Callback.Meta);
    }
    else if (Self->Callback.isScript()) {

--- a/src/network/class_netlookup_def.c
+++ b/src/network/class_netlookup_def.c
@@ -5,10 +5,10 @@ static const struct FieldDef clNetLookupFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maResolveName[] = { { "HostName", FD_STR }, { 0, 0 } };
-FDEF maResolveAddress[] = { { "Address", FD_STR }, { 0, 0 } };
-FDEF maBlockingResolveName[] = { { "HostName", FD_STR }, { 0, 0 } };
-FDEF maBlockingResolveAddress[] = { { "Address", FD_STR }, { 0, 0 } };
+FDEF maResolveName[] = { { "HostName", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maResolveAddress[] = { { "Address", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maBlockingResolveName[] = { { "HostName", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maBlockingResolveAddress[] = { { "Address", FD_CPP|FD_STR }, { 0, 0 } };
 
 static const struct MethodEntry clNetLookupMethods[] = {
    { AC(-1), (APTR)NETLOOKUP_ResolveName, "ResolveName", maResolveName, sizeof(struct nl::ResolveName) },

--- a/src/network/net_iocp.cpp
+++ b/src/network/net_iocp.cpp
@@ -409,19 +409,22 @@ public:
       return iocp_set_multicast_ttl(Handle.socket(), TTL, IPv6);
    }
 
-   ERR parse_multicast_group(CSTRING Group, bool &IPv6) override
+   ERR join_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) override
    {
-      return iocp_parse_multicast_group(Group, IPv6);
+      if (Group.empty()) return ERR::Args;
+
+      std::string group(Group);
+      if (auto error = iocp_parse_multicast_group(group.c_str(), IPv6); error != ERR::Okay) return error;
+      return iocp_join_multicast_group(Handle.socket(), group.c_str(), IPv6);
    }
 
-   ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   ERR leave_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) override
    {
-      return iocp_join_multicast_group(Handle.socket(), Group, IPv6);
-   }
+      if (Group.empty()) return ERR::Args;
 
-   ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
-   {
-      return iocp_leave_multicast_group(Handle.socket(), Group, IPv6);
+      std::string group(Group);
+      if (auto error = iocp_parse_multicast_group(group.c_str(), IPv6); error != ERR::Okay) return error;
+      return iocp_leave_multicast_group(Handle.socket(), group.c_str(), IPv6);
    }
 
    ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) override

--- a/src/network/net_linux.cpp
+++ b/src/network/net_linux.cpp
@@ -317,59 +317,53 @@ public:
       }
    }
 
-   ERR parse_multicast_group(CSTRING Group, bool &IPv6) override
+   ERR join_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) override
    {
-      if (!Group) return ERR::Args;
+      if (Group.empty()) return ERR::Args;
 
-      struct in6_addr addr6;
-      struct in_addr addr4;
-      kt::clearmem(&addr6, sizeof(addr6));
-      kt::clearmem(&addr4, sizeof(addr4));
+      std::string group(Group);
 
-      if (::inet_pton(AF_INET6, Group, &addr6) IS 1) {
+      struct ipv6_mreq mreq6;
+      kt::clearmem(&mreq6, sizeof(mreq6));
+      if (::inet_pton(AF_INET6, group.c_str(), &mreq6.ipv6mr_multiaddr) IS 1) {
          IPv6 = true;
-         return ERR::Okay;
+         mreq6.ipv6mr_interface = 0;
+         return setsockopt(Handle, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char *)&mreq6, sizeof(mreq6)) ?
+            ERR::Failed : ERR::Okay;
       }
-      else if (::inet_pton(AF_INET, Group, &addr4) IS 1) {
+      else {
+         struct ip_mreq mreq4;
+         kt::clearmem(&mreq4, sizeof(mreq4));
+         if (::inet_pton(AF_INET, group.c_str(), &mreq4.imr_multiaddr) != 1) return ERR::Args;
          IPv6 = false;
-         return ERR::Okay;
-      }
-      else return ERR::Args;
-   }
-
-   ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
-   {
-      if (IPv6) {
-         struct ipv6_mreq mreq;
-         kt::clearmem(&mreq, sizeof(mreq));
-         if (::inet_pton(AF_INET6, Group, &mreq.ipv6mr_multiaddr) != 1) return ERR::Args;
-         mreq.ipv6mr_interface = 0;
-         return setsockopt(Handle, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
-      }
-      else {
-         struct ip_mreq mreq;
-         kt::clearmem(&mreq, sizeof(mreq));
-         if (::inet_pton(AF_INET, Group, &mreq.imr_multiaddr) != 1) return ERR::Args;
-         mreq.imr_interface.s_addr = INADDR_ANY;
-         return setsockopt(Handle, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+         mreq4.imr_interface.s_addr = INADDR_ANY;
+         return setsockopt(Handle, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mreq4, sizeof(mreq4)) ?
+            ERR::Failed : ERR::Okay;
       }
    }
 
-   ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) override
+   ERR leave_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) override
    {
-      if (IPv6) {
-         struct ipv6_mreq mreq;
-         kt::clearmem(&mreq, sizeof(mreq));
-         if (::inet_pton(AF_INET6, Group, &mreq.ipv6mr_multiaddr) != 1) return ERR::Args;
-         mreq.ipv6mr_interface = 0;
-         return setsockopt(Handle, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+      if (Group.empty()) return ERR::Args;
+
+      std::string group(Group);
+
+      struct ipv6_mreq mreq6;
+      kt::clearmem(&mreq6, sizeof(mreq6));
+      if (::inet_pton(AF_INET6, group.c_str(), &mreq6.ipv6mr_multiaddr) IS 1) {
+         IPv6 = true;
+         mreq6.ipv6mr_interface = 0;
+         return setsockopt(Handle, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (char *)&mreq6, sizeof(mreq6)) ?
+            ERR::Failed : ERR::Okay;
       }
       else {
-         struct ip_mreq mreq;
-         kt::clearmem(&mreq, sizeof(mreq));
-         if (::inet_pton(AF_INET, Group, &mreq.imr_multiaddr) != 1) return ERR::Args;
-         mreq.imr_interface.s_addr = INADDR_ANY;
-         return setsockopt(Handle, IPPROTO_IP, IP_DROP_MEMBERSHIP, (char *)&mreq, sizeof(mreq)) ? ERR::Failed : ERR::Okay;
+         struct ip_mreq mreq4;
+         kt::clearmem(&mreq4, sizeof(mreq4));
+         if (::inet_pton(AF_INET, group.c_str(), &mreq4.imr_multiaddr) != 1) return ERR::Args;
+         IPv6 = false;
+         mreq4.imr_interface.s_addr = INADDR_ANY;
+         return setsockopt(Handle, IPPROTO_IP, IP_DROP_MEMBERSHIP, (char *)&mreq4, sizeof(mreq4)) ?
+            ERR::Failed : ERR::Okay;
       }
    }
 

--- a/src/network/net_platform.h
+++ b/src/network/net_platform.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <kotuku/main.h>
@@ -219,9 +220,8 @@ public:
    virtual ERR enable_keep_alive(SocketHandle Handle) = 0;
    virtual ERR enable_broadcast(SocketHandle Handle) = 0;
    virtual ERR set_multicast_ttl(SocketHandle Handle, int TTL, bool IPv6) = 0;
-   virtual ERR parse_multicast_group(CSTRING Group, bool &IPv6) = 0;
-   virtual ERR join_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
-   virtual ERR leave_multicast_group(SocketHandle Handle, CSTRING Group, bool IPv6) = 0;
+   virtual ERR join_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) = 0;
+   virtual ERR leave_multicast_group(SocketHandle Handle, std::string_view Group, bool &IPv6) = 0;
 
    virtual ERR receive(SocketHandle Handle, APTR Buffer, size_t Length, size_t &Received) = 0;
    virtual ERR append_receive(SocketHandle Handle, std::vector<uint8_t> &Buffer, size_t Length, size_t &Received) = 0;

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -114,7 +114,7 @@ Pre-Condition: Must be in a connection state of `NTC::DISCONNECTED`
 Post-Condition: If this method returns `ERR::Okay`, will be in state `NTC::CONNECTING`.
 
 -INPUT-
-cstr Address: String containing either a domain name (e.g. `www.google.com`) or an IP address (e.g. `123.123.123.123`)
+cpp(strview) Address: String containing either a domain name (e.g. `www.google.com`) or an IP address (e.g. `123.123.123.123`)
 int Port: Remote port to connect to.
 double Timeout: Connection timeout in seconds (0 = no timeout).
 
@@ -185,7 +185,7 @@ static ERR NETSOCKET_Connect(extNetSocket *Self, struct ns::Connect *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Address) or (Args->Port <= 0) or (Args->Port >= 65536)) return log.warning(ERR::Args);
+   if ((!Args) or Args->Address.empty() or (Args->Port <= 0) or (Args->Port >= 65536)) return log.warning(ERR::Args);
 
    if (Self->isDerived()) return ERR::InvalidState; // Server cannot use Connect()
 
@@ -205,9 +205,9 @@ static ERR NETSOCKET_Connect(extNetSocket *Self, struct ns::Connect *Args)
    }
 #endif
 
-   log.branch("Address: %s, Port: %d", Args->Address, Args->Port);
+   log.branch("Address: %.*s, Port: %d", int(Args->Address.size()), Args->Address.data(), Args->Port);
 
-   if (Self->Address != std::string_view(Args->Address)) {
+   if (Self->Address != Args->Address) {
       Self->Address.assign(Args->Address);
    }
    Self->Port = Args->Port;
@@ -235,7 +235,7 @@ static ERR NETSOCKET_Connect(extNetSocket *Self, struct ns::Connect *Args)
 
       ((extNetLookup *)Self->NetLookup)->Callback = C_FUNCTION(connect_name_resolved_nl);
 
-      if (Self->NetLookup->resolveName(Self->Address.c_str()) != ERR::Okay) {
+      if (Self->NetLookup->resolveName(Self->Address) != ERR::Okay) {
          // Cancel timer on DNS failure
          if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
          return log.warning(Self->Error = ERR::HostNotFound);
@@ -571,7 +571,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    if (Self->isDerived()) return ERR::Okay; // Will hand-off to the derived class
 
    if ((not Self->Address.empty()) and (Self->Port > 0)) {
-      if ((error = Self->connect(Self->Address.c_str(), Self->Port, 0)) != ERR::Okay) {
+      if ((error = Self->connect(Self->Address, Self->Port, 0)) != ERR::Okay) {
          free_socket(Self);
          return error;
       }
@@ -595,7 +595,7 @@ This is only available for UDP sockets.
 The socket must be bound to a local address before joining a multicast group.
 
 -INPUT-
-cstr Group: The multicast group address to join (e.g. `224.1.1.1`).
+cpp(strview) Group: The multicast group address to join (e.g. `224.1.1.1`).
 
 -ERRORS-
 Okay: Successfully joined the multicast group.
@@ -615,17 +615,18 @@ static ERR NETSOCKET_JoinMulticastGroup(extNetSocket *Self, struct ns::JoinMulti
 
    if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return ERR::NoSupport;
-   if (!Args->Group) return ERR::Args;
+   if (Args->Group.empty()) return ERR::Args;
 
-   log.branch("%s", Args->Group);
+   log.branch("%.*s", int(Args->Group.size()), Args->Group.data());
 
    bool group_ipv6 = false;
-   if (network_platform().parse_multicast_group(Args->Group, group_ipv6) != ERR::Okay) {
-      log.warning("Invalid multicast address: %s", Args->Group);
-      return ERR::Args;
-   }
+   if (auto error = network_platform().join_multicast_group(Self->Handle, Args->Group, group_ipv6);
+         error != ERR::Okay) {
+      if (error IS ERR::Args) {
+         log.warning("Invalid multicast address: %.*s", int(Args->Group.size()), Args->Group.data());
+         return ERR::Args;
+      }
 
-   if (network_platform().join_multicast_group(Self->Handle, Args->Group, group_ipv6) != ERR::Okay) {
       if (group_ipv6) {
          log.warning("Failed to join IPv6 multicast group");
       }
@@ -647,7 +648,7 @@ This method leaves a previously joined multicast group, stopping the reception o
 multicast address.
 
 -INPUT-
-cstr Group: The multicast group address to leave.
+cpp(strview) Group: The multicast group address to leave.
 
 -ERRORS-
 Okay: Successfully left the multicast group.
@@ -667,17 +668,18 @@ static ERR NETSOCKET_LeaveMulticastGroup(extNetSocket *Self, struct ns::LeaveMul
 
    if (!Args) return log.warning(ERR::NullArgs);
    if ((Self->Flags & NSF::UDP) IS NSF::NIL) return ERR::NoSupport;
-   if (!Args->Group) return ERR::Args;
+   if (Args->Group.empty()) return ERR::Args;
 
-   log.branch("%s", Args->Group);
+   log.branch("%.*s", int(Args->Group.size()), Args->Group.data());
 
    bool group_ipv6 = false;
-   if (network_platform().parse_multicast_group(Args->Group, group_ipv6) != ERR::Okay) {
-      log.warning("Invalid multicast address: %s", Args->Group);
-      return ERR::Args;
-   }
+   if (auto error = network_platform().leave_multicast_group(Self->Handle, Args->Group, group_ipv6);
+         error != ERR::Okay) {
+      if (error IS ERR::Args) {
+         log.warning("Invalid multicast address: %.*s", int(Args->Group.size()), Args->Group.data());
+         return ERR::Args;
+      }
 
-   if (network_platform().leave_multicast_group(Self->Handle, Args->Group, group_ipv6) != ERR::Okay) {
       if (group_ipv6) {
          log.warning("Failed to leave IPv6 multicast group");
       }

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -132,8 +132,8 @@ non-blocking, mutates-object, copies-input
 
 *********************************************************************************************************************/
 
-static void connect_name_resolved_nl(objNetLookup *, ERR, const std::string &, const std::vector<IPAddress> &);
-static void connect_name_resolved(extNetSocket *, ERR, const std::string &, const std::vector<IPAddress> &);
+static void connect_name_resolved_nl(objNetLookup *, ERR, std::string_view, const std::vector<IPAddress> &);
+static void connect_name_resolved(extNetSocket *, ERR, std::string_view, const std::vector<IPAddress> &);
 static ERR connect_timeout_handler(OBJECTPTR, int64_t, int64_t);
 
 static void clear_connect_timer(extNetSocket *Socket)
@@ -248,7 +248,7 @@ static ERR NETSOCKET_Connect(extNetSocket *Self, struct ns::Connect *Args)
 //********************************************************************************************************************
 // This function is called on completion of nlResolveName().
 
-static void connect_name_resolved_nl(objNetLookup *NetLookup, ERR Error, const std::string &HostName,
+static void connect_name_resolved_nl(objNetLookup *NetLookup, ERR Error, std::string_view HostName,
    const std::vector<IPAddress> &IPs)
 {
    connect_name_resolved((extNetSocket *)CurrentContext(), Error, HostName, IPs);
@@ -291,7 +291,7 @@ static ERR start_platform_connect(extNetSocket *Socket, const NetworkEndpoint &E
    return ERR::Okay;
 }
 
-static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::string &HostName,
+static void connect_name_resolved(extNetSocket *Socket, ERR Error, std::string_view HostName,
    const std::vector<IPAddress> &IPs)
 {
    kt::Log log(__FUNCTION__);
@@ -306,7 +306,7 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
    log.msg("Received callback on DNS resolution.  Handle: %d", Socket->Handle.int_value());
 
    if (IPs.empty()) {
-      log.warning("No IP addresses resolved for %s", HostName.c_str());
+      log.warning("No IP addresses resolved for %.*s", int(HostName.size()), HostName.data());
       Socket->Error = ERR::HostNotFound;
       Socket->setState(NTC::DISCONNECTED);
       return;

--- a/src/network/netsocket/netsocket_def.c
+++ b/src/network/netsocket/netsocket_def.c
@@ -22,12 +22,12 @@ static const struct FieldDef clNetSocketFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maConnect[] = { { "Address", FD_STR }, { "Port", FD_INT }, { "Timeout", FD_DOUBLE }, { 0, 0 } };
+FDEF maConnect[] = { { "Address", FD_CPP|FD_STR }, { "Port", FD_INT }, { "Timeout", FD_DOUBLE }, { 0, 0 } };
 FDEF maGetLocalIPAddress[] = { { "IPAddress:Address", FD_PTR|FD_STRUCT }, { 0, 0 } };
 FDEF maSendTo[] = { { "Dest", FD_PTR }, { "Data", FD_BUFFER|FD_PTR }, { "Length", FD_INT|FD_BUFSIZE }, { "BytesSent", FD_INT|FD_RESULT }, { 0, 0 } };
 FDEF maRecvFrom[] = { { "Source", FD_PTR }, { "Buffer", FD_BUFFER|FD_PTR|FD_MUTABLE }, { "BufferSize", FD_INT|FD_BUFSIZE }, { "BytesRead", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maJoinMulticastGroup[] = { { "Group", FD_STR }, { 0, 0 } };
-FDEF maLeaveMulticastGroup[] = { { "Group", FD_STR }, { 0, 0 } };
+FDEF maJoinMulticastGroup[] = { { "Group", FD_CPP|FD_STR }, { 0, 0 } };
+FDEF maLeaveMulticastGroup[] = { { "Group", FD_CPP|FD_STR }, { 0, 0 } };
 
 static const struct MethodEntry clNetSocketMethods[] = {
    { AC(-1), (APTR)NETSOCKET_Connect, "Connect", maConnect, sizeof(struct ns::Connect) },

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -943,7 +943,7 @@ positions are also supported as an alternative - a value of -1 inserts the text 
 value of -2 replaces currently selected text.
 
 -INPUT-
-cstr String: A text string to add.
+cpp(strview) String: A text string to add.
 int Pos: -1 inserts at the current cursor position, -2 replaces currently selected text, zero or above inserts at the character index indicated.
 
 -RESULT-
@@ -958,9 +958,9 @@ static ERR SCINTILLA_InsertText(extScintilla *Self, struct sci::InsertText *Args
    kt::Log log;
    int pos;
 
-   if ((!Args) or (!Args->String)) return log.warning(ERR::NullArgs);
+   if ((!Args) or (Args->String.empty())) return log.warning(ERR::NullArgs);
 
-   log.branch("Pos: %d, Text: %.10s", Args->Pos, Args->String);
+   log.branch("Pos: %d, Text: %.*s", Args->Pos, std::min<int>(Args->String.size(), 10), Args->String.data());
 
    pos = Args->Pos;
    if (pos IS -1) {
@@ -1069,7 +1069,7 @@ source string by setting the Length parameter.  To insert all characters from th
 
 -INPUT-
 int Line: Index of the line being targeted.
-cstr String: The new string that will replace the line.
+cpp(strview) String: The new string that will replace the line.
 int Length: The number of characters to replace the target with, or -1 for the entire source string.
 
 -RESULT-
@@ -1111,8 +1111,8 @@ given Start and End point.  The `STF::CASE`, `STF::SCAN_SELECTION` and `STF::EXP
 this method (see FindText for details).
 
 -INPUT-
-cstr Find: The keyword string to find.
-cstr Replace: The string that will replace the keyword.
+cpp(strview) Find: The keyword string to find.
+cpp(strview) Replace: The string that will replace the keyword.
 int(STF) Flags: Optional flags.
 int Start: The start of the search - set to zero if covering the entire document.  If -1, starts from the current cursor position.
 int End: The end of the search - set to -1 if covering the entire document.
@@ -1129,7 +1129,7 @@ static ERR SCINTILLA_ReplaceText(extScintilla *Self, struct sci::ReplaceText *Ar
    kt::Log log;
    int start, end;
 
-   if ((!Args) or (!Args->Find) or (!*Args->Find)) return log.warning(ERR::NullArgs);
+   if ((not Args) or (Args->Find.empty())) return log.warning(ERR::NullArgs);
 
    log.branch("Text: '%.10s'... Between: %d - %d, Flags: $%.8x", Args->Find, Args->Start, Args->End, int(Args->Flags));
 
@@ -1149,15 +1149,13 @@ static ERR SCINTILLA_ReplaceText(extScintilla *Self, struct sci::ReplaceText *Ar
       if (start IS end) return ERR::Search;
    }
 
-   CSTRING replace;
-   if (!Args->Replace) replace = "";
-   else replace = Args->Replace;
+   std::string_view replace = Args->Replace;
 
    SCICALL(SCI_SETTARGETSTART, start);
    SCICALL(SCI_SETTARGETEND, end);
 
-   int findlen = strlen(Args->Find);
-   int replacelen = strlen(replace);
+   int findlen = Args->Find.size();
+   int replacelen = Args->Replace.size();
 
    int flags = (((Args->Flags & STF::CASE) != STF::NIL) ? SCFIND_MATCHCASE : 0) |
                 (((Args->Flags & STF::EXPRESSION) != STF::NIL) ? SCFIND_REGEXP : 0);
@@ -1256,7 +1254,7 @@ details.
 If the new face is invalid or fails to load, the current font will remain unchanged.
 
 -INPUT-
-cstr Face: The name of the new font face.
+cpp(strview) Face: The name of the new font face.
 
 -RESULT-
 Okay:
@@ -1270,9 +1268,9 @@ static ERR SCINTILLA_SetFont(extScintilla *Self, struct sci::SetFont *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Face)) return log.warning(ERR::NullArgs);
+   if ((not Args) or Args->Face.empty()) return log.warning(ERR::NullArgs);
 
-   log.branch("%s", Args->Face);
+   log.branch("%.*s", int(Args->Face.size()), Args->Face.data());
 
    if ((Self->Font = objFont::create::local(fl::Face(Args->Face)))) {
       create_styled_fonts(Self);

--- a/src/scintilla/class_scintilla_ext.cxx
+++ b/src/scintilla/class_scintilla_ext.cxx
@@ -276,8 +276,8 @@ void ScintillaKTK::CopyToClipboard(const Scintilla::SelectionText &selectedText)
    log.traceBranch();
 
    auto clipboard = objClipboard::create { };
-   if (clipboard.ok()) {
-      if (clipboard->addText(selectedText.s) IS ERR::Okay) {
+   if ((clipboard.ok()) and (selectedText.s) and (selectedText.len > 0)) {
+      if (clipboard->addText(std::string_view(selectedText.s, size_t(selectedText.len - 1))) IS ERR::Okay) {
 
       }
    }

--- a/src/svg/anim_parsing.cpp
+++ b/src/svg/anim_parsing.cpp
@@ -62,8 +62,8 @@ static ERR set_anim_property(anim_base &Anim, XTag &Tag, uint32_t Hash, const st
       case SVF_href:
       case SVF_xlink_href: {
          OBJECTPTR ref_vector;
-         auto ref = uri_name(std::string(Value));
-         if (Anim.svg->Scene->findDef(ref.c_str(), &ref_vector) IS ERR::Okay) {
+         auto ref = uri_name(Value);
+         if (Anim.svg->Scene->findDef(ref, &ref_vector) IS ERR::Okay) {
             Anim.target_vector = ref_vector->UID;
          }
          break;

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -134,7 +134,7 @@ static ERR SVG_Free(extSVG *Self)
       Self->Target = nullptr;
    }
 
-   if (Self->XML)       { FreeResource(Self->XML);       Self->XML = nullptr; }
+   if (Self->XML) { FreeResource(Self->XML); Self->XML = nullptr; }
 
    if (!Self->Resources.empty()) {
       for (auto id : Self->Resources) FreeResource(id);
@@ -218,7 +218,7 @@ The generated content will be structured within the provided @VectorViewport, wh
 scene graph.
 
 -INPUT-
-cstr ID: Name of the symbol to parse.
+cpp(strview) ID: Name of the symbol to parse.
 obj(VectorViewport) Viewport: The target viewport.
 
 -RESULT-
@@ -236,7 +236,7 @@ static ERR SVG_ParseSymbol(extSVG *Self, struct svg::ParseSymbol *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->ID) or (!Args->Viewport)) return log.warning(ERR::NullArgs);
+   if ((!Args) or (Args->ID.empty()) or (!Args->Viewport)) return log.warning(ERR::NullArgs);
 
    if (auto tagref = find_href_tag(Self, Args->ID)) {
       svgState state(Self);
@@ -244,7 +244,7 @@ static ERR SVG_ParseSymbol(extSVG *Self, struct svg::ParseSymbol *Args)
       return ERR::Okay;
    }
    else {
-      log.warning("Symbol '%s' not found.", Args->ID);
+      log.warning("Symbol '%.*s' not found.", int(Args->ID.size()), Args->ID.data());
       return ERR::NotFound;
    }
 }

--- a/src/svg/class_svg_def.c
+++ b/src/svg/class_svg_def.c
@@ -8,7 +8,7 @@ static const struct FieldDef clSVGFlags[] = {
 };
 
 FDEF maRender[] = { { "Bitmap", FD_OBJECTPTR }, { "X", FD_INT }, { "Y", FD_INT }, { "Width", FD_INT }, { "Height", FD_INT }, { 0, 0 } };
-FDEF maParseSymbol[] = { { "ID", FD_STR }, { "Viewport", FD_OBJECTPTR }, { 0, 0 } };
+FDEF maParseSymbol[] = { { "ID", FD_CPP|FD_STR }, { "Viewport", FD_OBJECTPTR }, { 0, 0 } };
 
 static const struct MethodEntry clSVGMethods[] = {
    { AC(-1), (APTR)SVG_Render, "Render", maRender, sizeof(struct svg::Render) },

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -11,16 +11,16 @@ ERR svgState::set_paint_server(objVector *Vector, FIELD Field, const std::string
          std::string lookup;
          lookup.assign(Value, 5, i-5);
 
-         if (Self->Scene->findDef(lookup.c_str(), nullptr) != ERR::Okay) {
-            if (Self->IDs.contains(lookup)) {
-               auto tag = Self->IDs[lookup];
+         if (Self->Scene->findDef(lookup, nullptr) != ERR::Okay) {
+            if (auto tag = Self->IDs.find(lookup); tag != Self->IDs.end()) {
+               auto tagref = tag->second;
 
-               switch(svg_tag_hash(*tag)) {
-                  case SVF_contourGradient:  proc_contourgradient(*tag); break;
-                  case SVF_radialGradient:   proc_radialgradient(*tag); break;
-                  case SVF_diamondGradient:  proc_diamondgradient(*tag); break;
-                  case SVF_conicGradient:    proc_conicgradient(*tag); break;
-                  case SVF_linearGradient:   proc_lineargradient(*tag); break;
+               switch(svg_tag_hash(*tagref)) {
+                  case SVF_contourGradient:  proc_contourgradient(*tagref); break;
+                  case SVF_radialGradient:   proc_radialgradient(*tagref); break;
+                  case SVF_diamondGradient:  proc_diamondgradient(*tagref); break;
+                  case SVF_conicGradient:    proc_conicgradient(*tagref); break;
+                  case SVF_linearGradient:   proc_lineargradient(*tagref); break;
                }
             }
          }
@@ -2425,7 +2425,8 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
       return;
    }
 
-   if (!Self->IDs.contains(uri)) {
+   auto tag = Self->IDs.find(uri);
+   if (tag IS Self->IDs.end()) {
       log.warning("Unable to find element '%s' referenced at line %d", ref.c_str(), Tag.LineNo);
       return;
    }
@@ -2438,7 +2439,7 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
       }
    }
 
-   auto tagref = Self->IDs[uri];
+   auto tagref = tag->second;
 
    auto class_id = CLASSID::NIL;
    switch (svg_tag_hash(*tagref)) {
@@ -2466,7 +2467,7 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
       Parent->set(FID_Morph, shape);
       if (transvector) Parent->set(FID_Transition, transvector);
       Parent->set(FID_MorphFlags, int(flags));
-      if (!Self->Cloning) Self->Scene->addDef(uri.c_str(), shape);
+      if (!Self->Cloning) Self->Scene->addDef(uri, shape);
    }
 }
 
@@ -2935,7 +2936,7 @@ void svgState::proc_svg(XTag &Tag, OBJECTPTR Parent, objVector * &Vector) noexce
          case SVF_mask: {
             OBJECTPTR clip;
             auto ref = uri_name(val);
-            if (Self->Scene->findDef(ref.c_str(), &clip) IS ERR::Okay) viewport->set(FID_Mask, clip);
+            if (Self->Scene->findDef(ref, &clip) IS ERR::Okay) viewport->set(FID_Mask, clip);
             else log.warning("Unable to find mask '%s'", val.c_str());
             break;
          }
@@ -2943,7 +2944,7 @@ void svgState::proc_svg(XTag &Tag, OBJECTPTR Parent, objVector * &Vector) noexce
          case SVF_clip_path: {
             OBJECTPTR clip;
             auto ref = uri_name(val);
-            if (Self->Scene->findDef(ref.c_str(), &clip) IS ERR::Okay) viewport->set(FID_Mask, clip);
+            if (Self->Scene->findDef(ref, &clip) IS ERR::Okay) viewport->set(FID_Mask, clip);
             else log.warning("Unable to find clip-path '%s'", val.c_str());
             break;
          }
@@ -3837,7 +3838,7 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
       case SVF_mask: {
          OBJECTPTR clip;
          auto ref = uri_name(StrValue);
-         if (Self->Scene->findDef(ref.c_str(), &clip) IS ERR::Okay) {
+         if (Self->Scene->findDef(ref, &clip) IS ERR::Okay) {
             Vector->set(FID_Mask, clip);
          }
          else {
@@ -3850,7 +3851,7 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
       case SVF_clip_path: {
          OBJECTPTR clip;
          auto ref = uri_name(StrValue);
-         if (Self->Scene->findDef(ref.c_str(), &clip) IS ERR::Okay) {
+         if (Self->Scene->findDef(ref, &clip) IS ERR::Okay) {
             Vector->set(FID_Mask, clip);
          }
          else {

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -67,6 +67,26 @@ struct svgID { // All elements using the 'id' attribute will be registered with 
    svgID() { TagIndex = -1; }
 };
 
+struct SVGStringHash {
+   using is_avalanching = void;
+   using is_transparent = void;
+
+   [[nodiscard]] size_t operator()(std::string_view Value) const noexcept {
+      return ankerl::unordered_dense::hash<std::string_view>{}(Value);
+   }
+
+   [[nodiscard]] size_t operator()(const std::string &Value) const noexcept {
+      return (*this)(std::string_view(Value));
+   }
+
+   [[nodiscard]] size_t operator()(CSTRING Value) const noexcept {
+      return (*this)(std::string_view(Value));
+   }
+};
+
+template<typename Value> using SVGStringLookupMap =
+   ankerl::unordered_dense::map<std::string, Value, SVGStringHash, std::equal_to<>>;
+
 struct svgAnimState {
    VectorMatrix *matrix = nullptr;
    std::vector<class anim_transform *> transforms;
@@ -84,7 +104,7 @@ struct svgState;
 class extSVG : public objSVG {
    public:
    FUNCTION FrameCallback;
-   ankerl::unordered_dense::map<std::string, XTag *> IDs;
+   SVGStringLookupMap<XTag *> IDs;
    ankerl::unordered_dense::map<std::string, objFilterEffect *> Effects; // All effects, registered by their SVG identifier.
    double SVGVersion;
    double AnimEpoch;  // Epoch time for the animations.

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -238,33 +238,33 @@ static void parse_transform(objVector *Vector, const std::string Value, int Tag)
 
 //********************************************************************************************************************
 
-static const std::string uri_name(const std::string Ref)
+static std::string_view uri_name(const std::string_view Ref)
 {
    std::size_t skip = 0;
    while ((skip < Ref.size()) and (Ref[skip] <= 0x20)) skip++;
-   if (skip >= Ref.size()) return std::string("");
+   if (skip >= Ref.size()) return {};
 
    if (Ref[skip] IS '#') {
-      return Ref.substr(skip+1);
+      return Ref.substr(skip + 1);
    }
-   else if (startswith("url(#", Ref.c_str() + skip)) {
+   else if (Ref.substr(skip).starts_with("url(#")) {
       std::size_t i;
       skip += 5;
       for (i=0; ((skip + i) < Ref.size()) and (Ref[skip+i] != ')'); i++);
       return Ref.substr(skip, i);
    }
    else return Ref.substr(skip);
-
-   return std::string("");
 }
 
 //********************************************************************************************************************
 
-static XTag * find_href_tag(extSVG *Self, std::string Ref)
+static XTag * find_href_tag(extSVG *Self, std::string_view Ref)
 {
    auto ref = uri_name(Ref);
-   if ((!ref.empty()) and (Self->IDs.contains(ref))) {
-      return Self->IDs[ref];
+   if (not ref.empty()) {
+      if (auto tag = Self->IDs.find(ref); tag != Self->IDs.end()) {
+         return tag->second;
+      }
    }
    return nullptr;
 }

--- a/src/vector/scene/scene.cpp
+++ b/src/vector/scene/scene.cpp
@@ -229,7 +229,7 @@ At the time of writing, the provided object must belong to one of the following 
 @VectorClip.
 
 -INPUT-
-cstr Name: The unique name to associate with the definition.
+cpp(strview) Name: The unique name to associate with the definition.
 obj Def: Reference to the definition object.
 
 -TAGS-
@@ -248,13 +248,14 @@ static ERR VECTORSCENE_AddDef(extVectorScene *Self, struct sc::AddDef *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Name) or (!Args->Def)) return log.warning(ERR::NullArgs);
+   if ((!Args) or (!Args->Def)) return log.warning(ERR::NullArgs);
 
    if (Self->HostScene) { // Forward all definitions if a hosting scene is active.
       return Self->HostScene->addDef(Args->Name, Args->Def);
    }
 
    OBJECTPTR def = Args->Def;
+   std::string name(Args->Name);
 
    switch(def->classID()) {
       case CLASSID::VECTORGRADIENT:   ((extVectorGradient*)def)->HostScene = Self; break;
@@ -280,16 +281,16 @@ static ERR VECTORSCENE_AddDef(extVectorScene *Self, struct sc::AddDef *Args)
       return ERR::UnsupportedOwner;
    }
 
-   if (Self->Defs.contains(Args->Name)) { // Check that the definition name is unique.
-      log.detail("The vector definition name '%s' is already in use.", Args->Name);
+   if (Self->Defs.contains(name)) { // Check that the definition name is unique.
+      log.detail("The vector definition name '%s' is already in use.", name.c_str());
       return ERR::ResourceExists;
    }
 
-   log.detail("Adding definition '%s' referencing %s #%d", Args->Name, def->Class->ClassName.c_str(), def->UID);
+   log.detail("Adding definition '%s' referencing %s #%d", name.c_str(), def->Class->ClassName.c_str(), def->UID);
 
    SubscribeAction(def, AC::Free, C_FUNCTION(notify_def_free));
 
-   Self->Defs[Args->Name] = def;
+   Self->Defs[name] = def;
    return ERR::Okay;
 }
 
@@ -370,7 +371,7 @@ the search is successful.
 Definitions are created with the #AddDef() method.
 
 -INPUT-
-cstr Name: The name of the definition.
+cpp(strview) Name: The name of the definition.
 &obj Def: A pointer to the definition object is returned here if discovered.
 
 -TAGS-
@@ -388,18 +389,17 @@ static ERR VECTORSCENE_FindDef(extVectorScene *Self, struct sc::FindDef *Args)
 {
    kt::Log log;
 
-   if ((!Args) or (!Args->Name)) return log.warning(ERR::NullArgs);
+   if (!Args) return log.warning(ERR::NullArgs);
 
    if (Self->HostScene) return Self->HostScene->findDef(Args->Name, &Args->Def);
 
-   CSTRING name = Args->Name;
+   std::string_view name = Args->Name;
 
-   if (*name IS '#') name = name + 1;
-   else if (startswith("url(#", name)) {
-      int i;
-      for (i=5; (name[i] != ')') and name[i]; i++);
-      std::string lookup;
-      lookup.assign(name, 5, i-5);
+   if ((!name.empty()) and (name.front() IS '#')) name.remove_prefix(1);
+   else if (name.starts_with("url(#")) {
+      auto end = name.find(')', 5);
+      if (end IS std::string_view::npos) end = name.size();
+      std::string lookup(name.substr(5, end - 5));
 
       if (auto def = Self->Defs.find(lookup); def != Self->Defs.end()) {
          Args->Def = def->second;
@@ -408,7 +408,8 @@ static ERR VECTORSCENE_FindDef(extVectorScene *Self, struct sc::FindDef *Args)
       else return ERR::Search;
    }
 
-   if (auto def = Self->Defs.find(name); def != Self->Defs.end()) {
+   std::string lookup(name);
+   if (auto def = Self->Defs.find(lookup); def != Self->Defs.end()) {
       Args->Def = def->second;
       return ERR::Okay;
    }

--- a/src/vector/scene/scene_def.c
+++ b/src/vector/scene/scene_def.c
@@ -49,3 +49,4 @@ static const struct ActionArray clVectorSceneActions[] = {
    { AC::Resize, VECTORSCENE_Resize },
    { AC::NIL, nullptr }
 };
+

--- a/src/vector/scene/scene_def.c
+++ b/src/vector/scene/scene_def.c
@@ -25,9 +25,9 @@ static const struct FieldDef clVectorSceneSampleMethod[] = {
    { nullptr, 0 }
 };
 
-FDEF maAddDef[] = { { "Name", FD_STR }, { "Def", FD_OBJECTPTR }, { 0, 0 } };
+FDEF maAddDef[] = { { "Name", FD_CPP|FD_STR }, { "Def", FD_OBJECTPTR }, { 0, 0 } };
 FDEF maSearchByID[] = { { "ID", FD_INT }, { "Result", FD_OBJECTPTR|FD_RESULT }, { 0, 0 } };
-FDEF maFindDef[] = { { "Name", FD_STR }, { "Def", FD_OBJECTPTR|FD_RESULT }, { 0, 0 } };
+FDEF maFindDef[] = { { "Name", FD_CPP|FD_STR }, { "Def", FD_OBJECTPTR|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clVectorSceneMethods[] = {
    { AC(-1), (APTR)VECTORSCENE_AddDef, "AddDef", maAddDef, sizeof(struct sc::AddDef) },
@@ -49,4 +49,3 @@ static const struct ActionArray clVectorSceneActions[] = {
    { AC::Resize, VECTORSCENE_Resize },
    { AC::NIL, nullptr }
 };
-

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -489,9 +489,9 @@ The structure of the returned XML document is as follows, with each matching fun
  ```
 
 -INPUT-
-cstr Name: The name of the function or functions to inspect (supports wildcards).
+cpp(strview) Name: The name of the function or functions to inspect (supports wildcards).
 int(XIF) ResultFlags: Bitmask controlling the returned information.
-&!cstr Result: Receives a serialised XML document describing the function(s).
+^&cpp(str) Result: Receives a serialised XML document describing the function(s).
 
 -TAGS-
 mutates-object, caller-owns-result, null-terminated-result
@@ -507,7 +507,8 @@ NullArgs
 static ERR XQUERY_InspectFunctions(extXQuery *Self, struct xq::InspectFunctions *Args)
 {
    kt::Log log;
-   if (not Args) return log.warning(ERR::NullArgs);
+   if ((not Args) or (not Args->Result)) return log.warning(ERR::NullArgs);
+   Args->Result->clear();
 
    if (Self->StaleBuild) {
       if (auto err = build_query(Self); err != ERR::Okay) return err;
@@ -517,7 +518,7 @@ static ERR XQUERY_InspectFunctions(extXQuery *Self, struct xq::InspectFunctions 
 
    auto flags = Args->ResultFlags;
    if (flags IS XIF::NIL) flags = XIF::ALL;
-   auto name_filter = Args->Name ? Args->Name : "*";
+   auto name_filter = Args->Name.empty() ? std::string_view("*") : Args->Name;
 
    // Extract function information based on ResultFlags
    auto process_function = [&](const XQueryProlog &Prolog, const XQueryFunction &Function) {
@@ -594,10 +595,8 @@ static ERR XQUERY_InspectFunctions(extXQuery *Self, struct xq::InspectFunctions 
 
       if (not stream.tellp()) return log.warning(ERR::Search);
 
-      std::string result = stream.str();
-      Args->Result = kt::strclone(result.c_str());
-      if (Args->Result) return ERR::Okay;
-      else return ERR::AllocMemory;
+      *Args->Result = stream.str();
+      return ERR::Okay;
    }
    else return log.warning(ERR::Search);
 }
@@ -623,7 +622,7 @@ The C++ function prototype is `ERR (*XQuery, std::string_view FunctionName, cons
 Script callbacks are not currently supported.
 
 -INPUT-
-cstr FunctionName: The name of the function to register (e.g., "custom-function").
+cpp(strview) FunctionName: The name of the function to register (e.g., "custom-function").
 ptr(func) Callback: The callback function to register for FunctionName.
 
 -TAGS-
@@ -643,11 +642,11 @@ static ERR XQUERY_RegisterFunction(extXQuery *Self, struct xq::RegisterFunction 
    kt::Log log;
 
    if (not Args) return log.warning(ERR::NullArgs);
-   if ((not Args->FunctionName) or (!Args->FunctionName[0])) return log.warning(ERR::NullArgs);
+   if (Args->FunctionName.empty()) return log.warning(ERR::NullArgs);
    if ((not Args->Callback) or (not Args->Callback->defined())) return log.warning(ERR::NullArgs);
    if (not Args->Callback->isC()) return log.warning(ERR::NoSupport);
 
-   Self->RegisteredFunctions[Args->FunctionName] = *Args->Callback;
+   Self->RegisteredFunctions[std::string(Args->FunctionName)] = *Args->Callback;
    return ERR::Okay;
 }
 

--- a/src/xquery/xquery_class_def.cpp
+++ b/src/xquery/xquery_class_def.cpp
@@ -36,8 +36,8 @@ static const struct FieldDef clXQueryXEF[] = {
 
 FDEF maEvaluate[] = { { "XML", FD_OBJECTPTR }, { "Index", FD_INT }, { "Flags", FD_INT }, { 0, 0 } };
 FDEF maSearch[] = { { "XML", FD_OBJECTPTR }, { "Callback", FD_FUNCTIONPTR }, { "Index", FD_INT }, { "Flags", FD_INT }, { 0, 0 } };
-FDEF maRegisterFunction[] = { { "FunctionName", FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
-FDEF maInspectFunctions[] = { { "Name", FD_STR }, { "ResultFlags", FD_INT }, { "Result", FD_STR|FD_ALLOC|FD_RESULT }, { 0, 0 } };
+FDEF maRegisterFunction[] = { { "FunctionName", FD_CPP|FD_STR }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
+FDEF maInspectFunctions[] = { { "Name", FD_CPP|FD_STR }, { "ResultFlags", FD_INT }, { "Result", FD_CPP|FD_STR|FD_MUTABLE|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clXQueryMethods[] = {
    { AC(-1), (APTR)XQUERY_Evaluate, "Evaluate", maEvaluate, sizeof(struct xq::Evaluate) },


### PR DESCRIPTION
## Summary

- Converts method and callback parameters from raw `CSTRING`/`STRING` to `std::string_view` across five modules: Vector (VectorScene, Scintilla), Display (Clipboard, Display), Network (NetLookup, NetSocket), SVG (ParseSymbol), and XQuery (RegisterFunction, InspectFunctions)
- Adds transparent-hashing `SVGStringLookupMap` in the SVG module to enable `string_view` key lookups without constructing `std::string` copies
- Replaces heap-allocated `CSTRING` output in `XQuery::InspectFunctions` with a caller-supplied `std::string&`, eliminating a `strclone` allocation

## Test plan

- [ ] Build all affected modules (`vector`, `display`, `network`, `svg`, `xquery`) with no compile errors
- [ ] Run existing integration and Flute tests for each module
- [ ] Verify SVG symbol parsing still resolves IDs correctly (transparent hash lookup)
- [ ] Verify XQuery `InspectFunctions` returns correct XML output via `std::string` result parameter
- [ ] Verify Network connect/resolve callbacks fire correctly with `string_view` host name arguments