### PR TITLE
[Tiri] Improved error message handling and cleanup paths

### DIFF
--- a/include/kotuku/main.h
+++ b/include/kotuku/main.h
@@ -221,6 +221,14 @@ class ScopedObjectLock {
          }
       }
 
+      inline void unlock() {
+         if (error IS ERR::Okay) {
+            if (quicklock) obj->unlock();
+            else ReleaseObject((OBJECTPTR)obj);
+            error = ERR::ResourceNotLocked;
+         }
+      }
+
       inline ScopedObjectLock() = default;
       [[nodiscard]] inline bool granted() { return error IS ERR::Okay; }
 

--- a/include/kotuku/modules/scintilla.h
+++ b/include/kotuku/modules/scintilla.h
@@ -110,7 +110,7 @@ class objScintilla : public Object {
    using create = kt::Create<objScintilla>;
 
    objFont * Font;               // Refers to the font that is used for drawing text in the document.
-   std::string Path;               // Identifies the location of a text file to load.
+   std::string Path;             // Identifies the location of a text file to load.
    SEF       EventFlags;         // Specifies events that need to be reported from the Scintilla object.
    OBJECTID  SurfaceID;          // Refers to the Surface targeted by the Scintilla object.
    SCIF      Flags;              // Optional flags.

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -431,9 +431,9 @@ extern void register_async_class(lua_State *);
 //static void register_widget_class(lua_State *);
 void release_object(GCobject *);
 void new_module(lua_State *, objModule *);
-ERR struct_to_table(lua_State *, std::vector<lua_ref> &, struct struct_record &, CPTR);
+void struct_to_table(lua_State *, std::vector<lua_ref> &, struct struct_record &, CPTR);
 ERR table_to_struct(lua_State *, std::string_view, APTR *);
-ERR keyvalue_to_table(lua_State *, const KEYVALUE *);
+void keyvalue_to_table(lua_State *, const KEYVALUE *);
 
 int fcmd_arg(lua_State *);
 int fcmd_msg(lua_State *);
@@ -495,8 +495,8 @@ inline GCobject * push_object(lua_State *Lua, OBJECTPTR Object, bool Detached = 
 {
    if ((Error >= ERR::ExceptionThreshold) and in_try_immediate_scope(Lua)) {
       if ((Object) and (Object->classptr)) {
-         std::string call_name = std::format("{}.{}", Object->classptr->ClassName, Action ? Action : "Action");
-         raise_checked_call_error(Lua, Error, call_name.c_str());
+         luaL_error(Lua, Error, std::format("{}.{}() failed: {}", Object->classptr->ClassName,
+            Action ? Action : "Action", GetErrorMsg(Error)));
       }
       else raise_checked_call_error(Lua, Error, Action ? Action : "Action");
    }

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -431,7 +431,7 @@ extern void register_async_class(lua_State *);
 //static void register_widget_class(lua_State *);
 void release_object(GCobject *);
 void new_module(lua_State *, objModule *);
-void struct_to_table(lua_State *, std::vector<lua_ref> &, struct struct_record &, CPTR);
+ERR struct_to_table(lua_State *, std::vector<lua_ref> &, struct struct_record &, CPTR);
 ERR table_to_struct(lua_State *, std::string_view, APTR *);
 void keyvalue_to_table(lua_State *, const KEYVALUE *);
 

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -411,7 +411,7 @@ ERR named_struct_to_table(lua_State *, std::string_view, CPTR);
 void construct_struct_cpp_strings(const struct struct_record &, APTR);
 void destroy_struct_cpp_strings(const struct struct_record &, APTR);
 void make_struct_array(lua_State *, std::string_view, int, CPTR, int = 0);
-void make_struct_ptr_array(lua_State *, std::string_view, int, CPTR *);
+ERR make_struct_ptr_array(lua_State *, std::string_view, int, CPTR *);
 void make_struct_serial_array(lua_State *, std::string_view, int, CPTR);
 void notify_action(OBJECTPTR, ACTIONID, ERR, APTR);
 void process_error(objScript *, CSTRING);

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -56,6 +56,7 @@
 #define LUA_CORE
 
 #include <bit>
+#include <string>
 
 #include <kotuku/main.h>
 
@@ -1509,6 +1510,17 @@ extern void luaL_where(lua_State *L, int level)
    lj_debug_addloc(L, "", frame, size ? frame + size : nullptr);
 }
 
+static CSTRING luaL_push_error_string(lua_State *L, std::string &Message)
+{
+   auto lua_msg = lj_str_new(L, Message.data(), Message.size());
+   setstrV(L, L->top, lua_msg);
+   incr_top(L);
+
+   auto msg = strdata(lua_msg);
+   std::string().swap(Message);
+   return msg;
+}
+
 [[noreturn]] extern void luaL_error(lua_State *L, CSTRING Format, ...)
 {
    if (L->CaughtError <= ERR::ExceptionThreshold) L->CaughtError = ERR::Exception;
@@ -1516,6 +1528,13 @@ extern void luaL_where(lua_State *L, int level)
    va_start(argp, Format);
    auto msg = lj_strfmt_pushvf(L, Format, argp);
    va_end(argp);
+   lj_err_callermsg(L, msg);
+}
+
+[[noreturn]] extern void luaL_error(lua_State *L, std::string Message)
+{
+   if (L->CaughtError <= ERR::ExceptionThreshold) L->CaughtError = ERR::Exception;
+   auto msg = luaL_push_error_string(L, Message);
    lj_err_callermsg(L, msg);
 }
 
@@ -1534,6 +1553,13 @@ extern void luaL_where(lua_State *L, int level)
    va_start(argp, Format);
    auto msg = lj_strfmt_pushvf(L, Format, argp);
    va_end(argp);
+   lj_err_callermsg(L, msg);
+}
+
+[[noreturn]] extern void luaL_error(lua_State *L, ERR ErrorCode, std::string Message)
+{
+   L->CaughtError = ErrorCode;
+   auto msg = luaL_push_error_string(L, Message);
    lj_err_callermsg(L, msg);
 }
 

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdio>
+#include <string>
 #include <kotuku/system/errors.h>
 #include "lua.h"
 #include "lj_obj.h"
@@ -36,8 +37,10 @@ extern int  luaL_newmetatable(lua_State *, const char *);
 extern void * luaL_checkudata(lua_State *, int ud, const char *);
 extern void luaL_where(lua_State *, int lvl);
 [[noreturn]] extern void luaL_error(lua_State *, const char *fmt, ...);
+[[noreturn]] extern void luaL_error(lua_State *, std::string);
 [[noreturn]] extern void luaL_error(lua_State *, ERR);
 [[noreturn]] extern void luaL_error(lua_State *, ERR, const char *, ...);
+[[noreturn]] extern void luaL_error(lua_State *, ERR, std::string);
 extern int luaL_checkoption(lua_State *, int, const char *, const char *const lst[]);
 extern TValue * resolve_index(lua_State *L, int);
 

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -35,6 +35,7 @@ For more information on the Tiri syntax, please refer to the official Tiri Refer
 #include <kotuku/strings.hpp>
 
 #include <inttypes.h>
+#include <format>
 #include <vector>
 #include <iterator>
 #include <mutex>
@@ -193,7 +194,8 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
    std::string module_name;
    if (auto error = MetaClass->get(FID_Module, module_name); error IS ERR::Okay) {
       if (auto error = load_include(Lua->script, module_name.c_str()); error != ERR::Okay) {
-         luaL_error(Lua, error, "Failed to process module '%s' for class '%s'", module_name.c_str(), MetaClass->ClassName.c_str());
+         luaL_error(Lua, error,
+            std::format("Failed to process module '{}' for class '{}'", module_name, MetaClass->ClassName));
       }
    }
    else kt::Log(__FUNCTION__).traceWarning("Failed to get module name from class '%s', \"%s\"", MetaClass->ClassName.c_str(), GetErrorMsg(error));
@@ -555,19 +557,14 @@ void make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elem
       auto &sdef = glStructs[s_name];
 
       for (int i=0; i < Elements; i++) {
-         if (struct_to_table(Lua, ref, sdef, Values[i]) IS ERR::Okay) {
-            // Table is now on top of stack; retrieve arr from stack in case GC moved it
-            arr = arrayV(Lua->base + arr_idx - 1);
-            TValue *tv = Lua->top - 1;
-            GCtab *tab = tabV(tv);
-            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-            lj_gc_objbarrier(Lua, arr, tab);
-            Lua->top--;  // Pop the table
-         }
-         else {
-            arr = arrayV(Lua->base + arr_idx - 1);
-            setgcrefnull(arr->get<GCRef>()[i]);
-         }
+         struct_to_table(Lua, ref, sdef, Values[i]);
+         // Table is now on top of stack; retrieve arr from stack in case GC moved it
+         arr = arrayV(Lua->base + arr_idx - 1);
+         TValue *tv = Lua->top - 1;
+         GCtab *tab = tabV(tv);
+         setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+         lj_gc_objbarrier(Lua, arr, tab);
+         Lua->top--;  // Pop the table
       }
    }
 }
