### PR TITLE
[Core] Introduce RAII ZStream wrapper for zlib stream lifecycle in the Compression module

### DIFF
--- a/src/core/compression/class_archive.cpp
+++ b/src/core/compression/class_archive.cpp
@@ -36,14 +36,13 @@ constexpr int LEN_ARCHIVE = 8; // "archive:" length
 
 struct prvFileArchive {
    ZipFile  Info;
-   z_stream Stream;
+   ZStream  Inflate;      // Streaming decompression state for the active archive entry
    extFile  *FileStream;
    extCompression *Archive;
    uint8_t  InputBuffer[SIZE_COMPRESSION_BUFFER];
    uint8_t  OutputBuffer[SIZE_COMPRESSION_BUFFER];
    uint8_t  *ReadPtr;      // Current position within OutputBuffer
    int      InputLength;
-   bool     Inflating;
    bool     InvalidState; // Set to true if the archive is corrupt.
 };
 
@@ -65,9 +64,9 @@ static void reset_state(extFile *Self)
 {
    auto prv = (prvFileArchive *)Self->DerivedPtr;
 
-   if (prv->Inflating) { inflateEnd(&prv->Stream); prv->Inflating = false; }
+   prv->Inflate.reset();
 
-   prv->Stream.avail_in = 0;
+   prv->Inflate->avail_in = 0;
    prv->ReadPtr = nullptr;
    Self->Position = 0;
 }
@@ -96,8 +95,7 @@ static ERR seek_to_item(extFile *Self)
          Self->Size = item.CompressedSize;
          return ERR::Okay;
       }
