### PR TITLE
[Core] Added a Results field to the Script class and virtual field support to the IDL generator

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -3492,6 +3492,13 @@ class objScript : public Object {
       return ERR::Okay;
    }
 
+   inline ERR getResults(kt::vector<std::string> * &Value) noexcept {
+      auto field = &this->Class->Dictionary[16];
+      auto get_field = (ERR (*)(APTR, kt::vector<std::string> *&))field->GetValue;
+      auto error = get_field(this, Value);
+      return error;
+   }
+
    inline ERR getCacheFile(std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[20];
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
@@ -3505,13 +3512,6 @@ class objScript : public Object {
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
       RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getResults(kt::vector<std::string> * &Value) noexcept {
-      auto field = &this->Class->Dictionary[16];
-      auto get_field = (ERR (*)(APTR, kt::vector<std::string> *&))field->GetValue;
-      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3562,6 +3562,11 @@ class objScript : public Object {
       return ERR::Okay;
    }
 
+   inline ERR setResults(kt::vector<std::string> &Value) noexcept {
+      auto field = &this->Class->Dictionary[16];
+      return field->WriteValue(this, field, 0x00905300, &Value, int(Value.size()));
+   }
+
    inline ERR setCacheFile(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[20];
       return field->WriteValue(this, field, 0x00904300, &Value, 1);
@@ -3570,11 +3575,6 @@ class objScript : public Object {
    inline ERR setWorkingPath(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
       return field->WriteValue(this, field, 0x00804300, &Value, 1);
-   }
-
-   inline ERR setResults(const kt::vector<std::string> *Value) noexcept {
-      auto field = &this->Class->Dictionary[16];
-      return field->WriteValue(this, field, 0x00905300, Value, int(Value->size()));
    }
 
    inline ERR setStatement(const std::string_view &Value) noexcept {

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1480,6 +1480,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
     error Error         # If an error occurred, this field will indicate the error number
     int CurrentLine     # Current line being executed, or failed line if script execution terminated
     int LineOffset      # An optional offset to use when reporting line numbers
+    !vector(string) Results
   ]],
   [[
    int64_t  ProcedureID;          // For callbacks

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -96,7 +96,16 @@ global function extractFields(Def:str, Origin:str):table
       local type, name = rx_type_name.extract(content)
 
       if type?? then
-         field = cType({ type=type:trim(), name=name:trim(), comment=string.trim(comment) }, Origin)
+         local virtual = false
+         type = type:trim()
+
+         if type:startsWith('!') then
+            virtual = true
+            type = type:sub(1):trim()
+         end
+
+         field = cType({ type=type, name=name:trim(), comment=string.trim(comment) }, Origin)
+         if virtual then field.virtual = true end
          table.insert(fields, field)
       elseif not content:trim()?? then
          -- Ignore empty line

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -385,7 +385,7 @@ function outputFieldWriteSignature(Field:table, FidName:str, FieldType:str)
       output(f'   inline ERR set{FidName}({array_type} Value, int Elements) noexcept {{')
    elseif Field.flags has FD_ARRAY then
       if Field.flags has FD_CPP then -- kt::vector
-         output(f'   inline ERR set{FidName}({Field.basicType} &Value) noexcept {{')
+         output(f'   inline ERR set{FidName}(const {Field.basicType} &Value) noexcept {{')
       else
          output(f'   inline ERR set{FidName}({FieldType} Value, int Elements) noexcept {{')
       end

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -385,7 +385,7 @@ function outputFieldWriteSignature(Field:table, FidName:str, FieldType:str)
       output(f'   inline ERR set{FidName}({array_type} Value, int Elements) noexcept {{')
    elseif Field.flags has FD_ARRAY then
       if Field.flags has FD_CPP then -- kt::vector
-         output(f'   inline ERR set{FidName}({FieldType} *Value) noexcept {{')
+         output(f'   inline ERR set{FidName}({Field.basicType} &Value) noexcept {{')
       else
          output(f'   inline ERR set{FidName}({FieldType} Value, int Elements) noexcept {{')
       end
@@ -428,7 +428,7 @@ function outputFieldWriteSetter(Class:table, Field:table, FidName:str, FieldType
    elseif Field.flags has FD_ARRAY then
       local flags = fieldFlagsHex(Field.flags)
       if Field.flags has FD_CPP then -- kt::vector
-         output(Indent .. 'return field->WriteValue(this, field, 0x' .. flags .. ', Value, int(Value->size()));')
+         output(Indent .. 'return field->WriteValue(this, field, 0x' .. flags .. ', &Value, int(Value.size()));')
       else
          output(Indent .. 'return field->WriteValue(this, field, 0x' .. flags .. ', Value, Elements);')
       end


### PR DESCRIPTION
* Declared the Script Results field as a virtual vector(string) in core.tdl
* [Tools] Taught the IDL field parser to recognise the '!' prefix marking a field as virtual
* [Tools] Changed generated kt::vector array setters to take a reference instead of a pointer