@@ -594,19 +591,14 @@ void make_struct_array(lua_State *Lua, std::string_view StructName, int Elements
       int struct_stride = (Stride > 0) ? Stride : sdef.Size;
 
       for (int i=0; i < Elements; i++) {
-         if (struct_to_table(Lua, ref, sdef, Input) IS ERR::Okay) {
-            // Table is now on top of stack; retrieve arr from stack in case GC moved it
-            arr = arrayV(Lua->base + arr_idx - 1);
-            TValue *tv = Lua->top - 1;
-            GCtab *tab = tabV(tv);
-            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-            lj_gc_objbarrier(Lua, arr, tab);
-            Lua->top--;  // Pop the table
-         }
-         else {
-            arr = arrayV(Lua->base + arr_idx - 1);
-            setgcrefnull(arr->get<GCRef>()[i]);
-         }
+         struct_to_table(Lua, ref, sdef, Input);
+         // Table is now on top of stack; retrieve arr from stack in case GC moved it
+         arr = arrayV(Lua->base + arr_idx - 1);
+         TValue *tv = Lua->top - 1;
+         GCtab *tab = tabV(tv);
+         setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+         lj_gc_objbarrier(Lua, arr, tab);
+         Lua->top--;  // Pop the table
 
          Input = (int8_t *)Input + struct_stride;
       }

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -557,13 +557,14 @@ void make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elem
       auto &sdef = glStructs[s_name];
 
       for (int i=0; i < Elements; i++) {
-         struct_to_table(Lua, ref, sdef, Values[i]);
-         // Table is now on top of stack; retrieve arr from stack in case GC moved it
-         arr = arrayV(Lua->base + arr_idx - 1);
-         TValue *tv = Lua->top - 1;
-         GCtab *tab = tabV(tv);
-         setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-         lj_gc_objbarrier(Lua, arr, tab);
+         if (struct_to_table(Lua, ref, sdef, Values[i]) IS ERR::Okay) {
+            // Table is now on top of stack; retrieve arr from stack in case GC moved it
+            arr = arrayV(Lua->base + arr_idx - 1);
+            TValue *tv = Lua->top - 1;
+            GCtab *tab = tabV(tv);
+            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+            lj_gc_objbarrier(Lua, arr, tab);
+         }
          Lua->top--;  // Pop the table
       }
    }
@@ -591,13 +592,14 @@ void make_struct_array(lua_State *Lua, std::string_view StructName, int Elements
       int struct_stride = (Stride > 0) ? Stride : sdef.Size;
 
       for (int i=0; i < Elements; i++) {
-         struct_to_table(Lua, ref, sdef, Input);
-         // Table is now on top of stack; retrieve arr from stack in case GC moved it
-         arr = arrayV(Lua->base + arr_idx - 1);
-         TValue *tv = Lua->top - 1;
-         GCtab *tab = tabV(tv);
-         setgcref(arr->get<GCRef>()[i], obj2gco(tab));
-         lj_gc_objbarrier(Lua, arr, tab);
+         if (struct_to_table(Lua, ref, sdef, Input) IS ERR::Okay) {
+            // Table is now on top of stack; retrieve arr from stack in case GC moved it
+            arr = arrayV(Lua->base + arr_idx - 1);
+            TValue *tv = Lua->top - 1;
+            GCtab *tab = tabV(tv);
+            setgcref(arr->get<GCRef>()[i], obj2gco(tab));
+            lj_gc_objbarrier(Lua, arr, tab);
+         }
          Lua->top--;  // Pop the table
 
          Input = (int8_t *)Input + struct_stride;

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -533,7 +533,7 @@ void make_array(lua_State *Lua, AET Type, int Elements, CPTR Data, std::string_v
 //********************************************************************************************************************
 // Create a Lua array from a list of structure pointers.
 
-void make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elements, CPTR *Values)
+ERR make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elements, CPTR *Values)
 {
    kt::Log log(__FUNCTION__);
 
@@ -546,7 +546,7 @@ void make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elem
    }
 
    auto s_name = struct_name(StructName);
-   if (not glStructs.contains(s_name)) luaL_error(Lua, ERR::Search, "Failed to find struct '%.*s'", int(StructName.size()), StructName.data());
+   if (not glStructs.contains(s_name)) return ERR::Search;
 
    GCarray *arr = lj_array_new(Lua, Elements, AET::TABLE);
    setarrayV(Lua, Lua->top++, arr); // Push to stack immediately to protect from GC during loop
@@ -568,6 +568,8 @@ void make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Elem
          Lua->top--;  // Pop the table
       }
    }
