### PR TITLE
[Vector] Pool isolated render bitmaps

### DIFF
--- a/src/vector/CMakeLists.txt
+++ b/src/vector/CMakeLists.txt
@@ -69,4 +69,5 @@ flute_test(vector_parse_transform "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_parse_
 flute_test(vector_convolve_validation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_convolve_validation.tiri")
 flute_test(vector_apply_path "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_apply_path.tiri")
 flute_test(vector_clip_mask_cache "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_clip_mask_cache.tiri")
+flute_test(vector_isolated_bitmap_pool "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_isolated_bitmap_pool.tiri")
 flute_test(vector_shared_invalidation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shared_invalidation.tiri")

--- a/src/vector/agg/include/agg_alpha_mask_u8.h
+++ b/src/vector/agg/include/agg_alpha_mask_u8.h
@@ -16,473 +16,407 @@
 #include "agg_basics.h"
 #include "agg_rendering_buffer.h"
 
-namespace agg
+namespace agg {
+
+struct one_component_mask_u8 {
+    static unsigned calculate(const int8u* p) { return *p; }
+};
+
+template<unsigned R, unsigned G, unsigned B>
+struct rgb_to_gray_mask_u8 {
+    static unsigned calculate(const int8u* p) {
+        return (p[R]*77 + p[G]*150 + p[B]*29) >> 8;
+    }
+};
+
+template<unsigned Step=1, unsigned Offset=0, class MaskF=one_component_mask_u8>
+class alpha_mask_u8 {
+public:
+    typedef int8u cover_type;
+    typedef alpha_mask_u8<Step, Offset, MaskF> self_type;
+    enum cover_scale_e {
+        cover_shift = 8,
+        cover_none  = 0,
+        cover_full  = 255
+    };
+
+    alpha_mask_u8() : m_rbuf(0) {}
+    explicit alpha_mask_u8(rendering_buffer& rbuf) : m_rbuf(&rbuf) {}
+
+    void attach(rendering_buffer& rbuf) { m_rbuf = &rbuf; }
+
+    MaskF& mask_function() { return m_mask_function; }
+    const MaskF& mask_function() const { return m_mask_function; }
+
+    cover_type pixel(int x, int y) const {
+        if (x >= 0 and y >= 0 and x < (int)m_rbuf->width() and y < (int)m_rbuf->height()) {
+           return (cover_type)m_mask_function.calculate(m_rbuf->row_ptr(y) + x * Step + Offset);
+        }
+        return 0;
+    }
+
+    cover_type combine_pixel(int x, int y, cover_type val) const {
+        if (x >= 0 and y >= 0 and x < (int)m_rbuf->width() and y < (int)m_rbuf->height()) {
+            return (cover_type)((cover_full + val * m_mask_function.calculate(
+               m_rbuf->row_ptr(y) + x * Step + Offset)) >> cover_shift);
+        }
+        return 0;
+    }
+
+    void fill_hspan(int x, int y, cover_type* dst, int num_pix) const {
+        int xmax = m_rbuf->width() - 1;
+        int ymax = m_rbuf->height() - 1;
+
+        int count = num_pix;
+        cover_type* covers = dst;
+
+        if (y < 0 or y > ymax) {
+           memset(dst, 0, num_pix * sizeof(cover_type));
+           return;
+        }
+
+        if (x < 0) {
+            count += x;
+            if (count <= 0) {
+               memset(dst, 0, num_pix * sizeof(cover_type));
+               return;
+            }
+            memset(covers, 0, -x * sizeof(cover_type));
+            covers -= x;
+            x = 0;
+        }
+
+        if(x + count > xmax)
+        {
+            int rest = x + count - xmax - 1;
+            count -= rest;
+            if(count <= 0)
+            {
+                memset(dst, 0, num_pix * sizeof(cover_type));
+                return;
+            }
+            memset(covers + count, 0, rest * sizeof(cover_type));
+        }
+
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do
+        {
+            *covers++ = (cover_type)m_mask_function.calculate(mask);
+            mask += Step;
+        }
+        while(--count);
+    }
+
+
+    //--------------------------------------------------------------------
+    void combine_hspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        int xmax = m_rbuf->width() - 1;
+        int ymax = m_rbuf->height() - 1;
+
+        int count = num_pix;
+        cover_type* covers = dst;
+
+        if(y < 0 or y > ymax) {
+            memset(dst, 0, num_pix * sizeof(cover_type));
+            return;
+        }
+
+        if(x < 0) {
+            count += x;
+            if(count <= 0) {
+                memset(dst, 0, num_pix * sizeof(cover_type));
+                return;
+            }
+            memset(covers, 0, -x * sizeof(cover_type));
+            covers -= x;
+            x = 0;
+        }
+
+        if (x + count > xmax) {
+            int rest = x + count - xmax - 1;
+            count -= rest;
+            if (count <= 0) {
+               memset(dst, 0, num_pix * sizeof(cover_type));
+               return;
+            }
+            memset(covers + count, 0, rest * sizeof(cover_type));
+        }
+
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do {
+            *covers = (cover_type)((cover_full + (*covers) * m_mask_function.calculate(mask)) >> cover_shift);
+            ++covers;
+            mask += Step;
+        }
+        while(--count);
+    }
+
+    void fill_vspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        int xmax = m_rbuf->width() - 1;
+        int ymax = m_rbuf->height() - 1;
+
+        int count = num_pix;
+        cover_type* covers = dst;
+
+        if (x < 0 or x > xmax) {
+           memset(dst, 0, num_pix * sizeof(cover_type));
+           return;
+        }
+
+        if (y < 0) {
+            count += y;
+            if (count <= 0) {
+               memset(dst, 0, num_pix * sizeof(cover_type));
+               return;
+            }
+            memset(covers, 0, -y * sizeof(cover_type));
+            covers -= y;
+            y = 0;
+        }
+
+        if(y + count > ymax)
+        {
+            int rest = y + count - ymax - 1;
+            count -= rest;
+            if(count <= 0)
+            {
+                memset(dst, 0, num_pix * sizeof(cover_type));
+                return;
+            }
+            memset(covers + count, 0, rest * sizeof(cover_type));
+        }
+
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do {
+            *covers++ = (cover_type)m_mask_function.calculate(mask);
+            mask += m_rbuf->stride();
+        }
+        while(--count);
+    }
+
+    void combine_vspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        int xmax = m_rbuf->width() - 1;
+        int ymax = m_rbuf->height() - 1;
+
+        int count = num_pix;
+        cover_type* covers = dst;
+
+        if (x < 0 or x > xmax) {
+            memset(dst, 0, num_pix * sizeof(cover_type));
+            return;
+        }
+
+        if (y < 0) {
+            count += y;
+            if (count <= 0) {
+               memset(dst, 0, num_pix * sizeof(cover_type));
+               return;
+            }
+            memset(covers, 0, -y * sizeof(cover_type));
+            covers -= y;
+            y = 0;
+        }
+
+        if(y + count > ymax)
+        {
+            int rest = y + count - ymax - 1;
+            count -= rest;
+            if(count <= 0)
+            {
+                memset(dst, 0, num_pix * sizeof(cover_type));
+                return;
+            }
+            memset(covers + count, 0, rest * sizeof(cover_type));
+        }
+
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do {
+            *covers = (cover_type)((cover_full + (*covers) * m_mask_function.calculate(mask)) >> cover_shift);
+            ++covers;
+            mask += m_rbuf->stride();
+        }
+        while(--count);
+    }
+
+
+private:
+    alpha_mask_u8(const self_type&);
+    const self_type& operator = (const self_type&);
+
+    rendering_buffer* m_rbuf;
+    MaskF             m_mask_function;
+};
+
+
+typedef alpha_mask_u8<1, 0> alpha_mask_gray8;   //----alpha_mask_gray8
+
+typedef alpha_mask_u8<3, 0> alpha_mask_rgb24r;  //----alpha_mask_rgb24r
+typedef alpha_mask_u8<3, 1> alpha_mask_rgb24g;  //----alpha_mask_rgb24g
+typedef alpha_mask_u8<3, 2> alpha_mask_rgb24b;  //----alpha_mask_rgb24b
+
+typedef alpha_mask_u8<3, 2> alpha_mask_bgr24r;  //----alpha_mask_bgr24r
+typedef alpha_mask_u8<3, 1> alpha_mask_bgr24g;  //----alpha_mask_bgr24g
+typedef alpha_mask_u8<3, 0> alpha_mask_bgr24b;  //----alpha_mask_bgr24b
+
+typedef alpha_mask_u8<4, 0> alpha_mask_rgba32r; //----alpha_mask_rgba32r
+typedef alpha_mask_u8<4, 1> alpha_mask_rgba32g; //----alpha_mask_rgba32g
+typedef alpha_mask_u8<4, 2> alpha_mask_rgba32b; //----alpha_mask_rgba32b
+typedef alpha_mask_u8<4, 3> alpha_mask_rgba32a; //----alpha_mask_rgba32a
+
+typedef alpha_mask_u8<4, 1> alpha_mask_argb32r; //----alpha_mask_argb32r
+typedef alpha_mask_u8<4, 2> alpha_mask_argb32g; //----alpha_mask_argb32g
+typedef alpha_mask_u8<4, 3> alpha_mask_argb32b; //----alpha_mask_argb32b
+typedef alpha_mask_u8<4, 0> alpha_mask_argb32a; //----alpha_mask_argb32a
+
+typedef alpha_mask_u8<4, 2> alpha_mask_bgra32r; //----alpha_mask_bgra32r
+typedef alpha_mask_u8<4, 1> alpha_mask_bgra32g; //----alpha_mask_bgra32g
+typedef alpha_mask_u8<4, 0> alpha_mask_bgra32b; //----alpha_mask_bgra32b
+typedef alpha_mask_u8<4, 3> alpha_mask_bgra32a; //----alpha_mask_bgra32a
+
+typedef alpha_mask_u8<4, 3> alpha_mask_abgr32r; //----alpha_mask_abgr32r
+typedef alpha_mask_u8<4, 2> alpha_mask_abgr32g; //----alpha_mask_abgr32g
+typedef alpha_mask_u8<4, 1> alpha_mask_abgr32b; //----alpha_mask_abgr32b
+typedef alpha_mask_u8<4, 0> alpha_mask_abgr32a; //----alpha_mask_abgr32a
+
+typedef alpha_mask_u8<3, 0, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_rgb24gray;  //----alpha_mask_rgb24gray
+typedef alpha_mask_u8<3, 0, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_bgr24gray;  //----alpha_mask_bgr24gray
+typedef alpha_mask_u8<4, 0, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_rgba32gray; //----alpha_mask_rgba32gray
+typedef alpha_mask_u8<4, 1, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_argb32gray; //----alpha_mask_argb32gray
+typedef alpha_mask_u8<4, 0, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_bgra32gray; //----alpha_mask_bgra32gray
+typedef alpha_mask_u8<4, 1, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_abgr32gray; //----alpha_mask_abgr32gray
+
+template<unsigned Step=1, unsigned Offset=0, class MaskF=one_component_mask_u8>
+class amask_no_clip_u8
 {
-    //===================================================one_component_mask_u8
-    struct one_component_mask_u8
+public:
+    typedef int8u cover_type;
+    typedef amask_no_clip_u8<Step, Offset, MaskF> self_type;
+    enum cover_scale_e
     {
-        static unsigned calculate(const int8u* p) { return *p; }
+        cover_shift = 8,
+        cover_none  = 0,
+        cover_full  = 255
     };
 
+    amask_no_clip_u8() : m_rbuf(0) {}
+    explicit amask_no_clip_u8(rendering_buffer& rbuf) : m_rbuf(&rbuf) {}
 
-    //=====================================================rgb_to_gray_mask_u8
-    template<unsigned R, unsigned G, unsigned B>
-    struct rgb_to_gray_mask_u8
+    void attach(rendering_buffer& rbuf) { m_rbuf = &rbuf; }
+
+    MaskF& mask_function() { return m_mask_function; }
+    const MaskF& mask_function() const { return m_mask_function; }
+
+    cover_type pixel(int x, int y) const
     {
-        static unsigned calculate(const int8u* p)
-        {
-            return (p[R]*77 + p[G]*150 + p[B]*29) >> 8;
-        }
-    };
+        return (cover_type)m_mask_function.calculate(
+                                m_rbuf->row_ptr(y) + x * Step + Offset);
+    }
 
-    //==========================================================alpha_mask_u8
-    template<unsigned Step=1, unsigned Offset=0, class MaskF=one_component_mask_u8>
-    class alpha_mask_u8
+    cover_type combine_pixel(int x, int y, cover_type val) const
     {
-    public:
-        typedef int8u cover_type;
-        typedef alpha_mask_u8<Step, Offset, MaskF> self_type;
-        enum cover_scale_e
-        {
-            cover_shift = 8,
-            cover_none  = 0,
-            cover_full  = 255
-        };
+        return (cover_type)((cover_full + val *
+                                m_mask_function.calculate(
+                                m_rbuf->row_ptr(y) + x * Step + Offset)) >>
+                                cover_shift);
+    }
 
-        alpha_mask_u8() : m_rbuf(0) {}
-        explicit alpha_mask_u8(rendering_buffer& rbuf) : m_rbuf(&rbuf) {}
-
-        void attach(rendering_buffer& rbuf) { m_rbuf = &rbuf; }
-
-        MaskF& mask_function() { return m_mask_function; }
-        const MaskF& mask_function() const { return m_mask_function; }
-
-
-        //--------------------------------------------------------------------
-        cover_type pixel(int x, int y) const
-        {
-            if(x >= 0 && y >= 0 &&
-               x < (int)m_rbuf->width() &&
-               y < (int)m_rbuf->height())
-            {
-                return (cover_type)m_mask_function.calculate(
-                                        m_rbuf->row_ptr(y) + x * Step + Offset);
-            }
-            return 0;
-        }
-
-        //--------------------------------------------------------------------
-        cover_type combine_pixel(int x, int y, cover_type val) const
-        {
-            if(x >= 0 && y >= 0 &&
-               x < (int)m_rbuf->width() &&
-               y < (int)m_rbuf->height())
-            {
-                return (cover_type)((cover_full + val *
-                                     m_mask_function.calculate(
-                                        m_rbuf->row_ptr(y) + x * Step + Offset)) >>
-                                     cover_shift);
-            }
-            return 0;
-        }
-
-
-        //--------------------------------------------------------------------
-        void fill_hspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            int xmax = m_rbuf->width() - 1;
-            int ymax = m_rbuf->height() - 1;
-
-            int count = num_pix;
-            cover_type* covers = dst;
-
-            if(y < 0 || y > ymax)
-            {
-                memset(dst, 0, num_pix * sizeof(cover_type));
-                return;
-            }
-
-            if(x < 0)
-            {
-                count += x;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers, 0, -x * sizeof(cover_type));
-                covers -= x;
-                x = 0;
-            }
-
-            if(x + count > xmax)
-            {
-                int rest = x + count - xmax - 1;
-                count -= rest;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers + count, 0, rest * sizeof(cover_type));
-            }
-
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *covers++ = (cover_type)m_mask_function.calculate(mask);
-                mask += Step;
-            }
-            while(--count);
-        }
-
-
-        //--------------------------------------------------------------------
-        void combine_hspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            int xmax = m_rbuf->width() - 1;
-            int ymax = m_rbuf->height() - 1;
-
-            int count = num_pix;
-            cover_type* covers = dst;
-
-            if(y < 0 || y > ymax)
-            {
-                memset(dst, 0, num_pix * sizeof(cover_type));
-                return;
-            }
-
-            if(x < 0)
-            {
-                count += x;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers, 0, -x * sizeof(cover_type));
-                covers -= x;
-                x = 0;
-            }
-
-            if(x + count > xmax)
-            {
-                int rest = x + count - xmax - 1;
-                count -= rest;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers + count, 0, rest * sizeof(cover_type));
-            }
-
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *covers = (cover_type)((cover_full + (*covers) *
-                                       m_mask_function.calculate(mask)) >>
-                                       cover_shift);
-                ++covers;
-                mask += Step;
-            }
-            while(--count);
-        }
-
-        //--------------------------------------------------------------------
-        void fill_vspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            int xmax = m_rbuf->width() - 1;
-            int ymax = m_rbuf->height() - 1;
-
-            int count = num_pix;
-            cover_type* covers = dst;
-
-            if(x < 0 || x > xmax)
-            {
-                memset(dst, 0, num_pix * sizeof(cover_type));
-                return;
-            }
-
-            if(y < 0)
-            {
-                count += y;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers, 0, -y * sizeof(cover_type));
-                covers -= y;
-                y = 0;
-            }
-
-            if(y + count > ymax)
-            {
-                int rest = y + count - ymax - 1;
-                count -= rest;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers + count, 0, rest * sizeof(cover_type));
-            }
-
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *covers++ = (cover_type)m_mask_function.calculate(mask);
-                mask += m_rbuf->stride();
-            }
-            while(--count);
-        }
-
-        //--------------------------------------------------------------------
-        void combine_vspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            int xmax = m_rbuf->width() - 1;
-            int ymax = m_rbuf->height() - 1;
-
-            int count = num_pix;
-            cover_type* covers = dst;
-
-            if(x < 0 || x > xmax)
-            {
-                memset(dst, 0, num_pix * sizeof(cover_type));
-                return;
-            }
-
-            if(y < 0)
-            {
-                count += y;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers, 0, -y * sizeof(cover_type));
-                covers -= y;
-                y = 0;
-            }
-
-            if(y + count > ymax)
-            {
-                int rest = y + count - ymax - 1;
-                count -= rest;
-                if(count <= 0)
-                {
-                    memset(dst, 0, num_pix * sizeof(cover_type));
-                    return;
-                }
-                memset(covers + count, 0, rest * sizeof(cover_type));
-            }
-
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *covers = (cover_type)((cover_full + (*covers) *
-                                       m_mask_function.calculate(mask)) >>
-                                       cover_shift);
-                ++covers;
-                mask += m_rbuf->stride();
-            }
-            while(--count);
-        }
-
-
-    private:
-        alpha_mask_u8(const self_type&);
-        const self_type& operator = (const self_type&);
-
-        rendering_buffer* m_rbuf;
-        MaskF             m_mask_function;
-    };
-
-
-    typedef alpha_mask_u8<1, 0> alpha_mask_gray8;   //----alpha_mask_gray8
-
-    typedef alpha_mask_u8<3, 0> alpha_mask_rgb24r;  //----alpha_mask_rgb24r
-    typedef alpha_mask_u8<3, 1> alpha_mask_rgb24g;  //----alpha_mask_rgb24g
-    typedef alpha_mask_u8<3, 2> alpha_mask_rgb24b;  //----alpha_mask_rgb24b
-
-    typedef alpha_mask_u8<3, 2> alpha_mask_bgr24r;  //----alpha_mask_bgr24r
-    typedef alpha_mask_u8<3, 1> alpha_mask_bgr24g;  //----alpha_mask_bgr24g
-    typedef alpha_mask_u8<3, 0> alpha_mask_bgr24b;  //----alpha_mask_bgr24b
-
-    typedef alpha_mask_u8<4, 0> alpha_mask_rgba32r; //----alpha_mask_rgba32r
-    typedef alpha_mask_u8<4, 1> alpha_mask_rgba32g; //----alpha_mask_rgba32g
-    typedef alpha_mask_u8<4, 2> alpha_mask_rgba32b; //----alpha_mask_rgba32b
-    typedef alpha_mask_u8<4, 3> alpha_mask_rgba32a; //----alpha_mask_rgba32a
-
-    typedef alpha_mask_u8<4, 1> alpha_mask_argb32r; //----alpha_mask_argb32r
-    typedef alpha_mask_u8<4, 2> alpha_mask_argb32g; //----alpha_mask_argb32g
-    typedef alpha_mask_u8<4, 3> alpha_mask_argb32b; //----alpha_mask_argb32b
-    typedef alpha_mask_u8<4, 0> alpha_mask_argb32a; //----alpha_mask_argb32a
-
-    typedef alpha_mask_u8<4, 2> alpha_mask_bgra32r; //----alpha_mask_bgra32r
-    typedef alpha_mask_u8<4, 1> alpha_mask_bgra32g; //----alpha_mask_bgra32g
-    typedef alpha_mask_u8<4, 0> alpha_mask_bgra32b; //----alpha_mask_bgra32b
-    typedef alpha_mask_u8<4, 3> alpha_mask_bgra32a; //----alpha_mask_bgra32a
-
-    typedef alpha_mask_u8<4, 3> alpha_mask_abgr32r; //----alpha_mask_abgr32r
-    typedef alpha_mask_u8<4, 2> alpha_mask_abgr32g; //----alpha_mask_abgr32g
-    typedef alpha_mask_u8<4, 1> alpha_mask_abgr32b; //----alpha_mask_abgr32b
-    typedef alpha_mask_u8<4, 0> alpha_mask_abgr32a; //----alpha_mask_abgr32a
-
-    typedef alpha_mask_u8<3, 0, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_rgb24gray;  //----alpha_mask_rgb24gray
-    typedef alpha_mask_u8<3, 0, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_bgr24gray;  //----alpha_mask_bgr24gray
-    typedef alpha_mask_u8<4, 0, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_rgba32gray; //----alpha_mask_rgba32gray
-    typedef alpha_mask_u8<4, 1, rgb_to_gray_mask_u8<0, 1, 2> > alpha_mask_argb32gray; //----alpha_mask_argb32gray
-    typedef alpha_mask_u8<4, 0, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_bgra32gray; //----alpha_mask_bgra32gray
-    typedef alpha_mask_u8<4, 1, rgb_to_gray_mask_u8<2, 1, 0> > alpha_mask_abgr32gray; //----alpha_mask_abgr32gray
-
-
-
-    //==========================================================amask_no_clip_u8
-    template<unsigned Step=1, unsigned Offset=0, class MaskF=one_component_mask_u8>
-    class amask_no_clip_u8
+    void fill_hspan(int x, int y, cover_type* dst, int num_pix) const
     {
-    public:
-        typedef int8u cover_type;
-        typedef amask_no_clip_u8<Step, Offset, MaskF> self_type;
-        enum cover_scale_e
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do
         {
-            cover_shift = 8,
-            cover_none  = 0,
-            cover_full  = 255
-        };
-
-        amask_no_clip_u8() : m_rbuf(0) {}
-        explicit amask_no_clip_u8(rendering_buffer& rbuf) : m_rbuf(&rbuf) {}
-
-        void attach(rendering_buffer& rbuf) { m_rbuf = &rbuf; }
-
-        MaskF& mask_function() { return m_mask_function; }
-        const MaskF& mask_function() const { return m_mask_function; }
-
-
-        //--------------------------------------------------------------------
-        cover_type pixel(int x, int y) const
-        {
-            return (cover_type)m_mask_function.calculate(
-                                   m_rbuf->row_ptr(y) + x * Step + Offset);
+            *dst++ = (cover_type)m_mask_function.calculate(mask);
+            mask += Step;
         }
+        while(--num_pix);
+    }
 