-      else if ((item.DeflateMethod IS 8) and (!inflateInit2(&prv->Stream, -MAX_WBITS))) {
-         prv->Inflating = true;
+      else if ((item.DeflateMethod IS 8) and (!prv->Inflate.inflate_init(-MAX_WBITS))) {
          Self->Size = item.OriginalSize;
          return ERR::Okay;
       }
@@ -182,7 +180,6 @@ static ERR ARCHIVE_Free(extFile *Self)
 
    if (prv) {
       if (prv->FileStream) { FreeResource(prv->FileStream); prv->FileStream = nullptr; }
-      if (prv->Inflating)  { inflateEnd(&prv->Stream); prv->Inflating = false; }
       prv->~prvFileArchive();
    }
 
@@ -313,7 +310,7 @@ static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
 
       //log.trace("Decompressing %d bytes to %d, buffer size %d", zf.CompressedSize, zf.OriginalSize, Args->Length);
 
-      if ((prv->Inflating) and (!prv->Stream.avail_in)) { // Initial setup
+      if ((prv->Inflate.active()) and (!prv->Inflate->avail_in)) { // Initial setup
          struct acRead read = {
             .Buffer = prv->InputBuffer,
             .Length = (zf.CompressedSize < SIZE_COMPRESSION_BUFFER) ? (int)zf.CompressedSize : SIZE_COMPRESSION_BUFFER
@@ -322,18 +319,18 @@ static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
          if (Action(AC::Read, prv->FileStream, &read) != ERR::Okay) return ERR::Read;
          if (read.Result <= 0) return ERR::Read;
 
-         prv->ReadPtr          = prv->OutputBuffer;
-         prv->InputLength      = zf.CompressedSize - read.Result;
-         prv->Stream.next_in   = prv->InputBuffer;
-         prv->Stream.avail_in  = read.Result;
-         prv->Stream.next_out  = prv->OutputBuffer;
-         prv->Stream.avail_out = SIZE_COMPRESSION_BUFFER;
+         prv->ReadPtr            = prv->OutputBuffer;
+         prv->InputLength        = zf.CompressedSize - read.Result;
+         prv->Inflate->next_in   = prv->InputBuffer;
+         prv->Inflate->avail_in  = read.Result;
+         prv->Inflate->next_out  = prv->OutputBuffer;
+         prv->Inflate->avail_out = SIZE_COMPRESSION_BUFFER;
       }
 
       while (true) {
          // Output any buffered data to the client first
-         if (prv->ReadPtr < (uint8_t *)prv->Stream.next_out) {
-            int len = (int)(prv->Stream.next_out - (Bytef *)prv->ReadPtr);
+         if (prv->ReadPtr < (uint8_t *)prv->Inflate->next_out) {
+            int len = (int)(prv->Inflate->next_out - (Bytef *)prv->ReadPtr);
             if (len > Args->Length) len = Args->Length;
             copymem(prv->ReadPtr, (char *)Args->Buffer + Args->Result, len);
             prv->ReadPtr   += len;
@@ -343,27 +340,27 @@ static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
 
          // Stop if necessary
 
-         if (prv->Stream.total_out IS zf.OriginalSize) break; // All data decompressed
+         if (prv->Inflate->total_out IS zf.OriginalSize) break; // All data decompressed
          if (Args->Result >= Args->Length) return ERR::Okay;
-         if (!prv->Inflating) return ERR::Okay;
+         if (!prv->Inflate.active()) return ERR::Okay;
 
          // Reset the output buffer and decompress more data
 
-         prv->Stream.next_out  = prv->OutputBuffer;
-         prv->Stream.avail_out = SIZE_COMPRESSION_BUFFER;
+         prv->Inflate->next_out  = prv->OutputBuffer;
+         prv->Inflate->avail_out = SIZE_COMPRESSION_BUFFER;
 
-         int result = inflate(&prv->Stream, (prv->Stream.avail_in) ? Z_SYNC_FLUSH : Z_FINISH);
+         int result = inflate(prv->Inflate.get(), (prv->Inflate->avail_in) ? Z_SYNC_FLUSH : Z_FINISH);
 
          prv->ReadPtr = prv->OutputBuffer;
 
          if ((result) and (result != Z_STREAM_END)) {
             prv->InvalidState = true;
-            return convert_zip_error(&prv->Stream, result);
+            return convert_zip_error(prv->Inflate.get(), result);
          }
 
          // Read more data from the source if necessary
 
-         if ((prv->Stream.avail_in <= 0) and (prv->InputLength > 0) and (result != Z_STREAM_END)) {
+         if ((prv->Inflate->avail_in <= 0) and (prv->InputLength > 0) and (result != Z_STREAM_END)) {
             struct acRead read = { .Buffer = prv->InputBuffer };
 
             if (prv->InputLength < SIZE_COMPRESSION_BUFFER) read.Length = prv->InputLength;
@@ -373,15 +370,12 @@ static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
             if (read.Result <= 0) return ERR::Read;
 
             prv->InputLength -= read.Result;
-            prv->Stream.next_in  = prv->InputBuffer;
-            prv->Stream.avail_in = read.Result;
+            prv->Inflate->next_in  = prv->InputBuffer;
+            prv->Inflate->avail_in = read.Result;
          }
       }
 
-      if (prv->Inflating) {
-         inflateEnd(&prv->Stream);
-         prv->Inflating = false;
-      }
+      prv->Inflate.reset();
 
       return ERR::Okay;
    }

--- a/src/core/compression/class_compressed_stream.cpp
+++ b/src/core/compression/class_compressed_stream.cpp
@@ -29,9 +29,7 @@ signal an end to the streaming process.
 class extCompressedStream : public objCompressedStream {
    public:
    uint8_t *OutputBuffer;
-   uint8_t Inflating:1;
-   uint8_t Deflating:1;
-   z_stream Stream;
+   ZStream Stream;
    gz_header Header;
 
    ~extCompressedStream();
@@ -43,15 +41,7 @@ class extCompressedStream : public objCompressedStream {
    void reset() {
       TotalOutput = 0;
 
-      if (Inflating) {
-         inflateEnd(&Stream);
-         Inflating = false;
-      }
-
-      if (Deflating) {
-         deflateEnd(&Stream);
-         Deflating = false;
-      }
+      Stream.reset();
 
       if (OutputBuffer) { FreeResource(OutputBuffer); OutputBuffer = nullptr; }
    }
@@ -98,28 +88,25 @@ static ERR COMPRESSEDSTREAM_Read(extCompressedStream *Self, struct acRead *Args)
 
    if (length <= 0) return ERR::Okay;
 
-   if (!Self->Inflating) {
+   if (!Self->Stream.active()) {
       log.trace("Initialising decompression of the stream.");
-      clearmem(&Self->Stream, sizeof(Self->Stream));
       switch (Self->Format) {
          case CF::ZLIB:
-            if (inflateInit2(&Self->Stream, MAX_WBITS) != Z_OK) return log.warning(ERR::Decompression);
+            if (Self->Stream.inflate_init(MAX_WBITS) != Z_OK) return log.warning(ERR::Decompression);
             break;
 
          case CF::DEFLATE:
-            if (inflateInit2(&Self->Stream, -MAX_WBITS) != Z_OK) return log.warning(ERR::Decompression);
+            if (Self->Stream.inflate_init(-MAX_WBITS) != Z_OK) return log.warning(ERR::Decompression);
             break;
 
          case CF::GZIP:
          default:
-            if (inflateInit2(&Self->Stream, 15 + 32) != Z_OK) return log.warning(ERR::Decompression);
+            if (Self->Stream.inflate_init(15 + 32) != Z_OK) return log.warning(ERR::Decompression);
             // Read the uncompressed size from the gzip header
-            if (inflateGetHeader(&Self->Stream, &Self->Header) != Z_OK) {
+            if (inflateGetHeader(Self->Stream.get(), &Self->Header) != Z_OK) {
                return log.warning(ERR::InvalidData);
             }
       }
-
-      Self->Inflating = TRUE;
    }
 
    APTR output = Args->Buffer;
@@ -133,29 +120,29 @@ static ERR COMPRESSEDSTREAM_Read(extCompressedStream *Self, struct acRead *Args)
       }
    }
 
-   Self->Stream.next_in  = inputstream;
-   Self->Stream.avail_in = length;
+   Self->Stream->next_in  = inputstream;
+   Self->Stream->avail_in = length;
 
    ERR error = ERR::Okay;
    int result = Z_OK;
-   while ((result IS Z_OK) and (Self->Stream.avail_in > 0) and (outputsize > 0)) {
-      Self->Stream.next_out  = (Bytef *)output;
-      Self->Stream.avail_out = outputsize;
-      result = inflate(&Self->Stream, Z_SYNC_FLUSH);
+   while ((result IS Z_OK) and (Self->Stream->avail_in > 0) and (outputsize > 0)) {
+      Self->Stream->next_out  = (Bytef *)output;
+      Self->Stream->avail_out = outputsize;
+      result = inflate(Self->Stream.get(), Z_SYNC_FLUSH);
 
       if ((result) and (result != Z_STREAM_END)) {
-         error = convert_zip_error(&Self->Stream, result);
+         error = convert_zip_error(Self->Stream.get(), result);
          break;
       }
 
       if (error != ERR::Okay) break;
 
-      Args->Result += outputsize - Self->Stream.avail_out;
-      output = (Bytef *)output + outputsize - Self->Stream.avail_out;
+      Args->Result += outputsize - Self->Stream->avail_out;
+      output = (Bytef *)output + outputsize - Self->Stream->avail_out;
 
       if (result IS Z_STREAM_END) { // Decompression is complete
-         Self->Inflating = FALSE;
-         Self->TotalOutput = Self->Stream.total_out;
+         Self->TotalOutput = Self->Stream->total_out;
+         Self->Stream.reset();
          return ERR::Okay;
       }
    }
@@ -233,31 +220,28 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
    if ((!Args) or (!Args->Buffer)) return log.warning(ERR::NullArgs);
    if (!Self->initialised()) return log.warning(ERR::NotInitialised);
 
-   if (!Self->Deflating) {
-      clearmem(&Self->Stream, sizeof(Self->Stream));
-
+   if (!Self->Stream.active()) {
       switch (Self->Format) {
          case CF::ZLIB:
-            if (deflateInit2(&Self->Stream, 9, Z_DEFLATED, MAX_WBITS, ZLIB_MEM_LEVEL, Z_DEFAULT_STRATEGY)) {
+            if (Self->Stream.deflate_init(9, MAX_WBITS)) {
                return log.warning(ERR::Compression);
             }
             break;
 
          case CF::DEFLATE:
-            if (deflateInit2(&Self->Stream, 9, Z_DEFLATED, -MAX_WBITS, ZLIB_MEM_LEVEL, Z_DEFAULT_STRATEGY)) {
+            if (Self->Stream.deflate_init(9, -MAX_WBITS)) {
                return log.warning(ERR::Compression);
             }
             break;
 
          case CF::GZIP:
          default:
-            if (deflateInit2(&Self->Stream, 9, Z_DEFLATED, 15 + 32, ZLIB_MEM_LEVEL, Z_DEFAULT_STRATEGY)) {
+            if (Self->Stream.deflate_init(9, 15 + 32)) {
                return log.warning(ERR::Compression);
             }
       }
 
       Self->TotalOutput = 0;
-      Self->Deflating = TRUE;
    }
 
    if (!Self->OutputBuffer) {
@@ -268,30 +252,29 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
    int mode;
    if (Args->Length IS -1) { // A length of -1 is a signal to complete the compression process.
       mode = Z_FINISH;
-      Self->Stream.next_in  = Self->OutputBuffer;
-      Self->Stream.avail_in = 0;
+      Self->Stream->next_in  = Self->OutputBuffer;
+      Self->Stream->avail_in = 0;
    }
    else {
       mode = Z_NO_FLUSH;
-      Self->Stream.next_in  = (Bytef *)Args->Buffer;
-      Self->Stream.avail_in = Args->Length;
+      Self->Stream->next_in  = (Bytef *)Args->Buffer;
+      Self->Stream->avail_in = Args->Length;
    }
 
    // If zlib succeeds but sets avail_out to zero, this means that data was written to the output buffer, but the
    // output buffer is not large enough (so keep calling until avail_out > 0).
 
-   Self->Stream.avail_out = 0;
-   while (Self->Stream.avail_out IS 0) {
-      Self->Stream.next_out  = Self->OutputBuffer;
-      Self->Stream.avail_out = MIN_OUTPUT_SIZE;
+   Self->Stream->avail_out = 0;
+   while (Self->Stream->avail_out IS 0) {
+      Self->Stream->next_out  = Self->OutputBuffer;
+      Self->Stream->avail_out = MIN_OUTPUT_SIZE;
 
-      if ((deflate(&Self->Stream, mode))) {
-         deflateEnd(&Self->Stream);
-         Self->Deflating = FALSE;
+      if ((deflate(Self->Stream.get(), mode))) {
+         Self->Stream.reset();
          return ERR::BufferOverflow;
       }
 
-      const int len = MIN_OUTPUT_SIZE - Self->Stream.avail_out; // Get number of compressed bytes that were output
+      const int len = MIN_OUTPUT_SIZE - Self->Stream->avail_out; // Get number of compressed bytes that were output
 
       if (len > 0) {
          Self->TotalOutput += len;
@@ -307,10 +290,7 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
       }
    }
 
-   if (mode IS Z_FINISH) {
-      deflateEnd(&Self->Stream);
-      Self->Deflating = FALSE;
-   }
+   if (mode IS Z_FINISH) Self->Stream.reset();
 
    return ERR::Okay;
 }

--- a/src/core/compression/class_compression.cpp
+++ b/src/core/compression/class_compression.cpp
@@ -55,6 +55,8 @@ This code is based on the work of Jean-loup Gailly and Mark Adler.
 #include <kotuku/main.h>
 #include <sstream>
 
+#include "zstream.h"
+
 //********************************************************************************************************************
 // Central folder structure for each archived file.  This appears at the end of the zip file.
 
@@ -191,8 +193,8 @@ class extCompression : public objCompression {
 
    // Zip only fields
    z_stream Zip;
-   z_stream InflateStream;
-   z_stream DeflateStream;
+   ZStream  Inflate;            // Streaming decompression state (DecompressStream* methods)
+   ZStream  Deflate;            // Streaming compression state (CompressStream* methods)
    std::list<ZipFile> Files;    // List of files in the archive (must be in order of the archive's entries)
    std::vector<uint8_t> Output; // Internal scratch buffer for de/compressed output
    std::vector<uint8_t> Input;  // Internal scratch buffer for source input
@@ -200,8 +202,6 @@ class extCompression : public objCompression {
    int   TotalFiles;
    int   FileIndex;
    int16_t   CompressionCount;  // Counter of times that compression has occurred
-   bool   Deflating;
-   bool   Inflating;
 
    extCompression() : Output(SIZE_COMPRESSION_BUFFER), Input(SIZE_COMPRESSION_BUFFER) {
       CompressionLevel = 60; // 60% compression by default
@@ -753,21 +753,13 @@ static ERR COMPRESSION_CompressStreamStart(extCompression *Self)
 {
    kt::Log log;
 
-   if (Self->Deflating) {
-      deflateEnd(&Self->DeflateStream);
-      Self->Deflating = false;
-   }
-
    int level = Self->CompressionLevel / 10;
    if (level < 0) level = 0;
    else if (level > 9) level = 9;
 
-   clearmem(&Self->DeflateStream, sizeof(Self->DeflateStream));
-
    Self->TotalOutput = 0;
-   if (auto err = deflateInit2(&Self->DeflateStream, level, Z_DEFLATED, Self->WindowBits, ZLIB_MEM_LEVEL, Z_DEFAULT_STRATEGY); err IS Z_OK) {
+   if (Self->Deflate.deflate_init(level, Self->WindowBits) IS Z_OK) {
       log.trace("Compression stream initialised.");
-      Self->Deflating = true;
       return ERR::Okay;
    }
    else return log.warning(ERR::InvalidCompression);
@@ -854,10 +846,10 @@ static ERR COMPRESSION_CompressStream(extCompression *Self, struct cmp::Compress
 
    if ((!Args) or (!Args->Input) or (!Args->Callback)) return log.warning(ERR::NullArgs);
 
-   if (!Self->Deflating) return log.warning(ERR::InvalidState);
+   if (!Self->Deflate.active()) return log.warning(ERR::InvalidState);
 
-   Self->DeflateStream.next_in   = (Bytef *)Args->Input;
-   Self->DeflateStream.avail_in  = Args->Length;
+   Self->Deflate->next_in   = (Bytef *)Args->Input;
+   Self->Deflate->avail_in  = Args->Length;
 
    APTR output;
    int err, outputsize;
@@ -880,18 +872,18 @@ static ERR COMPRESSION_CompressStream(extCompression *Self, struct cmp::Compress
    // output buffer is not large enough (so keep calling until avail_out > 0).
 
    ERR error;
-   Self->DeflateStream.avail_out = 0;
-   while (Self->DeflateStream.avail_out IS 0) {
-      Self->DeflateStream.next_out  = (Bytef *)output;
-      Self->DeflateStream.avail_out = outputsize;
-      if ((err = deflate(&Self->DeflateStream, Z_NO_FLUSH))) {
-         deflateEnd(&Self->DeflateStream);
+   Self->Deflate->avail_out = 0;
+   while (Self->Deflate->avail_out IS 0) {
+      Self->Deflate->next_out  = (Bytef *)output;
+      Self->Deflate->avail_out = outputsize;
+      if ((err = deflate(Self->Deflate.get(), Z_NO_FLUSH))) {
+         Self->Deflate.reset();
          error = ERR::BufferOverflow;
          break;
       }
       else error = ERR::Okay;
 
-      auto len = outputsize - Self->DeflateStream.avail_out; // Get number of compressed bytes that were output
+      auto len = outputsize - Self->Deflate->avail_out; // Get number of compressed bytes that were output
 
       if (len > 0) {
          Self->TotalOutput += len;
@@ -960,7 +952,7 @@ static ERR COMPRESSION_CompressStreamEnd(extCompression *Self, struct cmp::Compr
    kt::Log log;
 
    if ((!Args) or (!Args->Callback)) return log.warning(ERR::NullArgs);
-   if (!Self->Deflating) return ERR::Okay;
+   if (!Self->Deflate.active()) return ERR::Okay;
 
    APTR output;
    int outputsize;
@@ -977,32 +969,32 @@ static ERR COMPRESSION_CompressStreamEnd(extCompression *Self, struct cmp::Compr
 
    log.trace("Output Size: %d", outputsize);
 
-   Self->DeflateStream.next_in   = 0;
-   Self->DeflateStream.avail_in  = 0;
-   Self->DeflateStream.avail_out = 0;
+   Self->Deflate->next_in   = 0;
+   Self->Deflate->avail_in  = 0;
+   Self->Deflate->avail_out = 0;
 
    ERR error;
    int err = Z_OK;
-   while ((Self->DeflateStream.avail_out IS 0) and (err IS Z_OK)) {
-      Self->DeflateStream.next_out  = (Bytef *)output;
-      Self->DeflateStream.avail_out = outputsize;
-      if ((err = deflate(&Self->DeflateStream, Z_FINISH)) and (err != Z_STREAM_END)) {
+   while ((Self->Deflate->avail_out IS 0) and (err IS Z_OK)) {
+      Self->Deflate->next_out  = (Bytef *)output;
+      Self->Deflate->avail_out = outputsize;
+      if ((err = deflate(Self->Deflate.get(), Z_FINISH)) and (err != Z_STREAM_END)) {
          error = log.warning(ERR::BufferOverflow);
          break;
       }
 
-      Self->TotalOutput += outputsize - Self->DeflateStream.avail_out;
+      Self->TotalOutput += outputsize - Self->Deflate->avail_out;
 
       if (Args->Callback->isC()) {
          kt::SwitchContext context(Args->Callback->Context);
          auto routine = (ERR (*)(extCompression *, APTR, int, APTR Meta))Args->Callback->Routine;
-         error = routine(Self, output, outputsize - Self->DeflateStream.avail_out, Args->Callback->Meta);
+         error = routine(Self, output, outputsize - Self->Deflate->avail_out, Args->Callback->Meta);
       }
       else if (Args->Callback->isScript()) {
          if (sc::Call(*Args->Callback, std::to_array<ScriptArg>({
             { "Compression",  Self,   FD_OBJECTPTR },
             { "Output",       output, FD_BUFFER },
-            { "OutputLength", int64_t(outputsize - Self->DeflateStream.avail_out), FD_INT64|FD_BUFSIZE }
+            { "OutputLength", int64_t(outputsize - Self->Deflate->avail_out), FD_INT64|FD_BUFSIZE }
          }), error) != ERR::Okay) error = ERR::Function;
       }
       else error = ERR::Okay;
@@ -1015,9 +1007,7 @@ static ERR COMPRESSION_CompressStreamEnd(extCompression *Self, struct cmp::Compr
       Self->OutputBuffer.shrink_to_fit();
    }
 
-   deflateEnd(&Self->DeflateStream);
-   clearmem(&Self->DeflateStream, sizeof(Self->DeflateStream));
-   Self->Deflating = false;
+   Self->Deflate.reset();
    return error;
 }
 
@@ -1048,15 +1038,10 @@ static ERR COMPRESSION_DecompressStreamStart(extCompression *Self)
 {
    kt::Log log;
 
-   if (Self->Inflating) { inflateEnd(&Self->InflateStream); Self->Inflating = false; }
-
-   clearmem(&Self->InflateStream, sizeof(Self->InflateStream));
-
    Self->TotalOutput = 0;
 
-   if (auto err = inflateInit2(&Self->InflateStream, Self->WindowBits); err IS Z_OK) {
+   if (Self->Inflate.inflate_init(Self->WindowBits) IS Z_OK) {
       log.trace("Decompression stream initialised.");
-      Self->Inflating = true;
       return ERR::Okay;
    }
    else return log.warning(ERR::InvalidCompression);
@@ -1107,7 +1092,7 @@ static ERR COMPRESSION_DecompressStream(extCompression *Self, struct cmp::Decomp
    kt::Log log;
 
    if ((!Args) or (!Args->Input) or (!Args->Callback)) return log.warning(ERR::NullArgs);
-   if (!Self->Inflating) return ERR::Okay; // Decompression is complete
+   if (!Self->Inflate.active()) return ERR::Okay; // Decompression is complete
 
    APTR output;
    int outputsize;
@@ -1122,20 +1107,20 @@ static ERR COMPRESSION_DecompressStream(extCompression *Self, struct cmp::Decomp
       outputsize = Self->OutputBuffer.size();
    }
 
-   Self->InflateStream.next_in  = (Bytef *)Args->Input;
-   Self->InflateStream.avail_in = Args->Length;
+   Self->Inflate->next_in  = (Bytef *)Args->Input;
+   Self->Inflate->avail_in = Args->Length;
 
    // Keep looping until Z_STREAM_END or an error is returned
 
    ERR error = ERR::Okay;
    int result = Z_OK;
-   while ((result IS Z_OK) and (Self->InflateStream.avail_in > 0)) {
-      Self->InflateStream.next_out  = (Bytef *)output;
-      Self->InflateStream.avail_out = outputsize;
-      result = inflate(&Self->InflateStream, Z_SYNC_FLUSH);
+   while ((result IS Z_OK) and (Self->Inflate->avail_in > 0)) {
+      Self->Inflate->next_out  = (Bytef *)output;
+      Self->Inflate->avail_out = outputsize;
+      result = inflate(Self->Inflate.get(), Z_SYNC_FLUSH);
 
       if ((result) and (result != Z_STREAM_END)) {
-         error = convert_zip_error(&Self->InflateStream, result);
+         error = convert_zip_error(Self->Inflate.get(), result);
          break;
       }
 
@@ -1143,7 +1128,7 @@ static ERR COMPRESSION_DecompressStream(extCompression *Self, struct cmp::Decomp
 
       // Write out the decompressed data
 
-      int len = outputsize - Self->InflateStream.avail_out;
+      int len = outputsize - Self->Inflate->avail_out;
       if (len > 0) {
          if (Args->Callback->isC()) {
             kt::SwitchContext context(Args->Callback->Context);
@@ -1166,9 +1151,8 @@ static ERR COMPRESSION_DecompressStream(extCompression *Self, struct cmp::Decomp
       if (error != ERR::Okay) break;
 
       if (result IS Z_STREAM_END) { // Decompression is complete, auto-perform DecompressStreamEnd()
-         inflateEnd(&Self->InflateStream);
-         Self->Inflating = false;
-         Self->TotalOutput = Self->InflateStream.total_out;
+         Self->TotalOutput = Self->Inflate->total_out;
+         Self->Inflate.reset();
          break;
       }
    }
@@ -1199,13 +1183,12 @@ mutates-object, callback-inlines
 
 static ERR COMPRESSION_DecompressStreamEnd(extCompression *Self, struct cmp::DecompressStreamEnd *Args)
 {
-   if (!Self->Inflating) return ERR::Okay; // If not inflating, not a problem
+   if (!Self->Inflate.active()) return ERR::Okay; // If not inflating, not a problem
 
    if ((!Args) or (!Args->Callback)) return ERR::NullArgs;
 
-   Self->TotalOutput = Self->InflateStream.total_out;
-   inflateEnd(&Self->InflateStream);
-   Self->Inflating = false;
+   Self->TotalOutput = Self->Inflate->total_out;
+   Self->Inflate.reset();
    return ERR::Okay;
 }
 
@@ -1701,8 +1684,6 @@ static ERR COMPRESSION_Free(extCompression *Self)
       Self->Feedback.clear();
    }
 
-   if (Self->Inflating)    { inflateEnd(&Self->InflateStream); Self->Inflating = false; }
-   if (Self->Deflating)    { deflateEnd(&Self->DeflateStream); Self->Deflating = false; }
    if (Self->FileIO)       { FreeResource(Self->FileIO); Self->FileIO = nullptr; }
 
    return ERR::Okay;

--- a/src/core/compression/zstream.h
+++ b/src/core/compression/zstream.h
@@ -1,0 +1,66 @@
+/*********************************************************************************************************************
+
+The source code of the Kotuku project is made publicly available under the terms described in the LICENSE.TXT file
+that is distributed with this package.  Please refer to it for further information on licensing.
+
+**********************************************************************************************************************
+
+RAII wrapper for a zlib z_stream.  This pairs the stream with the direction it is currently operating in, so that the
+matching deflateEnd()/inflateEnd() call can never be forgotten, duplicated, or applied in the wrong direction.
+
+The wrapper is pinned in place (move and copy deleted) because it is embedded directly as a member within its owning
+class.  No throwing paths are present; the init helpers return the raw zlib result code in keeping with the project's
+error-by-return-value convention.
+
+This header must be included after zlib.h and the ZLIB_MEM_LEVEL macro have been defined.
+
+*********************************************************************************************************************/
+
+#pragma once
+
+struct ZStream {
+   z_stream stream;
+   enum class Mode { NIL, INFLATE, DEFLATE } mode = Mode::NIL;
+
+   ZStream() { clearmem(&stream, sizeof(stream)); }
+   ~ZStream() { reset(); }
+
+   ZStream(const ZStream &) = delete;
+   ZStream(ZStream &&) = delete;
+   ZStream & operator=(const ZStream &) = delete;
+   ZStream & operator=(ZStream &&) = delete;
+
+   // Begin a decompression stream.  Any previously active stream is terminated first.  Returns the raw zlib result
+   // code, which is Z_OK on success.
+
+   int inflate_init(int WindowBits) {
+      reset();
+      clearmem(&stream, sizeof(stream));
+      auto err = inflateInit2(&stream, WindowBits);
+      if (err IS Z_OK) mode = Mode::INFLATE;
+      return err;
+   }
+
+   // Begin a compression stream.  Any previously active stream is terminated first.  Returns the raw zlib result
+   // code, which is Z_OK on success.
+
+   int deflate_init(int Level, int WindowBits) {
+      reset();
+      clearmem(&stream, sizeof(stream));
+      auto err = deflateInit2(&stream, Level, Z_DEFLATED, WindowBits, ZLIB_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+      if (err IS Z_OK) mode = Mode::DEFLATE;
+      return err;
+   }
+
+   // Terminate any active stream.  Idempotent and safe to call regardless of the current state.
+
+   void reset() {
+      if (mode IS Mode::INFLATE) inflateEnd(&stream);
+      else if (mode IS Mode::DEFLATE) deflateEnd(&stream);
+      mode = Mode::NIL;
+   }
+
+   bool active() const { return mode != Mode::NIL; }
+   z_stream * get() { return &stream; }
+   z_stream * operator-> () { return &stream; }
+};

--- a/src/core/tests/test_compression.tiri
+++ b/src/core/tests/test_compression.tiri
@@ -302,5 +302,21 @@ end
 
    assert(err is ERR_Okay, 'Inner decompression loop failed: ' .. mSys.GetErrorMsg(err))
    err = cmp.mtDecompressStreamEnd('streamedOutput')
+   assert(err is ERR_Okay, 'DecompressStreamEnd() failed: ' .. mSys.GetErrorMsg(err))
    glOutFile = nil
+   processing.collect() -- Flush the decompressed output to disk
+
+   -- Verify that the streamed round-trip reproduced the original source exactly.
+
+   source_file = obj.new('file', { path='scripts:gui.tiri' })
+   source_size = source_file.size
+
+   output_file = obj.new('file', { path='temp:gui.tiri' })
+   assert(output_file.size is source_size, f"Decompressed size {output_file.size} does not match source size {source_size}.")
+
+   source_data = array<byte, source_size>
+   output_data = array<byte, source_size>
+   assert(mSys.ReadFileToBuffer('scripts:gui.tiri', source_data) is ERR_Okay, 'Failed to read source data.')
+   assert(mSys.ReadFileToBuffer('temp:gui.tiri', output_data) is ERR_Okay, 'Failed to read decompressed output.')
+   assert(output_data:getString() is source_data:getString(), 'Round-tripped stream output does not match the source.')
 end


### PR DESCRIPTION
* Added zstream.h providing a move-pinned ZStream type that folds the active-direction flag into the z_stream, ensuring the matching inflateEnd/deflateEnd can never be forgotten, duplicated, or run in the wrong direction
* Migrated extCompression stream methods (CompressStream*/DecompressStream*) and the Free handler to the wrapper, removing the manual Deflating/Inflating booleans and clearmem/End teardown
* Migrated extFileArchive decompression state and extCompressedStream read/write paths to the wrapper, eliminating duplicated teardown and the bitfield flags
* [Doc] Strengthened the StreamedDecompression Flute test to assert the streamed round-trip reproduces the original source exactly