+
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -641,7 +643,11 @@ void make_struct_serial_array(lua_State *Lua, std::string_view StructName, int E
 void make_any_array(lua_State *Lua, int Flags, std::string_view TypeName, int Elements, CPTR Values)
 {
    if (Flags & FD_STRUCT) {
-      if (Flags & FD_POINTER) make_struct_ptr_array(Lua, TypeName, Elements, (CPTR *)Values);
+      if (Flags & FD_POINTER) {
+         if (make_struct_ptr_array(Lua, TypeName, Elements, (CPTR *)Values) != ERR::Okay) {
+            luaL_error(Lua, ERR::Search, "Failed to find struct '%.*s'", int(TypeName.size()), TypeName.data());
+         }
+      }
       else make_struct_serial_array(Lua, TypeName, Elements, Values);
    }
    else make_array(Lua, ff_to_aet(Flags), Elements, Values, TypeName);

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -224,16 +224,19 @@ static int async_action(lua_State *Lua)
       // Remove the first 4 required arguments so that the user's custom parameters are left on the stack.
       lua_rotate(Lua, 1, -4);
       lua_pop(Lua, 4);
-      if ((error = build_args(Lua, glActions[int(action_id)].Name, args, arg_size, arg_buffer.get(), &result_count)) IS ERR::Okay) {
+      if ((error = build_args(Lua, glActions[int(action_id)].Name, args, arg_size, arg_buffer.get(),
+            &result_count)) IS ERR::Okay) {
          if (not result_count) {
             error = AsyncAction(action_id, gc_obj->ptr, arg_buffer.get(), &callback);
          }
          else {
+            arg_buffer.reset();
             abort();
             luaL_error(Lua, "Actions that return results are not yet supported.");
          }
       }
       else {
+         arg_buffer.reset();
          abort();
          luaL_error(Lua, "Argument build failure for %s.", glActions[int(action_id)].Name);
       }
@@ -335,11 +338,13 @@ static int async_method(lua_State *Lua)
                   error = AsyncAction(action_id, gc_obj->ptr, argbuffer.get(), &callback);
                }
                else {
+                  argbuffer.reset();
                   abort();
                   luaL_error(Lua, "Methods that return results are not yet supported.");
                }
             }
             else {
+               argbuffer.reset();
                abort();
                luaL_error(Lua, "Argument build failure for %s.", glActions[int(action_id)].Name);
             }

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -8,9 +8,11 @@
 #include <kotuku/strings.hpp>
 
 #include <inttypes.h>
+#include <format>
 #include <mutex>
 #include <algorithm>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "lua.h"
@@ -71,7 +73,7 @@ static bool get_caller_src_folder(lua_State *Lua, std::string &Folder)
          if (not msg.empty()) msg += "\n";
          msg += entry.to_string(Lua->script->LineOffset);
       }