-
-        //--------------------------------------------------------------------
-        cover_type combine_pixel(int x, int y, cover_type val) const
+    void combine_hspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do
         {
-            return (cover_type)((cover_full + val *
-                                 m_mask_function.calculate(
-                                    m_rbuf->row_ptr(y) + x * Step + Offset)) >>
-                                 cover_shift);
+            *dst = (cover_type)((cover_full + (*dst) *
+                                m_mask_function.calculate(mask)) >>
+                                cover_shift);
+            ++dst;
+            mask += Step;
         }
+        while(--num_pix);
+    }
 
-
-        //--------------------------------------------------------------------
-        void fill_hspan(int x, int y, cover_type* dst, int num_pix) const
+    void fill_vspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do
         {
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *dst++ = (cover_type)m_mask_function.calculate(mask);
-                mask += Step;
-            }
-            while(--num_pix);
+            *dst++ = (cover_type)m_mask_function.calculate(mask);
+            mask += m_rbuf->stride();
         }
+        while(--num_pix);
+    }
 
-
-
-        //--------------------------------------------------------------------
-        void combine_hspan(int x, int y, cover_type* dst, int num_pix) const
+    void combine_vspan(int x, int y, cover_type* dst, int num_pix) const
+    {
+        const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
+        do
         {
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *dst = (cover_type)((cover_full + (*dst) *
-                                    m_mask_function.calculate(mask)) >>
-                                    cover_shift);
-                ++dst;
-                mask += Step;
-            }
-            while(--num_pix);
+            *dst = (cover_type)((cover_full + (*dst) *
+                                m_mask_function.calculate(mask)) >>
+                                cover_shift);
+            ++dst;
+            mask += m_rbuf->stride();
         }
