### PR TITLE
[Vector] Adopt public VLJ/VLC/VIJ enums in the stroke pipeline and promote shape fields to direct access

### DIFF
--- a/docs/xml/modules/classes/vector.xml
+++ b/docs/xml/modules/classes/vector.xml
@@ -333,7 +333,7 @@
     <field>
       <name>ClipRule</name>
       <comment>Determines the algorithm to use when clipping the shape.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type lookup="VFR">VFR</type>
       <description>
 <p>The ClipRule attribute only applies to vector shapes when they are contained within a <class name="VectorClip">VectorClip</class> object.  In terms of outcome, the ClipRule works similarly to <fl>FillRule</fl>.</p>
@@ -397,7 +397,7 @@
     <field>
       <name>Fill</name>
       <comment>Defines the fill painter using SVG's IRI format.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
       <description>
 <p>The painter used for filling a vector path can be defined through this field using SVG compatible formatting.  The string is parsed through the <function module="Vector">ReadPainter</function> function.  Please refer to it for further details on valid formatting.</p>
@@ -419,7 +419,7 @@
     <field>
       <name>FillOpacity</name>
       <comment>The opacity to use when filling the vector.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>DOUBLE</type>
       <description>
 <p>The FillOpacity value is used by the painting algorithm when it is rendering a filled vector.  It is multiplied with the <fl>Opacity</fl> to determine a final opacity value for the render.</p>
@@ -429,7 +429,7 @@
     <field>
       <name>FillRule</name>
       <comment>Determines the algorithm to use when filling the shape.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type lookup="VFR">VFR</type>
       <description>
 <p>The FillRule field indicates the algorithm which is to be used to determine what parts of the canvas are included when filling the shape. For a simple, non-intersecting path, it is intuitively clear what region lies &quot;inside&quot;; however, for a more complex path, such as a path that intersects itself or where one sub-path encloses another, the interpretation of &quot;inside&quot; is not so obvious.</p>
@@ -440,7 +440,7 @@
     <field>
       <name>Filter</name>
       <comment>Assign a post-effects filter to a vector.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
       <description>
 <p>This field assigns a graphics filter to the rendering pipeline of the vector.  The filter must initially be created using the <class name="VectorFilter">VectorFilter</class> class and added to a VectorScene using <class name="VectorScene" method="AddDef">VectorScene.AddDef()</class>.  The filter can then be referenced by ID in the Filter field of any vector object.  Please refer to the <class name="VectorFilter">VectorFilter</class> class for further details on filter configuration.</p>
@@ -461,7 +461,7 @@
     <field>
       <name>InnerJoin</name>
       <comment>Adjusts the handling of thickly stroked paths that cross back at the join.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type lookup="VIJ">VIJ</type>
       <description>
 <p>The InnerJoin value is used to make very technical adjustments to the way that paths are stroked when they form corners.  Visually, the impact of this setting is only noticeable when a path forms an awkward corner that crosses over itself - usually due to the placement of bezier control points.</p>
@@ -473,7 +473,7 @@
     <field>
       <name>LineCap</name>
       <comment>The shape to be used at the start and end of a stroked path.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type lookup="VLC">VLC</type>
       <description>
 <p>LineCap is the equivalent of SVG's stroke-linecap attribute.  It defines the shape to be used at the start and end of a stroked path.</p>
@@ -484,7 +484,7 @@
     <field>
       <name>LineJoin</name>
       <comment>The shape to be used at path corners that are stroked.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type lookup="VLJ">VLJ</type>
       <description>
 <p>LineJoin is the equivalent of SVG's stroke-linejoin attribute.  It defines the shape to be used at path corners that are being stroked.</p>
@@ -680,7 +680,7 @@ Z: Close Path
     <field>
       <name>Stroke</name>
       <comment>Defines the stroke of a path using SVG's IRI format.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
       <description>
 <p>The stroker used for rendering a vector path can be defined through this field.  The string is parsed through the <function>ReadPainter</function> function in the Vector module.  Please refer to it for further details on valid formatting.</p>
