### PR TITLE
[Vector] Lazily allocate clip mask caches

### DIFF
--- a/src/vector/scene/scene_clipping.cpp
+++ b/src/vector/scene/scene_clipping.cpp
@@ -34,22 +34,22 @@ bool SceneRenderer::ClipBuffer::use_cached_mask(const agg::trans_affine &Transfo
    // shape's path state alone.  Note that a viewport using both vpClip and a ClipMask shares the one cache slot,
    // distinguished by the Clip pointer, so the two masks evict each other on alternate draws.
 
-   auto &cache = m_shape->ClipCache;
+   auto cache = m_shape->ClipCache.get();
 
-   if ((!cache.Valid) or (cache.Clip != m_clip) or (cache.Bitmap.empty())) return false;
-   if (cache.PathTimestamp != m_shape->PathTimestamp) return false;
+   if ((!cache) or (!cache->Valid) or (cache->Clip != m_clip) or (cache->Bitmap.empty())) return false;
+   if (cache->PathTimestamp != m_shape->PathTimestamp) return false;
    if (m_clip) {
-      if (cache.ContentVersion != m_clip->ContentVersion) return false;
-      if (cache.Units != m_clip->Units) return false;
-      if (cache.Flags != m_clip->Flags) return false;
+      if (cache->ContentVersion != m_clip->ContentVersion) return false;
+      if (cache->Units != m_clip->Units) return false;
+      if (cache->Flags != m_clip->Flags) return false;
    }
-   if ((cache.ParentWidth != ParentWidth) or (cache.ParentHeight != ParentHeight)) return false;
-   if (!clip_transform_matches(cache.Transform, Transform)) return false;
+   if ((cache->ParentWidth != ParentWidth) or (cache->ParentHeight != ParentHeight)) return false;
+   if (!clip_transform_matches(cache->Transform, Transform)) return false;
 
-   m_width = cache.Width;
-   m_height = cache.Height;
-   if (m_clip) m_clip->Bounds = cache.Bounds;
-   m_renderer.attach(cache.Bitmap.data(), m_width - 1, m_height - 1, m_width);
+   m_width = cache->Width;
+   m_height = cache->Height;
+   if (m_clip) m_clip->Bounds = cache->Bounds;
+   m_renderer.attach(cache->Bitmap.data(), m_width - 1, m_height - 1, m_width);
    return true;
 }
 
@@ -61,11 +61,13 @@ void SceneRenderer::ClipBuffer::store_cached_mask(const agg::trans_affine &Trans
    if ((m_width <= 0) or (m_height <= 0)) return;
 
    if (uint64_t(m_width) * uint64_t(m_height) > CLIP_MASK_CACHE_LIMIT) {
-      m_shape->ClipCache.clear();
+      m_shape->ClipCache.reset();
       return;
    }
 
-   auto &cache = m_shape->ClipCache;
+   if (!m_shape->ClipCache) m_shape->ClipCache = std::make_unique<ClipMaskCache>();
+
+   auto &cache = *m_shape->ClipCache;
    cache.Bitmap = m_bitmap;
    cache.Bounds = m_clip ? m_clip->Bounds : TClipRectangle<double>();
    cache.Transform = Transform;

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -725,7 +725,7 @@ class extVector : public objVector {
    extVector           *Morph;
    extVector           *AppendPath;
    std::unique_ptr<DashedStroke> DashArray;
-   ClipMaskCache ClipCache;
+   std::unique_ptr<ClipMaskCache> ClipCache;
    std::unique_ptr<filter_bitmap> IsolatedBuffer;
    JTYPE InputMask;
    int   PathLength;
@@ -1163,7 +1163,7 @@ static void mark_buffers_for_refresh(extVector *Vector)
    if (Vector->Scene) ((extVectorScene *)Vector->Scene)->SubtreeDirty = true;
 
    for (auto node=Vector; node; ) {
-      node->ClipCache.clear();
+      node->ClipCache.reset();
 
       if ((!node->Parent) or (node->Parent->Class->BaseClassID != CLASSID::VECTOR)) break;
       node = (extVector *)node->Parent;

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -170,7 +170,7 @@ static void notify_free_clipmask(OBJECTPTR Object, ACTIONID ActionID, ERR Result
    auto Self = (extVector *)CurrentContext();
    if ((Self->ClipMask) and (Object->UID IS Self->ClipMask->UID)) {
       Self->ClipMask = nullptr;
-      Self->ClipCache.clear();
+      Self->ClipCache.reset();
    }
 }
 
@@ -1534,13 +1534,13 @@ static ERR VECTOR_SET_Mask(extVector *Self, extVectorClip *Value)
       if (Self->ClipMask) {
          UnsubscribeAction(Self->ClipMask, AC::Free);
          Self->ClipMask = nullptr;
-         Self->ClipCache.clear();
+         Self->ClipCache.reset();
       }
       return ERR::Okay;
    }
    else if (Value->classID() IS CLASSID::VECTORCLIP) {
       if (Self->ClipMask) UnsubscribeAction(Self->ClipMask, AC::Free);
-      Self->ClipCache.clear();
+      Self->ClipCache.reset();
       if (Value->initialised()) { // Ensure that the mask is initialised.
          SubscribeAction(Value, AC::Free, C_FUNCTION(notify_free_clipmask));
          Self->ClipMask = Value;
@@ -2224,7 +2224,7 @@ double extVector::fixed_stroke_width()
 //********************************************************************************************************************
 
 extVector::~extVector() {
-   ClipCache.clear();
+   ClipCache.reset();
 
    if (ClipMask)   UnsubscribeAction(ClipMask, AC::Free);
    if (Transition) UnsubscribeAction(Transition, AC::Free);


### PR DESCRIPTION
* Store vector clip mask cache state behind a unique pointer
* Allocate cache storage only when storing a reusable clip mask
* Release cached mask storage when clip state is invalidated