+        while(--num_pix);
+    }
+
+private:
+    amask_no_clip_u8(const self_type&);
+    const self_type& operator = (const self_type&);
+
+    rendering_buffer* m_rbuf;
+    MaskF             m_mask_function;
+};
 
 
-        //--------------------------------------------------------------------
-        void fill_vspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *dst++ = (cover_type)m_mask_function.calculate(mask);
-                mask += m_rbuf->stride();
-            }
-            while(--num_pix);
-        }
+typedef amask_no_clip_u8<1, 0> amask_no_clip_gray8;   //----amask_no_clip_gray8
 
+typedef amask_no_clip_u8<3, 0> amask_no_clip_rgb24r;  //----amask_no_clip_rgb24r
+typedef amask_no_clip_u8<3, 1> amask_no_clip_rgb24g;  //----amask_no_clip_rgb24g
+typedef amask_no_clip_u8<3, 2> amask_no_clip_rgb24b;  //----amask_no_clip_rgb24b
 
-        //--------------------------------------------------------------------
-        void combine_vspan(int x, int y, cover_type* dst, int num_pix) const
-        {
-            const int8u* mask = m_rbuf->row_ptr(y) + x * Step + Offset;
-            do
-            {
-                *dst = (cover_type)((cover_full + (*dst) *
-                                    m_mask_function.calculate(mask)) >>
-                                    cover_shift);
-                ++dst;
-                mask += m_rbuf->stride();
-            }
-            while(--num_pix);
-        }
+typedef amask_no_clip_u8<3, 2> amask_no_clip_bgr24r;  //----amask_no_clip_bgr24r
+typedef amask_no_clip_u8<3, 1> amask_no_clip_bgr24g;  //----amask_no_clip_bgr24g
+typedef amask_no_clip_u8<3, 0> amask_no_clip_bgr24b;  //----amask_no_clip_bgr24b
 
