### PR TITLE
[Vector] Strongly type the GradientVoronoi WorleyMode and WorleyMetric fields

### DIFF
--- a/docs/xml/modules/classes/convolvefx.xml
+++ b/docs/xml/modules/classes/convolvefx.xml
@@ -15,13 +15,13 @@
     <description>
 <p>Convolve applies a matrix convolution filter effect to an input source.  A convolution combines pixels in the input image with neighbouring pixels to produce a resulting image.  A wide variety of imaging operations can be achieved through convolutions, including blurring, edge detection, sharpening, embossing and beveling.</p>
 <p>A matrix convolution is based on an <code>n-by-m</code> matrix (the convolution kernel) which describes how a given pixel value in the input image is combined with its neighbouring pixel values to produce a resulting pixel value. Each result pixel is determined by applying the kernel matrix to the corresponding source pixel and its neighbouring pixels.  The basic convolution formula which is applied to each colour value for a given pixel is:</p>
-<pre>COLOURX,Y = (
+<pre>COLOUR(x,y) = (
      SUM I=0 to [MatrixRows-1] {
        SUM J=0 to [MatrixColumns-1] {
-         SOURCE X - TargetX + J, Y - TargetY + I * Matrix * MatrixColumns - J - 1,  MatrixRows - I - 1
+         SOURCE(x - TargetX + J, y - TargetY + I) * Matrix(MatrixColumns - J - 1, MatrixRows - I - 1)
        }
      }
-   ) / Divisor + Bias * ALPHAX,Y
+   ) / Divisor + Bias * ALPHA(x,y)
 </pre>
 <p>Note in the above formula that the values in the kernel matrix are applied such that the kernel matrix is rotated 180 degrees relative to the source and destination images in order to match convolution theory as described in many computer graphics textbooks.</p>
 <p>Because they operate on pixels, matrix convolutions are inherently resolution-dependent.  To make resolution-independent results, an explicit value should be provided for either the <code>ResX</code> and <code>ResY</code> attributes on the parent <class name="VectorFilter">VectorFilter</class> and/or <fl>UnitX</fl> and <fl>UnitY</fl>.</p></description>

--- a/docs/xml/modules/classes/displacementfx.xml
+++ b/docs/xml/modules/classes/displacementfx.xml
@@ -18,7 +18,7 @@
 </pre>
 <p>where <code>P(x,y)</code> is the Input image, and <code>P'(x,y)</code> is the Target.  <code>XC(x,y)</code> and <code>YC(x,y)</code> are the component values of the channel designated by the <fl>XChannel</fl> and <fl>YChannel</fl>.  For example, to use the red component of Mix to control displacement in <code>X</code> and the green component to control displacement in <code>Y</code>, set <fl>XChannel</fl> to <code>CMP::RED</code> and <fl>YChannel</fl> to <code>CMP::GREEN</code>.</p>
 <p>The displacement map defines the inverse of the mapping performed.</p>
-<p>The Input image is to remain premultiplied for this filter effect.  The calculations using the pixel values from Mix are performed using non-premultiplied color values.  If the image from Mix consists of premultiplied color values, those values are automatically converted into non-premultiplied color values before performing this operation.</p></description>
+<p>The Input image is to remain premultiplied for this filter effect.  The calculations using the pixel values from Mix are performed using non-premultiplied colour values.  If the image from Mix consists of premultiplied colour values, those values are automatically converted into non-premultiplied colour values before performing this operation.</p></description>
     <source>
       <file path="filters/">filter_displacement.cpp</file>
     </source>

--- a/docs/xml/modules/classes/filtereffect.xml
+++ b/docs/xml/modules/classes/filtereffect.xml
@@ -23,14 +23,14 @@
   <actions>
     <action>
       <name>MoveToBack</name>
-      <comment>Move an effect to the front of the VectorFilter's list order.</comment>
+      <comment>Move an effect to the back of the VectorFilter's list order.</comment>
       <prototype>ERR acMoveToBack(*Object)</prototype>
       <tiriPrototype>err = Object.acMoveToBack()</tiriPrototype>
     </action>
 
     <action>
       <name>MoveToFront</name>
-      <comment>Move an object to the front of its current location.</comment>
+      <comment>Move an effect to the front of the VectorFilter's list order.</comment>
       <prototype>ERR acMoveToFront(*Object)</prototype>
       <tiriPrototype>err = Object.acMoveToFront()</tiriPrototype>
     </action>
@@ -61,7 +61,7 @@
 
     <field>
       <name>Mix</name>
-      <comment>Reference to another effect to be used a mixer with Input.</comment>
+      <comment>Reference to another effect to be used as a mixer with Input.</comment>
       <access read="R" write="S">Read/Set</access>
       <type class="FilterEffect">*FilterEffect</type>
       <description>

--- a/docs/xml/modules/classes/gradientcontour.xml
+++ b/docs/xml/modules/classes/gradientcontour.xml
@@ -13,7 +13,8 @@
     <category>Graphics</category>
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
-<p>GradientContour follows the contours of the target vector path.  <code>Floor</code> controls the colour ramp floor and <code>Multiplier</code> controls the ramp scale.</p></description>
+<p>GradientContour follows the contours of the target vector path.  <code>Floor</code> controls the colour ramp floor and <code>Multiplier</code> controls the ramp scale.</p>
+<p>This gradient operates exclusively in <code>BOUNDING_BOX</code> space.  If <class name="Gradient" field="Units">Gradient.Units</class> is set to <code>USERSPACE</code> it will be reset to <code>BOUNDING_BOX</code> during initialisation.</p></description>
     <source>
       <file path="painters/">gradient_contour.cpp</file>
     </source>
@@ -26,7 +27,7 @@
       <access read="G" write="S">Get/Set</access>
       <type>UNIT</type>
       <description>
