### PR TITLE
[Tiri] Corrected noreturn Lua error API signatures

### DIFF
--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -1478,7 +1478,7 @@ extern lua_CFunction lua_atpanic(lua_State *L, lua_CFunction panicf)
 }
 
 // Forwarders for the public API (C calling convention and no LJ_NORET).
-[[noreturn]] extern int lua_error(lua_State *L)
+[[noreturn]] extern void lua_error(lua_State *L)
 {
    err_clear_pending_exception(L);
    if (L->top > L->base and tvisstr(L->top - 1)) {
@@ -1487,20 +1487,17 @@ extern lua_CFunction lua_atpanic(lua_State *L, lua_CFunction panicf)
       // can fall back to parsing luaL_where() prefixes from preformatted C API error strings.
    }
    lj_err_run(L);
-   return 0;  //  unreachable
 }
 
-[[noreturn]] extern int luaL_argerror(lua_State *L, int narg, CSTRING msg)
+[[noreturn]] extern void luaL_argerror(lua_State *L, int narg, CSTRING msg)
 {
    L->CaughtError = ERR::Args;
    err_argmsg(L, narg, msg);
-   return 0;  //  unreachable
 }
 
-extern int luaL_typerror(lua_State *L, int narg, CSTRING xname)
+[[noreturn]] extern void luaL_typerror(lua_State *L, int narg, CSTRING xname)
 {
    lj_err_argtype(L, narg, xname);
-   return 0;  //  unreachable
 }
 
 extern void luaL_where(lua_State *L, int level)

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -21,8 +21,8 @@ struct luaL_Reg {
 
 extern void luaL_openlib(lua_State *, const char *, const luaL_Reg *, int);
 extern void luaL_register(lua_State *, const char *, const luaL_Reg *);
-extern int luaL_typerror(lua_State *, int, const char *);
-[[noreturn]] extern int luaL_argerror(lua_State *, int, const char *);
+[[noreturn]] extern void luaL_typerror(lua_State *, int, const char *);
+[[noreturn]] extern void luaL_argerror(lua_State *, int, const char *);
 extern const char * luaL_checklstring(lua_State *, int, size_t * = nullptr);
 extern uint32_t luaL_checkstringhash(lua_State *, int);
 extern const char * luaL_optlstring(lua_State *, int, const char *, size_t * = nullptr);

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -197,7 +197,7 @@ constexpr int LUA_GCISRUNNING = 9;
 
 extern int (lua_gc) (lua_State *L, int what, int data = 0);
 
-[[noreturn]] extern int   (lua_error) (lua_State *L);
+[[noreturn]] extern void (lua_error) (lua_State *L);
 extern int   (lua_next) (lua_State *L, int idx);
 extern void  (lua_concat) (lua_State *L, int n);
 extern lua_Alloc (lua_getallocf) (lua_State *L, void **ud);

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -43,7 +43,6 @@ static int processing_new(lua_State *Lua)
          }
 
          luaL_error(Lua, Error, std::move(Message));
-         return 0;
       };
 
       if (not (fp->Signals = new (std::nothrow) std::list<ObjectSignal>)) {
@@ -133,7 +132,7 @@ static int processing_halt(lua_State *Lua)
 {
    double seconds;
    if (lua_type(Lua, 1) IS LUA_TNUMBER) seconds = lua_tonumber(Lua, 1);
-   else return luaL_argerror(Lua, 1, "Seconds must be a number.");
+   else luaL_argerror(Lua, 1, "Seconds must be a number.");
 
    if (seconds < 0) luaL_error(Lua, ERR::Args, "Seconds must be a positive number.");
 


### PR DESCRIPTION
* Updated Lua error helpers to return void where control cannot resume
* Removed unreachable returns from Tiri processing error paths