-    private:
-        amask_no_clip_u8(const self_type&);
-        const self_type& operator = (const self_type&);
+typedef amask_no_clip_u8<4, 0> amask_no_clip_rgba32r; //----amask_no_clip_rgba32r
+typedef amask_no_clip_u8<4, 1> amask_no_clip_rgba32g; //----amask_no_clip_rgba32g
+typedef amask_no_clip_u8<4, 2> amask_no_clip_rgba32b; //----amask_no_clip_rgba32b
+typedef amask_no_clip_u8<4, 3> amask_no_clip_rgba32a; //----amask_no_clip_rgba32a
 
-        rendering_buffer* m_rbuf;
-        MaskF             m_mask_function;
-    };
+typedef amask_no_clip_u8<4, 1> amask_no_clip_argb32r; //----amask_no_clip_argb32r
+typedef amask_no_clip_u8<4, 2> amask_no_clip_argb32g; //----amask_no_clip_argb32g
+typedef amask_no_clip_u8<4, 3> amask_no_clip_argb32b; //----amask_no_clip_argb32b
+typedef amask_no_clip_u8<4, 0> amask_no_clip_argb32a; //----amask_no_clip_argb32a
 
+typedef amask_no_clip_u8<4, 2> amask_no_clip_bgra32r; //----amask_no_clip_bgra32r
+typedef amask_no_clip_u8<4, 1> amask_no_clip_bgra32g; //----amask_no_clip_bgra32g
+typedef amask_no_clip_u8<4, 0> amask_no_clip_bgra32b; //----amask_no_clip_bgra32b
+typedef amask_no_clip_u8<4, 3> amask_no_clip_bgra32a; //----amask_no_clip_bgra32a
 
