### PR TITLE
[Vector] Preserve viewport unit declarations

### DIFF
--- a/docs/xml/modules/classes/vectorviewport.xml
+++ b/docs/xml/modules/classes/vectorviewport.xml
@@ -135,16 +135,6 @@
     </field>
 
     <field>
-      <name>Dimensions</name>
-      <comment>Dimension flags define whether individual dimension fields contain fixed or scaled values.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type lookup="DMF">DMF</type>
-      <description>
-<types lookup="DMF"/>
-      </description>
-    </field>
-
-    <field>
       <name>DragCallback</name>
       <comment>Receiver for drag requests originating from the viewport.</comment>
       <access read="G" write="S">Get/Set</access>
@@ -163,7 +153,7 @@
       <name>Height</name>
       <comment>The height of the viewport's target area.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The height of the viewport's target area is defined here as a fixed or scaled value.  The default value is <code>100%</code> for full coverage.</p>
 <p>The fixed value is always returned when retrieving the height.</p>
@@ -250,7 +240,7 @@
       <name>Width</name>
       <comment>The width of the viewport's target area.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The width of the viewport's target area is defined here as a fixed or scaled value.  The default value is <code>100%</code> for full coverage.</p>
       </description>
@@ -260,7 +250,7 @@
       <name>X</name>
       <comment>Positions the viewport on the x-axis.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The display position targeted by the viewport is declared by the (<fl>X</fl>,<fl>Y</fl>) field values.  Coordinates can be expressed as fixed or scaled pixel units.</p>
 <p>If an offset from the edge of the parent is desired, the <fl>XOffset</fl> field must be defined.  If a X and <fl>XOffset</fl> value are defined together, the width of the viewport is computed on-the-fly and will change in response to the parent's width.</p>
@@ -271,7 +261,7 @@
       <name>XOffset</name>
       <comment>Positions the viewport on the x-axis.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The display position targeted by the viewport is declared by the (<fl>X</fl>,<fl>Y</fl>) field values.  Coordinates can be expressed as fixed or scaled pixel units.</p>
 <p>If an offset from the edge of the parent is desired, the <fl>XOffset</fl> field must be defined.  If the <fl>X</fl> and XOffset values are defined together, the width of the viewport is computed on-the-fly and will change in response to the parent's width.</p>
@@ -282,7 +272,7 @@
       <name>Y</name>
       <comment>Positions the viewport on the y-axis.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The display position targeted by the viewport is declared by the (<fl>X</fl>,<fl>Y</fl>) field values.  Coordinates can be expressed as fixed or scaled pixel units.</p>
 <p>If an offset from the edge of the parent is desired, the <fl>YOffset</fl> must be defined.  If the Y and <fl>YOffset</fl> values are defined together, the height of the viewport is computed on-the-fly and will change in response to the parent's height.</p>
@@ -293,7 +283,7 @@
       <name>YOffset</name>
       <comment>Positions the viewport on the y-axis.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>DOUBLE</type>
+      <type>UNIT</type>
       <description>
 <p>The display position targeted by the viewport is declared by the (<fl>X</fl>,<fl>Y</fl>) field values.  Coordinates can be expressed as fixed or scaled pixel units.</p>
 <p>If an offset from the edge of the parent is desired, the <fl>YOffset</fl> must be defined.  If a <fl>Y</fl> and YOffset value are defined together, the height of the viewport is computed on-the-fly and will change in response to the parent's height.</p>
@@ -317,35 +307,6 @@
       <const name="Y_MAX">Align to the bottom.</const>
       <const name="Y_MID">Align to the vertical center.</const>
       <const name="Y_MIN">Align to the top.</const>
-    </constants>
-
-    <constants lookup="DMF">
-      <const name="FIXED_CENTER_X">The CenterX field is a fixed size.</const>
-      <const name="FIXED_CENTER_Y">The CenterY field is a fixed size.</const>
-      <const name="FIXED_DEPTH">The Depth field is a fixed size.</const>
-      <const name="FIXED_HEIGHT">The Height field is a fixed size.</const>
-      <const name="FIXED_RADIUS_X">The RadiusX field is a fixed size.</const>
-      <const name="FIXED_RADIUS_Y">The RadiusY field is a fixed size.</const>
-      <const name="FIXED_WIDTH">The Width field is a fixed suze.</const>
-      <const name="FIXED_X">The X field is a fixed coordinate.</const>
-      <const name="FIXED_X_OFFSET">The XOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Y">The Y field is a fixed coordinate.</const>
-      <const name="FIXED_Y_OFFSET">The YOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Z">The Z field is a fixed coordinate.</const>
-      <const name="SCALED_CENTER_X">The CenterX field is scaled to this object's parent.</const>
-      <const name="SCALED_CENTER_Y">The CenterY field is scaled to this object's parent.</const>
-      <const name="SCALED_DEPTH">The Depth field is scaled to this object's parent.</const>
-      <const name="SCALED_HEIGHT">The Height field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_X">The RadiusX field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_Y">The RadiusY field is a scaled size to this object's parent.</const>
-      <const name="SCALED_WIDTH">The Width field is scaled to this object's parent.</const>
-      <const name="SCALED_X">The X field is scaled to this object's parent.</const>
-      <const name="SCALED_X_OFFSET">The XOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Y">The Y field is scaled to this object's parent.</const>
-      <const name="SCALED_Y_OFFSET">The YOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Z">The Z field is a scaled coordinate to this object's parent.</const>
-      <const name="STATUS_CHANGE_H"/>
-      <const name="STATUS_CHANGE_V"/>
     </constants>
 
     <constants lookup="VOF" comment="Viewport overflow options.">

--- a/docs/xml/modules/vector.xml
+++ b/docs/xml/modules/vector.xml
@@ -768,35 +768,6 @@ Hue (<code>H</code>) is in degrees.  Alpha (<code>A</code>) is optional, precede
       <const name="RED">The red colour channel.</const>
     </constants>
 