-<p>The Floor value is used as the floor for contour gradient colour values.  It has a valid range of <code>0 &lt; Floor &lt; Multiplier</code>.</p>
+<p>The Floor value is used as the floor for contour gradient colour values.  It has a valid range of <code>0 &lt;= Floor &lt; Multiplier</code>; the constraint against <fl>Multiplier</fl> is enforced at initialisation.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/gradientdistal.xml
+++ b/docs/xml/modules/classes/gradientdistal.xml
@@ -25,7 +25,8 @@ full strength, repeating until the parent area is filled.</li>
 <code>REFLECT</code> tiles the fade outward as a triangle wave: each cycle alternates direction, ramping the alpha back up
 from zero before fading again, repeating until the parent area is filled.</li>
 </list>
-<p>Setting <fl>OuterFall</fl> to <code>GFALL::OPAQUE</code> holds the exterior alpha at full strength rather than tapering it, so with <code>REPEAT</code> or <code>REFLECT</code> the full colour ramp is painted solidly out to the parent edge with no fade between tiles.  Under <code>PAD</code> the alpha still cuts to transparent at the padding edge as usual.</p></description>
+<p>Setting <fl>OuterFall</fl> to <code>GFALL::OPAQUE</code> holds the exterior alpha at full strength rather than tapering it, so with <code>REPEAT</code> or <code>REFLECT</code> the full colour ramp is painted solidly out to the parent edge with no fade between tiles.  Under <code>PAD</code> the alpha still cuts to transparent at the padding edge as usual.</p>
+<p>This gradient operates exclusively in <code>BOUNDING_BOX</code> space.  If <class name="Gradient" field="Units">Gradient.Units</class> is set to <code>USERSPACE</code> it will be reset to <code>BOUNDING_BOX</code> during initialisation.</p></description>
     <source>
       <file path="painters/">gradient_distal.cpp</file>
     </source>
@@ -38,7 +39,7 @@ from zero before fading again, repeating until the parent area is filled.</li>
       <access read="G" write="S">Get/Set</access>
       <type>UNIT</type>
       <description>
-<p>The Floor value is used as the floor for distal gradient colour values.</p>
+<p>The Floor value is used as the floor for distal gradient colour values.  It has a valid range of <code>0 &lt;= Floor &lt; Multiplier</code>; the constraint against <fl>Multiplier</fl> is enforced at initialisation.</p>
       </description>
     </field>
 
@@ -69,7 +70,7 @@ from zero before fading again, repeating until the parent area is filled.</li>
       <access read="G" write="S">Get/Set</access>
       <type>UNIT</type>
       <description>
-<p>The Multiplier value acts as a multiplier for distal gradient colour values.</p>
+<p>The Multiplier value acts as a multiplier for distal gradient colour values.  It has a valid range of <code>.01 &lt; Multiplier &lt; 10</code>.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/gradientvoronoi.xml
+++ b/docs/xml/modules/classes/gradientvoronoi.xml
@@ -13,7 +13,8 @@
     <category>Graphics</category>
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
-<p>GradientVoronoi scatters deterministic feature points inside the target path bounds and maps the selected Worley field through the inherited colour ramp.  <code>Seed</code> controls repeatability, <code>PointCount</code> controls feature density, <code>WorleyMode</code> selects the field interpretation, and <code>WorleyMetric</code> selects the distance metric.</p></description>
+<p>GradientVoronoi scatters deterministic feature points inside the target path bounds and maps the selected Worley field through the inherited colour ramp.  <code>Seed</code> controls repeatability, <code>PointCount</code> controls feature density, <code>WorleyMode</code> selects the field interpretation, and <code>WorleyMetric</code> selects the distance metric.</p>
+<p>This gradient operates exclusively in <code>BOUNDING_BOX</code> space.  If <class name="Gradient" field="Units">Gradient.Units</class> is set to <code>USERSPACE</code> it will be reset to <code>BOUNDING_BOX</code> during initialisation.</p></description>
     <source>
       <file path="painters/">gradient_voronoi.cpp</file>
     </source>
@@ -26,7 +27,7 @@
       <access read="G" write="S">Get/Set</access>
       <type>UNIT</type>
       <description>
-<p>The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of <code>0 &lt; Floor &lt; Multiplier</code>.</p>
+<p>The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of <code>0 &lt;= Floor &lt; Multiplier</code>; the constraint against <fl>Multiplier</fl> is enforced at initialisation.</p>
       </description>
     </field>
 
@@ -76,7 +77,7 @@
       <access read="G" write="S">Get/Set</access>
       <type>INT</type>
       <description>
-<p>PointCount controls how many feature points are generated inside the target path bounds.  The accepted range is <code>1</code> to <code>4096</code>.</p>
+<p>PointCount controls how many feature points are generated inside the target path bounds.  The accepted range is <code>1</code> to <code>4096</code> and the default is <code>16</code>.  This field is ignored when explicit <fl>Points</fl> are supplied.</p>
       </description>
     </field>
 
@@ -105,7 +106,7 @@
       <name>WorleyMetric</name>
       <comment>Distance metric for the Voronoi field.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type lookup="WLM">INT</type>
+      <type lookup="WLM">WLM</type>
       <description>
 <p>WorleyMetric selects the distance function used when measuring each pixel against the seeded feature points.</p>
 <types lookup="WLM"/>
@@ -116,7 +117,7 @@
       <name>WorleyMode</name>
       <comment>Field mode for the Voronoi gradient.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type lookup="WLF">INT</type>
+      <type lookup="WLF">WLF</type>
       <description>
 <p>WorleyMode selects how distances to feature points are converted into the scalar field that feeds the colour ramp.</p>
 <types lookup="WLF"/>

--- a/docs/xml/modules/classes/metaclass.xml
+++ b/docs/xml/modules/classes/metaclass.xml
@@ -269,6 +269,16 @@
     </field>
 
     <field>
+      <name>PublicSize</name>
+      <comment>The size of the class in bytes, as seen by the client.</comment>
+      <access>-/-</access>
+      <type>INT</type>
+      <description>
+<p>The public size reflects the size of the class before any private variables are taken into account.</p>
+      </description>
+    </field>
+
+    <field>
       <name>RootModule</name>
       <comment>Returns a direct reference to the RootModule object that hosts the class.</comment>
       <access read="G">Get</access>