@@ -701,7 +701,7 @@ Z: Close Path
     <field>
       <name>StrokeOpacity</name>
       <comment>Defines the opacity of the path stroke.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>DOUBLE</type>
       <description>
 <p>The StrokeOpacity value expresses the opacity of a path stroke as a value between 0 and 1.0.  A value of zero would render the stroke invisible and the maximum value of one would render it opaque.</p>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -3741,13 +3741,13 @@ class objVector : public Object {
    }
 
    inline ERR getStrokeOpacity(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[0];
-      return field->GetValue(this, &Value);
+      Value = this->StrokeOpacity;
+      return ERR::Okay;
    }
 
    inline ERR getFillOpacity(double &Value) noexcept {
-      auto field = &this->Class->Dictionary[35];
-      return field->GetValue(this, &Value);
+      Value = this->FillOpacity;
+      return ERR::Okay;
    }
 
    inline ERR getOpacity(double &Value) noexcept {
@@ -3806,13 +3806,13 @@ class objVector : public Object {
    }
 
    inline ERR getFillRule(VFR &Value) noexcept {
-      auto field = &this->Class->Dictionary[25];
-      return field->GetValue(this, &Value);
+      Value = *((VFR *)(((int8_t *)this) + 304));
+      return ERR::Okay;
    }
 
    inline ERR getClipRule(VFR &Value) noexcept {
-      auto field = &this->Class->Dictionary[42];
-      return field->GetValue(this, &Value);
+      Value = *((VFR *)(((int8_t *)this) + 308));
+      return ERR::Okay;
    }
 
    inline ERR getMorphFlags(VMF &Value) noexcept {
@@ -3821,18 +3821,33 @@ class objVector : public Object {
    }
 
    inline ERR getLineJoin(VLJ &Value) noexcept {
-      auto field = &this->Class->Dictionary[31];
-      return field->GetValue(this, &Value);
+      Value = *((VLJ *)(((int8_t *)this) + 312));
+      return ERR::Okay;
    }
 
    inline ERR getLineCap(VLC &Value) noexcept {
-      auto field = &this->Class->Dictionary[22];
-      return field->GetValue(this, &Value);
+      Value = *((VLC *)(((int8_t *)this) + 316));
+      return ERR::Okay;
    }
 
    inline ERR getInnerJoin(VIJ &Value) noexcept {
-      auto field = &this->Class->Dictionary[5];
-      return field->GetValue(this, &Value);
+      Value = *((VIJ *)(((int8_t *)this) + 320));
+      return ERR::Okay;
+   }
+
+   inline ERR getStroke(std::string_view &Value) noexcept {
+      Value = *((std::string *)(((int8_t *)this) + 208));
+      return ERR::Okay;
+   }
+
+   inline ERR getFill(std::string_view &Value) noexcept {
+      Value = *((std::string *)(((int8_t *)this) + 240));
+      return ERR::Okay;
+   }
+
+   inline ERR getFilter(std::string_view &Value) noexcept {
+      Value = *((std::string *)(((int8_t *)this) + 272));
+      return ERR::Okay;
    }
 
    inline ERR getDashArray(std::span<double> &Value) noexcept {
@@ -3889,12 +3904,6 @@ class objVector : public Object {
       return error;
    }
 
-   inline ERR getStroke(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[14];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      return get_field(this, Value);
-   }
-
    inline ERR getStrokeWidth(Unit &Value) noexcept {
       auto field = &this->Class->Dictionary[23];
       return field->GetValue(this, &Value);
@@ -3903,18 +3912,6 @@ class objVector : public Object {
    inline ERR getTransition(OBJECTPTR &Value) noexcept {
       auto field = &this->Class->Dictionary[39];
       return field->GetValue(this, &Value);
-   }
-
-   inline ERR getFill(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      return get_field(this, Value);
-   }
-
-   inline ERR getFilter(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[3];
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      return get_field(this, Value);
    }
 
    inline ERR getTabOrder(int &Value) noexcept {
@@ -4026,6 +4023,21 @@ class objVector : public Object {
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
+   inline ERR setStroke(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[14];
+      return field->WriteValue(this, field, 0x00804300, &Value);
+   }
+
+   inline ERR setFill(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[9];
+      return field->WriteValue(this, field, 0x00804300, &Value);
+   }
+
+   inline ERR setFilter(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[3];
+      return field->WriteValue(this, field, 0x00804300, &Value);
+   }
+
    inline ERR setDashArray(std::span<const double> Value) noexcept {
       auto field = &this->Class->Dictionary[8];
       return field->WriteValue(this, field, 0x80101308, &Value);
@@ -4061,11 +4073,6 @@ class objVector : public Object {
       return field->WriteValue(this, field, FD_FUNCTION, &Value);
    }
 
-   inline ERR setStroke(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(this, field, 0x00904308, &Value);
-   }
-
    inline ERR setStrokeWidth(const Unit Value) noexcept {
       auto field = &this->Class->Dictionary[23];
       return field->WriteValue(this, field, FD_UNIT, &Value);
@@ -4074,16 +4081,6 @@ class objVector : public Object {
    inline ERR setTransition(OBJECTPTR Value) noexcept {
       auto field = &this->Class->Dictionary[39];
       return field->WriteValue(this, field, 0x08100309, Value);
-   }
-
-   inline ERR setFill(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(this, field, 0x00904308, &Value);
-   }
-
-   inline ERR setFilter(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[3];
-      return field->WriteValue(this, field, 0x00904308, &Value);
    }
 
    inline ERR setTabOrder(const int Value) noexcept {

--- a/src/vector/agg/include/agg_conv_contour.h
+++ b/src/vector/agg/include/agg_conv_contour.h
@@ -29,8 +29,8 @@ namespace agg
         {
         }
 
-        void line_join(line_join_e lj) { base_type::generator().line_join(lj); }
-        void inner_join(inner_join_e ij) { base_type::generator().inner_join(ij); }
+        void line_join(VLJ LineJoin) { base_type::generator().line_join(LineJoin); }
+        void inner_join(VIJ InnerJoin) { base_type::generator().inner_join(InnerJoin); }
         void width(double w) { base_type::generator().width(w); }
         void miter_limit(double ml) { base_type::generator().miter_limit(ml); }
         void miter_limit_theta(double t) { base_type::generator().miter_limit_theta(t); }
@@ -38,8 +38,8 @@ namespace agg
         void approximation_scale(double as) { base_type::generator().approximation_scale(as); }
         void auto_detect_orientation(bool v) { base_type::generator().auto_detect_orientation(v); }
 
-        line_join_e line_join() const { return base_type::generator().line_join(); }
-        inner_join_e inner_join() const { return base_type::generator().inner_join(); }
+        VLJ line_join() const { return base_type::generator().line_join(); }
+        VIJ inner_join() const { return base_type::generator().inner_join(); }
         double width() const { return base_type::generator().width(); }
         double miter_limit() const { return base_type::generator().miter_limit(); }
         double inner_miter_limit() const { return base_type::generator().inner_miter_limit(); }

--- a/src/vector/agg/include/agg_conv_stroke.h
+++ b/src/vector/agg/include/agg_conv_stroke.h
@@ -30,13 +30,13 @@ namespace agg
         {
         }
 
-        void line_cap(line_cap_e lc)     { base_type::generator().line_cap(lc);  }
-        void line_join(line_join_e lj)   { base_type::generator().line_join(lj); }
-        void inner_join(inner_join_e ij) { base_type::generator().inner_join(ij); }
+        void line_cap(VLC LineCap)     { base_type::generator().line_cap(LineCap);  }
+        void line_join(VLJ LineJoin)   { base_type::generator().line_join(LineJoin); }
+        void inner_join(VIJ InnerJoin) { base_type::generator().inner_join(InnerJoin); }
 
-        line_cap_e   line_cap()   const { return base_type::generator().line_cap();  }
-        line_join_e  line_join()  const { return base_type::generator().line_join(); }
-        inner_join_e inner_join() const { return base_type::generator().inner_join(); }
+        VLC line_cap()   const { return base_type::generator().line_cap();  }
+        VLJ line_join()  const { return base_type::generator().line_join(); }
+        VIJ inner_join() const { return base_type::generator().inner_join(); }
 
         void width(double w) { base_type::generator().width(w); }
         void miter_limit(double ml) { base_type::generator().miter_limit(ml); }

--- a/src/vector/agg/include/agg_math_stroke.h
+++ b/src/vector/agg/include/agg_math_stroke.h
@@ -13,48 +13,23 @@
 
 #include "agg_math.h"
 #include "agg_vertex_sequence.h"
+#include <kotuku/modules/vector.h>
 
 namespace agg
 {
-    enum line_cap_e
-    {
-        butt_cap = 1,
-        square_cap,
-        round_cap,
-        inherit_cap
-    };
-
-    enum line_join_e
-    {
-        miter_join         = 0,
-        miter_join_revert  = 1,
-        round_join         = 2,
-        bevel_join         = 3,
-        miter_join_round   = 4,
-        inherit_join = 5
-    };
-
-    enum inner_join_e {
-        inner_bevel = 1,
-        inner_miter,
-        inner_jag,
-        inner_round,
-        inner_inherit
-    };
-
     template<class VertexConsumer> class math_stroke {
     public:
         typedef typename VertexConsumer::value_type coord_type;
 
         math_stroke();
 
-        void line_cap(line_cap_e lc)     { m_line_cap = lc; }
-        void line_join(line_join_e lj)   { m_line_join = lj; }
-        void inner_join(inner_join_e ij) { m_inner_join = ij; }
+        void line_cap(VLC lc)   { m_line_cap = lc; }
+        void line_join(VLJ lj)  { m_line_join = lj; }
+        void inner_join(VIJ ij) { m_inner_join = ij; }
 
-        line_cap_e   line_cap()   const { return m_line_cap; }
-        line_join_e  line_join()  const { return m_line_join; }
-        inner_join_e inner_join() const { return m_inner_join; }
+        VLC line_cap()   const { return m_line_cap; }
+        VLJ line_join()  const { return m_line_join; }
+        VIJ inner_join() const { return m_inner_join; }
 
         void width(double w);
         void miter_limit(double ml) { m_miter_limit = ml; }
@@ -78,7 +53,7 @@ namespace agg
         void calc_arc(VertexConsumer& vc, double x, double y, double dx1, double dy1, double dx2, double dy2);
 
         void calc_miter(VertexConsumer& vc, const vertex_dist& v0, const vertex_dist& v1, const vertex_dist& v2,
-           double dx1, double dy1, double dx2, double dy2, line_join_e lj, double mlimit, double dbevel);
+           double dx1, double dy1, double dx2, double dy2, VLJ lj, double mlimit, double dbevel);
 
         double       m_width;
         double       m_width_abs;
@@ -87,9 +62,9 @@ namespace agg
         double       m_miter_limit;
         double       m_inner_miter_limit;
         double       m_approx_scale;
-        line_cap_e   m_line_cap;
-        line_join_e  m_line_join;
-        inner_join_e m_inner_join;
+        VLC m_line_cap;
+        VLJ m_line_join;
+        VIJ m_inner_join;
     };
 
     template<class VC> math_stroke<VC>::math_stroke() :
@@ -100,9 +75,9 @@ namespace agg
         m_miter_limit(4.0),
         m_inner_miter_limit(1.01),
         m_approx_scale(1.0),
-        m_line_cap(butt_cap),
-        m_line_join(miter_join),
-        m_inner_join(inner_miter)
+        m_line_cap(VLC::BUTT),
+        m_line_join(VLJ::MITER_SMART),
+        m_inner_join(VIJ::MITER)
     {
     }
 
@@ -160,7 +135,7 @@ namespace agg
     template<class VC>
     void math_stroke<VC>::calc_miter(VC& vc,
        const vertex_dist& v0, const vertex_dist& v1, const vertex_dist& v2,
-       double dx1, double dy1, double dx2, double dy2, line_join_e lj,
+       double dx1, double dy1, double dx2, double dy2, VLJ LineJoin,
        double mlimit, double dbevel)
     {
         double xi  = v1.x;
@@ -190,7 +165,7 @@ namespace agg
 
             double x2 = v1.x + dx1;
             double y2 = v1.y - dy1;
-            if ((cross_product(v0.x, v0.y, v1.x, v1.y, x2, y2) < 0.0) ==
+            if ((cross_product(v0.x, v0.y, v1.x, v1.y, x2, y2) < 0.0) IS
                 (cross_product(v1.x, v1.y, v2.x, v2.y, x2, y2) < 0.0)) {
                 // This case means that the next segment continues the previous one (straight line)
 
@@ -200,15 +175,15 @@ namespace agg
         }
 
         if (miter_limit_exceeded) {
-            switch(lj) {
-            case miter_join_revert:
+            switch(LineJoin) {
+            case VLJ::MITER:
                 // For the compatibility with SVG, PDF, etc, we use a simple bevel join instead of "smart" bevel
 
                 add_vertex(vc, v1.x + dx1, v1.y - dy1);
                 add_vertex(vc, v1.x + dx2, v1.y - dy2);
                 break;
 
-            case miter_join_round:
+            case VLJ::MITER_ROUND:
                 calc_arc(vc, v1.x, v1.y, dx1, -dy1, dx2, -dy2);
                 break;
 
@@ -246,8 +221,8 @@ namespace agg
         dx1 *= m_width;
         dy1 *= m_width;
 
-        if(m_line_cap != round_cap) {
-            if(m_line_cap == square_cap) {
+        if (m_line_cap != VLC::ROUND) {
+            if (m_line_cap IS VLC::SQUARE) {
                 dx2 = dy1 * m_width_sign;
                 dy2 = dx1 * m_width_sign;
             }
@@ -294,7 +269,7 @@ namespace agg
       vc.remove_all();
 
       double cp = cross_product(v0.x, v0.y, v1.x, v1.y, v2.x, v2.y);
-      if (cp != 0 and (cp > 0) == (m_width > 0)) {
+      if (cp != 0 and ((cp > 0) IS (m_width > 0))) {
          // Inner join
 
          double limit = ((len1 < len2) ? len1 : len2) / m_width_abs;
@@ -306,17 +281,17 @@ namespace agg
                add_vertex(vc, v1.x + dx2, v1.y - dy2);
                break;
 
-            case inner_miter:
-               calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, miter_join_revert, limit, 0);
+            case VIJ::MITER:
+               calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, VLJ::MITER, limit, 0);
                break;
 
-            case inner_jag:
-            case inner_round:
+            case VIJ::JAG:
+            case VIJ::ROUND:
                cp = (dx1-dx2) * (dx1-dx2) + (dy1-dy2) * (dy1-dy2);
                if (cp < len1 * len1 and cp < len2 * len2) {
-                  calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, miter_join_revert, limit, 0);
+                  calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, VLJ::MITER, limit, 0);
                }
-               else if (m_inner_join == inner_jag) {
+               else if (m_inner_join IS VIJ::JAG) {
                   add_vertex(vc, v1.x + dx1, v1.y - dy1);
                   add_vertex(vc, v1.x,       v1.y      );
                   add_vertex(vc, v1.x + dx2, v1.y - dy2);
@@ -338,7 +313,7 @@ namespace agg
             double dy = (dy1 + dy2) / 2;
             double dbevel = sqrt(dx * dx + dy * dy);
 
-            if(m_line_join == round_join or m_line_join == bevel_join) {
+            if((m_line_join IS VLJ::ROUND) or (m_line_join IS VLJ::BEVEL)) {
                 // This is an optimization that reduces the number of points in cases of almost collinear segments. If there's no
                 // visible difference between bevel and miter joins we'd rather use miter join because it adds only one point instead of two.
                 //
@@ -362,20 +337,20 @@ namespace agg
             }
 
             switch(m_line_join) {
-            case miter_join:
-            case miter_join_revert:
-            case miter_join_round:
-                calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, m_line_join, m_miter_limit, dbevel);
-                break;
+                case VLJ::MITER:
+                case VLJ::MITER_SMART:
+                case VLJ::MITER_ROUND:
+                    calc_miter(vc, v0, v1, v2, dx1, dy1, dx2, dy2, m_line_join, m_miter_limit, dbevel);
+                    break;
 
-            case round_join:
-                calc_arc(vc, v1.x, v1.y, dx1, -dy1, dx2, -dy2);
-                break;
+                case VLJ::ROUND:
+                    calc_arc(vc, v1.x, v1.y, dx1, -dy1, dx2, -dy2);
+                    break;
 
-            default: // Bevel join
-                add_vertex(vc, v1.x + dx1, v1.y - dy1);
-                add_vertex(vc, v1.x + dx2, v1.y - dy2);
-                break;
+                default: // Bevel join
+                    add_vertex(vc, v1.x + dx1, v1.y - dy1);
+                    add_vertex(vc, v1.x + dx2, v1.y - dy2);
+                    break;
             }
         }
     }

--- a/src/vector/agg/include/agg_vcgen_contour.h
+++ b/src/vector/agg/include/agg_vcgen_contour.h
@@ -35,13 +35,13 @@ namespace agg
 
         vcgen_contour();
 
-        void line_cap(line_cap_e lc)     { m_stroker.line_cap(lc); }
-        void line_join(line_join_e lj)   { m_stroker.line_join(lj); }
-        void inner_join(inner_join_e ij) { m_stroker.inner_join(ij); }
+        void line_cap(VLC LineCap)     { m_stroker.line_cap(LineCap); }
+        void line_join(VLJ LineJoin)   { m_stroker.line_join(LineJoin); }
+        void inner_join(VIJ InnerJoin) { m_stroker.inner_join(InnerJoin); }
 
-        line_cap_e   line_cap()   const { return m_stroker.line_cap(); }
-        line_join_e  line_join()  const { return m_stroker.line_join(); }
-        inner_join_e inner_join() const { return m_stroker.inner_join(); }
+        VLC line_cap()   const { return m_stroker.line_cap(); }
+        VLJ line_join()  const { return m_stroker.line_join(); }
+        VIJ inner_join() const { return m_stroker.inner_join(); }
 
         void width(double w) { m_stroker.width(m_width = w); }
         void miter_limit(double ml) { m_stroker.miter_limit(ml); }

--- a/src/vector/agg/include/agg_vcgen_stroke.h
+++ b/src/vector/agg/include/agg_vcgen_stroke.h
@@ -38,13 +38,13 @@ namespace agg
 
       vcgen_stroke();
 
-      void line_cap(line_cap_e lc)     { m_stroker.line_cap(lc); }
-      void line_join(line_join_e lj)   { m_stroker.line_join(lj); }
-      void inner_join(inner_join_e ij) { m_stroker.inner_join(ij); }
+      void line_cap(VLC LineCap)     { m_stroker.line_cap(LineCap); }
+      void line_join(VLJ LineJoin)   { m_stroker.line_join(LineJoin); }
+      void inner_join(VIJ InnerJoin) { m_stroker.inner_join(InnerJoin); }
 
-      line_cap_e   line_cap()   const { return m_stroker.line_cap(); }
-      line_join_e  line_join()  const { return m_stroker.line_join(); }
-      inner_join_e inner_join() const { return m_stroker.inner_join(); }
+      VLC line_cap()   const { return m_stroker.line_cap(); }
+      VLJ line_join()  const { return m_stroker.line_join(); }
+      VIJ inner_join() const { return m_stroker.inner_join(); }
 
       void width(double w) { m_stroker.width(w); }
       void miter_limit(double ml) { m_stroker.miter_limit(ml); }

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -189,9 +189,9 @@ public:
 class VectorState {
 public:
    TClipRectangle<double> mClip; // Current clip region as defined by the viewports
-   agg::line_join_e  mLineJoin;
-   agg::line_cap_e   mLineCap;
-   agg::inner_join_e mInnerJoin;
+   VLJ mLineJoin;
+   VLC mLineCap;
+   VIJ mInnerJoin;
    double mOpacity;
    VIS    mVisible;
    VOF    mOverflowX, mOverflowY;
@@ -201,9 +201,9 @@ public:
 
    VectorState() :
       mClip(0, 0, DBL_MAX, DBL_MAX),
-      mLineJoin(agg::miter_join),
-      mLineCap(agg::butt_cap),
-      mInnerJoin(agg::inner_miter),
+      mLineJoin(VLJ::MITER),
+      mLineCap(VLC::BUTT),
+      mInnerJoin(VIJ::MITER),
       mOpacity(1.0),
       mVisible(VIS::VISIBLE),
       mOverflowX(VOF::VISIBLE), mOverflowY(VOF::VISIBLE),
@@ -933,9 +933,9 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       else if (shape->ColourSpace IS VCS::LINEAR_RGB) state.mLinearRGB = true; // Use the parent value unless a specific CS is required by the client
       else if (shape->ColourSpace IS VCS::SRGB) state.mLinearRGB = false;
 
-      if (shape->LineJoin  != agg::inherit_join)  state.mLineJoin  = shape->LineJoin;
-      if (shape->InnerJoin != agg::inner_inherit) state.mInnerJoin = shape->InnerJoin;
-      if (shape->LineCap   != agg::inherit_cap)   state.mLineCap   = shape->LineCap;
+      if (shape->LineJoin  != VLJ::INHERIT) state.mLineJoin  = shape->LineJoin;
+      if (shape->InnerJoin != VIJ::INHERIT) state.mInnerJoin = shape->InnerJoin;
+      if (shape->LineCap   != VLC::INHERIT) state.mLineCap   = shape->LineCap;
       state.mOpacity = shape->Opacity * state.mOpacity;
 
       // Support for isolated vectors.  A vector will be isolated if it has children using a filter that uses BackgroundImage

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -684,13 +684,22 @@ class extVector : public objVector {
    public:
    using create = kt::Create<extVector>;
 
+   std::string StrokeString;
+   std::string FillString;
+   std::string FilterString;
+   VFR FillRule;
+   VFR ClipRule;
+   VLJ LineJoin;
+   VLC LineCap;
+   VIJ InnerJoin;
+
    extPainter Fill[2], Stroke;
    double FinalX, FinalY;         // Used by Viewport to define the target X,Y; also VectorText to position the text' final position.
    TClipRectangle<double> Bounds; // Must be calculated by GeneratePath() and called from calc_full_boundary()
-   double StrokeWidth;
+   Unit StrokeWidth;
    agg::path_storage BasePath;
    agg::trans_affine Transform;   // Final transform.  Accumulated from the Matrix list during path generation.
-   std::string FilterString, StrokeString, FillString;
+
    std::string SID;
    void   (*GeneratePath)(extVector *, agg::path_storage &);
    agg::rasterizer_scanline_aa<>     *StrokeRaster;
@@ -711,34 +720,28 @@ class extVector : public objVector {
    int   NumericID;
    int   PathLength;
    VMF   MorphFlags;
-   VFR   FillRule;
-   VFR   ClipRule;
    RC    Dirty;
    uint16_t  TabOrder;
    uint16_t  Isolated:1;
    uint16_t  DisableFillColour:1;  // Bitmap fonts set this to true in order to disable colour fills
    uint16_t  ButtonLock:1;
-   uint16_t  ScaledStrokeWidth:1;
    uint16_t  DisableHitTesting:1;
    uint16_t  ResizeSubscription:1;
    uint16_t  FGFill:1;
    uint16_t  Stroked:1;
    uint16_t  ValidState:1;         // Can be set to false during path generation if the shape is invalid
    uint16_t  RequiresRedraw:1;
-   agg::line_join_e  LineJoin;
-   agg::line_cap_e   LineCap;
-   agg::inner_join_e InnerJoin;
 
    extVector() {
       StrokeOpacity = 1.0;
       FillOpacity   = 1.0;
       Opacity       = 1.0;              // Overall opacity multiplier
       MiterLimit    = 4;                // SVG default is 4;
-      LineJoin      = agg::miter_join_revert;  // SVG default is miter; the 'revert' version matches SVG rules
-      LineCap       = agg::butt_cap;    // SVG default is butt
-      InnerJoin     = agg::inner_miter; // AGG only
+      LineJoin      = VLJ::MITER; // SVG default is miter
+      LineCap       = VLC::BUTT;  // SVG default is butt
+      InnerJoin     = VIJ::MITER; // AGG only
       NumericID     = 0x7fffffff;
-      StrokeWidth   = 1.0; // SVG default is 1, note that an actual stroke colour needs to be defined for this value to actually matter.
+      StrokeWidth   = Unit(1); // SVG default is 1, note that an actual stroke colour needs to be defined for this value to actually matter.
       Visibility    = VIS::VISIBLE;
       FillRule      = VFR::NON_ZERO;
       ClipRule      = VFR::NON_ZERO;
@@ -1668,25 +1671,25 @@ void configure_stroke(extVector &Vector, T &Stroke)
 {
    Stroke.width(Vector.fixed_stroke_width());
 
-   if (Vector.LineJoin)  Stroke.line_join(Vector.LineJoin); //miter, round, bevel
-   if (Vector.LineCap)   Stroke.line_cap(Vector.LineCap); // butt, square, round
-   if (Vector.InnerJoin) Stroke.inner_join(Vector.InnerJoin); // miter, round, bevel, jag
+   if (Vector.LineJoin != VLJ::INHERIT) Stroke.line_join(Vector.LineJoin); // miter, round, bevel
+   if (Vector.LineCap != VLC::INHERIT) Stroke.line_cap(Vector.LineCap); // butt, square, round
+   if (Vector.InnerJoin != VIJ::INHERIT) Stroke.inner_join(Vector.InnerJoin); // miter, round, bevel, jag
 
    // It has been noted that there may be issues between miter_join, miter_join_revert and line-caps that
    // need further investigation.  This section experiments with adjusting the line-cap according to the selected
    // line-join.
 
    /*
-   if (Vector.LineJoin) {
+   if (Vector.LineJoin != VLJ::INHERIT) {
       if (Vector.classID() IS CLASSID::VECTORPOLYGON) {
          if (((extVectorPoly &)Vector).Closed) {
             switch(Vector.LineJoin) {
-               case agg::miter_join:        Stroke.line_cap(agg::square_cap); break;
-               case agg::bevel_join:        Stroke.line_cap(agg::square_cap); break;
-               case agg::miter_join_revert: Stroke.line_cap(agg::square_cap); break;
-               case agg::round_join:        Stroke.line_cap(agg::round_cap); break;
-               case agg::miter_join_round:  Stroke.line_cap(agg::round_cap); break;
-               case agg::inherit_join:      break;
+               case VLJ::MITER_SMART: Stroke.line_cap(VLC::SQUARE); break;
+               case VLJ::BEVEL:       Stroke.line_cap(VLC::SQUARE); break;
+               case VLJ::MITER:       Stroke.line_cap(VLC::SQUARE); break;
+               case VLJ::ROUND:       Stroke.line_cap(VLC::ROUND); break;
+               case VLJ::MITER_ROUND: Stroke.line_cap(VLC::ROUND); break;
+               case VLJ::INHERIT:     break;
             }
          }
       }

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -89,7 +89,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     "BLUE: The blue colour channel.",
     "ALPHA: The alpha channel.")
 
-  enums("VLJ", { type="int", start=0, comment="Options for the look of line joins." }, // Match to agg::line_join_e
+  enums("VLJ", { type="int", start=0, comment="Options for the look of line joins." },
     "MITER: The default.  A sharp corner is used to join path segments.  The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect. If the ‘stroke-miterlimit’ is exceeded, the line join falls back to BEVEL.",
     "MITER_SMART: An alternative form of MITER that extends beyond the intersection point, similarly to the miter-clip SVG rules.",
     "ROUND: The join is rounded.",
@@ -97,13 +97,13 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     "MITER_ROUND: Default to `MITER`, but switch to `ROUND` if the miter limit is exceeded.",
     "INHERIT: Inherit the join option from the parent.")
 
-  enums("VLC", { type="int", start=1, comment="Line-cap options." }, // Match to agg::line_cap_e
+  enums("VLC", { type="int", start=1, comment="Line-cap options." },
     "BUTT: The default.  The line is sharply squared off at its exact end point.",
     "SQUARE: Similar to butt, the line is sharply squared off but will extend past the end point by `StrokeWidth / 2`.",
     "ROUND: The line cap is a half-circle and the line's end-point forms the center point.",
     "INHERIT: The cap type is inherited from the parent (defaults to butt if unspecified).")
 
-  enums("VIJ", { type="int", start=1, comment="Inner join options for angled lines." },  // Match to agg::inner_join_e
+  enums("VIJ", { type="int", start=1, comment="Inner join options for angled lines." },
     "BEVEL: Blunts the edge of the join.",
     "MITER: Forms a sharp point at the join.  Typically not the best looking option.",
     "JAG: A special non-SVG option.",
@@ -710,7 +710,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     { id=10, name='FreeMatrix' }
   })
 
-  klass('Vector', { src='vectors/vector.cpp', output='vectors/vector_def.c', version=1, extended=true }, [[
+  klass('Vector', { src='vectors/vector.cpp', output='vectors/vector_def.c', version=1, extended=true, references={ 'VIJ', 'VLC', 'VLJ', 'VFR', 'VMF' } }, [[
     obj(Vector) Child       # The first child vector, or `NULL`.
     obj(VectorScene) Scene  # Short-cut to the top-level @VectorScene.
     obj(Vector) Next        # The next vector in the branch, or `NULL`.

--- a/src/vector/vectors/path.cpp
+++ b/src/vector/vectors/path.cpp
@@ -82,7 +82,7 @@ void convert_to_aggpath(extVectorPath *Vector, std::vector<PathCommand> &Paths, 
    // 'stroke-linecap' set to 'square' or 'round' is stroked, but not stroked when 'stroke-linecap' is set to 'butt'.
 
    auto check_point = [&lp, &Vector](PathCommand &Cmd) {
-      if ((Cmd.AbsX IS lp.x) and (Cmd.AbsY IS lp.y) and Vector and (Vector->LineCap != agg::line_cap_e::butt_cap)) {
+      if ((Cmd.AbsX IS lp.x) and (Cmd.AbsY IS lp.y) and Vector and (Vector->LineCap != VLC::BUTT)) {
          Cmd.AbsX += 1.0e-10;
       }
    };

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -56,7 +56,7 @@ static void generate_polygon(extVectorPolygon *Vector, agg::path_storage &Path)
          // A ham-fisted way of controlling whether or not the line is stroked is to make a micro-adjustment
          // to the coordinate so that they remain unequal.
 
-         if ((Vector->LineCap != agg::line_cap_e::butt_cap) and (p IS last)) p.x += 1.0e-10;
+         if ((Vector->LineCap != VLC::BUTT) and (p IS last)) p.x += 1.0e-10;
 
          Path.line_to(p.x, p.y);
          last = p;

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -1172,12 +1172,6 @@ terms of outcome, the ClipRule works similarly to #FillRule.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_ClipRule(extVector *Self, VFR *Value)
-{
-   *Value = Self->ClipRule;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_ClipRule(extVector *Self, VFR Value)
 {
    Self->ClipRule = Value;
@@ -1365,12 +1359,6 @@ feature is intended for programmed use-cases and is not SVG compliant.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Fill(extVector *Self, std::string_view &Value)
-{
-   Value = Self->FillString;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_Fill(extVector *Self, const std::string_view &Value)
 {
    // Note that if an internal routine sets DisableFillColour then the colour will be stored but effectively does nothing.
@@ -1465,12 +1453,6 @@ the #Opacity to determine a final opacity value for the render.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_FillOpacity(extVector *Self, double *Value)
-{
-   *Value = Self->FillOpacity;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_FillOpacity(extVector *Self, double Value)
 {
    kt::Log log;
@@ -1498,12 +1480,6 @@ for further details on filter configuration.
 The Filter value can be in the format `ID` or `url(#SID)` according to client preference.
 
 *********************************************************************************************************************/
-
-static ERR VECTOR_GET_Filter(extVector *Self, std::string_view &Value)
-{
-   Value = Self->FilterString;
-   return ERR::Okay;
-}
 
 static ERR VECTOR_SET_Filter(extVector *Self, const std::string_view &Value)
 {
@@ -1547,12 +1523,6 @@ however, for a more complex path, such as a path that intersects itself or where
 interpretation of "inside" is not so obvious.
 
 *********************************************************************************************************************/
-
-static ERR VECTOR_GET_FillRule(extVector *Self, VFR *Value)
-{
-   *Value = Self->FillRule;
-   return ERR::Okay;
-}
 
 static ERR VECTOR_SET_FillRule(extVector *Self, VFR Value)
 {
@@ -1609,27 +1579,9 @@ path.
 
 // See the AGG bezier_div demo to get a better understanding of what is affected by this field value.
 
-static ERR VECTOR_GET_InnerJoin(extVector *Self, VIJ *Value)
-{
-   if (Self->InnerJoin IS agg::inner_miter)      *Value = VIJ::MITER;
-   else if (Self->InnerJoin IS agg::inner_round) *Value = VIJ::ROUND;
-   else if (Self->InnerJoin IS agg::inner_bevel) *Value = VIJ::BEVEL;
-   else if (Self->InnerJoin IS agg::inner_jag)   *Value = VIJ::JAG;
-   else if (Self->InnerJoin IS agg::inner_inherit) *Value = VIJ::INHERIT;
-   else *Value = VIJ::NIL;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_InnerJoin(extVector *Self, VIJ Value)
 {
-   switch(Value) {
-      case VIJ::MITER: Self->InnerJoin = agg::inner_miter; break;
-      case VIJ::ROUND: Self->InnerJoin = agg::inner_round; break;
-      case VIJ::BEVEL: Self->InnerJoin = agg::inner_bevel; break;
-      case VIJ::JAG:   Self->InnerJoin = agg::inner_jag; break;
-      case VIJ::INHERIT: Self->InnerJoin = agg::inner_inherit; break;
-      default: return ERR::InvalidValue;
-   }
+   Self->InnerJoin = Value;
    mark_buffers_for_refresh(Self);
    return ERR::Okay;
 }
@@ -1648,25 +1600,9 @@ of a stroked path.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_LineCap(extVector *Self, VLC *Value)
-{
-   if (Self->LineCap IS agg::butt_cap)         *Value = VLC::BUTT;
-   else if (Self->LineCap IS agg::square_cap)  *Value = VLC::SQUARE;
-   else if (Self->LineCap IS agg::round_cap)   *Value = VLC::ROUND;
-   else if (Self->LineCap IS agg::inherit_cap) *Value = VLC::INHERIT;
-   else *Value = VLC::NIL;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_LineCap(extVector *Self, VLC Value)
 {
-   switch(Value) {
-      case VLC::BUTT:    Self->LineCap = agg::butt_cap; break;
-      case VLC::SQUARE:  Self->LineCap = agg::square_cap; break;
-      case VLC::ROUND:   Self->LineCap = agg::round_cap; break;
-      case VLC::INHERIT: Self->LineCap = agg::inherit_cap; break;
-      default: return ERR::InvalidValue;
-   }
+   Self->LineCap = Value;
    mark_buffers_for_refresh(Self);
    return ERR::Okay;
 }
@@ -1681,30 +1617,9 @@ that are being stroked.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_LineJoin(extVector *Self, VLJ *Value)
-{
-   if (Self->LineJoin IS agg::miter_join_revert) *Value = VLJ::MITER;
-   else if (Self->LineJoin IS agg::round_join)   *Value = VLJ::ROUND;
-   else if (Self->LineJoin IS agg::bevel_join)   *Value = VLJ::BEVEL;
-   else if (Self->LineJoin IS agg::inherit_join) *Value = VLJ::INHERIT;
-   else if (Self->LineJoin IS agg::miter_join)   *Value = VLJ::MITER_SMART;
-   else if (Self->LineJoin IS agg::miter_join_round)  *Value = VLJ::MITER_ROUND;
-   else *Value = VLJ::NIL;
-
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_LineJoin(extVector *Self, VLJ Value)
 {
-   switch (Value) {
-      case VLJ::MITER:        Self->LineJoin = agg::miter_join_revert; break;
-      case VLJ::ROUND:        Self->LineJoin = agg::round_join; break;
-      case VLJ::BEVEL:        Self->LineJoin = agg::bevel_join; break;
-      case VLJ::MITER_SMART:  Self->LineJoin = agg::miter_join; break;
-      case VLJ::MITER_ROUND:  Self->LineJoin = agg::miter_join_round; break;
-      case VLJ::INHERIT:      Self->LineJoin = agg::inherit_join; break;
-      default: return ERR::InvalidValue;
-   }
+   Self->LineJoin = Value;
    mark_buffers_for_refresh(Self);
    return ERR::Okay;
 }
@@ -2207,12 +2122,6 @@ the ~ReadPainter() function in the Vector module.  Please refer to it for furthe
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Stroke(extVector *Self, std::string_view &Value)
-{
-   Value = Self->StrokeString;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_Stroke(extVector *Self, const std::string_view &Value)
 {
    Self->StrokeString.clear();
@@ -2277,12 +2186,6 @@ rendering.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_StrokeOpacity(extVector *Self, double *Value)
-{
-   *Value = Self->StrokeOpacity;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_StrokeOpacity(extVector *Self, double Value)
 {
    if ((Value >= 0) and (Value <= 1.0)) {
@@ -2306,13 +2209,16 @@ The size of the stroke is also affected by scaling factors imposed by transforms
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_StrokeWidth(extVector *Self, Unit *Value)
+static ERR VECTOR_GET_StrokeWidth(extVector *Self, Unit &Value)
 {
-   if (Value->scaled()) {
-      if (Self->ScaledStrokeWidth) Value->set(Self->StrokeWidth * 100.0);
-      else Value->set(0);
+   if (Value.scaled()) {
+      if (Self->StrokeWidth.scaled()) Value = Self->StrokeWidth;
+      else {
+         const auto diagonal = get_parent_diagonal(Self) * INV_SQRT2;
+         Value = Unit((diagonal > 0.0) ? double(Self->StrokeWidth) / diagonal : 0.0, FD_SCALED);
+      }
    }
-   else Value->set(Self->fixed_stroke_width());
+   else Value = Unit(Self->fixed_stroke_width());
 
    return ERR::Okay;
 }
@@ -2321,7 +2227,6 @@ static ERR VECTOR_SET_StrokeWidth(extVector *Self, Unit &Value)
 {
    if ((Value >= 0.0) and (Value <= 2000.0)) {
       Self->StrokeWidth = Value;
-      Self->ScaledStrokeWidth = Value.scaled();
       Self->Stroked = Self->is_stroked();
       mark_dirty(Self, RC::FINAL_PATH); // Not really a path change, but needed for some dependent code like clip-masks.
       return ERR::Okay;
@@ -2456,59 +2361,13 @@ void send_feedback(extVector *Vector, FM Event, OBJECTPTR EventObject)
 
 double extVector::fixed_stroke_width()
 {
-   if (this->ScaledStrokeWidth) {
+   if (this->StrokeWidth.scaled()) {
       return get_parent_diagonal(this) * INV_SQRT2 * this->StrokeWidth;
    }
    else return this->StrokeWidth;
 }
 
 //********************************************************************************************************************
-
-static const FieldDef clMorphFlags[] = {
-   { "Stretch",     VMF::STRETCH },
-   { "AutoSpacing", VMF::AUTO_SPACING },
-   { "XMin",        VMF::X_MIN },
-   { "XMid",        VMF::X_MID },
-   { "XMax",        VMF::X_MAX },
-   { "YMin",        VMF::Y_MIN },
-   { "YMid",        VMF::Y_MID },
-   { "YMax",        VMF::Y_MAX },
-   { nullptr, 0 }
-};
-
-static const FieldDef clLineJoin[] = {
-   { "Miter",      VLJ::MITER },
-   { "Round",      VLJ::ROUND },
-   { "Bevel",      VLJ::BEVEL },
-   { "MiterSmart", VLJ::MITER_SMART },
-   { "MiterRound", VLJ::MITER_ROUND },
-   { "Inherit",    VLJ::INHERIT },
-   { nullptr, 0 }
-};
-
-static const FieldDef clLineCap[] = {
-   { "Butt",    VLC::BUTT },
-   { "Square",  VLC::SQUARE },
-   { "Round",   VLC::ROUND },
-   { "Inherit", VLC::INHERIT },
-   { nullptr, 0 }
-};
-
-static const FieldDef clInnerJoin[] = {
-   { "Miter",   VIJ::MITER },
-   { "Round",   VIJ::ROUND },
-   { "Bevel",   VIJ::BEVEL },
-   { "Jag",     VIJ::JAG },
-   { "Inherit", VIJ::INHERIT },
-   { nullptr, 0 }
-};
-
-static const FieldDef clFillRule[] = {
-   { "EvenOdd", VFR::EVEN_ODD },
-   { "NonZero", VFR::NON_ZERO },
-   { "Inherit", VFR::INHERIT },
-   { nullptr, 0 }
-};
 
 #include "vector_def.c"
 
@@ -2519,8 +2378,8 @@ static const FieldArray clVectorFields[] = {
    { "Prev",            FDF_OBJECT|FD_RW, nullptr, VECTOR_SET_Prev, CLASSID::VECTOR },
    { "Parent",          FDF_OBJECT|FD_R },
    { "Matrices",        FDF_POINTER|FDF_STRUCT|FDF_R, nullptr, nullptr, "VectorMatrix" },
-   { "StrokeOpacity",   FDF_DOUBLE|FDF_RW|FDF_PURE, VECTOR_GET_StrokeOpacity, VECTOR_SET_StrokeOpacity },
-   { "FillOpacity",     FDF_DOUBLE|FDF_RW|FDF_PURE, VECTOR_GET_FillOpacity, VECTOR_SET_FillOpacity },
+   { "StrokeOpacity",   FDF_DOUBLE|FDF_RW, nullptr, VECTOR_SET_StrokeOpacity },
+   { "FillOpacity",     FDF_DOUBLE|FDF_RW, nullptr, VECTOR_SET_FillOpacity },
    { "Opacity",         FDF_DOUBLE|FD_RW, nullptr, VECTOR_SET_Opacity },
    { "MiterLimit",      FDF_DOUBLE|FD_RW, nullptr, VECTOR_SET_MiterLimit },
    { "InnerMiterLimit", FDF_DOUBLE|FD_RW },
@@ -2531,30 +2390,31 @@ static const FieldArray clVectorFields[] = {
    { "PathQuality",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorPathQuality },
    { "ColourSpace",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorColourSpace },
    { "PathTimestamp",   FDF_INT|FDF_R },
+   // Directly accessible private fields
+   { "Stroke",       FDF_CPPSTRING|FDF_RW, nullptr, VECTOR_SET_Stroke },
+   { "Fill",         FDF_CPPSTRING|FDF_RW, nullptr, VECTOR_SET_Fill },
+   { "Filter",       FDF_CPPSTRING|FDF_RW, nullptr, VECTOR_SET_Filter },
+   { "FillRule",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, VECTOR_SET_FillRule, &clVectorVFR },
+   { "ClipRule",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, VECTOR_SET_ClipRule, &clVectorVFR },
+   { "LineJoin",     FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_LineJoin, &clVectorVLJ },
+   { "LineCap",      FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_LineCap, &clVectorVLC },
+   { "InnerJoin",    FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_InnerJoin, &clVectorVIJ },
    // Virtual fields
-   { "ClipRule",     FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_PURE|FDF_RW,  VECTOR_GET_ClipRule, VECTOR_SET_ClipRule, &clFillRule },
    { "DashArray",    FDF_VIRTUAL|FDF_ARRAY|FDF_DOUBLE|FD_RW|FDF_PURE, VECTOR_GET_DashArray, VECTOR_SET_DashArray },
-   { "DisplayScale", FDF_VIRTUAL|FDF_DOUBLE|FDF_R,                    VECTOR_GET_DisplayScale },
-   { "Mask",         FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,          VECTOR_GET_Mask, VECTOR_SET_Mask },
-   { "Morph",        FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,          VECTOR_GET_Morph, VECTOR_SET_Morph },
-   { "AppendPath",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,          VECTOR_GET_AppendPath, VECTOR_SET_AppendPath },
-   { "MorphFlags",   FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW|FDF_PURE,        VECTOR_GET_MorphFlags, VECTOR_SET_MorphFlags, &clMorphFlags },
-   { "NumericID",    FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE,             VECTOR_GET_NumericID, VECTOR_SET_NumericID },
-   { "SID",          FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW|FDF_PURE,       VECTOR_GET_SID, VECTOR_SET_SID },
-   { "ResizeEvent",  FDF_VIRTUAL|FDF_FUNCTION|FDF_W,                  nullptr, VECTOR_SET_ResizeEvent },
-   { "Sequence",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,       VECTOR_GET_Sequence },
-   { "Stroke",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW|FDF_PURE,       VECTOR_GET_Stroke, VECTOR_SET_Stroke },
-   { "StrokeColour", FDF_VIRTUAL|FDF_STRUCT|FD_RW|FDF_PURE,           VECTOR_GET_StrokeColour, VECTOR_SET_StrokeColour, "FRGB" },
-   { "StrokeWidth",  FDF_VIRTUAL|FDF_UNIT|FDF_RW|FDF_PURE, VECTOR_GET_StrokeWidth, VECTOR_SET_StrokeWidth },
-   { "Transition",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,          VECTOR_GET_Transition, VECTOR_SET_Transition },
-   { "Fill",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW|FDF_PURE,       VECTOR_GET_Fill, VECTOR_SET_Fill },
-   { "FillColour",   FDF_VIRTUAL|FDF_STRUCT|FDF_RW|FDF_PURE,          VECTOR_GET_FillColour, VECTOR_SET_FillColour, "FRGB" },
-   { "FillRule",     FDF_VIRTUAL|FDF_INT|FDF_LOOKUP|FDF_RW|FDF_PURE,  VECTOR_GET_FillRule, VECTOR_SET_FillRule, &clFillRule },
-   { "Filter",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW|FDF_PURE,       VECTOR_GET_Filter, VECTOR_SET_Filter },
-   { "LineJoin",     FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW|FDF_PURE,    VECTOR_GET_LineJoin, VECTOR_SET_LineJoin, &clLineJoin },
-   { "LineCap",      FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW|FDF_PURE,    VECTOR_GET_LineCap, VECTOR_SET_LineCap, &clLineCap },
-   { "InnerJoin",    FDF_VIRTUAL|FD_INT|FD_LOOKUP|FDF_RW|FDF_PURE,    VECTOR_GET_InnerJoin, VECTOR_SET_InnerJoin, &clInnerJoin },
-   { "TabOrder",     FDF_VIRTUAL|FD_INT|FD_RW|FDF_PURE,               VECTOR_GET_TabOrder, VECTOR_SET_TabOrder },
+   { "DisplayScale", FDF_VIRTUAL|FDF_DOUBLE|FDF_R,              VECTOR_GET_DisplayScale },
+   { "Mask",         FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Mask, VECTOR_SET_Mask },
+   { "Morph",        FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Morph, VECTOR_SET_Morph },
+   { "AppendPath",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_AppendPath, VECTOR_SET_AppendPath },
+   { "MorphFlags",   FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW|FDF_PURE,  VECTOR_GET_MorphFlags, VECTOR_SET_MorphFlags, &clVectorVMF },
+   { "NumericID",    FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE,       VECTOR_GET_NumericID, VECTOR_SET_NumericID },
+   { "SID",          FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW|FDF_PURE, VECTOR_GET_SID, VECTOR_SET_SID },
+   { "ResizeEvent",  FDF_VIRTUAL|FDF_FUNCTION|FDF_W,            nullptr, VECTOR_SET_ResizeEvent },
+   { "Sequence",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTOR_GET_Sequence },
+   { "StrokeColour", FDF_VIRTUAL|FDF_STRUCT|FD_RW|FDF_PURE,     VECTOR_GET_StrokeColour, VECTOR_SET_StrokeColour, "FRGB" },
+   { "StrokeWidth",  FDF_VIRTUAL|FDF_UNIT|FDF_RW|FDF_PURE,      VECTOR_GET_StrokeWidth, VECTOR_SET_StrokeWidth },
+   { "Transition",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Transition, VECTOR_SET_Transition },
+   { "FillColour",   FDF_VIRTUAL|FDF_STRUCT|FDF_RW|FDF_PURE,    VECTOR_GET_FillColour, VECTOR_SET_FillColour, "FRGB" },
+   { "TabOrder",     FDF_VIRTUAL|FD_INT|FD_RW|FDF_PURE,         VECTOR_GET_TabOrder, VECTOR_SET_TabOrder },
    END_FIELD
 };
 

--- a/src/vector/vectors/vector_def.c
+++ b/src/vector/vectors/vector_def.c
@@ -61,6 +61,52 @@ static const struct FieldDef clVectorColourSpace[] = {
    { nullptr, 0 }
 };
 
+static const struct FieldDef clVectorVIJ[] = {
+   { "Bevel", 0x00000001 },
+   { "Miter", 0x00000002 },
+   { "Jag", 0x00000003 },
+   { "Round", 0x00000004 },
+   { "Inherit", 0x00000005 },
+   { nullptr, 0 }
+};
+
+static const struct FieldDef clVectorVLC[] = {
+   { "Butt", 0x00000001 },
+   { "Square", 0x00000002 },
+   { "Round", 0x00000003 },
+   { "Inherit", 0x00000004 },
+   { nullptr, 0 }
+};
+
+static const struct FieldDef clVectorVLJ[] = {
+   { "Miter", 0x00000000 },
+   { "MiterSmart", 0x00000001 },
+   { "Round", 0x00000002 },
+   { "Bevel", 0x00000003 },
+   { "MiterRound", 0x00000004 },
+   { "Inherit", 0x00000005 },
+   { nullptr, 0 }
+};
+
+static const struct FieldDef clVectorVFR[] = {
+   { "NonZero", 0x00000001 },
+   { "EvenOdd", 0x00000002 },
+   { "Inherit", 0x00000003 },
+   { nullptr, 0 }
+};
+
+static const struct FieldDef clVectorVMF[] = {
+   { "Stretch", 0x00000001 },
+   { "AutoSpacing", 0x00000002 },
+   { "XMin", 0x00000004 },
+   { "XMid", 0x00000008 },
+   { "XMax", 0x00000010 },
+   { "YMin", 0x00000020 },
+   { "YMid", 0x00000040 },
+   { "YMax", 0x00000080 },
+   { nullptr, 0 }
+};
+
 FDEF maPush[] = { { "Position", FD_INT }, { 0, 0 } };
 FDEF maTrace[] = { { "Callback", FD_FUNCTIONPTR }, { "Scale", FD_DOUBLE }, { "Transform", FD_INT }, { 0, 0 } };
 FDEF maGetBoundary[] = { { "Flags", FD_INT }, { "X", FD_RESULT|FD_DOUBLE }, { "Y", FD_RESULT|FD_DOUBLE }, { "Width", FD_RESULT|FD_DOUBLE }, { "Height", FD_RESULT|FD_DOUBLE }, { 0, 0 } };


### PR DESCRIPTION
* Replaced AGG's internal line_join_e/line_cap_e/inner_join_e enums with the public VLJ/VLC/VIJ enums throughout the stroke and contour generators, removing the translation layer in the field handlers
* Promoted Stroke, Fill, Filter, FillRule, ClipRule, LineJoin, LineCap and InnerJoin from virtual fields to directly accessible class fields, dropping their dedicated GET handlers
* Converted StrokeWidth to a Unit type and removed the redundant ScaledStrokeWidth flag, deriving the scaled state from the Unit itself
* StrokeWidth getter now resolves a fixed width into a scaled Unit relative to the parent diagonal when requested
* [Doc] Added VIJ/VLC/VLJ/VFR/VMF lookup tables to the Vector class references