### PR TITLE
[Vector] Store supershape dimensions as Unit fields

### DIFF
--- a/docs/xml/modules/classes/vectorpolygon.xml
+++ b/docs/xml/modules/classes/vectorpolygon.xml
@@ -117,16 +117,6 @@
     </field>
 
     <field>
-      <name>TotalPoints</name>
-      <comment>The total number of coordinates defined in the Points field.</comment>
-      <access read="G">Get</access>
-      <type>INT</type>
-      <description>
-<p>TotalPoints is a read-only field value that reflects the total number of coordinates that have been set in the <fl>Points</fl> array.  The minimum value is 2.</p>
-      </description>
-    </field>
-
-    <field>
       <name>X1</name>
       <comment>Defines the X coordinate of the first point.</comment>
       <access read="G" write="S">Get/Set</access>

--- a/docs/xml/modules/classes/vectorshape.xml
+++ b/docs/xml/modules/classes/vectorshape.xml
@@ -45,7 +45,7 @@
       <name>CenterX</name>
       <comment>The center of the shape on the x-axis.  Expressed as a fixed or scaled coordinate.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The horizontal center of the shape is defined here as either a fixed or scaled value.</p>
       </description>
@@ -55,7 +55,7 @@
       <name>CenterY</name>
       <comment>The center of the shape on the y-axis.  Expressed as a fixed or scaled coordinate.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The vertical center of the shape is defined here as either a fixed or scaled value.</p>
       </description>
@@ -68,24 +68,6 @@
       <type>INT</type>
       <description>
 <p>If TRUE, the shape path will be closed between the beginning and end points.</p>
-      </description>
-    </field>
-
-    <field>
-      <name>Dimensions</name>
-      <comment>Dimension flags define whether individual dimension fields contain fixed or scaled values.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type lookup="DMF">DMF</type>
-      <description>
-<p>The following dimension flags are supported:</p>
-<types lookup="DMF">
-<type name="FIXED_CENTER_X">The <fl>CenterX</fl> value is a fixed coordinate.</type>
-<type name="FIXED_CENTER_Y">The <fl>CenterY</fl> value is a fixed coordinate.</type>
-<type name="FIXED_RADIUS">The <fl>Radius</fl> value is a fixed coordinate.</type>
-<type name="SCALED_CENTER_X">The <fl>CenterX</fl> value is a scaled coordinate.</type>
-<type name="SCALED_CENTER_Y">The <fl>CenterY</fl> value is a scaled coordinate.</type>
-<type name="SCALED_RADIUS">The <fl>Radius</fl> value is a scaled coordinate.</type>
-</types>
       </description>
     </field>
 
@@ -164,7 +146,7 @@
       <name>Radius</name>
       <comment>The radius of the generated shape.  Expressed as a fixed or scaled coordinate.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The Radius defines the final size of the generated shape.  It can be expressed in fixed or scaled terms.</p>
       </description>
@@ -202,37 +184,6 @@
     </field>
 
   </fields>