-    typedef amask_no_clip_u8<1, 0> amask_no_clip_gray8;   //----amask_no_clip_gray8
+typedef amask_no_clip_u8<4, 3> amask_no_clip_abgr32r; //----amask_no_clip_abgr32r
+typedef amask_no_clip_u8<4, 2> amask_no_clip_abgr32g; //----amask_no_clip_abgr32g
+typedef amask_no_clip_u8<4, 1> amask_no_clip_abgr32b; //----amask_no_clip_abgr32b
+typedef amask_no_clip_u8<4, 0> amask_no_clip_abgr32a; //----amask_no_clip_abgr32a
 
-    typedef amask_no_clip_u8<3, 0> amask_no_clip_rgb24r;  //----amask_no_clip_rgb24r
-    typedef amask_no_clip_u8<3, 1> amask_no_clip_rgb24g;  //----amask_no_clip_rgb24g
-    typedef amask_no_clip_u8<3, 2> amask_no_clip_rgb24b;  //----amask_no_clip_rgb24b
+typedef amask_no_clip_u8<3, 0, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_rgb24gray;  //----amask_no_clip_rgb24gray
+typedef amask_no_clip_u8<3, 0, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_bgr24gray;  //----amask_no_clip_bgr24gray
+typedef amask_no_clip_u8<4, 0, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_rgba32gray; //----amask_no_clip_rgba32gray
+typedef amask_no_clip_u8<4, 1, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_argb32gray; //----amask_no_clip_argb32gray
+typedef amask_no_clip_u8<4, 0, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_bgra32gray; //----amask_no_clip_bgra32gray
+typedef amask_no_clip_u8<4, 1, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_abgr32gray; //----amask_no_clip_abgr32gray
 
-    typedef amask_no_clip_u8<3, 2> amask_no_clip_bgr24r;  //----amask_no_clip_bgr24r
-    typedef amask_no_clip_u8<3, 1> amask_no_clip_bgr24g;  //----amask_no_clip_bgr24g
-    typedef amask_no_clip_u8<3, 0> amask_no_clip_bgr24b;  //----amask_no_clip_bgr24b
-
-    typedef amask_no_clip_u8<4, 0> amask_no_clip_rgba32r; //----amask_no_clip_rgba32r
-    typedef amask_no_clip_u8<4, 1> amask_no_clip_rgba32g; //----amask_no_clip_rgba32g
-    typedef amask_no_clip_u8<4, 2> amask_no_clip_rgba32b; //----amask_no_clip_rgba32b
-    typedef amask_no_clip_u8<4, 3> amask_no_clip_rgba32a; //----amask_no_clip_rgba32a
-
-    typedef amask_no_clip_u8<4, 1> amask_no_clip_argb32r; //----amask_no_clip_argb32r
-    typedef amask_no_clip_u8<4, 2> amask_no_clip_argb32g; //----amask_no_clip_argb32g
-    typedef amask_no_clip_u8<4, 3> amask_no_clip_argb32b; //----amask_no_clip_argb32b
-    typedef amask_no_clip_u8<4, 0> amask_no_clip_argb32a; //----amask_no_clip_argb32a
-
-    typedef amask_no_clip_u8<4, 2> amask_no_clip_bgra32r; //----amask_no_clip_bgra32r
-    typedef amask_no_clip_u8<4, 1> amask_no_clip_bgra32g; //----amask_no_clip_bgra32g
-    typedef amask_no_clip_u8<4, 0> amask_no_clip_bgra32b; //----amask_no_clip_bgra32b
-    typedef amask_no_clip_u8<4, 3> amask_no_clip_bgra32a; //----amask_no_clip_bgra32a
-
-    typedef amask_no_clip_u8<4, 3> amask_no_clip_abgr32r; //----amask_no_clip_abgr32r
-    typedef amask_no_clip_u8<4, 2> amask_no_clip_abgr32g; //----amask_no_clip_abgr32g
-    typedef amask_no_clip_u8<4, 1> amask_no_clip_abgr32b; //----amask_no_clip_abgr32b
-    typedef amask_no_clip_u8<4, 0> amask_no_clip_abgr32a; //----amask_no_clip_abgr32a
-
-    typedef amask_no_clip_u8<3, 0, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_rgb24gray;  //----amask_no_clip_rgb24gray
-    typedef amask_no_clip_u8<3, 0, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_bgr24gray;  //----amask_no_clip_bgr24gray
-    typedef amask_no_clip_u8<4, 0, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_rgba32gray; //----amask_no_clip_rgba32gray
-    typedef amask_no_clip_u8<4, 1, rgb_to_gray_mask_u8<0, 1, 2> > amask_no_clip_argb32gray; //----amask_no_clip_argb32gray
-    typedef amask_no_clip_u8<4, 0, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_bgra32gray; //----amask_no_clip_bgra32gray
-    typedef amask_no_clip_u8<4, 1, rgb_to_gray_mask_u8<2, 1, 0> > amask_no_clip_abgr32gray; //----amask_no_clip_abgr32gray
-
-
-}
+} // namespace

