### PR TITLE
[IDL] Correct generated array field types

### DIFF
--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -419,7 +419,7 @@
       <name>Buffer</name>
       <comment>Points to the internal data buffer if the file content is held in memory.</comment>
       <access read="G">Get</access>
-      <type>INT8 *</type>
+      <type>INT8[]</type>
       <description>
 <p>If a file has been created with an internal buffer (by setting the <code>BUFFER</code> flag on creation), this field will point to the address of that buffer.  The size of the buffer will match the <fl>Size</fl> field.</p>
       </description>

--- a/docs/xml/modules/classes/gradientgouraud.xml
+++ b/docs/xml/modules/classes/gradientgouraud.xml
@@ -36,7 +36,7 @@
       <name>Vertices</name>
       <comment>Defines the coloured vertices for a Gouraud gradient.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>GouraudVertex[]</type>
+      <type>kt::vector&lt;GouraudVertex&gt;</type>
       <description>
 <p>The Vertices array defines the mesh of coloured points across which colour is interpolated barycentrically.  Each <st>GouraudVertex</st> carries an <code>(X, Y)</code> position and an <code>FRGB</code> colour.</p>
 <p>By default the vertices are treated as a flat triangle list, where every three consecutive vertices form one triangle.  Supplying an <fl>Indices</fl> array instead expresses triangle connectivity explicitly.</p>

--- a/docs/xml/modules/classes/gradientvoronoi.xml
+++ b/docs/xml/modules/classes/gradientvoronoi.xml
@@ -85,7 +85,7 @@
       <name>Points</name>
       <comment>User-defined Voronoi feature points.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>VoronoiPoint[]</type>
+      <type>kt::vector&lt;VoronoiPoint&gt;</type>
       <description>
 <p>The Points field accepts a vector of <st>VoronoiPoint</st> structures that define the feature-point coordinates used by the Voronoi field.  When at least one point is supplied, the procedural <fl>Seed</fl>, <fl>PointCount</fl>, <fl>HeightMin</fl>, <fl>HeightMax</fl> and <fl>Jitter</fl> fields are ignored and the field is generated from the supplied points instead.</p>
 <p>Point coordinates are normalised to the target path bounds, with <code>(0, 0)</code> at the top-left of the bounds and <code>(1, 1)</code> at the bottom-right.  The Height value is used by the <code>WEIGHTED</code> and <code>PEAKS</code> Worley modes and ignored by the distance only modes.</p>

--- a/docs/xml/modules/classes/metaclass.xml
+++ b/docs/xml/modules/classes/metaclass.xml
@@ -146,7 +146,7 @@
       <name>Fields</name>
       <comment>Points to a <st>FieldArray</st> that describes the class' object structure.</comment>
       <access read="G" write="S">Get/Set</access>
-      <type>const struct FieldArray *</type>
+      <type>const struct FieldArray[]</type>
       <description>
 <p>This field points to an array that describes the structure of objects that will be generated for this class.  It is compulsory that base classes define this array.  Sub-classes will inherit the structure of their base, but they may set Fields with additional virtual fields if desired.</p>
 <p>Refer to the Kotuku Wiki on class development for more information.</p>

--- a/docs/xml/modules/classes/wavefunctionfx.xml
+++ b/docs/xml/modules/classes/wavefunctionfx.xml
@@ -115,7 +115,7 @@
       <name>Stops</name>
       <comment>Defines the colours to use for the wave function.</comment>
       <access read="R" write="S">Read/Set</access>
-      <type>GradientStop[]</type>
+      <type>kt::vector&lt;GradientStop&gt;</type>
       <description>
 <p>The colours that will be used for drawing a wave function can be defined by the Stops array.  At least two stops are required to define a start and end point for interpolating the gradient colours.</p>
 <p>If no stops are defined, the wave function will be drawn in greyscale.</p>

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -495,9 +495,9 @@ class objNetLookup : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getAddresses(std::span<struct IPAddress> &Value) noexcept {
+   inline ERR getAddresses(std::span<IPAddress> &Value) noexcept {
       auto field = &this->Class->Dictionary[2];
-      auto get_field = (ERR (*)(APTR, std::span<struct IPAddress> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<IPAddress> &))field->GetValue;
       return get_field(this, Value);
    }
 
@@ -883,12 +883,12 @@ class objNetServer : public objNetSocket {
    }
 
    inline ERR getSSLCertificate(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + {offset}));