-    <constants lookup="DMF">
-      <const name="FIXED_CENTER_X">The CenterX field is a fixed size.</const>
-      <const name="FIXED_CENTER_Y">The CenterY field is a fixed size.</const>
-      <const name="FIXED_DEPTH">The Depth field is a fixed size.</const>
-      <const name="FIXED_HEIGHT">The Height field is a fixed size.</const>
-      <const name="FIXED_RADIUS_X">The RadiusX field is a fixed size.</const>
-      <const name="FIXED_RADIUS_Y">The RadiusY field is a fixed size.</const>
-      <const name="FIXED_WIDTH">The Width field is a fixed suze.</const>
-      <const name="FIXED_X">The X field is a fixed coordinate.</const>
-      <const name="FIXED_X_OFFSET">The XOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Y">The Y field is a fixed coordinate.</const>
-      <const name="FIXED_Y_OFFSET">The YOffset field is a fixed coordinate.</const>
-      <const name="FIXED_Z">The Z field is a fixed coordinate.</const>
-      <const name="SCALED_CENTER_X">The CenterX field is scaled to this object's parent.</const>
-      <const name="SCALED_CENTER_Y">The CenterY field is scaled to this object's parent.</const>
-      <const name="SCALED_DEPTH">The Depth field is scaled to this object's parent.</const>
-      <const name="SCALED_HEIGHT">The Height field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_X">The RadiusX field is scaled to this object's parent.</const>
-      <const name="SCALED_RADIUS_Y">The RadiusY field is a scaled size to this object's parent.</const>
-      <const name="SCALED_WIDTH">The Width field is scaled to this object's parent.</const>
-      <const name="SCALED_X">The X field is scaled to this object's parent.</const>
-      <const name="SCALED_X_OFFSET">The XOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Y">The Y field is scaled to this object's parent.</const>
-      <const name="SCALED_Y_OFFSET">The YOffset field is scaled to this object's parent.</const>
-      <const name="SCALED_Z">The Z field is a scaled coordinate to this object's parent.</const>
-      <const name="STATUS_CHANGE_H"/>
-      <const name="STATUS_CHANGE_V"/>
-    </constants>
-
     <constants lookup="EM">
       <const name="DUPLICATE">The input image is extended along its borders by duplicating the color values at its edges.</const>
       <const name="NONE">The input image is extended with colour values of zero.</const>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -1841,6 +1841,7 @@ struct Unit {
 
    constexpr void set(const double pValue) { Value = pValue; }
    constexpr bool scaled() const { return (Type & FD_SCALED) ? true : false; }
+   constexpr bool verbatim() const { return (Type & FD_PURE) ? true : false; }
    inline bool defined() const { return !std::isnan(Value); } // A NaN value denotes an undefined unit
 
    inline void read(std::string_view String) {

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -5344,22 +5344,17 @@ class objVectorViewport : public objVector {
    // Customised field getting
 
    inline ERR getAspectRatio(ARF &Value) noexcept {
-      auto field = &this->Class->Dictionary[58];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getDimensions(DMF &Value) noexcept {
-      auto field = &this->Class->Dictionary[52];
+      auto field = &this->Class->Dictionary[57];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getOverflow(VOF &Value) noexcept {
-      auto field = &this->Class->Dictionary[53];
+      auto field = &this->Class->Dictionary[52];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getOverflowX(VOF &Value) noexcept {
-      auto field = &this->Class->Dictionary[65];
+      auto field = &this->Class->Dictionary[64];
       return field->GetValue(this, &Value);
    }
 
@@ -5369,7 +5364,7 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR getAbsX(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[62];
+      auto field = &this->Class->Dictionary[61];
       SetObjectContext(this, field, AC::NIL);
       auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
@@ -5385,77 +5380,65 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR getBuffer(OBJECTPTR &Value) noexcept {
-      auto field = &this->Class->Dictionary[56];
+      auto field = &this->Class->Dictionary[55];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getBuffered(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[64];
+      auto field = &this->Class->Dictionary[63];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getDragCallback(FUNCTION * &Value) noexcept {
-      auto field = &this->Class->Dictionary[57];
+      auto field = &this->Class->Dictionary[56];
       auto get_field = (ERR (*)(APTR, FUNCTION * &))field->GetValue;
       return get_field(this, Value);
    }
 
-   inline ERR getX(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[59];
+   inline ERR getX(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[58];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
 
-   inline ERR getY(double &Value) noexcept {
+   inline ERR getY(Unit &Value) noexcept {
       auto field = &this->Class->Dictionary[51];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
 
-   inline ERR getXOffset(double &Value) noexcept {
+   inline ERR getXOffset(Unit &Value) noexcept {
       auto field = &this->Class->Dictionary[48];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
 
-   inline ERR getYOffset(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[55];
+   inline ERR getYOffset(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[54];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
 
-   inline ERR getWidth(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[60];
+   inline ERR getWidth(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[59];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
 
-   inline ERR getHeight(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[63];
+   inline ERR getHeight(Unit &Value) noexcept {
+      auto field = &this->Class->Dictionary[62];
       SetObjectContext(this, field, AC::NIL);
-      Unit var(0, FD_DOUBLE);
-      auto error = field->GetValue(this, &var);
-      if (error IS ERR::Okay) Value = var.Value;
+      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
@@ -5466,12 +5449,12 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR getViewY(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[61];
+      auto field = &this->Class->Dictionary[60];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getViewWidth(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
+      auto field = &this->Class->Dictionary[53];
       return field->GetValue(this, &Value);
    }
 
@@ -5484,22 +5467,17 @@ class objVectorViewport : public objVector {
    // Customised field setting
 
    inline ERR setAspectRatio(const ARF Value) noexcept {
-      auto field = &this->Class->Dictionary[58];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setDimensions(const DMF Value) noexcept {
-      auto field = &this->Class->Dictionary[52];
+      auto field = &this->Class->Dictionary[57];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setOverflow(const VOF Value) noexcept {
-      auto field = &this->Class->Dictionary[53];
+      auto field = &this->Class->Dictionary[52];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setOverflowX(const VOF Value) noexcept {
-      auto field = &this->Class->Dictionary[65];
+      auto field = &this->Class->Dictionary[64];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -5509,49 +5487,43 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR setBuffered(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[64];
+      auto field = &this->Class->Dictionary[63];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setDragCallback(const FUNCTION Value) noexcept {
-      auto field = &this->Class->Dictionary[57];
+      auto field = &this->Class->Dictionary[56];
       return field->WriteValue(this, field, FD_FUNCTION, &Value);
    }
 
-   inline ERR setX(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[59];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setX(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[58];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setY(const double Value) noexcept {
+   inline ERR setY(const Unit Value) noexcept {
       auto field = &this->Class->Dictionary[51];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setXOffset(const double Value) noexcept {
+   inline ERR setXOffset(const Unit Value) noexcept {
       auto field = &this->Class->Dictionary[48];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setYOffset(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[55];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setYOffset(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[54];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setWidth(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[60];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setWidth(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[59];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setHeight(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[63];
-      Unit var(Value);
-      return field->WriteValue(this, field, FD_UNIT, &var);
+   inline ERR setHeight(const Unit Value) noexcept {
+      auto field = &this->Class->Dictionary[62];
+      return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
    inline ERR setViewX(const double Value) noexcept {
@@ -5560,12 +5532,12 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR setViewY(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[61];
+      auto field = &this->Class->Dictionary[60];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
    inline ERR setViewWidth(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[54];
+      auto field = &this->Class->Dictionary[53];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 

--- a/scripts/gui/divider.tiri
+++ b/scripts/gui/divider.tiri
@@ -73,18 +73,14 @@ gui.divider = function(Options:table)
       self._secondary   = Options.right
       self._anchor      = 'x'
       self._length      = 'width'
-
-      sd = self._secondary.dimensions
-      assert((sd has DMF_FIXED_X and sd has DMF_FIXED_X_OFFSET), 'The opposing viewport must use fixed x and xOffset coordinates.')
+      -- NB: The opposing viewport must use fixed x and xOffset coordinates.
    elseif Options.top and Options.bottom then
       self._orientation = 'v'
       self._primary     = Options.top
       self._secondary   = Options.bottom
       self._anchor      = 'y'
       self._length      = 'height'
-
-      sd = self._secondary.dimensions
-      assert((sd has DMF_FIXED_Y) and (sd has DMF_FIXED_Y_OFFSET), 'The opposing viewport must use fixed y and yOffset coordinates.')
+      -- NB: The opposing viewport must use fixed y and yOffset coordinates.
    else
       error('A left/right or top/bottom pair must be specified.')
    end

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -836,6 +836,7 @@ using ModTest    = void (*)(std::string_view, int *, int *);
 
    constexpr void set(const double pValue) { Value = pValue; }
    constexpr bool scaled() const { return (Type & FD_SCALED) ? true : false; }
+   constexpr bool verbatim() const { return (Type & FD_PURE) ? true : false; }
    inline bool defined() const { return !std::isnan(Value); } // A NaN value denotes an undefined unit
 
    inline void read(std::string_view String) {

--- a/src/document/ui.cpp
+++ b/src/document/ui.cpp
@@ -1280,18 +1280,18 @@ static ERR inputevent_button(objVectorViewport *Viewport, const InputEvent *Even
                button->viewport->newMatrix(&matrix, false);
             }
 
-            double width;
+            Unit width;
             button->viewport->getWidth(width);
-            double height;
+            Unit height;
             button->viewport->getHeight(height);
 
             if (auto m = button->viewport->Matrices) {
                const auto SCALE = 0.95;
-               m->TranslateX -= width * 0.5;
-               m->TranslateY -= height * 0.5;
+               m->TranslateX -= double(width) * 0.5;
+               m->TranslateY -= double(height) * 0.5;
                vec::Scale(m, SCALE, SCALE);
-               m->TranslateX += width * 0.5;
-               m->TranslateY += height * 0.5;
+               m->TranslateX += double(width) * 0.5;
+               m->TranslateY += double(height) * 0.5;
                vec::FlushMatrix(button->viewport->Matrices);
             }
          }

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -3,7 +3,10 @@
 -CLASS-
 SVG: Provides comprehensive support for parsing, rendering and animating SVG documents.
 
-The SVG class serves as a complete solution for integrating Scalable Vector Graphics documents into applications.  It parses SVG statements into a scene graph consisting of @Vector objects and related constructs, providing direct programmatic access to all graphical elements.  The generated scene graph is accessible via the #Scene and #Viewport fields, enabling real-time manipulation of individual elements.
+The SVG class serves as a complete solution for integrating Scalable Vector Graphics documents into applications.
+It parses SVG statements into a scene graph consisting of @Vector objects and related constructs, providing direct
+programmatic access to all graphical elements.  The generated scene graph is accessible via the #Scene and #Viewport
+fields, enabling real-time manipulation of individual elements.
 
 Key capabilities include:
 
@@ -17,9 +20,13 @@ Key capabilities include:
 <li>Export capabilities to multiple formats including PNG images</li>
 </list>
 
-The class supports both file-based loading via #Path and direct string-based parsing via #Statement.  SVG documents can be integrated into existing scene graphs by setting the #Target field, or rendered independently through the automatically created scene structure.
+The class supports both file-based loading via #Path and direct string-based parsing via #Statement.  SVG documents
+can be integrated into existing scene graphs by setting the #Target field, or rendered independently through the
+automatically created scene structure.
 
-Animation timing is controlled through the #FrameRate field, with callback support via #FrameCallback for custom rendering workflows.  The implementation maintains compatibility with the complete SVG specification while providing enhanced programmatic access unique to Kotuku.
+Animation timing is controlled through the #FrameRate field, with callback support via #FrameCallback for custom
+rendering workflows.  The implementation maintains compatibility with the complete SVG specification while providing
+enhanced programmatic access unique to Kotuku.
 
 Please refer to the W3C's online documentation for exhaustive information on the SVG standard.
 
@@ -73,11 +80,15 @@ static ERR SVG_Activate(extSVG *Self)
 -ACTION-
 Deactivate: Halts all SVG animation playback and suspends frame processing.
 
-This action immediately terminates any active animation playback, stopping all animation timers and suspending frame processing.  The SVG document will remain visible in its current state, but no further animation updates will occur until the object is reactivated.
+This action immediately terminates any active animation playback, stopping all animation timers and suspending
+frame processing.  The SVG document will remain visible in its current state, but no further animation updates will
+occur until the object is reactivated.
 
-The deactivation process is immediate and does not affect the underlying scene graph structure.  Animation sequences can be resumed from their current positions by calling the #Activate() action again.
+The deactivation process is immediate and does not affect the underlying scene graph structure.  Animation sequences
+can be resumed from their current positions by calling the #Activate() action again.
 
-This action is particularly useful for implementing pause functionality or conserving system resources when animations are not required.
+This action is particularly useful for implementing pause functionality or conserving system resources when
+animations are not required.
 
 -END-
 *********************************************************************************************************************/
@@ -92,13 +103,17 @@ static ERR SVG_Deactivate(extSVG *Self)
 -ACTION-
 DataFeed: Processes SVG data streams for incremental document parsing.
 
-The DataFeed action enables real-time processing of SVG data streams, allowing documents to be parsed incrementally as data becomes available.  This is particularly useful for network-based loading scenarios or when processing large SVG documents that may arrive in segments.
+The DataFeed action enables real-time processing of SVG data streams, allowing documents to be parsed incrementally
+as data becomes available.  This is particularly useful for network-based loading scenarios or when processing large
+SVG documents that may arrive in segments.
 
-The action accepts XML data streams and integrates them into the existing document structure.  Multiple DataFeed calls can be made to build up complex SVG documents progressively.
+The action accepts XML data streams and integrates them into the existing document structure.  Multiple DataFeed
+calls can be made to build up complex SVG documents progressively.
 
 <b>Supported data types:</b> `DATA::XML` for SVG content streams.
 
-This mechanism provides an alternative to the static #Statement field for scenarios requiring dynamic content loading or streaming workflows.
+This mechanism provides an alternative to the static #Statement field for scenarios requiring dynamic content
+loading or streaming workflows.
 
 -END-
 *********************************************************************************************************************/
@@ -147,9 +162,13 @@ static ERR SVG_Free(extSVG *Self)
 -ACTION-
 Init: Initialises the SVG object and processes source content.
 
-The initialisation process establishes the scene graph structure and processes any specified SVG source content.  If a #Path has been configured, the referenced SVG file will be loaded and parsed immediately.  Alternatively, if #Statement contains SVG data, that content will be processed instead.
+The initialisation process establishes the scene graph structure and processes any specified SVG source content.  If
+a #Path has been configured, the referenced SVG file will be loaded and parsed immediately.  Alternatively, if
+#Statement contains SVG data, that content will be processed instead.
 
-The default behaviour creates a local @VectorScene object to contain the generated scene graph.  This can be overridden by setting the #Target field to redirect content into an existing scene graph structure, enabling integration with existing UI components.
+The default behaviour creates a local @VectorScene object to contain the generated scene graph.  This can be
+overridden by setting the #Target field to redirect content into an existing scene graph structure, enabling
+integration with existing UI components.
 
 The initialisation sequence includes:
 
@@ -160,7 +179,8 @@ The initialisation sequence includes:
 <li>Animation sequence preparation for documents containing SMIL features</li>
 </list>
 
-Successfully initialised SVG objects provide immediate access to the generated scene graph via the #Scene and #Viewport fields, enabling programmatic manipulation of individual graphic elements.
+Successfully initialised SVG objects provide immediate access to the generated scene graph via the #Scene and
+#Viewport fields, enabling programmatic manipulation of individual graphic elements.
 
 -END-
 *********************************************************************************************************************/
@@ -244,13 +264,21 @@ static ERR SVG_ParseSymbol(extSVG *Self, struct svg::ParseSymbol *Args)
 -METHOD-
 Render: Performs high-quality rasterisation of the SVG document to a target bitmap.
 
-This method executes complete rasterisation of the SVG scene graph, producing a pixel-based representation within the specified target bitmap.  The rendering process handles all vector elements, gradients, filters, and effects with full anti-aliasing and precision.
+This method executes complete rasterisation of the SVG scene graph, producing a pixel-based representation within the
+specified target bitmap.  The rendering process handles all vector elements, gradients, filters, and effects with
+full anti-aliasing and precision.
 
-The rendered output is positioned at coordinates `(X,Y)` within the target bitmap and scaled to the specified `(Width,Height)` dimensions.  The scaling operation maintains aspect ratios and applies appropriate filtering to ensure optimal visual quality.
+The rendered output is positioned at coordinates `(X,Y)` within the target bitmap and scaled to the specified
+`(Width,Height)` dimensions.  The scaling operation maintains aspect ratios and applies appropriate filtering to
+ensure optimal visual quality.
 
-The scene's page dimensions are temporarily adjusted to match the specified width and height, ensuring that the entire document content is properly scaled and positioned within the target area.  This approach enables flexible rendering at arbitrary resolutions without affecting the original scene graph.
+The scene's page dimensions are temporarily adjusted to match the specified width and height, ensuring that the
+entire document content is properly scaled and positioned within the target area.  This approach enables flexible
+rendering at arbitrary resolutions without affecting the original scene graph.
 
-<b>Performance considerations:</b> Rendering complex SVG documents with multiple effects and high resolutions may require significant processing time.  Consider using appropriate dimensions that balance quality requirements with performance constraints.
+<b>Performance considerations:</b> Rendering complex SVG documents with multiple effects and high resolutions may
+require significant processing time.  Consider using appropriate dimensions that balance quality requirements with
+performance constraints.
 
 -INPUT-
 obj(Bitmap) Bitmap: The target bitmap object to receive the rendered content.
@@ -414,19 +442,12 @@ static ERR SVG_SaveToObject(extSVG *Self, struct acSaveToObject *Args)
                }
 
                if (!error) {
-                  DMF dim;
-                  Self->Viewport->getDimensions(dim);
-                  if (dmf::hasAnyX(dim) and (!Self->Viewport->getX(x)))
-                     set_dimension(tag, "x", x, dmf::hasScaledX(dim));
+                  Unit unit(0, FD_PURE); // Request original client setting
 
-                  if (dmf::hasAnyY(dim) and (!Self->Viewport->getY(y)))
-                     set_dimension(tag, "y", y, dmf::hasScaledY(dim));
-
-                  if (dmf::hasAnyWidth(dim) and (!Self->Viewport->getWidth(width)))
-                     set_dimension(tag, "width", width, dmf::hasScaledWidth(dim));
-
-                  if (dmf::hasAnyHeight(dim) and (!Self->Viewport->getHeight(height)))
-                     set_dimension(tag, "height", height, dmf::hasScaledHeight(dim));
+                  if ((!error) and (!Self->Viewport->getX(unit))) set_dimension(tag, "x", unit);
+                  if ((!error) and (!Self->Viewport->getY(unit))) set_dimension(tag, "y", unit);
+                  if ((!error) and (!Self->Viewport->getWidth(unit))) set_dimension(tag, "width", unit);
+                  if ((!error) and (!Self->Viewport->getHeight(unit))) set_dimension(tag, "height", unit);
                }
 
                if (!error) {
@@ -529,7 +550,9 @@ static ERR SET_FrameCallback(extSVG *Self, FUNCTION *Value)
 -FIELD-
 FrameRate: Controls the maximum frame rate for SVG animation playback.
 
-This field establishes the upper limit for animation frame processing, measured in frames per second.  The frame rate directly impacts animation smoothness and system resource consumption, requiring careful balance between visual quality and performance efficiency.
+This field establishes the upper limit for animation frame processing, measured in frames per second.  The frame rate
+directly impacts animation smoothness and system resource consumption, requiring careful balance between visual
+quality and performance efficiency.
 
 <b>Recommended ranges:</b>
 <list type="bullet">
@@ -538,11 +561,15 @@ This field establishes the upper limit for animation frame processing, measured 
 <li><b>Low-power devices:</b> 20-30 FPS conserves battery while maintaining acceptable quality</li>
 </list>
 
-<b>Performance considerations:</b> Higher frame rates increase CPU usage proportionately.  A frame rate of 100 FPS consumes approximately twice the processing power of 50 FPS, with corresponding impact on power consumption and thermal characteristics.
+<b>Performance considerations:</b> Higher frame rates increase CPU usage proportionately.  A frame rate of 100 FPS
+consumes approximately twice the processing power of 50 FPS, with corresponding impact on power consumption and
+thermal characteristics.
 
-<b>Valid range:</b> 20-1000 FPS, though values above 120 FPS rarely provide perceptible improvements on standard displays.
+<b>Valid range:</b> 20-1000 FPS, though values above 120 FPS rarely provide perceptible improvements on standard
+displays.
 
-The frame rate only affects animated SVG documents containing SMIL features.  Static documents are unaffected by this setting.
+The frame rate only affects animated SVG documents containing SMIL features.  Static documents are unaffected by
+this setting.
 
 *********************************************************************************************************************/
 
@@ -560,15 +587,21 @@ static ERR SET_FrameRate(extSVG *Self, int Value)
 -FIELD-
 Path: File system path to the source SVG document.
 
-This field specifies the location of the SVG file to be loaded and processed during object initialisation.  The path supports both absolute and relative file references, with relative paths resolved according to the current working directory context.
+This field specifies the location of the SVG file to be loaded and processed during object initialisation.  The path
+supports both absolute and relative file references, with relative paths resolved according to the current working
+directory context.
 
-The loading process occurs automatically during initialisation when a valid path is specified.  The referenced file must contain well-formed SVG content that conforms to W3C SVG standards for successful parsing.
+The loading process occurs automatically during initialisation when a valid path is specified.  The referenced file
+must contain well-formed SVG content that conforms to W3C SVG standards for successful parsing.
 
-<b>Supported file types:</b> Standard SVG files (*.svg) and compressed SVG files (*.svgz) are both supported, with automatic decompression handling for compressed formats.
+<b>Supported file types:</b> Standard SVG files (*.svg) and compressed SVG files (*.svgz) are both supported, with
+automatic decompression handling for compressed formats.
 
-<b>Path resolution:</b> The file system path is resolved through the standard Kotuku file access mechanisms, supporting virtual file systems, archives, and network-accessible resources where configured.
+<b>Path resolution:</b> The file system path is resolved through the standard Kotuku file access mechanisms,
+supporting virtual file systems, archives, and network-accessible resources where configured.
 
-When both #Path and #Statement are specified, the Path field takes precedence and the Statement content is ignored during initialisation.
+When both #Path and #Statement are specified, the Path field takes precedence and the Statement content is ignored
+during initialisation.
 
 *********************************************************************************************************************/
 

--- a/src/svg/save_svg.cpp
+++ b/src/svg/save_svg.cpp
@@ -795,6 +795,9 @@ static ERR save_svg_scan_viewport(extSVG *Self, objXML *XML, objVector *Vector, 
    ERR error = XML->insertStatement(Parent, XMI::CHILD_END, "<svg/>", &tag);
 
    auto viewport = (objVectorViewport *)Vector;
+
+   // Build the viewBox value
+
    if (!error) error = viewport->getViewX(x);
    if (!error) error = viewport->getViewY(y);
    if (!error) error = viewport->getViewWidth(width);
@@ -806,21 +809,15 @@ static ERR save_svg_scan_viewport(extSVG *Self, objXML *XML, objVector *Vector, 
       xml::NewAttrib(tag, "viewBox", buffer.str());
    }
 
+   // Output viewport dimensions, if defined
+
    if (!error) {
-      DMF dim;
-      viewport->getDimensions(dim);
+      Unit unit(0, FD_PURE); // Request original client setting
 
-      if ((!error) and dmf::hasAnyX(dim) and (!viewport->getX(x)))
-         set_dimension(tag, "x", x, dmf::hasScaledX(dim));
-
-      if ((!error) and dmf::hasAnyY(dim) and (!viewport->getY(y)))
-         set_dimension(tag, "y", y, dmf::hasScaledY(dim));
-
-      if ((!error) and dmf::hasAnyWidth(dim) and (!viewport->getWidth(width)))
-         set_dimension(tag, "width", width, dmf::hasScaledWidth(dim));
-
-      if ((!error) and dmf::hasAnyHeight(dim) and (!viewport->getHeight(height)))
-         set_dimension(tag, "height", height, dmf::hasScaledHeight(dim));
+      if ((!error) and (!viewport->getX(unit))) set_dimension(tag, "x", unit);
+      if ((!error) and (!viewport->getY(unit))) set_dimension(tag, "y", unit);
+      if ((!error) and (!viewport->getWidth(unit))) set_dimension(tag, "width", unit);
+      if ((!error) and (!viewport->getHeight(unit))) set_dimension(tag, "height", unit);
    }
 
    if (!error) ChildIndex = tag->ID;

--- a/src/vector/painters/pattern.cpp
+++ b/src/vector/painters/pattern.cpp
@@ -114,9 +114,9 @@ then the dimension is calculated relative to the bounding box or viewport applyi
 
 *********************************************************************************************************************/
 
-static ERR VECTORPATTERN_GET_Height(extVectorPattern *Self, Unit *Value)
+static ERR VECTORPATTERN_GET_Height(extVectorPattern *Self, Unit &Value)
 {
-   Value->set(Self->Height);
+   Value = Self->Height;
    return ERR::Okay;
 }
 
@@ -309,9 +309,9 @@ the dimension is calculated relative to the bounding box or viewport applying th
 
 *********************************************************************************************************************/
 
-static ERR VECTORPATTERN_GET_Width(extVectorPattern *Self, Unit *Value)
+static ERR VECTORPATTERN_GET_Width(extVectorPattern *Self, Unit &Value)
 {
-   Value->set(Self->Width);
+   Value = Self->Width;
    return ERR::Okay;
 }
 
@@ -331,9 +331,9 @@ The (X,Y) field values define the starting coordinate for mapping patterns.
 
 *********************************************************************************************************************/
 
-static ERR VECTORPATTERN_GET_X(extVectorPattern *Self, Unit *Value)
+static ERR VECTORPATTERN_GET_X(extVectorPattern *Self, Unit &Value)
 {
-   Value->set(Self->X);
+   Value = Self->X;
    return ERR::Okay;
 }
 
@@ -354,9 +354,9 @@ The (X,Y) field values define the starting coordinate for mapping patterns.
 
 *********************************************************************************************************************/
 
-static ERR VECTORPATTERN_GET_Y(extVectorPattern *Self, Unit *Value)
+static ERR VECTORPATTERN_GET_Y(extVectorPattern *Self, Unit &Value)
 {
-   Value->set(Self->Y);
+   Value = Self->Y;
    return ERR::Okay;
 }
 

--- a/src/vector/paths.cpp
+++ b/src/vector/paths.cpp
@@ -85,26 +85,6 @@ void gen_vector_path(extVector *Vector)
       // vpBX1/BY1/BX2/BY2 are fixed coordinate bounding box values from root position (0,0) and define the clip region imposed on all children of the viewport.
       // vpFixedX/Y are the fixed coordinate position of the viewport relative to root position (0,0)
 
-      if (!dmf::hasAnyHorizontalPosition(view->vpDimensions)) { // Client failed to set a horizontal position
-         view->vpTargetX = 0;
-         view->vpDimensions |= DMF::FIXED_X;
-      }
-      else if (dmf::hasAnyXOffset(view->vpDimensions) and (!dmf::has(view->vpDimensions, DMF::FIXED_X|DMF::SCALED_X|DMF::FIXED_WIDTH|DMF::SCALED_WIDTH))) {
-         // Client set an offset but failed to combine it with a width or position value.
-         view->vpTargetX = 0;
-         view->vpDimensions |= DMF::FIXED_X;
-      }
-
-      if (!dmf::hasAnyVerticalPosition(view->vpDimensions)) { // Client failed to set a vertical position
-         view->vpTargetY = 0;
-         view->vpDimensions |= DMF::FIXED_Y;
-      }
-      else if (dmf::hasAnyYOffset(view->vpDimensions) and (!dmf::has(view->vpDimensions, DMF::FIXED_Y|DMF::SCALED_Y|DMF::FIXED_HEIGHT|DMF::SCALED_HEIGHT))) {
-         // Client set an offset but failed to combine it with a height or position value.
-         view->vpTargetY = 0;
-         view->vpDimensions |= DMF::FIXED_Y;
-      }
-
       if (parent_view) {
          if (parent_view->vpViewWidth) parent_width = parent_view->vpViewWidth;
          else parent_width = parent_view->vpFixedWidth;
@@ -114,7 +94,8 @@ void gen_vector_path(extVector *Vector)
 
          if ((!parent_width) or (!parent_height)) {
             // NB: It is perfectly legal, even if unlikely, that a viewport has a width/height of zero.
-            log.msg("Size of parent viewport #%d is %.2fx%.2f, dimensions $%.8x", parent_view->UID, parent_view->vpFixedWidth, parent_view->vpFixedHeight, int(parent_view->vpDimensions));
+            log.msg("Size of parent viewport #%d is %.2fx%.2f", parent_view->UID, parent_view->vpFixedWidth,
+               parent_view->vpFixedHeight);
          }
 
          parent_id = parent_view->UID;
@@ -129,44 +110,28 @@ void gen_vector_path(extVector *Vector)
       // NB: In SVG it is a requirement that the top level viewport is always located at (0,0), but we
       // leave that as something for the SVG parser to enforce.
 
-      if (dmf::hasScaledX(view->vpDimensions)) view->FinalX = (parent_width * view->vpTargetX);
-      else view->FinalX = view->vpTargetX;
+      view->FinalX = view->vpTargetX.defined() ? unit_to_fixed(view->vpTargetX, parent_width) : 0;
+      view->FinalY = view->vpTargetY.defined() ? unit_to_fixed(view->vpTargetY, parent_height) : 0;
 
-      if (dmf::hasScaledY(view->vpDimensions)) view->FinalY = (parent_height * view->vpTargetY);
-      else view->FinalY = view->vpTargetY;
+      view->vpFixedWidth = view->vpTargetWidth.defined() ? unit_to_fixed(view->vpTargetWidth, parent_width) :
+         parent_width;
+      view->vpFixedHeight = view->vpTargetHeight.defined() ? unit_to_fixed(view->vpTargetHeight, parent_height) :
+         parent_height;
 
-      if (dmf::hasScaledWidth(view->vpDimensions)) view->vpFixedWidth = parent_width * view->vpTargetWidth;
-      else if (dmf::hasWidth(view->vpDimensions)) view->vpFixedWidth = view->vpTargetWidth;
-      else view->vpFixedWidth = parent_width;
-
-      if (dmf::hasScaledHeight(view->vpDimensions)) view->vpFixedHeight = parent_height * view->vpTargetHeight;
-      else if (dmf::hasHeight(view->vpDimensions)) view->vpFixedHeight = view->vpTargetHeight;
-      else view->vpFixedHeight = parent_height;
-
-      if (dmf::hasScaledXOffset(view->vpDimensions)) {
-         if (dmf::hasAnyX(view->vpDimensions)) {
-            view->vpFixedWidth = parent_width - (parent_width * view->vpTargetXO) - view->FinalX;
+      if (view->vpTargetXO.defined()) {
+         auto offset = unit_to_fixed(view->vpTargetXO, parent_width);
+         if (view->vpTargetX.defined() or (not view->vpTargetWidth.defined())) {
+            view->vpFixedWidth = parent_width - offset - view->FinalX;
          }
-         else view->FinalX = parent_width - view->vpFixedWidth - (parent_width * view->vpTargetXO);
-      }
-      else if (dmf::hasXOffset(view->vpDimensions)) {
-         if (dmf::hasAnyX(view->vpDimensions)) {
-            view->vpFixedWidth = parent_width - view->vpTargetXO - view->FinalX;
-         }
-         else view->FinalX = parent_width - view->vpFixedWidth - view->vpTargetXO;
+         else view->FinalX = parent_width - view->vpFixedWidth - offset;
       }
 
-      if (dmf::hasScaledYOffset(view->vpDimensions)) {
-         if (dmf::hasAnyY(view->vpDimensions)) {
-            view->vpFixedHeight = parent_height - (parent_height * view->vpTargetYO) - view->FinalY;
+      if (view->vpTargetYO.defined()) {
+         auto offset = unit_to_fixed(view->vpTargetYO, parent_height);
+         if (view->vpTargetY.defined() or (not view->vpTargetHeight.defined())) {
+            view->vpFixedHeight = parent_height - offset - view->FinalY;
          }
-         else view->FinalY = parent_height - view->vpFixedHeight - (parent_height * view->vpTargetYO);
-      }
-      else if (dmf::hasYOffset(view->vpDimensions)) {
-         if (dmf::hasAnyY(view->vpDimensions)) {
-            view->vpFixedHeight = parent_height - view->vpTargetYO - view->FinalY;
-         }
-         else view->FinalY = parent_height - view->vpFixedHeight - view->vpTargetYO;
+         else view->FinalY = parent_height - view->vpFixedHeight - offset;
       }
 
       // Contained vectors are normally scaled to the area defined by the viewport.
@@ -184,8 +149,9 @@ void gen_vector_path(extVector *Vector)
          view->vpFixedHeight = parent_height;
       }
 
-      log.trace("Vector: #%d, Dimensions: $%.8x, Parent: #%d %.2fw %.2fh, Target: %.2fw %.2fh, Viewbox: %.2f %.2f %.2f %.2f",
-         Vector->UID, view->vpDimensions, parent_id, parent_width, parent_height, target_width, target_height, view->vpViewX, view->vpViewY, view->vpViewWidth, view->vpViewHeight);
+      log.trace("Vector: #%d, Parent: #%d %.2fw %.2fh, Target: %.2fw %.2fh, Viewbox: %.2f %.2f %.2f %.2f",
+         Vector->UID, parent_id, parent_width, parent_height, target_width, target_height, view->vpViewX, view->vpViewY,
+         view->vpViewWidth, view->vpViewHeight);
 
       // This part computes the alignment of the viewbox (source) within the viewport's target area.
       // AspectRatio choices affect this, e.g. "xMinYMin slice".  Note that alignment specifically impacts

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -45,10 +45,10 @@ static bool viewport_has_fixed_size(const objVectorViewport *Viewport, double Wi
 {
    auto viewport = (const extVectorViewport *)Viewport;
 
-   return dmf::hasWidth(viewport->vpDimensions) and
-      dmf::hasHeight(viewport->vpDimensions) and
-      (not dmf::hasScaledWidth(viewport->vpDimensions)) and
-      (not dmf::hasScaledHeight(viewport->vpDimensions)) and
+   return viewport->vpTargetWidth.defined() and
+      viewport->vpTargetHeight.defined() and
+      (not viewport->vpTargetWidth.scaled()) and
+      (not viewport->vpTargetHeight.scaled()) and
       (viewport->vpTargetWidth IS Width) and
       (viewport->vpTargetHeight IS Height);
 }
@@ -68,11 +68,11 @@ static bool viewport_has_fixed_bounds(const objVectorViewport *Viewport, double 
    if (Width < 1) Width = 1;
    if (Height < 1) Height = 1;
 
-   return dmf::hasX(viewport->vpDimensions) and
-      dmf::hasY(viewport->vpDimensions) and
+   return viewport->vpTargetX.defined() and
+      viewport->vpTargetY.defined() and
       viewport_has_fixed_size(Viewport, Width, Height) and
-      (not dmf::hasScaledX(viewport->vpDimensions)) and
-      (not dmf::hasScaledY(viewport->vpDimensions)) and
+      (not viewport->vpTargetX.scaled()) and
+      (not viewport->vpTargetY.scaled()) and
       (viewport->vpTargetX IS X) and
       (viewport->vpTargetY IS Y);
 }
@@ -143,16 +143,14 @@ public:
 private:
    std::stack<ClipBuffer> mClipStack;
 
-   constexpr double view_width() {
+   double view_width() {
       if (mView->vpViewWidth > 0) return mView->vpViewWidth;
-      else if (dmf::hasAnyWidth(mView->vpDimensions)) return mView->vpFixedWidth;
-      else return mView->Scene->PageWidth;
+      else return viewport_coordinate_width(mView);
    }
 
-   constexpr double view_height() {
+   double view_height() {
       if (mView->vpViewHeight > 0) return mView->vpViewHeight;
-      else if (dmf::hasAnyHeight(mView->vpDimensions)) return mView->vpFixedHeight;
-      else return mView->Scene->PageHeight;
+      else return viewport_coordinate_height(mView);
    }
 
    void render_fill(VectorState &, extVector &, agg::rasterizer_scanline_aa<> &, extPainter &);

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -844,7 +844,9 @@ class extVectorViewport : public extVector {
 
    FUNCTION vpDragCallback;
    double vpViewX, vpViewY, vpViewWidth, vpViewHeight;     // Viewbox values determine the area of the SVG content that is being sourced.  These values are always fixed pixel units.
-   double vpTargetX, vpTargetY, vpTargetXO, vpTargetYO, vpTargetWidth, vpTargetHeight; // Target dimensions
+   Unit vpTargetX, vpTargetY;
+   Unit vpTargetWidth, vpTargetHeight;
+   Unit vpTargetXO, vpTargetYO; // Target dimensions
    double vpXScale, vpYScale; // Internal scaling for ViewN -to-> TargetN; takes the AspectRatio into consideration.
    double vpFixedWidth, vpFixedHeight; // Fixed pixel position values, relative to parent viewport
    TClipRectangle<double> vpBounds; // Bounding box coordinates relative to (0,0), used for clipping
@@ -856,7 +858,6 @@ class extVectorViewport : public extVector {
    std::unique_ptr<std::vector<class InputBoundary>> vpInputBounds; // Cached boundaries for buffered viewports; allocated on first use only.
    extVectorClip *vpClipOwner;
    bool  vpClip; // Viewport requires non-rectangular clipping, e.g. because it is rotated or sheared.
-   DMF   vpDimensions;
    ARF   vpAspectRatio;
    VOF   vpOverflowX, vpOverflowY;
    uint8_t vpClipConfiguring:1;
@@ -870,6 +871,37 @@ class extVectorViewport : public extVector {
       vpSeenShareVersion = 0;
    }
 };
+
+inline static double unit_to_fixed(const Unit &Value, double ParentSize)
+{
+   return Value.scaled() ? (double(Value) * ParentSize) : double(Value);
+}
+
+inline static bool viewport_has_target_width(const extVectorViewport *View)
+{
+   return View->vpTargetWidth.defined() or (View->vpTargetX.defined() and View->vpTargetXO.defined());
+}
+
+inline static bool viewport_has_target_height(const extVectorViewport *View)
+{
+   return View->vpTargetHeight.defined() or (View->vpTargetY.defined() and View->vpTargetYO.defined());
+}
+
+inline static double viewport_coordinate_width(const extVectorViewport *View)
+{
+   if (View->vpViewWidth > 0) return View->vpViewWidth;
+   else if (viewport_has_target_width(View)) return View->vpFixedWidth;
+   else if (View->Scene) return View->Scene->PageWidth;
+   else return 0;
+}
+
+inline static double viewport_coordinate_height(const extVectorViewport *View)
+{
+   if (View->vpViewHeight > 0) return View->vpViewHeight;
+   else if (viewport_has_target_height(View)) return View->vpFixedHeight;
+   else if (View->Scene) return View->Scene->PageHeight;
+   else return 0;
+}
 
 //********************************************************************************************************************
 
@@ -1388,12 +1420,7 @@ inline static double get_parent_width(const objVector *Vector)
 {
    auto eVector = (const extVector *)Vector;
    if (auto view = (extVectorViewport *)eVector->ParentView) {
-      if (view->vpViewWidth > 0) return view->vpViewWidth;
-      else if ((dmf::hasAnyWidth(view->vpDimensions)) or
-          ((dmf::hasAnyX(view->vpDimensions)) and (dmf::hasAnyXOffset(view->vpDimensions)))) {
-         return view->vpFixedWidth;
-      }
-      else return eVector->Scene->PageWidth;
+      return viewport_coordinate_width(view);
    }
    else if (eVector->Scene) return eVector->Scene->PageWidth;
    else return 0;
@@ -1403,12 +1430,7 @@ inline static double get_parent_height(const objVector *Vector)
 {
    auto eVector = (const extVector *)Vector;
    if (auto view = (extVectorViewport *)eVector->ParentView) {
-      if (view->vpViewHeight > 0) return view->vpViewHeight;
-      else if ((dmf::hasAnyHeight(view->vpDimensions)) or
-          ((dmf::hasAnyY(view->vpDimensions)) and (dmf::hasAnyYOffset(view->vpDimensions)))) {
-         return view->vpFixedHeight;
-      }
-      else return eVector->Scene->PageHeight;
+      return viewport_coordinate_height(view);
    }
    else if (eVector->Scene) return eVector->Scene->PageHeight;
    else return 0;

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -877,14 +877,17 @@ inline static double unit_to_fixed(const Unit &Value, double ParentSize)
    return Value.scaled() ? (double(Value) * ParentSize) : double(Value);
 }
 
+// NB: If XOffset is defined without X then layout routines will presume X to be zero, effectively meaning XOffset is
+// always treatable as a width value.
+
 inline static bool viewport_has_target_width(const extVectorViewport *View)
 {
-   return View->vpTargetWidth.defined() or (View->vpTargetX.defined() and View->vpTargetXO.defined());
+   return View->vpTargetWidth.defined() or View->vpTargetXO.defined();
 }
 
 inline static bool viewport_has_target_height(const extVectorViewport *View)
 {
-   return View->vpTargetHeight.defined() or (View->vpTargetY.defined() and View->vpTargetYO.defined());
+   return View->vpTargetHeight.defined() or View->vpTargetYO.defined();
 }
 
 inline static double viewport_coordinate_width(const extVectorViewport *View)

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -700,9 +700,8 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
 
   klass('VectorEllipse', { base='Vector', src='vectors/ellipse.cpp', extended=true, output='vectors/ellipse_def.cpp' })
 
-  klass('VectorViewport', { base='Vector', references={ 'VOF', 'DMF' }, src='vectors/viewport.cpp', output='vectors/viewport_def.cpp', extended=true }, [[
+  klass('VectorViewport', { base='Vector', references={ 'VOF' }, src='vectors/viewport.cpp', output='vectors/viewport_def.cpp', extended=true }, [[
     ~int(ARF) AspectRatio
-    ~int(DMF) Dimensions
     ~int(VOF) Overflow
     ~int(VOF) OverflowX
     ~int(VOF) OverflowY

--- a/src/vector/vectors/path.cpp
+++ b/src/vector/vectors/path.cpp
@@ -607,12 +607,12 @@ commands remain unchanged.
 -END-
 *********************************************************************************************************************/
 
-static ERR VECTORPATH_GET_X(extVectorPath *Self, Unit *Value)
+static ERR VECTORPATH_GET_X(extVectorPath *Self, Unit &Value)
 {
    // With no X placement there is no horizontal translation, so the unplaced bounds are authoritative.  They are
    // computed on demand because Self->Bounds is only refreshed during path generation.
-   if (Self->pX.defined()) Value->set(Self->pX);
-   else Value->set(get_unplaced_path_bounds(Self).left);
+   if (Self->pX.defined()) Value = Self->pX;
+   else Value = Unit(get_unplaced_path_bounds(Self).left);
    return ERR::Okay;
 }
 
@@ -632,10 +632,10 @@ commands remain unchanged.
 -END-
 *********************************************************************************************************************/
 
-static ERR VECTORPATH_GET_Y(extVectorPath *Self, Unit *Value)
+static ERR VECTORPATH_GET_Y(extVectorPath *Self, Unit &Value)
 {
-   if (Self->pY.defined()) Value->set(Self->pY);
-   else Value->set(get_unplaced_path_bounds(Self).top);
+   if (Self->pY.defined()) Value = Self->pY;
+   else Value = Unit(get_unplaced_path_bounds(Self).top);
    return ERR::Okay;
 }
 

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -319,9 +319,9 @@ a percentage.
 
 *********************************************************************************************************************/
 
-static ERR POLY_GET_X1(extVectorPolygon *Self, Unit *Value)
+static ERR POLY_GET_X1(extVectorPolygon *Self, Unit &Value)
 {
-   Value->set(Self->Points[0].X);
+   Value = Self->Points[0].X;
    return ERR::Okay;
 }
 
@@ -345,9 +345,9 @@ a percentage.
 
 *********************************************************************************************************************/
 
-static ERR POLY_GET_X2(extVectorPolygon *Self, Unit *Value)
+static ERR POLY_GET_X2(extVectorPolygon *Self, Unit &Value)
 {
-   Value->set(Self->Points[1].X);
+   Value = Self->Points[1].X;
    return ERR::Okay;
 }
 
@@ -371,9 +371,9 @@ a percentage.
 
 *********************************************************************************************************************/
 
-static ERR POLY_GET_Y1(extVectorPolygon *Self, Unit *Value)
+static ERR POLY_GET_Y1(extVectorPolygon *Self, Unit &Value)
 {
-   Value->set(Self->Points[0].Y);
+   Value = Self->Points[0].Y;
    return ERR::Okay;
 }
 
@@ -397,9 +397,9 @@ a percentage.
 -END-
 *********************************************************************************************************************/
 
-static ERR POLY_GET_Y2(extVectorPolygon *Self, Unit *Value)
+static ERR POLY_GET_Y2(extVectorPolygon *Self, Unit &Value)
 {
-   Value->set(Self->Points[1].Y);
+   Value = Self->Points[1].Y;
    return ERR::Okay;
 }
 

--- a/src/vector/vectors/rectangle.cpp
+++ b/src/vector/vectors/rectangle.cpp
@@ -373,7 +373,7 @@ XOffset: The right-side of the rectangle, expressed as a fixed or scaled offset 
 
 *********************************************************************************************************************/
 
-static ERR VECTORRECTANGLE_GET_XOffset(extVectorRectangle *Self, Unit *Value)
+static ERR VECTORRECTANGLE_GET_XOffset(extVectorRectangle *Self, Unit &Value)
 {
    double value = 0;
 
@@ -384,9 +384,8 @@ static ERR VECTORRECTANGLE_GET_XOffset(extVectorRectangle *Self, Unit *Value)
    }
    else value = 0;
 
-   if ((Value->scaled()) and (get_parent_width(Self) != 0)) value = value / get_parent_width(Self);
-
-   Value->set(value);
+   if ((Value.scaled()) and (get_parent_width(Self) != 0)) Value = Unit(value / get_parent_width(Self), FD_SCALED);
+   else Value = Unit(value);
 
    return ERR::Okay;
 }
@@ -452,7 +451,7 @@ YOffset: The bottom of the rectangle, expressed as a fixed or scaled offset valu
 
 *********************************************************************************************************************/
 
-static ERR VECTORRECTANGLE_GET_YOffset(extVectorRectangle *Self, Unit *Value)
+static ERR VECTORRECTANGLE_GET_YOffset(extVectorRectangle *Self, Unit &Value)
 {
    double value = 0;
 
@@ -463,8 +462,8 @@ static ERR VECTORRECTANGLE_GET_YOffset(extVectorRectangle *Self, Unit *Value)
    }
    else value = 0;
 
-   if ((Value->scaled()) and (get_parent_height(Self) != 0)) Value->set(value / get_parent_height(Self));
-   else Value->set(value);
+   if ((Value.scaled()) and (get_parent_height(Self) != 0)) Value = Unit(value / get_parent_height(Self), FD_SCALED);
+   else Value = Unit(value);
    return ERR::Okay;
 }
 

--- a/src/vector/vectors/viewport.cpp
+++ b/src/vector/vectors/viewport.cpp
@@ -23,6 +23,26 @@ NOTE: Refer to gen_vector_path() for the code that manages viewport dimensions i
 
 *********************************************************************************************************************/
 
+static double viewport_parent_width(extVectorViewport *Self)
+{
+   if (Self->ParentView) return viewport_coordinate_width(Self->ParentView);
+   else if (Self->Scene) return Self->Scene->PageWidth;
+   else return 0;
+}
+
+static double viewport_parent_height(extVectorViewport *Self)
+{
+   if (Self->ParentView) return viewport_coordinate_height(Self->ParentView);
+   else if (Self->Scene) return Self->Scene->PageHeight;
+   else return 0;
+}
+
+static Unit fixed_to_requested_unit(double Value, double ParentSize, bool Scaled)
+{
+   if (Scaled) return Unit(ParentSize ? Value / ParentSize : 0, FD_SCALED);
+   else return Unit(Value);
+}
+
 //********************************************************************************************************************
 // Input event handler for the dragging of viewports by the user.  Requires the client to set the DragCallback field
 // to be active.
@@ -68,12 +88,6 @@ static ERR drag_callback(extVectorViewport *Viewport, const InputEvent *Events)
 
             Viewport->get(FID_X, glDragOriginX);
             Viewport->get(FID_Y, glDragOriginY);
-
-            // Ensure that the X,Y coordinates are fixed.
-
-            Viewport->vpDimensions = (Viewport->vpDimensions | DMF::FIXED_X | DMF::FIXED_Y) &
-               (~(DMF::SCALED_X|DMF::SCALED_Y|DMF::SCALED_X_OFFSET|DMF::SCALED_Y_OFFSET));
-
          }
          else Viewport->vpDragging = 0; // Released
       }
@@ -151,9 +165,12 @@ static ERR VECTORVIEWPORT_Move(extVectorViewport *Self, struct acMove *Args)
 {
    if (!Args) return ERR::NullArgs;
 
-   Self->vpDimensions = (Self->vpDimensions|DMF::FIXED_X|DMF::FIXED_Y) & (~(DMF::SCALED_X|DMF::SCALED_Y));
-   Self->vpTargetX += Args->DeltaX;
-   Self->vpTargetY += Args->DeltaY;
+   Unit x, y;
+   Self->get(FID_X, x);
+   Self->get(FID_Y, y);
+
+   Self->vpTargetX = Unit(x + Args->DeltaX);
+   Self->vpTargetY = Unit(y + Args->DeltaY);
 
    mark_dirty((extVector *)Self, RC::FINAL_PATH|RC::TRANSFORM);
    return ERR::Okay;
@@ -169,15 +186,8 @@ static ERR VECTORVIEWPORT_MoveToPoint(extVectorViewport *Self, struct acMoveToPo
 {
    if (!Args) return ERR::NullArgs;
 
-   if ((Args->Flags & MTF::X) != MTF::NIL) {
-      Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_X) & (~DMF::SCALED_X);
-      Self->vpTargetX = Args->X;
-   }
-
-   if ((Args->Flags & MTF::Y) != MTF::NIL) {
-      Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_Y) & (~DMF::SCALED_Y);
-      Self->vpTargetY = Args->Y;
-   }
+   if ((Args->Flags & MTF::X) != MTF::NIL) Self->vpTargetX = Args->X;
+   if ((Args->Flags & MTF::Y) != MTF::NIL) Self->vpTargetY = Args->Y;
 
    mark_dirty((extVector *)Self, RC::FINAL_PATH|RC::TRANSFORM);
    return ERR::Okay;
@@ -207,16 +217,13 @@ static ERR VECTORVIEWPORT_Redimension(extVectorViewport *Self, struct acRedimens
 {
    if (!Args) return ERR::NullArgs;
 
-   Self->vpDimensions = (Self->vpDimensions|DMF::FIXED_X|DMF::FIXED_Y|DMF::FIXED_WIDTH|DMF::FIXED_HEIGHT) &
-      (~(DMF::SCALED_X|DMF::SCALED_Y|DMF::SCALED_WIDTH|DMF::SCALED_HEIGHT));
+   Self->vpTargetX      = Unit(Args->X);
+   Self->vpTargetY      = Unit(Args->Y);
+   Self->vpTargetWidth  = Unit(Args->Width);
+   Self->vpTargetHeight = Unit(Args->Height);
 
-   Self->vpTargetX      = Args->X;
-   Self->vpTargetY      = Args->Y;
-   Self->vpTargetWidth  = Args->Width;
-   Self->vpTargetHeight = Args->Height;
-
-   if (Self->vpTargetWidth < 1) Self->vpTargetWidth = 1;
-   if (Self->vpTargetHeight < 1) Self->vpTargetHeight = 1;
+   if (Self->vpTargetWidth < 1) Self->vpTargetWidth = Unit(1);
+   if (Self->vpTargetHeight < 1) Self->vpTargetHeight = Unit(1);
    mark_dirty((extVector *)Self, RC::FINAL_PATH|RC::TRANSFORM);
    return ERR::Okay;
 }
@@ -231,14 +238,11 @@ static ERR VECTORVIEWPORT_Resize(extVectorViewport *Self, struct acResize *Args)
 {
    if (!Args) return ERR::NullArgs;
 
-   Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_WIDTH) & (~DMF::SCALED_WIDTH);
-   Self->vpTargetWidth = Args->Width;
+   Self->vpTargetWidth  = Unit(Args->Width);
+   Self->vpTargetHeight = Unit(Args->Height);
 
-   Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_HEIGHT) & (~DMF::SCALED_HEIGHT);
-   Self->vpTargetHeight = Args->Height;
-
-   if (Self->vpTargetWidth < 1) Self->vpTargetWidth = 1;
-   if (Self->vpTargetHeight < 1) Self->vpTargetHeight = 1;
+   if (Self->vpTargetWidth < 1) Self->vpTargetWidth = Unit(1);
+   if (Self->vpTargetHeight < 1) Self->vpTargetHeight = Unit(1);
    mark_dirty((extVector *)Self, RC::FINAL_PATH|RC::TRANSFORM);
    return ERR::Okay;
 }
@@ -345,28 +349,6 @@ static ERR VIEW_SET_Buffered(extVectorViewport *Self, int Value)
 }
 
 /*********************************************************************************************************************
--FIELD-
-Dimensions: Dimension flags define whether individual dimension fields contain fixed or scaled values.
-Lookup: DMF
-
-<types lookup="DMF"/>
-
-*********************************************************************************************************************/
-
-static ERR VIEW_GET_Dimensions(extVectorViewport *Self, DMF &Value)
-{
-   Value = Self->vpDimensions;
-   return ERR::Okay;
-}
-
-static ERR VIEW_SET_Dimensions(extVectorViewport *Self, DMF Value)
-{
-   Self->vpDimensions = Value;
-   mark_dirty((extVector *)Self, RC::DIRTY);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 DragCallback: Receiver for drag requests originating from the viewport.
@@ -423,54 +405,35 @@ Height: The height of the viewport's target area.
 The height of the viewport's target area is defined here as a fixed or scaled value.  The default value is `100%` for
 full coverage.
 
-The fixed value is always returned when retrieving the height.
-
 *********************************************************************************************************************/
 
 static ERR VIEW_GET_Height(extVectorViewport *Self, Unit &Value)
 {
-   double val;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasHeight(Self->vpDimensions)) { // Working with a fixed dimension
-      if (Value.Type & FD_SCALED) {
-         if (Self->ParentView) val = Self->vpFixedHeight * Self->ParentView->vpFixedHeight;
-         else val = Self->vpFixedHeight * Self->Scene->PageHeight;
-      }
-      else val = Self->vpTargetHeight;
-   }
-   else if (dmf::hasScaledHeight(Self->vpDimensions)) { // Working with a scaled dimension
-      if (Value.Type & FD_SCALED) val = Self->vpTargetHeight;
-      else if (Self->ParentView) val = Self->vpTargetHeight * Self->ParentView->vpFixedHeight;
-      else val = Self->vpTargetHeight * Self->Scene->PageHeight;
-   }
-   else if (dmf::hasAnyYOffset(Self->vpDimensions)) {
-      double y, parent_height;
-
-      if (dmf::hasScaledY(Self->vpDimensions)) y = Self->vpTargetY * Self->ParentView->vpFixedHeight;
-      else y = Self->vpTargetY;
-
-      if (Self->ParentView) Self->ParentView->get(FID_Height, parent_height);
-      else parent_height = Self->Scene->PageHeight;
-
-      if (dmf::hasYOffset(Self->vpDimensions)) val = parent_height - Self->vpTargetYO - y;
-      else val = parent_height - (Self->vpTargetYO * parent_height) - y;
-   }
-   else { // If no height set by the client, the full height is inherited from the parent
-      if (Self->ParentView) return Self->ParentView->get(FID_Height, Value);
-      else Self->Scene->get(FID_PageHeight, val);
+   if (Value.verbatim()) {
+      Value = Self->vpTargetHeight;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
 
-   Value.set(val);
+   auto parent_height = viewport_parent_height(Self);
+   double val;
+
+   if (Self->vpTargetHeight.defined()) val = unit_to_fixed(Self->vpTargetHeight, parent_height);
+   else if (Self->vpTargetYO.defined()) {
+      auto y = Self->vpTargetY.defined() ? unit_to_fixed(Self->vpTargetY, parent_height) : 0;
+      val = parent_height - unit_to_fixed(Self->vpTargetYO, parent_height) - y;
+   }
+   else val = parent_height;
+
+   Value = fixed_to_requested_unit(val, parent_height, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_Height(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetHeight = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_HEIGHT) & (~DMF::FIXED_HEIGHT);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_HEIGHT) & (~DMF::SCALED_HEIGHT);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -660,48 +623,31 @@ full coverage.
 
 static ERR VIEW_GET_Width(extVectorViewport *Self, Unit &Value)
 {
-   double val;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasWidth(Self->vpDimensions)) { // Working with a fixed dimension
-      if (Value.Type & FD_SCALED) {
-         if (Self->ParentView) val = Self->vpFixedWidth * Self->ParentView->vpFixedWidth;
-         else val = Self->vpFixedWidth * Self->Scene->PageWidth;
-      }
-      else val = Self->vpTargetWidth;
-   }
-   else if (dmf::hasScaledWidth(Self->vpDimensions)) { // Working with a scaled dimension
-      if (Value.Type & FD_SCALED) val = Self->vpTargetWidth;
-      else if (Self->ParentView) val = Self->vpTargetWidth * Self->ParentView->vpFixedWidth;
-      else val = Self->vpTargetWidth * Self->Scene->PageWidth;
-   }
-   else if (dmf::hasAnyXOffset(Self->vpDimensions)) {
-      double x, parent_width;
-
-      if (dmf::hasScaledX(Self->vpDimensions)) x = Self->vpTargetX * Self->ParentView->vpFixedWidth;
-      else x = Self->vpTargetX;
-
-      if (Self->ParentView) Self->ParentView->get(FID_Width, parent_width);
-      else parent_width = Self->Scene->PageWidth;
-
-      if (dmf::hasXOffset(Self->vpDimensions)) val = parent_width - Self->vpTargetXO - x;
-      else val = parent_width - (Self->vpTargetXO * parent_width) - x;
-   }
-   else { // If no width set by the client, the full width is inherited from the parent
-      if (Self->ParentView) return Self->ParentView->get(FID_Width, Value);
-      else Self->Scene->get(FID_PageWidth, val);
+   if (Value.verbatim()) {
+      Value = Self->vpTargetWidth;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
 
-   Value.set(val);
+   auto parent_width = viewport_parent_width(Self);
+   double val;
+
+   if (Self->vpTargetWidth.defined()) val = unit_to_fixed(Self->vpTargetWidth, parent_width);
+   else if (Self->vpTargetXO.defined()) {
+      auto x = Self->vpTargetX.defined() ? unit_to_fixed(Self->vpTargetX, parent_width) : 0;
+      val = parent_width - unit_to_fixed(Self->vpTargetXO, parent_width) - x;
+   }
+   else val = parent_width;
+
+   Value = fixed_to_requested_unit(val, parent_width, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_Width(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetWidth = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_WIDTH) & (~DMF::FIXED_WIDTH);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_WIDTH) & (~DMF::SCALED_WIDTH);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -721,32 +667,30 @@ width.
 
 static ERR VIEW_GET_X(extVectorViewport *Self, Unit &Value)
 {
-   double width, value;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasX(Self->vpDimensions)) value = Self->vpTargetX;
-   else if (dmf::hasScaledX(Self->vpDimensions)) {
-      value = Self->vpTargetX * Self->ParentView->vpFixedWidth;
+   if (Value.verbatim()) {
+      Value = Self->vpTargetX;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
-   else if ((dmf::hasAnyWidth(Self->vpDimensions)) and (dmf::hasAnyXOffset(Self->vpDimensions))) {
-      if (dmf::hasWidth(Self->vpDimensions)) width = Self->vpTargetWidth;
-      else width = Self->ParentView->vpFixedWidth * Self->vpTargetWidth;
-      if (dmf::hasXOffset(Self->vpDimensions)) value = Self->ParentView->vpFixedWidth - width - Self->vpTargetXO;
-      else value = Self->ParentView->vpFixedWidth - width - (Self->ParentView->vpFixedWidth * Self->vpTargetXO);
-   }
-   else value = 0;
 
-   if (Value.scaled()) Value.set(value / Self->ParentView->vpFixedWidth);
-   else Value.set(value);
+   auto parent_width = viewport_parent_width(Self);
+   double value = 0;
+
+   if (Self->vpTargetX.defined()) value = unit_to_fixed(Self->vpTargetX, parent_width);
+   else if (Self->vpTargetWidth.defined() and Self->vpTargetXO.defined()) {
+      value = parent_width - unit_to_fixed(Self->vpTargetWidth, parent_width) -
+         unit_to_fixed(Self->vpTargetXO, parent_width);
+   }
+
+   Value = fixed_to_requested_unit(value, parent_width, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_X(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetX = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_X) & (~DMF::FIXED_X);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_X) & (~DMF::SCALED_X);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -766,34 +710,30 @@ parent's width.
 
 static ERR VIEW_GET_XOffset(extVectorViewport *Self, Unit &Value)
 {
-   double width;
-   double value = 0;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasXOffset(Self->vpDimensions)) value = Self->vpTargetXO;
-   else if (dmf::hasScaledXOffset(Self->vpDimensions)) {
-      value = Self->vpTargetXO * Self->ParentView->vpFixedWidth;
+   if (Value.verbatim()) {
+      Value = Self->vpTargetXO;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
-   else if ((dmf::hasAnyX(Self->vpDimensions)) and (dmf::hasAnyWidth(Self->vpDimensions))) {
-      if (dmf::hasWidth(Self->vpDimensions)) width = Self->vpTargetWidth;
-      else width = Self->ParentView->vpFixedWidth * Self->vpTargetWidth;
 
-      if (dmf::hasX(Self->vpDimensions)) value = Self->ParentView->vpFixedWidth - (Self->vpTargetX + width);
-      else value = Self->ParentView->vpFixedWidth - ((Self->vpTargetX * Self->ParentView->vpFixedWidth) + width);
+   auto parent_width = viewport_parent_width(Self);
+   double value = 0;
+
+   if (Self->vpTargetXO.defined()) value = unit_to_fixed(Self->vpTargetXO, parent_width);
+   else if (Self->vpTargetX.defined() and Self->vpTargetWidth.defined()) {
+      value = parent_width - unit_to_fixed(Self->vpTargetX, parent_width) -
+         unit_to_fixed(Self->vpTargetWidth, parent_width);
    }
-   else value = 0;
 
-   if (Value.scaled()) Value.set(value / Self->ParentView->vpFixedWidth);
-   else Value.set(value);
+   Value = fixed_to_requested_unit(value, parent_width, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_XOffset(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetXO = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_X_OFFSET) & (~DMF::FIXED_X_OFFSET);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_X_OFFSET) & (~DMF::SCALED_X_OFFSET);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -813,33 +753,30 @@ height.
 
 static ERR VIEW_GET_Y(extVectorViewport *Self, Unit &Value)
 {
-   double value, height;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasY(Self->vpDimensions)) value = Self->vpTargetY;
-   else if (dmf::hasScaledY(Self->vpDimensions)) {
-      value = Self->vpTargetY * Self->ParentView->vpFixedHeight;
+   if (Value.verbatim()) {
+      Value = Self->vpTargetY;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
-   else if ((dmf::hasAnyHeight(Self->vpDimensions)) and (dmf::hasAnyYOffset(Self->vpDimensions))) {
-      if (dmf::hasHeight(Self->vpDimensions)) height = Self->vpTargetHeight;
-      else height = Self->ParentView->vpFixedHeight * Self->vpTargetHeight;
 
-      if (dmf::hasYOffset(Self->vpDimensions)) value = Self->ParentView->vpFixedHeight - height - Self->vpTargetYO;
-      else value = Self->ParentView->vpFixedHeight - height - (Self->ParentView->vpFixedHeight * Self->vpTargetYO);
+   auto parent_height = viewport_parent_height(Self);
+   double value = 0;
+
+   if (Self->vpTargetY.defined()) value = unit_to_fixed(Self->vpTargetY, parent_height);
+   else if (Self->vpTargetHeight.defined() and Self->vpTargetYO.defined()) {
+      value = parent_height - unit_to_fixed(Self->vpTargetHeight, parent_height) -
+         unit_to_fixed(Self->vpTargetYO, parent_height);
    }
-   else value = 0;
 
-   if (Value.scaled()) Value.set(value / Self->ParentView->vpFixedHeight);
-   else Value.set(value);
+   Value = fixed_to_requested_unit(value, parent_height, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_Y(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetY = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_Y) & (~DMF::FIXED_Y);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_Y) & (~DMF::SCALED_Y);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -859,34 +796,30 @@ height.
 
 static ERR VIEW_GET_YOffset(extVectorViewport *Self, Unit &Value)
 {
-   double height;
-   double value = 0;
-
    gen_vector_tree(Self);
 
-   if (dmf::hasYOffset(Self->vpDimensions)) value = Self->vpTargetYO;
-   else if (dmf::hasScaledYOffset(Self->vpDimensions)) {
-      value = Self->vpTargetYO * Self->ParentView->vpFixedHeight;
+   if (Value.verbatim()) {
+      Value = Self->vpTargetYO;
+      Value.Type |= FD_PURE;
+      return ERR::Okay;
    }
-   else if ((dmf::hasAnyY(Self->vpDimensions)) and (dmf::hasAnyHeight(Self->vpDimensions))) {
-      if (dmf::hasHeight(Self->vpDimensions)) height = Self->vpTargetHeight;
-      else height = Self->ParentView->vpFixedHeight * Self->vpTargetHeight;
 
-      if (dmf::hasY(Self->vpDimensions)) value = Self->ParentView->vpFixedHeight - (Self->vpTargetY + height);
-      else value = Self->ParentView->vpFixedHeight - ((Self->vpTargetY * Self->ParentView->vpFixedHeight) + height);
+   auto parent_height = viewport_parent_height(Self);
+   double value = 0;
+
+   if (Self->vpTargetYO.defined()) value = unit_to_fixed(Self->vpTargetYO, parent_height);
+   else if (Self->vpTargetY.defined() and Self->vpTargetHeight.defined()) {
+      value = parent_height - unit_to_fixed(Self->vpTargetY, parent_height) -
+         unit_to_fixed(Self->vpTargetHeight, parent_height);
    }
-   else value = 0;
 
-   if (Value.scaled()) Value.set(value / Self->ParentView->vpFixedHeight);
-   else Value.set(value);
+   Value = fixed_to_requested_unit(value, parent_height, Value.scaled());
    return ERR::Okay;
 }
 
 static ERR VIEW_SET_YOffset(extVectorViewport *Self, Unit &Value)
 {
    Self->vpTargetYO = Value;
-   if (Value.scaled()) Self->vpDimensions = (Self->vpDimensions | DMF::SCALED_Y_OFFSET) & (~DMF::FIXED_Y_OFFSET);
-   else Self->vpDimensions = (Self->vpDimensions | DMF::FIXED_Y_OFFSET) & (~DMF::SCALED_Y_OFFSET);
    mark_dirty((extVector *)Self, RC::DIRTY);
    return ERR::Okay;
 }
@@ -901,17 +834,16 @@ static const FieldArray clViewFields[] = {
    { "AspectRatio",  FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW|FDF_PURE, VIEW_GET_AspectRatio, VIEW_SET_AspectRatio, &clAspectRatio },
    { "Buffer",       FDF_VIRTUAL|FDF_OBJECT|FDF_R|FDF_PURE, VIEW_GET_Buffer },
    { "Buffered",     FDF_VIRTUAL|FDF_INT|FDF_RI|FDF_PURE, VIEW_GET_Buffered, VIEW_SET_Buffered },
-   { "Dimensions",   FDF_VIRTUAL|FDF_INTFLAGS|FDF_R|FDF_PURE, VIEW_GET_Dimensions, VIEW_SET_Dimensions, &clVectorViewportDMF },
    { "DragCallback", FDF_VIRTUAL|FDF_FUNCTION|FDF_RW|FDF_PURE, VIEW_GET_DragCallback, VIEW_SET_DragCallback },
    { "Overflow",     FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW|FDF_PURE, VIEW_GET_Overflow, VIEW_SET_Overflow, &clVectorViewportVOF },
    { "OverflowX",    FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW|FDF_PURE, VIEW_GET_OverflowX, VIEW_SET_OverflowX, &clVectorViewportVOF },
    { "OverflowY",    FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW|FDF_PURE, VIEW_GET_OverflowY, VIEW_SET_OverflowY, &clVectorViewportVOF },
-   { "X",            FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_X,       VIEW_SET_X },
-   { "Y",            FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_Y,       VIEW_SET_Y },
-   { "XOffset",      FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_XOffset, VIEW_SET_XOffset },
-   { "YOffset",      FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_YOffset, VIEW_SET_YOffset },
-   { "Width",        FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_Width,   VIEW_SET_Width },
-   { "Height",       FDF_VIRTUAL|FDF_UNIT|FDF_DOUBLE|FDF_SCALED|FDF_RW, VIEW_GET_Height,  VIEW_SET_Height },
+   { "X",            FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_X,       VIEW_SET_X },
+   { "Y",            FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_Y,       VIEW_SET_Y },
+   { "XOffset",      FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_XOffset, VIEW_SET_XOffset },
+   { "YOffset",      FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_YOffset, VIEW_SET_YOffset },
+   { "Width",        FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_Width,   VIEW_SET_Width },
+   { "Height",       FDF_VIRTUAL|FDF_UNIT|FDF_SCALED|FDF_RW, VIEW_GET_Height,  VIEW_SET_Height },
    { "ViewX",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, VIEW_GET_ViewX,      VIEW_SET_ViewX },
    { "ViewY",        FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, VIEW_GET_ViewY,      VIEW_SET_ViewY },
    { "ViewWidth",    FDF_VIRTUAL|FDF_DOUBLE|FDF_RW|FDF_PURE, VIEW_GET_ViewWidth,  VIEW_SET_ViewWidth },

--- a/src/vector/vectors/viewport_def.cpp
+++ b/src/vector/vectors/viewport_def.cpp
@@ -8,36 +8,6 @@ static const struct FieldDef clVectorViewportVOF[] = {
    { nullptr, 0 }
 };
 
-static const struct FieldDef clVectorViewportDMF[] = {
-   { "ScaledX", 0x00000001 },
-   { "ScaledY", 0x00000002 },
-   { "FixedX", 0x00000004 },
-   { "FixedY", 0x00000008 },
-   { "ScaledXOffset", 0x00000010 },
-   { "ScaledYOffset", 0x00000020 },
-   { "FixedXOffset", 0x00000040 },
-   { "FixedYOffset", 0x00000080 },
-   { "FixedHeight", 0x00000100 },
-   { "FixedWidth", 0x00000200 },
-   { "ScaledHeight", 0x00000400 },
-   { "ScaledWidth", 0x00000800 },
-   { "FixedDepth", 0x00001000 },
-   { "ScaledDepth", 0x00002000 },
-   { "FixedZ", 0x00004000 },
-   { "ScaledZ", 0x00008000 },
-   { "ScaledRadiusX", 0x00010000 },
-   { "FixedRadiusX", 0x00020000 },
-   { "ScaledCenterX", 0x00040000 },
-   { "ScaledCenterY", 0x00080000 },
-   { "FixedCenterX", 0x00100000 },
-   { "FixedCenterY", 0x00200000 },
-   { "StatusChangeH", 0x00400000 },
-   { "StatusChangeV", 0x00800000 },
-   { "ScaledRadiusY", 0x01000000 },
-   { "FixedRadiusY", 0x02000000 },
-   { nullptr, 0 }
-};
-
 static ERR VECTORVIEWPORT_NewPlacement(extVectorViewport *Self) {
    new (Self) extVectorViewport;
    return ERR::Okay;


### PR DESCRIPTION
* Store viewport target dimensions as Unit values instead of separate dimension flags
* Preserve scaled and undefined viewport dimensions during SVG export
* [Core] Added verbatim unit requests for field getters