### PR TITLE
[SVG] Adopted typed field accessors throughout the parser

### DIFF
--- a/docs/xml/modules/classes/netserver.xml
+++ b/docs/xml/modules/classes/netserver.xml
@@ -150,7 +150,7 @@
     <field>
       <name>SSLKeyPassword</name>
       <comment>SSL private key password.</comment>
-      <access read="R" write="S">Read/Set</access>
+      <access read="R" write="I">Read/Init</access>
       <type>STRING</type>
       <description>
 <p>If the SSL private key is encrypted, set this field to the password required to decrypt it.  If the private key is not encrypted, this field can be left empty.</p>

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -921,6 +921,7 @@ class objNetServer : public objNetSocket {
    }
 
    inline ERR setSSLKeyPassword(const std::string_view &Value) noexcept {
+      if (this->initialised()) return ERR::ImmutableField;
       auto field = &this->Class->Dictionary[20];
       return field->WriteValue(this, field, 0x00804500, &Value);
    }

--- a/src/network/class_netserver.cpp
+++ b/src/network/class_netserver.cpp
@@ -220,32 +220,15 @@ SSLKeyPassword: SSL private key password.
 If the SSL private key is encrypted, set this field to the password required to decrypt it.  If the private key is
 not encrypted, this field can be left empty.
 