--- a/docs/xml/modules/classes/morphologyfx.xml
+++ b/docs/xml/modules/classes/morphologyfx.xml
@@ -16,7 +16,7 @@
 <p>The MorphologyFX class performs &quot;fattening&quot; or &quot;thinning&quot; of artwork.  It is particularly useful for fattening or thinning an alpha channel.</p>
 <p>The dilation (or erosion) kernel is a rectangle with a width of <code>2 * RadiusX</code> and a height of <code>2 * RadiusY</code>. In dilation, the output pixel is the individual component-wise maximum of the corresponding R,G,B,A values in the input image's kernel rectangle.  In erosion, the output pixel is the individual component-wise minimum of the corresponding R,G,B,A values in the input image's kernel rectangle.</p>
 <p>Frequently this operation will take place on alpha-only images, such as that produced by the built-in input, SourceAlpha.  In that case, the implementation might want to optimize the single channel case.</p>
-<p>Because the algorithm operates on premultipied color values, it will always result in color values less than or equal to the alpha channel.</p></description>
+<p>Because the algorithm operates on premultiplied colour values, it will always result in colour values less than or equal to the alpha channel.</p></description>
     <source>
       <file path="filters/">filter_morphology.cpp</file>
     </source>

--- a/docs/xml/modules/classes/vectorpattern.xml
+++ b/docs/xml/modules/classes/vectorpattern.xml
@@ -14,7 +14,7 @@
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
 <p>The VectorPattern class is used by Vector painting algorithms to fill and stroke vectors with pre-rendered patterns. It is the most efficient way of rendering a common set of graphics multiple times.</p>
