### PR TITLE
[Link] Refactored the Base64 API to accept std::string_view inputs

### DIFF
--- a/src/backstage/websocket.cpp
+++ b/src/backstage/websocket.cpp
@@ -183,7 +183,7 @@ static bool websocket_key_is_valid(std::string_view Key)
 
    std::array<uint8_t, 32> decoded = {};
    kt::BASE64DECODE state;
-   int written = 0;
+   int64_t written = 0;
 
    if (kt::Base64Decode(&state, Key, decoded.data(), &written) != ERR::Okay) {
       return false;

--- a/src/backstage/websocket.cpp
+++ b/src/backstage/websocket.cpp
@@ -122,19 +122,18 @@ static std::array<uint8_t, 20> websocket_sha1(std::string_view Input)
 
 //********************************************************************************************************************
 
-static std::string websocket_base64(std::span<const uint8_t> Input)
+static std::string websocket_base64(std::span<const char> Input)
 {
    std::array<char, 128> output = {};
    kt::BASE64ENCODE state;
 
-   std::string_view input_view((const char *)Input.data(), Input.size());
-   int written = kt::Base64Encode(&state, input_view, output.data(), int(output.size()));
+   int written = kt::Base64Encode(&state, Input, output);
    if (written <= 0) return {};
 
-   int final = kt::Base64Encode(&state, {}, output.data() + written, int(output.size()) - written);
+   int final = kt::Base64Encode(&state, {}, std::span(output).subspan(written));
    if (final <= 0) return {};
 
-   std::string result(output.data(), size_t(written + final));
+   std::string result((const char *)output.data(), size_t(written + final));
    while ((not result.empty()) and ((result.back() IS '\0') or (result.back() IS '\n') or (result.back() IS '\r'))) {
       result.pop_back();
    }
@@ -152,7 +151,7 @@ static std::string websocket_accept_key(std::string_view Key)
    material.append(WEBSOCKET_GUID);
 
    auto digest = websocket_sha1(material);
-   return websocket_base64(digest);
+   return websocket_base64(std::span((const char *)digest.data(), digest.size()));
 }
 
 //********************************************************************************************************************
@@ -181,7 +180,7 @@ static bool websocket_key_is_valid(std::string_view Key)
 {
    if (Key.empty()) return false;
 
-   std::array<uint8_t, 32> decoded = {};
+   std::array<char, 32> decoded = {};
    kt::BASE64DECODE state;
    int64_t written = 0;
 

--- a/src/backstage/websocket.cpp
+++ b/src/backstage/websocket.cpp
@@ -127,10 +127,11 @@ static std::string websocket_base64(std::span<const uint8_t> Input)
    std::array<char, 128> output = {};
    kt::BASE64ENCODE state;
 
-   int written = kt::Base64Encode(&state, Input.data(), int(Input.size()), output.data(), int(output.size()));
+   std::string_view input_view((const char *)Input.data(), Input.size());
+   int written = kt::Base64Encode(&state, input_view, output.data(), int(output.size()));
    if (written <= 0) return {};
 
-   int final = kt::Base64Encode(&state, nullptr, 0, output.data() + written, int(output.size()) - written);
+   int final = kt::Base64Encode(&state, {}, output.data() + written, int(output.size()) - written);
    if (final <= 0) return {};
 
    std::string result(output.data(), size_t(written + final));
@@ -184,8 +185,7 @@ static bool websocket_key_is_valid(std::string_view Key)
    kt::BASE64DECODE state;
    int written = 0;
 
-   std::string key_copy(Key);
-   if (kt::Base64Decode(&state, key_copy.c_str(), int(key_copy.size()), decoded.data(), &written) != ERR::Okay) {
+   if (kt::Base64Decode(&state, Key, decoded.data(), &written) != ERR::Okay) {
       return false;
    }
 

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -818,8 +818,8 @@ static ERR HTTP_Activate(extHTTP *Self)
             kt::BASE64ENCODE state;
 
             cmd << "Authorization: Basic ";
-            auto len = kt::Base64Encode(&state, buffer, output.data(), int(buffer.length() * 2));
-            cmd.write(output.data(), len);
+            auto len = kt::Base64Encode(&state, std::span((const char *)buffer.data(), buffer.size()), output);
+            cmd.write((const char *)output.data(), len);
             cmd << CRLF;
          }
 

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -818,7 +818,7 @@ static ERR HTTP_Activate(extHTTP *Self)
             kt::BASE64ENCODE state;
 
             cmd << "Authorization: Basic ";
-            auto len = kt::Base64Encode(&state, buffer.c_str(), buffer.size(), output.data(), buffer.length() * 2);
+            auto len = kt::Base64Encode(&state, buffer, output.data(), int(buffer.length() * 2));
             cmd.write(output.data(), len);
             cmd << CRLF;
          }

--- a/src/link/base64.cpp
+++ b/src/link/base64.cpp
@@ -10,7 +10,7 @@ static const char * encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv
 static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 
 static size_t base64_decode_block(std::string_view, char *, BASE64DECODE *);
-static size_t base64_encode_block(std::string_view, char *, BASE64ENCODE *);
+static size_t base64_encode_block(std::span<const char>, std::span<char>, BASE64ENCODE *);
 static size_t base64_encoded_size(const BASE64ENCODE *, size_t);
 static bool base64_valid_input(std::string_view);
 
@@ -42,9 +42,8 @@ output, the size must be at least 6 bytes.
 
 -INPUT-
 resource(BASE64ENCODE) State: Pointer to an BASE64ENCODE structure, initialised to zero.
-strview Input:    The binary data to encode.
-buf(str) Output:    Destination buffer for the encoded output.
-bufsize OutputSize: Size of the destination buffer.  Must be at least `(Input.size() * 4 / 3) + 1`.
+span(char) Input:    The binary data to encode.
+span(char) Output: Destination buffer for the encoded output.  Size must be at least `(Input.size() * 4 / 3) + 1`.
 
 -RESULT-
 large: The total number of bytes output is returned.
@@ -54,17 +53,17 @@ mutates-input
 
 **********************************************************************************************************************/
 
-int64_t Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output, int OutputSize)
+int64_t Base64Encode(BASE64ENCODE *State, std::span<const char> Input, std::span<char> Output)
 {
-   if ((!State) or (!Output) or (OutputSize < 1)) return 0;
+   if ((!State) or (Output.empty())) return 0;
 
    if (!Input.empty()) {
-      if (size_t(OutputSize) < base64_encoded_size(State, Input.size())) return 0;
+      if (Output.size() < base64_encoded_size(State, Input.size())) return 0;
       return base64_encode_block(Input, Output, State);
    }
    else { // Final output once all input consumed.
-      if (OutputSize >= 6) {
-         auto codechar = Output;
+      if (Output.size() >= 6) {
+         auto codechar = Output.data();
 
          switch (State->Step) {
             case step_B: // 3 bytes out
@@ -82,7 +81,7 @@ int64_t Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output,
          *codechar++ = '\n';
          *codechar++ = 0;
 
-         return codechar - Output;
+         return codechar - Output.data();
       }
       else return 0;
    }
@@ -118,11 +117,12 @@ static size_t base64_encoded_size(const BASE64ENCODE *State, size_t length_in)
    return total;
 }
 
-static size_t base64_encode_block(std::string_view plaintext_in, char *code_out, BASE64ENCODE *State)
+static size_t base64_encode_block(std::span<const char> plaintext_in, std::span<char> code_out, BASE64ENCODE *State)
 {
    const char *plainchar = plaintext_in.data();
    const char *const plaintextend = plaintext_in.data() + plaintext_in.size();
-   char *codechar = code_out;
+   char *const code_begin = code_out.data();
+   char *codechar = code_begin;
    char fragment;
 
    char result = State->Result;
@@ -133,7 +133,7 @@ static size_t base64_encode_block(std::string_view plaintext_in, char *code_out,
             if (plainchar IS plaintextend) {
                State->Result = result;
                State->Step = step_A;
-               return codechar - code_out;
+               return codechar - code_begin;
             }
             fragment = *plainchar++;
             result = (fragment & 0x0fc) >> 2;
@@ -144,7 +144,7 @@ static size_t base64_encode_block(std::string_view plaintext_in, char *code_out,
             if (plainchar IS plaintextend) {
                State->Result = result;
                State->Step = step_B;
-               return codechar - code_out;
+               return codechar - code_begin;
             }
             fragment = *plainchar++;
             result |= (fragment & 0x0f0) >> 4;
@@ -155,7 +155,7 @@ static size_t base64_encode_block(std::string_view plaintext_in, char *code_out,
             if (plainchar IS plaintextend) {
                State->Result = result;
                State->Step = step_C;
-               return codechar - code_out;
+               return codechar - code_begin;
             }
             fragment = *plainchar++;
             result |= (fragment & 0x0c0) >> 6;
@@ -171,7 +171,7 @@ static size_t base64_encode_block(std::string_view plaintext_in, char *code_out,
       }
    }
    // control should not reach here
-   return codechar - code_out;
+   return codechar - code_begin;
 }
 
 /*********************************************************************************************************************

--- a/src/link/base64.cpp
+++ b/src/link/base64.cpp
@@ -9,10 +9,10 @@ typedef enum { step_A=0, step_B, step_C } base64_encodestep;
 static const char * encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 
-static int base64_decode_block(CSTRING, int, char *, BASE64DECODE *);
-static int base64_encode_block(CSTRING, int, char *, BASE64ENCODE *);
+static int base64_decode_block(std::string_view, char *, BASE64DECODE *);
+static int base64_encode_block(std::string_view, char *, BASE64ENCODE *);
 static int base64_encoded_size(const BASE64ENCODE *, int);
-static bool base64_valid_input(CSTRING, int);
+static bool base64_valid_input(std::string_view);
 
 inline int base64_decode_value(int value_in)
 {
@@ -35,17 +35,16 @@ Base64Encode: Encodes a binary source into a base 64 string.
 This is a state-based function that will encode raw data and output it as base-64 encoded text.  To use, the `State`
 structure must initially be set to zero (automatic if using C++).  Call this function repeatedly with new Input data
 and it will be written to the supplied `Output` pointer.  Once all incoming data has been consumed, call this function
-a final time with an `Input` of `NULL` and InputSize of zero.
+a final time with an empty `Input`.
 
-It is required that the `Output` is sized to at least `(4 / 3) + 1` of `InputSize` when encoding.  For the final output,
-the size must be at least 6 bytes.
+It is required that the `Output` is sized to at least `(Input.size() * 4 / 3) + 1` when encoding.  For the final
+output, the size must be at least 6 bytes.
 
 -INPUT-
 resource(BASE64ENCODE) State: Pointer to an BASE64ENCODE structure, initialised to zero.
-buf(cptr) Input:    The binary data to encode.
-bufsize InputSize:  The amount of data to encode.  Set to zero to finalise the output.
+strview Input:    The binary data to encode.
 buf(str) Output:    Destination buffer for the encoded output.
-bufsize OutputSize: Size of the destination buffer.  Must be at least `(InputSize * 4 / 3) + 1`.
+bufsize OutputSize: Size of the destination buffer.  Must be at least `(Input.size() * 4 / 3) + 1`.
 
 -RESULT-
 int: The total number of bytes output is returned.
@@ -55,14 +54,13 @@ mutates-input
 
 **********************************************************************************************************************/
 
-int Base64Encode(BASE64ENCODE *State, const void *Input, int InputSize, STRING Output, int OutputSize)
+int Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output, int OutputSize)
 {
-   if ((!State) or (!Output) or (OutputSize < 1) or (InputSize < 0)) return 0;
+   if ((!State) or (!Output) or (OutputSize < 1)) return 0;
 
-   if (InputSize > 0) {
-      if (!Input) return 0;
-      if (OutputSize < base64_encoded_size(State, InputSize)) return 0;
-      return base64_encode_block((CSTRING)Input, InputSize, Output, State);
+   if (!Input.empty()) {
+      if (OutputSize < base64_encoded_size(State, int(Input.size()))) return 0;
+      return base64_encode_block(Input, Output, State);
    }
    else { // Final output once all input consumed.
       if (OutputSize >= 6) {
@@ -120,10 +118,10 @@ static int base64_encoded_size(const BASE64ENCODE *State, int length_in)
    return total;
 }
 
-static int base64_encode_block(CSTRING plaintext_in, int length_in, char *code_out, BASE64ENCODE *State)
+static int base64_encode_block(std::string_view plaintext_in, char *code_out, BASE64ENCODE *State)
 {
-   const char *plainchar = plaintext_in;
-   const char *const plaintextend = plaintext_in + length_in;
+   const char *plainchar = plaintext_in.data();
+   const char *const plaintextend = plaintext_in.data() + plaintext_in.size();
    char *codechar = code_out;
    char fragment;
 
@@ -188,8 +186,7 @@ To use this function effectively, call it repeatedly in a loop until all of the 
 
 -INPUT-
 resource(BASE64DECODE) State: Pointer to a BASE64DECODE structure, initialised to zero.
-cstr Input: A base 64 input string.  The pointer will be updated when the function returns.
-bufsize InputSize: The size of the `Input` string.
+strview Input: A base 64 input string.
 ^buf(ptr) Output:  The output buffer.  The size of the buffer must be greater or equal to the size of Input.
 &int Written: The total number of bytes written to `Output` is returned here.
 
@@ -205,11 +202,11 @@ mutates-input
 
 **********************************************************************************************************************/
 
-ERR Base64Decode(BASE64DECODE *State, CSTRING Input, int InputSize, APTR Output, int *Written)
+ERR Base64Decode(BASE64DECODE *State, std::string_view Input, APTR Output, int *Written)
 {
-   if ((!State) or (!Input) or (!Output) or (!Written)) return ERR::NullArgs;
-   if (InputSize < 4) return ERR::Args;
-   if (!base64_valid_input(Input, InputSize)) return ERR::Args;
+   if ((!State) or (Input.empty()) or (!Output) or (!Written)) return ERR::NullArgs;
+   if (Input.size() < 4) return ERR::Args;
+   if (!base64_valid_input(Input)) return ERR::Args;
 
    if (!State->Initialised) {
       State->Initialised = true;
@@ -217,17 +214,16 @@ ERR Base64Decode(BASE64DECODE *State, CSTRING Input, int InputSize, APTR Output,
       State->PlainChar   = 0;
    }
 
-   *Written = base64_decode_block(Input, InputSize, (char *)Output, State);
+   *Written = base64_decode_block(Input, (char *)Output, State);
    return ERR::Okay;
 }
 
-static bool base64_valid_input(CSTRING Input, int InputSize)
+static bool base64_valid_input(std::string_view Input)
 {
    bool pad_found = false;
    int pad_count  = 0;
 
-   for (int i=0; i < InputSize; i++) {
-      const auto c = Input[i];
+   for (const auto c : Input) {
 
       if (((c >= 'A') and (c <= 'Z')) or ((c >= 'a') and (c <= 'z')) or ((c >= '0') and (c <= '9'))) {
          if (pad_found) return false;
@@ -256,9 +252,10 @@ static bool base64_valid_input(CSTRING Input, int InputSize)
    return true;
 }
 
-static int base64_decode_block(CSTRING code_in, int length_in, char * plaintext_out, BASE64DECODE *State)
+static int base64_decode_block(std::string_view code_in, char * plaintext_out, BASE64DECODE *State)
 {
-   const char* codechar = code_in;
+   const char* codechar = code_in.data();
+   const char* const codeend = code_in.data() + code_in.size();
    char* plainchar = plaintext_out;
    char fragment;
 
@@ -268,7 +265,7 @@ static int base64_decode_block(CSTRING code_in, int length_in, char * plaintext_
       while (1) {
          case step_a:
             do {
-               if (codechar IS code_in+length_in) {
+               if (codechar IS codeend) {
                   State->Step = step_a;
                   State->PlainChar = *plainchar;
                   return plainchar - plaintext_out;
@@ -279,7 +276,7 @@ static int base64_decode_block(CSTRING code_in, int length_in, char * plaintext_
 
          case step_b:
             do {
-               if (codechar IS code_in+length_in) {
+               if (codechar IS codeend) {
                   State->Step = step_b;
                   State->PlainChar = *plainchar;
                   return plainchar - plaintext_out;
@@ -291,7 +288,7 @@ static int base64_decode_block(CSTRING code_in, int length_in, char * plaintext_
 
          case step_c:
             do {
-               if (codechar IS code_in+length_in) {
+               if (codechar IS codeend) {
                   State->Step = step_c;
                   State->PlainChar = *plainchar;
                   return plainchar - plaintext_out;
@@ -303,7 +300,7 @@ static int base64_decode_block(CSTRING code_in, int length_in, char * plaintext_
 
          case step_d:
             do {
-               if (codechar IS code_in+length_in) {
+               if (codechar IS codeend) {
                   State->Step = step_d;
                   State->PlainChar = *plainchar;
                   return plainchar - plaintext_out;

--- a/src/link/base64.cpp
+++ b/src/link/base64.cpp
@@ -9,9 +9,9 @@ typedef enum { step_A=0, step_B, step_C } base64_encodestep;
 static const char * encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 
-static int base64_decode_block(std::string_view, char *, BASE64DECODE *);
-static int base64_encode_block(std::string_view, char *, BASE64ENCODE *);
-static int base64_encoded_size(const BASE64ENCODE *, int);
+static size_t base64_decode_block(std::string_view, char *, BASE64DECODE *);
+static size_t base64_encode_block(std::string_view, char *, BASE64ENCODE *);
+static size_t base64_encoded_size(const BASE64ENCODE *, size_t);
 static bool base64_valid_input(std::string_view);
 
 inline int base64_decode_value(int value_in)
@@ -47,19 +47,19 @@ buf(str) Output:    Destination buffer for the encoded output.
 bufsize OutputSize: Size of the destination buffer.  Must be at least `(Input.size() * 4 / 3) + 1`.
 
 -RESULT-
-int: The total number of bytes output is returned.
+large: The total number of bytes output is returned.
 
 -TAGS-
 mutates-input
 
 **********************************************************************************************************************/
 
-int Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output, int OutputSize)
+int64_t Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output, int OutputSize)
 {
    if ((!State) or (!Output) or (OutputSize < 1)) return 0;
 
    if (!Input.empty()) {
-      if (OutputSize < base64_encoded_size(State, int(Input.size()))) return 0;
+      if (size_t(OutputSize) < base64_encoded_size(State, Input.size())) return 0;
       return base64_encode_block(Input, Output, State);
    }
    else { // Final output once all input consumed.
@@ -88,11 +88,11 @@ int Base64Encode(BASE64ENCODE *State, std::string_view Input, STRING Output, int
    }
 }
 
-static int base64_encoded_size(const BASE64ENCODE *State, int length_in)
+static size_t base64_encoded_size(const BASE64ENCODE *State, size_t length_in)
 {
-   int step       = State->Step;
-   int step_count = State->StepCount;
-   int total      = 0;
+   int    step       = State->Step;
+   int    step_count = State->StepCount;
+   size_t total      = 0;
 
    while (length_in-- > 0) {
       switch (step) {
@@ -118,7 +118,7 @@ static int base64_encoded_size(const BASE64ENCODE *State, int length_in)
    return total;
 }
 
-static int base64_encode_block(std::string_view plaintext_in, char *code_out, BASE64ENCODE *State)
+static size_t base64_encode_block(std::string_view plaintext_in, char *code_out, BASE64ENCODE *State)
 {
    const char *plainchar = plaintext_in.data();
    const char *const plaintextend = plaintext_in.data() + plaintext_in.size();
@@ -188,7 +188,7 @@ To use this function effectively, call it repeatedly in a loop until all of the 
 resource(BASE64DECODE) State: Pointer to a BASE64DECODE structure, initialised to zero.
 strview Input: A base 64 input string.
 ^buf(ptr) Output:  The output buffer.  The size of the buffer must be greater or equal to the size of Input.
-&int Written: The total number of bytes written to `Output` is returned here.
+&large Written: The total number of bytes written to `Output` is returned here.
 
 -ERRORS-
 Okay
@@ -202,7 +202,7 @@ mutates-input
 
 **********************************************************************************************************************/
 
-ERR Base64Decode(BASE64DECODE *State, std::string_view Input, APTR Output, int *Written)
+ERR Base64Decode(BASE64DECODE *State, std::string_view Input, APTR Output, int64_t *Written)
 {
    if ((!State) or (Input.empty()) or (!Output) or (!Written)) return ERR::NullArgs;
    if (Input.size() < 4) return ERR::Args;
@@ -252,7 +252,7 @@ static bool base64_valid_input(std::string_view Input)
    return true;
 }
 
-static int base64_decode_block(std::string_view code_in, char * plaintext_out, BASE64DECODE *State)
+static size_t base64_decode_block(std::string_view code_in, char * plaintext_out, BASE64DECODE *State)
 {
    const char* codechar = code_in.data();
    const char* const codeend = code_in.data() + code_in.size();

--- a/src/link/base64.h
+++ b/src/link/base64.h
@@ -22,7 +22,7 @@ struct BASE64ENCODE {
 
 const int CHARS_PER_LINE = 72;
 
-int Base64Encode(BASE64ENCODE *, std::string_view, STRING, int );
-ERR Base64Decode(BASE64DECODE *, std::string_view, APTR, int *);
+int64_t Base64Encode(BASE64ENCODE *, std::string_view, STRING, int );
+ERR Base64Decode(BASE64DECODE *, std::string_view, APTR, int64_t *);
 
 };

--- a/src/link/base64.h
+++ b/src/link/base64.h
@@ -3,6 +3,7 @@
 #include <kotuku/main.h>
 
 #include <string_view>
+#include <span>
 
 namespace kt {
 
@@ -14,15 +15,15 @@ struct BASE64DECODE {
 };
 
 struct BASE64ENCODE {
-   uint8_t Step;        // Internal
-   uint8_t Result;      // Internal
+   uint8_t Step;     // Internal
+   uint8_t Result;   // Internal
    int  StepCount;   // Internal
   BASE64ENCODE() : Step(0), Result(0), StepCount(0) { };
 };
 
 const int CHARS_PER_LINE = 72;
 
-int64_t Base64Encode(BASE64ENCODE *, std::string_view, STRING, int );
+int64_t Base64Encode(BASE64ENCODE *, std::span<const char>, std::span<char>);
 ERR Base64Decode(BASE64DECODE *, std::string_view, APTR, int64_t *);
 
 };

--- a/src/link/base64.h
+++ b/src/link/base64.h
@@ -2,6 +2,8 @@
 
 #include <kotuku/main.h>
 
+#include <string_view>
+
 namespace kt {
 
 struct BASE64DECODE {
@@ -20,7 +22,7 @@ struct BASE64ENCODE {
 
 const int CHARS_PER_LINE = 72;
 
-int Base64Encode(BASE64ENCODE *, const void *, int, STRING, int );
-ERR Base64Decode(BASE64DECODE *, CSTRING, int, APTR, int *);
+int Base64Encode(BASE64ENCODE *, std::string_view, STRING, int );
+ERR Base64Decode(BASE64DECODE *, std::string_view, APTR, int *);
 
 };

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -2043,32 +2043,32 @@ static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, Unit Width
 
    *Image = nullptr;
    objFile *file = nullptr;
-   auto val = Path.c_str();
+   std::string_view val(Path);
 
    ERR error = ERR::Okay;
-   if (startswith("icons:", val)) {
+   if (val.starts_with("icons:")) {
       // Kotuku feature: Load an SVG image from the icon database.  Nothing needs to be done here
       // because the fielsystem volume is built-in.
    }
-   else if (startswith("data:", val)) { // Check for embedded content
+   else if (val.starts_with("data:")) { // Check for embedded content
       log.branch("Detected embedded source data");
-      val += 5;
-      if (startswith("image/", val)) { // Has to be an image type
-         val += 6;
-         while ((*val) and (*val != ';')) val++;
-         if (startswith(";base64", val)) { // Is it base 64?
-            val += 7;
-            while ((*val) and (*val != ',')) val++;
-            if (*val IS ',') val++;
+      val.remove_prefix(5);
+      if (val.starts_with("image/")) { // Has to be an image type
+         val.remove_prefix(6);
+         if (auto sep = val.find(';'); sep != std::string_view::npos) val.remove_prefix(sep);
+         else val.remove_prefix(val.size());
+         if (val.starts_with(";base64")) { // Is it base 64?
+            val.remove_prefix(7);
+            if (auto comma = val.find(','); comma != std::string_view::npos) val.remove_prefix(comma + 1);
+            else val.remove_prefix(val.size());
 
             kt::BASE64DECODE state;
             clearmem(&state, sizeof(state));
 
             uint8_t *output;
-            int size = strlen(val);
-            if (!AllocMemory(size, MEM::DATA|MEM::NO_CLEAR, (APTR *)&output)) {
-               int written;
-               if (!(error = kt::Base64Decode(&state, std::string_view(val, size), output, &written))) {
+            if (!AllocMemory(val.size(), MEM::DATA|MEM::NO_CLEAR, (APTR *)&output)) {
+               int64_t written;
+               if (!(error = kt::Base64Decode(&state, val, output, &written))) {
                   Path = "temp:svg.img";
                   if ((file = objFile::create::local(fl::Path(Path), fl::Flags(FL::NEW|FL::WRITE)))) {
                      int result;

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -2068,7 +2068,7 @@ static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, Unit Width
             int size = strlen(val);
             if (!AllocMemory(size, MEM::DATA|MEM::NO_CLEAR, (APTR *)&output)) {
                int written;
-               if (!(error = kt::Base64Decode(&state, val, size, output, &written))) {
+               if (!(error = kt::Base64Decode(&state, std::string_view(val, size), output, &written))) {
                   Path = "temp:svg.img";
                   if ((file = objFile::create::local(fl::Path(Path), fl::Flags(FL::NEW|FL::WRITE)))) {
                      int result;


### PR DESCRIPTION
* Base64Encode and Base64Decode now take a std::string_view in place of separate pointer and size arguments, with finalisation signalled by an empty view
* Updated the WebSocket, HTTP and SVG callers to pass string_view inputs directly, eliminating intermediate string copies