-*********************************************************************************************************************/
-
-static ERR NETSERVER_SET_SSLKeyPassword(extNetServer *Self, const std::string_view &Value)
-{
-   Self->SSLKeyPassword.assign(Value);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
 
 -FIELD-
 Clients: Lists all NetClient records connected to the NetServer.
-
-*********************************************************************************************************************/
-
-/*********************************************************************************************************************
 
 -FIELD-
 TotalClients: Indicates the total number of clients currently connected to the NetServer.
 
 NetServer maintains a count of the total number of currently connected TCP client sockets.  You can read the total
 number of connections from this field.
-
-*********************************************************************************************************************/
-
-/*********************************************************************************************************************
 
 -FIELD-
 Backlog: The maximum number of connections that can be queued against the socket.
@@ -558,7 +541,7 @@ static const FieldArray clNetServerFields[] = {
    { "Clients",        FDF_OBJECT|FDF_R,     nullptr, nullptr, CLASSID::NETCLIENT },
    { "SSLCertificate", FDF_CPPSTRING|FDF_RI, nullptr, NETSERVER_SET_SSLCertificate },
    { "SSLPrivateKey",  FDF_CPPSTRING|FDF_RI, nullptr, NETSERVER_SET_SSLPrivateKey },
-   { "SSLKeyPassword", FDF_CPPSTRING|FDF_RI, nullptr, NETSERVER_SET_SSLKeyPassword },
+   { "SSLKeyPassword", FDF_CPPSTRING|FDF_RI },
    { "Backlog",        FDF_INT|FDF_RI,       nullptr, NETSERVER_SET_Backlog },
    { "ClientLimit",    FDF_INT|FDF_RW,       nullptr, NETSERVER_SET_ClientLimit },
    { "SocketLimit",    FDF_INT|FDF_RW,       nullptr, NETSERVER_SET_SocketLimit },

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -123,7 +123,7 @@ static ERR SVG_DataFeed(extSVG *Self, struct acDataFeed *Args)
    if (!Args) return ERR::NullArgs;
 
    if (Args->Datatype IS DATA::XML) {
-      return parse_svg(Self, 0, (CSTRING)Args->Buffer);
+      return parse_svg(Self, std::string_view{}, std::string_view((const char *)Args->Buffer, Args->Size));
    }
 
    return ERR::Okay;
@@ -165,8 +165,8 @@ static ERR SVG_Init(extSVG *Self)
       else return ERR::NewObject;
    }
 
-   if (not Self->Path.empty()) return parse_svg(Self, Self->Path.c_str(), nullptr);
-   else if (not Self->Statement.empty()) return parse_svg(Self, nullptr, Self->Statement.c_str());
+   if (not Self->Path.empty()) return parse_svg(Self, Self->Path, std::string_view{});
+   else if (not Self->Statement.empty()) return parse_svg(Self, std::string_view{}, Self->Statement);
 
    return ERR::Okay;
 }

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -1567,7 +1567,7 @@ ERR svgState::parse_fe_image(objVectorFilter *Filter, XTag &Tag) noexcept
          }
       }
 
-      if (auto fl = folder(Self)) {
+      if (auto fl = folder(Self); not fl.empty()) {
          std::string comp_path = std::string(fl) + path;
          fx->setPath(comp_path);
       }
@@ -2008,7 +2008,9 @@ static std::string resolve_image_href(extSVG *Self, XTag &Tag, const std::string
    }
 
    std::string base;
-   if (auto doc_folder = folder(Self)) base = xml::uri::normalise_uri_separators(doc_folder);
+   if (auto doc_folder = folder(Self); not doc_folder.empty()) {
+      base = xml::uri::normalise_uri_separators(std::string(doc_folder));
+   }
 
    // xml:base values are themselves relative to the active base URI at the point where they are declared.
    for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
@@ -2026,7 +2028,7 @@ static std::string resolve_image_href(extSVG *Self, XTag &Tag, const std::string
 
 //********************************************************************************************************************
 
-static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, double Width = 0, double Height = 0)
+static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, Unit Width = Unit(), Unit Height = Unit())
 {
    kt::Log log(__FUNCTION__);
 
@@ -2077,16 +2079,17 @@ static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, double Wid
    else log.branch("%s", Path.c_str());
 
    if (!error) {
+      // Note: A Width/Height of 0 will use the image's actual width/height.
       if (!(*Image = objImage::create::global(
          fl::Owner(Self->Scene->UID),
          fl::Path(Path),
          fl::BitsPerPixel(32),
-         fl::DisplayWidth(Width), fl::DisplayHeight(Height),
+         fl::DisplayWidth(Width.defined() ? int(Width) : 0), fl::DisplayHeight(Height.defined() ? int(Height) : 0),
          fl::Flags(PCF::FORCE_ALPHA_32)))) error = ERR::CreateObject;
    }
 
    if (file) {
-      Action(fl::Delete::id, file, nullptr);
+      file->del({});
       FreeResource(file);
    }
 
@@ -2175,7 +2178,7 @@ ERR svgState::proc_image(XTag &Tag, OBJECTPTR Parent, objVector * &Vector) noexc
 
    std::string src, filter, transform, id;
    ARF ratio = ARF::X_MID|ARF::Y_MID|ARF::MEET; // SVG default if the client leaves preserveAspectRatio undefined
-   Unit x, y, width(0), height(0);
+   Unit x, y, width, height;
 
    for (int a=1; a < std::ssize(Tag.Attribs); a++) {
       auto &value = Tag.Attribs[a].Value;

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -1,8 +1,7 @@
 //********************************************************************************************************************
-// For setting Fill and Stroke fields.  If the value is a url() then the referenced paint server will be initialised
-// if it has not been already.
+// If the value is a url() then the referenced paint server will be initialised if it has not been already.
 
-ERR svgState::set_paint_server(objVector *Vector, FIELD Field, const std::string Value)
+void svgState::resolve_paint_server(const std::string &Value) noexcept
 {
    if (Value.starts_with("url(")) {
       if (Value[4] IS '#') {
@@ -27,8 +26,6 @@ ERR svgState::set_paint_server(objVector *Vector, FIELD Field, const std::string
          }
       }
    }
-
-   return Vector->set(Field, Value);
 }
 
 //********************************************************************************************************************
@@ -556,7 +553,7 @@ ERR svgState::parse_fe_blur(objVectorFilter *Filter, XTag &Tag) noexcept
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -589,7 +586,7 @@ ERR svgState::parse_fe_offset(objVectorFilter *Filter, XTag &Tag) noexcept
       switch(strhash(Tag.Attribs[a].Name)) {
          case SVF_dx: fx->setXOffset(svtonum<int>(val)); break;
          case SVF_dy: fx->setYOffset(svtonum<int>(val)); break;
-         case SVF_in: parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in: parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -745,7 +742,7 @@ ERR svgState::parse_fe_colour_matrix(objVectorFilter *Filter, XTag &Tag) noexcep
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -846,7 +843,7 @@ ERR svgState::parse_fe_convolve_matrix(objVectorFilter *Filter, XTag &Tag) noexc
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -909,7 +906,7 @@ ERR svgState::parse_fe_lighting(objVectorFilter *Filter, XTag &Tag, LT Type) noe
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
          default:         log.warning("Unknown %s attribute %s", Tag.name(), Tag.Attribs[a].Name.c_str());
       }
@@ -1027,8 +1024,8 @@ ERR svgState::parse_fe_displacement_map(objVectorFilter *Filter, XTag &Tag) noex
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
 
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
-         case SVF_in2:    parse_input(Self, fx, val, FID_MixType, FID_Mix); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
+         case SVF_in2:    parse_input_mix(Self, fx, val); break;
 
          case SVF_result: result_name = val; break;
       }
@@ -1110,7 +1107,7 @@ ERR svgState::parse_fe_component_xfer(objVectorFilter *Filter, XTag &Tag) noexce
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -1262,8 +1259,8 @@ ERR svgState::parse_fe_composite(objVectorFilter *Filter, XTag &Tag) noexcept
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
-         case SVF_in2:    parse_input(Self, fx, val, FID_MixType, FID_Mix); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
+         case SVF_in2:    parse_input_mix(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -1314,7 +1311,7 @@ ERR svgState::parse_fe_flood(objVectorFilter *Filter, XTag &Tag) noexcept
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -1367,7 +1364,7 @@ ERR svgState::parse_fe_turbulence(objVectorFilter *Filter, XTag &Tag) noexcept
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -1411,7 +1408,7 @@ ERR svgState::parse_fe_morphology(objVectorFilter *Filter, XTag &Tag) noexcept
          case SVF_y:      fx->setY(SVGUnit(val)); break;
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
-         case SVF_in:     parse_input(Self, fx, val, FID_SourceType, FID_Input); break;
+         case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_result: result_name = val; break;
       }
    }
@@ -2178,7 +2175,7 @@ ERR svgState::proc_image(XTag &Tag, OBJECTPTR Parent, objVector * &Vector) noexc
 
    std::string src, filter, transform, id;
    ARF ratio = ARF::X_MID|ARF::Y_MID|ARF::MEET; // SVG default if the client leaves preserveAspectRatio undefined
-   Unit x, y, width, height;
+   Unit x, y, width(0), height(0);
 
    for (int a=1; a < std::ssize(Tag.Attribs); a++) {
       auto &value = Tag.Attribs[a].Value;
@@ -2902,8 +2899,8 @@ void svgState::proc_svg(XTag &Tag, OBJECTPTR Parent, objVector * &Vector) noexce
          case SVF_x: viewport->setX(SVGUnit(val)); break;
          case SVF_y: viewport->setY(SVGUnit(val)); break;
 
-         case SVF_xOffset: viewport->set(FID_XOffset, SVGUnit(val)); break;
-         case SVF_yOffset: viewport->set(FID_YOffset, SVGUnit(val)); break;
+         case SVF_xOffset: viewport->setXOffset(SVGUnit(val)); break;
+         case SVF_yOffset: viewport->setYOffset(SVGUnit(val)); break;
 
          case SVF_width:
             viewport->setWidth(SVGUnit(val));
@@ -3515,15 +3512,17 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
       }
 
       // VectorPolygon handles polygon, polyline and line.
-      case CLASSID::VECTORPOLYGON:
+      case CLASSID::VECTORPOLYGON: {
+         auto polygon = (objVectorPolygon *)Vector;
          switch (Hash) {
-            case SVF_points: ((objVectorPolygon *)Vector)->setPoints(StrValue); return ERR::Okay;
-            case SVF_x1: Vector->set(FID_X1, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_y1: Vector->set(FID_Y1, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_x2: Vector->set(FID_X2, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_y2: Vector->set(FID_Y2, SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_points: polygon->setPoints(StrValue); return ERR::Okay;
+            case SVF_x1: polygon->setX1(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_y1: polygon->setY1(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_x2: polygon->setX2(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_y2: polygon->setY2(SVGUnit(StrValue)); return ERR::Okay;
          }
          break;
+      }
 
       case CLASSID::VECTORTEXT: {
          auto vt = (objVectorText *)Vector;
@@ -3531,8 +3530,17 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
             case SVF_x: vt->setX(SVGUnit(StrValue)); return ERR::Okay;
             case SVF_y: vt->setY(SVGUnit(StrValue)); return ERR::Okay;
 
-            case SVF_dx: vt->set(FID_DX, StrValue); return ERR::Okay;
-            case SVF_dy: vt->set(FID_DY, StrValue); return ERR::Okay;
+            case SVF_dx: {
+               auto values = read_array(StrValue);
+               vt->setDX(values);
+               return ERR::Okay;
+            }
+
+            case SVF_dy: {
+               auto values = read_array(StrValue);
+               vt->setDY(values);
+               return ERR::Okay;
+            }
 
             case SVF_lengthAdjust: // Can be set to either 'spacing' or 'spacingAndGlyphs'
                //if (iequals("spacingAndGlyphs", va_arg(list, STRING))) vt->VT.SpacingAndGlyphs = TRUE;
@@ -3573,17 +3581,17 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
 
             case SVF_font_stretch: // NYI
                //switch(strhash(StrValue)) {
-               //   case SVF_condensed:       vt->set(FID_Stretch, int(VTS::CONDENSED)); return ERR::Okay;
-               //   case SVF_expanded:        vt->set(FID_Stretch, int(VTS::EXPANDED)); return ERR::Okay;
-               //   case SVF_extra_condensed: vt->set(FID_Stretch, int(VTS::EXTRA_CONDENSED)); return ERR::Okay;
-               //   case SVF_extra_expanded:  vt->set(FID_Stretch, int(VTS::EXTRA_EXPANDED)); return ERR::Okay;
-               //   case SVF_narrower:        vt->set(FID_Stretch, int(VTS::NARROWER)); return ERR::Okay;
-               //   case SVF_normal:          vt->set(FID_Stretch, int(VTS::NORMAL)); return ERR::Okay;
-               //   case SVF_semi_condensed:  vt->set(FID_Stretch, int(VTS::SEMI_CONDENSED)); return ERR::Okay;
-               //   case SVF_semi_expanded:   vt->set(FID_Stretch, int(VTS::SEMI_EXPANDED)); return ERR::Okay;
-               //   case SVF_ultra_condensed: vt->set(FID_Stretch, int(VTS::ULTRA_CONDENSED)); return ERR::Okay;
-               //   case SVF_ultra_expanded:  vt->set(FID_Stretch, int(VTS::ULTRA_EXPANDED)); return ERR::Okay;
-               //   case SVF_wider:           vt->set(FID_Stretch, int(VTS::WIDER)); return ERR::Okay;
+               //   case SVF_condensed:       vt->setStretch(VTS::CONDENSED)); return ERR::Okay;
+               //   case SVF_expanded:        vt->setStretch(VTS::EXPANDED)); return ERR::Okay;
+               //   case SVF_extra_condensed: vt->setStretch(VTS::EXTRA_CONDENSED)); return ERR::Okay;
+               //   case SVF_extra_expanded:  vt->setStretch(VTS::EXTRA_EXPANDED)); return ERR::Okay;
+               //   case SVF_narrower:        vt->setStretch(VTS::NARROWER)); return ERR::Okay;
+               //   case SVF_normal:          vt->setStretch(VTS::NORMAL)); return ERR::Okay;
+               //   case SVF_semi_condensed:  vt->setStretch(VTS::SEMI_CONDENSED)); return ERR::Okay;
+               //   case SVF_semi_expanded:   vt->setStretch(VTS::SEMI_EXPANDED)); return ERR::Okay;
+               //   case SVF_ultra_condensed: vt->setStretch(VTS::ULTRA_CONDENSED)); return ERR::Okay;
+               //   case SVF_ultra_expanded:  vt->setStretch(VTS::ULTRA_EXPANDED)); return ERR::Okay;
+               //   case SVF_wider:           vt->setStretch(VTS::WIDER)); return ERR::Okay;
                //   default: log.warning("no support for font-stretch value '%s'", StrValue.c_str());
                //}
                return ERR::NoSupport;
@@ -3623,7 +3631,7 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
                }
                break;
 
-            case SVF_textLength: vt->set(FID_TextLength, StrValue); return ERR::Okay;
+            case SVF_textLength: vt->setTextLength(SVGUnit(StrValue)); return ERR::Okay;
             // TextPath only
             //case SVF_startOffset: vt->set(FID_StartOffset, StrValue); return ERR::Okay;
             //case SVF_method: // The default is align.  For 'stretch' mode, set VMF::STRETCH in MorphFlags
@@ -3650,42 +3658,46 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
          break;
       }
 
-      case CLASSID::VECTORSPIRAL:
+      case CLASSID::VECTORSPIRAL: {
+         auto spiral = (objVectorSpiral *)Vector;
          switch (Hash) {
-            case SVF_pathLength: ((objVectorSpiral *)Vector)->setPathLength(svtonum<int>(StrValue)); return ERR::Okay;
-            case SVF_cx:         Vector->set(FID_CX, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_cy:         Vector->set(FID_CY, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_r:          Vector->set(FID_Radius, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_offset:     Vector->set(FID_Offset, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_step:       Vector->set(FID_Step, SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_pathLength: spiral->setPathLength(svtonum<int>(StrValue)); return ERR::Okay;
+            case SVF_cx:         spiral->setCX(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_cy:         spiral->setCY(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_r:          spiral->setRadius(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_offset:     spiral->setOffset(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_step:       spiral->setStep(SVGUnit(StrValue)); return ERR::Okay;
             case SVF_vertices:   Vector->set(FID_Vertices, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_spacing:    Vector->set(FID_Spacing, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_loop_limit: Vector->set(FID_LoopLimit, SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_spacing:    spiral->setSpacing(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_loop_limit: spiral->setLoopLimit(SVGUnit(StrValue)); return ERR::Okay;
          }
          break;
+      }
 
-      case CLASSID::VECTORSHAPE:
+      case CLASSID::VECTORSHAPE: {
+         auto shape = (objVectorShape *)Vector;
          switch (Hash) {
-            case SVF_cx:       Vector->set(FID_CX, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_cy:       Vector->set(FID_CY, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_r:        Vector->set(FID_Radius, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_n1:       Vector->set(FID_N1, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_n2:       Vector->set(FID_N2, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_n3:       Vector->set(FID_N3, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_m:        Vector->set(FID_M, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_a:        Vector->set(FID_A, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_b:        Vector->set(FID_B, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_phi:      Vector->set(FID_Phi, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_vertices: Vector->set(FID_Vertices, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_mod:      Vector->set(FID_Mod, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_spiral:   Vector->set(FID_Spiral, SVGUnit(StrValue)); return ERR::Okay;
-            case SVF_repeat:   Vector->set(FID_Repeat, SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_cx:       shape->setCX(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_cy:       shape->setCY(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_r:        shape->setRadius(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_n1:       shape->setN1(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_n2:       shape->setN2(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_n3:       shape->setN3(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_m:        shape->setM(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_a:        shape->setA(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_b:        shape->setB(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_phi:      shape->setPhi(SVGUnit(StrValue)); return ERR::Okay;
+            case SVF_vertices: shape->setVertices(int(SVGUnit(StrValue))); return ERR::Okay;
+            case SVF_mod:      shape->setMod(int(SVGUnit(StrValue))); return ERR::Okay;
+            case SVF_spiral:   shape->setSpiral(int(SVGUnit(StrValue))); return ERR::Okay;
+            case SVF_repeat:   shape->setRepeat(int(SVGUnit(StrValue))); return ERR::Okay;
             case SVF_close:
-               if ((iequals("true", StrValue)) or (iequals("1", StrValue))) ((objVectorShape *)Vector)->setClose(TRUE);
-               else ((objVectorShape *)Vector)->setClose(FALSE);
+               if ((iequals("true", StrValue)) or (iequals("1", StrValue))) shape->setClose(TRUE);
+               else shape->setClose(FALSE);
                break;
          }
          break;
+      }
 
       case CLASSID::VECTORPATH:
          switch (Hash) {
@@ -3836,7 +3848,10 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
             FRGB rgb;
             if (current_colour(Vector, rgb)) Vector->setStrokeColour(rgb);
          }
-         else set_paint_server(Vector, FID_Stroke, StrValue);
+         else {
+            resolve_paint_server(StrValue);
+            Vector->setStroke(StrValue);
+         }
          break;
 
       case SVF_fill:
@@ -3844,7 +3859,10 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
             FRGB rgb;
             if (current_colour(Vector, rgb)) Vector->setFillColour(rgb);
          }
-         else set_paint_server(Vector, FID_Fill, StrValue);
+         else {
+            resolve_paint_server(StrValue);
+            Vector->setFill(StrValue);
+         }
          break;
 
       case SVF_transform: parse_transform(Vector, StrValue, MTAG_SVG_TRANSFORM); break;
@@ -3864,7 +3882,7 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
       case SVF_stroke_miterlimit:       Vector->setMiterLimit(svtonum<double>(StrValue)); break;
       //case SVF_stroke_miterlimit_theta: Vector->setMiterLimitTheta(svtonum<double>(StrValue)); break;
       //case SVF_stroke_inner_miterlimit: Vector->setInnerMiterLimit(svtonum<double>(StrValue)); break;
-      case SVF_stroke_dashoffset:       Vector->set(FID_DashOffset, SVGUnit(StrValue)); break;
+      case SVF_stroke_dashoffset:       Vector->setDashOffset(SVGUnit(StrValue)); break;
 
       case SVF_mask: {
          OBJECTPTR clip;

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -203,7 +203,7 @@ private:
    void process_attrib(XTag &, objVector *) noexcept;
    void process_inherit_refs(XTag &) noexcept;
    void process_shape_children(XTag &, OBJECTPTR) noexcept;
-   ERR  set_paint_server(objVector *, FIELD, const std::string);
+   void resolve_paint_server(const std::string &) noexcept;
    bool current_colour(objVector *, FRGB &) noexcept;
 
    void parse_contourgradient(const XTag &, objGradientContour *, std::string &) noexcept;

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -72,8 +72,8 @@ static HSV rgb_to_hsl(FRGB Colour)
 static FRGB hsl_to_rgb(HSV Colour)
 {
    auto hueToRgb = [](float p, float q, float t) -> float {
-      if (t < 0) t += 1;
-      if (t > 1) t -= 1;
+      if (t < 0) t++;
+      if (t > 1) t--;
       if (t < 1.0/6.0) return p + (q - p) * 6.0 * t;
       if (t < 1.0/2.0) return q;
       if (t < 2.0/3.0) return p + (q - p) * (2.0/3.0 - t) * 6.0;
@@ -217,26 +217,26 @@ static std::vector<Transition> process_transition_stops(extSVG *Self, const objX
 
 //********************************************************************************************************************
 
-static CSTRING folder(extSVG *Self)
+static std::string_view folder(extSVG *Self)
 {
-   if (not Self->Folder.empty()) return Self->Folder.c_str();
-   if (Self->Path.empty()) return nullptr;
+   if (not Self->Folder.empty()) return Self->Folder;
+   if (Self->Path.empty()) return std::string_view{};
 
    // Setting a path of "my/house/is/red.svg" results in "my/house/is/"
 
    if (!ResolvePath(Self->Path, RSF::NO_FILE_CHECK, &Self->Folder)) {
       if (auto last = Self->Folder.find_last_of("/\\"); last != std::string::npos) {
          Self->Folder.resize(last + 1);
-         return Self->Folder.c_str();
+         return Self->Folder;
       }
       else Self->Folder.clear();
    }
-   return nullptr;
+   return std::string_view{};
 }
 
 //********************************************************************************************************************
 
-static void parse_transform(objVector *Vector, const std::string Value, int Tag)
+static void parse_transform(objVector *Vector, std::string_view Value, int Tag)
 {
    if ((Vector->Class->BaseClassID IS CLASSID::VECTOR) and (not Value.empty())) {
       VectorMatrix *matrix;
@@ -460,13 +460,14 @@ static void parse_ids(extSVG *Self, XTag &Tag)
 //********************************************************************************************************************
 // Parse SVG from a file or string buffer.
 
-static ERR parse_svg(extSVG *Self, CSTRING Path, CSTRING Buffer)
+static ERR parse_svg(extSVG *Self, std::string_view Path, std::string_view Buffer)
 {
    kt::Log log(__FUNCTION__);
 
-   if ((not Path) and (not Buffer)) return ERR::NullArgs;
+   if ((Path.empty()) and (Buffer.empty())) return ERR::NullArgs;
 
-   log.branch("Path: %s [Log-level reduced]", Path ? Path : "<xml-statement>");
+   if (not Path.empty()) log.branch("Path: %.*s [Log-level reduced]", int(Path.size()), Path.data());
+   else log.branch("Path: <xml-statement> [Log-level reduced]");
 
 #ifndef DEBUG
    AdjustLogLevel(1);
@@ -483,7 +484,7 @@ static ERR parse_svg(extSVG *Self, CSTRING Path, CSTRING Buffer)
       objTask *task = CurrentTask();
       std::string working_path;
 
-      if (Path) {
+      if (not Path.empty()) {
          if (wildcmp("*.svgz", Path)) {
             if (auto file = objFile::create::global(fl::Owner(xml->UID), fl::Path(Path), fl::Flags(FL::READ))) {
                if (auto stream = objCompressedStream::create::global(fl::Owner(file->UID), fl::Input(file))) {
@@ -509,16 +510,11 @@ static ERR parse_svg(extSVG *Self, CSTRING Path, CSTRING Buffer)
 
          // Set a new working path based on the path
 
-         auto last = std::string::npos;
-         for (int i=0; Path[i]; i++) {
-            if ((Path[i] IS '/') or (Path[i] IS '\\') or (Path[i] IS ':')) last = i+1;
-         }
-         if (last != std::string::npos) {
-            auto folder = std::string(Path, last);
-            task->setPath(folder);
+         if (auto last = Path.find_last_of("/\\:"); last != std::string::npos) {
+            task->setPath(Path.substr(0, last + 1));
          }
       }
-      else if (Buffer) xml->setStatement(Buffer);
+      else if (not Buffer.empty()) xml->setStatement(Buffer);
 
       if (!InitObject(xml)) {
          Self->SVGVersion = 1.0;

--- a/src/svg/utility.cpp
+++ b/src/svg/utility.cpp
@@ -139,23 +139,35 @@ static void parse_result(extSVG *Self, objFilterEffect *Effect, std::string Valu
 
 //********************************************************************************************************************
 
-static void parse_input(extSVG *Self, OBJECTPTR Effect, const std::string Input, FIELD SourceField, FIELD RefField)
+static void parse_input_source(extSVG *Self, objFilterEffect *Effect, const std::string Input)
 {
    switch (strhash(Input)) {
-      case SVF_SourceGraphic:   Effect->set(SourceField, int(VSF::GRAPHIC)); break;
-      case SVF_SourceAlpha:     Effect->set(SourceField, int(VSF::ALPHA)); break;
-      case SVF_BackgroundImage: Effect->set(SourceField, int(VSF::BKGD)); break;
-      case SVF_BackgroundAlpha: Effect->set(SourceField, int(VSF::BKGD_ALPHA)); break;
-      case SVF_FillPaint:       Effect->set(SourceField, int(VSF::FILL)); break;
-      case SVF_StrokePaint:     Effect->set(SourceField, int(VSF::STROKE)); break;
+      case SVF_SourceGraphic:   Effect->setSourceType(VSF::GRAPHIC); break;
+      case SVF_SourceAlpha:     Effect->setSourceType(VSF::ALPHA); break;
+      case SVF_BackgroundImage: Effect->setSourceType(VSF::BKGD); break;
+      case SVF_BackgroundAlpha: Effect->setSourceType(VSF::BKGD_ALPHA); break;
+      case SVF_FillPaint:       Effect->setSourceType(VSF::FILL); break;
+      case SVF_StrokePaint:     Effect->setSourceType(VSF::STROKE); break;
       default:  {
-         if (Self->Effects.contains(Input)) {
-            Effect->set(RefField, Self->Effects[Input]);
-         }
-         else {
-            kt::Log log;
-            log.warning("Unrecognised input '%s'", Input.c_str());
-         }
+         if (Self->Effects.contains(Input)) Effect->setInput(Self->Effects[Input]);
+         else kt::Log().warning("Unrecognised input '%s'", Input.c_str());
+         break;
+      }
+   }
+}
+
+static void parse_input_mix(extSVG *Self, objFilterEffect *Effect, const std::string Input)
+{
+   switch (strhash(Input)) {
+      case SVF_SourceGraphic:   Effect->setMixType(VSF::GRAPHIC); break;
+      case SVF_SourceAlpha:     Effect->setMixType(VSF::ALPHA); break;
+      case SVF_BackgroundImage: Effect->setMixType(VSF::BKGD); break;
+      case SVF_BackgroundAlpha: Effect->setMixType(VSF::BKGD_ALPHA); break;
+      case SVF_FillPaint:       Effect->setMixType(VSF::FILL); break;
+      case SVF_StrokePaint:     Effect->setMixType(VSF::STROKE); break;
+      default:  {
+         if (Self->Effects.contains(Input)) Effect->setMix(Self->Effects[Input]);
+         else kt::Log().warning("Unrecognised input '%s'", Input.c_str());
          break;
       }
    }


### PR DESCRIPTION
* Replaced generic set(FIELD, ...) calls with typed setters across VectorPolygon, VectorText, VectorSpiral, VectorShape, viewport and stroke/dash property handling
* Split parse_input into parse_input_source and parse_input_mix using typed setSourceType/setMixType/setInput/setMix accessors
* Reworked set_paint_server into resolve_paint_server, separating paint server resolution from the field assignment
* dx/dy text attributes now parsed via read_array and applied with setDX/setDY