+      Value = *((std::string *)(((int8_t *)this) + 336));
       return ERR::Okay;
    }
 
    inline ERR getSSLKeyPassword(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + {offset}));
+      Value = *((std::string *)(((int8_t *)this) + 400));
       return ERR::Okay;
    }
 

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -748,7 +748,7 @@ class objVectorTransition : public Object {
 
    // Customised field setting
 
-   inline ERR setStops(std::span<const struct Transition> Value) noexcept {
+   inline ERR setStops(std::span<const Transition> Value) noexcept {
       auto field = &this->Class->Dictionary[6];
       return field->WriteValue(this, field, 0x00001218, &Value);
    }
@@ -1704,9 +1704,9 @@ class objGradientGouraud : public objGradient {
 
    // Customised field getting
 
-   inline ERR getVertices(std::span<struct GouraudVertex> &Value) noexcept {
+   inline ERR getVertices(std::span<GouraudVertex> &Value) noexcept {
       auto field = &this->Class->Dictionary[19];
-      auto get_field = (ERR (*)(APTR, std::span<struct GouraudVertex> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<GouraudVertex> &))field->GetValue;
       return get_field(this, Value);
    }
 
@@ -1719,7 +1719,7 @@ class objGradientGouraud : public objGradient {
 
    // Customised field setting
 
-   inline ERR setVertices(std::span<const struct GouraudVertex> Value) noexcept {
+   inline ERR setVertices(std::span<const GouraudVertex> Value) noexcept {
       auto field = &this->Class->Dictionary[19];
       return field->WriteValue(this, field, 0x00101318, &Value);
    }
@@ -1830,9 +1830,9 @@ class objGradientVoronoi : public objGradient {
 
    // Customised field getting
 
-   inline ERR getPoints(std::span<struct VoronoiPoint *> &Value) noexcept {
-      auto ktv = (struct VoronoiPoint * *)(((int8_t *)this) + 312);
-      Value = std::span<nil>(ktv->data(), ktv->size());
+   inline ERR getPoints(std::span<VoronoiPoint> &Value) noexcept {
+      auto ktv = (kt::vector<VoronoiPoint> *)(((int8_t *)this) + 312);
+      Value = std::span<VoronoiPoint>(ktv->data(), ktv->size());
       return ERR::Okay;
    }
 
@@ -1884,7 +1884,7 @@ class objGradientVoronoi : public objGradient {
 
    // Customised field setting
 
-   inline ERR setPoints(const std::span<const nil> Value) noexcept {
+   inline ERR setPoints(const std::span<const VoronoiPoint> Value) noexcept {
       auto field = &this->Class->Dictionary[19];
       return field->WriteValue(this, field, 0x00005310, &Value);
    }
@@ -2694,7 +2694,7 @@ class objFloodFX : public objFilterEffect {
    // Customised field getting
 
    inline ERR getColour(struct FRGB * &Value) noexcept {
-      Value = *((struct FRGB *)(((int8_t *)this) + 216));
+      Value = ((struct FRGB *)(((int8_t *)this) + 216));
       return ERR::Okay;
    }
 
@@ -2776,7 +2776,7 @@ class objLightingFX : public objFilterEffect {
    // Customised field getting
 
    inline ERR getColour(struct FRGB * &Value) noexcept {
-      Value = *((struct FRGB *)(((int8_t *)this) + 216));
+      Value = ((struct FRGB *)(((int8_t *)this) + 216));
       return ERR::Okay;
    }
 
@@ -2886,9 +2886,9 @@ class objMergeFX : public objFilterEffect {
 
    // Customised field getting
 
-   inline ERR getSourceList(std::span<struct MergeSource> &Value) noexcept {
+   inline ERR getSourceList(std::span<MergeSource> &Value) noexcept {
       auto field = &this->Class->Dictionary[16];
-      auto get_field = (ERR (*)(APTR, std::span<struct MergeSource> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<MergeSource> &))field->GetValue;
       return get_field(this, Value);
    }
 
@@ -2909,7 +2909,7 @@ class objMergeFX : public objFilterEffect {
 
    // Customised field setting
 
-   inline ERR setSourceList(std::span<const struct MergeSource> Value) noexcept {
+   inline ERR setSourceList(std::span<const MergeSource> Value) noexcept {
       auto field = &this->Class->Dictionary[16];
       return field->WriteValue(this, field, 0x00101318, &Value);
    }
@@ -3255,9 +3255,9 @@ class objWaveFunctionFX : public objFilterEffect {
 
    // Customised field getting
 
-   inline ERR getStops(std::span<struct GradientStop *> &Value) noexcept {
-      auto ktv = (struct GradientStop * *)(((int8_t *)this) + 256);
-      Value = std::span<nil>(ktv->data(), ktv->size());
+   inline ERR getStops(std::span<GradientStop> &Value) noexcept {
+      auto ktv = (kt::vector<GradientStop> *)(((int8_t *)this) + 256);
+      Value = std::span<GradientStop>(ktv->data(), ktv->size());
       return ERR::Okay;
    }
 
@@ -3267,7 +3267,7 @@ class objWaveFunctionFX : public objFilterEffect {
    }
 
    inline ERR getColourMap(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + {offset}));
+      Value = *((std::string *)(((int8_t *)this) + 216));
       return ERR::Okay;
    }
 
@@ -3313,7 +3313,7 @@ class objWaveFunctionFX : public objFilterEffect {
 
    // Customised field setting
 
-   inline ERR setStops(const std::span<const nil> Value) noexcept {
+   inline ERR setStops(const std::span<const GradientStop> Value) noexcept {
       auto field = &this->Class->Dictionary[24];
       return field->WriteValue(this, field, 0x00005310, &Value);
    }
@@ -4141,9 +4141,9 @@ class objVectorPath : public objVector {
 
    // Customised field getting
 
-   inline ERR getCommands(std::span<struct PathCommand> &Value) noexcept {
+   inline ERR getCommands(std::span<PathCommand> &Value) noexcept {
       auto field = &this->Class->Dictionary[46];
-      auto get_field = (ERR (*)(APTR, std::span<struct PathCommand> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<PathCommand> &))field->GetValue;
       return get_field(this, Value);
    }
 
@@ -4179,7 +4179,7 @@ class objVectorPath : public objVector {
 
    // Customised field setting
 
-   inline ERR setCommands(std::span<const struct PathCommand> Value) noexcept {
+   inline ERR setCommands(std::span<const PathCommand> Value) noexcept {
       auto field = &this->Class->Dictionary[46];
       return field->WriteValue(this, field, 0x00101318, &Value);
    }
@@ -4882,9 +4882,9 @@ class objVectorPolygon : public objVector {
 
    // Customised field getting
 
-   inline ERR getPointsArray(std::span<struct VectorPoint> &Value) noexcept {
+   inline ERR getPointsArray(std::span<VectorPoint> &Value) noexcept {
       auto field = &this->Class->Dictionary[50];
-      auto get_field = (ERR (*)(APTR, std::span<struct VectorPoint> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<VectorPoint> &))field->GetValue;
       return get_field(this, Value);
    }
 
@@ -4921,7 +4921,7 @@ class objVectorPolygon : public objVector {
 
    // Customised field setting
 
-   inline ERR setPointsArray(std::span<const struct VectorPoint> Value) noexcept {
+   inline ERR setPointsArray(std::span<const VectorPoint> Value) noexcept {
       auto field = &this->Class->Dictionary[50];
       return field->WriteValue(this, field, 0x00101318, &Value);
    }

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -426,9 +426,9 @@ class objXML : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getTags(std::span<struct XTag> &Value) noexcept {
+   inline ERR getTags(std::span<XTag> &Value) noexcept {
       auto field = &this->Class->Dictionary[16];
-      auto get_field = (ERR (*)(APTR, std::span<struct XTag> &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::span<XTag> &))field->GetValue;
       return get_field(this, Value);
    }
 

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1327,7 +1327,7 @@ typedef std::vector<obj_write> WRITE_TABLE;
 
   klass("MetaClass", { src="../classes/class_metaclass.cpp" }, [[
     double ClassVersion    # Version of the class
-    cstruct(*FieldArray) Fields  # Original field array supplied by the module
+    array(cstruct(FieldArray)) Fields  # Original field array supplied by the module
     array(struct(Field)) Dictionary # Field lookup by ID
     string ClassName       # Name of the class
     string FileExtension   # File extension(s) supported by this class
@@ -1387,7 +1387,7 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
     large     Position  # The current read/write byte position in a file.
     string    Path      # The file path.
     int(FL)   Flags     # File flags and options.
-    ptr(char) Buffer    # Points to the internal data buffer if the file content is held in memory.
+    array(char) Buffer  # Points to the internal data buffer if the file content is held in memory.
     ~struct(DateTime) Date
     ~struct(DateTime) Created
     ~int(PERMIT) Permissions

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -562,13 +562,13 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
   klass('GradientContour', { base='Gradient', src='painters/gradient_contour.cpp', output='painters/gradient_contour_def.cpp', extended=true })
 
   klass('GradientGouraud', { base='Gradient', src='painters/gradient_gouraud.cpp', output='painters/gradient_gouraud_def.cpp', extended=true }, [[
-    ~array(struct(GouraudVertex)) Vertices
+    ~vector(struct(GouraudVertex)) Vertices
   ]])
 
   klass('GradientDistal', { base='Gradient', src='painters/gradient_distal.cpp', output='painters/gradient_distal_def.cpp', references={ 'GFALL' }, extended=true })
 
   klass('GradientVoronoi', { base='Gradient', src='painters/gradient_voronoi.cpp', output='painters/gradient_voronoi_def.cpp', references={ 'WLF', 'WLM' }, extended=true }, [[
-    ~array(struct(VoronoiPoint)) Points # Optional list of Voronoi feature points provided by the client
+    ~vector(struct(VoronoiPoint)) Points # Optional list of Voronoi feature points provided by the client
     ~int(WLF) WorleyMode
     ~int(WLM) WorleyMetric
   ]])
@@ -665,7 +665,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
   ]])
 
   klass('WaveFunctionFX',   { base='FilterEffect', src='filters/filter_wavefunction.cpp', output='filters/filter_wavefunction_def.c', comment='WaveFunction filter support class.', extended=true }, [[
-    ~array(struct(GradientStop)) Stops
+    ~vector(struct(GradientStop)) Stops
     ~int(ARF) AspectRatio
   ]])
 

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -145,7 +145,7 @@ end
 -- Return the element type for generated array getters.
 
 function fieldArrayElementType(Field:table):str
-   local field_type = Field.type
+   local field_type = Field.innerType ?? Field.type
 
    if field_type:endsWith('[]') then return field_type:sub(0, -3):trim() end
    if field_type:endsWith('*') then return field_type:sub(0, -2):trim() end
@@ -177,6 +177,7 @@ function fieldGetType(Field:table):str
       return fieldArrayElementType(Field)
    elseif Field.flags has FD_STRING then
       if Field.flags has FD_ALLOC then return 'std::string' end
+      -- Always prefer std::string_view to avoid taking copies of std::string values
       return 'std::string_view'
    else
       return field_type
@@ -257,7 +258,7 @@ function outputGetValueCall(Field:table, FieldType:str, Indent:str)
       outputResult('field->GetValue(this, &Value);')
       return
    elseif Field.flags has FD_ARRAY then
-      output(Indent .. f'auto get_field = (ERR (*)(APTR, std::span<{FieldType}> &))field->GetValue;')
+      output(Indent .. f'auto get_field = (ERR (*)(APTR, std::span<{Field.innerType ?? Field.type}> &))field->GetValue;')
       outputResult('get_field(this, Value);')
       return
    elseif Field.flags has FD_STRING then
@@ -318,12 +319,14 @@ function outputFieldReadGetter(Class:table, Field:table, FidName:str, FieldType:
          end
       elseif Field.flags has FD_STRING then
          if Field.flags has FD_ALLOC then
-            output(Indent .. 'Value.assign(*((std::string *)(((int8_t *)this) + {offset})));')
+            output(Indent .. f'Value.assign(*((std::string *)(((int8_t *)this) + {offset})));')
          else
-            output(Indent .. 'Value = *((std::string *)(((int8_t *)this) + {offset}));')
+            output(Indent .. f'Value = *((std::string *)(((int8_t *)this) + {offset}));')
          end
       elseif Field.flags has FD_FUNCTION then
          output(Indent .. f'Value = ((FUNCTION *)(((int8_t *)this) + {offset}));')
+      elseif Field.flags has FD_STRUCT then
+         output(Indent .. f'Value = (({FieldType} *)(((int8_t *)this) + {offset}));')
       else
          output(Indent .. f'Value = *(({FieldType} *)(((int8_t *)this) + {offset}));')
       end
@@ -410,6 +413,7 @@ end
 function outputFieldSetterSignature(Field:table, FidName:str, FieldType:str)
    if Field.flags has FD_ARRAY then
       if Field.flags has FD_CPP then -- Virtual kt::vector; the setter function will still be in C format for type compatibility
+         assert(Field.innerType, f'Missing innerType for virtual kt::vector {FidName}')
          output(f'   inline ERR set{FidName}(const std::span<const {Field.innerType}> Value) noexcept {{')
       else
          output(f'   inline ERR set{FidName}(std::span<{fieldArraySetterElementType(Field)}> Value) noexcept {{')

--- a/tools/idl/include/types.tiri
+++ b/tools/idl/include/types.tiri
@@ -128,30 +128,34 @@ global function getFieldType(Def:table, Type:num, CustomName:str, Option:any)
          Def.type = f'kt::vector<{Def.innerType}>'
       else
          if Type has FD_BYTE then
-            Def.type = 'int8_t []'
+            Def.type = 'int8_t'
             Def.doc_type = 'INT8 []'
          elseif Type has FD_WORD then
-            Def.type = 'int16_t []'
+            Def.type = 'int16_t'
             Def.doc_type = 'INT16 []'
          elseif Type has FD_INT then
-            Def.type = 'int []'
+            Def.type = 'int'
             Def.doc_type = 'INT []'
          elseif Type has FD_FLOAT then
-            Def.type = 'float []'
+            Def.type = 'float'
             Def.doc_type = 'FLOAT []'
          elseif Type has FD_DOUBLE then
-            Def.type = 'double []'
+            Def.type = 'double'
             Def.doc_type = 'DOUBLE []'
          elseif Type has FD_STRING then
-            Def.type = 'STRING []'
+            Def.type = 'STRING'
+            Def.doc_type = 'STRING []'
          elseif Type has FD_POINTER then
-            Def.type = 'APTR []'
+            Def.type = 'APTR'
+            Def.doc_type = 'APTR []'
          elseif Type has FD_STRUCT then
-            Def.type = fieldStructType(Option) .. ' []'
+            Def.type = fieldStructType(Option) .. ''
          elseif Type has FD_OBJECT then
-            Def.type = 'OBJECTPTR []'
+            Def.type = 'OBJECTPTR'
+            Def.doc_type = 'OBJECTPTR []'
          elseif Type has FD_UNIT then
-            Def.type = 'Unit []'
+            Def.type = 'Unit'
+            Def.doc_type = 'Unit []'
          else
             Def.type = 'UNKNOWN_ARRAY_TYPE'
          end
@@ -188,6 +192,7 @@ global function getFieldType(Def:table, Type:num, CustomName:str, Option:any)
       elseif Type has FD_STRUCT then
          if Option?? then
             -- We need the developer to declare a virtual reference in order to name the struct, e.g. `~struct(TheName)`
+            -- because Tiri can't read strings from Field.arg
             result = 'REQUIRES_VIRTUAL_REF'
          else
             result = 'APTR'
@@ -350,6 +355,7 @@ global function cType(Value:table, Origin:str):table
 
          if const?? then
             Value.type = 'const ' .. Value.type
+            Value.isConst = true
          end
 
          return Value
@@ -616,6 +622,9 @@ global function cType(Value:table, Origin:str):table
          Value.isArray = true
          Value.type    = array_type
          Value         = cType(Value, Origin) -- Inner type will amend the value definition
+         local inner_type = Value.struct ?? 'struct ' .. Value.struct :> Value.type
+         if Value.isConst then inner_type = 'const ' .. inner_type end
+
          if Value.docType and not Value.isFunction and not Value.isMethod then
             Value.docType ..= '[]'
             if Value.docType:startsWith('struct ') then
@@ -625,6 +634,7 @@ global function cType(Value:table, Origin:str):table
             Value.docType = Value.type
          end
          Value.type  ..= ' *'
+         Value.innerType = inner_type
          Value.fullType = {
             fd       = 'FD_ARRAY|' .. Value.fullType.fd,
             t_type   = 'array'


### PR DESCRIPTION
* Preserve const struct element types when generating unsized array spans
* Regenerate module headers and XML docs for corrected array and vector field declarations