-      luaL_error(Lua, "%s", msg.c_str());
+      luaL_error(Lua, std::move(msg));
    }
    else if (auto error_msg = lua_tostring(Lua, -1)) {
       // When not in diagnose mode, errors are thrown via lj_err_lex which pushes the message to the stack
@@ -203,23 +205,22 @@ int fcmd_subscribe_event(lua_State *Lua)
    EVENTID event_id = GetEventID(group_id, subgroup_str.c_str(), event);
 
    if (not event_id) luaL_argerror(Lua, 1, "Failed to build event ID.");
-   else {
-      APTR handle;
-      lua_settop(Lua, 2);
-      auto client_function = luaL_ref(Lua, LUA_REGISTRYINDEX);
-      if (auto error = SubscribeEvent(event_id, C_FUNCTION(receive_event, client_function), &handle); error IS ERR::Okay) {
-         auto prv = (prvTiri *)Lua->script->DerivedPtr;
-         prv->EventList.emplace_back(client_function, event_id, handle);
-         lua_pushinteger(Lua, int(error)); // 1: Error code
-         lua_pushlightuserdata(Lua, handle); // 2: Handle
-      }
-      else {
-         luaL_unref(Lua, LUA_REGISTRYINDEX, client_function);
-         lua_pushinteger(Lua, int(error)); // Error code
-         lua_pushnil(Lua); // Handle
-      }
-      return 2;
+
+   APTR handle;
+   lua_settop(Lua, 2);
+   auto client_function = luaL_ref(Lua, LUA_REGISTRYINDEX);
+   if (auto error = SubscribeEvent(event_id, C_FUNCTION(receive_event, client_function), &handle); error IS ERR::Okay) {
+      auto prv = (prvTiri *)Lua->script->DerivedPtr;
+      prv->EventList.emplace_back(client_function, event_id, handle);
+      lua_pushinteger(Lua, int(error)); // 1: Error code
+      lua_pushlightuserdata(Lua, handle); // 2: Handle
    }
+   else {
+      luaL_unref(Lua, LUA_REGISTRYINDEX, client_function);
+      lua_pushinteger(Lua, int(error)); // Error code
+      lua_pushnil(Lua); // Handle
+   }
+   return 2;
 }
 
 //********************************************************************************************************************
@@ -290,7 +291,7 @@ int fcmd_include(lua_State *Lua)
 
    int top = lua_gettop(Lua);
    for (int n=1; n <= top; n++) {
-      CSTRING include = lua_tostring(Lua, n);
+      auto include = lua_tostring(Lua, n);
 
       // For security purposes, check the validity of the include name.
 
@@ -331,135 +332,137 @@ int fcmd_loadfile(lua_State *Lua)
    int results = 0;
    ERR error = ERR::Okay;
 
-   if (auto path = lua_tostringview(Lua, 1); not path.empty()) {
-      kt::Log log("loadfile");
+   auto path = lua_tostringview(Lua, 1);
+   if (path.empty()) luaL_argerror(Lua, 1, "File path required.");
 
-      log.branch("%.*s", int(path.size()), path.data());
+   kt::Log log("loadfile");
 
-      bool recompile = false;
-      bool inject_working_path = false;
-      if (path.starts_with("./")) {
-         path.remove_prefix(2);
-         inject_working_path = true;
+   log.branch("%.*s", int(path.size()), path.data());
+
+   bool recompile = false;
+   bool inject_working_path = false;
+   if (path.starts_with("./")) {
+      path.remove_prefix(2);
+      inject_working_path = true;
+   }
+   else if (path.starts_with("../")) {
+      // Maintain the prefix to access the parent folder - ResolvePath() takes care of it.
+      inject_working_path = true;
+   }
+   std::string src(path);
+
+   if (inject_working_path) {
+      std::string directory;
+      if (get_caller_src_folder(Lua, directory)) {
+         src.insert(0, directory);
       }
-      else if (path.starts_with("../")) {
-         // Maintain the prefix to access the parent folder - ResolvePath() takes care of it.
-         inject_working_path = true;
+      else {
+         std::string_view wp;
+         if (Lua->script->get(FID_WorkingPath, wp) IS ERR::Okay) src.insert(0, wp);
       }
-      std::string src(path);
+   }
 
-      if (inject_working_path) {
-         std::string directory;
-         if (get_caller_src_folder(Lua, directory)) {
-            src.insert(0, directory);
-         }
-         else {
-            std::string_view wp;
-            if (Lua->script->get(FID_WorkingPath, wp) IS ERR::Okay) src.insert(0, wp);
-         }
-      }
+   #if 0
+   if (src.ends_with(".tiri")) {
+      // File is a text script.  Let's check if a .tbc exists and is date-stamped for the same date as the .tiri version.
+      // Note: The developer can also delete the .tiri file in favour of a .tbc that is already present (for
+      // production releases)
 
-      #if 0
-      if (src.ends_with(".tiri")) {
-         // File is a text script.  Let's check if a .tbc exists and is date-stamped for the same date as the .tiri version.
-         // Note: The developer can also delete the .tiri file in favour of a .tbc that is already present (for
-         // production releases)
+      std::string tbcpath(src.substr(0, src.size() - 5));
+      tbcpath.append(".tbc");
 
-         std::string tbcpath(src.substr(0, src.size() - 5));
-         tbcpath.append(".tbc");
+      log.msg("Checking for a compiled Tiri file: %s", tbcpath.c_str());
 
-         log.msg("Checking for a compiled Tiri file: %s", tbcpath.c_str());
+      objFile::create tbc_file = { fl::Path(tbcpath) };
+      if (tbc_file.ok()) { // A compiled version exists.  Compare datestamps
+         objFile::create src_file = { fl::Path(src) };
+         if (src_file.ok()) {
+            int64_t tbc_ts, src_ts;
+            tbc_file->get(FID_Timestamp, &tbc_ts);
+            src_file->get(FID_Timestamp, &src_ts);
 
-         objFile::create tbc_file = { fl::Path(tbcpath) };
-         if (tbc_file.ok()) { // A compiled version exists.  Compare datestamps
-            objFile::create src_file = { fl::Path(src) };
-            if (src_file.ok()) {
-               int64_t tbc_ts, src_ts;
-               tbc_file->get(FID_Timestamp, &tbc_ts);
-               src_file->get(FID_Timestamp, &src_ts);
-
-               if (tbc_ts != src_ts) {
-                  log.msg("Timestamp mismatch, will recompile the cached version.");
-                  recompile = true;
-                  error = ERR::Failed;
-               }
-               else src = tbcpath;
+            if (tbc_ts != src_ts) {
+               log.msg("Timestamp mismatch, will recompile the cached version.");
+               recompile = true;
+               error = ERR::Failed;
             }
-            else if (error IS ERR::FileNotFound) {
-               src = tbcpath; // Use the .tbc if the developer removed the .tiri (typically done for production releases)
-            }
+            else src = tbcpath;
+         }
+         else if (error IS ERR::FileNotFound) {
+            src = tbcpath; // Use the .tbc if the developer removed the .tiri (typically done for production releases)
          }
       }
-      #endif
+   }
+   #endif
 
-      objFile::create file = { fl::Path(src), fl::Flags(FL::READ) };
-      if (file.ok()) {
-         // Check for the presence of a compiled header and skip it if present
+   objFile::create file = { fl::Path(src), fl::Flags(FL::READ) };
+   if (file.ok()) {
+      // Check for the presence of a compiled header and skip it if present
 
-         {
-            int len, i;
-            char header[256];
-            if (file->read(header, sizeof(header), &len) IS ERR::Okay) {
-               if (kt::startswith(LUA_COMPILED, std::string_view(header, sizeof(header)))) {
-                  recompile = false; // Do not recompile that which is already compiled
-                  for (i=sizeof(LUA_COMPILED)-1; (i < len) and (header[i]); i++);
-                  if (not header[i]) i++;
-                  else i = 0;
-               }
+      {
+         int len, i;
+         char header[256];
+         if (file->read(header, sizeof(header), &len) IS ERR::Okay) {
+            if (kt::startswith(LUA_COMPILED, std::string_view(header, sizeof(header)))) {
+               recompile = false; // Do not recompile that which is already compiled
+               for (i=sizeof(LUA_COMPILED)-1; (i < len) and (header[i]); i++);
+               if (not header[i]) i++;
                else i = 0;
             }
             else i = 0;
-
-            file->setPosition(i);
          }
+         else i = 0;
 
-         // Resolve the full path for the chunk name (needed for import statement path resolution)
-         std::string resolved_path;
-         if (ResolvePath(src, RSF::NIL, &resolved_path) IS ERR::Okay) {
-            // Use resolved path for chunk name
-         }
-         else resolved_path = src;  // Fall back to original if resolution fails
+         file->setPosition(i);
+      }
 
-         // Prefix chunk name with '@' (Lua convention for file-based chunks) for better debug output
-         std::string chunk_name = std::string("@") + resolved_path;
+      // Resolve the full path for the chunk name (needed for import statement path resolution)
+      std::string resolved_path;
+      if (ResolvePath(src, RSF::NIL, &resolved_path) IS ERR::Okay) {
+         // Use resolved path for chunk name
+      }
+      else resolved_path = src;  // Fall back to original if resolution fails
 
-         if (not lua_load(Lua, *file, chunk_name.c_str())) {
-            // TODO Code compilation not currently supported
+      // Prefix chunk name with '@' (Lua convention for file-based chunks) for better debug output
+      std::string chunk_name = std::string("@") + resolved_path;
+
+      if (not lua_load(Lua, *file, chunk_name.c_str())) {
+         // TODO Code compilation not currently supported
 /*
-            if (recompile) {
-               objFile::create cachefile = {
-                  fl::Path(tbcpath),
-                  fl::Flags(FL::NEW|FL::WRITE),
-                  fl::Permissions(PERMIT::USER_READ|PERMIT::USER_WRITE)
-               };
+         if (recompile) {
+            objFile::create cachefile = {
+               fl::Path(tbcpath),
+               fl::Flags(FL::NEW|FL::WRITE),
+               fl::Permissions(PERMIT::USER_READ|PERMIT::USER_WRITE)
+            };
 
-               if (cachefile.ok()) {
-                  const Proto *f;
-                  struct DateTime *date;
-                  f = clvalue(Lua->top + (-1))->l.p;
-                  luaU_dump(Lua, f, &code_writer, cachefile, (Self->Flags & SCF_DEBUG) ? 0 : 1);
-                  if (not file.obj->getPtr(FID_Date, &date)) {
-                     cachefile->setDate(date);
-                  }
+            if (cachefile.ok()) {
+               const Proto *f;
+               struct DateTime *date;
+               f = clvalue(Lua->top + (-1))->l.p;
+               luaU_dump(Lua, f, &code_writer, cachefile, (Self->Flags & SCF_DEBUG) ? 0 : 1);
+               if (not file.obj->getPtr(FID_Date, &date)) {
+                  cachefile->setDate(date);
                }
             }
+         }
 */
 
-            int result_top = lua_gettop(Lua);
+         int result_top = lua_gettop(Lua);
 
-            if (not lua_pcall(Lua, 0, LUA_MULTRET, 0)) {
-               results = lua_gettop(Lua) - result_top + 1;
-            }
-            else error_msg = lua_tostringview(Lua, -1);
+         if (not lua_pcall(Lua, 0, LUA_MULTRET, 0)) {
+            results = lua_gettop(Lua) - result_top + 1;
          }
-         else { lua_load_failed(Lua); return 0; }
+         else error_msg = lua_tostringview(Lua, -1);
       }
-      else error = ERR::DoesNotExist;
-
-      if ((error_msg.empty()) and (error != ERR::Okay)) error_msg = GetErrorMsg(error);
-      if (not error_msg.empty()) luaL_error(Lua, "Failed to load/parse file '%.*s', error: %.*s", int(path.size()), path.data(), int(error_msg.size()), error_msg.data());
+      else { lua_load_failed(Lua); return 0; }
    }
-   else luaL_argerror(Lua, 1, "File path required.");
+   else error = ERR::DoesNotExist;
+
+   if ((error_msg.empty()) and (error != ERR::Okay)) error_msg = GetErrorMsg(error);
+   if (not error_msg.empty()) {
+      luaL_error(Lua, std::format("Failed to load/parse file '{}', error: {}", path, error_msg));
+   }
 
    return results;
 }
@@ -475,35 +478,35 @@ int fcmd_exec(lua_State *Lua)
    int results = 0;
 
    size_t len;
-   if (auto statement = lua_tolstring(Lua, 1, &len)) {
-      CSTRING error_msg = nullptr;
+   auto statement = lua_tolstring(Lua, 1, &len);
+   if (not statement) luaL_argerror(Lua, 1, "Tiri statement required.");
 
-      {
-         kt::Log log("exec");
-         log.branch();
+   CSTRING error_msg = nullptr;
 
-         // Check for the presence of a compiled header and skip it if present
+   {
+      kt::Log log("exec");
+      log.branch();
 
-         if (kt::startswith(LUA_COMPILED, std::string_view(statement, len))) {
-            size_t i;
-            for (i=sizeof(LUA_COMPILED)-1; statement[i]; i++);
-            statement += i + 1;
-            len -= (i + 1);
-         }
+      // Check for the presence of a compiled header and skip it if present
 
-         if (not lua_load(Lua, std::string_view(statement, len), "exec")) {
-            int result_top = lua_gettop(Lua);
-            if (not lua_pcall(Lua, 0, LUA_MULTRET, 0)) {
-               results = lua_gettop(Lua) - result_top + 1;
-            }
-            else error_msg = lua_tostring(Lua, -1);
-         }
-         else { lua_load_failed(Lua); return 0; }
+      if (kt::startswith(LUA_COMPILED, std::string_view(statement, len))) {
+         size_t i;
+         for (i=sizeof(LUA_COMPILED)-1; statement[i]; i++);
+         statement += i + 1;
+         len -= (i + 1);
       }
 
-      if (error_msg) luaL_error(Lua, error_msg);
+      if (not lua_load(Lua, std::string_view(statement, len), "exec")) {
+         int result_top = lua_gettop(Lua);
+         if (not lua_pcall(Lua, 0, LUA_MULTRET, 0)) {
+            results = lua_gettop(Lua) - result_top + 1;
+         }
+         else error_msg = lua_tostring(Lua, -1);
+      }
+      else { lua_load_failed(Lua); return 0; }
    }
-   else luaL_argerror(Lua, 1, "Tiri statement required.");
+
+   if (error_msg) luaL_error(Lua, error_msg);
 
    return results;
 }

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -78,11 +78,12 @@ static void key_event(evKey *, int, struct finput *);
 
          lua_rawgeti(prv->Lua, LUA_REGISTRYINDEX, list->Callback); // +1 Reference to callback
          lua_rawgeti(prv->Lua, LUA_REGISTRYINDEX, list->InputValue); // +1 Optional input value registered by the Tiri client
-         named_struct_to_table(prv->Lua, "InputEvent", Events); // +1 Input message
-
-         if (lua_pcall(prv->Lua, 2, 0, 0)) {
-            process_error(Self, "Input DataFeed Callback");
+         if (named_struct_to_table(prv->Lua, "InputEvent", Events) IS ERR::Okay) { // +1 Input message
+            if (lua_pcall(prv->Lua, 2, 0, 0)) {
+               process_error(Self, "Input DataFeed Callback");
+            }
          }
+         else process_error(Self, "Failed to process InputEvent struct");
 
          Events = Events->Next;
       }

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -270,7 +270,11 @@ static void key_event(evKey *, int, struct finput *);
          };
 
          auto error = acDataFeed(*src, Lua->script, DATA::REQUEST, &dcr, sizeof(dcr));
-         if (error != ERR::Okay) luaL_error(Lua, ERR::Failed, "Failed to request item %d from source #%d: %s", item, source_id, GetErrorMsg(error));
+         if (error != ERR::Okay) {
+            src.unlock();
+            luaL_error(Lua, ERR::Failed, "Failed to request item %d from source #%d: %s", item, source_id,
+               GetErrorMsg(error));
+         }
       }
    }
 
@@ -332,19 +336,24 @@ static void key_event(evKey *, int, struct finput *);
 
       lua_pushvalue(Lua, lua_gettop(Lua)); // Take a copy of the Tiri.input object
       input->InputValue = luaL_ref(Lua, LUA_REGISTRYINDEX);
+      input->Script      = Lua->script;
       input->KeyEvent    = nullptr;
       input->InputHandle = 0;
       input->Mask        = mask;
       input->Mode        = FIM_DEVICE;
-      input->Next        = prv->InputList;
-
-      prv->InputList = input;
+      input->Next        = nullptr;
 
       auto callback = C_FUNCTION(consume_input_events);
-      if ((error = gfx::SubscribeInput(&callback, input->SurfaceID, mask, device_id, &input->InputHandle)) != ERR::Okay) {
+      if ((error = gfx::SubscribeInput(&callback, input->SurfaceID, mask, device_id,
+            &input->InputHandle)) != ERR::Okay) {
+         if (input->InputHandle) { gfx::UnsubscribeInput(input->InputHandle); input->InputHandle = 0; }
+         if (input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, input->InputValue); input->InputValue = 0; }
+         if (input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, input->Callback); input->Callback = 0; }
          luaL_error(Lua, error);
       }
 
+      input->Next = prv->InputList;
+      prv->InputList = input;
       return 1;
    }
    else luaL_error(Lua, ERR::Memory, "Failed to initialise input subscription.");

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -20,6 +20,7 @@
 #include "lj_proto_registry.h"
 
 #include <ffi.h>
+#include <utility>
 #include <unordered_map>
 #include <algorithm>
 #include <set>
@@ -421,6 +422,7 @@ static int module_load(lua_State *Lua)
       }
 
       if (defs_error != ERR::Okay) {
+         FreeResource(loaded_mod);
          luaL_error(Lua, defs_error, "Failed to process definitions for the %s module.", modname);
       }
 
@@ -549,7 +551,7 @@ static int module_call(lua_State *Lua)
    auto err = module_call_inner(Lua, error_msg, results);
    if (err != ERR::Okay) {
       if (error_msg.empty()) error_msg = GetErrorMsg(err);
-      luaL_error(Lua, err, "%s", error_msg.c_str());
+      luaL_error(Lua, err, std::move(error_msg));
    }
    return results;
 }

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -520,7 +520,7 @@ static int object_get_struct(lua_State *Lua, const obj_read &Handle, GCobject *D
                if (field->Flags & FD_RESOURCE) {
                    push_struct(Lua->script, result, (CSTRING)field->Arg, (field->Flags & FD_ALLOC) ? TRUE : FALSE, TRUE);
                }
-               else named_struct_to_table(Lua, (CSTRING)field->Arg, result);
+               else error = named_struct_to_table(Lua, (CSTRING)field->Arg, result);
             }
             else lua_pushnil(Lua);
          }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -4,8 +4,10 @@
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
 #include <kotuku/modules/tiri.h>
+#include <format>
 #include <inttypes.h>
 #include <mutex>
+#include <utility>
 
 #include "lib.h"
 #include "lua.h"
@@ -33,20 +35,33 @@ static int processing_new(lua_State *Lua)
       fp->Signals = 0;
       fp->SignalRefs = 0;
 
+      auto fail = [&](ERR Error, std::string Message) -> int {
+         if (fp->SignalRefs) {
+            for (auto ref : *fp->SignalRefs) luaL_unref(Lua, LUA_REGISTRYINDEX, ref);
+            delete fp->SignalRefs;
+            fp->SignalRefs = nullptr;
+         }
+         if (fp->Signals) {
+            delete fp->Signals;
+            fp->Signals = nullptr;
+         }
+
+         luaL_error(Lua, Error, std::move(Message));
+         return 0;
+      };
+
       if (not (fp->Signals = new (std::nothrow) std::list<ObjectSignal>)) {
-         luaL_error(Lua, ERR::Memory);
+         return fail(ERR::Memory, std::format("Failed to initialise processing signal list."));
       }
 
       if (not (fp->SignalRefs = new (std::nothrow) std::list<int>)) {
-         delete fp->Signals;
-         fp->Signals = nullptr;
-         luaL_error(Lua, ERR::Memory);
+         return fail(ERR::Memory, std::format("Failed to initialise processing signal references."));
       }
 
       if (lua_istable(Lua, 1)) {
          lua_pushnil(Lua);  // Access first key for lua_next()
          while (lua_next(Lua, 1) != 0) {
-            if (auto field_name = luaL_checkstring(Lua, -2)) {
+            if (auto field_name = lua_tostring(Lua, -2)) {
                auto field_hash = strihash(field_name);
 
                switch (field_hash) {
@@ -63,25 +78,37 @@ static int processing_new(lua_State *Lua)
                               if (gcref(refs[i])) {
                                  auto obj = gco_to_object(gcref(refs[i]));
                                  ObjectSignal sig = { .Object = obj->ptr ? obj->ptr : GetObjectPtr(obj->uid) };
-                                 if (not sig.Object) luaL_error(Lua, ERR::AccessObject, "Signal object at index %d is not available.", i);
+                                 if (not sig.Object) {
+                                    return fail(ERR::AccessObject,
+                                       std::format("Signal object at index {} is not available.", i));
+                                 }
                                  fp->Signals->push_back(sig);
                                  setobjectV(Lua, Lua->top++, obj);
                                  fp->SignalRefs->push_back(luaL_ref(Lua, LUA_REGISTRYINDEX));
                               }
-                              else luaL_error(Lua, ERR::InvalidType, "Nil entry at index %d in signal array.", i);
+                              else {
+                                 return fail(ERR::InvalidType,
+                                    std::format("Nil entry at index {} in signal array.", i));
+                              }
                            }
                         }
-                        else luaL_error(Lua, ERR::InvalidType, "The signals option requires an array of objects.");
+                        else {
+                           return fail(ERR::InvalidType,
+                              std::format("The signals option requires an array of objects."));
+                        }
                      }
-                     else luaL_error(Lua, "The signals option requires an array<object> reference.");
+                     else {
+                        return fail(ERR::InvalidType,
+                           std::format("The signals option requires an array<object> reference."));
+                     }
                      break;
                   }
 
                   default:
-                     luaL_error(Lua, ERR::UnknownProperty, "Unrecognised option '%s'", field_name);
+                     return fail(ERR::UnknownProperty, std::format("Unrecognised option '{}'", field_name));
                }
             }
-            else luaL_error(Lua, ERR::UnknownProperty, "Unrecognised option.");
+            else return fail(ERR::UnknownProperty, std::format("Unrecognised option."));
 
             lua_pop(Lua, 1);  // removes 'value'; keeps 'key' for the proceeding lua_next() iteration
          }

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -17,6 +17,7 @@ Examples:
 #include <kotuku/strings.hpp>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <cctype>
 
 #include "lauxlib.h"
@@ -223,7 +224,8 @@ static int regex_new(lua_State *Lua)
 
       std::string error_msg;
       if (rx::Compile(pattern, flags, &error_msg, &r->regex_obj) != ERR::Okay) {
-         luaL_error(Lua, ERR::Syntax, "Regex compilation failed: %s", error_msg.c_str());
+         error_msg.insert(0, "Regex compilation failed: ");
+         luaL_error(Lua, ERR::Syntax, std::move(error_msg));
       }
 
       return 1; // userdata is already on stack

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -111,8 +111,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
    // NB: Custom comparator will stop if a colon is encountered in StructName
    if (auto def = glStructs.find(StructName); def != glStructs.end()) {
       std::vector<lua_ref> ref;
-      struct_to_table(Lua, ref, def->second, Address);
-      return ERR::Okay;
+      return struct_to_table(Lua, ref, def->second, Address);
    }
    else if (StructName.starts_with("KeyValue")) {
       // A struct name of 'KeyValue' allows the KEYVALUE type to be used for building structures dynamically.
@@ -220,15 +219,13 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
 
 //********************************************************************************************************************
 
-[[nodiscard]] void struct_to_table(lua_State *Lua, std::vector<lua_ref> &References, struct_record &StructDef, CPTR Address)
+[[nodiscard]] ERR struct_to_table(lua_State *Lua, std::vector<lua_ref> &References, struct_record &StructDef, CPTR Address)
 {
    kt::Log log(__FUNCTION__);
 
    log.traceBranch("Struct: %s, Data: %p", StructDef.Name.c_str(), Address);
 
-   // Do not push a Lua value in the event of an error.
-
-   if (not Address) { lua_pushnil(Lua); return; }
+   if (not Address) { lua_pushnil(Lua); return ERR::NullArgs; }
 
    // Check if there is an existing struct table already associated with this address.  If so, return it
    // rather than creating another table.
@@ -236,7 +233,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
    for (auto &rec : References) {
       if (Address IS rec.Address) {
          lua_rawgeti(Lua, LUA_REGISTRYINDEX, rec.Ref);
-         return;
+         return ERR::Okay;
       }
    }
 
@@ -320,6 +317,8 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
 
       lua_settable(Lua, -3);
    }
+
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -111,23 +111,27 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
    // NB: Custom comparator will stop if a colon is encountered in StructName
    if (auto def = glStructs.find(StructName); def != glStructs.end()) {
       std::vector<lua_ref> ref;
-      return struct_to_table(Lua, ref, def->second, Address);
+      struct_to_table(Lua, ref, def->second, Address);
+      return ERR::Okay;
    }
    else if (StructName.starts_with("KeyValue")) {
       // A struct name of 'KeyValue' allows the KEYVALUE type to be used for building structures dynamically.
       // ankerl::unordered_dense::map<std::string, std::string>
 
-      return keyvalue_to_table(Lua, (const KEYVALUE *)Address);
+      keyvalue_to_table(Lua, (const KEYVALUE *)Address);
+      return ERR::Okay;
    }
-   else luaL_error(Lua, ERR::Search, "Unknown struct name '%.*s' - use 'include' to load module definitions.", int(StructName.size()), StructName.data());
-   return ERR::Search;
+   else {
+      kt::Log().warning("Unknown struct name '%.*s' - use 'include' to load module definitions.", int(StructName.size()), StructName.data());
+      return ERR::Search;
+   }
 }
 
 //********************************************************************************************************************
 
-[[nodiscard]] ERR keyvalue_to_table(lua_State *Lua, const KEYVALUE *Map)
+[[nodiscard]] void keyvalue_to_table(lua_State *Lua, const KEYVALUE *Map)
 {
-   if (not Map) { lua_pushnil(Lua); return ERR::Okay; }
+   if (not Map) { lua_pushnil(Lua); return; }
 
    lua_createtable(Lua, 0, Map->size()); // Create a new table on the stack.
 
@@ -136,8 +140,6 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
       lua_pushlstring(Lua, val.c_str(), val.size());
       lua_settable(Lua, -3);
    }
-
-   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -218,7 +220,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
 
 //********************************************************************************************************************
 
-[[nodiscard]] ERR struct_to_table(lua_State *Lua, std::vector<lua_ref> &References, struct_record &StructDef, CPTR Address)
+[[nodiscard]] void struct_to_table(lua_State *Lua, std::vector<lua_ref> &References, struct_record &StructDef, CPTR Address)
 {
    kt::Log log(__FUNCTION__);
 
@@ -226,7 +228,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
 
    // Do not push a Lua value in the event of an error.
 
-   if (not Address) { lua_pushnil(Lua); return ERR::Okay; }
+   if (not Address) { lua_pushnil(Lua); return; }
 
    // Check if there is an existing struct table already associated with this address.  If so, return it
    // rather than creating another table.
@@ -234,7 +236,7 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
    for (auto &rec : References) {
       if (Address IS rec.Address) {
          lua_rawgeti(Lua, LUA_REGISTRYINDEX, rec.Ref);
-         return ERR::Okay;
+         return;
       }
    }
 
@@ -288,11 +290,11 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
          if (auto def = glStructs.find(std::string_view(field.StructRef)); def != glStructs.end()) {
             if (type & FD_PTR) {
                if (((APTR *)address)[0]) {
-                  if (struct_to_table(Lua, References, def->second, ((APTR *)address)[0]) != ERR::Okay) lua_pushnil(Lua);
+                  struct_to_table(Lua, References, def->second, ((APTR *)address)[0]);
                }
                else lua_pushnil(Lua);
             }
-            else if (struct_to_table(Lua, References, def->second, address) != ERR::Okay) lua_pushnil(Lua);
+            else struct_to_table(Lua, References, def->second, address);
          }
          else {
             log.msg("Struct '%s' not found for field '%s'", field.StructRef.c_str(), field.Name.c_str());
@@ -318,8 +320,6 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
 
       lua_settable(Lua, -3);
    }
-
-   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -346,7 +346,7 @@ struct fstruct * push_struct(objScript *Self, APTR Address, std::string_view Str
    }
    else {
       if (Deallocate) FreeResource(Address);
-      luaL_error(prv->Lua, ERR::Search, "Unrecognised struct '%s'", StructName.data());
+      kt::Log(__FUNCTION__).warning("Unrecognised struct '%s'", StructName.data());
       return nullptr;
    }
 }
@@ -363,7 +363,7 @@ struct fstruct * push_struct_def(lua_State *Lua, APTR Address, struct_record &St
       lua_setmetatable(Lua, -2);
       return fs;
    }
-   else luaL_error(Lua, ERR::Memory, "Failed to create new struct.");
+   else kt::Log(__FUNCTION__).warning("Failed to create new struct.");
 
    return nullptr;
 }
@@ -745,7 +745,6 @@ static int struct_get(lua_State *Lua)
 
          if (not fs->Data) {
             luaL_error(Lua, ERR::Failed, "Cannot reference field '%s' because struct address is NULL.", fieldname);
-            return 0;
          }
 
          if (auto field_opt = find_field(fs, fieldname)) {
@@ -833,15 +832,13 @@ static int struct_get(lua_State *Lua)
                else lua_pushinteger(Lua, ((uint8_t *)address)[0]);
             }
             else {
-               luaL_error(Lua, ERR::InvalidType, "%s", std::format("Field '{}' does not use a supported type of {:x}", fieldname, field.Type).c_str());
-               return 0;
+               luaL_error(Lua, ERR::InvalidType,
+                  std::format("Field '{}' does not use a supported type of {:x}", fieldname, field.Type));
             }
+
             return 1;
          }
