### PR TITLE
[Vector] Add bilinear displacement filtering

### DIFF
--- a/docs/xml/modules/classes/displacementfx.xml
+++ b/docs/xml/modules/classes/displacementfx.xml
@@ -42,6 +42,17 @@
 
   <fields>
     <field>
+      <name>ResampleMethod</name>
+      <comment>The resample algorithm to use for transforming the source image.</comment>
+      <access read="R" write="W">Read/Write</access>
+      <type lookup="VSM">VSM</type>
+      <description>
+<types lookup="VSM"/>
+<p>Currently <code>NEIGHBOUR</code> and <code>BILINEAR</code> are supported. Other resample methods fall back to bilinear filtering.</p>
+      </description>
+    </field>
+
+    <field>
       <name>Scale</name>
       <comment>Displacement scale factor.</comment>
       <access read="R" write="W">Read/Write</access>
@@ -87,6 +98,22 @@
       <const name="BLUE">The blue colour channel.</const>
       <const name="GREEN">The green colour channel.</const>
       <const name="RED">The red colour channel.</const>
+    </constants>
+
+    <constants lookup="VSM">
+      <const name="AUTO">The default option is chosen by the system.  This will typically be <code>BILINEAR</code>, but slow machines may switch to nearest neighbour and high speed machines could use more advanced methods.</const>
+      <const name="BESSEL">Uses a broad Bessel filter that can preserve detail during resampling, but is slower than the smaller-kernel methods.</const>
+      <const name="BICUBIC">Produces a similar result to <code>BILINEAR</code> at a slightly higher CPU cost and a marginally sharper after-effect.</const>
+      <const name="BILINEAR">Bilinear is a common algorithm that produces a reasonable quality image quickly.</const>
+      <const name="BLACKMAN">Five times slower than <code>BILINEAR</code>, the final result will be less sharp than SINC.</const>
+      <const name="GAUSSIAN">Uses a Gaussian filter that softens the result, reducing aliasing at the cost of sharp edge detail.</const>
+      <const name="KAISER">Uses a Kaiser-windowed filter, giving smooth interpolation with low ringing and a cost close to <code>BILINEAR</code>.</const>
+      <const name="LANCZOS">This well known algorithm may serve as a point of comparison for evaluating the results of other methods.  It shares characteristics with <code>SINC</code> and <code>BLACKMAN</code>.</const>
+      <const name="MITCHELL">Uses a Mitchell-Netravali filter, balancing sharpness and smoothness at a cost similar to <code>BICUBIC</code>.</const>
+      <const name="NEIGHBOUR">Nearest neighbour is the fastest sampler at the cost of poor quality.</const>
+      <const name="QUADRIC">Uses a quadratic filter with a modest kernel, giving smoother results than <code>BILINEAR</code> with limited extra cost.</const>
+      <const name="SINC">Five times slower than <code>BILINEAR</code>, the final result is of very good quality.</const>
+      <const name="SPLINE16">About twice as slow as <code>BILINEAR</code>, this method samples a 4x4 area and produces a considerably better result, and is a good choice for enlarging images without producing artifacts when contrasting colours are present.</const>
     </constants>
 
   </types>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -2624,13 +2624,18 @@ class objDisplacementFX : public objFilterEffect {
 
    // Customised field getting
 
+   inline ERR getResampleMethod(VSM &Value) noexcept {
+      Value = *((VSM *)(((int8_t *)this) + 224));
+      return ERR::Okay;
+   }
+
    inline ERR getXChannel(CMP &Value) noexcept {
-      Value = *((CMP *)(((int8_t *)this) + 224));
+      Value = *((CMP *)(((int8_t *)this) + 228));
       return ERR::Okay;
    }
 
    inline ERR getYChannel(CMP &Value) noexcept {
-      Value = *((CMP *)(((int8_t *)this) + 228));
+      Value = *((CMP *)(((int8_t *)this) + 232));
       return ERR::Okay;
    }
 
@@ -2640,7 +2645,7 @@ class objDisplacementFX : public objFilterEffect {
    }
 
    inline ERR getXMLDef(std::string &Value) noexcept {
-      auto field = &this->Class->Dictionary[19];
+      auto field = &this->Class->Dictionary[20];
       SetObjectContext(this, field, AC::NIL);
       std::string_view view;
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
@@ -2656,18 +2661,23 @@ class objDisplacementFX : public objFilterEffect {
 
    // Customised field setting
 
+   inline ERR setResampleMethod(const VSM Value) noexcept {
+      auto field = &this->Class->Dictionary[17];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
    inline ERR setXChannel(const CMP Value) noexcept {
       auto field = &this->Class->Dictionary[16];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setYChannel(const CMP Value) noexcept {
-      auto field = &this->Class->Dictionary[18];
+      auto field = &this->Class->Dictionary[19];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setScale(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
+      auto field = &this->Class->Dictionary[18];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -1024,6 +1024,15 @@ ERR svgState::parse_fe_displacement_map(objVectorFilter *Filter, XTag &Tag) noex
          case SVF_width:  fx->setWidth(SVGUnit(val)); break;
          case SVF_height: fx->setHeight(SVGUnit(val)); break;
 
+         case SVF_image_rendering: {
+            if ("optimizeSpeed" IS val) fx->setResampleMethod(VSM::BILINEAR);
+            else if ("optimizeQuality" IS val) fx->setResampleMethod(VSM::LANCZOS);
+            else if ("auto" IS val);
+            else if ("inherit" IS val);
+            else log.warning("Unrecognised image-rendering option '%s'", val.c_str());
+            break;
+         }
+
          case SVF_in:     parse_input_source(Self, fx, val); break;
          case SVF_in2:    parse_input_mix(Self, fx, val); break;
 

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -235,7 +235,7 @@ end
 @Test global function W3Convolve2()        hashTestSVG('filters/w3-filters-conv-02-f.svg', 0x47ded148) end
 @Test; @Disabled global function W3Convolve4()        hashTestSVG('filters/w3-filters-conv-04-f.svg', 0x3e4d8a13) end
 @Test; @Disabled global function W3Convolve5()        hashTestSVG('filters/w3-filters-conv-05-f.svg', 0xda23deb4) end
-@Test global function W3Displacement1()    hashTestSVG('filters/w3-filters-displace-01-f.svg', 0x0c1b324a) end
+@Test global function W3Displacement1()    hashTestSVG('filters/w3-filters-displace-01-f.svg', 0x5b759ef6) end
 @Test global function W3Transfer()         hashTestSVG('filters/w3-filters-comptran-01-b.svg', 0x060263af) end
 @Test global function W3Transfer2()        hashTestSVG('filters/w3-filters-color-02-b.svg', 0x49928379) end
 @Test global function W3Filters()          hashTestSVG('filters/w3-filters.svg', 0x2f6ef991) end

--- a/src/vector/filters/filter_displacement.cpp
+++ b/src/vector/filters/filter_displacement.cpp
@@ -50,6 +50,7 @@ class extDisplacementFX : public extFilterEffect {
    using create = kt::Create<extDisplacementFX>;
 
    double Scale = 0; // SVG default requires this is 0, which makes the displacment algorithm ineffective.
+   VSM ResampleMethod = VSM::BILINEAR; // Resample method.
    CMP XChannel = CMP::ALPHA, YChannel = CMP::ALPHA;
 };
 
@@ -126,25 +127,73 @@ static ERR DISPLACEMENTFX_Draw(extDisplacementFX *Self, struct acDraw *Args)
       else return Pixel[Type];
    };
 
+   auto get_input_pixel = [input, inBmp, in_width, in_height](int X, int Y) -> uint8_t * {
+      if ((X < 0) or (X >= in_width) or (Y < 0) or (Y >= in_height)) return nullptr;
+      else return input + (X * inBmp->BytesPerPixel) + (Y * inBmp->LineWidth);
+   };
+
+   auto sample_input_bilinear = [get_input_pixel](uint8_t *Output, double X, double Y) {
+      if ((X < 0.0) or (Y < 0.0)) {
+         ((uint32_t *)Output)[0] = 0;
+         return;
+      }
+
+      const int x0 = int(std::floor(X));
+      const int y0 = int(std::floor(Y));
+      const int x1 = x0 + 1;
+      const int y1 = y0 + 1;
+      const double tx = X - double(x0);
+      const double ty = Y - double(y0);
+
+      auto p00 = get_input_pixel(x0, y0);
+      auto p10 = get_input_pixel(x1, y0);
+      auto p01 = get_input_pixel(x0, y1);
+      auto p11 = get_input_pixel(x1, y1);
+
+      if (!p00) {
+         ((uint32_t *)Output)[0] = 0;
+         return;
+      }
+
+      for (int i=0; i < 4; i++) {
+         const double c00 = p00 ? double(p00[i]) : 0.0;
+         const double c10 = p10 ? double(p10[i]) : 0.0;
+         const double c01 = p01 ? double(p01[i]) : 0.0;
+         const double c11 = p11 ? double(p11[i]) : 0.0;
+         const double top = (c00 * (1.0 - tx)) + (c10 * tx);
+         const double bottom = (c01 * (1.0 - tx)) + (c11 * tx);
+         Output[i] = uint8_t(std::clamp(int(std::lrint((top * (1.0 - ty)) + (bottom * ty))), 0, 255));
+      }
+   };
+
    //log.warning("W/H: %dx%d; MW/H: %dx%d; IW/H: %dx%d; CW/H: %.2fx%.2f, BBox: %d", width, height, mix_width, mix_height, in_width, in_height, c_width, c_height, Self->Filter->PrimitiveUnits IS VUNIT::BOUNDING_BOX);
    //log.warning("X Channel: %d, Y Channel: %d; Scale: %.2f / %.2f -> %.2f,%.2f; WH: %dx%d", Self->XChannel, Self->YChannel, Self->Scale, scale_against, sx, sy, width, height);
 
    constexpr double HALF8BIT = 255.0 * 0.5;
+   const bool nearest = Self->ResampleMethod IS VSM::NEIGHBOUR;
    for (int y=0; y < draw_height; y++) {
       auto m = mix;
-      auto d = (uint32_t *)dest;
-      for (int x=0; x < draw_width; x++, m += mixBmp->BytesPerPixel, d++) {
+      auto d = dest;
+      for (int x=0; x < draw_width; x++, m += mixBmp->BytesPerPixel, d += Self->Target->BytesPerPixel) {
          auto dx = sample_mix(m, Self->XChannel, x_type);
          auto dy = sample_mix(m, Self->YChannel, y_type);
-         // TODO: SVG recommends using interpolation between pixels rather than the dropping the fractional part
-         // as done here.
-         const int cx = x + std::lrint(sx * (double(dx) - HALF8BIT));
-         const int cy = y + std::lrint(sy * (double(dy) - HALF8BIT));
-         if ((cx < 0) or (cx >= in_width) or (cy < 0) or (cy >= in_height)) {
-            // The source pixel is outside of retrievable bounds
-            *d = 0;
+         const double sample_x = double(x) + (sx * (double(dx) - HALF8BIT));
+         const double sample_y = double(y) + (sy * (double(dy) - HALF8BIT));
+
+         if (nearest) {
+            const int cx = std::lrint(sample_x);
+            const int cy = std::lrint(sample_y);
+            if ((cx < 0) or (cx >= in_width) or (cy < 0) or (cy >= in_height)) {
+               // The source pixel is outside of retrievable bounds
+               ((uint32_t *)d)[0] = 0;
+            }
+            else ((uint32_t *)d)[0] = ((uint32_t *)(input + (cx * 4) + (cy * inBmp->LineWidth)))[0];
          }
-         else *d = ((uint32_t *)(input + (cx * 4) + (cy * inBmp->LineWidth)))[0];
+         else if ((sample_x < 0.0) or (sample_x >= double(in_width)) or (sample_y < 0.0) or (sample_y >= double(in_height))) {
+            // The source pixel is outside of retrievable bounds
+            ((uint32_t *)d)[0] = 0;
+         }
+         else sample_input_bilinear(d, sample_x, sample_y);
       }
       mix  += mixBmp->LineWidth;
       dest += Self->Target->LineWidth;
@@ -154,6 +203,13 @@ static ERR DISPLACEMENTFX_Draw(extDisplacementFX *Self, struct acDraw *Args)
 }
 
 /*********************************************************************************************************************
+
+-FIELD-
+ResampleMethod: The resample algorithm to use for transforming the source image.
+
+Currently `NEIGHBOUR` and `BILINEAR` are supported.  Other resample methods fall back to bilinear filtering.
+
+!VSM
 
 -FIELD-
 Scale: Displacement scale factor.
@@ -195,6 +251,7 @@ static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, std::string_view &
 
 static const FieldArray clDisplacementFXFields[] = {
    { "Scale",     FDF_DOUBLE|FDF_RW },
+   { "ResampleMethod", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXVSM },
    { "XChannel",  FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXCMP },
    { "YChannel",  FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXCMP },
    { "XMLDef",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, DISPLACEMENTFX_GET_XMLDef },

--- a/src/vector/filters/filter_displacement_def.c
+++ b/src/vector/filters/filter_displacement_def.c
@@ -9,6 +9,23 @@ static const struct FieldDef clDisplacementFXCMP[] = {
    { nullptr, 0 }
 };
 
+static const struct FieldDef clDisplacementFXVSM[] = {
+   { "Auto", 0x00000000 },
+   { "Neighbour", 0x00000001 },
+   { "Bilinear", 0x00000002 },
+   { "Bicubic", 0x00000003 },
+   { "Spline16", 0x00000004 },
+   { "Kaiser", 0x00000005 },
+   { "Quadric", 0x00000006 },
+   { "Gaussian", 0x00000007 },
+   { "Bessel", 0x00000008 },
+   { "Mitchell", 0x00000009 },
+   { "Sinc", 0x0000000a },
+   { "Lanczos", 0x0000000b },
+   { "Blackman", 0x0000000c },
+   { nullptr, 0 }
+};
+
 static ERR DISPLACEMENTFX_NewPlacement(extDisplacementFX *Self) {
    new (Self) extDisplacementFX;
    return ERR::Okay;

--- a/src/vector/transformers/transition.cpp
+++ b/src/vector/transformers/transition.cpp
@@ -48,7 +48,7 @@ void apply_transition(extVectorTransition *Self, double Index, agg::trans_affine
       for (left=std::ssize(Self->Stops)-1; (left > 0) and (Index < Self->Stops[left].Offset); left--);
       for (right=left+1; (right < std::ssize(Self->Stops)) and (Self->Stops[right].Offset < Index); right++);
 
-      if ((left < right) and (right < Self->Stops.size())) {
+      if ((left < right) and (right < std::ssize(Self->Stops))) {
          agg::trans_affine interp;
 
          // Normalise the index

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -639,7 +639,8 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     ~int(EM) EdgeMode
   ]])
 
-  klass('DisplacementFX', { base='FilterEffect', src='filters/filter_displacement.cpp', output='filters/filter_displacement_def.c', comment='Displacement filter support class.', extended=true, references= { 'CMP' } }, [[
+  klass('DisplacementFX', { base='FilterEffect', src='filters/filter_displacement.cpp', output='filters/filter_displacement_def.c', comment='Displacement filter support class.', extended=true, references= { 'CMP', 'VSM' } }, [[
+    ~int(VSM) ResampleMethod
     ~int(CMP) XChannel
     ~int(CMP) YChannel
   ]])


### PR DESCRIPTION
* Added resample method support to DisplacementFX and implemented bilinear source sampling
* [SVG] Parsed image-rendering for feDisplacementMap and updated the displacement reference test hash
* Fixed the transition stop bounds comparison warning