--- a/src/vector/filters/filter.cpp
+++ b/src/vector/filters/filter.cpp
@@ -298,15 +298,38 @@ static ERR get_source_bitmap(extVectorFilter *Self, objBitmap **BitmapResult, VS
    else if (SourceType IS VSF::BKGD_ALPHA) {
       if (auto error = get_banked_bitmap(Self, &bmp); error != ERR::Okay) return log.warning(error);
       if ((Self->BkgdBitmap) and ((Self->BkgdBitmap->Flags & BMF::ALPHA_CHANNEL) != BMF::NIL)) {
-         int dy = bmp->Clip.Top;
-         for (int sy=Self->BkgdBitmap->Clip.Top; sy < Self->BkgdBitmap->Clip.Bottom; sy++) {
-            auto src = (uint32_t *)(Self->BkgdBitmap->Data + (sy * Self->BkgdBitmap->LineWidth));
-            auto dest = (uint32_t *)(bmp->Data + (dy * bmp->LineWidth));
-            int dx = bmp->Clip.Left;
-            for (int sx=Self->BkgdBitmap->Clip.Left; sx < Self->BkgdBitmap->Clip.Right; sx++) {
-               dest[dx++] = src[sx] & 0xff000000;
+         int src_left = std::max(Self->VectorClip.left, Self->BkgdBitmap->Clip.Left);
+         int src_top = std::max(Self->VectorClip.top, Self->BkgdBitmap->Clip.Top);
+         int src_right = std::min(Self->VectorClip.right, Self->BkgdBitmap->Clip.Right);
+         int src_bottom = std::min(Self->VectorClip.bottom, Self->BkgdBitmap->Clip.Bottom);
+
+         int dest_x = bmp->Clip.Left + (src_left - Self->VectorClip.left);
+         int dest_y = bmp->Clip.Top + (src_top - Self->VectorClip.top);
+
+         if (dest_x < bmp->Clip.Left) {
+            src_left += bmp->Clip.Left - dest_x;
+            dest_x = bmp->Clip.Left;
+         }
+
+         if (dest_y < bmp->Clip.Top) {
+            src_top += bmp->Clip.Top - dest_y;
+            dest_y = bmp->Clip.Top;
+         }
+
+         int width = std::min(src_right - src_left, bmp->Clip.Right - dest_x);
+         int height = std::min(src_bottom - src_top, bmp->Clip.Bottom - dest_y);
+
+         if ((width > 0) and (height > 0)) {
+            int dy = dest_y;
+            for (int sy=src_top; sy < src_top + height; sy++) {
+               auto src = (uint32_t *)(Self->BkgdBitmap->Data + (sy * Self->BkgdBitmap->LineWidth));
+               auto dest = (uint32_t *)(bmp->Data + (dy * bmp->LineWidth));
+               int dx = dest_x;
+               for (int sx=src_left; sx < src_left + width; sx++) {
+                  dest[dx++] = src[sx] & 0xff000000;
+               }
+               dy++;
             }
-            dy++;
          }
       }
    }

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -104,6 +104,7 @@ private:
    agg::scanline32_p8 mScanLine; // Use scanline32_p8 for large solid polygons/rectangles and scanline_u for complex shapes like text
    extVectorViewport  *mView;    // The current view
    objBitmap          *mBitmap;
+   int mBitmapOriginX, mBitmapOriginY;
    std::vector<class InputBoundary> mInputBounds; // Records boundaries for input events and cursor changes.
 
 public:
@@ -154,6 +155,7 @@ private:
 
    void render_fill(VectorState &, extVector &, agg::rasterizer_scanline_aa<> &, extPainter &);
    void render_stroke(VectorState &, extVector &);
+   void copy_filter_bitmap(objBitmap *, extVectorFilter *);
    bool shape_intersects_clip(extVector *);
    void draw_vectors(extVector *, VectorState &);
    static const agg::trans_affine build_fill_transform(extVector &, bool,  VectorState &);
@@ -165,7 +167,7 @@ public:
    bool clip_stack_empty() const { return mClipStack.empty(); }
    ClipBuffer &clip_stack_top() { return mClipStack.top(); }
 
-   SceneRenderer(extVectorScene *pScene) : Scene(pScene) { }
+   SceneRenderer(extVectorScene *pScene) : mBitmapOriginX(0), mBitmapOriginY(0), Scene(pScene) { }
    void draw(objBitmap *, objVectorViewport *);
 };
 
@@ -799,6 +801,33 @@ bool SceneRenderer::shape_intersects_clip(extVector *Shape)
       (bounds.left <= double(clip.x2)) and (bounds.top <= double(clip.y2));
 }
 
+//********************************************************************************************************************
+// Filter bitmaps use absolute clip coordinates.  Buffered viewport targets are local bitmaps with their Data pointer
+// shifted so vector rasterisation can still address absolute scene coordinates.  CopyArea() clips against bitmap
+// dimensions, so translate the final filter copy back to viewport-local coordinates when a buffered target is active.
+
+void SceneRenderer::copy_filter_bitmap(objBitmap *Bitmap, extVectorFilter *Filter)
+{
+   Bitmap->Opacity = (Filter->Opacity < 1.0) ? (255.0 * Filter->Opacity) : 255;
+
+   if (mBitmapOriginX or mBitmapOriginY) {
+      const int src_x = Bitmap->Clip.Left;
+      const int src_y = Bitmap->Clip.Top;
+      const int width = Bitmap->Clip.Right - Bitmap->Clip.Left;
+      const int height = Bitmap->Clip.Bottom - Bitmap->Clip.Top;
+
+      if ((width > 0) and (height > 0)) {
+         auto save_data = mBitmap->offset(mBitmapOriginX, mBitmapOriginY);
+
+         gfx::CopyArea(Bitmap, mBitmap, BAF::BLEND|BAF::COPY, src_x, src_y, width, height,
+            src_x - mBitmapOriginX, src_y - mBitmapOriginY);
+
+         mBitmap->Data = save_data;
+      }
+   }
+   else gfx::CopyArea(Bitmap, mBitmap, BAF::BLEND|BAF::COPY, 0, 0, Bitmap->Width, Bitmap->Height, 0, 0);
+}
+
 // This is the main routine for parsing the vector tree for drawing.
 
 void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentState) {
@@ -846,8 +875,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
 
          objBitmap *bmp;
          if (!render_filter(filter, mView, shape, mBitmap, &bmp)) {
-            bmp->Opacity = (filter->Opacity < 1.0) ? (255.0 * filter->Opacity) : 255;
-            gfx::CopyArea(bmp, mBitmap, BAF::BLEND|BAF::COPY, 0, 0, bmp->Width, bmp->Height, 0, 0);
+            copy_filter_bitmap(bmp, filter);
          }
          continue;
       }
@@ -1049,12 +1077,16 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
                         auto save_bmp    = mBitmap;
                         auto save_format = mFormat;
                         auto save_rb     = mRenderBase;
+                        auto save_origin_x = mBitmapOriginX;
+                        auto save_origin_y = mBitmapOriginY;
 
                         // The vector paths will target the coordinate space of their parents, so we
                         // make adjustments to the bitmap to orient to (0,0).
 
                         mBitmap = view->vpBuffer;
-                        auto save_data = mBitmap->offset(-view->vpBounds.left, -view->vpBounds.top);
+                        mBitmapOriginX = int(view->vpBounds.left);
+                        mBitmapOriginY = int(view->vpBounds.top);
+                        auto save_data = mBitmap->offset(-mBitmapOriginX, -mBitmapOriginY);
                         mFormat.setBitmap(*view->vpBuffer);
 
                         auto ib_size = mInputBounds.size();