-         else {
-            luaL_error(Lua, ERR::FieldSearch, "Field '%s' does not exist in structure.", fieldname);
-            return 0;
-         }
+         else luaL_error(Lua, ERR::FieldSearch, "Field '%s' does not exist in structure.", fieldname);
       }
    }
 
@@ -855,10 +852,7 @@ static int struct_set(lua_State *Lua)
 {
    if (auto fs = (struct fstruct *)lua_touserdata(Lua, 1)) {
       if (auto ref = luaL_checkstring(Lua, 2)) {
-         if (not fs->Data) {
-            luaL_error(Lua, "Cannot reference field '%s' because struct address is NULL.", ref);
-            return 0;
-         }
+         if (not fs->Data) luaL_error(Lua, "Cannot reference field '%s' because struct address is NULL.", ref);
 
          if (auto field_opt = find_field(fs, ref)) {
             auto &field = field_opt->get();
@@ -900,10 +894,7 @@ static int struct_destruct(lua_State *Lua)
          destroy_struct_cpp_strings(*fs->Def, fs->Data);
       }
 
-      if (fs->Deallocate) {
-         FreeResource(fs->Data);
-         fs->Data = nullptr;
-      }
+      if (fs->Deallocate) { FreeResource(fs->Data); fs->Data = nullptr; }
    }
 
    return 0;

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -287,11 +287,11 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
          if (auto def = glStructs.find(std::string_view(field.StructRef)); def != glStructs.end()) {
             if (type & FD_PTR) {
                if (((APTR *)address)[0]) {
-                  struct_to_table(Lua, References, def->second, ((APTR *)address)[0]);
+                  (void)struct_to_table(Lua, References, def->second, ((APTR *)address)[0]);
                }
                else lua_pushnil(Lua);
             }
-            else struct_to_table(Lua, References, def->second, address);
+            else (void)struct_to_table(Lua, References, def->second, address);
          }
          else {
             log.msg("Struct '%s' not found for field '%s'", field.StructRef.c_str(), field.Name.c_str());
@@ -331,13 +331,12 @@ struct fstruct * push_struct(objScript *Self, APTR Address, std::string_view Str
    log.traceBranch("Struct: %s, Address: %p, Deallocate: %d", StructName.data(), Address, Deallocate);
 
    auto prv = (prvTiri *)Self->DerivedPtr;
-   auto def = glStructs.find(StructName);
-   if (def != glStructs.end()) {
+   if (auto def = glStructs.find(StructName); def != glStructs.end()) {
       return push_struct_def(prv->Lua, Address, def->second, Deallocate);
    }
    else if (AllowEmpty) {
       // The AllowEmpty option is useful in situations where a successful API call returns a structure that is strictly
-      // unavailable to Tiri.  Rather than throw an exception because the structure isn't in the dictionary, we return
+      // unavailable to Tiri.  Rather than return NULL because the structure isn't in the dictionary, we return
       // an empty structure declaration.
 
       static struct_record empty("");
@@ -345,7 +344,7 @@ struct fstruct * push_struct(objScript *Self, APTR Address, std::string_view Str
    }
    else {
       if (Deallocate) FreeResource(Address);
-      kt::Log(__FUNCTION__).warning("Unrecognised struct '%s'", StructName.data());
+      log.warning("Unrecognised struct '%s'", StructName.data());
       return nullptr;
    }
 }
@@ -765,7 +764,9 @@ static int struct_get(lua_State *Lua)
                      }
                      else lua_createarray(Lua, array_size, ff_to_element(field.Type), (APTR *)address, ARRAY_CACHED, field.StructRef);
                   }
-                  else push_struct(Lua->script, ((APTR *)address)[0], field.StructRef, false, false);
+                  else if (!push_struct(Lua->script, ((APTR *)address)[0], field.StructRef, false, false)) {
+                     luaL_error(Lua, ERR::Search, "Failed to find struct '%s'", field.StructRef.c_str());
+                  }
                }
                else lua_pushnil(Lua);
             }
@@ -777,7 +778,9 @@ static int struct_get(lua_State *Lua)
                else make_struct_array(Lua, field.StructRef, array_size, address);
             }
             else if (field.Type & FD_STRUCT) { // Embedded structure
-               push_struct(Lua->script, address, field.StructRef, false, false);
+               if (!push_struct(Lua->script, address, field.StructRef, false, false)) {
+                  luaL_error(Lua, ERR::Search, "Failed to find struct '%s'", field.StructRef.c_str());
+               }
             }
             else if (field.Type & FD_STRING) {
                if (field.Type & FD_ARRAY) {
@@ -788,7 +791,7 @@ static int struct_get(lua_State *Lua)
                   else lua_createarray(Lua, array_size, AET::CSTR, (APTR *)address, ARRAY_CACHED);
                }
                else if (field.Type & FD_CPP) {
-                  lua_pushstring(Lua, ((std::string *)address)->c_str());
+                  lua_pushstring(Lua, *((std::string *)address));
                }
                else lua_pushstring(Lua, ((STRING *)address)[0]);
             }


### PR DESCRIPTION
* Added string-based luaL_error overloads for formatted Tiri diagnostics

* Hardened input, async, module and processing cleanup on failure paths

* Updated struct-to-table helpers to avoid throwing from conversion routines