-<p>The VectorPattern must be registered with a <class name="VectorScene">VectorScene</class> via the <method class="VectorScene">AddDef</method> method. Any vector within the target scene will be able to utilise the pattern for filling or stroking by referencing its name through the <class name="Vector" field="Fill">Vector.Fill</class> and <class name="Vector" field="Stroke">Vector.Stroke</class> fields.  For instance <code>url(#dots)</code>.</p>
+<p>The VectorPattern must be registered with a <class name="VectorScene">VectorScene</class> via the <class name="VectorScene" method="AddDef">VectorScene.AddDef()</class> method. Any vector within the target scene will be able to utilise the pattern for filling or stroking by referencing its name through the <class name="Vector" field="Fill">Vector.Fill</class> and <class name="Vector" field="Stroke">Vector.Stroke</class> fields.  For instance <code>url(#dots)</code>.</p>
 <p>A special use case is made for patterns that are applied as a fill operation in <class name="VectorViewport">VectorViewport</class> objects.  In this case the renderer will dynamically render the pattern as a background within the viewport.  This ensures that the pattern is rendered at maximum fidelity whenever it is used, and not affected by bitmap clipping restrictions.  It should be noted that this means the image caching feature will be disabled.</p>
 <p>It is strongly recommended that the VectorPattern is owned by the <class name="VectorScene">VectorScene</class> that is handling the definition.  This will ensure that the VectorPattern is deallocated when the scene is destroyed.</p></description>
     <source>
@@ -107,7 +107,7 @@
       <access read="R" write="S">Read/Set</access>
       <type lookup="VSPREAD">VSPREAD</type>
       <description>
-<p>Indicates what happens if the pattern starts or ends inside the bounds of the target vector.  The default value is PAD.</p>
+<p>Indicates what happens if the pattern starts or ends inside the bounds of the target vector.  The default value is <code>VSPREAD::PAD</code>.</p>
 <types lookup="VSPREAD"/>
       </description>
     </field>
@@ -128,7 +128,7 @@
       <access read="R" write="W">Read/Write</access>
       <type lookup="VUNIT">VUNIT</type>
       <description>
-<p>This field declares the coordinate system that is used for values in the <fl>X</fl> and <fl>Y</fl> fields.  The default setting is <code>BOUNDING_BOX</code>, which means the pattern will be drawn to scale in realtime.  The most efficient method is USERSPACE, which allows the pattern image to be persistently cached.</p>
+<p>This field declares the coordinate system that is used for values in the <fl>X</fl>, <fl>Y</fl>, <fl>Width</fl> and <fl>Height</fl> fields.  The default setting is <code>BOUNDING_BOX</code>, which means the pattern will be drawn to scale in realtime.  The most efficient method is <code>USERSPACE</code>, which allows the pattern image to be persistently cached.</p>
 <types lookup="VUNIT"/>
       </description>
     </field>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2645,7 +2645,7 @@ class objMetaClass : public Object {
    }
 
    inline ERR getLocation(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[21];
+      auto field = &this->Class->Dictionary[22];
       SetObjectContext(this, field, AC::NIL);
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
@@ -2654,7 +2654,7 @@ class objMetaClass : public Object {
    }
 
    inline ERR getModule(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[24];
+      auto field = &this->Class->Dictionary[25];
       SetObjectContext(this, field, AC::NIL);
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
@@ -2663,7 +2663,7 @@ class objMetaClass : public Object {
    }
 
    inline ERR getObjects(std::span<int> &Value) noexcept {
-      auto field = &this->Class->Dictionary[25];
+      auto field = &this->Class->Dictionary[26];
       SetObjectContext(this, field, AC::NIL);
       auto get_field = (ERR (*)(APTR, std::span<int> &))field->GetValue;
       auto error = get_field(this, Value);

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2531,6 +2531,7 @@ class objMetaClass : public Object {
    CLASSID BaseClassID;                 // Specifies the base class ID of a class object.
    int     OpenCount;                   // The total number of active objects that are linked back to the MetaClass.
    CCF     Category;                    // The system category that a class belongs to.
+   int     PublicSize;                  // The size of the class in bytes, as seen by the client.
 
 #ifdef PRV_METACLASS
     // Field table cache for Tiri - eliminates per-instance hash tables.

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -1954,7 +1954,7 @@ class objFilterEffect : public Object {
    objFilterEffect * Prev;    // Previous filter in the chain.
    objBitmap * Target;        // Target bitmap for rendering the effect.
    objFilterEffect * Input;   // Reference to another effect to be used as an input source.
-   objFilterEffect * Mix;     // Reference to another effect to be used a mixer with Input.
+   objFilterEffect * Mix;     // Reference to another effect to be used as a mixer with Input.
    Unit X;                    // Primitive X coordinate for the effect.
    Unit Y;                    // Primitive Y coordinate for the effect.
    Unit Width;                // Primitive width of the effect area.

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -1839,6 +1839,16 @@ class objGradientVoronoi : public objGradient {
       return get_field(this, Value);
    }
 
+   inline ERR getWorleyMode(WLF &Value) noexcept {
+      auto field = &this->Class->Dictionary[20];
+      return field->GetValue(this, &Value);
+   }
+
+   inline ERR getWorleyMetric(WLM &Value) noexcept {
+      auto field = &this->Class->Dictionary[24];
+      return field->GetValue(this, &Value);
+   }
+
    inline ERR getFloor(Unit &Value) noexcept {
       auto field = &this->Class->Dictionary[22];
       return field->GetValue(this, &Value);
@@ -1856,16 +1866,6 @@ class objGradientVoronoi : public objGradient {
 
    inline ERR getPointCount(int &Value) noexcept {
       auto field = &this->Class->Dictionary[25];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getWorleyMode(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[20];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getWorleyMetric(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[24];
       return field->GetValue(this, &Value);
    }
 
@@ -1892,6 +1892,16 @@ class objGradientVoronoi : public objGradient {
       return field->WriteValue(this, field, 0x00101318, &Value);
    }
 
+   inline ERR setWorleyMode(const WLF Value) noexcept {
+      auto field = &this->Class->Dictionary[20];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
+   inline ERR setWorleyMetric(const WLM Value) noexcept {
+      auto field = &this->Class->Dictionary[24];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
    inline ERR setFloor(const Unit Value) noexcept {
       auto field = &this->Class->Dictionary[22];
       return field->WriteValue(this, field, FD_UNIT, &Value);
@@ -1909,16 +1919,6 @@ class objGradientVoronoi : public objGradient {
 
    inline ERR setPointCount(const int Value) noexcept {
       auto field = &this->Class->Dictionary[25];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setWorleyMode(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[20];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setWorleyMetric(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[24];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 

--- a/include/kotuku/system/fields.h
+++ b/include/kotuku/system/fields.h
@@ -1019,4 +1019,5 @@
 #define FID_SSLPrivateKey 0x5734bfb2LL
 #define FID_SSLKeyPassword 0x23ce0c86LL
 #define FID_SubClasses 0x8fec1031LL
+#define FID_PublicSize 0xaa74794cLL
 

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -87,6 +87,7 @@ static constexpr uint16_t glMetaClassIDOffset = meta_align_offset(glMetaFlagsOff
 static constexpr uint16_t glMetaBaseClassIDOffset = meta_align_offset(glMetaClassIDOffset + sizeof(CLASSID), alignof(CLASSID));
 static constexpr uint16_t glMetaOpenCountOffset = meta_align_offset(glMetaBaseClassIDOffset + sizeof(CLASSID), alignof(int));
 static constexpr uint16_t glMetaCategoryOffset = meta_align_offset(glMetaOpenCountOffset + sizeof(int), alignof(CCF));
+static constexpr uint16_t glMetaPublicSizeOffset = meta_align_offset(glMetaCategoryOffset + sizeof(int), alignof(int));
 
 static ERR GET_ClassName(extMetaClass *Self, std::string_view &Value)
 {
@@ -127,18 +128,19 @@ static const std::vector<Field> glMetaFieldsPreset = {
    { 0, nullptr, nullptr, writeval_default, "BaseClassID",     FID_BaseClassID,     glMetaBaseClassIDOffset,      12, FDF_INT|FDF_UNSIGNED|FDF_RI },
    { 0, nullptr, nullptr, writeval_default, "OpenCount",       FID_OpenCount,       glMetaOpenCountOffset,        13, FDF_INT|FDF_R },
    { MAXINT(&CategoryTable), nullptr, nullptr, writeval_default, "Category",  FID_Category, glMetaCategoryOffset, 14, FDF_INT|FDF_LOOKUP|FDF_RI },
+   { 0, nullptr, nullptr, writeval_default, "PublicSize",      FID_PublicSize,      glMetaPublicSizeOffset,       15, FDF_INT|FDF_RI },
    // Virtual fields
-   { MAXINT("MethodEntry"), (ERR (*)(APTR, APTR))GET_Methods, (APTR)SET_Methods, writeval_default, "Methods", FID_Methods, sizeof(Object), 15, FDF_ARRAY|FD_STRUCT|FDF_RI },
-   { 0, nullptr, (APTR)SET_Actions,               writeval_default,   "Actions",           FID_Actions,         sizeof(Object), 16, FDF_POINTER|FDF_I },
-   { 0, (ERR (*)(APTR, APTR))GET_ActionTable, 0,  writeval_default,   "ActionTable",       FID_ActionTable,     sizeof(Object), 17, FDF_ARRAY|FDF_POINTER|FDF_R },
-   { 0, (ERR (*)(APTR, APTR))GET_Location, 0,     writeval_default,   "Location",          FID_Location,        sizeof(Object), 18, FDF_CPPSTRING|FDF_R },
-   { 0, (ERR (*)(APTR, APTR))GET_ClassName, (APTR)SET_ClassName, writeval_default, "Name", FID_Name,            sizeof(Object), 19, FDF_CPPSTRING|FDF_SYSTEM|FDF_RI },
-   { 0, (ERR (*)(APTR, APTR))GET_Module, 0,       writeval_default,   "Module",            FID_Module,          sizeof(Object), 20, FDF_CPPSTRING|FDF_R },
-   { 0, (ERR (*)(APTR, APTR))GET_Objects, 0,      writeval_default,   "Objects",           FID_Objects,         sizeof(Object), 21, FDF_ARRAY|FDF_INT|FDF_ALLOC|FDF_R },
-   { MAXINT(CLASSID::METACLASS), (ERR (*)(APTR, APTR))GET_SubClasses, nullptr, writeval_default, "SubClasses", FID_SubClasses, sizeof(Object), 22, FDF_ARRAY|FD_OBJECT|FDF_R },
-   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_SubFields, 0, writeval_default, "SubFields", FID_SubFields, sizeof(Object), 23, FDF_ARRAY|FD_STRUCT|FDF_SYSTEM|FDF_R },
-   { MAXINT(CLASSID::ROOTMODULE), (ERR (*)(APTR, APTR))GET_RootModule, 0, writeval_default, "RootModule", FID_RootModule, sizeof(Object), 24, FDF_OBJECT|FDF_R },
-   { 0, (ERR (*)(APTR, APTR))OBJECT_GetID, 0,     writeval_default,   "ID",                FID_ID,              sizeof(Object), 25, FDF_INT|FDF_SYSTEM|FDF_R },
+   { MAXINT("MethodEntry"), (ERR (*)(APTR, APTR))GET_Methods, (APTR)SET_Methods, writeval_default, "Methods", FID_Methods, sizeof(Object), 16, FDF_ARRAY|FD_STRUCT|FDF_RI },
+   { 0, nullptr, (APTR)SET_Actions,               writeval_default,   "Actions",           FID_Actions,         sizeof(Object), 17, FDF_POINTER|FDF_I },
+   { 0, (ERR (*)(APTR, APTR))GET_ActionTable, 0,  writeval_default,   "ActionTable",       FID_ActionTable,     sizeof(Object), 18, FDF_ARRAY|FDF_POINTER|FDF_R },
+   { 0, (ERR (*)(APTR, APTR))GET_Location, 0,     writeval_default,   "Location",          FID_Location,        sizeof(Object), 19, FDF_CPPSTRING|FDF_R },
+   { 0, (ERR (*)(APTR, APTR))GET_ClassName, (APTR)SET_ClassName, writeval_default, "Name", FID_Name,            sizeof(Object), 20, FDF_CPPSTRING|FDF_SYSTEM|FDF_RI },
+   { 0, (ERR (*)(APTR, APTR))GET_Module, 0,       writeval_default,   "Module",            FID_Module,          sizeof(Object), 21, FDF_CPPSTRING|FDF_R },
+   { 0, (ERR (*)(APTR, APTR))GET_Objects, 0,      writeval_default,   "Objects",           FID_Objects,         sizeof(Object), 22, FDF_ARRAY|FDF_INT|FDF_ALLOC|FDF_R },
+   { MAXINT(CLASSID::METACLASS), (ERR (*)(APTR, APTR))GET_SubClasses, nullptr, writeval_default, "SubClasses", FID_SubClasses, sizeof(Object), 23, FDF_ARRAY|FD_OBJECT|FDF_R },
+   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_SubFields, 0, writeval_default, "SubFields", FID_SubFields, sizeof(Object), 24, FDF_ARRAY|FD_STRUCT|FDF_SYSTEM|FDF_R },
+   { MAXINT(CLASSID::ROOTMODULE), (ERR (*)(APTR, APTR))GET_RootModule, 0, writeval_default, "RootModule", FID_RootModule, sizeof(Object), 25, FDF_OBJECT|FDF_R },
+   { 0, (ERR (*)(APTR, APTR))OBJECT_GetID, 0,     writeval_default,   "ID",                FID_ID,              sizeof(Object), 26, FDF_INT|FDF_SYSTEM|FDF_R },
    { 0, 0, 0, nullptr, "", 0, 0, 0,  0 }
 };
 
@@ -812,6 +814,11 @@ example `modules:display`. For reasons of platform portability, the file extensi
 end of the file name.
 
 -FIELD-
+PublicSize: The size of the class in bytes, as seen by the client.
+
+The public size reflects the size of the class before any private variables are taken into account.
+
+-FIELD-
 RootModule: Returns a direct reference to the RootModule object that hosts the class.
 
 *********************************************************************************************************************/
@@ -880,7 +887,7 @@ static void field_setup(extMetaClass *Class)
 
       if (Class->SubFields) {
          std::vector<Field> subFields;
-         uint16_t offset = 0;
+         uint16_t offset = Class->Size; // Offset starts from sizeof(extClassName)
          for (unsigned i=0; Class->SubFields[i].Name; i++) {
             bool found = false;
             auto hash = fieldhash(Class->SubFields[i].Name);

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -887,7 +887,7 @@ static void field_setup(extMetaClass *Class)
 
       if (Class->SubFields) {
          std::vector<Field> subFields;
-         uint16_t offset = Class->Size; // Offset starts from sizeof(extClassName)
+         uint16_t offset = Class->Base->Size; // Offset starts from sizeof(extClassName)
          for (unsigned i=0; Class->SubFields[i].Name; i++) {
             bool found = false;
             auto hash = fieldhash(Class->SubFields[i].Name);

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1341,6 +1341,7 @@ typedef std::vector<obj_write> WRITE_TABLE;
     cid BaseClassID        # Base-class ID
     int OpenCount          # Number of objects allocated to this class
     int(CCF) Category      # Assigned category
+    int PublicSize         # Byte-size of the class as seen by the client
     ~array(struct(ActionEntry)) ActionTable
     ~array(struct(MethodEntry)) Methods
   ]],

--- a/src/core/defs/fields.tdl
+++ b/src/core/defs/fields.tdl
@@ -1027,6 +1027,7 @@ header({ path="system/fields", copyright="Paul Manias © 1996-2026" }, function(
     "SSLCertificate",
     "SSLPrivateKey",
     "SSLKeyPassword",
-    "SubClasses"
+    "SubClasses",
+    "PublicSize"
     )
 end)

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -1478,7 +1478,7 @@ extern lua_CFunction lua_atpanic(lua_State *L, lua_CFunction panicf)
 }
 
 // Forwarders for the public API (C calling convention and no LJ_NORET).
-extern int lua_error(lua_State *L)
+[[noreturn]] extern int lua_error(lua_State *L)
 {
    err_clear_pending_exception(L);
    if (L->top > L->base and tvisstr(L->top - 1)) {
@@ -1490,7 +1490,7 @@ extern int lua_error(lua_State *L)
    return 0;  //  unreachable
 }
 
-extern int luaL_argerror(lua_State *L, int narg, CSTRING msg)
+[[noreturn]] extern int luaL_argerror(lua_State *L, int narg, CSTRING msg)
 {
    L->CaughtError = ERR::Args;
    err_argmsg(L, narg, msg);

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -22,7 +22,7 @@ struct luaL_Reg {
 extern void luaL_openlib(lua_State *, const char *, const luaL_Reg *, int);
 extern void luaL_register(lua_State *, const char *, const luaL_Reg *);
 extern int luaL_typerror(lua_State *, int, const char *);
-extern int luaL_argerror(lua_State *, int, const char *);
+[[noreturn]] extern int luaL_argerror(lua_State *, int, const char *);
 extern const char * luaL_checklstring(lua_State *, int, size_t * = nullptr);
 extern uint32_t luaL_checkstringhash(lua_State *, int);
 extern const char * luaL_optlstring(lua_State *, int, const char *, size_t * = nullptr);

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -197,7 +197,7 @@ constexpr int LUA_GCISRUNNING = 9;
 
 extern int (lua_gc) (lua_State *L, int what, int data = 0);
 
-extern int   (lua_error) (lua_State *L);
+[[noreturn]] extern int   (lua_error) (lua_State *L);
 extern int   (lua_next) (lua_State *L, int idx);
 extern void  (lua_concat) (lua_State *L, int n);
 extern lua_Alloc (lua_getallocf) (lua_State *L, void **ud);

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -183,7 +183,8 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
    }
 
    std::string_view module_name;
-   if (auto error = MetaClass->getModule(module_name); !error) {
+   // NOTE: Stick to the indirect get() method here because it otherwise crashes if the MetaClass table requires regeneration
+   if (auto error = MetaClass->get(FID_Module, module_name); !error) {
       if (auto error = load_include(Lua->script, module_name.data()); error != ERR::Okay) {
          luaL_error(Lua, error,
             std::format("Failed to process module '{}' for class '{}'", module_name, MetaClass->ClassName));

--- a/src/vector/filters/filter_convolve.cpp
+++ b/src/vector/filters/filter_convolve.cpp
@@ -13,13 +13,13 @@ is determined by applying the kernel matrix to the corresponding source pixel an
 convolution formula which is applied to each colour value for a given pixel is:
 
 <pre>
-COLOURX,Y = (
+COLOUR(x,y) = (
      SUM I=0 to [MatrixRows-1] {
        SUM J=0 to [MatrixColumns-1] {
-         SOURCE X - TargetX + J, Y - TargetY + I * Matrix * MatrixColumns - J - 1,  MatrixRows - I - 1
+         SOURCE(x - TargetX + J, y - TargetY + I) * Matrix(MatrixColumns - J - 1, MatrixRows - I - 1)
        }
      }
-   ) / Divisor + Bias * ALPHAX,Y
+   ) / Divisor + Bias * ALPHA(x,y)
 </pre>
 
 Note in the above formula that the values in the kernel matrix are applied such that the kernel matrix is rotated

--- a/src/vector/filters/filter_displacement.cpp
+++ b/src/vector/filters/filter_displacement.cpp
@@ -23,8 +23,8 @@ and #YChannel to `CMP::GREEN`.
 The displacement map defines the inverse of the mapping performed.
 
 The Input image is to remain premultiplied for this filter effect.  The calculations using the pixel values
-from Mix are performed using non-premultiplied color values.  If the image from Mix consists of premultiplied
-color values, those values are automatically converted into non-premultiplied color values before performing this
+from Mix are performed using non-premultiplied colour values.  If the image from Mix consists of premultiplied
+colour values, those values are automatically converted into non-premultiplied colour values before performing this
 operation.
 
 -END-

--- a/src/vector/filters/filter_effect.cpp
+++ b/src/vector/filters/filter_effect.cpp
@@ -67,7 +67,7 @@ static ERR FILTEREFFECT_MoveToBack(extFilterEffect *Self)
 
 /*********************************************************************************************************************
 -ACTION-
-MoveToBack: Move an effect to the front of the VectorFilter's list order.
+MoveToFront: Move an effect to the front of the VectorFilter's list order.
 -END-
 *********************************************************************************************************************/
 
@@ -154,7 +154,7 @@ static ERR FILTEREFFECT_SET_Height(extFilterEffect *Self, Unit &Value)
 /*********************************************************************************************************************
 
 -FIELD-
-Mix: Reference to another effect to be used a mixer with Input.
+Mix: Reference to another effect to be used as a mixer with Input.
 
 If another effect should be used as a mixed source input, it must be referenced here.  The #MixType will be
 automatically set to `REFERENCE` as a result.

--- a/src/vector/filters/filter_morphology.cpp
+++ b/src/vector/filters/filter_morphology.cpp
@@ -19,7 +19,7 @@ corresponding R,G,B,A values in the input image's kernel rectangle.
 Frequently this operation will take place on alpha-only images, such as that produced by the built-in input,
 SourceAlpha.  In that case, the implementation might want to optimize the single channel case.
 
-Because the algorithm operates on premultipied color values, it will always result in color values less than or
+Because the algorithm operates on premultiplied colour values, it will always result in colour values less than or
 equal to the alpha channel.
 
 -END-

--- a/src/vector/painters/gradient_contour.cpp
+++ b/src/vector/painters/gradient_contour.cpp
@@ -31,7 +31,7 @@ static ERR GRADIENTCONTOUR_Init(extGradientContour *Self)
 -FIELD-
 Floor: Colour ramp floor for contour gradients.
 
-The Floor value is used as the floor for contour gradient colour values.  It has a valid range of `0 <= Floor <
+The Floor value is used as the floor for contour gradient colour values.  It has a valid range of `0 &lt;= Floor &lt;
 Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/

--- a/src/vector/painters/gradient_contour.cpp
+++ b/src/vector/painters/gradient_contour.cpp
@@ -6,6 +6,9 @@ GradientContour: Contour-following colour gradient paint server.
 GradientContour follows the contours of the target vector path.  `Floor` controls the colour ramp floor and
 `Multiplier` controls the ramp scale.
 
+This gradient operates exclusively in `BOUNDING_BOX` space.  If @Gradient.Units is set to `USERSPACE` it will be
+reset to `BOUNDING_BOX` during initialisation.
+
 -END-
 
 *********************************************************************************************************************/
@@ -28,8 +31,8 @@ static ERR GRADIENTCONTOUR_Init(extGradientContour *Self)
 -FIELD-
 Floor: Colour ramp floor for contour gradients.
 
-The Floor value is used as the floor for contour gradient colour values.  It has a valid range of `0 < Floor <
-Multiplier`.
+The Floor value is used as the floor for contour gradient colour values.  It has a valid range of `0 <= Floor <
+Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/
 

--- a/src/vector/painters/gradient_distal.cpp
+++ b/src/vector/painters/gradient_distal.cpp
@@ -21,6 +21,9 @@ Setting #OuterFall to `GFALL::OPAQUE` holds the exterior alpha at full strength 
 `REPEAT` or `REFLECT` the full colour ramp is painted solidly out to the parent edge with no fade between tiles.  Under
 `PAD` the alpha still cuts to transparent at the padding edge as usual.
 
+This gradient operates exclusively in `BOUNDING_BOX` space.  If @Gradient.Units is set to `USERSPACE` it will be
+reset to `BOUNDING_BOX` during initialisation.
+
 -END-
 
 *********************************************************************************************************************/
@@ -96,7 +99,8 @@ static ERR GRADIENTDISTAL_SET_Radius(extGradientDistal *Self, Unit &Value)
 -FIELD-
 Floor: Colour ramp floor for distal gradients.
 
-The Floor value is used as the floor for distal gradient colour values.
+The Floor value is used as the floor for distal gradient colour values.  It has a valid range of `0 <= Floor <
+Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/
 
@@ -119,7 +123,8 @@ static ERR GRADIENTDISTAL_SET_Floor(extGradientDistal *Self, Unit &Value)
 -FIELD-
 Multiplier: Colour ramp multiplier for distal gradients.
 
-The Multiplier value acts as a multiplier for distal gradient colour values.
+The Multiplier value acts as a multiplier for distal gradient colour values.  It has a valid range of `.01 <
+Multiplier < 10`.
 
 -END-
 *********************************************************************************************************************/

--- a/src/vector/painters/gradient_distal.cpp
+++ b/src/vector/painters/gradient_distal.cpp
@@ -99,7 +99,7 @@ static ERR GRADIENTDISTAL_SET_Radius(extGradientDistal *Self, Unit &Value)
 -FIELD-
 Floor: Colour ramp floor for distal gradients.
 
-The Floor value is used as the floor for distal gradient colour values.  It has a valid range of `0 <= Floor <
+The Floor value is used as the floor for distal gradient colour values.  It has a valid range of `0 &lt;= Floor &lt;
 Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/
@@ -123,8 +123,8 @@ static ERR GRADIENTDISTAL_SET_Floor(extGradientDistal *Self, Unit &Value)
 -FIELD-
 Multiplier: Colour ramp multiplier for distal gradients.
 
-The Multiplier value acts as a multiplier for distal gradient colour values.  It has a valid range of `.01 <
-Multiplier < 10`.
+The Multiplier value acts as a multiplier for distal gradient colour values.  It has a valid range of `.01 &lt;
+Multiplier &lt; 10`.
 
 -END-
 *********************************************************************************************************************/

--- a/src/vector/painters/gradient_voronoi.cpp
+++ b/src/vector/painters/gradient_voronoi.cpp
@@ -7,6 +7,9 @@ GradientVoronoi scatters deterministic feature points inside the target path bou
 field through the inherited colour ramp.  `Seed` controls repeatability, `PointCount` controls feature density,
 `WorleyMode` selects the field interpretation, and `WorleyMetric` selects the distance metric.
 
+This gradient operates exclusively in `BOUNDING_BOX` space.  If @Gradient.Units is set to `USERSPACE` it will be
+reset to `BOUNDING_BOX` during initialisation.
+
 -END-
 
 *********************************************************************************************************************/
@@ -53,8 +56,8 @@ static ERR GRADIENTVORONOI_Init(extGradientVoronoi *Self)
 -FIELD-
 Floor: Colour ramp floor for Voronoi gradients.
 
-The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of `0 < Floor <
-Multiplier`.
+The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of `0 <= Floor <
+Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/
 
@@ -169,7 +172,7 @@ static ERR GRADIENTVORONOI_SET_Multiplier(extGradientVoronoi *Self, Unit &Value)
 PointCount: Number of seeded Voronoi feature points.
 
 PointCount controls how many feature points are generated inside the target path bounds.  The accepted range is
-`1` to `4096`.
+`1` to `4096` and the default is `16`.  This field is ignored when explicit #Points are supplied.
 
 *********************************************************************************************************************/
 

--- a/src/vector/painters/gradient_voronoi.cpp
+++ b/src/vector/painters/gradient_voronoi.cpp
@@ -56,7 +56,7 @@ static ERR GRADIENTVORONOI_Init(extGradientVoronoi *Self)
 -FIELD-
 Floor: Colour ramp floor for Voronoi gradients.
 
-The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of `0 <= Floor <
+The Floor value is used as the floor for Voronoi gradient colour values.  It has a valid range of `0 &lt;= Floor &lt;
 Multiplier`; the constraint against #Multiplier is enforced at initialisation.
 
 *********************************************************************************************************************/

--- a/src/vector/painters/pattern.cpp
+++ b/src/vector/painters/pattern.cpp
@@ -8,7 +8,7 @@ VectorPattern: Provides support for the filling and stroking of vectors with pat
 The VectorPattern class is used by Vector painting algorithms to fill and stroke vectors with pre-rendered patterns.
 It is the most efficient way of rendering a common set of graphics multiple times.
 
-The VectorPattern must be registered with a @VectorScene via the <method class="VectorScene">AddDef</> method.
+The VectorPattern must be registered with a @VectorScene via the @VectorScene.AddDef() method.
 Any vector within the target scene will be able to utilise the pattern for filling or stroking by referencing its
 name through the @Vector.Fill and @Vector.Stroke fields.  For instance `url(#dots)`.
 
@@ -198,7 +198,8 @@ managing the vectors that will be rendered.
 -FIELD-
 SpreadMethod: The behaviour to use when the pattern bounds do not match the vector path.
 
-Indicates what happens if the pattern starts or ends inside the bounds of the target vector.  The default value is PAD.
+Indicates what happens if the pattern starts or ends inside the bounds of the target vector.  The default value is
+`VSPREAD::PAD`.
 
 *********************************************************************************************************************/
 
@@ -239,9 +240,9 @@ static ERR VECTORPATTERN_SET_Transform(extVectorPattern *Self, const std::string
 -FIELD-
 Units:  Defines the coordinate system for fields X, Y, Width and Height.
 
-This field declares the coordinate system that is used for values in the #X and #Y fields.  The default setting is
-`BOUNDING_BOX`, which means the pattern will be drawn to scale in realtime.  The most efficient method is USERSPACE,
-which allows the pattern image to be persistently cached.
+This field declares the coordinate system that is used for values in the #X, #Y, #Width and #Height fields.  The
+default setting is `BOUNDING_BOX`, which means the pattern will be drawn to scale in realtime.  The most efficient
+method is `USERSPACE`, which allows the pattern image to be persistently cached.
 
 -FIELD-
 Viewport: Refers to the viewport that contains the pattern.

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -568,7 +568,9 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
   klass('GradientDistal', { base='Gradient', src='painters/gradient_distal.cpp', output='painters/gradient_distal_def.cpp', references={ 'GFALL' }, extended=true })
 
   klass('GradientVoronoi', { base='Gradient', src='painters/gradient_voronoi.cpp', output='painters/gradient_voronoi_def.cpp', references={ 'WLF', 'WLM' }, extended=true }, [[
-    ~array(struct(VoronoiPoint)) Points
+    ~array(struct(VoronoiPoint)) Points # Optional list of Voronoi feature points provided by the client
+    ~int(WLF) WorleyMode
+    ~int(WLM) WorleyMetric
   ]])
 
   klass('FilterEffect', { src='filters/filter_effect.cpp', output='filters/filter_effect_def.c', references={ 'VSF' }, extended=true }, [[

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -7,7 +7,7 @@ rx_strip_newlines = <{ regex.new([[^\n*(.*\S)]], regex.DOT_ALL) }>
 ----------------------------------------------------------------------------------------------------------------------
 -- Return true when the class owns at least one concrete storage field.
 
-function classHasPhysicalFields(Class:table):bool
+function classHasVisibleFields(Class:table):bool
    for f in values(Class.fields) do
       if not f.virtual then return true end
    end
@@ -30,10 +30,20 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Emit the class member storage declarations and any private or custom C++ blocks.
 
-function outputPhysicalFields(Class:table, Private:str, Custom:str)
+function outputVisibleFields(Class:table, Private:str, Custom:str)
    output('')
 
    local max_len = 3 + Class.longestFieldType + 1 + 2
+
+   if Class.meta.classID != Class.meta.baseClassID then
+      -- Compute any necessary padding to accommodate private fields in the base class.
+      if Class.meta.publicSize then
+         base_padding = Class.meta.size - Class.meta.publicSize
+         output(f'   uint8_t _padding[{base_padding};')
+      elseif Class.fields then
+         print(f'Class {Class.name} needs to declare a PublicSize in order to support directly accessible fields.')
+      end
+   end
 
    for f in values(Class.fields) do
       if f.virtual then continue end
@@ -539,8 +549,8 @@ global function outputClassHeader(Class:table, Private:str, Custom:str)
    output('')
    output('   using create = kt::Create<obj' .. Class.name .. '>;')
 
-   if classHasPhysicalFields(Class) then
-      outputPhysicalFields(Class, Private, Custom)
+   if classHasVisibleFields(Class) then
+      outputVisibleFields(Class, Private, Custom)
    end
 
    outputActionStubs(Class)

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -35,16 +35,6 @@ function outputVisibleFields(Class:table, Private:str, Custom:str)
 
    local max_len = 3 + Class.longestFieldType + 1 + 2
 
-   if Class.meta.classID != Class.meta.baseClassID then
-      -- Compute any necessary padding to accommodate private fields in the base class.
-      if Class.meta.publicSize then
-         base_padding = Class.meta.size - Class.meta.publicSize
-         output(f'   uint8_t _padding[{base_padding};')
-      elseif Class.fields then
-         print(f'Class {Class.name} needs to declare a PublicSize in order to support directly accessible fields.')
-      end
-   end
-
    for f in values(Class.fields) do
       if f.virtual then continue end
 

--- a/tools/idl/include/parser.tiri
+++ b/tools/idl/include/parser.tiri
@@ -374,11 +374,11 @@ global function parseClassFields(Class:table, ClientSpec:str)
       -- NB: Some classes don't output any fields (which is permissable)
 
       metaFields = Class.meta.subFields
-      if (not metaFields or #metaFields is 0) and (Class.meta.classID is Class.meta.baseClassID) then
+      if (not metaFields??) and (Class.meta.classID is Class.meta.baseClassID) then
          metaFields = Class.meta.fields
       end
 
-      if metaFields then
+      if metaFields?? then
          for i=0,#metaFields-1 do
             f = metaFields[i]
             def = getMetaFieldDefinition(f)


### PR DESCRIPTION
* Declared WorleyMode and WorleyMetric as WLF/WLM enum types in the TDL, regenerating typed accessors in the public header
* [Doc] Documented the BOUNDING_BOX-only constraint and Floor/Multiplier ranges for the contour, distal and Voronoi gradients
* [Doc] Clarified GradientVoronoi PointCount default and its interaction with explicit Points
* [Doc] Corrected the FilterEffect MoveToFront action marker and fixed the convolution formula and colour-value spelling in the filter classes
* [Doc] Updated VectorPattern Units and SpreadMethod field references for X/Y/Width/Height coverage
* [Tiri] Marked lua_error and luaL_argerror as [[noreturn]] in the public API forwarders