### PR TITLE
[Core] Harden object field access and pin release ordering

### DIFF
--- a/include/kotuku/field_values.hpp
+++ b/include/kotuku/field_values.hpp
@@ -1,0 +1,245 @@
+#pragma once
+
+//********************************************************************************************************************
+// These field name and type declarations help to ensure that fields are paired with the correct type during create().
+//
+// This header depends on declarations from main.h and must not be included directly.
+
+#ifndef KOTUKU_MAIN_H
+#error "Include <kotuku/main.h> instead of <kotuku/field_values.hpp>"
+#endif
+
+class objBitmap;
+class objNetClient;
+
+namespace fl {
+   using namespace kt;
+
+// Declares a string_view overload and a null-safe CSTRING overload for a string field helper.
+
+#define KT_FIELD_STRING(FieldName) \
+[[nodiscard]] inline FieldValue FieldName(std::string_view Value) { return FieldValue(FID_##FieldName, Value); } \
+[[nodiscard]] inline FieldValue FieldName(CSTRING Value) { return FieldValue(FID_##FieldName, Value ? std::string_view(Value) : std::string_view()); }
+
+KT_FIELD_STRING(Path)
+KT_FIELD_STRING(Location)
+KT_FIELD_STRING(Args)
+KT_FIELD_STRING(Fill)
+KT_FIELD_STRING(Statement)
+KT_FIELD_STRING(Stroke)
+KT_FIELD_STRING(String)
+KT_FIELD_STRING(Name)
+KT_FIELD_STRING(Allow)
+KT_FIELD_STRING(Style)
+KT_FIELD_STRING(Face)
+KT_FIELD_STRING(FileExtension)
+KT_FIELD_STRING(FileDescription)
+KT_FIELD_STRING(FileHeader)
+KT_FIELD_STRING(ArchiveName)
+KT_FIELD_STRING(Volume)
+KT_FIELD_STRING(DPMS)
+KT_FIELD_STRING(Icon)
+KT_FIELD_STRING(Procedure)
+KT_FIELD_STRING(ButtonOrder)
+KT_FIELD_STRING(Points)
+KT_FIELD_STRING(Pretext)
+KT_FIELD_STRING(Point)
+
+#undef KT_FIELD_STRING
+
+[[nodiscard]] constexpr FieldValue FontSize(double Value) { return FieldValue(FID_FontSize, Value); }
+[[nodiscard]] constexpr FieldValue FontSize(int Value) { return FieldValue(FID_FontSize, Value); }
+inline FieldValue FontSize(std::string_view Value) { return FieldValue(FID_FontSize, Value); }
+
+[[nodiscard]] constexpr FieldValue ReadOnly(int Value) { return FieldValue(FID_ReadOnly, Value); }
+[[nodiscard]] constexpr FieldValue ReadOnly(bool Value) { return FieldValue(FID_ReadOnly, (Value ? 1 : 0)); }
+
+[[nodiscard]] constexpr FieldValue Point(double Value) { return FieldValue(FID_Point, Value); }
+[[nodiscard]] constexpr FieldValue Point(int Value) { return FieldValue(FID_Point, Value); }
+[[nodiscard]] constexpr FieldValue Acceleration(double Value) { return FieldValue(FID_Acceleration, Value); }
+[[nodiscard]] constexpr FieldValue Actions(CPTR Value) { return FieldValue(FID_Actions, Value); }
+[[nodiscard]] constexpr FieldValue AmtColours(int Value) { return FieldValue(FID_AmtColours, Value); }
+[[nodiscard]] constexpr FieldValue BaseClassID(CLASSID Value) { return FieldValue(FID_BaseClassID, int(Value)); }
+[[nodiscard]] constexpr FieldValue Bitmap(objBitmap *Value) { return FieldValue(FID_Bitmap, Value); }
+[[nodiscard]] constexpr FieldValue BitsPerPixel(int Value) { return FieldValue(FID_BitsPerPixel, Value); }
+[[nodiscard]] constexpr FieldValue BytesPerPixel(int Value) { return FieldValue(FID_BytesPerPixel, Value); }
+[[nodiscard]] constexpr FieldValue Category(CCF Value) { return FieldValue(FID_Category, int(Value)); }
+[[nodiscard]] constexpr FieldValue ClassID(CLASSID Value) { return FieldValue(FID_ClassID, int(Value)); }
+[[nodiscard]] constexpr FieldValue ClassVersion(double Value) { return FieldValue(FID_ClassVersion, Value); }
+[[nodiscard]] constexpr FieldValue Client(struct NetClient *Value) { return FieldValue(FID_Client, Value); }
+[[nodiscard]] constexpr FieldValue Closed(bool Value) { return FieldValue(FID_Closed, (Value ? 1 : 0)); }
+[[nodiscard]] constexpr FieldValue Cursor(PTC Value) { return FieldValue(FID_Cursor, int(Value)); }
+[[nodiscard]] constexpr FieldValue DataFlags(MEM Value) { return FieldValue(FID_DataFlags, int(Value)); }
+[[nodiscard]] constexpr FieldValue DoubleClick(double Value) { return FieldValue(FID_DoubleClick, Value); }
+[[nodiscard]] inline    FieldValue Feedback(const FUNCTION &Value) { return FieldValue(FID_Feedback, Value); }
+[[nodiscard]] constexpr FieldValue Feedback(CPTR Value) { return FieldValue(FID_Feedback, Value); }
+[[nodiscard]] constexpr FieldValue Fields(const FieldArray *Value) { return FieldValue(FID_Fields, Value, FD_ARRAY); }
+[[nodiscard]] constexpr FieldValue Flags(int Value) { return FieldValue(FID_Flags, Value); }
+[[nodiscard]] constexpr FieldValue Font(OBJECTPTR Value) { return FieldValue(FID_Font, Value); }
+[[nodiscard]] constexpr FieldValue Handle(int Value) { return FieldValue(FID_Handle, Value); }
+[[nodiscard]] constexpr FieldValue Handle(APTR Value) { return FieldValue(FID_Handle, Value); }
+[[nodiscard]] constexpr FieldValue HostScene(OBJECTPTR Value) { return FieldValue(FID_HostScene, Value); }
+[[nodiscard]] inline    FieldValue Incoming(const FUNCTION &Value) { return FieldValue(FID_Incoming, Value); }
+[[nodiscard]] constexpr FieldValue Incoming(CPTR Value) { return FieldValue(FID_Incoming, Value); }
+[[nodiscard]] constexpr FieldValue Input(CPTR Value) { return FieldValue(FID_Input, Value); }
+[[nodiscard]] constexpr FieldValue LineLimit(int Value) { return FieldValue(FID_LineLimit, Value); }
+[[nodiscard]] constexpr FieldValue Listener(int Value) { return FieldValue(FID_Listener, Value); }
+[[nodiscard]] constexpr FieldValue MatrixColumns(int Value) { return FieldValue(FID_MatrixColumns, Value); }
+[[nodiscard]] constexpr FieldValue MatrixRows(int Value) { return FieldValue(FID_MatrixRows, Value); }
+[[nodiscard]] constexpr FieldValue MaxHeight(int Value) { return FieldValue(FID_MaxHeight, Value); }
+[[nodiscard]] constexpr FieldValue MaxSpeed(double Value) { return FieldValue(FID_MaxSpeed, Value); }
+[[nodiscard]] constexpr FieldValue MaxWidth(int Value) { return FieldValue(FID_MaxWidth, Value); }
+[[nodiscard]] constexpr FieldValue Methods(const MethodEntry *Value) { return FieldValue(FID_Methods, Value, FD_ARRAY); }
+[[nodiscard]] constexpr FieldValue Opacity(double Value) { return FieldValue(FID_Opacity, Value); }
+[[nodiscard]] constexpr FieldValue Owner(OBJECTID Value) { return FieldValue(FID_Owner, Value); }
+[[nodiscard]] constexpr FieldValue Parent(OBJECTID Value) { return FieldValue(FID_Parent, Value); }
+[[nodiscard]] constexpr FieldValue Permissions(PERMIT Value) { return FieldValue(FID_Permissions, int(Value)); }
+[[nodiscard]] constexpr FieldValue Image(OBJECTPTR Value) { return FieldValue(FID_Image, Value); }
+[[nodiscard]] constexpr FieldValue PopOver(OBJECTID Value) { return FieldValue(FID_PopOver, Value); }
+[[nodiscard]] constexpr FieldValue Port(int Value) { return FieldValue(FID_Port, Value); }
+[[nodiscard]] constexpr FieldValue RefreshRate(double Value) { return FieldValue(FID_RefreshRate, Value); }
+[[nodiscard]] constexpr FieldValue Routine(CPTR Value) { return FieldValue(FID_Routine, Value); }
+[[nodiscard]] constexpr FieldValue Size(int Value) { return FieldValue(FID_Size, Value); }
+[[nodiscard]] constexpr FieldValue Speed(double Value) { return FieldValue(FID_Speed, Value); }
+[[nodiscard]] constexpr FieldValue StrokeWidth(double Value) { return FieldValue(FID_StrokeWidth, Value); }
+[[nodiscard]] constexpr FieldValue Surface(OBJECTID Value) { return FieldValue(FID_Surface, Value); }
+[[nodiscard]] constexpr FieldValue Target(OBJECTID Value) { return FieldValue(FID_Target, Value); }
+[[nodiscard]] constexpr FieldValue Target(OBJECTPTR Value) { return FieldValue(FID_Target, Value); }
+[[nodiscard]] constexpr FieldValue ClientData(CPTR Value) { return FieldValue(FID_ClientData, Value); }
+[[nodiscard]] constexpr FieldValue Version(double Value) { return FieldValue(FID_Version, Value); }
+[[nodiscard]] constexpr FieldValue Viewport(OBJECTID Value) { return FieldValue(FID_Viewport, Value); }
+[[nodiscard]] constexpr FieldValue Viewport(OBJECTPTR Value) { return FieldValue(FID_Viewport, Value); }
+[[nodiscard]] constexpr FieldValue Weight(int Value) { return FieldValue(FID_Weight, Value); }
+[[nodiscard]] constexpr FieldValue WheelSpeed(double Value) { return FieldValue(FID_WheelSpeed, Value); }
+[[nodiscard]] constexpr FieldValue WindowHandle(APTR Value) { return FieldValue(FID_WindowHandle, Value); }
+[[nodiscard]] constexpr FieldValue WindowHandle(int Value) { return FieldValue(FID_WindowHandle, Value); }
+
+// Template-based Flags are required for strongly typed enums
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue Type(T Value) {
+   return FieldValue(FID_Type, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue AspectRatio(T Value) {
+   return FieldValue(FID_AspectRatio, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue BlendMode(T Value) {
+   return FieldValue(FID_BlendMode, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue ColourSpace(T Value) {
+   return FieldValue(FID_ColourSpace, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue Flags(T Value) {
+   return FieldValue(FID_Flags, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue Units(T Value) {
+   return FieldValue(FID_Units, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue SpreadMethod(T Value) {
+   return FieldValue(FID_SpreadMethod, int(Value));
+}
+
+template <NumericOrEnum T> [[nodiscard]] FieldValue Visibility(T Value) {
+   return FieldValue(FID_Visibility, int(Value));
+}
+
+// Dimension fields that accept any arithmetic type but not SCALE values.
+
+template <Numeric T> [[nodiscard]] FieldValue PageWidth(T Value) {
+   return FieldValue(FID_PageWidth, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue PageHeight(T Value) {
+   return FieldValue(FID_PageHeight, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ResX(T Value) {
+   return FieldValue(FID_ResX, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ResY(T Value) {
+   return FieldValue(FID_ResY, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ViewX(T Value) {
+   return FieldValue(FID_ViewX, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ViewY(T Value) {
+   return FieldValue(FID_ViewY, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ViewWidth(T Value) {
+   return FieldValue(FID_ViewWidth, Value);
+}
+
+template <Numeric T> [[nodiscard]] FieldValue ViewHeight(T Value) {
+   return FieldValue(FID_ViewHeight, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Radius(T Value) {
+   return FieldValue(FID_Radius, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue CenterX(T Value) {
+   return FieldValue(FID_CenterX, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue CenterY(T Value) {
+   return FieldValue(FID_CenterY, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue FX(T Value) {
+   return FieldValue(FID_FX, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue FY(T Value) {
+   return FieldValue(FID_FY, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Width(T Value) {
+   return FieldValue(FID_Width, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Height(T Value) {
+   return FieldValue(FID_Height, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue X(T Value) {
+   return FieldValue(FID_X, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue XOffset(T Value) {
+   return FieldValue(FID_XOffset, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Y(T Value) {
+   return FieldValue(FID_Y, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue YOffset(T Value) {
+   return FieldValue(FID_YOffset, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue X1(T Value) {
+   return FieldValue(FID_X1, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Y1(T Value) {
+   return FieldValue(FID_Y1, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue X2(T Value) {
+   return FieldValue(FID_X2, Value);
+}
+
+template <NumericOrScale T> [[nodiscard]] FieldValue Y2(T Value) {
+   return FieldValue(FID_Y2, Value);
+}
+
+}

--- a/include/kotuku/main.h
+++ b/include/kotuku/main.h
@@ -32,7 +32,7 @@
 #include <optional>
 #include <concepts>
 
-#define TAGEND 0LL
+inline constexpr int64_t TAGEND = 0;
 
 namespace kt {
 
@@ -48,6 +48,10 @@ concept Lockable = requires(T obj, int timeout) {
 // Concept for Kotuku object types (either derived from Object or implementing Lockable interface)
 template<typename T>
 concept KotukuObject = std::is_base_of_v<Object, T> or Lockable<T>;
+
+// Concept for arithmetic types (integral or floating point)
+template<typename T>
+concept Numeric = std::is_arithmetic_v<T>;
 
 // Concept for numeric types (arithmetic or enum)
 template<typename T>
@@ -75,17 +79,9 @@ template <class T = double> struct POINT {
       y += Other.y;
       return *this;
    }
+
+   [[nodiscard]] constexpr bool operator==(const POINT &) const = default;
 };
-
-template <std::floating_point T = double>
-[[nodiscard]] bool operator==(const POINT<T> &a, const POINT<T> &b) {
-   return (a.x == b.x) and (a.y == b.y);
-}
-
-template <std::integral T>
-[[nodiscard]] bool operator==(const POINT<T> &a, const POINT<T> &b) {
-   return (a.x == b.x) and (a.y == b.y);
-}
 
 // Fast distance approximation for integral types
 template <std::integral T>
@@ -204,7 +200,14 @@ class ScopedObjectLock {
       }
 
       inline ScopedObjectLock() = default;
-      [[nodiscard]] inline bool granted() { return error IS ERR::Okay; }
+
+      // Copying or moving would result in a double-release of the lock.
+      ScopedObjectLock(const ScopedObjectLock &) = delete;
+      ScopedObjectLock & operator=(const ScopedObjectLock &) = delete;
+      ScopedObjectLock(ScopedObjectLock &&) = delete;
+      ScopedObjectLock & operator=(ScopedObjectLock &&) = delete;
+
+      [[nodiscard]] inline bool granted() const { return error IS ERR::Okay; }
 
       inline T * operator->() { return obj; }; // Promotes underlying methods and fields
       inline T * & operator*() { return obj; }; // To allow object pointer referencing when calling functions
@@ -229,6 +232,12 @@ class LocalResource {
          id = ((int *)Resource)[RESOURCE_ID_OFFSET];
       }
       ~LocalResource() { FreeResource(id); }
+
+      // Copying or moving would result in a double-free of the resource.
+      LocalResource(const LocalResource &) = delete;
+      LocalResource & operator=(const LocalResource &) = delete;
+      LocalResource(LocalResource &&) = delete;
+      LocalResource & operator=(LocalResource &&) = delete;
 };
 
 //********************************************************************************************************************
@@ -274,7 +283,9 @@ class GuardedObject {
          id     = other.id;
          object = other.object;
          count  = other.count;
-         other.count = nullptr;
+         other.count  = nullptr;
+         other.object = nullptr;
+         other.id     = 0;
       }
 
       // Destructor
@@ -290,7 +301,10 @@ class GuardedObject {
 
       GuardedObject & operator = (const GuardedObject &other) { // Copy assignment
          if (this == &other) return *this;
-         if (!--count[0]) delete count;
+         if ((count) and (!--count[0])) {
+            if (id) FreeResource(id);
+            delete count;
+         }
          if (other.object) {
             object = other.object;
             count  = other.count;
@@ -307,11 +321,16 @@ class GuardedObject {
 
       GuardedObject & operator = (GuardedObject &&other) { // Move assignment
          if (this == &other) return *this;
-         if (!--count[0]) delete count;
+         if ((count) and (!--count[0])) {
+            if (id) FreeResource(id);
+            delete count;
+         }
          id     = other.id;
          object = other.object;
          count  = other.count;
-         other.count = nullptr;
+         other.count  = nullptr;
+         other.object = nullptr;
+         other.id     = 0;
          return *this;
       }
 
@@ -326,7 +345,7 @@ class GuardedObject {
          else { kt::Log log(__FUNCTION__); log.warning(ERR::InUse); }
       }
 
-      constexpr bool empty() { return !object; } // Returns true if no object is being guarded.
+      constexpr bool empty() const { return !object; } // Returns true if no object is being guarded.
 
       T * operator->() { return object; }; // Promotes underlying methods and fields
       T * & operator*() { return object; }; // To allow object pointer referencing when calling functions
@@ -357,6 +376,7 @@ class GuardedResource {
             resource = other.resource;
             count    = other.count;
             count[0]++;
+            id       = other.id;
          }
          else { // If the other resource is undefined then use a default state
             resource = nullptr;
@@ -369,7 +389,9 @@ class GuardedResource {
          id       = other.id;
          resource = other.resource;
          count    = other.count;
-         other.count = nullptr;
+         other.count    = nullptr;
+         other.resource = nullptr;
+         other.id       = 0;
       }
 
       // Destructor
@@ -385,27 +407,36 @@ class GuardedResource {
 
       GuardedResource & operator = (const GuardedResource &other) { // Copy assignment
          if (this == &other) return *this;
-         if (!--count[0]) delete count;
+         if ((count) and (!--count[0])) {
+            if (id) FreeResource(id);
+            delete count;
+         }
          if (other.resource) {
             resource = other.resource;
-            count  = other.count;
+            count    = other.count;
             count[0]++;
+            id       = other.id;
          }
          else { // If the other resource is undefined then we reset our state with no count inheritance.
             resource = nullptr;
             id       = 0;
-            count[0] = 1;
+            count    = new C(1);
          }
          return *this;
       }
 
       GuardedResource & operator = (GuardedResource &&other) { // Move assignment
          if (this == &other) return *this;
-         if (!--count[0]) delete count;
+         if ((count) and (!--count[0])) {
+            if (id) FreeResource(id);
+            delete count;
+         }
          id       = other.id;
          resource = other.resource;
          count    = other.count;
-         other.count = nullptr;
+         other.count    = nullptr;
+         other.resource = nullptr;
+         other.id       = 0;
          return *this;
       }
 
@@ -420,7 +451,7 @@ class GuardedResource {
          else { kt::Log log(__FUNCTION__); log.warning(ERR::InUse); }
       }
 
-      constexpr bool empty() { return !resource; } // Returns true if no resource is being guarded.
+      constexpr bool empty() const { return !resource; } // Returns true if no resource is being guarded.
 
       T * operator->() { return resource; }; // Promotes underlying methods and fields
       T * & operator*() { return resource; }; // To allow resource pointer referencing when calling functions
@@ -456,291 +487,14 @@ class SwitchContext { // C++ wrapper for changing the current context with a res
          if (object) ((OBJECTPTR)object)->unlock();
          if (restore) SetObjectContext(nullptr, nullptr, AC::NIL);
       }
+
+      // Copying or moving would result in a double-unlock and unbalanced context restoration.
+      SwitchContext(const SwitchContext &) = delete;
+      SwitchContext & operator=(const SwitchContext &) = delete;
+      SwitchContext(SwitchContext &&) = delete;
+      SwitchContext & operator=(SwitchContext &&) = delete;
 };
 
 } // namespace
 
-//********************************************************************************************************************
-// These field name and type declarations help to ensure that fields are paired with the correct type during create().
-
-class objBitmap;
-class objNetClient;
-
-namespace fl {
-   using namespace kt;
-
-[[nodiscard]] inline FieldValue Path(std::string_view Value) { return FieldValue(FID_Path, Value); }
-[[nodiscard]] inline FieldValue Location(std::string_view Value) { return FieldValue(FID_Location, Value); }
-[[nodiscard]] inline FieldValue Args(std::string_view Value) { return FieldValue(FID_Args, Value); }
-[[nodiscard]] inline FieldValue Fill(std::string_view Value) { return FieldValue(FID_Fill, Value); }
-[[nodiscard]] inline FieldValue Statement(std::string_view Value) { return FieldValue(FID_Statement, Value); }
-[[nodiscard]] inline FieldValue Stroke(std::string_view Value) { return FieldValue(FID_Stroke, Value); }
-[[nodiscard]] inline FieldValue String(std::string_view Value) { return FieldValue(FID_String, Value); }
-[[nodiscard]] inline FieldValue Name(std::string_view Value) { return FieldValue(FID_Name, Value); }
-[[nodiscard]] inline FieldValue Allow(std::string_view Value) { return FieldValue(FID_Allow, Value); }
-[[nodiscard]] inline FieldValue Style(std::string_view Value) { return FieldValue(FID_Style, Value); }
-[[nodiscard]] inline FieldValue Face(std::string_view Value) { return FieldValue(FID_Face, Value); }
-[[nodiscard]] inline FieldValue FileExtension(std::string_view Value) { return FieldValue(FID_FileExtension, Value); }
-[[nodiscard]] inline FieldValue FileDescription(std::string_view Value) { return FieldValue(FID_FileDescription, Value); }
-[[nodiscard]] inline FieldValue FileHeader(std::string_view Value) { return FieldValue(FID_FileHeader, Value); }
-[[nodiscard]] inline FieldValue ArchiveName(std::string_view Value) { return FieldValue(FID_ArchiveName, Value); }
-[[nodiscard]] inline FieldValue Volume(std::string_view Value) { return FieldValue(FID_Volume, Value); }
-[[nodiscard]] inline FieldValue DPMS(std::string_view Value) { return FieldValue(FID_DPMS, Value); }
-[[nodiscard]] inline FieldValue Icon(std::string_view Value) { return FieldValue(FID_Icon, Value); }
-[[nodiscard]] inline FieldValue Procedure(std::string_view Value) { return FieldValue(FID_Procedure, Value); }
-[[nodiscard]] inline FieldValue ButtonOrder(std::string_view Value) { return FieldValue(FID_ButtonOrder, Value); }
-[[nodiscard]] inline FieldValue Points(std::string_view Value) { return FieldValue(FID_Points, Value); }
-[[nodiscard]] inline FieldValue Pretext(std::string_view Value) { return FieldValue(FID_Pretext, Value); }
-[[nodiscard]] inline FieldValue Point(std::string_view Value) { return FieldValue(FID_Point, Value); }
-
-// Handlers to prevent failure on receipt of a nullptr value
-[[nodiscard]] inline FieldValue Path(CSTRING Value) { return FieldValue(FID_Path, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Location(CSTRING Value) { return FieldValue(FID_Location, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Args(CSTRING Value) { return FieldValue(FID_Args, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Fill(CSTRING Value) { return FieldValue(FID_Fill, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Statement(CSTRING Value) { return FieldValue(FID_Statement, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Stroke(CSTRING Value) { return FieldValue(FID_Stroke, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue String(CSTRING Value) { return FieldValue(FID_String, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Name(CSTRING Value) { return FieldValue(FID_Name, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Allow(CSTRING Value) { return FieldValue(FID_Allow, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Style(CSTRING Value) { return FieldValue(FID_Style, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Face(CSTRING Value) { return FieldValue(FID_Face, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue FileExtension(CSTRING Value) { return FieldValue(FID_FileExtension, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue FileDescription(CSTRING Value) { return FieldValue(FID_FileDescription, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue FileHeader(CSTRING Value) { return FieldValue(FID_FileHeader, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue ArchiveName(CSTRING Value) { return FieldValue(FID_ArchiveName, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Volume(CSTRING Value) { return FieldValue(FID_Volume, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue DPMS(CSTRING Value) { return FieldValue(FID_DPMS, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Icon(CSTRING Value) { return FieldValue(FID_Icon, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Procedure(CSTRING Value) { return FieldValue(FID_Procedure, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue ButtonOrder(CSTRING Value) { return FieldValue(FID_ButtonOrder, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Points(CSTRING Value) { return FieldValue(FID_Points, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Pretext(CSTRING Value) { return FieldValue(FID_Pretext, Value ? std::string_view(Value) : std::string_view()); }
-[[nodiscard]] inline FieldValue Point(CSTRING Value) { return FieldValue(FID_Point, Value ? std::string_view(Value) : std::string_view()); }
-
-[[nodiscard]] constexpr FieldValue FontSize(double Value) { return FieldValue(FID_FontSize, Value); }
-[[nodiscard]] constexpr FieldValue FontSize(int Value) { return FieldValue(FID_FontSize, Value); }
-inline FieldValue FontSize(std::string_view Value) { return FieldValue(FID_FontSize, Value); }
-
-[[nodiscard]] constexpr FieldValue ReadOnly(int Value) { return FieldValue(FID_ReadOnly, Value); }
-[[nodiscard]] constexpr FieldValue ReadOnly(bool Value) { return FieldValue(FID_ReadOnly, (Value ? 1 : 0)); }
-
-[[nodiscard]] constexpr FieldValue Point(double Value) { return FieldValue(FID_Point, Value); }
-[[nodiscard]] constexpr FieldValue Point(int Value) { return FieldValue(FID_Point, Value); }
-[[nodiscard]] constexpr FieldValue Acceleration(double Value) { return FieldValue(FID_Acceleration, Value); }
-[[nodiscard]] constexpr FieldValue Actions(CPTR Value) { return FieldValue(FID_Actions, Value); }
-[[nodiscard]] constexpr FieldValue AmtColours(int Value) { return FieldValue(FID_AmtColours, Value); }
-[[nodiscard]] constexpr FieldValue BaseClassID(CLASSID Value) { return FieldValue(FID_BaseClassID, int(Value)); }
-[[nodiscard]] constexpr FieldValue Bitmap(objBitmap *Value) { return FieldValue(FID_Bitmap, Value); }
-[[nodiscard]] constexpr FieldValue BitsPerPixel(int Value) { return FieldValue(FID_BitsPerPixel, Value); }
-[[nodiscard]] constexpr FieldValue BytesPerPixel(int Value) { return FieldValue(FID_BytesPerPixel, Value); }
-[[nodiscard]] constexpr FieldValue Category(CCF Value) { return FieldValue(FID_Category, int(Value)); }
-[[nodiscard]] constexpr FieldValue ClassID(CLASSID Value) { return FieldValue(FID_ClassID, int(Value)); }
-[[nodiscard]] constexpr FieldValue ClassVersion(double Value) { return FieldValue(FID_ClassVersion, Value); }
-[[nodiscard]] constexpr FieldValue Client(struct NetClient *Value) { return FieldValue(FID_Client, Value); }
-[[nodiscard]] constexpr FieldValue Closed(bool Value) { return FieldValue(FID_Closed, (Value ? 1 : 0)); }
-[[nodiscard]] constexpr FieldValue Cursor(PTC Value) { return FieldValue(FID_Cursor, int(Value)); }
-[[nodiscard]] constexpr FieldValue DataFlags(MEM Value) { return FieldValue(FID_DataFlags, int(Value)); }
-[[nodiscard]] constexpr FieldValue DoubleClick(double Value) { return FieldValue(FID_DoubleClick, Value); }
-[[nodiscard]] inline    FieldValue Feedback(const FUNCTION &Value) { return FieldValue(FID_Feedback, Value); }
-[[nodiscard]] constexpr FieldValue Feedback(CPTR Value) { return FieldValue(FID_Feedback, Value); }
-[[nodiscard]] constexpr FieldValue Fields(const FieldArray *Value) { return FieldValue(FID_Fields, Value, FD_ARRAY); }
-[[nodiscard]] constexpr FieldValue Flags(int Value) { return FieldValue(FID_Flags, Value); }
-[[nodiscard]] constexpr FieldValue Font(OBJECTPTR Value) { return FieldValue(FID_Font, Value); }
-[[nodiscard]] constexpr FieldValue Handle(int Value) { return FieldValue(FID_Handle, Value); }
-[[nodiscard]] constexpr FieldValue Handle(APTR Value) { return FieldValue(FID_Handle, Value); }
-[[nodiscard]] constexpr FieldValue HostScene(OBJECTPTR Value) { return FieldValue(FID_HostScene, Value); }
-[[nodiscard]] inline    FieldValue Incoming(const FUNCTION &Value) { return FieldValue(FID_Incoming, Value); }
-[[nodiscard]] constexpr FieldValue Incoming(CPTR Value) { return FieldValue(FID_Incoming, Value); }
-[[nodiscard]] constexpr FieldValue Input(CPTR Value) { return FieldValue(FID_Input, Value); }
-[[nodiscard]] constexpr FieldValue LineLimit(int Value) { return FieldValue(FID_LineLimit, Value); }
-[[nodiscard]] constexpr FieldValue Listener(int Value) { return FieldValue(FID_Listener, Value); }
-[[nodiscard]] constexpr FieldValue MatrixColumns(int Value) { return FieldValue(FID_MatrixColumns, Value); }
-[[nodiscard]] constexpr FieldValue MatrixRows(int Value) { return FieldValue(FID_MatrixRows, Value); }
-[[nodiscard]] constexpr FieldValue MaxHeight(int Value) { return FieldValue(FID_MaxHeight, Value); }
-[[nodiscard]] constexpr FieldValue MaxSpeed(double Value) { return FieldValue(FID_MaxSpeed, Value); }
-[[nodiscard]] constexpr FieldValue MaxWidth(int Value) { return FieldValue(FID_MaxWidth, Value); }
-[[nodiscard]] constexpr FieldValue Methods(const MethodEntry *Value) { return FieldValue(FID_Methods, Value, FD_ARRAY); }
-[[nodiscard]] constexpr FieldValue Opacity(double Value) { return FieldValue(FID_Opacity, Value); }
-[[nodiscard]] constexpr FieldValue Owner(OBJECTID Value) { return FieldValue(FID_Owner, Value); }
-[[nodiscard]] constexpr FieldValue Parent(OBJECTID Value) { return FieldValue(FID_Parent, Value); }
-[[nodiscard]] constexpr FieldValue Permissions(PERMIT Value) { return FieldValue(FID_Permissions, int(Value)); }
-[[nodiscard]] constexpr FieldValue Image(OBJECTPTR Value) { return FieldValue(FID_Image, Value); }
-[[nodiscard]] constexpr FieldValue PopOver(OBJECTID Value) { return FieldValue(FID_PopOver, Value); }
-[[nodiscard]] constexpr FieldValue Port(int Value) { return FieldValue(FID_Port, Value); }
-[[nodiscard]] constexpr FieldValue RefreshRate(double Value) { return FieldValue(FID_RefreshRate, Value); }
-[[nodiscard]] constexpr FieldValue Routine(CPTR Value) { return FieldValue(FID_Routine, Value); }
-[[nodiscard]] constexpr FieldValue Size(int Value) { return FieldValue(FID_Size, Value); }
-[[nodiscard]] constexpr FieldValue Speed(double Value) { return FieldValue(FID_Speed, Value); }
-[[nodiscard]] constexpr FieldValue StrokeWidth(double Value) { return FieldValue(FID_StrokeWidth, Value); }
-[[nodiscard]] constexpr FieldValue Surface(OBJECTID Value) { return FieldValue(FID_Surface, Value); }
-[[nodiscard]] constexpr FieldValue Target(OBJECTID Value) { return FieldValue(FID_Target, Value); }
-[[nodiscard]] constexpr FieldValue Target(OBJECTPTR Value) { return FieldValue(FID_Target, Value); }
-[[nodiscard]] constexpr FieldValue ClientData(CPTR Value) { return FieldValue(FID_ClientData, Value); }
-[[nodiscard]] constexpr FieldValue Version(double Value) { return FieldValue(FID_Version, Value); }
-[[nodiscard]] constexpr FieldValue Viewport(OBJECTID Value) { return FieldValue(FID_Viewport, Value); }
-[[nodiscard]] constexpr FieldValue Viewport(OBJECTPTR Value) { return FieldValue(FID_Viewport, Value); }
-[[nodiscard]] constexpr FieldValue Weight(int Value) { return FieldValue(FID_Weight, Value); }
-[[nodiscard]] constexpr FieldValue WheelSpeed(double Value) { return FieldValue(FID_WheelSpeed, Value); }
-[[nodiscard]] constexpr FieldValue WindowHandle(APTR Value) { return FieldValue(FID_WindowHandle, Value); }
-[[nodiscard]] constexpr FieldValue WindowHandle(int Value) { return FieldValue(FID_WindowHandle, Value); }
-
-// Template-based Flags are required for strongly typed enums
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue Type(T Value) {
-   return FieldValue(FID_Type, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue AspectRatio(T Value) {
-   return FieldValue(FID_AspectRatio, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue BlendMode(T Value) {
-   return FieldValue(FID_BlendMode, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue ColourSpace(T Value) {
-   return FieldValue(FID_ColourSpace, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue Flags(T Value) {
-   return FieldValue(FID_Flags, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue Units(T Value) {
-   return FieldValue(FID_Units, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue SpreadMethod(T Value) {
-   return FieldValue(FID_SpreadMethod, int(Value));
-}
-
-template <NumericOrEnum T> [[nodiscard]] FieldValue Visibility(T Value) {
-   return FieldValue(FID_Visibility, int(Value));
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue PageWidth(T Value) {
-   return FieldValue(FID_PageWidth, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue PageWidth(T Value) {
-   return FieldValue(FID_PageWidth, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue PageHeight(T Value) {
-   return FieldValue(FID_PageHeight, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue PageHeight(T Value) {
-   return FieldValue(FID_PageHeight, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Radius(T Value) {
-   return FieldValue(FID_Radius, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue CenterX(T Value) {
-   return FieldValue(FID_CenterX, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue CenterY(T Value) {
-   return FieldValue(FID_CenterY, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue FX(T Value) {
-   return FieldValue(FID_FX, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue FY(T Value) {
-   return FieldValue(FID_FY, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ResX(T Value) {
-   return FieldValue(FID_ResX, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ResX(T Value) {
-   return FieldValue(FID_ResX, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ResY(T Value) {
-   return FieldValue(FID_ResY, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ResY(T Value) {
-   return FieldValue(FID_ResY, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ViewX(T Value) {
-   return FieldValue(FID_ViewX, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ViewX(T Value) {
-   return FieldValue(FID_ViewX, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ViewY(T Value) {
-   return FieldValue(FID_ViewY, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ViewY(T Value) {
-   return FieldValue(FID_ViewY, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ViewWidth(T Value) {
-   return FieldValue(FID_ViewWidth, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ViewWidth(T Value) {
-   return FieldValue(FID_ViewWidth, Value);
-}
-
-template <std::floating_point T> [[nodiscard]] FieldValue ViewHeight(T Value) {
-   return FieldValue(FID_ViewHeight, Value);
-}
-
-template <std::integral T> [[nodiscard]] FieldValue ViewHeight(T Value) {
-   return FieldValue(FID_ViewHeight, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Width(T Value) {
-   return FieldValue(FID_Width, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Height(T Value) {
-   return FieldValue(FID_Height, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue X(T Value) {
-   return FieldValue(FID_X, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue XOffset(T Value) {
-   return FieldValue(FID_XOffset, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Y(T Value) {
-   return FieldValue(FID_Y, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue YOffset(T Value) {
-   return FieldValue(FID_YOffset, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue X1(T Value) {
-   return FieldValue(FID_X1, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Y1(T Value) {
-   return FieldValue(FID_Y1, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue X2(T Value) {
-   return FieldValue(FID_X2, Value);
-}
-
-template <NumericOrScale T> [[nodiscard]] FieldValue Y2(T Value) {
-   return FieldValue(FID_Y2, Value);
-}
-
-}
+#include <kotuku/field_values.hpp>

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -192,7 +192,7 @@ inline void RestoreObjectContext() { SetObjectContext(nullptr, nullptr, AC::NIL)
 // state of the object's superset, it is not strictly necessary to acquire a lock.  Writeable values are managed with
 // atomics and the rest are considered read-only, making many operating patterns safe.
 
-struct Object { // Must be 64-bit aligned
+struct alignas(8) Object { // Must be 64-bit aligned
    union {
       objMetaClass *Class;          // [Public] Class pointer
       class extMetaClass *ExtClass; // [Private] Internal version of the class pointer
@@ -804,7 +804,7 @@ struct Object { // Must be 64-bit aligned
       return ERR::Okay;
    }
 
-} alignas(8);
+};
 
 namespace kt {
 

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -84,7 +84,7 @@ inline ERR write_field_value(OBJECTPTR Target, struct Field *FieldPtr, const Fie
 }
 
 namespace dmf { // Helper functions for DMF flags
-inline bool has(DMF Value, DMF Flags) { return (Value & Flags) != DMF::NIL; }
+[[nodiscard]] inline bool has(DMF Value, DMF Flags) { return (Value & Flags) != DMF::NIL; }
 
 [[nodiscard]] inline bool hasX(DMF Value) { return (Value & DMF::FIXED_X) != DMF::NIL; }
 [[nodiscard]] inline bool hasY(DMF Value) { return (Value & DMF::FIXED_Y) != DMF::NIL; }
@@ -136,7 +136,7 @@ class ScopedObjectAccess {
       ScopedObjectAccess(const ScopedObjectAccess &) = delete;
       ScopedObjectAccess & operator=(const ScopedObjectAccess &) = delete;
       inline ~ScopedObjectAccess();
-      inline bool granted() { return error IS ERR::Okay; }
+      inline bool granted() const { return error IS ERR::Okay; }
       inline void release();
 };
 
@@ -158,25 +158,23 @@ class SharedObjectAccess {
       SharedObjectAccess(const SharedObjectAccess &) = delete;
       SharedObjectAccess & operator=(const SharedObjectAccess &) = delete;
       inline ~SharedObjectAccess();
-      inline bool granted() { return error IS ERR::Okay; }
+      inline bool granted() const { return error IS ERR::Okay; }
       inline void release();
 };
 
 //********************************************************************************************************************
-// For testing if type T can be matched to an FD flag.
+// For testing if type T can be matched to an FD flag.  All integral types are mapped by size so that types without
+// an explicit branch (e.g. uint32_t, int16_t) cannot fall through to the pointer/struct default.
 
-template <class T> inline int FIELD_TYPECHECK()     { return FD_PTR|FD_STRUCT|FD_STRING; }
-template <> inline int FIELD_TYPECHECK<double>()    { return FD_DOUBLE; }
-template <> inline int FIELD_TYPECHECK<bool>()      { return FD_INT; }
-template <> inline int FIELD_TYPECHECK<int>()       { return FD_INT; }
-template <> inline int FIELD_TYPECHECK<int64_t>()   { return FD_INT64; }
-template <> inline int FIELD_TYPECHECK<uint64_t>()  { return FD_INT64; }
-template <> inline int FIELD_TYPECHECK<float>()     { return FD_FLOAT; }
-template <> inline int FIELD_TYPECHECK<OBJECTPTR>() { return FD_PTR; }
-template <> inline int FIELD_TYPECHECK<APTR>()      { return FD_PTR; }
-template <> inline int FIELD_TYPECHECK<CSTRING>()   { return FD_STRING; }
-template <> inline int FIELD_TYPECHECK<STRING>()    { return FD_STRING; }
-template <> inline int FIELD_TYPECHECK<std::string>() { return FD_STRING|FD_CPP; }
+template <class T> [[nodiscard]] constexpr int FIELD_TYPECHECK() {
+   if constexpr (std::is_same_v<T, double>) return FD_DOUBLE;
+   else if constexpr (std::is_same_v<T, float>) return FD_FLOAT;
+   else if constexpr (std::is_integral_v<T>) return (sizeof(T) > 4) ? FD_INT64 : FD_INT;
+   else if constexpr (std::is_same_v<T, std::string>) return FD_STRING|FD_CPP;
+   else if constexpr (std::is_same_v<T, CSTRING> or std::is_same_v<T, STRING>) return FD_STRING;
+   else if constexpr (std::is_same_v<T, OBJECTPTR> or std::is_same_v<T, APTR>) return FD_PTR;
+   else return FD_PTR|FD_STRUCT|FD_STRING;
+}
 
 //********************************************************************************************************************
 
@@ -217,10 +215,10 @@ struct Object { // Must be 64-bit aligned
    Object() : Class(nullptr), DerivedPtr(nullptr), CreatorMeta(nullptr), Owner(nullptr), NotifyFlags(0),
       ActionDepth(0), Queue(0), SleepQueue(0), RefCount(0), UID(0), Flags(0), ThreadID(0), Name("") { }
 
-   [[nodiscard]] inline bool initialised() { return Flags.load(std::memory_order_relaxed) & uint32_t(NF::INITIALISED); }
-   [[nodiscard]] inline bool defined(NF pFlags) { return Flags.load(std::memory_order_relaxed) & uint32_t(pFlags); }
+   [[nodiscard]] inline bool initialised() const { return Flags.load(std::memory_order_relaxed) & uint32_t(NF::INITIALISED); }
+   [[nodiscard]] inline bool defined(NF pFlags) const { return Flags.load(std::memory_order_relaxed) & uint32_t(pFlags); }
    [[nodiscard]] inline bool isDerived();
-   [[nodiscard]] inline OBJECTID ownerID() { return Owner ? Owner->UID : 0; }
+   [[nodiscard]] inline OBJECTID ownerID() const { return Owner ? Owner->UID : 0; }
    [[nodiscard]] inline CLASSID classID();
    [[nodiscard]] inline CLASSID baseClassID();
    [[nodiscard]] inline NF flags() { return NF(Flags.load(std::memory_order_relaxed)); }
@@ -250,21 +248,26 @@ struct Object { // Must be 64-bit aligned
    }
 
    inline void unpin(bool FreeIfReady = false) {
+      // CAS loop saturates at zero; a plain load-check-decrement would allow two racing threads to underflow the
+      // counter.  The release on a successful decrement pairs with acquire zero checks before destruction.
       auto ref_count = RefCount.load(std::memory_order_relaxed);
+      while (ref_count > 0) {
+         if (RefCount.compare_exchange_weak(ref_count, uint8_t(ref_count - 1), std::memory_order_release,
+               std::memory_order_relaxed)) break;
+      }
       #ifndef NDEBUG
       if (ref_count IS 0) {
          kt::Log("unpin").warning("Unbalanced unpin() on object #%d (%s) - RefCount is already 0.", UID, className());
          DEBUG_BREAK
       }
       #endif
-      if (ref_count > 0) RefCount.fetch_sub(1, std::memory_order_relaxed);
       if (FreeIfReady) freeIfReady();
    }
 
-   [[nodiscard]] inline bool isPinned() { return RefCount.load(std::memory_order_relaxed) > 0; }
+   [[nodiscard]] inline bool isPinned() const { return RefCount.load(std::memory_order_acquire) > 0; }
 
    inline bool freeIfReady() {
-      auto ref_count = RefCount.load(std::memory_order_relaxed);
+      auto ref_count = RefCount.load(std::memory_order_acquire);
       auto queue = Queue.load(std::memory_order_relaxed);
       if ((ref_count IS 0) and (queue IS 0) and defined(NF::FREE_ON_UNLOCK)) {
          FreeResource(this->UID);
@@ -275,11 +278,11 @@ struct Object { // Must be 64-bit aligned
 
    [[nodiscard]] CSTRING className();
 
-   [[nodiscard]] inline bool collecting() { // Is object being freed or marked for collection?
+   [[nodiscard]] inline bool collecting() const { // Is object being freed or marked for collection?
       return defined(NF::FREE|NF::FREE_ON_UNLOCK);
    }
 
-   [[nodiscard]] inline bool terminating() { // Is object currently being freed?
+   [[nodiscard]] inline bool terminating() const { // Is object currently being freed?
       return defined(NF::FREE);
    }
 
@@ -327,7 +330,7 @@ struct Object { // Must be 64-bit aligned
       return Queue > 0;
    }
 
-   [[nodiscard]] inline bool hasOwner(OBJECTID ID) { // Return true if ID has ownership.
+   [[nodiscard]] inline bool hasOwner(OBJECTID ID) const { // Return true if ID has ownership.
       auto obj = this->Owner;
       while ((obj) and (obj->UID != ID)) obj = obj->Owner;
       return obj ? true : false;
@@ -397,7 +400,12 @@ struct Object { // Must be 64-bit aligned
       Object *target;
       struct Field *field;
       if (auto error = resolve_write_field(FieldID, target, field, false); error != ERR::Okay) return error;
-      return field->WriteValue(target, field, FIELD_TYPECHECK<T>(), &Value, 1);
+      if constexpr (std::is_integral_v<T> and (sizeof(T) < sizeof(int))) {
+         // Promote small integrals to int so that WriteValue does not read 4 bytes from a 1 or 2 byte value.
+         const int promoted = int(Value);
+         return field->WriteValue(target, field, FD_INT, &promoted, 1);
+      }
+      else return field->WriteValue(target, field, FIELD_TYPECHECK<T>(), &Value, 1);
    }
 
    inline ERR set(FIELD FieldID, const FUNCTION *Value) {
@@ -469,7 +477,7 @@ struct Object { // Must be 64-bit aligned
       return error;
    }
 
-   inline std::pair<ERR, APTR> get_field_value(Object *Object, struct Field &Field, int8_t Buffer[8], int &ArraySize) {
+   inline std::pair<ERR, APTR> get_field_value(Object *Object, struct Field &Field, int8_t (&Buffer)[sizeof(std::string_view)], int &ArraySize) {
       if (Field.GetValue) {
          SetObjectContext(Object, &Field, AC::NIL);
          auto get_field = (ERR (*)(APTR, APTR, int &))Field.GetValue;
@@ -487,8 +495,6 @@ struct Object { // Must be 64-bit aligned
       Object *target;
       if (auto field = FindField(this, FieldID, &target)) {
          if (not field->readable()) return ERR::NoFieldAccess;
-
-         ScopedObjectAccess objlock(target);
 
          auto flags = field->Flags;
 
@@ -512,6 +518,7 @@ struct Object { // Must be 64-bit aligned
 
    inline ERR get(FIELD FieldID, std::string &Value) { // Retrieve field as a string, supports type conversion.
       Object *target;
+      Value.clear(); // Guarantees that no path can return a stale result in Value
       if (auto field = FindField(this, FieldID, &target)) {
          if (not field->readable()) return ERR::NoFieldAccess;
 
@@ -705,9 +712,11 @@ struct Object { // Must be 64-bit aligned
    };
 
    template <class T> T get(FIELD FieldID) requires std::is_same_v<T, std::string> {
-      std::string_view result;
+      // Delegates to the std::string getter so that numeric, flag and unit conversions behave identically to
+      // get(FIELD, std::string &).  The string_view getter is unsuitable here as it only supports string fields.
+      std::string result;
       get(FieldID, result);
-      return std::string(result);
+      return result;
    };
 
    template <class T> T get(FIELD FieldID) requires std::is_enum_v<T> {
@@ -795,7 +804,7 @@ struct Object { // Must be 64-bit aligned
       return ERR::Okay;
    }
 
-} __attribute__ ((aligned (8)));
+} alignas(8);
 
 namespace kt {
 
@@ -954,7 +963,8 @@ class Create {
 
       T * operator->() { return obj; }; // Promotes underlying methods and fields
       const T * operator->() const { return obj; };
-      T * & operator*() { return obj; }; // To allow object pointer referencing when calling functions
+      T * operator*() { return obj; };
+      const T * operator*() const { return obj; };
 
       [[nodiscard]] inline T * get() { return obj; }
       [[nodiscard]] inline const T * get() const { return obj; }


### PR DESCRIPTION
## Summary

This PR tightens core object helper behaviour in `objects.h` and splits field helper declarations out of `main.h` into `field_values.hpp`.

The object lifetime fix changes pin release ordering so a thread that observes the final reference before destruction performs an acquire read paired with the releasing unpin. The same change keeps the saturating CAS loop for unpin underflow protection.

The field helper changes improve type matching for integral fields, promote small integral writes before passing them to `WriteValue()`, clear string outputs before conversion, and move the field helper overload list into a separate header included by `main.h`.

## Validation

- `cmake --build build/wsl-agents --parallel` from WSL Kotuku distro

The build passed. GCC still reports the existing `objects.h` `alignas(8)` placement warning, which is outside this PR's validation result but visible in the build output.