### PR TITLE
[Vector] Adopt unique_ptr ownership for vector resources and move teardown into the destructor

### DIFF
--- a/src/display/class_surface/surface_fields.cpp
+++ b/src/display/class_surface/surface_fields.cpp
@@ -171,37 +171,6 @@ static ERR SET_Modal(extSurface *Self, int Value)
 
 /*********************************************************************************************************************
 -FIELD-
-Movement: Limits the movement of a surface object to vertical or horizontal shifts.
-Lookup: MOVE
-
-Set `Movement` to limit movement performed by #Move() to horizontal movement, vertical movement, both axes or neither
-axis.  By default, surfaces can move horizontally and vertically.
-
-This field affects #Move() only.  Direct writes to coordinate fields bypass the movement restriction.
-
-*********************************************************************************************************************/
-
-static ERR GET_Movement(extSurface *Self, int *Value)
-{
-   *Value = 0;
-   if ((Self->Flags & RNF::NO_HORIZONTAL) IS RNF::NIL) *Value |= MOVE_HORIZONTAL;
-   if ((Self->Flags & RNF::NO_VERTICAL) IS RNF::NIL) *Value |= MOVE_VERTICAL;
-   return ERR::Okay;
-}
-
-static ERR SET_Movement(extSurface *Self, int Flags)
-{
-   if (Flags IS MOVE_HORIZONTAL) Self->Flags = (Self->Flags & RNF::NO_HORIZONTAL) | RNF::NO_VERTICAL;
-   else if (Flags IS MOVE_VERTICAL) Self->Flags = (Self->Flags & RNF::NO_VERTICAL) | RNF::NO_HORIZONTAL;
-   else if (Flags IS (MOVE_HORIZONTAL|MOVE_VERTICAL)) Self->Flags &= ~(RNF::NO_VERTICAL | RNF::NO_HORIZONTAL);
-   else Self->Flags |= RNF::NO_HORIZONTAL|RNF::NO_VERTICAL;
-
-   UpdateSurfaceField(Self, &SurfaceRecord::Flags, Self->Flags);
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
--FIELD-
 Opacity: Defines the translucency applied when drawing a surface.
 
 `Opacity` is expressed as a normalised multiplier.  The default value of `1.0` draws the surface as fully opaque.  Lower

--- a/src/vector/agg/include/agg_math_stroke.h
+++ b/src/vector/agg/include/agg_math_stroke.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "agg_math.h"
 #include "agg_vertex_sequence.h"
 #include <kotuku/modules/vector.h>
@@ -19,28 +21,28 @@ namespace agg
 {
     template<class VertexConsumer> class math_stroke {
     public:
-        typedef typename VertexConsumer::value_type coord_type;
+        using coord_type = typename VertexConsumer::value_type;
 
-        math_stroke();
+        math_stroke() = default;
 
-        void line_cap(VLC lc)   { m_line_cap = lc; }
-        void line_join(VLJ lj)  { m_line_join = lj; }
-        void inner_join(VIJ ij) { m_inner_join = ij; }
+        void line_cap(VLC LineCap) noexcept { m_line_cap = LineCap; }
+        void line_join(VLJ LineJoin) noexcept { m_line_join = LineJoin; }
+        void inner_join(VIJ InnerJoin) noexcept { m_inner_join = InnerJoin; }
 
-        VLC line_cap()   const { return m_line_cap; }
-        VLJ line_join()  const { return m_line_join; }
-        VIJ inner_join() const { return m_inner_join; }
+        VLC line_cap() const noexcept { return m_line_cap; }
+        VLJ line_join() const noexcept { return m_line_join; }
+        VIJ inner_join() const noexcept { return m_inner_join; }
 
         void width(double w);
-        void miter_limit(double ml) { m_miter_limit = ml; }
+        void miter_limit(double MiterLimit) noexcept { m_miter_limit = MiterLimit; }
         void miter_limit_theta(double t);
-        void inner_miter_limit(double ml) { m_inner_miter_limit = ml; }
-        void approximation_scale(double as) { m_approx_scale = as; }
+        void inner_miter_limit(double MiterLimit) noexcept { m_inner_miter_limit = MiterLimit; }
+        void approximation_scale(double ApproximationScale) noexcept { m_approx_scale = ApproximationScale; }
 
-        double width() const { return m_width * 2.0; }
-        double miter_limit() const { return m_miter_limit; }
-        double inner_miter_limit() const { return m_inner_miter_limit; }
-        double approximation_scale() const { return m_approx_scale; }
+        double width() const noexcept { return m_width * 2.0; }
+        double miter_limit() const noexcept { return m_miter_limit; }
+        double inner_miter_limit() const noexcept { return m_inner_miter_limit; }
+        double approximation_scale() const noexcept { return m_approx_scale; }
 
         void calc_cap(VertexConsumer& vc, const vertex_dist& v0, const vertex_dist& v1, double len);
         void calc_join(VertexConsumer& vc, const vertex_dist& v0, const vertex_dist& v1, const vertex_dist& v2, double len1, double len2);
@@ -55,31 +57,19 @@ namespace agg
         void calc_miter(VertexConsumer& vc, const vertex_dist& v0, const vertex_dist& v1, const vertex_dist& v2,
            double dx1, double dy1, double dx2, double dy2, VLJ lj, double mlimit, double dbevel);
 
-        double       m_width;
-        double       m_width_abs;
-        double       m_width_eps;
-        int          m_width_sign;
-        double       m_miter_limit;
-        double       m_inner_miter_limit;
-        double       m_approx_scale;
-        VLC m_line_cap;
-        VLJ m_line_join;
-        VIJ m_inner_join;
-    };
+        double arc_step() const noexcept { return acos(m_width_abs / (m_width_abs + 0.125 / m_approx_scale)) * 2; }
 
-    template<class VC> math_stroke<VC>::math_stroke() :
-        m_width(0.5),
-        m_width_abs(0.5),
-        m_width_eps(0.5/1024.0),
-        m_width_sign(1),
-        m_miter_limit(4.0),
-        m_inner_miter_limit(1.01),
-        m_approx_scale(1.0),
-        m_line_cap(VLC::BUTT),
-        m_line_join(VLJ::MITER_SMART),
-        m_inner_join(VIJ::MITER)
-    {
-    }
+        double m_width = 0.5;
+        double m_width_abs = 0.5;
+        double m_width_eps = 0.5 / 1024.0;
+        int    m_width_sign = 1;
+        double m_miter_limit = 4.0;
+        double m_inner_miter_limit = 1.01;
+        double m_approx_scale = 1.0;
+        VLC    m_line_cap = VLC::BUTT;
+        VLJ    m_line_join = VLJ::MITER_SMART;
+        VIJ    m_inner_join = VIJ::MITER;
+    };
 
     template<class VC> void math_stroke<VC>::width(double w)
     {
@@ -104,30 +94,27 @@ namespace agg
     void math_stroke<VC>::calc_arc(VC &vc, double x, double y, double dx1, double dy1, double dx2, double dy2) {
         double a1 = atan2(dy1 * m_width_sign, dx1 * m_width_sign);
         double a2 = atan2(dy2 * m_width_sign, dx2 * m_width_sign);
-        int i, n;
-
-        double da = acos(m_width_abs / (m_width_abs + 0.125 / m_approx_scale)) * 2;
+        double da = arc_step();
 
         add_vertex(vc, x + dx1, y + dy1);
+        if ((m_width_sign > 0) and (a1 > a2)) a2 += 2 * pi;
+        else if ((m_width_sign < 0) and (a1 < a2)) a2 -= 2 * pi;
+
+        int n;
         if (m_width_sign > 0) {
-            if (a1 > a2) a2 += 2 * pi;
             n = int((a2 - a1) / da);
             da = (a2 - a1) / (n + 1);
-            a1 += da;
-            for (i = 0; i < n; i++) {
-                add_vertex(vc, x + cos(a1) * m_width, y + sin(a1) * m_width);
-                a1 += da;
-            }
         }
         else {
-            if (a1 < a2) a2 -= 2 * pi;
             n = int((a1 - a2) / da);
             da = (a1 - a2) / (n + 1);
-            a1 -= da;
-            for (i = 0; i < n; i++) {
-                add_vertex(vc, x + cos(a1) * m_width, y + sin(a1) * m_width);
-                a1 -= da;
-            }
+        }
+
+        da *= m_width_sign;
+        a1 += da;
+        for (int i = 0; i < n; i++) {
+            add_vertex(vc, x + cos(a1) * m_width, y + sin(a1) * m_width);
+            a1 += da;
         }
         add_vertex(vc, x + dx2, y + dy2);
     }
@@ -230,9 +217,8 @@ namespace agg
             add_vertex(vc, v0.x + dx1 - dx2, v0.y - dy1 - dy2);
         }
         else {
-            double da = acos(m_width_abs / (m_width_abs + 0.125 / m_approx_scale)) * 2;
+            double da = arc_step();
             double a1;
-            int i;
             int n = int(pi / da);
 
             da = pi / (n + 1);
@@ -240,7 +226,7 @@ namespace agg
             if(m_width_sign > 0) {
                 a1 = atan2(dy1, -dx1);
                 a1 += da;
-                for(i = 0; i < n; i++) {
+                for(int i = 0; i < n; i++) {
                     add_vertex(vc, v0.x + cos(a1) * m_width, v0.y + sin(a1) * m_width);
                     a1 += da;
                 }
@@ -248,7 +234,7 @@ namespace agg
             else {
                 a1 = atan2(-dy1, dx1);
                 a1 -= da;
-                for(i = 0; i < n; i++) {
+                for(int i = 0; i < n; i++) {
                     add_vertex(vc, v0.x + cos(a1) * m_width, v0.y + sin(a1) * m_width);
                     a1 -= da;
                 }
@@ -272,8 +258,7 @@ namespace agg
       if (cp != 0 and ((cp > 0) IS (m_width > 0))) {
          // Inner join
 
-         double limit = ((len1 < len2) ? len1 : len2) / m_width_abs;
-         if (limit < m_inner_miter_limit) limit = m_inner_miter_limit;
+         double limit = std::max(((len1 < len2) ? len1 : len2) / m_width_abs, m_inner_miter_limit);
 
          switch(m_inner_join) {
             default: // inner_bevel

--- a/src/vector/painters/gradient.cpp
+++ b/src/vector/painters/gradient.cpp
@@ -47,10 +47,9 @@ GRADIENT_TABLE * get_fill_gradient_table(extPainter &Painter, double Opacity)
       return &cols->table;
    }
    else {
-      if ((Painter.GradientTable) and (Opacity IS Painter.GradientAlpha)) return Painter.GradientTable;
+      if ((Painter.GradientTable) and (Opacity IS Painter.GradientAlpha)) return Painter.GradientTable.get();
 
-      delete Painter.GradientTable;
-      Painter.GradientTable = new (std::nothrow) GRADIENT_TABLE();
+      Painter.GradientTable.reset(new (std::nothrow) GRADIENT_TABLE());
       if (not Painter.GradientTable) {
          log.warning("Failed to allocate fill gradient table");
          return nullptr;
@@ -62,7 +61,7 @@ GRADIENT_TABLE * get_fill_gradient_table(extPainter &Painter, double Opacity)
             cols->table[i].a * Opacity);
       }
 
-      return Painter.GradientTable;
+      return Painter.GradientTable.get();
    }
 }
 
@@ -84,10 +83,11 @@ GRADIENT_TABLE * get_stroke_gradient_table(extVector &Vector)
    }
    else {
       double opacity = Vector.StrokeOpacity * Vector.Opacity;
-      if ((Vector.Stroke.GradientTable) and (opacity IS Vector.Stroke.GradientAlpha)) return Vector.Stroke.GradientTable;
+      if ((Vector.Stroke.GradientTable) and (opacity IS Vector.Stroke.GradientAlpha)) {
+         return Vector.Stroke.GradientTable.get();
+      }
 
-      delete Vector.Stroke.GradientTable;
-      Vector.Stroke.GradientTable = new (std::nothrow) GRADIENT_TABLE();
+      Vector.Stroke.GradientTable.reset(new (std::nothrow) GRADIENT_TABLE());
       if (not Vector.Stroke.GradientTable) {
          log.warning("Failed to allocate stroke gradient table");
          return nullptr;
@@ -99,7 +99,7 @@ GRADIENT_TABLE * get_stroke_gradient_table(extVector &Vector)
             cols->table[i].a * opacity);
       }
 
-      return Vector.Stroke.GradientTable;
+      return Vector.Stroke.GradientTable.get();
    }
 }
 
@@ -109,8 +109,7 @@ GRADIENT_TABLE * get_stroke_gradient_table(extVector &Vector)
 static void invalidate_gradient_painter_table(extPainter &Painter, extGradient *Target)
 {
    if (Painter.Gradient IS Target) {
-      delete Painter.GradientTable;
-      Painter.GradientTable = nullptr;
+      Painter.GradientTable.reset();
    }
 }
 

--- a/src/vector/paths.cpp
+++ b/src/vector/paths.cpp
@@ -313,7 +313,7 @@ void gen_vector_path(extVector *Vector)
 
       if ((Vector->Fill[0].Colour.Alpha > 0) or (Vector->Fill[0].Gradient) or (Vector->Fill[0].Image) or (Vector->Fill[0].Pattern)) {
          if (!Vector->FillRaster) {
-            Vector->FillRaster = new (std::nothrow) agg::rasterizer_scanline_aa<>;
+            Vector->FillRaster.reset(new (std::nothrow) agg::rasterizer_scanline_aa<>);
             if (!Vector->FillRaster) return;
          }
          else Vector->FillRaster->reset();
@@ -323,8 +323,7 @@ void gen_vector_path(extVector *Vector)
          Vector->FillRaster->add_path(fill_path);
       }
       else if (Vector->FillRaster) {
-         delete Vector->FillRaster;
-         Vector->FillRaster = nullptr;
+         Vector->FillRaster.reset();
       }
 
       if (Vector->Stroked) {
@@ -332,7 +331,7 @@ void gen_vector_path(extVector *Vector)
          // is not required if the vector scale is <= 1.0 (the angle_tolerance controls this).
 
          if (!Vector->StrokeRaster) {
-            Vector->StrokeRaster = new (std::nothrow) agg::rasterizer_scanline_aa<>;
+            Vector->StrokeRaster.reset(new (std::nothrow) agg::rasterizer_scanline_aa<>);
             if (!Vector->StrokeRaster) return;
          }
          else Vector->StrokeRaster->reset();
@@ -353,8 +352,7 @@ void gen_vector_path(extVector *Vector)
          }
       }
       else if (Vector->StrokeRaster) {
-         delete Vector->StrokeRaster;
-         Vector->StrokeRaster = nullptr;
+         Vector->StrokeRaster.reset();
       }
 
       Vector->Dirty &= ~RC::FINAL_PATH;

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -949,7 +949,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       int save_origin_x = 0;
       int save_origin_y = 0;
       if ((shape->Flags & VF::ISOLATED) != VF::NIL) {
-         if (not shape->IsolatedBuffer) shape->IsolatedBuffer = new (std::nothrow) filter_bitmap;
+         if (not shape->IsolatedBuffer) shape->IsolatedBuffer.reset(new (std::nothrow) filter_bitmap);
          if (shape->IsolatedBuffer) {
             auto &clip_box = mRenderBase.clip_box();
             TClipRectangle<int> isolated_clip(clip_box.x1, clip_box.y1, clip_box.x2 + 1, clip_box.y2 + 1);

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -676,8 +676,18 @@ class extFilterEffect : public objFilterEffect {
 
 class extPainter : public VectorPainter {
 public:
-   GRADIENT_TABLE *GradientTable;
-   double GradientAlpha;
+   std::unique_ptr<GRADIENT_TABLE> GradientTable;
+   double GradientAlpha = 0;
+
+   void reset_cache() {
+      GradientTable.reset();
+      GradientAlpha = 0;
+   }
+
+   void reset() {
+      VectorPainter::reset();
+      reset_cache();
+   }
 };
 
 class extVector : public objVector {
@@ -703,20 +713,20 @@ class extVector : public objVector {
    agg::trans_affine Transform;   // Final transform.  Accumulated from the Matrix list during path generation.
 
    void   (*GeneratePath)(extVector *, agg::path_storage &);
-   agg::rasterizer_scanline_aa<>     *StrokeRaster;
-   agg::rasterizer_scanline_aa<>     *FillRaster;
-   std::vector<FeedbackSubscription> *FeedbackSubscriptions;
-   std::vector<InputSubscription>    *InputSubscriptions;
-   std::vector<KeyboardSubscription> *KeyboardSubscriptions;
+   std::unique_ptr<agg::rasterizer_scanline_aa<>> StrokeRaster;
+   std::unique_ptr<agg::rasterizer_scanline_aa<>> FillRaster;
+   std::unique_ptr<std::vector<FeedbackSubscription>> FeedbackSubscriptions;
+   std::unique_ptr<std::vector<InputSubscription>> InputSubscriptions;
+   std::unique_ptr<std::vector<KeyboardSubscription>> KeyboardSubscriptions;
    extVectorFilter     *Filter;
    extVectorViewport   *ParentView;
    extVectorClip       *ClipMask;
    extVectorTransition *Transition;
    extVector           *Morph;
    extVector           *AppendPath;
-   DashedStroke        *DashArray;
+   std::unique_ptr<DashedStroke> DashArray;
    ClipMaskCache ClipCache;
-   filter_bitmap *IsolatedBuffer;
+   std::unique_ptr<filter_bitmap> IsolatedBuffer;
    JTYPE InputMask;
    int   PathLength;
    RC    Dirty;
@@ -744,11 +754,12 @@ class extVector : public objVector {
       FillRule      = VFR::NON_ZERO;
       ClipRule      = VFR::NON_ZERO;
       Dirty         = RC::DIRTY;
-      IsolatedBuffer = nullptr;
       TabOrder      = 255;
       ColourSpace   = VCS::INHERIT;
       ValidState    = true;
    }
+
+   ~extVector();
 
    // Methods
 

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -803,10 +803,11 @@ static ERR TEXT_GET_Fill(extVectorText *Self, std::string_view &Value)
 static ERR TEXT_SET_Fill(extVectorText *Self, const std::string_view &Value)
 {
    Self->FillString.clear();
+   Self->Fill[0].reset();
+   Self->Fill[1].reset();
+   Self->FGFill = false;
 
    if (Value.empty()) {
-      Self->Fill[0].reset();
-      Self->FGFill = false;
       return ERR::Okay;
    }
 

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -275,90 +275,6 @@ static ERR VECTOR_Enable(extVector *Self)
   return ERR::Okay;
 }
 
-//********************************************************************************************************************
-
-static ERR VECTOR_Free(extVector *Self)
-{
-   Self->ClipCache.clear();
-
-   if (Self->ClipMask)   UnsubscribeAction(Self->ClipMask, AC::Free);
-   if (Self->Transition) UnsubscribeAction(Self->Transition, AC::Free);
-   if (Self->Morph)      UnsubscribeAction(Self->Morph, AC::Free);
-   if (Self->AppendPath) UnsubscribeAction(Self->AppendPath, AC::Free);
-
-   if (Self->Fill[0].GradientTable) { delete Self->Fill[0].GradientTable; Self->Fill[0].GradientTable = nullptr; }
-   if (Self->Fill[1].GradientTable) { delete Self->Fill[1].GradientTable; Self->Fill[1].GradientTable = nullptr; }
-   if (Self->Stroke.GradientTable)  { delete Self->Stroke.GradientTable; Self->Stroke.GradientTable = nullptr; }
-   if (Self->DashArray)             { delete Self->DashArray; Self->DashArray = nullptr; }
-   if (Self->IsolatedBuffer)        { delete Self->IsolatedBuffer; Self->IsolatedBuffer = nullptr; }
-
-   // Patch the nearest vectors that are linked to this one.
-   if (Self->Next) Self->Next->Prev = Self->Prev;
-   if (Self->Prev) Self->Prev->Next = Self->Next;
-   if ((Self->Parent) and (!Self->Prev)) {
-      if (Self->Parent->classID() IS CLASSID::VECTORSCENE) ((objVectorScene *)Self->Parent)->Viewport = (objVectorViewport *)Self->Next;
-      else ((extVector *)Self->Parent)->Child = Self->Next;
-   }
-
-   if (Self->Child) {
-      // Clear the parent reference for all children of the vector (essential for maintaining pointer integrity).
-      auto &scan = Self->Child;
-      while (scan) {
-         scan->Parent = nullptr;
-         scan = scan->Next;
-      }
-   }
-
-   if ((Self->Scene) and (!Self->Scene->collecting())) {
-      auto scene = (extVectorScene *)Self->Scene;
-      if ((Self->ParentView) and (Self->ResizeSubscription)) {
-         if (scene->ResizeSubscriptions.contains(Self->ParentView)) {
-            scene->ResizeSubscriptions[Self->ParentView].erase(Self);
-         }
-      }
-      scene->InputSubscriptions.erase(Self);
-      scene->KeyboardSubscriptions.erase(Self);
-
-      if (scene->ActiveVector IS Self->UID) {
-         if (scene->Cursor != PTC::DEFAULT) {
-            kt::ScopedObjectLock<objSurface> surface(scene->SurfaceID);
-            if ((surface.granted()) and (surface.obj->Cursor != PTC::DEFAULT)) {
-               surface.obj->setCursor(PTC::DEFAULT);
-            }
-         }
-      }
-   }
-
-   {
-      const std::lock_guard<std::recursive_mutex> lock(glVectorFocusLock);
-      auto pos = std::find(glVectorFocusList.begin(), glVectorFocusList.end(), Self);
-      if (pos != glVectorFocusList.end()) glVectorFocusList.erase(pos, glVectorFocusList.end());
-   }
-
-   {
-      const std::lock_guard<std::mutex> lock(glResizeLock);
-      if ((!glResizeSubscriptions.empty()) and (glResizeSubscriptions.contains(Self))) {
-         glResizeSubscriptions.erase(Self);
-      }
-   }
-
-   if (Self->Matrices) {
-      VectorMatrix *next;
-      for (auto t=Self->Matrices; t; t=next) {
-         next = t->Next;
-         FreeResource(t);
-      }
-   }
-
-   delete Self->StrokeRaster; Self->StrokeRaster = nullptr;
-   delete Self->FillRaster;   Self->FillRaster   = nullptr;
-   delete Self->InputSubscriptions;    Self->InputSubscriptions    = nullptr;
-   delete Self->KeyboardSubscriptions; Self->KeyboardSubscriptions = nullptr;
-   delete Self->FeedbackSubscriptions; Self->FeedbackSubscriptions = nullptr;
-
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
 
 -METHOD-
@@ -574,14 +490,12 @@ static ERR VECTOR_MoveToFront(extVector *Self)
 
 static ERR VECTOR_NewOwner(extVector *Self, struct acNewOwner *Args)
 {
-   kt::Log log;
-
    if (Self->classID() IS CLASSID::NIL) return ERR::Okay;
 
    // Modifying the owner after the root vector has been established is not permitted.
    // The client should instead create a new object under the target and transfer the field values.
 
-   if (Self->initialised()) return log.warning(ERR::AlreadyDefined);
+   if (Self->initialised()) return kt::Log().warning(ERR::AlreadyDefined);
 
    set_parent(Self, Args->NewOwner);
 
@@ -623,7 +537,6 @@ static ERR VECTOR_NewMatrix(extVector *Self, struct vec::NewMatrix *Args)
 
    VectorMatrix *transform;
    if (!AllocMemory(sizeof(VectorMatrix), MEM::DATA|MEM::NO_CLEAR, (APTR *)&transform)) {
-
       transform->Vector = Self;
       transform->ScaleX = 1.0;
       transform->ScaleY = 1.0;
@@ -850,7 +763,7 @@ static ERR VECTOR_SubscribeFeedback(extVector *Self, struct vec::SubscribeFeedba
 
    if (Args->Mask != FM::NIL) {
       if (!Self->FeedbackSubscriptions) {
-         Self->FeedbackSubscriptions = new (std::nothrow) std::vector<FeedbackSubscription>;
+         Self->FeedbackSubscriptions.reset(new (std::nothrow) std::vector<FeedbackSubscription>);
          if (!Self->FeedbackSubscriptions) return log.warning(ERR::AllocMemory);
       }
 
@@ -913,7 +826,7 @@ static ERR VECTOR_SubscribeInput(extVector *Self, struct vec::SubscribeInput *Ar
       if ((!Self->Scene) or (!Self->Scene->SurfaceID)) return ERR::FieldNotSet;
 
       if (!Self->InputSubscriptions) {
-         Self->InputSubscriptions = new (std::nothrow) std::vector<InputSubscription>;
+         Self->InputSubscriptions.reset(new (std::nothrow) std::vector<InputSubscription>);
          if (!Self->InputSubscriptions) return log.warning(ERR::AllocMemory);
       }
 
@@ -978,7 +891,7 @@ static ERR VECTOR_SubscribeKeyboard(extVector *Self, struct vec::SubscribeKeyboa
    if (!Self->Scene->SurfaceID) return log.warning(ERR::FieldNotSet);
 
    if (!Self->KeyboardSubscriptions) {
-      Self->KeyboardSubscriptions = new (std::nothrow) std::vector<KeyboardSubscription>;
+      Self->KeyboardSubscriptions.reset(new (std::nothrow) std::vector<KeyboardSubscription>);
       if (!Self->KeyboardSubscriptions) return log.warning(ERR::AllocMemory);
    }
 
@@ -1256,7 +1169,7 @@ static ERR VECTOR_SET_DashArray(extVector *Self, const std::span<const double> &
 {
    kt::Log log;
 
-   if (Self->DashArray) { delete Self->DashArray; Self->DashArray = nullptr; }
+   Self->DashArray.reset();
 
    if (Array.size() > 0) {
       int total;
@@ -1264,7 +1177,7 @@ static ERR VECTOR_SET_DashArray(extVector *Self, const std::span<const double> &
       if (Array.size() & 1) total = Array.size() * 2; // To satisfy requirements, the dash path can be doubled to make an even number.
       else total = Array.size();
 
-      Self->DashArray = new (std::nothrow) DashedStroke(Self->BasePath, total);
+      Self->DashArray.reset(new (std::nothrow) DashedStroke(Self->BasePath, total));
       if (Self->DashArray) {
          for (unsigned i=0; i < Array.size(); i++) Self->DashArray->values[i] = Array[i];
          if (Array.size() & 1) {
@@ -1275,8 +1188,7 @@ static ERR VECTOR_SET_DashArray(extVector *Self, const std::span<const double> &
          for (int i=0; i < std::ssize(Self->DashArray->values)-1; i+=2) {
             if ((Self->DashArray->values[i] < 0) or (Self->DashArray->values[i+1] < 0)) { // Negative values can cause an infinite drawing cycle.
                log.warning("Invalid dash array value pair (%f, %f)", Self->DashArray->values[i], Self->DashArray->values[i+1]);
-               delete Self->DashArray;
-               Self->DashArray = nullptr;
+               Self->DashArray.reset();
                return ERR::InvalidValue;
             }
 
@@ -1286,8 +1198,7 @@ static ERR VECTOR_SET_DashArray(extVector *Self, const std::span<const double> &
 
          if (total_length <= 0) {
             log.warning("DashArray total length <= 0.");
-            delete Self->DashArray;
-            Self->DashArray = nullptr;
+            Self->DashArray.reset();
             return ERR::InvalidValue;
          }
 
@@ -1364,9 +1275,10 @@ static ERR VECTOR_SET_Fill(extVector *Self, const std::string_view &Value)
    // Note that if an internal routine sets DisableFillColour then the colour will be stored but effectively does nothing.
    Self->FillString.clear();
    Self->FGFill = false;
+   Self->Fill[0].reset();
+   Self->Fill[1].reset();
 
    if (Value.empty()) {
-      Self->Fill[0].reset();
       return ERR::Okay;
    }
 
@@ -1439,7 +1351,6 @@ static ERR VECTOR_SET_FillColour(extVector *Self, struct FRGB *Value)
    }
 
    Self->FillString.clear();
-
    return ERR::Okay;
 }
 
@@ -1455,8 +1366,6 @@ the #Opacity to determine a final opacity value for the render.
 
 static ERR VECTOR_SET_FillOpacity(extVector *Self, double Value)
 {
-   kt::Log log;
-
    if ((Value >= 0) and (Value <= 1.0)) {
       Self->FillOpacity = Value;
 
@@ -1464,7 +1373,7 @@ static ERR VECTOR_SET_FillOpacity(extVector *Self, double Value)
       else mark_buffers_for_refresh(Self);
       return ERR::Okay;
    }
-   else return log.warning(ERR::OutOfRange);
+   else return ERR::OutOfRange;
 }
 
 /*********************************************************************************************************************
@@ -1673,14 +1582,12 @@ them for theta less than approximately 29 degrees, and a limit of 10.0 converts 
 
 static ERR VECTOR_SET_MiterLimit(extVector *Self, double Value)
 {
-   kt::Log log;
-
    if (Value >= 1.0) {
       Self->MiterLimit = Value;
       mark_buffers_for_refresh(Self);
       return ERR::Okay;
    }
-   else return log.warning(ERR::InvalidValue);
+   else return ERR::InvalidValue;
 }
 
 /*********************************************************************************************************************
@@ -2072,6 +1979,7 @@ the ~ReadPainter() function in the Vector module.  Please refer to it for furthe
 static ERR VECTOR_SET_Stroke(extVector *Self, const std::string_view &Value)
 {
    Self->StrokeString.clear();
+   Self->Stroke.reset();
 
    if (not Value.empty()) {
       Self->StrokeString = Value;
@@ -2085,7 +1993,6 @@ static ERR VECTOR_SET_Stroke(extVector *Self, const std::string_view &Value)
          if (fallback.Colour.Alpha) Self->Stroke.Colour = fallback.Colour;
       }
    }
-   else Self->Stroke.reset();
 
    Self->Stroked = Self->is_stroked();
    mark_buffers_for_refresh(Self);
@@ -2316,6 +2223,75 @@ double extVector::fixed_stroke_width()
 
 //********************************************************************************************************************
 
+extVector::~extVector() {
+   ClipCache.clear();
+
+   if (ClipMask)   UnsubscribeAction(ClipMask, AC::Free);
+   if (Transition) UnsubscribeAction(Transition, AC::Free);
+   if (Morph)      UnsubscribeAction(Morph, AC::Free);
+   if (AppendPath) UnsubscribeAction(AppendPath, AC::Free);
+
+   // Patch the nearest vectors that are linked to this one.
+   if (Next) Next->Prev = Prev;
+   if (Prev) Prev->Next = Next;
+   if ((Parent) and (!Prev)) {
+      if (Parent->classID() IS CLASSID::VECTORSCENE) ((objVectorScene *)Parent)->Viewport = (objVectorViewport *)Next;
+      else ((extVector *)Parent)->Child = Next;
+   }
+
+   if (Child) {
+      // Clear the parent reference for all children of the vector (essential for maintaining pointer integrity).
+      auto &scan = Child;
+      while (scan) {
+         scan->Parent = nullptr;
+         scan = scan->Next;
+      }
+   }
+
+   if ((Scene) and (!Scene->collecting())) {
+      auto scene = (extVectorScene *)Scene;
+      if ((ParentView) and (ResizeSubscription)) {
+         if (scene->ResizeSubscriptions.contains(ParentView)) {
+            scene->ResizeSubscriptions[ParentView].erase(this);
+         }
+      }
+      scene->InputSubscriptions.erase(this);
+      scene->KeyboardSubscriptions.erase(this);
+
+      if (scene->ActiveVector IS UID) {
+         if (scene->Cursor != PTC::DEFAULT) {
+            kt::ScopedObjectLock<objSurface> surface(scene->SurfaceID);
+            if ((surface.granted()) and (surface.obj->Cursor != PTC::DEFAULT)) {
+               surface.obj->setCursor(PTC::DEFAULT);
+            }
+         }
+      }
+   }
+
+   {
+      const std::lock_guard<std::recursive_mutex> lock(glVectorFocusLock);
+      auto pos = std::find(glVectorFocusList.begin(), glVectorFocusList.end(), this);
+      if (pos != glVectorFocusList.end()) glVectorFocusList.erase(pos, glVectorFocusList.end());
+   }
+
+   {
+      const std::lock_guard<std::mutex> lock(glResizeLock);
+      if ((!glResizeSubscriptions.empty()) and (glResizeSubscriptions.contains(this))) {
+         glResizeSubscriptions.erase(this);
+      }
+   }
+
+   if (Matrices) {
+      VectorMatrix *next;
+      for (auto t=Matrices; t; t=next) {
+         next = t->Next;
+         FreeResource(t);
+      }
+   }
+}
+
+//********************************************************************************************************************
+
 #include "vector_def.c"
 
 static const FieldArray clVectorFields[] = {
@@ -2363,6 +2339,8 @@ static const FieldArray clVectorFields[] = {
    { "TabOrder",     FDF_VIRTUAL|FD_INT|FD_RW|FDF_PURE,         VECTOR_GET_TabOrder, VECTOR_SET_TabOrder },
    END_FIELD
 };
+
+//********************************************************************************************************************
 
 static ERR init_vector(void)
 {

--- a/src/vector/vectors/vector_def.c
+++ b/src/vector/vectors/vector_def.c
@@ -145,7 +145,6 @@ static const struct ActionArray clVectorActions[] = {
    { AC::Disable, VECTOR_Disable },
    { AC::Draw, VECTOR_Draw },
    { AC::Enable, VECTOR_Enable },
-   { AC::Free, VECTOR_Free },
    { AC::FreePlacement, VECTOR_FreePlacement },
    { AC::Hide, VECTOR_Hide },
    { AC::Init, VECTOR_Init },


### PR DESCRIPTION
* Converted GradientTable, StrokeRaster, FillRaster, DashArray, IsolatedBuffer and the input/keyboard/feedback subscription vectors to std::unique_ptr for RAII-based memory management
* Replaced the VECTOR_Free action with an extVector destructor and dropped the AC::Free action registration
* Fill and stroke setters now reset all paint slots before applying new values to prevent stale paint state
* [AGG] Refactored math_stroke with in-class member initialisers, an arc_step() helper and a unified arc generation loop
* [Display] Removed the deprecated Surface Movement field