### PR TITLE
[Core] Cleaned up string handling and unused includes

### DIFF
--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -112,7 +112,7 @@ typedef struct XMLAttrib {
    std::string Value;   // Value of the attribute
    inline bool isContent() const { return Name.empty(); }
    inline bool isTag() const { return !Name.empty(); }
-   XMLAttrib(std::string pName, std::string pValue = "") : Name(pName), Value(pValue) { };
+   XMLAttrib(std::string_view pName, std::string_view pValue = "") : Name(pName), Value(pValue) { };
    XMLAttrib() = default;
 } XMLATTRIB;
 
@@ -147,7 +147,7 @@ typedef struct XTag {
       return false;
    }
 
-   inline const std::string * attrib(const std::string &Name) const {
+   inline const std::string * attrib(std::string_view Name) const {
       for (unsigned a=1; a < Attribs.size(); a++) {
          if (kt::iequals(Attribs[a].Name, Name)) return &Attribs[a].Value;
       }
@@ -594,11 +594,11 @@ inline void UpdateAttrib(XTag &Tag, const std::string Name, const std::string Va
    if (CanCreate) Tag.Attribs.emplace_back(Name, Value);
 }
 
-inline void NewAttrib(XTag &Tag, const std::string Name, const std::string Value) {
+inline void NewAttrib(XTag &Tag, const std::string_view Name, const std::string_view Value) {
    Tag.Attribs.emplace_back(Name, Value);
 }
 
-inline void NewAttrib(XTag *Tag, const std::string Name, const std::string Value) {
+inline void NewAttrib(XTag *Tag, const std::string_view Name, const std::string_view Value) {
    Tag->Attribs.emplace_back(Name, Value);
 }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -22,7 +22,6 @@ This documentation is intended for technical reference and is not suitable as an
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <inttypes.h>
 #include <string.h>
 
 #ifdef _MSC_VER

--- a/src/core/lib_log.cpp
+++ b/src/core/lib_log.cpp
@@ -32,7 +32,6 @@ Log levels are:
 #endif
 
 #include <stdarg.h>
-#include <fcntl.h>
 
 #ifdef __ANDROID__
 #include <android/log.h>

--- a/src/core/lib_memory.cpp
+++ b/src/core/lib_memory.cpp
@@ -10,8 +10,6 @@ Name: Memory
 
 *********************************************************************************************************************/
 
-#include <stdlib.h> // Contains free(), malloc() etc
-
 #ifdef _WIN32
 #include <malloc.h> // For _aligned_malloc, _aligned_free
 #endif

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -24,12 +24,6 @@ Name: Messages
 #include <sys/wait.h>
 #endif
 
-#ifdef _WIN32
-#include <time.h>
-#include <stdlib.h>
-#include <stdio.h>
-#endif
-
 #include "defs.h"
 
 #include <deque>

--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -908,7 +908,7 @@ static ERR DISPLAY_Init(extDisplay *Self)
             }
          }
 
-         std::string name;
+         std::string_view name;
          CurrentTask()->get(FID_Name, name);
          HWND popover = 0;
          if (Self->PopOverID) {
@@ -919,7 +919,7 @@ static ERR DISPLAY_Init(extDisplay *Self)
          }
 
          if (not (Self->WindowHandle = (APTR)winCreateScreen(popover, &Self->X, &Self->Y, &Self->Width, &Self->Height,
-               ((Self->Flags & SCR::MAXIMISE) != SCR::NIL) ? 1 : 0, ((Self->Flags & SCR::BORDERLESS) != SCR::NIL) ? 1 : 0, name.c_str(),
+               ((Self->Flags & SCR::MAXIMISE) != SCR::NIL) ? 1 : 0, ((Self->Flags & SCR::BORDERLESS) != SCR::NIL) ? 1 : 0, name.data(),
                ((Self->Flags & SCR::COMPOSITE) != SCR::NIL) ? 1 : 0, Self->Opacity, desktop))) {
             return log.warning(ERR::SystemCall);
          }

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -34,8 +34,6 @@ that is distributed with this package.  Please refer to it for further informati
 #include "../link/unicode.h"
 #include <kotuku/modules/xquery.h>
 #include <atomic>
-#include <cassert>
-#include <limits>
 
 using BYTECODE = uint32_t;
 using CELL_ID = uint32_t;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -23,13 +23,8 @@ sockets and HTTP, please refer to the @NetSocket, @NetServer and @HTTP classes.
 #define PRV_CLIENTSOCKET
 #define PRV_NETCLIENT
 
-#include <stdio.h>
-#include <sys/types.h>
 #include <unordered_set>
-#include <ctime>
 #include <type_traits>
-
-#include <string.h>
 
 #include <kotuku/main.h>
 #include <kotuku/modules/network.h>
@@ -54,11 +49,8 @@ sockets and HTTP, please refer to the @NetSocket, @NetServer and @HTTP classes.
   #endif
 #endif
 
-#include <stack>
 #include <mutex>
 #include <shared_mutex>
-#include <span>
-#include <cstring>
 #include <thread>
 #include <optional>
 #include <string_view>

--- a/src/svg/save_svg.cpp
+++ b/src/svg/save_svg.cpp
@@ -340,11 +340,10 @@ static ERR save_svg_scan_std(extSVG *Self, objXML *XML, objVector *Vector, int T
       XTag *morph_tag;
       error = XML->insertStatement(TagID, XMI::CHILD_END, "<kotuku:morph/>", &morph_tag);
 
-      std::string shape_id;
+      std::string_view shape_id;
       if ((error IS ERR::Okay) and (shape->get(FID_ID, shape_id) IS ERR::Okay) and not shape_id.empty()) {
          // NB: It is required that the shape has previously been registered as a definition, otherwise the url will refer to a dud tag.
-         char shape_ref[120];
-         snprintf(shape_ref, sizeof(shape_ref), "url(#%s)", shape_id.c_str());
+         auto shape_ref = std::format("url(#{})", shape_id);
          xml::NewAttrib(morph_tag, "xlink:href", shape_ref);
       }
 
@@ -485,6 +484,7 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
       double x, y, *dx, *dy, *rotate, text_length;
       int total, i, weight;
       std::string str;
+      std::string_view sv;
       char buffer[1024];
 
       error = XML->insertStatement(Parent, XMI::CHILD_END, "<text/>", &tag);
@@ -530,14 +530,14 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
       if ((error IS ERR::Okay) and ((error = Vector->get(FID_TextLength, text_length)) IS ERR::Okay) and (text_length))
          xml::NewAttrib(tag, "textLength", std::to_string(text_length));
 
-      if ((error IS ERR::Okay) and ((error = Vector->get(FID_Face, str)) IS ERR::Okay))
-         xml::NewAttrib(tag, "font-family", str);
+      if ((error IS ERR::Okay) and ((error = Vector->get(FID_Face, sv)) IS ERR::Okay))
+         xml::NewAttrib(tag, "font-family", sv);
 
       if ((error IS ERR::Okay) and ((error = Vector->get(FID_Weight, weight)) IS ERR::Okay) and (weight != 400))
          xml::NewAttrib(tag, "font-weight", std::to_string(weight));
 
-      if ((error IS ERR::Okay) and ((error = Vector->get(FID_String, str)) IS ERR::Okay))
-         error = XML->insertContent(tag->ID, XMI::CHILD, str.c_str(), nullptr);
+      if ((error IS ERR::Okay) and ((error = Vector->get(FID_String, sv)) IS ERR::Okay))
+         error = XML->insertContent(tag->ID, XMI::CHILD, sv, nullptr);
 
       // TODO: lengthAdjust, font, font-size-adjust, font-stretch, font-style, font-variant, text-anchor, kerning, letter-spacing, path-length, word-spacing, text-decoration
 

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -17,6 +17,7 @@ https://www.w3.org/Graphics/SVG/Test/Overview.html
 #define PRV_SVG
 #include <unordered_map>
 #include <string>
+#include <format>
 #include <sstream>
 #include <charconv>
 #include <list>

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -19,20 +19,16 @@ https://www.w3.org/Graphics/SVG/Test/Overview.html
 #include <string>
 #include <format>
 #include <sstream>
-#include <charconv>
 #include <list>
 #include <variant>
-#include <algorithm>
 #include <cfloat>
 #include <kotuku/main.h>
-#include <kotuku/modules/image.h>
 #include <kotuku/modules/xml.h>
 #include <kotuku/modules/vector.h>
 #include <kotuku/modules/display.h>
 #include <kotuku/strings.hpp>
 #include "svg_def.c"
 #include <katana.h>
-#include <math.h>
 #include "../link/base64.h"
 #include "../xml/uri_utils.h"
 

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -469,7 +469,7 @@ static ERR parse_svg(extSVG *Self, CSTRING Path, CSTRING Buffer)
       xml->setFlags(XMF::NAMESPACE_AWARE|XMF::WELL_FORMED);
 
       objTask *task = CurrentTask();
-      std::string working_path;
+      std::string_view working_path;
 
       if (Path) {
          if (wildcmp("*.svgz", Path)) {

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -469,7 +469,7 @@ static ERR parse_svg(extSVG *Self, CSTRING Path, CSTRING Buffer)
       xml->setFlags(XMF::NAMESPACE_AWARE|XMF::WELL_FORMED);
 
       objTask *task = CurrentTask();
-      std::string_view working_path;
+      std::string working_path;
 
       if (Path) {
          if (wildcmp("*.svgz", Path)) {

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -28,29 +28,20 @@ For more information on the Tiri syntax, please refer to the official Tiri Refer
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/xml.h>
-#include <kotuku/modules/display.h>
 #include <kotuku/modules/tiri.h>
 #include <kotuku/modules/regex.h>
 #include <kotuku/strings.hpp>
 
-#include <inttypes.h>
 #include <format>
 #include <vector>
 #include <iterator>
-#include <mutex>
 
 #include "lua.h"
-#include "lualib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
-#include "parser/parser.h"
 #include "lj_bc.h"
 #include "lj_array.h"
 #include "lj_gc.h"
-#include "lj_object.h"
-
-#include "hashes.h"
 
 JUMPTABLE_CORE
 JUMPTABLE_REGEX

--- a/src/tiri/tiri_async.cpp
+++ b/src/tiri/tiri_async.cpp
@@ -17,17 +17,12 @@ additional functionality in the future.
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
-#include <thread>
-#include <cassert>
 #include <mutex>
 
 #include "lib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
-#include "lj_object.h"
-#include "hashes.h"
 #include "defs.h"
 #include "lj_proto_registry.h"
 

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -4,17 +4,14 @@
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
 #include <kotuku/modules/xml.h>
-#include <kotuku/modules/display.h>
 #include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
 #include <algorithm>
 #include <array>
 #include <cctype>
 #include <format>
-#include <iomanip>
 #include <limits>
 #include <ranges>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -22,12 +19,10 @@
 #include "lua.hpp"
 
 #include "lj_obj.h"
-#include "lj_bc.h"
 #include "parser/parser_diagnostics.h"
 #include "jit/src/debug/dump_bytecode.h"
 #include "lj_proto_registry.h"
 
-#include "hashes.h"
 #include "defs.h"
 
 static ERR run_script(objScript *);

--- a/src/tiri/tiri_functions.cpp
+++ b/src/tiri/tiri_functions.cpp
@@ -4,12 +4,9 @@
 #define PRV_TIRI_MODULE
 
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
 
-#include <inttypes.h>
 #include <format>
-#include <mutex>
 #include <algorithm>
 #include <string_view>
 #include <utility>
@@ -17,7 +14,6 @@
 
 #include "lua.h"
 #include "lj_obj.h"
-#include "lj_str.h"
 #include "parser/parser_diagnostics.h"
 
 #include "hashes.h"

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -5,14 +5,11 @@
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
 #include <inttypes.h>
 
 #include "lauxlib.h"
 #include "lj_obj.h"
-#include "hashes.h"
-#include "defs.h"
 #include "lj_proto_registry.h"
 
 enum {
@@ -640,9 +637,9 @@ static int file_seek(lua_State *Lua)
       auto offset = luaL_optnumber(Lua, 3, 0);
 
       auto whence = SEEK::CURRENT;
-      if (iequals("set", whence_str)) whence = SEEK::START;
-      else if (iequals("cur", whence_str)) whence = SEEK::CURRENT;
-      else if (iequals("end", whence_str)) whence = SEEK::END;
+      if (kt::iequals("set", whence_str)) whence = SEEK::START;
+      else if (kt::iequals("cur", whence_str)) whence = SEEK::CURRENT;
+      else if (kt::iequals("end", whence_str)) whence = SEEK::END;
 
       if (acSeek(file, offset, whence) IS ERR::Okay) {
          lua_pushnumber(Lua, file->Position);

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -3,19 +3,13 @@
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <kotuku/strings.hpp>
-#include <inttypes.h>
 
 #include "lua.h"
-#include "lualib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
-#include "lj_object.h"
 #include "lj_str.h"
-#include "lib.h"
 
-#include "hashes.h"
 #include "defs.h"
 #include "lj_proto_registry.h"
 
@@ -25,8 +19,6 @@
 #include <algorithm>
 #include <set>
 #include <mutex>
-#include <memory>
-#include <span>
 #include <new>
 
 template<class... Args> void RMSG(Args...) {

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -3,18 +3,14 @@
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <format>
-#include <inttypes.h>
 #include <mutex>
 #include <utility>
 
 #include "lib.h"
 #include "lua.h"
-#include "lualib.h"
 #include "lauxlib.h"
 #include "lj_obj.h"
-#include "lj_object.h"
 #include "hashes.h"
 #include "defs.h"
 #include "lj_proto_registry.h"

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -12,7 +12,6 @@ Examples:
 #define PRV_TIRI
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
-#include <kotuku/modules/tiri.h>
 #include <kotuku/modules/regex.h>
 #include <kotuku/strings.hpp>
 #include <string>
@@ -26,7 +25,6 @@ Examples:
 #include "lj_str.h"
 #include "lj_gc.h"
 #include "lj_proto_registry.h"
-#include "hashes.h"
 #include "defs.h"
 
 struct regex_callback {

--- a/src/vector/colours.cpp
+++ b/src/vector/colours.cpp
@@ -1,6 +1,4 @@
 
-#include <kotuku/modules/display.h>
-
 static const ankerl::unordered_dense::map<uint32_t, RGB8> glNamedColours = { // For vecReadPainter()
   { kt::strhash("none"),                 { 0, 0, 0, 0 } },
   { kt::strhash("aliceblue"),            { 240,248,255, 255 } },

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -460,8 +460,8 @@ static const ActionArray clPolygonActions[] = {
 static const FieldArray clPolygonFields[] = {
    { "Closed",      FDF_VIRTUAL|FDF_INT|FD_RW|FDF_PURE,                 POLY_GET_Closed, POLY_SET_Closed },
    { "PathLength",  FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE,                POLY_GET_PathLength, POLY_SET_PathLength },
-   { "PointsArray", FDF_VIRTUAL|FDF_ARRAY|FDF_POINTER|FDF_RW|FDF_PURE,   POLY_GET_PointsArray, POLY_SET_PointsArray },
-   { "Points",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,            nullptr, POLY_SET_Points },
+   { "PointsArray", FDF_VIRTUAL|FDF_ARRAY|FDF_POINTER|FDF_RW|FDF_PURE,  POLY_GET_PointsArray, POLY_SET_PointsArray },
+   { "Points",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,                    nullptr, POLY_SET_Points },
    { "TotalPoints", FDF_VIRTUAL|FDF_INT|FDF_R|FDF_PURE,                 POLY_GET_TotalPoints },
    { "X1",          FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, POLY_GET_X1, POLY_SET_X1 },
    { "Y1",          FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, POLY_GET_Y1, POLY_SET_Y1 },

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -46,15 +46,15 @@ void debug_tree(extVector *Vector, int &Level)
    Level++;
 
    for (auto v=Vector; v; v=(extVector *)v->Next) {
-      std::string dim;
+      int dim = 0;
       if (FindField(v, FID_Dimensions, nullptr)) v->get(strihash("Dimensions"), dim);
 
       if ((v->Class->BaseClassID IS CLASSID::VECTOR) and (v->Child)) {
          kt::Log blog(__FUNCTION__);
-         blog.branch(" #%d%s %s %s %s", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim.c_str());
+         blog.branch(" #%d%s %s %s $%.8x", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim);
          debug_tree((extVector *)v->Child, Level);
       }
-      else log.msg(" #%d%s %s %s %s", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim.c_str());
+      else log.msg(" #%d%s %s %s $%.8x", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim);
    }
 
    Level--;

--- a/src/xml/xml.tdl
+++ b/src/xml/xml.tdl
@@ -12,7 +12,7 @@ module({ name="XML", src="xml.cpp", copyright="Paul Manias © 2001-2026", versio
   [[
    inline bool isContent() const { return Name.empty(); }
    inline bool isTag() const { return !Name.empty(); }
-   XMLAttrib(std::string pName, std::string pValue = "") : Name(pName), Value(pValue) { };
+   XMLAttrib(std::string_view pName, std::string_view pValue = "") : Name(pName), Value(pValue) { };
    XMLAttrib() = default;
   ]])
 
@@ -51,7 +51,7 @@ module({ name="XML", src="xml.cpp", copyright="Paul Manias © 2001-2026", versio
       return false;
    }
 
-   inline const std::string * attrib(const std::string &Name) const {
+   inline const std::string * attrib(std::string_view Name) const {
       for (unsigned a=1; a < Attribs.size(); a++) {
          if (kt::iequals(Attribs[a].Name, Name)) return &Attribs[a].Value;
       }
@@ -260,11 +260,11 @@ inline void UpdateAttrib(XTag &Tag, const std::string Name, const std::string Va
    if (CanCreate) Tag.Attribs.emplace_back(Name, Value);
 }
 
-inline void NewAttrib(XTag &Tag, const std::string Name, const std::string Value) {
+inline void NewAttrib(XTag &Tag, const std::string_view Name, const std::string_view Value) {
    Tag.Attribs.emplace_back(Name, Value);
 }
 
-inline void NewAttrib(XTag *Tag, const std::string Name, const std::string Value) {
+inline void NewAttrib(XTag *Tag, const std::string_view Name, const std::string_view Value) {
    Tag->Attribs.emplace_back(Name, Value);
 }
 

--- a/src/xquery/tests/test_module_loading.tiri
+++ b/src/xquery/tests/test_module_loading.tiri
@@ -1,6 +1,7 @@
 -- XQuery module loading integration tests
 
    include 'xml'
+   include 'xquery'
 
 @BeforeAll
 function init(State)
@@ -85,7 +86,7 @@ end
 
    -- Verify feature flags include ModuleImports
 
-   assert(string.find(xq.get("$featureFlags"), 'ModuleImports', 0, true), "Expected feature flags to include ModuleImports")
+   assert(xq.featureFlags has XQF_MODULE_IMPORTS,  "Expected feature flags to include XQF_MODULE_IMPORTS")
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -758,10 +758,25 @@ global function docClass(Class)
    class_hash = string.format('%08x', Class.name:hash()):sub(-8)
    out ..= '    <id>' .. class_hash .. '</id>\n'
    out ..= '    <idstring>' .. Class.name:upper() .. '</idstring>\n'
-   cat = meta.get('$category')
-   if cat?? then
-      out ..= '    <category>' .. cat .. '</category>\n'
+
+   cat_name = choose meta.category from
+      CCF_COMMAND ->    'Command'
+      CCF_FILESYSTEM -> 'Filesystem'
+      CCF_GRAPHICS ->   'Graphics'
+      CCF_GUI ->        'GUI'
+      CCF_IO ->         'IO'
+      CCF_SYSTEM ->     'System'
+      CCF_TOOL ->       'Tool'
+      CCF_DATA ->       'Data'
+      CCF_AUDIO ->      'Audio'
+      CCF_MISC ->       'Misc'
+      CCF_NETWORK ->    'Network'
+      CCF_MULTIMEDIA -> 'Multimedia'
+      else -> nil
    end
+
+   if cat_name then out ..= '    <category>' .. cat_name .. '</category>\n' end
+
    if Class.include??      then out ..= '    <include>' .. Class.include .. '</include>\n' end
    if Class.date??         then out ..= '    <date>' .. Class.date .. '</date>\n' end
    if glModule.copyright?? then out ..= '    <copyright>' .. glModule.copyright:escXML() .. '</copyright>\n' end


### PR DESCRIPTION
* [XML] Accepted string views when constructing XML attributes

* [SVG] Avoided temporary string copies while serialising SVG text and morph references

* [Tiri] Removed unused includes from module implementation files

* [Doc] Read class categories directly from metaclass metadata