### PR TITLE
[Vector] Fix shared vector cache invalidation

### DIFF
--- a/src/vector/CMakeLists.txt
+++ b/src/vector/CMakeLists.txt
@@ -69,3 +69,4 @@ flute_test(vector_parse_transform "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_parse_
 flute_test(vector_convolve_validation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_convolve_validation.tiri")
 flute_test(vector_apply_path "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_apply_path.tiri")
 flute_test(vector_clip_mask_cache "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_clip_mask_cache.tiri")
+flute_test(vector_shared_invalidation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shared_invalidation.tiri")

--- a/src/vector/agg/include/agg_basics.h
+++ b/src/vector/agg/include/agg_basics.h
@@ -17,11 +17,9 @@
 #include <algorithm>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #ifdef __cpp_lib_math_constants
 #include <numbers>
-#endif
-#ifdef _MSC_VER
-#include <intrin.h>
 #endif
 
 #ifdef AGG_CUSTOM_ALLOCATOR
@@ -122,50 +120,6 @@ namespace agg
     using int64  = std::int64_t;
     using int64u = std::uint64_t;
 
-#if defined(AGG_FISTP)
-#pragma warning(push)
-#pragma warning(disable : 4035) //Disable warning "no return value"
-    inline int iround(double v)
-    {
-        int t;
-        __asm fld   qword ptr [v]
-        __asm fistp dword ptr [t]
-        __asm mov eax, dword ptr [t]
-    }
-    inline unsigned uround(double v)
-    {
-        unsigned t;
-        __asm fld   qword ptr [v]
-        __asm fistp dword ptr [t]
-        __asm mov eax, dword ptr [t]
-    }
-#pragma warning(pop)
-    inline unsigned ufloor(double v)
-    {
-        return unsigned(floor(v));
-    }
-    inline unsigned uceil(double v)
-    {
-        return unsigned(ceil(v));
-    }
-#elif defined(AGG_QIFIST)
-    inline int iround(double v)
-    {
-        return int(v);
-    }
-    inline int uround(double v)
-    {
-        return unsigned(v);
-    }
-    inline unsigned ufloor(double v)
-    {
-        return unsigned(floor(v));
-    }
-    inline unsigned uceil(double v)
-    {
-        return unsigned(ceil(v));
-    }
-#else
     inline int iround(double v)
     {
         return int((v < 0.0) ? v - 0.5 : v + 0.5);
@@ -182,7 +136,6 @@ namespace agg
     {
         return unsigned(ceil(v));
     }
-#endif
 
     template<int Limit> struct saturation {
         static constexpr int iround(double v) noexcept {
@@ -257,7 +210,7 @@ namespace agg
 
     template<typename T>
     requires std::is_arithmetic_v<T>
-    struct alignas(32) rect_base {
+    struct rect_base {
         using value_type = T;
         using self_type = rect_base<T>;
         T x1, y1, x2, y2;
@@ -340,14 +293,14 @@ namespace agg
 
     constexpr bool is_vertex(unsigned c) noexcept    { return c >= path_cmd_move_to and c < path_cmd_end_poly; }
     constexpr bool is_drawing(unsigned c) noexcept   { return c >= path_cmd_line_to and c < path_cmd_end_poly; }
-    constexpr bool is_stop(unsigned c) noexcept      { return c == path_cmd_stop; }
-    constexpr bool is_move_to(unsigned c) noexcept   { return c == path_cmd_move_to; }
-    constexpr bool is_line_to(unsigned c) noexcept   { return c == path_cmd_line_to; }
-    constexpr bool is_curve(unsigned c) noexcept     { return c == path_cmd_curve3 or c == path_cmd_curve4; }
-    constexpr bool is_curve3(unsigned c) noexcept    { return c == path_cmd_curve3; }
-    constexpr bool is_curve4(unsigned c) noexcept    { return c == path_cmd_curve4; }
-    constexpr bool is_end_poly(unsigned c) noexcept  { return (c & path_cmd_mask) == path_cmd_end_poly; }
-    constexpr bool is_close(unsigned c) noexcept     { return (c & ~(path_flags_cw | path_flags_ccw)) == (path_cmd_end_poly | path_flags_close); }
+    constexpr bool is_stop(unsigned c) noexcept      { return c IS path_cmd_stop; }
+    constexpr bool is_move_to(unsigned c) noexcept   { return c IS path_cmd_move_to; }
+    constexpr bool is_line_to(unsigned c) noexcept   { return c IS path_cmd_line_to; }
+    constexpr bool is_curve(unsigned c) noexcept     { return c IS path_cmd_curve3 or c IS path_cmd_curve4; }
+    constexpr bool is_curve3(unsigned c) noexcept    { return c IS path_cmd_curve3; }
+    constexpr bool is_curve4(unsigned c) noexcept    { return c IS path_cmd_curve4; }
+    constexpr bool is_end_poly(unsigned c) noexcept  { return (c & path_cmd_mask) IS path_cmd_end_poly; }
+    constexpr bool is_close(unsigned c) noexcept     { return (c & ~(path_flags_cw | path_flags_ccw)) IS (path_cmd_end_poly | path_flags_close); }
     constexpr bool is_next_poly(unsigned c) noexcept { return is_stop(c) or is_move_to(c) or is_end_poly(c); }
     constexpr bool is_cw(unsigned c) noexcept        { return (c & path_flags_cw) != 0; }
     constexpr bool is_ccw(unsigned c) noexcept       { return (c & path_flags_ccw) != 0; }
@@ -360,7 +313,7 @@ namespace agg
 
     template<typename T>
     requires std::is_arithmetic_v<T>
-    struct alignas(16) point_base {
+    struct point_base {
         using value_type = T;
         T x, y;
         point_base() {}
@@ -373,7 +326,7 @@ namespace agg
 
     template<typename T>
     requires std::is_arithmetic_v<T>
-    struct alignas(16) vertex_base {
+    struct vertex_base {
         using value_type = T;
         T x, y;
         unsigned cmd;

--- a/src/vector/painters/pattern.cpp
+++ b/src/vector/painters/pattern.cpp
@@ -46,7 +46,8 @@ static ERR PATTERN_Draw(extVectorPattern *Self, struct acDraw *Args)
 
    clearmem(Self->Bitmap->Data, Self->Bitmap->LineWidth * Self->Bitmap->Height);
    Self->Scene->Bitmap = Self->Bitmap;
-   acDraw(Self->Scene);
+   auto error = acDraw(Self->Scene);
+   if (error != ERR::Okay) return error;
 
    return ERR::Okay;
 }

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -167,10 +167,6 @@ public:
 
    SceneRenderer(extVectorScene *pScene) : Scene(pScene) { }
    void draw(objBitmap *, objVectorViewport *);
-
-   ~SceneRenderer() {
-      Scene->ShareModified = false;
-   }
 };
 
 //********************************************************************************************************************
@@ -393,23 +389,6 @@ private:
 };
 } // namespace
 
-//********************************************************************************************************************
-// Check a Shape, its siblings and children for dirty markers.
-
-static bool check_dirty(extVector *Shape) {
-   while (Shape) {
-      if (Shape->Class->BaseClassID != CLASSID::VECTOR) return true;
-      if (Shape->dirty()) return true;
-
-      if (Shape->Child) {
-         if (check_dirty((extVector *)Shape->Child)) return true;
-      }
-      Shape = (extVector *)Shape->Next;
-   }
-   return false;
-}
-
-//********************************************************************************************************************
 // Return the correct transformation matrix for a fill operation.  Requires that the vector's path has been generated.
 
 const agg::trans_affine SceneRenderer::build_fill_transform(extVector &Vector, bool Userspace,  VectorState &State)
@@ -698,6 +677,7 @@ void SceneRenderer::draw(objBitmap *Bitmap, objVectorViewport *Viewport)
       draw_vectors((extVector *)Viewport, state);
 
       Scene->InputBoundaries = std::move(mInputBounds);
+      Scene->SubtreeDirty = false;
    }
 }
 
@@ -1029,7 +1009,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
                      bool redraw = view->vpRefreshBuffer or state.mDirty;
                      view->vpRefreshBuffer = false;
 
-                     if ((not redraw) and (Scene->ShareModified)) redraw = true;
+                     if ((not redraw) and (view->vpSeenShareVersion != Scene->ShareVersion)) redraw = true;
 
                      if (view->vpBuffer) {
                         if ((view->vpBuffer->Width != view->vpFixedWidth) or (view->vpBuffer->Height != view->vpFixedHeight)) {
@@ -1093,6 +1073,8 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
                         mRenderBase = save_rb;
                         mBitmap     = save_bmp;
                         mFormat     = save_format;
+
+                        view->vpSeenShareVersion = Scene->ShareVersion;
 
                         //save_bitmap(view->vpBuffer, std::string("viewport"));
                      }

--- a/src/vector/scene/scene_fill.cpp
+++ b/src/vector/scene/scene_fill.cpp
@@ -605,8 +605,8 @@ static void fill_pattern(VectorState &State, const TClipRectangle<double> &Bound
    // (see draw_vectors()), so restore the identity transform before checking for a redraw.
    set_render_transform(Pattern.Scene->Viewport, agg::trans_affine());
 
-   // Redraw the pattern source if any part of the definition is marked as dirty.
-   if ((check_dirty((extVector *)Pattern.Scene->Viewport)) or (!Pattern.Bitmap)) {
+   // Redraw the pattern source if any part of the definition has been marked dirty.
+   if ((((extVectorScene *)Pattern.Scene)->SubtreeDirty) or (!Pattern.Bitmap)) {
       if (acDraw(&Pattern) != ERR::Okay) return;
    }
 

--- a/src/vector/tests/test_shared_invalidation.tiri
+++ b/src/vector/tests/test_shared_invalidation.tiri
@@ -1,0 +1,77 @@
+   include 'vector'
+
+function newBitmap(Width, Height)
+   bmp = obj.new('bitmap', { width=Width, height=Height, bitsPerPixel=32, bkgd='0,0,0,255' })
+   bmp.acClear()
+   return bmp
+end
+
+function setClip(Bitmap, Left, Top, Right, Bottom)
+   check Bitmap.mtSetClipRegion(Left, Top, Right, Bottom)
+end
+
+function hashBitmap(Bitmap)
+   return mSys.GenCRC32(0, Bitmap.data, Bitmap.size)
+end
+
+function drawScene(Scene, Bitmap, Left, Top, Right, Bottom)
+   setClip(Bitmap, Left, Top, Right, Bottom)
+   Bitmap.acClear()
+   Scene.bitmap = Bitmap
+   Scene.acDraw()
+   return hashBitmap(Bitmap)
+end
+
+function drawFull(Scene, Bitmap)
+   return drawScene(Scene, Bitmap, 0, 0, Bitmap.width, Bitmap.height)
+end
+
+@Test function SharedGradientChangeInvalidatesOffscreenBufferedViewport()
+   scene = obj.new('VectorScene', { pageWidth=120, pageHeight=80 })
+   viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   gradient = scene.new('VectorGradient', {
+      type='linear', colourMap='cmap:magma', x1=0, y1=0, x2='100%', y2=0, units=VUNIT_BOUNDING_BOX
+   })
+   check scene.mtAddDef('test_gradient', gradient)
+
+   buffered = viewport.new('VectorViewport', { x=20, y=20, width=50, height=40, buffered=true })
+   target = buffered.new('VectorRectangle', { x=0, y=0, width='100%', height='100%', fill='url(#test_gradient)' })
+   bitmap = newBitmap(120, 80)
+
+   initial_hash = drawFull(scene, bitmap)
+   initial_timestamp = target.pathTimestamp
+
+   gradient.colourMap = 'cmap:viridis'
+   drawScene(scene, bitmap, 0, 0, 1, 1)
+   changed_hash = drawFull(scene, bitmap)
+
+   assert(target.pathTimestamp is initial_timestamp,
+      'Changing a shared gradient should not regenerate the consumer path')
+   assert(changed_hash != initial_hash,
+      'Buffered viewport should redraw after missing a shared gradient change offscreen')
+end
+
+@Test function PatternChildFillChangeInvalidatesPatternBitmap()
+   scene = obj.new('VectorScene', { pageWidth=120, pageHeight=80 })
+   viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   pattern = scene.new('VectorPattern', {
+      width=20, height=20, units=VUNIT_USERSPACE, spreadMethod=VSPREAD_REPEAT
+   })
+   tile = pattern.viewport.new('VectorRectangle', { x=0, y=0, width=20, height=20, fill='rgb(255,0,0)' })
+   check scene.mtAddDef('test_pattern', pattern)
+
+   target = viewport.new('VectorRectangle', { x=10, y=10, width=70, height=40, fill='url(#test_pattern)' })
+   bitmap = newBitmap(120, 80)
+
+   first_hash = drawFull(scene, bitmap)
+   second_hash = drawFull(scene, bitmap)
+   initial_timestamp = target.pathTimestamp
+
+   assert(first_hash is second_hash, 'Repeated render of unchanged pattern should be stable')
+
+   tile.fill = 'rgb(0,0,255)'
+   changed_hash = drawFull(scene, bitmap)
+
+   assert(target.pathTimestamp is initial_timestamp, 'Changing pattern content should not regenerate the consumer path')
+   assert(changed_hash != first_hash, 'Changing pattern content should invalidate the cached pattern bitmap')
+end

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -570,8 +570,11 @@ class extVectorScene : public objVectorScene {
    int InputHandle;
    PTC Cursor; // Current cursor image
    bool RefreshCursor;
-   bool ShareModified; // True if a shareable object has been modified (e.g. VectorGradient), requiring a redraw of any vectors that use it.
+   uint64_t ShareVersion; // Incremented whenever a shareable object has been modified.
+   bool SubtreeDirty; // True if any vector in this scene's tree has been marked dirty since the last completed draw.
    uint8_t BufferCount; // Active tally of viewports that are buffered.
+
+   extVectorScene() : ShareVersion(1), SubtreeDirty(true) { }
 
    // Returns the rasteriser gamma table for the scene's current Gamma value; one shared LUT serves
    // every rasteriser in the scene.  Returns nullptr for identity gamma, which restores the
@@ -610,6 +613,7 @@ class extVectorViewport : public extVector {
    objBitmap *vpBuffer;
    uint8_t *vpBufferData;
    int vpBufferSize; // Size of the vpBufferData in bytes
+   uint64_t vpSeenShareVersion; // Scene ShareVersion that was current when vpBuffer was last rendered.
    std::unique_ptr<std::vector<class InputBoundary>> vpInputBounds; // Cached boundaries for buffered viewports; allocated on first use only.
    extVectorClip *vpClipOwner;
    bool  vpClip; // Viewport requires non-rectangular clipping, e.g. because it is rotated or sheared.
@@ -624,6 +628,7 @@ class extVectorViewport : public extVector {
    extVectorViewport() {
       vpClipOwner = nullptr;
       vpClipConfiguring = false;
+      vpSeenShareVersion = 0;
    }
 };
 
@@ -818,6 +823,8 @@ TClipRectangle<T> get_bounds(VertexSource &vs, const unsigned path_id = 0)
 
 static void mark_buffers_for_refresh(extVector *Vector)
 {
+   if (Vector->Scene) ((extVectorScene *)Vector->Scene)->SubtreeDirty = true;
+
    for (auto node=Vector; node; ) {
       node->ClipCache.clear();
 
@@ -909,6 +916,15 @@ inline static void mark_dirty(objVector *Vector, RC Flags)
    mark_buffers_for_refresh((extVector *)Vector);
 
    mark_children((extVector *)Vector, Flags);
+}
+
+//********************************************************************************************************************
+// Keep shared-definition versions monotonic and reserve zero as the "never rendered" value for viewport caches.
+
+inline static void bump_share_version(extVectorScene *Scene)
+{
+   Scene->ShareVersion++;
+   if (Scene->ShareVersion IS 0) Scene->ShareVersion = 1;
 }
 
 //********************************************************************************************************************
@@ -1465,5 +1481,5 @@ template <class T> TClipRectangle<T>::TClipRectangle(const class extVectorViewpo
 }
 
 inline void SceneDef::modified() {
-   if (HostScene) HostScene->ShareModified = true;
+   if (HostScene) bump_share_version(HostScene);
 }


### PR DESCRIPTION
* Version shared scene definitions so buffered viewports redraw after offscreen definition changes
* Track vector subtree dirtiness for cached pattern bitmap refresh and add regression coverage
* [AGG] Remove stale rounding branches and over-alignment from basic geometry types
