### PR TITLE
[Vector] Cached image filter LUTs and accelerated RGBA sampling

### DIFF
--- a/docs/xml/modules/classes/colourfx.xml
+++ b/docs/xml/modules/classes/colourfx.xml
@@ -14,7 +14,8 @@
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
 <p>Use ColourFX to perform colour transformations on an input source.  A <fl>Mode</fl> must be selected and any required <fl>Values</fl> defined prior to rendering.</p>
-<p>SVG requires that the calculations are performed on non-premultiplied colour values.  If the input graphics consists of premultiplied colour values, those values are automatically converted into non-premultiplied colour values for this operation.</p></description>
+<p>SVG requires that the calculations are performed on non-premultiplied colour values.  If the input graphics consists of premultiplied colour values, those values are automatically converted into non-premultiplied colour values for this operation.</p>
+<p>The matrix is applied in the colour space defined by the parent <class name="VectorFilter">VectorFilter</class>'s ColourSpace field.  If set to <code>LINEAR_RGB</code> (the SVG default) then pixel values are converted to linear RGB prior to transformation and back to sRGB on output, otherwise the transformation is performed directly on the sRGB values.</p></description>
     <source>
       <file path="filters/">filter_colourmatrix.cpp</file>
     </source>

--- a/docs/xml/modules/classes/imagefx.xml
+++ b/docs/xml/modules/classes/imagefx.xml
@@ -112,7 +112,7 @@
       <const name="NEIGHBOUR">Nearest neighbour is the fastest sampler at the cost of poor quality.</const>
       <const name="QUADRIC">Uses a quadratic filter with a modest kernel, giving smoother results than <code>BILINEAR</code> with limited extra cost.</const>
       <const name="SINC">Five times slower than <code>BILINEAR</code>, the final result is of very good quality.</const>
-      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
+      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method samples a 4x4 area and produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
     </constants>
 
   </types>

--- a/docs/xml/modules/classes/vector.xml
+++ b/docs/xml/modules/classes/vector.xml
@@ -602,7 +602,7 @@
       <access read="R">Read</access>
       <type>INT</type>
       <description>
-<p>The PathTimestamp can be used as a basic means of recording the state of the vector's path, and checking that state for changes at a later time.  For more active monitoring and response, clients should subscribe to the <code>PATH_CHANGED</code> event.</p>
+<p>The PathTimestamp is a counter that can be used as a basic means of recording the state of the vector's path, and checking that state for changes at a later time.  For more active monitoring and response, clients should subscribe to the <code>PATH_CHANGED</code> event.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/vectorscene.xml
+++ b/docs/xml/modules/classes/vectorscene.xml
@@ -287,7 +287,7 @@
       <const name="NEIGHBOUR">Nearest neighbour is the fastest sampler at the cost of poor quality.</const>
       <const name="QUADRIC">Uses a quadratic filter with a modest kernel, giving smoother results than <code>BILINEAR</code> with limited extra cost.</const>
       <const name="SINC">Five times slower than <code>BILINEAR</code>, the final result is of very good quality.</const>
-      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
+      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method samples a 4x4 area and produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
     </constants>
 
   </types>

--- a/docs/xml/modules/vector.xml
+++ b/docs/xml/modules/vector.xml
@@ -1033,7 +1033,7 @@ Hue (<code>H</code>) is in degrees.  Alpha (<code>A</code>) is optional, precede
       <const name="NEIGHBOUR">Nearest neighbour is the fastest sampler at the cost of poor quality.</const>
       <const name="QUADRIC">Uses a quadratic filter with a modest kernel, giving smoother results than <code>BILINEAR</code> with limited extra cost.</const>
       <const name="SINC">Five times slower than <code>BILINEAR</code>, the final result is of very good quality.</const>
-      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
+      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method samples a 4x4 area and produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
     </constants>
 
     <constants lookup="VSPREAD" comment="Spread method options define the method to use for tiling filled graphics.">