-  <types>
-    <constants lookup="DMF">
-      <const name="FIXED_CENTER_X">The CenterX field is a fixed size.</const>
-      <const name="FIXED_CENTER_Y">The CenterY field is a fixed size.</const>
-      <const name="FIXED_DEPTH">The Depth field is a fixed size.</const>
-      <const name="FIXED_HEIGHT">The Height field is a fixed size.</const>
-      <const name="FIXED_RADIUS_X">The RadiusX field is a fixed size.</const>
-      <const name="FIXED_RADIUS_Y">The RadiusY field is a fixed size.</const>
-      <const name="FIXED_WIDTH">The Width field is a fixed suze.</const>
-      <const name="FIXED_X">The X field is a fixed coordinate.</const>
-      <const name="FIXED_X_OFFSET">The XOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Y">The Y field is a fixed coordinate.</const>
-      <const name="FIXED_Y_OFFSET">The YOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Z">The Z field is a fixed coordinate.</const>
-      <const name="SCALED_CENTER_X">The CenterX field is scaled to this object's parent.</const>
-      <const name="SCALED_CENTER_Y">The CenterY field is scaled to this object's parent.</const>
-      <const name="SCALED_DEPTH">The Depth field is scaled to this object's parent.</const>
-      <const name="SCALED_HEIGHT">The Height field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_X">The RadiusX field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_Y">The RadiusY field is a scaled size to this object's parent.</const>
-      <const name="SCALED_WIDTH">The Width field is scaled to this object's parent.</const>
-      <const name="SCALED_X">The X field is scaled to this object's parent.</const>
-      <const name="SCALED_X_OFFSET">The XOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Y">The Y field is scaled to this object's parent.</const>
-      <const name="SCALED_Y_OFFSET">The YOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Z">The Z field is a scaled coordinate to this object's parent.</const>
-      <const name="STATUS_CHANGE_H"/>
-      <const name="STATUS_CHANGE_V"/>
-    </constants>
-
-  </types>
   <structs>
   </structs>
 </book>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -4921,17 +4921,12 @@ class objVectorPolygon : public objVector {
    }
 
    inline ERR getClosed(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
+      auto field = &this->Class->Dictionary[53];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getPathLength(int &Value) noexcept {
       auto field = &this->Class->Dictionary[51];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getTotalPoints(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[53];
       return field->GetValue(this, &Value);
    }
 
@@ -4964,7 +4959,7 @@ class objVectorPolygon : public objVector {
    }
 
    inline ERR setClosed(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
+      auto field = &this->Class->Dictionary[53];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -5017,37 +5012,23 @@ class objVectorShape : public objVector {
 
    // Customised field getting
 
-   inline ERR getDimensions(DMF &Value) noexcept {
-      auto field = &this->Class->Dictionary[51];
+   inline ERR getCenterX(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[50];
       return field->GetValue(this, &Value);
    }
 
-   inline ERR getCenterX(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[50];
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
-      return error;
+   inline ERR getCenterY(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[57];
+      return field->GetValue(this, &Value);
    }
 
-   inline ERR getCenterY(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[58];
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
-      return error;
-   }
-
-   inline ERR getRadius(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[64];
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
-      return error;
+   inline ERR getRadius(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[63];
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getClose(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[52];
+      auto field = &this->Class->Dictionary[51];
       return field->GetValue(this, &Value);
    }
 
@@ -5057,17 +5038,17 @@ class objVectorShape : public objVector {
    }
 
    inline ERR getA(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[60];
+      auto field = &this->Class->Dictionary[59];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getB(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[63];
+      auto field = &this->Class->Dictionary[62];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getM(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[55];
+      auto field = &this->Class->Dictionary[54];
       return field->GetValue(this, &Value);
    }
 
@@ -5082,58 +5063,50 @@ class objVectorShape : public objVector {
    }
 
    inline ERR getN3(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[57];
+      auto field = &this->Class->Dictionary[56];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getVertices(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[62];
+      auto field = &this->Class->Dictionary[61];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getMod(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getSpiral(int &Value) noexcept {
       auto field = &this->Class->Dictionary[53];
       return field->GetValue(this, &Value);
    }
 
+   inline ERR getSpiral(int &Value) noexcept {
+      auto field = &this->Class->Dictionary[52];
+      return field->GetValue(this, &Value);
+   }
+
    inline ERR getRepeat(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[56];
+      auto field = &this->Class->Dictionary[55];
       return field->GetValue(this, &Value);
    }
 
 
    // Customised field setting
 
-   inline ERR setDimensions(const DMF Value) noexcept {
-      auto field = &this->Class->Dictionary[51];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setCenterX(const double Value) noexcept {
+   inline ERR setCenterX(const Unit Value) noexcept {
       auto field = &this->Class->Dictionary[50];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setCenterY(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[58];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setCenterY(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[57];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setRadius(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[64];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setRadius(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[63];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
    inline ERR setClose(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[52];
+      auto field = &this->Class->Dictionary[51];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -5143,17 +5116,17 @@ class objVectorShape : public objVector {
    }
 
    inline ERR setA(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[60];
+      auto field = &this->Class->Dictionary[59];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
    inline ERR setB(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[63];
+      auto field = &this->Class->Dictionary[62];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
    inline ERR setM(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[55];
+      auto field = &this->Class->Dictionary[54];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
@@ -5168,27 +5141,27 @@ class objVectorShape : public objVector {
    }
 
    inline ERR setN3(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[57];
+      auto field = &this->Class->Dictionary[56];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
    inline ERR setVertices(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[62];
+      auto field = &this->Class->Dictionary[61];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setMod(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setSpiral(const int Value) noexcept {
       auto field = &this->Class->Dictionary[53];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
+   inline ERR setSpiral(const int Value) noexcept {
+      auto field = &this->Class->Dictionary[52];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
    inline ERR setRepeat(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[56];
+      auto field = &this->Class->Dictionary[55];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <memory>
 #include <sstream>
+#include <type_traits>
 #ifndef STRINGS_HPP
 #include <kotuku/strings.hpp>
 #endif
@@ -599,6 +600,16 @@ inline void NewAttrib(XTag &Tag, const std::string_view Name, const std::string_
 
 inline void NewAttrib(XTag *Tag, const std::string_view Name, const std::string_view Value) {
    Tag->Attribs.emplace_back(Name, Value);
+}
+
+template <class T> requires std::is_arithmetic_v<T>
+inline void NewAttrib(XTag &Tag, const std::string_view Name, const T Value) {
+   Tag.Attribs.emplace_back(Name, std::to_string(Value));
+}
+
+template <class T> requires std::is_arithmetic_v<T>
+inline void NewAttrib(XTag *Tag, const std::string_view Name, const T Value) {
+   Tag->Attribs.emplace_back(Name, std::to_string(Value));
 }
 
 inline std::string GetContent(const XTag &Tag) {

--- a/src/svg/save_svg.cpp
+++ b/src/svg/save_svg.cpp
@@ -2,14 +2,14 @@
 static void set_dimension(XTag *Tag, const std::string Attrib, double Value, bool Scaled)
 {
    if (Scaled) xml::NewAttrib(*Tag, Attrib, std::to_string(Value * 100.0) + "%");
-   else xml::NewAttrib(*Tag, Attrib, std::to_string(Value));
+   else xml::NewAttrib(*Tag, Attrib, Value);
 }
 
 static void set_dimension(XTag *Tag, const std::string Attrib, Unit &Value)
 {
    if (Value.defined()) {
       if (Value.scaled()) xml::NewAttrib(*Tag, Attrib, std::to_string(Value * 100.0) + "%");
-      else xml::NewAttrib(*Tag, Attrib, std::to_string(double(Value)));
+      else xml::NewAttrib(*Tag, Attrib, double(Value));
    }
 }
 
@@ -110,7 +110,7 @@ static ERR save_svg_defs(extSVG *Self, objXML *XML, objVectorScene *Scene, int P
 
             double resolution;
             if ((!error) and (!gradient->getResolution(resolution)) and (resolution != 1.0)) {
-               xml::NewAttrib(tag, "resolution", std::to_string(resolution));
+               xml::NewAttrib(tag, "resolution", resolution);
             }
 
             if (def->classID() IS CLASSID::GRADIENTLINEAR) {
@@ -161,7 +161,7 @@ static ERR save_svg_defs(extSVG *Self, objXML *XML, objVectorScene *Scene, int P
 
                   double span;
                   if ((!error) and (!conic->getSpan(span)) and (span != 1.0)) {
-                     xml::NewAttrib(tag, "span", std::to_string(span));
+                     xml::NewAttrib(tag, "span", span);
                   }
                }
                else {
@@ -188,14 +188,14 @@ static ERR save_svg_defs(extSVG *Self, objXML *XML, objVectorScene *Scene, int P
                   if (!(error = XML->insertXML(tag->ID, XMI::CHILD_END, "<stop/>", &stop_index))) {
                      XTag *stop_tag;
                      error = XML->getTag(stop_index, &stop_tag);
-                     if (!error) xml::NewAttrib(stop_tag, "offset", std::to_string(stop.Offset));
+                     if (!error) xml::NewAttrib(stop_tag, "offset", stop.Offset);
 
                      std::stringstream buffer;
                      buffer << "rgb(" << stop.RGB.Red*255.0 << "," << stop.RGB.Green*255.0 << ","
                         << stop.RGB.Blue*255.0 << ")";
                      if (!error) xml::NewAttrib(stop_tag, "stop-color", buffer.str());
                      if ((!error) and (stop.RGB.Alpha != 1.0)) {
-                        xml::NewAttrib(stop_tag, "stop-opacity", std::to_string(stop.RGB.Alpha));
+                        xml::NewAttrib(stop_tag, "stop-opacity", stop.RGB.Alpha);
                      }
                   }
                }
@@ -302,9 +302,9 @@ static ERR save_svg_scan_std(extSVG *Self, objXML *XML, objVector *Vector, int T
    XTag *tag;
    if ((error = XML->getTag(TagID, &tag)) != ERR::Okay) return error;
 
-   if (Vector->Opacity != 1.0) xml::NewAttrib(tag, "opacity", std::to_string(Vector->Opacity));
-   if (Vector->FillOpacity != 1.0) xml::NewAttrib(tag, "fill-opacity", std::to_string(Vector->FillOpacity));
-   if (Vector->StrokeOpacity != 1.0) xml::NewAttrib(tag, "stroke-opacity", std::to_string(Vector->StrokeOpacity));
+   if (Vector->Opacity != 1.0) xml::NewAttrib(tag, "opacity", (Vector->Opacity));
+   if (Vector->FillOpacity != 1.0) xml::NewAttrib(tag, "fill-opacity", (Vector->FillOpacity));
+   if (Vector->StrokeOpacity != 1.0) xml::NewAttrib(tag, "stroke-opacity", (Vector->StrokeOpacity));
 
    if ((!Vector->getStroke(sv)) and not sv.empty()) {
       xml::NewAttrib(tag, "stroke", sv);
@@ -343,7 +343,7 @@ static ERR save_svg_scan_std(extSVG *Self, objXML *XML, objVector *Vector, int T
    if ((!error) and (!Vector->getDashArray(dash_array)) and (not dash_array.empty())) {
       double dash_offset;
       if ((!Vector->getDashOffset(dash_offset)) and (dash_offset != 0)) {
-         xml::NewAttrib(tag, "stroke-dashoffset", std::to_string(Vector->DashOffset));
+         xml::NewAttrib(tag, "stroke-dashoffset", (Vector->DashOffset));
       }
 
       int pos = 0;
@@ -373,7 +373,12 @@ static ERR save_svg_scan_std(extSVG *Self, objXML *XML, objVector *Vector, int T
    Unit stroke_width;
    if ((!error) and (!Vector->getStrokeWidth(stroke_width))) {
       if (not stroke_width.defined()) stroke_width = 0;
-      if (stroke_width != 1) xml::NewAttrib(tag, "stroke-width", std::to_string(stroke_width));
+      if (stroke_width.scaled()) {
+         xml::NewAttrib(tag, "stroke-width", std::to_string(stroke_width) + "%");
+      }
+      else if (stroke_width != 1) {
+         xml::NewAttrib(tag, "stroke-width", std::to_string(stroke_width));
+      }
    }
 
    if ((!error) and (!Vector->getFill(sv)) and not sv.empty()) {
@@ -545,7 +550,7 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
 
       int path_length;
       if ((!(error = vp->getPathLength(path_length))) and (path_length != 0)) {
-         xml::NewAttrib(tag, "pathLength", std::to_string(path_length));
+         xml::NewAttrib(tag, "pathLength", (path_length));
       }
 
       if (!error) error = save_svg_scan_std(Self, XML, Vector, tag->ID);
@@ -603,13 +608,13 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
       }
 
       if ((!error) and (!(error = vt->getTextLength(text_length))) and (text_length))
-         xml::NewAttrib(tag, "textLength", std::to_string(text_length));
+         xml::NewAttrib(tag, "textLength", text_length);
 
       if ((!error) and (!(error = vt->getFace(sv))))
          xml::NewAttrib(tag, "font-family", sv);
 
       if ((!error) and (!(error = vt->getWeight(weight))) and (weight != 400))
-         xml::NewAttrib(tag, "font-weight", std::to_string(weight));
+         xml::NewAttrib(tag, "font-weight", weight);
 
       if ((!error) and (!(error = vt->getString(sv))))
          error = XML->insertContent(tag->ID, XMI::CHILD, sv, nullptr);
@@ -652,18 +657,18 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
       if (!error) {
          DMF dim;
          wave->getDimensions(dim);
-         if (!wave->getX(dbl)) set_dimension(tag, "x", dbl, dmf::hasScaledX(dim));
-         if (!wave->getY(dbl)) set_dimension(tag, "y", dbl, dmf::hasScaledY(dim));
-         if (!wave->getWidth(dbl)) set_dimension(tag, "width", dbl, dmf::hasScaledWidth(dim));
-         if (!wave->getHeight(dbl)) set_dimension(tag, "height", dbl, dmf::hasScaledHeight(dim));
-         if (!wave->getAmplitude(dbl)) xml::NewAttrib(tag, "amplitude", std::to_string(dbl));
-         if (!wave->getFrequency(dbl)) xml::NewAttrib(tag, "frequency", std::to_string(dbl));
-         if (!wave->getDecay(dbl)) xml::NewAttrib(tag, "decay", std::to_string(dbl));
-         if (!wave->getDegree(dbl)) xml::NewAttrib(tag, "degree", std::to_string(dbl));
+         if (!wave->getX(dbl))         set_dimension(tag, "x", dbl, dmf::hasScaledX(dim));
+         if (!wave->getY(dbl))         set_dimension(tag, "y", dbl, dmf::hasScaledY(dim));
+         if (!wave->getWidth(dbl))     set_dimension(tag, "width", dbl, dmf::hasScaledWidth(dim));
+         if (!wave->getHeight(dbl))    set_dimension(tag, "height", dbl, dmf::hasScaledHeight(dim));
+         if (!wave->getAmplitude(dbl)) xml::NewAttrib(tag, "amplitude", dbl);
+         if (!wave->getFrequency(dbl)) xml::NewAttrib(tag, "frequency", dbl);
+         if (!wave->getDecay(dbl))     xml::NewAttrib(tag, "decay", dbl);
+         if (!wave->getDegree(dbl))    xml::NewAttrib(tag, "degree", dbl);
 
          int close;
-         if (!wave->getClose(close)) xml::NewAttrib(tag, "close", std::to_string(close));
-         if (!wave->getThickness(dbl)) xml::NewAttrib(tag, "thickness", std::to_string(dbl));
+         if (!wave->getClose(close)) xml::NewAttrib(tag, "close", close);
+         if (!wave->getThickness(dbl)) xml::NewAttrib(tag, "thickness", dbl);
 
          if (!error) error = save_svg_scan_std(Self, XML, Vector, tag->ID);
       }
@@ -684,10 +689,10 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
          if (!spiral->getCenterY(dbl)) set_dimension(tag, "cy", dbl, dmf::hasScaledCenterY(dim));
          if (!spiral->getWidth(dbl))   set_dimension(tag, "width", dbl, dmf::hasScaledWidth(dim));
          if (!spiral->getHeight(dbl))  set_dimension(tag, "height", dbl, dmf::hasScaledHeight(dim));
-         if (!spiral->getOffset(dbl))  xml::NewAttrib(tag, "offset", std::to_string(dbl));
+         if (!spiral->getOffset(dbl))  xml::NewAttrib(tag, "offset", dbl);
          if (!spiral->getRadius(dbl))  set_dimension(tag, "r", dbl, dmf::hasAnyScaledRadius(dim));
-         if (!spiral->getStep(dbl))    xml::NewAttrib(tag, "step", std::to_string(dbl));
-         if ((!spiral->getPathLength(length)) and (length != 0)) xml::NewAttrib(tag, "pathLength", std::to_string(length));
+         if (!spiral->getStep(dbl))    xml::NewAttrib(tag, "step", dbl);
+         if ((!spiral->getPathLength(length)) and (length != 0)) xml::NewAttrib(tag, "pathLength", length);
 
          error = save_svg_scan_std(Self, XML, Vector, tag->ID);
       }
@@ -696,28 +701,27 @@ static ERR save_svg_scan(extSVG *Self, objXML *XML, objVector *Vector, int Paren
       auto shape = (objVectorShape *)Vector;
       XTag *tag;
       double dbl;
+      Unit val;
       int num;
 
       error = XML->insertStatement(Parent, XMI::CHILD_END, "<kotuku:shape/>", &tag);
 
       if (!error) {
-         DMF dim;
-         shape->getDimensions(dim);
-         if (!shape->getCenterX(dbl)) set_dimension(tag, "cx", dbl, dmf::hasScaledCenterX(dim));
-         if (!shape->getCenterY(dbl)) set_dimension(tag, "cy", dbl, dmf::hasScaledCenterY(dim));
-         if (!shape->getRadius(dbl)) set_dimension(tag, "r", dbl, dmf::hasAnyScaledRadius(dim));
-         if (!shape->getA(dbl)) xml::NewAttrib(tag, "a", std::to_string(dbl));
-         if (!shape->getB(dbl)) xml::NewAttrib(tag, "b", std::to_string(dbl));
-         if (!shape->getM(dbl)) xml::NewAttrib(tag, "m", std::to_string(dbl));
-         if (!shape->getN1(dbl)) xml::NewAttrib(tag, "n1", std::to_string(dbl));
-         if (!shape->getN2(dbl)) xml::NewAttrib(tag, "n2", std::to_string(dbl));
-         if (!shape->getN3(dbl)) xml::NewAttrib(tag, "n3", std::to_string(dbl));
-         if (!shape->getPhi(dbl)) xml::NewAttrib(tag, "phi", std::to_string(dbl));
-         if (!shape->getVertices(num)) xml::NewAttrib(tag, "vertices", std::to_string(num));
-         if (!shape->getMod(num)) xml::NewAttrib(tag, "mod", std::to_string(num));
-         if (!shape->getSpiral(num)) xml::NewAttrib(tag, "spiral", std::to_string(num));
-         if (!shape->getRepeat(num)) xml::NewAttrib(tag, "repeat", std::to_string(num));
-         if (!shape->getClose(num)) xml::NewAttrib(tag, "close", std::to_string(num));
+         if (!shape->getCenterX(val))  set_dimension(tag, "cx", val);
+         if (!shape->getCenterY(val))  set_dimension(tag, "cy", val);
+         if (!shape->getRadius(val))   set_dimension(tag, "r", val);
+         if (!shape->getA(dbl))        xml::NewAttrib(tag, "a", dbl);
+         if (!shape->getB(dbl))        xml::NewAttrib(tag, "b", dbl);
+         if (!shape->getM(dbl))        xml::NewAttrib(tag, "m", dbl);
+         if (!shape->getN1(dbl))       xml::NewAttrib(tag, "n1", dbl);
+         if (!shape->getN2(dbl))       xml::NewAttrib(tag, "n2", dbl);
+         if (!shape->getN3(dbl))       xml::NewAttrib(tag, "n3", dbl);
+         if (!shape->getPhi(dbl))      xml::NewAttrib(tag, "phi", dbl);
+         if (!shape->getVertices(num)) xml::NewAttrib(tag, "vertices", num);
+         if (!shape->getMod(num))      xml::NewAttrib(tag, "mod", num);
+         if (!shape->getSpiral(num))   xml::NewAttrib(tag, "spiral", num);
+         if (!shape->getRepeat(num))   xml::NewAttrib(tag, "repeat", num);
+         if (!shape->getClose(num))    xml::NewAttrib(tag, "close", num);
 
          error = save_svg_scan_std(Self, XML, Vector, tag->ID);
       }

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -700,7 +700,6 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
   ]])
 
   klass('VectorShape', { base='Vector', src='vectors/supershape.cpp', extended=true }, [[
-    ~int(DMF) Dimensions
   ]])
 
   klass('VectorSpiral', { base='Vector', src='vectors/spiral.cpp', output='vectors/spiral_def.cpp', extended=true }, [[

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -78,13 +78,13 @@ static ERR read_points(extVectorPolygon *Self, std::string_view Value)
 
    double x = 0, y = 0;
    bool expect_x = true;
-   while (!Value.empty()) {
+   while (not Value.empty()) {
       if (std::isdigit(Value.front()) or (Value.front() == '-')) {
          auto [ptr, error] = std::from_chars(Value.data(), Value.data() + Value.size(), expect_x ? x : y);
          if (error != std::errc()) break;
          Value.remove_prefix(ptr - Value.data());
 
-         if (!expect_x) Self->Points.emplace_back(VectorPoint{x, y});
+         if (not expect_x) Self->Points.emplace_back(VectorPoint{x, y});
 
          expect_x = !expect_x;
       }
@@ -92,15 +92,11 @@ static ERR read_points(extVectorPolygon *Self, std::string_view Value)
    }
 
    if (Self->Points.size() < 2) {
-      kt::Log log(__FUNCTION__);
-      log.traceWarning("List of points requires a minimum of 2 number pairs.");
       Self->Points.clear();
-      return log.warning(ERR::InvalidValue);
+      return kt::Log(__FUNCTION__).warning(ERR::InvalidValue);
    }
    return ERR::Okay;
 }
-
-//********************************************************************************************************************
 
 /*********************************************************************************************************************
 -ACTION-
@@ -110,9 +106,7 @@ Move: Moves a polygon to a new position.
 
 static ERR VECTORPOLYGON_Move(extVectorPolygon *Self, struct acMove *Args)
 {
-   kt::Log log;
-
-   if (!Args) return log.warning(ERR::NullArgs);
+   if (not Args) return ERR::NullArgs;
 
    // If any of the polygon's points are relative then we have to cancel the move.
    for (unsigned i=0; i < Self->Points.size(); i++) {
@@ -145,9 +139,7 @@ The operation will abort if any of the points in the polygon are discovered to b
 
 static ERR VECTORPOLYGON_MoveToPoint(extVectorPolygon *Self, struct acMoveToPoint *Args)
 {
-   kt::Log log;
-
-   if (!Args) return log.warning(ERR::NullArgs);
+   if (not Args) return ERR::NullArgs;
 
    // Check if any of the polygon's points are relative, in which case we have to cancel the move.
    for (unsigned i=0; i < Self->Points.size(); i++) {
@@ -203,9 +195,7 @@ If a Width and/or Height value of zero is passed, no scaling on the associated a
 
 static ERR VECTORPOLYGON_Resize(extVectorPolygon *Self, struct acResize *Args)
 {
-   kt::Log log;
-
-   if (!Args) return log.warning(ERR::NullArgs);
+   if (not Args) return ERR::NullArgs;
 
    double current_width = Self->Bounds.width();
    double current_height = Self->Bounds.height();
@@ -315,21 +305,6 @@ static ERR POLY_SET_Points(extVectorPolygon *Self, const std::string_view &Value
       return ERR::Okay;
    }
    else return error;
-}
-
-/*********************************************************************************************************************
--FIELD-
-TotalPoints: The total number of coordinates defined in the Points field.
-
-TotalPoints is a read-only field value that reflects the total number of coordinates that have been set in the
-#Points array.  The minimum value is 2.
-
-*********************************************************************************************************************/
-
-static ERR POLY_GET_TotalPoints(extVectorPolygon *Self, int *Value)
-{
-   *Value = Self->Points.size();
-   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -445,7 +420,6 @@ static const FieldArray clPolygonFields[] = {
    { "PathLength",  FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE,              POLY_GET_PathLength, POLY_SET_PathLength },
    { "PointsArray", FDF_VIRTUAL|FDF_ARRAY|FDF_STRUCT|FDF_RW|FDF_PURE, POLY_GET_PointsArray, POLY_SET_PointsArray, "VectorPoint" },
    { "Points",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_W,                  nullptr, POLY_SET_Points },
-   { "TotalPoints", FDF_VIRTUAL|FDF_INT|FDF_R|FDF_PURE,               POLY_GET_TotalPoints },
    { "X1",          FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, POLY_GET_X1, POLY_SET_X1 },
    { "Y1",          FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, POLY_GET_Y1, POLY_SET_Y1 },
    { "X2",          FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, POLY_GET_X2, POLY_SET_X2 },

--- a/src/vector/vectors/supershape.cpp
+++ b/src/vector/vectors/supershape.cpp
@@ -21,31 +21,48 @@ class extVectorShape : public extVector {
    static constexpr CSTRING CLASS_NAME = "VectorShape";
    using create = kt::Create<extVectorShape>;
 
-   double Radius;
-   double CX, CY;
+   Unit Radius;
+   Unit CX, CY;
    double M, N1, N2, N3, A, B, Phi;
    int Vertices;
    int Spiral;
    int Repeat;
-   DMF Dimensions;
    bool Close;
    uint8_t Mod;
 };
 
 //********************************************************************************************************************
 
+static double shape_fixed_x(extVectorShape *Vector, const Unit &Value)
+{
+   if (!Value.defined()) return 0;
+   return Value.scaled() ? double(Value) * get_parent_width(Vector) : double(Value);
+}
+
+static double shape_fixed_y(extVectorShape *Vector, const Unit &Value)
+{
+   if (!Value.defined()) return 0;
+   return Value.scaled() ? double(Value) * get_parent_height(Vector) : double(Value);
+}
+
+static double shape_fixed_radius(extVectorShape *Vector, const Unit &Value)
+{
+   if (!Value.defined()) return 0;
+   return Value.scaled() ? double(Value) * svg_diag(get_parent_width(Vector), get_parent_height(Vector)) : double(Value);
+}
+
+//********************************************************************************************************************
+
 static void generate_supershape(extVectorShape *Vector, agg::path_storage &Path)
 {
-   double cx = Vector->CX, cy = Vector->CY;
+   double cx = shape_fixed_x(Vector, Vector->CX);
+   double cy = shape_fixed_y(Vector, Vector->CY);
 
    agg::path_storage path_buffer, *target;
    if (Path.empty()) target = &Path;
    else target = &path_buffer;
 
-   if (dmf::hasScaledCenterX(Vector->Dimensions)) cx *= get_parent_width(Vector);
-   if (dmf::hasScaledCenterY(Vector->Dimensions)) cy *= get_parent_height(Vector);
-
-   const double scale = Vector->Radius;
+   const double scale = shape_fixed_radius(Vector, Vector->Radius);
    double rescale = 0;
    double tscale = Vector->Transform.scale();
 
@@ -146,6 +163,8 @@ static void generate_supershape(extVectorShape *Vector, agg::path_storage &Path)
 static ERR SUPER_NewObject(extVectorShape *Self)
 {
    Self->Radius = 100;
+   Self->CX = 0;
+   Self->CY = 0;
    Self->N1 = 0.1;
    Self->N2 = 1.7;
    Self->N3 = 1.7;
@@ -211,14 +230,12 @@ The horizontal center of the shape is defined here as either a fixed or scaled v
 
 static ERR SUPER_GET_CenterX(extVectorShape *Self, Unit *Value)
 {
-   Value->set(Self->CX);
+   *Value = Self->CX.defined() ? Self->CX : Unit(0);
    return ERR::Okay;
 }
 
 static ERR SUPER_SET_CenterX(extVectorShape *Self, Unit &Value)
 {
-   if (Value.scaled()) Self->Dimensions = (Self->Dimensions | DMF::SCALED_CENTER_X) & (~DMF::FIXED_CENTER_X);
-   else Self->Dimensions = (Self->Dimensions | DMF::FIXED_CENTER_X) & (~DMF::SCALED_CENTER_X);
    Self->CX = Value;
    reset_path(Self);
    return ERR::Okay;
@@ -234,14 +251,12 @@ The vertical center of the shape is defined here as either a fixed or scaled val
 
 static ERR SUPER_GET_CenterY(extVectorShape *Self, Unit *Value)
 {
-   Value->set(Self->CY);
+   *Value = Self->CY.defined() ? Self->CY : Unit(0);
    return ERR::Okay;
 }
 
 static ERR SUPER_SET_CenterY(extVectorShape *Self, Unit &Value)
 {
-   if (Value.scaled()) Self->Dimensions = (Self->Dimensions | DMF::SCALED_CENTER_Y) & (~DMF::FIXED_CENTER_Y);
-   else Self->Dimensions = (Self->Dimensions | DMF::FIXED_CENTER_Y) & (~DMF::SCALED_CENTER_Y);
    Self->CY = Value;
    reset_path(Self);
    return ERR::Okay;
@@ -264,37 +279,6 @@ static ERR SUPER_GET_Close(extVectorShape *Self, int *Value)
 static ERR SUPER_SET_Close(extVectorShape *Self, int Value)
 {
    Self->Close = Value;
-   reset_path(Self);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--FIELD-
-Dimensions: Dimension flags define whether individual dimension fields contain fixed or scaled values.
-
-The following dimension flags are supported:
-
-<types lookup="DMF">
-<type name="FIXED_CENTER_X">The #CenterX value is a fixed coordinate.</>
-<type name="FIXED_CENTER_Y">The #CenterY value is a fixed coordinate.</>
-<type name="FIXED_RADIUS">The #Radius value is a fixed coordinate.</>
-<type name="SCALED_CENTER_X">The #CenterX value is a scaled coordinate.</>
-<type name="SCALED_CENTER_Y">The #CenterY value is a scaled coordinate.</>
-<type name="SCALED_RADIUS">The #Radius value is a scaled coordinate.</>
-</types>
-
-*********************************************************************************************************************/
-
-static ERR SUPER_GET_Dimensions(extVectorShape *Self, DMF *Value)
-{
-   *Value = Self->Dimensions;
-   return ERR::Okay;
-}
-
-static ERR SUPER_SET_Dimensions(extVectorShape *Self, DMF Value)
-{
-   Self->Dimensions = Value;
    reset_path(Self);
    return ERR::Okay;
 }
@@ -455,15 +439,12 @@ The Radius defines the final size of the generated shape.  It can be expressed i
 
 static ERR SUPER_GET_Radius(extVectorShape *Self, Unit *Value)
 {
-   Value->set(Self->Radius);
+   *Value = Self->Radius.defined() ? Self->Radius : Unit(0);
    return ERR::Okay;
 }
 
 static ERR SUPER_SET_Radius(extVectorShape *Self, Unit &Value)
 {
-   if (Value.scaled()) Self->Dimensions = (Self->Dimensions|DMF::SCALED_RADIUS_X|DMF::SCALED_RADIUS_Y) & (~(DMF::FIXED_RADIUS_X|DMF::FIXED_RADIUS_Y));
-   else Self->Dimensions = (Self->Dimensions|DMF::FIXED_RADIUS_X|DMF::FIXED_RADIUS_Y) & (~(DMF::SCALED_RADIUS_X|DMF::SCALED_RADIUS_Y));
-
    Self->Radius = Value;
    reset_path(Self);
    return ERR::Okay;
@@ -549,40 +530,31 @@ static ERR SUPER_SET_Vertices(extVectorShape *Self, int Value)
 
 //********************************************************************************************************************
 
-static const FieldDef clSuperDimensions[] = {
-   { "FixedCenterX",  DMF::FIXED_CENTER_X },
-   { "FixedCenterY",  DMF::FIXED_CENTER_Y },
-   { "ScaledCenterX", DMF::SCALED_CENTER_X },
-   { "ScaledCenterY", DMF::SCALED_CENTER_Y },
-   { nullptr, 0 }
-};
-
 static const ActionArray clVectorShapeActions[] = {
    { AC::NewObject, SUPER_NewObject },
    { AC::NIL, nullptr }
 };
 
 static const FieldArray clVectorShapeFields[] = {
-   { "CenterX",    FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterX, SUPER_SET_CenterX },
-   { "CenterY",    FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterY, SUPER_SET_CenterY },
-   { "Radius",     FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_Radius,  SUPER_SET_Radius },
-   { "Close",      FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Close, SUPER_SET_Close },
-   { "Dimensions", FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW|FDF_PURE, SUPER_GET_Dimensions, SUPER_SET_Dimensions, &clSuperDimensions },
-   { "Phi",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_Phi,  SUPER_SET_Phi },
-   { "A",          FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_A,  SUPER_SET_A },
-   { "B",          FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_B,  SUPER_SET_B },
-   { "M",          FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_M,  SUPER_SET_M },
-   { "N1",         FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N1, SUPER_SET_N1 },
-   { "N2",         FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N2, SUPER_SET_N2 },
-   { "N3",         FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N3, SUPER_SET_N3 },
-   { "Vertices",   FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Vertices, SUPER_SET_Vertices },
-   { "Mod",        FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Mod, SUPER_SET_Mod },
-   { "Spiral",     FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Spiral, SUPER_SET_Spiral },
-   { "Repeat",     FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Repeat, SUPER_SET_Repeat },
+   { "CenterX",  FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterX, SUPER_SET_CenterX },
+   { "CenterY",  FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterY, SUPER_SET_CenterY },
+   { "Radius",   FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_Radius,  SUPER_SET_Radius },
+   { "Close",    FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Close, SUPER_SET_Close },
+   { "Phi",      FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_Phi,  SUPER_SET_Phi },
+   { "A",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_A,  SUPER_SET_A },
+   { "B",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_B,  SUPER_SET_B },
+   { "M",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_M,  SUPER_SET_M },
+   { "N1",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N1, SUPER_SET_N1 },
+   { "N2",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N2, SUPER_SET_N2 },
+   { "N3",       FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, SUPER_GET_N3, SUPER_SET_N3 },
+   { "Vertices", FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Vertices, SUPER_SET_Vertices },
+   { "Mod",      FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Mod, SUPER_SET_Mod },
+   { "Spiral",   FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Spiral, SUPER_SET_Spiral },
+   { "Repeat",   FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, SUPER_GET_Repeat, SUPER_SET_Repeat },
    // Synonyms
-   { "CX", FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterX, SUPER_SET_CenterX },
-   { "CY", FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterY, SUPER_SET_CenterY },
-   { "R",  FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_Radius,  SUPER_SET_Radius },
+   { "CX", FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterX, SUPER_SET_CenterX },
+   { "CY", FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_CenterY, SUPER_SET_CenterY },
+   { "R",  FDF_SYNONYM|FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, SUPER_GET_Radius,  SUPER_SET_Radius },
    END_FIELD
 };
 

--- a/src/xml/xml.tdl
+++ b/src/xml/xml.tdl
@@ -1,7 +1,7 @@
 --$TIRI:Include
 
 module({ name="XML", src="xml.cpp", copyright="Paul Manias © 2001-2026", version=1.0, timestamp=20240611 }, function()
-  cpp_include("<functional>", "<memory>", "<sstream>", "<kotuku/strings.hpp>")
+  cpp_include("<functional>", "<memory>", "<sstream>", "<type_traits>", "<kotuku/strings.hpp>")
 
   loadFile('./constants.tdl')
 
@@ -267,6 +267,16 @@ inline void NewAttrib(XTag &Tag, const std::string_view Name, const std::string_
 
 inline void NewAttrib(XTag *Tag, const std::string_view Name, const std::string_view Value) {
    Tag->Attribs.emplace_back(Name, Value);
+}
+
+template <class T> requires std::is_arithmetic_v<T>
+inline void NewAttrib(XTag &Tag, const std::string_view Name, const T Value) {
+   Tag.Attribs.emplace_back(Name, std::to_string(Value));
+}
+
+template <class T> requires std::is_arithmetic_v<T>
+inline void NewAttrib(XTag *Tag, const std::string_view Name, const T Value) {
+   Tag->Attribs.emplace_back(Name, std::to_string(Value));
 }
 
 inline std::string GetContent(const XTag &Tag) {


### PR DESCRIPTION
* Updated VectorShape centre and radius fields to preserve fixed and scaled Unit values directly
* Removed obsolete VectorShape Dimensions and VectorPolygon TotalPoints API entries
* Updated SVG shape export and XML attribute helpers for Unit-aware dimensions