@@ -1080,6 +1112,8 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
                         mRenderBase = save_rb;
                         mBitmap     = save_bmp;
                         mFormat     = save_format;
+                        mBitmapOriginX = save_origin_x;
+                        mBitmapOriginY = save_origin_y;
 
                         view->vpSeenShareVersion = Scene->ShareVersion;
 

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -901,6 +901,8 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
 
       objBitmap *bmpBkgd = nullptr;
       objBitmap *bmpSave = nullptr;
+      int save_origin_x = 0;
+      int save_origin_y = 0;
       if ((shape->Flags & VF::ISOLATED) != VF::NIL) {
          if (!shape->IsolatedBuffer) shape->IsolatedBuffer = new (std::nothrow) filter_bitmap;
          if (shape->IsolatedBuffer) {
@@ -917,6 +919,10 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
             bmpBkgd->Flags       = (bmpBkgd->Flags & ~BMF::PREMUL) | BMF::ALPHA_CHANNEL | BMF::NO_DATA;
             bmpSave = mBitmap;
             mBitmap = bmpBkgd;
+            save_origin_x = mBitmapOriginX;
+            save_origin_y = mBitmapOriginY;
+            mBitmapOriginX = 0;
+            mBitmapOriginY = 0;
             mFormat.setBitmap(*bmpBkgd);
             clearmem(bmpBkgd->CreatorMeta, bmpBkgd->LineWidth * (bmpBkgd->Clip.Bottom - bmpBkgd->Clip.Top));
             state.mIsolated = true;
@@ -1232,6 +1238,8 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
          basic_path(raster, bmpBkgd->Clip.Left, bmpBkgd->Clip.Top, bmpBkgd->Clip.Right, bmpBkgd->Clip.Bottom);
 
          mBitmap = bmpSave;
+         mBitmapOriginX = save_origin_x;
+         mBitmapOriginY = save_origin_y;
          mFormat.setBitmap(*mBitmap);
          if (!mClipStack.empty()) {
             agg::alpha_mask_gray8 alpha_mask(mClipStack.top().m_renderer);

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -899,11 +899,6 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       // a placeholder over the existing target bitmap, and the new content will be rendered to the target
       // after processing the current branch.  The background is then discarded.
 
-      // TODO: The allocation of this bitmap during rendering isn't optimal.  Perhaps we could allocate it as a permanent
-      // dummy bitmap to be retained with the Vector, and the Data would be allocated dynamically during rendering.
-      //
-      // TODO: The clipping area of the bitmap should be declared so that unnecessary pixel interaction is avoided.
-
       objBitmap *bmpBkgd = nullptr;
       objBitmap *bmpSave = nullptr;
       if ((shape->Flags & VF::ISOLATED) != VF::NIL) {

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -879,16 +879,23 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       objBitmap *bmpBkgd = nullptr;
       objBitmap *bmpSave = nullptr;
       if ((shape->Flags & VF::ISOLATED) != VF::NIL) {
-         if ((bmpBkgd = objBitmap::create::local(fl::Name("scene_temp_bkgd"),
-               fl::Width(mBitmap->Width),
-               fl::Height(mBitmap->Height),
-               fl::BitsPerPixel(32),
-               fl::Flags(BMF::ALPHA_CHANNEL),
-               fl::ColourSpace(mBitmap->ColourSpace)))) {
+         if (!shape->IsolatedBuffer) shape->IsolatedBuffer = new (std::nothrow) filter_bitmap;
+         if (shape->IsolatedBuffer) {
+            auto &clip_box = mRenderBase.clip_box();
+            TClipRectangle<int> isolated_clip(clip_box.x1, clip_box.y1, clip_box.x2 + 1, clip_box.y2 + 1);
+
+            bmpBkgd = shape->IsolatedBuffer->get_bitmap(mBitmap->Width, mBitmap->Height, isolated_clip, false,
+               shape->UID, "isolated_bkgd");
+         }
+
+         if (bmpBkgd) {
+            bmpBkgd->ColourSpace = mBitmap->ColourSpace;
+            bmpBkgd->BlendMode   = mBitmap->BlendMode;
+            bmpBkgd->Flags       = (bmpBkgd->Flags & ~BMF::PREMUL) | BMF::ALPHA_CHANNEL | BMF::NO_DATA;
             bmpSave = mBitmap;
             mBitmap = bmpBkgd;
             mFormat.setBitmap(*bmpBkgd);
-            clearmem(bmpBkgd->Data, bmpBkgd->LineWidth * bmpBkgd->Height);
+            clearmem(bmpBkgd->CreatorMeta, bmpBkgd->LineWidth * (bmpBkgd->Clip.Bottom - bmpBkgd->Clip.Top));
             state.mIsolated = true;
          }
       }
@@ -1193,7 +1200,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       if (bmpBkgd) {
          agg::rasterizer_scanline_aa raster;
 
-         basic_path(raster, 0, 0, bmpBkgd->Width, bmpBkgd->Height);
+         basic_path(raster, bmpBkgd->Clip.Left, bmpBkgd->Clip.Top, bmpBkgd->Clip.Right, bmpBkgd->Clip.Bottom);
 
          mBitmap = bmpSave;
          mFormat.setBitmap(*mBitmap);
@@ -1206,7 +1213,6 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
             agg::scanline_u8 scanline;
             drawBitmap(scanline, shape->Scene->SampleMethod, mRenderBase, raster, bmpBkgd, VSPREAD::CLIP, 1.0);
          }
-         FreeResource(bmpBkgd);
       }
    } // for loop
 }

--- a/src/vector/tests/test_isolated_bitmap_pool.tiri
+++ b/src/vector/tests/test_isolated_bitmap_pool.tiri
@@ -1,0 +1,103 @@
+   include 'vector'
+
+WIDTH <const> = 120
+HEIGHT <const> = 80
+CLIP_LEFT <const> = 30
+CLIP_TOP <const> = 20
+CLIP_RIGHT <const> = 90
+CLIP_BOTTOM <const> = 60
+
+function newBitmap(Colour)
+   bmp = obj.new('bitmap', { width=WIDTH, height=HEIGHT, bitsPerPixel=32, bkgd=Colour })
+   bmp.acClear()
+   return bmp
+end
+
+function setClip(Bitmap, Left, Top, Right, Bottom)
+   check Bitmap.mtSetClipRegion(Left, Top, Right, Bottom)
+end
+
+function hashBitmap(Bitmap)
+   return mSys.GenCRC32(0, Bitmap.data, Bitmap.size)
+end
+
+function copyArea(Source, Dest, Left, Top, Right, Bottom, XDest, YDest)
+   check Source.mtCopyArea(Dest, BAF_NIL, Left, Top, Right - Left, Bottom - Top, XDest, YDest)
+end
+
+function copyRegion(Source, Dest, Left, Top, Right, Bottom)
+   copyArea(Source, Dest, Left, Top, Right, Bottom, Left, Top)
+end
+
+function cropRegion(Source, Left, Top, Right, Bottom)
+   crop = newBitmap('0,0,0,255')
+   copyArea(Source, crop, Left, Top, Right, Bottom, 0, 0)
+   return crop
+end
+
+function drawScene(Scene, Bitmap, Left, Top, Right, Bottom)
+   setClip(Bitmap, Left, Top, Right, Bottom)
+   Scene.bitmap = Bitmap
+   check Scene.acDraw()
+end
+
+function buildScene(UseBackgroundFilter)
+   scene = obj.new('VectorScene', { pageWidth=WIDTH, pageHeight=HEIGHT })
+   viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+
+   if UseBackgroundFilter then
+      filter = scene.new('VectorFilter', { x=0, y=0, width='100%', height='100%' })
+      composite = filter.new('CompositeFX', { sourceType='Graphic', mixType='Bkgd', operator='Over' })
+      check scene.mtAddDef('background_over', filter)
+   end
+
+   viewport.new('VectorRectangle', { x=0, y=0, width='100%', height='100%', fill='rgb(24,64,96)' })
+   isolated = viewport.new('VectorGroup', { flags=VF_ISOLATED })
+   isolated.new('VectorRectangle', { x=36, y=24, width=48, height=32, fill='rgb(192,48,32)', opacity=0.65 })
+   if UseBackgroundFilter then
+      isolated.new('VectorEllipse', {
+         cx=60, cy=40, radiusX=20, radiusY=14, fill='rgb(32,160,220)', filter='url(#background_over)'
+      })
+   else
+      isolated.new('VectorEllipse', { cx=60, cy=40, radiusX=20, radiusY=14, fill='rgb(32,160,220)' })
+   end
+
+   return scene
+end
+
+@Test function IsolatedRenderMatchesFullSceneInsideClippedRedraw()
+   full_scene = buildScene(false)
+   clipped_scene = buildScene(false)
+   full = newBitmap('0,0,0,255')
+   clipped = newBitmap('240,0,160,255')
+   expected = newBitmap('240,0,160,255')
+
+   drawScene(full_scene, full, 0, 0, WIDTH, HEIGHT)
+   copyRegion(full, expected, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+
+   drawScene(clipped_scene, clipped, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+
+   full_crop = cropRegion(full, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+   clipped_crop = cropRegion(clipped, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+
+   assert(hashBitmap(clipped_crop) is hashBitmap(full_crop),
+      'Clipped isolated redraw should match the full render inside the clip')
+   assert(hashBitmap(clipped) is hashBitmap(expected),
+      'Clipped isolated redraw should leave outside pixels untouched')
+end
+
+@Test function RepeatedIsolatedRendersAreStableAcrossClipSizes()
+   scene = buildScene(true)
+   full_first = newBitmap('0,0,0,255')
+   full_second = newBitmap('0,0,0,255')
+   clipped_first = newBitmap('240,0,160,255')
+   clipped_second = newBitmap('240,0,160,255')
+
+   drawScene(scene, full_first, 0, 0, WIDTH, HEIGHT)
+   drawScene(scene, clipped_first, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+   drawScene(scene, full_second, 0, 0, WIDTH, HEIGHT)
+   drawScene(scene, clipped_second, CLIP_LEFT, CLIP_TOP, CLIP_RIGHT, CLIP_BOTTOM)
+
+   assert(hashBitmap(full_first) is hashBitmap(full_second), 'Repeated full isolated renders should be stable')
+   assert(hashBitmap(clipped_first) is hashBitmap(clipped_second), 'Repeated clipped isolated renders should be stable')
+end

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -261,7 +261,8 @@ public:
       if (Bitmap) { FreeResource(Bitmap); Bitmap = nullptr; }
    };
 
-   objBitmap * get_bitmap(int Width, int Height, TClipRectangle<int> &Clip, bool Debug) {
+   objBitmap * get_bitmap(int Width, int Height, TClipRectangle<int> &Clip, bool Debug, OBJECTID Owner = 0,
+      CSTRING Name = "dummy_fx_bitmap") {
       kt::Log log;
 
       if (Width < Clip.right) Width = Clip.right;
@@ -283,10 +284,19 @@ public:
       }
       else {
          // NB: The clip region defines the true size and no data is allocated by the bitmap itself unless in debug mode.
-         Bitmap = objBitmap::create::local(
-            fl::Name("dummy_fx_bitmap"),
-            fl::Width(Width), fl::Height(Height), fl::BitsPerPixel(32),
-            fl::Flags(Debug ? BMF::ALPHA_CHANNEL : (BMF::ALPHA_CHANNEL|BMF::NO_DATA)));
+         if (Owner) {
+            Bitmap = objBitmap::create::local(
+               fl::Name(Name),
+               fl::Owner(Owner),
+               fl::Width(Width), fl::Height(Height), fl::BitsPerPixel(32),
+               fl::Flags(Debug ? BMF::ALPHA_CHANNEL : (BMF::ALPHA_CHANNEL|BMF::NO_DATA)));
+         }
+         else {
+            Bitmap = objBitmap::create::local(
+               fl::Name(Name),
+               fl::Width(Width), fl::Height(Height), fl::BitsPerPixel(32),
+               fl::Flags(Debug ? BMF::ALPHA_CHANNEL : (BMF::ALPHA_CHANNEL|BMF::NO_DATA)));
+         }
          if (!Bitmap) return nullptr;
       }
 
@@ -489,6 +499,7 @@ class extVector : public objVector {
    extVector           *AppendPath;
    DashedStroke        *DashArray;
    ClipMaskCache ClipCache;
+   filter_bitmap *IsolatedBuffer;
    JTYPE InputMask;
    int   NumericID;
    int   PathLength;
@@ -525,6 +536,7 @@ class extVector : public objVector {
       FillRule      = VFR::NON_ZERO;
       ClipRule      = VFR::NON_ZERO;
       Dirty         = RC::DIRTY;
+      IsolatedBuffer = nullptr;
       TabOrder      = 255;
       ColourSpace   = VCS::INHERIT;
       ValidState    = true;

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -290,6 +290,7 @@ static ERR VECTOR_Free(extVector *Self)
    if (Self->Fill[1].GradientTable) { delete Self->Fill[1].GradientTable; Self->Fill[1].GradientTable = nullptr; }
    if (Self->Stroke.GradientTable)  { delete Self->Stroke.GradientTable; Self->Stroke.GradientTable = nullptr; }
    if (Self->DashArray)             { delete Self->DashArray; Self->DashArray = nullptr; }
+   if (Self->IsolatedBuffer)        { delete Self->IsolatedBuffer; Self->IsolatedBuffer = nullptr; }
 
    // Patch the nearest vectors that are linked to this one.
    if (Self->Next) Self->Next->Prev = Self->Prev;


### PR DESCRIPTION
* Retained clipped NO_DATA scratch bitmaps for isolated vector rendering

* Added Flute coverage for clipped isolated redraws and background-filter stability