--- a/src/vector/agg/include/agg_image_filters.h
+++ b/src/vector/agg/include/agg_image_filters.h
@@ -66,10 +66,11 @@ class image_filter_lut {
     const int16* weight_array() const { return &m_weight_array[0]; }
     void         normalize();
 
+    image_filter_lut(const image_filter_lut&) = delete;
+    image_filter_lut& operator=(const image_filter_lut&) = delete;
+
 private:
     void realloc_lut(double radius);
-    image_filter_lut(const image_filter_lut&);
-    const image_filter_lut& operator = (const image_filter_lut&);
 
     double           m_radius;
     unsigned         m_diameter;
@@ -89,8 +90,8 @@ private:
 
 //-----------------------------------------------image_filter_bilinear
 struct image_filter_bilinear {
-    static double radius() { return 1.0; }
-    static double calc_weight(double x) {
+    static constexpr double radius() { return 1.0; }
+    static constexpr double calc_weight(double x) {
         return 1.0 - x;
     }
 };
@@ -99,7 +100,7 @@ struct image_filter_bilinear {
 //-----------------------------------------------image_filter_hanning
 struct image_filter_hanning
 {
-    static double radius() { return 1.0; }
+    static constexpr double radius() { return 1.0; }
     static double calc_weight(double x)
     {
         return 0.5 + 0.5 * cos(pi * x);
@@ -110,7 +111,7 @@ struct image_filter_hanning
 //-----------------------------------------------image_filter_hamming
 struct image_filter_hamming
 {
-    static double radius() { return 1.0; }
+    static constexpr double radius() { return 1.0; }
     static double calc_weight(double x)
     {
         return 0.54 + 0.46 * cos(pi * x);
@@ -120,8 +121,8 @@ struct image_filter_hamming
 //-----------------------------------------------image_filter_hermite
 struct image_filter_hermite
 {
-    static double radius() { return 1.0; }
-    static double calc_weight(double x)
+    static constexpr double radius() { return 1.0; }
+    static constexpr double calc_weight(double x)
     {
         return (2.0 * x - 3.0) * x * x + 1.0;
     }
@@ -130,8 +131,8 @@ struct image_filter_hermite
 //------------------------------------------------image_filter_quadric
 struct image_filter_quadric
 {
-    static double radius() { return 1.5; }
-    static double calc_weight(double x)
+    static constexpr double radius() { return 1.5; }
+    static constexpr double calc_weight(double x)
     {
         double t;
         if(x <  0.5) return 0.75 - x * x;
@@ -141,26 +142,27 @@ struct image_filter_quadric
 };
 
 class image_filter_bicubic {
-    static double pow3(double x) {
+    static constexpr double pow3(double x) {
         return (x <= 0.0) ? 0.0 : x * x * x;
     }
 
 public:
-    static double radius() { return 2.0; }
-    static double calc_weight(double x) {
+    static constexpr double radius() { return 2.0; }
+    static constexpr double calc_weight(double x) {
         return (1.0/6.0) * (pow3(x + 2) - 4 * pow3(x + 1) + 6 * pow3(x) - 4 * pow3(x - 1));
     }
 };
 
 class image_filter_kaiser {
-    double a, i0a, epsilon;
+    static constexpr double epsilon = 1e-12;
+    double a, i0a;
 
 public:
-    image_filter_kaiser(double b = 6.33) : a(b), epsilon(1e-12) {
+    image_filter_kaiser(double b = 6.33) : a(b) {
         i0a = 1.0 / bessel_i0(b);
     }
 
-    static double radius() { return 1.0; }
+    static constexpr double radius() { return 1.0; }
     double calc_weight(double x) const {
         return bessel_i0(a * sqrt(1. - x * x)) * i0a;
     }
@@ -184,8 +186,8 @@ private:
 
 struct image_filter_catrom
 {
-    static double radius() { return 2.0; }
-    static double calc_weight(double x)
+    static constexpr double radius() { return 2.0; }
+    static constexpr double calc_weight(double x)
     {
         if(x <  1.0) return 0.5 * (2.0 + x * x * (-5.0 + x * 3.0));
         if(x <  2.0) return 0.5 * (4.0 + x * (-8.0 + x * (5.0 - x)));
@@ -209,8 +211,8 @@ public:
         q3((-b - 6.0 * c) / 6.0)
     {}
 
-    static double radius() { return 2.0; }
-    double calc_weight(double x) const
+    static constexpr double radius() { return 2.0; }
+    constexpr double calc_weight(double x) const
     {
         if(x < 1.0) return p0 + x * x * (p2 + x * p3);
         if(x < 2.0) return q0 + x * (q1 + x * (q2 + x * q3));
@@ -220,16 +222,16 @@ public:
 
 struct image_filter_spline16
 {
-    static double radius() { return 2.0; }
-    static double calc_weight(double x) {
+    static constexpr double radius() { return 2.0; }
+    static constexpr double calc_weight(double x) {
         if(x < 1.0) return ((x - 9.0/5.0 ) * x - 1.0/5.0 ) * x + 1.0;
         return ((-1.0/3.0 * (x-1) + 4.0/5.0) * (x-1) - 7.0/15.0 ) * (x-1);
     }
 };
 
 struct image_filter_spline36 {
-    static double radius() { return 3.0; }
-    static double calc_weight(double x) {
+    static constexpr double radius() { return 3.0; }
+    static constexpr double calc_weight(double x) {
         if(x < 1.0) return ((13.0/11.0 * x - 453.0/209.0) * x - 3.0/209.0) * x + 1.0;
         if(x < 2.0) return ((-6.0/11.0 * (x-1) + 270.0/209.0) * (x-1) - 156.0/ 209.0) * (x-1);
         return ((1.0/11.0 * (x-2) - 45.0/209.0) * (x-2) +  26.0/209.0) * (x-2);
@@ -238,7 +240,7 @@ struct image_filter_spline36 {
 
 struct image_filter_gaussian
 {
-    static double radius() { return 2.0; }
+    static constexpr double radius() { return 2.0; }
     static double calc_weight(double x)
     {
         return exp(-2.0 * x * x) * sqrt(2.0 / pi);
@@ -247,7 +249,7 @@ struct image_filter_gaussian
 
 
 struct image_filter_bessel {
-    static double radius() { return 3.2383; }
+    static constexpr double radius() { return 3.2383; }
     static double calc_weight(double x) {
         return (x == 0.0) ? pi / 4.0 : besj(pi * x, 1) / (2.0 * x);
     }
@@ -255,7 +257,7 @@ struct image_filter_bessel {
 
 class image_filter_sinc {
 public:
-    image_filter_sinc(double r) : m_radius(r < 2.0 ? 2.0 : r) {}
+    image_filter_sinc(double r) : m_radius(r) {}
     double radius() const { return m_radius; }
     double calc_weight(double x) const
     {
@@ -272,7 +274,7 @@ private:
 class image_filter_lanczos
 {
 public:
-    image_filter_lanczos(double r) : m_radius(r < 2.0 ? 2.0 : r) {}
+    image_filter_lanczos(double r) : m_radius(r) {}
     double radius() const { return m_radius; }
     double calc_weight(double x) const
     {
@@ -291,7 +293,7 @@ private:
 class image_filter_blackman
 {
 public:
-    image_filter_blackman(double r) : m_radius(r < 2.0 ? 2.0 : r) {}
+    image_filter_blackman(double r) : m_radius(r) {}
     double radius() const { return m_radius; }
     double calc_weight(double x) const
     {

--- a/src/vector/agg/include/agg_span_image_filter_rgba.h
+++ b/src/vector/agg/include/agg_span_image_filter_rgba.h
@@ -19,9 +19,12 @@
 #ifndef AGG_SPAN_IMAGE_FILTER_RGBA_INCLUDED
 #define AGG_SPAN_IMAGE_FILTER_RGBA_INCLUDED
 
+#include <cstring>
+
 #include "agg_basics.h"
 #include "agg_color_rgba.h"
 #include "agg_span_image_filter.h"
+#include "../../../link/simd.h"
 
 namespace agg
 {
@@ -31,29 +34,32 @@ namespace agg
    public:
       typedef Source source_type;
       typedef typename source_type::color_type color_type;
-      typedef typename source_type::order_type order_type;
       typedef Interpolator in_type;
       typedef span_image_filter<source_type, in_type> base_type;
       typedef typename color_type::value_type value_type;
+      unsigned char oR, oG, oB, oA;
 
       enum base_scale_e {
           base_shift = color_type::base_shift,
           base_mask  = color_type::base_mask
       };
 
-      span_image_filter_rgba_nn() {}
-      span_image_filter_rgba_nn(source_type &src, in_type &inter) : base_type(src, inter, 0)
-      {}
+      span_image_filter_rgba_nn(source_type &src, in_type &inter) : base_type(src, inter, 0) {
+         oR = src.m_src->mPixelOrder.Red;
+         oG = src.m_src->mPixelOrder.Green;
+         oB = src.m_src->mPixelOrder.Blue;
+         oA = src.m_src->mPixelOrder.Alpha;
+      }
 
       void generate(color_type *span, int x, int y, unsigned len) {
          base_type::interpolator().begin(x + base_type::filter_dx_dbl(), y + base_type::filter_dy_dbl(), len);
          do {
             base_type::interpolator().coordinates(&x, &y);
             auto fg_ptr = (const value_type *)base_type::source().span(x >> image_subpixel_shift, y >> image_subpixel_shift, 1);
-            span->r = fg_ptr[order_type::R];
-            span->g = fg_ptr[order_type::G];
-            span->b = fg_ptr[order_type::B];
-            span->a = fg_ptr[order_type::A];
+            span->r = fg_ptr[oR];
+            span->g = fg_ptr[oG];
+            span->b = fg_ptr[oB];
+            span->a = fg_ptr[oA];
             ++span;
             ++base_type::interpolator();
 
@@ -491,6 +497,17 @@ namespace agg
          int          start        = base_type::filter().start();
          const int16* weight_array = base_type::filter().weight_array();
 
+#ifdef KOTUKU_SSE2
+         if (diameter IS 2) { // Bilinear: the 2x2 kernel maps onto two _mm_madd_epi16 ops per pixel.
+            generate_2x2(span, len, start, weight_array);
+            return;
+         }
+         else if (diameter IS 4) { // Spline16/bicubic/mitchell etc: 4x4 kernel, two madds per row.
+            generate_4x4(span, len, start, weight_array);
+            return;
+         }
+#endif
+
          int x_count, weight_y;
 
          do {
@@ -540,32 +557,177 @@ namespace agg
             fg[2] >>= image_filter_shift;
             fg[3] >>= image_filter_shift;
 
-            if (fg[0] < 0) fg[0] = 0;
-            if (fg[1] < 0) fg[1] = 0;
-            if (fg[2] < 0) fg[2] = 0;
-            if (fg[3] < 0) fg[3] = 0;
-
-            if (fg[oA] > base_mask) fg[oA] = base_mask;
-
-            if (alpha_limit) { // Enable only if pipeline is blending with background color
-               if (fg[oR] > fg[oA]) fg[oR] = fg[oA];
-               if (fg[oG] > fg[oA]) fg[oG] = fg[oA];
-               if (fg[oB] > fg[oA]) fg[oB] = fg[oA];
-            }
-            else { // For copy-only, non-blending pipelines
-               if (fg[oR] > base_mask) fg[oR] = base_mask;
-               if (fg[oG] > base_mask) fg[oG] = base_mask;
-               if (fg[oB] > base_mask) fg[oB] = base_mask;
-            }
-
-            span->r = (value_type)fg[oR];
-            span->g = (value_type)fg[oG];
-            span->b = (value_type)fg[oB];
-            span->a = (value_type)fg[oA];
+            store_clamped(span, fg);
             ++span;
             ++base_type::interpolator();
          } while(--len);
       }
+
+   private:
+      // Clamp the accumulated channel values (already shifted down to pixel range) and write them to the span
+      // in destination colour order.
+
+      inline void store_clamped(color_type *span, int (&fg)[4]) const {
+         if (fg[0] < 0) fg[0] = 0;
+         if (fg[1] < 0) fg[1] = 0;
+         if (fg[2] < 0) fg[2] = 0;
+         if (fg[3] < 0) fg[3] = 0;
+
+         if (fg[oA] > base_mask) fg[oA] = base_mask;
+
+         if (alpha_limit) { // Enable only if pipeline is blending with background color
+            if (fg[oR] > fg[oA]) fg[oR] = fg[oA];
+            if (fg[oG] > fg[oA]) fg[oG] = fg[oA];
+            if (fg[oB] > fg[oA]) fg[oB] = fg[oA];
+         }
+         else { // For copy-only, non-blending pipelines
+            if (fg[oR] > base_mask) fg[oR] = base_mask;
+            if (fg[oG] > base_mask) fg[oG] = base_mask;
+            if (fg[oB] > base_mask) fg[oB] = base_mask;
+         }
+
+         span->r = (value_type)fg[oR];
+         span->g = (value_type)fg[oG];
+         span->b = (value_type)fg[oB];
+         span->a = (value_type)fg[oA];
+      }
+
+#ifdef KOTUKU_SSE2
+      // SSE2 specialisation of the 2x2 (bilinear) kernel for 4-byte pixels.  Bit-exact with the generic loop:
+      // the four combined weights are computed with the same fixed-point arithmetic, and bilinear LUT weights
+      // are non-negative and bounded by image_filter_scale (16384) after normalisation, so each fits a signed
+      // 16-bit lane for _mm_madd_epi16.  Texel fetches stay on the source accessor so edge wrapping semantics
+      // are unchanged.
+
+      void generate_2x2(color_type *span, unsigned len, int start, const int16 *weight_array) {
+         const __m128i zero     = _mm_setzero_si128();
+         const __m128i rounding = _mm_set1_epi32(image_filter_scale / 2);
+
+         do {
+            int x, y;
+            base_type::interpolator().coordinates(&x, &y);
+
+            x -= base_type::filter_dx_int();
+            y -= base_type::filter_dy_int();
+
+            const int x_lr = x >> image_subpixel_shift;
+            const int y_lr = y >> image_subpixel_shift;
+
+            const int x_hr = image_subpixel_mask - (x & image_subpixel_mask);
+            const int y_hr = image_subpixel_mask - (y & image_subpixel_mask);
+
+            const int wx0 = weight_array[x_hr];
+            const int wx1 = weight_array[x_hr + image_subpixel_scale];
+            const int wy0 = weight_array[y_hr];
+            const int wy1 = weight_array[y_hr + image_subpixel_scale];
+
+            const int w00 = (wy0 * wx0 + image_filter_scale / 2) >> image_filter_shift;
+            const int w01 = (wy0 * wx1 + image_filter_scale / 2) >> image_filter_shift;
+            const int w10 = (wy1 * wx0 + image_filter_scale / 2) >> image_filter_shift;
+            const int w11 = (wy1 * wx1 + image_filter_scale / 2) >> image_filter_shift;
+
+            // Texel fetch order matches the generic loop: (0,0), (1,0), then next_y resets x for (0,1), (1,1).
+
+            int32_t t00, t01, t10, t11;
+            std::memcpy(&t00, base_type::source().span(x_lr + start, y_lr + start, 2), 4);
+            std::memcpy(&t01, base_type::source().next_x(), 4);
+            std::memcpy(&t10, base_type::source().next_y(), 4);
+            std::memcpy(&t11, base_type::source().next_x(), 4);
+
+            // Interleave row pairs per channel so madd produces w_left*left + w_right*right per 32-bit lane.
+
+            const __m128i top = _mm_unpacklo_epi16(
+               _mm_unpacklo_epi8(_mm_cvtsi32_si128(t00), zero),
+               _mm_unpacklo_epi8(_mm_cvtsi32_si128(t01), zero));
+            const __m128i bottom = _mm_unpacklo_epi16(
+               _mm_unpacklo_epi8(_mm_cvtsi32_si128(t10), zero),
+               _mm_unpacklo_epi8(_mm_cvtsi32_si128(t11), zero));
+
+            __m128i acc = _mm_add_epi32(
+               _mm_madd_epi16(top, _mm_set1_epi32((w01 << 16) | (w00 & 0xffff))),
+               _mm_madd_epi16(bottom, _mm_set1_epi32((w11 << 16) | (w10 & 0xffff))));
+            acc = _mm_srai_epi32(_mm_add_epi32(acc, rounding), image_filter_shift);
+
+            alignas(16) int fg[4];
+            _mm_store_si128((__m128i *)fg, acc);
+
+            store_clamped(span, fg);
+            ++span;
+            ++base_type::interpolator();
+         } while (--len);
+      }
+
+      // SSE2 specialisation of the 4x4 kernel (spline16, bicubic, mitchell, quadric, gaussian) for 4-byte
+      // pixels.  Bit-exact with the generic loop: each row's four combined weights use the same fixed-point
+      // arithmetic and the row is accumulated with two _mm_madd_epi16 ops, replacing 64 scalar multiply-adds
+      // per pixel with 8 madds.  Diameter-4 kernels peak at ~1.0 so combined weights are bounded by
+      // ~image_filter_scale (16384) and fit a signed 16-bit lane.  Negative lobes are handled by the signed
+      // madd and the negative clamp in store_clamped().  Texel fetches stay on the source accessor so edge
+      // wrapping semantics are unchanged.
+
+      void generate_4x4(color_type *span, unsigned len, int start, const int16 *weight_array) {
+         const __m128i zero     = _mm_setzero_si128();
+         const __m128i rounding = _mm_set1_epi32(image_filter_scale / 2);
+
+         do {
+            int x, y;
+            base_type::interpolator().coordinates(&x, &y);
+
+            x -= base_type::filter_dx_int();
+            y -= base_type::filter_dy_int();
+
+            const int x_lr = x >> image_subpixel_shift;
+            const int y_lr = y >> image_subpixel_shift;
+
+            const int x_hr = image_subpixel_mask - (x & image_subpixel_mask);
+            const int y_hr = image_subpixel_mask - (y & image_subpixel_mask);
+
+            const int wx0 = weight_array[x_hr];
+            const int wx1 = weight_array[x_hr + image_subpixel_scale];
+            const int wx2 = weight_array[x_hr + image_subpixel_scale * 2];
+            const int wx3 = weight_array[x_hr + image_subpixel_scale * 3];
+
+            __m128i acc = rounding;
+
+            for (int row = 0; row < 4; row++) {
+               const int wy = weight_array[y_hr + (row << image_subpixel_shift)];
+
+               const int w0 = (wy * wx0 + image_filter_scale / 2) >> image_filter_shift;
+               const int w1 = (wy * wx1 + image_filter_scale / 2) >> image_filter_shift;
+               const int w2 = (wy * wx2 + image_filter_scale / 2) >> image_filter_shift;
+               const int w3 = (wy * wx3 + image_filter_scale / 2) >> image_filter_shift;
+
+               // Texel fetch order matches the generic loop: row start (span or next_y), then next_x x3.
+
+               int32_t t0, t1, t2, t3;
+               if (row IS 0) std::memcpy(&t0, base_type::source().span(x_lr + start, y_lr + start, 4), 4);
+               else std::memcpy(&t0, base_type::source().next_y(), 4);
+               std::memcpy(&t1, base_type::source().next_x(), 4);
+               std::memcpy(&t2, base_type::source().next_x(), 4);
+               std::memcpy(&t3, base_type::source().next_x(), 4);
+
+               const __m128i pair01 = _mm_unpacklo_epi16(
+                  _mm_unpacklo_epi8(_mm_cvtsi32_si128(t0), zero),
+                  _mm_unpacklo_epi8(_mm_cvtsi32_si128(t1), zero));
+               const __m128i pair23 = _mm_unpacklo_epi16(
+                  _mm_unpacklo_epi8(_mm_cvtsi32_si128(t2), zero),
+                  _mm_unpacklo_epi8(_mm_cvtsi32_si128(t3), zero));
+
+               acc = _mm_add_epi32(acc, _mm_madd_epi16(pair01, _mm_set1_epi32((w1 << 16) | (w0 & 0xffff))));
+               acc = _mm_add_epi32(acc, _mm_madd_epi16(pair23, _mm_set1_epi32((w3 << 16) | (w2 & 0xffff))));
+            }
+
+            acc = _mm_srai_epi32(acc, image_filter_shift);
+
+            alignas(16) int fg[4];
+            _mm_store_si128((__m128i *)fg, acc);
+
+            store_clamped(span, fg);
+            ++span;
+            ++base_type::interpolator();
+         } while (--len);
+      }
+#endif
    };
 
    // span_image_resample_rgba_affine

--- a/src/vector/agg/src/agg_image_filters.cpp
+++ b/src/vector/agg/src/agg_image_filters.cpp
@@ -7,87 +7,72 @@
 // This software is provided "as is" without express or implied
 // warranty, and with no claim as to its suitability for any purpose.
 
-//
-// Filtering class image_filter_lut implementation
-//
-//----------------------------------------------------------------------------
-
 #include "agg_image_filters.h"
 
-namespace agg
+namespace agg {
+
+void image_filter_lut::realloc_lut(double radius)
 {
-    void image_filter_lut::realloc_lut(double radius)
-    {
-        m_radius = radius;
-        m_diameter = uceil(radius) * 2;
-        m_start = -int(m_diameter / 2 - 1);
-        unsigned size = m_diameter << image_subpixel_shift;
-        if(size > m_weight_array.size())
-        {
-            m_weight_array.resize(size);
-        }
-    }
-
-    //--------------------------------------------------------------------
-    // This function normalizes integer values and corrects the rounding
-    // errors. It doesn't do anything with the source floating point values
-    // (m_weight_array_dbl), it corrects only integers according to the rule
-    // of 1.0 which means that any sum of pixel weights must be equal to 1.0.
-    // So, the filter function must produce a graph of the proper shape.
-    //--------------------------------------------------------------------
-    void image_filter_lut::normalize()
-    {
-        unsigned i;
-        int flip = 1;
-
-        for(i = 0; i < image_subpixel_scale; i++)
-        {
-            for(;;)
-            {
-                int sum = 0;
-                unsigned j;
-                for(j = 0; j < m_diameter; j++)
-                {
-                    sum += m_weight_array[j * image_subpixel_scale + i];
-                }
-
-                if(sum == image_filter_scale) break;
-
-                double k = double(image_filter_scale) / double(sum);
-                sum = 0;
-                for(j = 0; j < m_diameter; j++)
-                {
-                    sum +=     m_weight_array[j * image_subpixel_scale + i] =
-                        iround(m_weight_array[j * image_subpixel_scale + i] * k);
-                }
-
-                sum -= image_filter_scale;
-                int inc = (sum > 0) ? -1 : 1;
-
-                for(j = 0; j < m_diameter && sum; j++)
-                {
-                    flip ^= 1;
-                    unsigned idx = flip ? m_diameter/2 + j/2 : m_diameter/2 - j/2;
-                    int v = m_weight_array[idx * image_subpixel_scale + i];
-                    if(v < image_filter_scale)
-                    {
-                        m_weight_array[idx * image_subpixel_scale + i] += inc;
-                        sum += inc;
-                    }
-                }
-            }
-        }
-
-        unsigned pivot = m_diameter << (image_subpixel_shift - 1);
-
-        for(i = 0; i < pivot; i++)
-        {
-            m_weight_array[pivot + i] = m_weight_array[pivot - i];
-        }
-        unsigned end = (diameter() << image_subpixel_shift) - 1;
-        m_weight_array[0] = m_weight_array[end];
-    }
-
-
+   m_radius = radius;
+   m_diameter = uceil(radius) * 2;
+   m_start = -int(m_diameter / 2 - 1);
+   unsigned size = m_diameter << image_subpixel_shift;
+   if (size > m_weight_array.size()) m_weight_array.resize(size);
 }
 
+// This function normalizes integer values and corrects the rounding
+// errors. It doesn't do anything with the source floating point values
+// (m_weight_array_dbl), it corrects only integers according to the rule
+// of 1.0 which means that any sum of pixel weights must be equal to 1.0.
+// So, the filter function must produce a graph of the proper shape.
+
+void image_filter_lut::normalize()
+{
+   unsigned i;
+   int flip = 1;
+
+   for (i = 0; i < image_subpixel_scale; i++) {
+      // Bounded iteration: convergence normally takes one or two passes, but a degenerate
+      // filter (weights summing to zero or saturated at the scale limit) must not hang.
+      for (int pass = 0; pass < 16; pass++) {
+         int sum = 0;
+         unsigned j;
+         for(j = 0; j < m_diameter; j++) {
+            sum += m_weight_array[j * image_subpixel_scale + i];
+         }
+
+         if (sum == image_filter_scale) break;
+         if (sum <= 0) break; // Degenerate phase; cannot be normalised.
+
+         double k = double(image_filter_scale) / double(sum);
+         sum = 0;
+         for(j = 0; j < m_diameter; j++) {
+            sum += m_weight_array[j * image_subpixel_scale + i] =
+               iround(m_weight_array[j * image_subpixel_scale + i] * k);
+         }
+
+         sum -= image_filter_scale;
+         int inc = (sum > 0) ? -1 : 1;
+
+         for (j = 0; j < m_diameter && sum; j++) {
+            flip ^= 1;
+            unsigned idx = flip ? m_diameter/2 + j/2 : m_diameter/2 - j/2;
+            int v = m_weight_array[idx * image_subpixel_scale + i];
+            if (v < image_filter_scale) {
+               m_weight_array[idx * image_subpixel_scale + i] += inc;
+               sum += inc;
+            }
+         }
+      }
+   }
+
+   unsigned pivot = m_diameter << (image_subpixel_shift - 1);
+
+   for(i = 0; i < pivot; i++) {
+      m_weight_array[pivot + i] = m_weight_array[pivot - i];
+   }
+   unsigned end = (diameter() << image_subpixel_shift) - 1;
+   m_weight_array[0] = m_weight_array[end];
+}
+
+} // namespace

--- a/src/vector/filters/filter.cpp
+++ b/src/vector/filters/filter.cpp
@@ -104,19 +104,23 @@ template <class T> void render_to_filter(T *Self, objBitmap *Bitmap, ARF AspectR
       renderBase.clip_box(Self->Target->Clip.Left, Self->Target->Clip.Top, Self->Target->Clip.Right-1, Self->Target->Clip.Bottom-1);
 
       agg::span_interpolator_linear<> interpolator(img_transform);
-
-      agg::image_filter_lut ifilter;
-      set_filter(ifilter, SampleMethod, img_transform);
-
       agg::span_once<agg::pixfmt_psl> source(pixSource, 0, 0);
-      agg::span_image_filter_rgba<agg::span_once<agg::pixfmt_psl>, agg::span_interpolator_linear<>>
-         spangen(source, interpolator, ifilter, false);
 
       set_raster_rect_path(raster, Self->Target->Clip.Left, Self->Target->Clip.Top,
          Self->Target->Clip.Right - Self->Target->Clip.Left,
          Self->Target->Clip.Bottom - Self->Target->Clip.Top);
 
-      renderSolidBitmap(renderBase, raster, spangen); // Solid render without blending.
+      if (SampleMethod IS VSM::NEIGHBOUR) {
+         agg::span_image_filter_rgba_nn<agg::span_once<agg::pixfmt_psl>, agg::span_interpolator_linear<>>
+            spangen(source, interpolator);
+         renderSolidBitmap(renderBase, raster, spangen); // Solid render without blending.
+      }
+      else {
+         const agg::image_filter_lut &ifilter = get_filter(SampleMethod, img_transform);
+         agg::span_image_filter_rgba<agg::span_once<agg::pixfmt_psl>, agg::span_interpolator_linear<>>
+            spangen(source, interpolator, ifilter, false);
+         renderSolidBitmap(renderBase, raster, spangen); // Solid render without blending.
+      }
    }
    else gfx::CopyArea(Bitmap, Self->Target, BAF::NIL, 0, 0, Bitmap->Width, Bitmap->Height, -img_transform.tx, -img_transform.ty);
 }

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -429,33 +429,43 @@ const agg::trans_affine SceneRenderer::build_fill_transform(extVector &Vector, b
 
 //********************************************************************************************************************
 
-void set_filter(agg::image_filter_lut &Filter, VSM Method, agg::trans_affine &Transform, double Kernel)
+const agg::image_filter_lut & get_filter(VSM Method, agg::trans_affine &Transform, double Kernel)
 {
-   auto compute_kernel = [&Transform, &Kernel]() {
+   double kernel = 0;
+   if ((Method IS VSM::SINC) or (Method IS VSM::LANCZOS) or (Method IS VSM::BLACKMAN)) {
       // For auto kernel calculation, use larger kernel sizes when shrinking.  A base-level of 3.0 is used so that
       // the use of advanced filter algorithms is justified for the client.
       double k;
       if (Kernel > 0.0) k = Kernel;
       else k = 3.0 + (1.0 / svg_diag(Transform.sx, Transform.sy));
-      return std::clamp(k, 2.0, 8.0);
-   };
+      // Quantised to 0.25 steps; visually indistinguishable and it bounds the cache size.
+      kernel = std::round(std::clamp(k, 2.0, 8.0) * 4.0) * 0.25;
+   }
 
+   // LUT construction is deterministic for a given method and kernel, so tables are computed once and
+   // cached.  Thread-local storage keeps the cache lock-free
+
+   thread_local std::unordered_map<int, agg::image_filter_lut> cache;
+   const int key = (int(Method) << 8) | int(kernel * 4.0);
+   if (auto it = cache.find(key); it != cache.end()) return it->second;
+
+   auto &filter = cache[key];
    switch(Method) {
       case VSM::AUTO:
-      case VSM::NEIGHBOUR: // There is a 'span_image_filter_rgb_nn' class but no equivalent image_filter_neighbour() routine?
-      case VSM::BILINEAR:  Filter.calculate(agg::image_filter_bilinear(), true); break;
-      case VSM::BICUBIC:   Filter.calculate(agg::image_filter_bicubic(), true); break;
-      case VSM::SPLINE16:  Filter.calculate(agg::image_filter_spline16(), true); break;
-      case VSM::KAISER:    Filter.calculate(agg::image_filter_kaiser(), true); break;
-      case VSM::QUADRIC:   Filter.calculate(agg::image_filter_quadric(), true); break;
-      case VSM::GAUSSIAN:  Filter.calculate(agg::image_filter_gaussian(), true); break;
-      case VSM::BESSEL:    Filter.calculate(agg::image_filter_bessel(), true); break;
-      case VSM::MITCHELL:  Filter.calculate(agg::image_filter_mitchell(), true); break;
-      case VSM::SINC:      Filter.calculate(agg::image_filter_sinc(compute_kernel()), true); break;
-      case VSM::LANCZOS:   Filter.calculate(agg::image_filter_lanczos(compute_kernel()), true); break;
-      case VSM::BLACKMAN:  Filter.calculate(agg::image_filter_blackman(compute_kernel()), true); break;
-      default:             Filter.calculate(agg::image_filter_bicubic(), true); break;
+      case VSM::BILINEAR:  filter.calculate(agg::image_filter_bilinear(), true); break;
+      case VSM::BICUBIC:   filter.calculate(agg::image_filter_bicubic(), true); break;
+      case VSM::SPLINE16:  filter.calculate(agg::image_filter_spline16(), true); break;
+      case VSM::KAISER:    filter.calculate(agg::image_filter_kaiser(), true); break;
+      case VSM::QUADRIC:   filter.calculate(agg::image_filter_quadric(), true); break;
+      case VSM::GAUSSIAN:  filter.calculate(agg::image_filter_gaussian(), true); break;
+      case VSM::BESSEL:    filter.calculate(agg::image_filter_bessel(), true); break;
+      case VSM::MITCHELL:  filter.calculate(agg::image_filter_mitchell(), true); break;
+      case VSM::SINC:      filter.calculate(agg::image_filter_sinc(kernel), true); break;
+      case VSM::LANCZOS:   filter.calculate(agg::image_filter_lanczos(kernel), true); break;
+      case VSM::BLACKMAN:  filter.calculate(agg::image_filter_blackman(kernel), true); break;
+      default:             filter.calculate(agg::image_filter_bicubic(), true); break;
    }
+   return filter;
 }
 
 //********************************************************************************************************************
@@ -472,28 +482,35 @@ template <class T> void drawBitmap(T &Scanline, VSM SampleMethod, agg::renderer_
 
    if (requires_interpolation) {
       agg::span_interpolator_linear interpolator(*Transform);
-      agg::image_filter_lut filter;
-      set_filter(filter, SampleMethod, *Transform);  // Set the interpolation filter to use.
+
+      auto render_source = [&](auto &source) {
+         using source_t = std::remove_reference_t<decltype(source)>;
+         if (SampleMethod IS VSM::NEIGHBOUR) {
+            agg::span_image_filter_rgba_nn<source_t, agg::span_interpolator_linear<>> spangen(source, interpolator);
+            drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         }
+         else {
+            const agg::image_filter_lut &filter = get_filter(SampleMethod, *Transform);
+            agg::span_image_filter_rgba<source_t, agg::span_interpolator_linear<>> spangen(source, interpolator, filter, true);
+            drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         }
+      };
 
       if (SpreadMethod IS VSPREAD::REFLECT_X) {
          agg::span_reflect_x source(pixels, XOffset, YOffset);
-         agg::span_image_filter_rgba<agg::span_reflect_x, agg::span_interpolator_linear<>> spangen(source, interpolator, filter, true);
-         drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         render_source(source);
       }
       else if (SpreadMethod IS VSPREAD::REFLECT_Y) {
          agg::span_reflect_y source(pixels, XOffset, YOffset);
-         agg::span_image_filter_rgba<agg::span_reflect_y, agg::span_interpolator_linear<>> spangen(source, interpolator, filter, true);
-         drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         render_source(source);
       }
       else if (SpreadMethod IS VSPREAD::REPEAT) {
          agg::span_repeat_pf source(pixels, XOffset, YOffset);
-         agg::span_image_filter_rgba<agg::span_repeat_pf, agg::span_interpolator_linear<>> spangen(source, interpolator, filter, true);
-         drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         render_source(source);
       }
       else { // VSPREAD::PAD and VSPREAD::CLIP modes.
          agg::span_once<agg::pixfmt_psl> source(pixels, XOffset, YOffset);
-         agg::span_image_filter_rgba<agg::span_once<agg::pixfmt_psl>, agg::span_interpolator_linear<>> spangen(source, interpolator, filter, true);
-         drawBitmapRender(Scanline, RenderBase, Raster, spangen, Opacity);
+         render_source(source);
       }
    }
    else {

--- a/src/vector/scene/scene_fill.cpp
+++ b/src/vector/scene/scene_fill.cpp
@@ -97,7 +97,7 @@ static void fill_image(VectorState &State, const TClipRectangle<double> &Bounds,
    if (SampleMethod IS VSM::AUTO) {
       if ((final_x_scale <= 0.5) or (final_y_scale <= 0.5)) SampleMethod = VSM::BICUBIC;
       else if ((final_x_scale <= 1.0) or (final_y_scale <= 1.0)) SampleMethod = VSM::SINC;
-      else SampleMethod = VSM::SPLINE16; // Spline works well for enlarging monotone vectors and avoids sharpening artifacts.
+      else SampleMethod = VSM::SPLINE16; // Spline is a better bicubic, it works well for enlarging monotone vectors and avoids sharpening artifacts.
    }
 
    if ((Render) and (!Render->clip_stack_empty())) {

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -749,7 +749,7 @@ extern ERR read_path(std::vector<PathCommand> &, std::string_view);
 extern ERR render_filter(extVectorFilter *, extVectorViewport *, extVector *, objBitmap *, objBitmap **);
 extern ERR scene_input_events(const InputEvent *, int);
 extern void send_feedback(extVector *, FM, OBJECTPTR = nullptr);
-extern void set_filter(agg::image_filter_lut &, VSM, agg::trans_affine &, double Kernel = 0);
+extern const agg::image_filter_lut & get_filter(VSM, agg::trans_affine &, double Kernel = 0);
 
 extern void render_scene_from_viewport(extVectorScene *, objBitmap *, objVectorViewport *);
 

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -257,7 +257,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     "NEIGHBOUR: Nearest neighbour is the fastest sampler at the cost of poor quality.",
     "BILINEAR: Bilinear is a common algorithm that produces a reasonable quality image quickly.",
     "BICUBIC: Produces a similar result to `BILINEAR` at a slightly higher CPU cost and a marginally sharper after-effect.",
-    "SPLINE16: About twice as slow as `BILINEAR`, this method produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.",
+    "SPLINE16: About twice as slow as `BILINEAR`, this method samples a 4x4 area and produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.",
     "KAISER: Uses a Kaiser-windowed filter, giving smooth interpolation with low ringing and a cost close to `BILINEAR`.",
     "QUADRIC: Uses a quadratic filter with a modest kernel, giving smoother results than `BILINEAR` with limited extra cost.",
     "GAUSSIAN: Uses a Gaussian filter that softens the result, reducing aliasing at the cost of sharp edge detail.",


### PR DESCRIPTION
* Cached interpolation filter lookup tables by sample method and quantised kernel
* Added nearest-neighbour and SSE2 2x2/4x4 RGBA sampling paths
* [Doc] Clarified Spline16 sampling and related Vector documentation