### PR TITLE
[Object] Moved class lifecycle setup into constructors

### DIFF
--- a/include/kotuku/modules/scintilla.h
+++ b/include/kotuku/modules/scintilla.h
@@ -259,39 +259,33 @@ class objScintilla : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getLineHighlight(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 156);
+   inline ERR getLineHighlight(struct RGB8 * &Value) noexcept {
+      Value = &this->LineHighlight;
       return ERR::Okay;
    }
 
-   inline ERR getSelectFore(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 160);
+   inline ERR getSelectFore(struct RGB8 * &Value) noexcept {
+      Value = &this->SelectFore;
       return ERR::Okay;
    }
 
-   inline ERR getSelectBkgd(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 164);
+   inline ERR getSelectBkgd(struct RGB8 * &Value) noexcept {
+      Value = &this->SelectBkgd;
       return ERR::Okay;
    }
 
-   inline ERR getBkgdColour(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 168);
+   inline ERR getBkgdColour(struct RGB8 * &Value) noexcept {
+      Value = &this->BkgdColour;
       return ERR::Okay;
    }
 
-   inline ERR getCursorColour(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 172);
+   inline ERR getCursorColour(struct RGB8 * &Value) noexcept {
+      Value = &this->CursorColour;
       return ERR::Okay;
    }
 
-   inline ERR getTextColour(struct RGB8 * &Value, int &Elements) noexcept {
-      Elements = 4;
-      Value = (struct RGB8 *)(((int8_t *)this) + 176);
+   inline ERR getTextColour(struct RGB8 * &Value) noexcept {
+      Value = &this->TextColour;
       return ERR::Okay;
    }
 
@@ -317,27 +311,23 @@ class objScintilla : public Object {
 
    inline ERR getAllowTabs(int &Value) noexcept {
       auto field = &this->Class->Dictionary[25];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getAutoIndent(int &Value) noexcept {
       auto field = &this->Class->Dictionary[34];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getFileDrop(FUNCTION * &Value) noexcept {
       auto field = &this->Class->Dictionary[9];
       auto get_field = (ERR (*)(APTR, FUNCTION * &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
+      return get_field(this, Value);
    }
 
    inline ERR getFoldingMarkers(int &Value) noexcept {
       auto field = &this->Class->Dictionary[13];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getLineCount(int &Value) noexcept {
@@ -350,21 +340,18 @@ class objScintilla : public Object {
 
    inline ERR getLineNumbers(int &Value) noexcept {
       auto field = &this->Class->Dictionary[28];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getShowWhitespace(int &Value) noexcept {
       auto field = &this->Class->Dictionary[18];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getEventCallback(FUNCTION * &Value) noexcept {
       auto field = &this->Class->Dictionary[14];
       auto get_field = (ERR (*)(APTR, FUNCTION * &))field->GetValue;
-      auto error = get_field(this, Value);
-      return error;
+      return get_field(this, Value);
    }
 
    inline ERR getString(std::string_view &Value) noexcept {
@@ -378,20 +365,17 @@ class objScintilla : public Object {
 
    inline ERR getSymbols(int &Value) noexcept {
       auto field = &this->Class->Dictionary[23];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getTabWidth(int &Value) noexcept {
       auto field = &this->Class->Dictionary[20];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
    inline ERR getWordwrap(int &Value) noexcept {
       auto field = &this->Class->Dictionary[32];
-      auto error = field->GetValue(this, &Value);
-      return error;
+      return field->GetValue(this, &Value);
    }
 
 
@@ -399,7 +383,7 @@ class objScintilla : public Object {
 
    inline ERR setPath(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[11];
-      return field->WriteValue(this, field, 0x00804300, &Value, 1);
+      return field->WriteValue(this, field, 0x00804300, &Value);
    }
 
    inline ERR setEventFlags(const SEF Value) noexcept {
@@ -408,67 +392,67 @@ class objScintilla : public Object {
    }
 
    inline ERR setSurface(OBJECTID Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
+      if (this->initialised()) return ERR::ImmutableField;
       this->SurfaceID = Value;
       return ERR::Okay;
    }
 
    inline ERR setFlags(const SCIF Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
+      if (this->initialised()) return ERR::ImmutableField;
       this->Flags = Value;
       return ERR::Okay;
    }
 
    inline ERR setFocus(OBJECTID Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
+      if (this->initialised()) return ERR::ImmutableField;
       this->FocusID = Value;
       return ERR::Okay;
    }
 
    inline ERR setVisible(const int Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
+      if (this->initialised()) return ERR::ImmutableField;
       this->Visible = Value;
       return ERR::Okay;
    }
 
    inline ERR setLeftMargin(const int Value) noexcept {
       auto field = &this->Class->Dictionary[36];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setRightMargin(const int Value) noexcept {
       auto field = &this->Class->Dictionary[35];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
-   inline ERR setLineHighlight(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setLineHighlight(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[21];
-      return field->WriteValue(this, field, 0x01001300, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
-   inline ERR setSelectFore(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setSelectFore(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[31];
-      return field->WriteValue(this, field, 0x01001500, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
-   inline ERR setSelectBkgd(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setSelectBkgd(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[26];
-      return field->WriteValue(this, field, 0x01001500, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
-   inline ERR setBkgdColour(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setBkgdColour(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[15];
-      return field->WriteValue(this, field, 0x01001300, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
-   inline ERR setCursorColour(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setCursorColour(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[4];
-      return field->WriteValue(this, field, 0x01001300, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
-   inline ERR setTextColour(const struct RGB8 * Value, int Elements) noexcept {
+   inline ERR setTextColour(const struct RGB8 & Value) noexcept {
       auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(this, field, 0x01001300, Value, Elements);
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
    inline ERR setCursorRow(const int Value) noexcept {
@@ -483,72 +467,72 @@ class objScintilla : public Object {
 
    inline ERR setLexer(const SCLEX Value) noexcept {
       auto field = &this->Class->Dictionary[24];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setModified(const int Value) noexcept {
       auto field = &this->Class->Dictionary[7];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setAllowTabs(const int Value) noexcept {
       auto field = &this->Class->Dictionary[25];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setAutoIndent(const int Value) noexcept {
       auto field = &this->Class->Dictionary[34];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setFileDrop(const FUNCTION Value) noexcept {
       auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(this, field, FD_FUNCTION, &Value, 1);
+      return field->WriteValue(this, field, FD_FUNCTION, &Value);
    }
 
    inline ERR setFoldingMarkers(const int Value) noexcept {
       auto field = &this->Class->Dictionary[13];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setLineNumbers(const int Value) noexcept {
       auto field = &this->Class->Dictionary[28];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setOrigin(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(this, field, 0x00804200, &Value, 1);
+      return field->WriteValue(this, field, 0x00804200, &Value);
    }
 
    inline ERR setShowWhitespace(const int Value) noexcept {
       auto field = &this->Class->Dictionary[18];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setEventCallback(const FUNCTION Value) noexcept {
       auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(this, field, FD_FUNCTION, &Value, 1);
+      return field->WriteValue(this, field, FD_FUNCTION, &Value);
    }
 
    inline ERR setString(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      return field->WriteValue(this, field, 0x00804300, &Value, 1);
+      return field->WriteValue(this, field, 0x00804300, &Value);
    }
 
    inline ERR setSymbols(const int Value) noexcept {
       auto field = &this->Class->Dictionary[23];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setTabWidth(const int Value) noexcept {
       auto field = &this->Class->Dictionary[20];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setWordwrap(const int Value) noexcept {
       auto field = &this->Class->Dictionary[32];
-      return field->WriteValue(this, field, FD_INT, &Value, 1);
+      return field->WriteValue(this, field, FD_INT, &Value);
    }
 
 };
@@ -622,7 +606,7 @@ class objScintillaSearch : public Object {
    // Customised field setting
 
    inline ERR setScintilla(objScintilla * Value) noexcept {
-      if (this->initialised()) return ERR::NoFieldAccess;
+      if (this->initialised()) return ERR::ImmutableField;
       this->Scintilla = Value;
       return ERR::Okay;
    }

--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -48,7 +48,6 @@ static int glDefaultSpeed = 160;
 static double glDefaultAcceleration = 0.8;
 static TIMER glRepeatTimer = 0;
 
-static void set_pointer_defaults(extPointer *);
 static ERR repeat_timer(extPointer *, int64_t, int64_t);
 static int examine_chain(extPointer *, int, SURFACELIST &, int);
 static bool get_over_object(extPointer *);
@@ -674,14 +673,6 @@ static ERR POINTER_MoveToPoint(extPointer *Self, struct acMoveToPoint *Args)
    return ERR::Okay|ERR(ERR::Notified);
 }
 
-//********************************************************************************************************************
-
-static ERR POINTER_NewObject(extPointer *Self)
-{
-   set_pointer_defaults(Self);
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
 -ACTION-
 Refresh: Refreshes the pointer's target and cursor image.
@@ -1043,36 +1034,6 @@ static ERR POINTER_SET_Y(extPointer *Self, double Value)
    if (Self->initialised()) acMoveToPoint(Self, 0, Value, 0, MTF::Y);
    else Self->Y = Value;
    return ERR::Okay;
-}
-
-//********************************************************************************************************************
-
-static void set_pointer_defaults(extPointer *Self)
-{
-   double speed        = glDefaultSpeed;
-   double acceleration = glDefaultAcceleration;
-   int maxspeed       = 100;
-   double wheelspeed   = DEFAULT_WHEELSPEED;
-   double doubleclick  = 0.36;
-   std::string buttonorder = "123456789ABCDEF";
-
-   if (auto config = objConfig::create { fl::Path("user:config/pointer.cfg") }; config.ok()) {
-      config->read("POINTER", "Speed", speed);
-      config->read("POINTER", "Acceleration", acceleration);
-      config->read("POINTER", "MaxSpeed", maxspeed);
-      config->read("POINTER", "WheelSpeed", wheelspeed);
-      config->read("POINTER", "DoubleClick", doubleclick);
-      config->read("POINTER", "ButtonOrder", buttonorder);
-   }
-
-   if (doubleclick < 0.2) doubleclick = 0.2;
-
-   Self->setFields(fl::Speed(speed),
-       fl::Acceleration(acceleration),
-       fl::MaxSpeed(maxspeed),
-       fl::WheelSpeed(wheelspeed),
-       fl::DoubleClick(doubleclick),
-       fl::ButtonOrder(buttonorder));
 }
 
 //********************************************************************************************************************

--- a/src/display/class_pointer_def.c
+++ b/src/display/class_pointer_def.c
@@ -83,7 +83,6 @@ static const struct ActionArray clPointerActions[] = {
    { AC::Init, POINTER_Init },
    { AC::Move, POINTER_Move },
    { AC::MoveToPoint, POINTER_MoveToPoint },
-   { AC::NewObject, POINTER_NewObject },
    { AC::NewPlacement, POINTER_NewPlacement },
    { AC::Refresh, POINTER_Refresh },
    { AC::Reset, POINTER_Reset },

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -321,6 +321,27 @@ class extPointer : public objPointer {
       CursorID = PTC::DEFAULT;
       ClickSlop = 2;
       ButtonClicks.resize(3); // 0 = LMB, 1 = RMB, 2 = MMB
+
+      double speed        = 160;
+      double acceleration = 0.8;
+      int maxspeed        = 100;
+      double wheelspeed   = DEFAULT_WHEELSPEED;
+      double doubleclick  = 0.36;
+      std::string buttonorder = "123456789ABCDEF";
+
+      if (auto config = objConfig::create { fl::Path("user:config/pointer.cfg") }; config.ok()) {
+         config->read("POINTER", "Speed", Speed);
+         config->read("POINTER", "Acceleration", Acceleration);
+         config->read("POINTER", "MaxSpeed", MaxSpeed);
+         config->read("POINTER", "WheelSpeed", WheelSpeed);
+         config->read("POINTER", "DoubleClick", DoubleClick);
+         config->read("POINTER", "ButtonOrder", ButtonOrder);
+      }
+
+      if (DoubleClick < 0.2) DoubleClick = 0.2;
+
+      if (MaxSpeed < 2) MaxSpeed = 2;
+      else if (MaxSpeed > 200) MaxSpeed = 200;
    }
 };
 

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -322,13 +322,15 @@ class extPointer : public objPointer {
       ClickSlop = 2;
       ButtonClicks.resize(3); // 0 = LMB, 1 = RMB, 2 = MMB
 
-      double speed        = 160;
-      double acceleration = 0.8;
-      int maxspeed        = 100;
-      double wheelspeed   = DEFAULT_WHEELSPEED;
-      double doubleclick  = 0.36;
-      std::string buttonorder = "123456789ABCDEF";
+      Speed        = 160;
+      Acceleration = 0.8;
+      MaxSpeed     = 100;
+      WheelSpeed   = DEFAULT_WHEELSPEED;
+      DoubleClick  = 0.36;
+      ButtonOrder  = "123456789ABCDEF";
 
+      // Currently unused because all current targets have their own cursor management
+      #if 0
       if (auto config = objConfig::create { fl::Path("user:config/pointer.cfg") }; config.ok()) {
          config->read("POINTER", "Speed", Speed);
          config->read("POINTER", "Acceleration", Acceleration);
@@ -336,12 +338,14 @@ class extPointer : public objPointer {
          config->read("POINTER", "WheelSpeed", WheelSpeed);
          config->read("POINTER", "DoubleClick", DoubleClick);
          config->read("POINTER", "ButtonOrder", ButtonOrder);
+
+         if (DoubleClick < 0.2) DoubleClick = 0.2;
+
+         if (MaxSpeed < 2) MaxSpeed = 2;
+         else if (MaxSpeed > 200) MaxSpeed = 200;
       }
+      #endif
 
-      if (DoubleClick < 0.2) DoubleClick = 0.2;
-
-      if (MaxSpeed < 2) MaxSpeed = 2;
-      else if (MaxSpeed > 200) MaxSpeed = 200;
    }
 };
 

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -1028,14 +1028,6 @@ static ERR DOCUMENT_InsertText(extDocument *Self, doc::InsertText *Args)
 }
 
 //********************************************************************************************************************
-
-static ERR DOCUMENT_NewObject(extDocument *Self)
-{
-   unload_doc(Self);
-   return ERR::Okay;
-}
-
-//********************************************************************************************************************
 // XML-safe element names for every SCODE entry.  Kept parallel to strCodes in document.cpp, but uses lowercase,
 // hyphenated tokens that are valid XML identifiers.  Used by the DATA::XML branch of ReadContent().
 

--- a/src/document/class/document_def.c
+++ b/src/document/class/document_def.c
@@ -76,7 +76,6 @@ static const struct ActionArray clDocumentActions[] = {
    { AC::FreePlacement, DOCUMENT_FreePlacement },
    { AC::GetKey, DOCUMENT_GetKey },
    { AC::Init, DOCUMENT_Init },
-   { AC::NewObject, DOCUMENT_NewObject },
    { AC::NewPlacement, DOCUMENT_NewPlacement },
    { AC::Refresh, DOCUMENT_Refresh },
    { AC::SaveToObject, DOCUMENT_SaveToObject },

--- a/src/document/defs/document.h
+++ b/src/document/defs/document.h
@@ -1397,7 +1397,7 @@ class extDocument : public objDocument {
    }
 
    extDocument() {
-      unload_doc(this);
+      if (auto error = unload_doc(this); error != ERR::Okay) kt::Log().fatal(error);
    }
 };
 

--- a/src/document/defs/document.h
+++ b/src/document/defs/document.h
@@ -195,6 +195,314 @@ class RSTREAM;
 #include "dunit.h"
 
 //********************************************************************************************************************
+// stream_char provides indexing to specific characters in the stream.  It is designed to handle positional changes so
+// that text string boundaries can be crossed without incident.
+//
+// The index and offset are set to -1 if the stream_char is invalidated.
+
+struct stream_char {
+   INDEX index;     // Byte code position within the stream
+   size_t offset;   // Specific character offset within the bc_text.text string
+
+   stream_char() : index(-1), offset(-1) { }
+   stream_char(INDEX pIndex, uint32_t pOffset) : index(pIndex), offset(pOffset) { }
+   stream_char(INDEX pIndex) : index(pIndex), offset(0) { }
+
+   bool operator==(const stream_char &Other) const {
+      return (this->index IS Other.index) and (this->offset IS Other.offset);
+   }
+
+   bool operator<(const stream_char &Other) const {
+      if (this->index < Other.index) return true;
+      else if ((this->index IS Other.index) and (this->offset < Other.offset)) return true;
+      else return false;
+   }
+
+   bool operator>(const stream_char &Other) const {
+      if (this->index > Other.index) return true;
+      else if ((this->index IS Other.index) and (this->offset > Other.offset)) return true;
+      else return false;
+   }
+
+   bool operator<=(const stream_char &Other) const {
+      if (this->index < Other.index) return true;
+      else if ((this->index IS Other.index) and (this->offset <= Other.offset)) return true;
+      else return false;
+   }
+
+   bool operator>=(const stream_char &Other) const {
+      if (this->index > Other.index) return true;
+      else if ((this->index IS Other.index) and (this->offset >= Other.offset)) return true;
+      else return false;
+   }
+
+   void operator+=(const int Value) {
+      offset += Value;
+   }
+
+   inline void reset() { index = -1; offset = -1; }
+   inline bool valid() { return index != -1; }
+
+   inline void set(INDEX pIndex, uint32_t pOffset = 0) {
+      index  = pIndex;
+      offset = pOffset;
+   }
+
+   inline INDEX prev_code() {
+      index--;
+      if (index < 0) { index = -1; offset = -1; }
+      else offset = 0;
+      return index;
+   }
+
+   inline INDEX next_code() {
+      offset = 0;
+      index++;
+      return index;
+   }
+
+   // NB: None of these support unicode.
+
+   uint8_t get_char(RSTREAM &);
+   uint8_t get_char(RSTREAM &, int);
+   uint8_t get_prev_char(RSTREAM &);
+   uint8_t get_prev_char_or_inline(RSTREAM &);
+   void erase_char(RSTREAM &); // Erase a character OR an escape code.
+   void next_char(RSTREAM &);
+   void prev_char(RSTREAM &);
+};
+
+//********************************************************************************************************************
+// Basic font caching on an index basis.
+
+struct font_entry {
+   APTR handle;
+   std::string face;
+   std::string style;
+   FontMetrics metrics; // Derived from vec::GetFontMetrics() at the time of caching
+   int font_size; // 72 DPI pixel size
+   ALIGN align;
+   int16_t space_width = 0; // Cached pixel width of ' ' (matches m_space_width type)
+   double zero_width = 0;   // Cached pixel width of '0' (for DU::CHAR unit conversion)
+
+   font_entry(APTR pHandle, const std::string_view pFace, const std::string_view pStyle, double pSize) :
+      handle(pHandle), face(pFace), style(pStyle), font_size(pSize), align(ALIGN::NIL) {
+      vec::GetFontMetrics(pHandle, &metrics);
+      double kerning = 0;
+      space_width = int16_t(vec::CharWidth(pHandle, ' ', 0, &kerning) + kerning);
+      kerning = 0;
+      zero_width = vec::CharWidth(pHandle, '0', 0, &kerning) + kerning;
+   }
+
+   ~font_entry() { }
+
+   font_entry(font_entry &&other) noexcept { // Move constructor
+      handle      = other.handle;
+      metrics     = other.metrics;
+      font_size   = other.font_size;
+      face        = other.face;
+      style       = other.style;
+      align       = other.align;
+      space_width = other.space_width;
+      zero_width  = other.zero_width;
+      other.handle = nullptr;
+   }
+
+   font_entry(const font_entry &other) { // Copy constructor
+      handle      = other.handle;
+      font_size   = other.font_size;
+      metrics     = other.metrics;
+      face        = other.face;
+      style       = other.style;
+      align       = other.align;
+      space_width = other.space_width;
+      zero_width  = other.zero_width;
+   }
+
+   font_entry& operator=(font_entry &&other) noexcept { // Move assignment
+      if (this IS &other) return *this;
+      handle      = other.handle;
+      font_size   = other.font_size;
+      metrics     = other.metrics;
+      face        = other.face;
+      style       = other.style;
+      align       = other.align;
+      space_width = other.space_width;
+      zero_width  = other.zero_width;
+      other.handle = nullptr;
+      return *this;
+   }
+
+   font_entry& operator=(const font_entry& other) { // Copy assignment
+      if (this IS &other) return *this;
+      handle      = other.handle;
+      font_size   = other.font_size;
+      metrics     = other.metrics;
+      face        = other.face;
+      style       = other.style;
+      align       = other.align;
+      space_width = other.space_width;
+      zero_width  = other.zero_width;
+      return *this;
+   }
+
+   // NB: FontMetrics are not reported identically by all backends.
+   // Bitmap fonts expose Height as the full region above the baseline, while FreeType-backed fonts may expose Ascent
+   // for that role instead.
+
+   double descent() const {
+      auto gap = metrics.LineSpacing - metrics.Height - metrics.Descent;
+      return metrics.Descent + gap;
+   }
+};
+
+//********************************************************************************************************************
+// Refer to layout::new_segment().  A segment represents graphical content, which can be in the form of text,
+// graphics or both.  A segment can consist of one line only - so if the layout process encounters a boundary causing
+// wordwrap then a new segment must be created.
+
+struct doc_segment {
+   stream_char start;       // Starting index (including character if text)
+   stream_char stop;        // Stop at this index/character
+   stream_char trim_stop;   // The stopping point when whitespace is removed
+   FloatRect area;          // Dimensions of the segment.
+   double  descent;         // The largest descent (gutter) value in pixels after taking into account all fonts used on the line
+   double  align_width;     // Full width of this segment if it were non-breaking
+   RSTREAM *stream;         // The stream that this segment refers to
+   bool    edit;            // true if this segment represents content that can be edited
+   bool    allow_merge;     // true if this segment can be merged with siblings that have allow_merge set to true
+
+   inline double x(double Advance, FSO StyleOptions) {
+      if ((StyleOptions & FSO::ALIGN_CENTER) != FSO::NIL) return Advance + ((align_width - area.Width) * 0.5);
+      else if ((StyleOptions & FSO::ALIGN_RIGHT) != FSO::NIL) return Advance + (align_width - area.Width);
+      else return Advance;
+   }
+
+   inline double y(ALIGN VAlign, font_entry *Font) {
+      if ((VAlign & ALIGN::TOP) != ALIGN::NIL) return area.Y + Font->metrics.Ascent;
+      else if ((VAlign & ALIGN::VERTICAL) != ALIGN::NIL) {
+         const double avail_space = area.Height - descent;
+         return area.Y + avail_space - ((avail_space - Font->metrics.Ascent) * 0.5);
+      }
+      else return area.Y + area.Height - descent;
+   }
+};
+
+struct doc_clip {
+   double left = 0, top = 0, right = 0, bottom = 0;
+   INDEX index = 0; // The stream index of the object/table/item that is creating the clip.
+   bool transparent = false; // If true, wrapping will not be performed around the clip region.
+   std::string name;
+
+   doc_clip() = default;
+
+   doc_clip(double pLeft, double pTop, double pRight, double pBottom, int pIndex, bool pTransparent, const std::string &pName) :
+      left(pLeft), top(pTop), right(pRight), bottom(pBottom), index(pIndex), transparent(pTransparent), name(pName) {
+
+      if ((right - left > 20000) or (bottom - top > 20000)) {
+         kt::Log log;
+         log.warning("%s set invalid clip dimensions: %.0f,%.0f,%.0f,%.0f", name.c_str(), left, top, right, bottom);
+         right = left;
+         bottom = top;
+      }
+   }
+};
+
+struct doc_edit {
+   int max_chars;
+   std::string name;
+   std::string on_enter, on_exit, on_change;
+   std::vector<std::pair<std::string, std::string>> args;
+   bool line_breaks;
+
+   doc_edit() : max_chars(-1), args(0), line_breaks(false) { }
+};
+
+struct bc_link;
+struct bc_cell;
+
+struct mouse_over {
+   std::string function; // name of function to call.
+   double top, left, bottom, right;
+   int element_id;
+};
+
+struct tablecol {
+   double preset_width = 0;
+   double min_width = 0;   // For assisting layout
+   double width = 0;
+   bool preset_width_rel = false;
+};
+
+//********************************************************************************************************************
+
+struct link_activated {
+   std::map<std::string, std::string> Values;  // All key-values associated with the link.
+};
+
+//********************************************************************************************************************
+// Every instruction in the document stream is represented by a stream_code entity.  The code refers to what the thing
+// is, while the UID hash refers to further information in the Codes table.
+
+struct stream_code {
+   SCODE code;  // Type
+   BYTECODE uid; // Lookup for the Codes table
+
+   stream_code() : code(SCODE::NIL), uid(0) { }
+   stream_code(SCODE pCode, BYTECODE pID) : code(pCode), uid(pID) { }
+};
+
+//********************************************************************************************************************
+
+class entity {
+public:
+   BYTECODE uid;   // Unique identifier for lookup
+   SCODE code = SCODE::NIL; // Byte code
+
+   entity() { uid = alloc_bytecode_id(); }
+   entity(SCODE pCode) : code(pCode) { uid = alloc_bytecode_id(); }
+};
+
+//********************************************************************************************************************
+
+static ERR  activate_cell_edit(extDocument *, int, stream_char);
+static ERR  add_document_class(void);
+static int add_tabfocus(extDocument *, TT, BYTECODE);
+static void advance_tabfocus(extDocument *, int8_t);
+static void deactivate_edit(extDocument *, bool);
+static ERR  extract_script(extDocument *, std::string_view, objScript **, std::string &, std::string &);
+static void error_dialog(std::string_view, const std::string_view);
+static void error_dialog(std::string_view, ERR);
+static SEGINDEX find_segment(std::vector<doc_segment> &, stream_char, bool);
+static int  find_tabfocus(extDocument *, TT, BYTECODE);
+static ERR  flash_cursor(extDocument *, int64_t, int64_t);
+static int getutf8(CSTRING, int *);
+static ERR  insert_text(extDocument *, RSTREAM *, stream_char &, const std::string_view, bool);
+static ERR  insert_xml(extDocument *, RSTREAM *, objXML *, const objXML::TAGS &, int, STYLE = STYLE::NIL, IPF = IPF::NIL);
+static ERR  key_event(objVectorViewport *, KQ, KEY, int);
+static void layout_doc(extDocument *);
+static ERR  load_doc(extDocument *, std::string_view, bool, ULD = ULD::NIL);
+static void notify_disable_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
+static void notify_enable_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
+static void notify_focus_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
+static void notify_free_script_context(OBJECTPTR, ACTIONID, ERR, APTR);
+static void notify_lostfocus_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
+static ERR  feedback_view(objVectorViewport *, FM);
+static void process_parameters(extDocument *, const std::string_view);
+static std::string_view read_unit(std::string_view, double &, bool &);
+static void redraw(extDocument *, bool);
+static ERR  report_event(extDocument *, DEF, entity *, KEYVALUE *);
+static void reset_cursor(extDocument *);
+static ERR  resolve_fontx_by_index(extDocument *, stream_char, double &);
+static int  safe_file_path(extDocument *, std::string_view);
+static void set_focus(extDocument *, int, CSTRING);
+static void show_bookmark(extDocument *, std::string_view);
+static std::string stream_to_string(RSTREAM &, stream_char, stream_char);
+static ERR  unload_doc(extDocument *, ULD = ULD::NIL);
+static bool valid_objectid(extDocument *, OBJECTID);
+static bool view_area(extDocument *, double, double, double, double);
+
+//********************************************************************************************************************
 // UI hooks for the client
 
 struct ui_hooks {
@@ -284,35 +592,6 @@ struct edit_cell {
 
 //********************************************************************************************************************
 
-struct link_activated {
-   std::map<std::string, std::string> Values;  // All key-values associated with the link.
-};
-
-//********************************************************************************************************************
-// Every instruction in the document stream is represented by a stream_code entity.  The code refers to what the thing
-// is, while the UID hash refers to further information in the Codes table.
-
-struct stream_code {
-   SCODE code;  // Type
-   BYTECODE uid; // Lookup for the Codes table
-
-   stream_code() : code(SCODE::NIL), uid(0) { }
-   stream_code(SCODE pCode, BYTECODE pID) : code(pCode), uid(pID) { }
-};
-
-//********************************************************************************************************************
-
-class entity {
-public:
-   BYTECODE uid;   // Unique identifier for lookup
-   SCODE code = SCODE::NIL; // Byte code
-
-   entity() { uid = alloc_bytecode_id(); }
-   entity(SCODE pCode) : code(pCode) { uid = alloc_bytecode_id(); }
-};
-
-//********************************************************************************************************************
-
 class docresource {
 public:
    OBJECTID object_id;
@@ -384,90 +663,6 @@ struct case_insensitive_map {
          [](unsigned char Left, unsigned char Right) {
             return std::tolower(Left) < std::tolower(Right);
          });
-   }
-};
-
-//********************************************************************************************************************
-// Basic font caching on an index basis.
-
-struct font_entry {
-   APTR handle;
-   std::string face;
-   std::string style;
-   FontMetrics metrics; // Derived from vec::GetFontMetrics() at the time of caching
-   int font_size; // 72 DPI pixel size
-   ALIGN align;
-   int16_t space_width = 0; // Cached pixel width of ' ' (matches m_space_width type)
-   double zero_width = 0;   // Cached pixel width of '0' (for DU::CHAR unit conversion)
-
-   font_entry(APTR pHandle, const std::string_view pFace, const std::string_view pStyle, double pSize) :
-      handle(pHandle), face(pFace), style(pStyle), font_size(pSize), align(ALIGN::NIL) {
-      vec::GetFontMetrics(pHandle, &metrics);
-      double kerning = 0;
-      space_width = int16_t(vec::CharWidth(pHandle, ' ', 0, &kerning) + kerning);
-      kerning = 0;
-      zero_width = vec::CharWidth(pHandle, '0', 0, &kerning) + kerning;
-   }
-
-   ~font_entry() { }
-
-   font_entry(font_entry &&other) noexcept { // Move constructor
-      handle      = other.handle;
-      metrics     = other.metrics;
-      font_size   = other.font_size;
-      face        = other.face;
-      style       = other.style;
-      align       = other.align;
-      space_width = other.space_width;
-      zero_width  = other.zero_width;
-      other.handle = nullptr;
-   }
-
-   font_entry(const font_entry &other) { // Copy constructor
-      handle      = other.handle;
-      font_size   = other.font_size;
-      metrics     = other.metrics;
-      face        = other.face;
-      style       = other.style;
-      align       = other.align;
-      space_width = other.space_width;
-      zero_width  = other.zero_width;
-   }
-
-   font_entry& operator=(font_entry &&other) noexcept { // Move assignment
-      if (this IS &other) return *this;
-      handle      = other.handle;
-      font_size   = other.font_size;
-      metrics     = other.metrics;
-      face        = other.face;
-      style       = other.style;
-      align       = other.align;
-      space_width = other.space_width;
-      zero_width  = other.zero_width;
-      other.handle = nullptr;
-      return *this;
-   }
-
-   font_entry& operator=(const font_entry& other) { // Copy assignment
-      if (this IS &other) return *this;
-      handle      = other.handle;
-      font_size   = other.font_size;
-      metrics     = other.metrics;
-      face        = other.face;
-      style       = other.style;
-      align       = other.align;
-      space_width = other.space_width;
-      zero_width  = other.zero_width;
-      return *this;
-   }
-
-   // NB: FontMetrics are not reported identically by all backends.
-   // Bitmap fonts expose Height as the full region above the baseline, while FreeType-backed fonts may expose Ascent
-   // for that role instead.
-
-   double descent() const {
-      auto gap = metrics.LineSpacing - metrics.Height - metrics.Descent;
-      return metrics.Descent + gap;
    }
 };
 
@@ -545,162 +740,6 @@ public:
 
 struct bc_font_end : public entity {
    bc_font_end() : entity(SCODE::FONT_END) { }
-};
-
-//********************************************************************************************************************
-// stream_char provides indexing to specific characters in the stream.  It is designed to handle positional changes so
-// that text string boundaries can be crossed without incident.
-//
-// The index and offset are set to -1 if the stream_char is invalidated.
-
-struct stream_char {
-   INDEX index;     // Byte code position within the stream
-   size_t offset;   // Specific character offset within the bc_text.text string
-
-   stream_char() : index(-1), offset(-1) { }
-   stream_char(INDEX pIndex, uint32_t pOffset) : index(pIndex), offset(pOffset) { }
-   stream_char(INDEX pIndex) : index(pIndex), offset(0) { }
-
-   bool operator==(const stream_char &Other) const {
-      return (this->index IS Other.index) and (this->offset IS Other.offset);
-   }
-
-   bool operator<(const stream_char &Other) const {
-      if (this->index < Other.index) return true;
-      else if ((this->index IS Other.index) and (this->offset < Other.offset)) return true;
-      else return false;
-   }
-
-   bool operator>(const stream_char &Other) const {
-      if (this->index > Other.index) return true;
-      else if ((this->index IS Other.index) and (this->offset > Other.offset)) return true;
-      else return false;
-   }
-
-   bool operator<=(const stream_char &Other) const {
-      if (this->index < Other.index) return true;
-      else if ((this->index IS Other.index) and (this->offset <= Other.offset)) return true;
-      else return false;
-   }
-
-   bool operator>=(const stream_char &Other) const {
-      if (this->index > Other.index) return true;
-      else if ((this->index IS Other.index) and (this->offset >= Other.offset)) return true;
-      else return false;
-   }
-
-   void operator+=(const int Value) {
-      offset += Value;
-   }
-
-   inline void reset() { index = -1; offset = -1; }
-   inline bool valid() { return index != -1; }
-
-   inline void set(INDEX pIndex, uint32_t pOffset = 0) {
-      index  = pIndex;
-      offset = pOffset;
-   }
-
-   inline INDEX prev_code() {
-      index--;
-      if (index < 0) { index = -1; offset = -1; }
-      else offset = 0;
-      return index;
-   }
-
-   inline INDEX next_code() {
-      offset = 0;
-      index++;
-      return index;
-   }
-
-   // NB: None of these support unicode.
-
-   uint8_t get_char(RSTREAM &);
-   uint8_t get_char(RSTREAM &, int);
-   uint8_t get_prev_char(RSTREAM &);
-   uint8_t get_prev_char_or_inline(RSTREAM &);
-   void erase_char(RSTREAM &); // Erase a character OR an escape code.
-   void next_char(RSTREAM &);
-   void prev_char(RSTREAM &);
-};
-
-//********************************************************************************************************************
-// Refer to layout::new_segment().  A segment represents graphical content, which can be in the form of text,
-// graphics or both.  A segment can consist of one line only - so if the layout process encounters a boundary causing
-// wordwrap then a new segment must be created.
-
-struct doc_segment {
-   stream_char start;       // Starting index (including character if text)
-   stream_char stop;        // Stop at this index/character
-   stream_char trim_stop;   // The stopping point when whitespace is removed
-   FloatRect area;          // Dimensions of the segment.
-   double  descent;         // The largest descent (gutter) value in pixels after taking into account all fonts used on the line
-   double  align_width;     // Full width of this segment if it were non-breaking
-   RSTREAM *stream;         // The stream that this segment refers to
-   bool    edit;            // true if this segment represents content that can be edited
-   bool    allow_merge;     // true if this segment can be merged with siblings that have allow_merge set to true
-
-   inline double x(double Advance, FSO StyleOptions) {
-      if ((StyleOptions & FSO::ALIGN_CENTER) != FSO::NIL) return Advance + ((align_width - area.Width) * 0.5);
-      else if ((StyleOptions & FSO::ALIGN_RIGHT) != FSO::NIL) return Advance + (align_width - area.Width);
-      else return Advance;
-   }
-
-   inline double y(ALIGN VAlign, font_entry *Font) {
-      if ((VAlign & ALIGN::TOP) != ALIGN::NIL) return area.Y + Font->metrics.Ascent;
-      else if ((VAlign & ALIGN::VERTICAL) != ALIGN::NIL) {
-         const double avail_space = area.Height - descent;
-         return area.Y + avail_space - ((avail_space - Font->metrics.Ascent) * 0.5);
-      }
-      else return area.Y + area.Height - descent;
-   }
-};
-
-struct doc_clip {
-   double left = 0, top = 0, right = 0, bottom = 0;
-   INDEX index = 0; // The stream index of the object/table/item that is creating the clip.
-   bool transparent = false; // If true, wrapping will not be performed around the clip region.
-   std::string name;
-
-   doc_clip() = default;
-
-   doc_clip(double pLeft, double pTop, double pRight, double pBottom, int pIndex, bool pTransparent, const std::string &pName) :
-      left(pLeft), top(pTop), right(pRight), bottom(pBottom), index(pIndex), transparent(pTransparent), name(pName) {
-
-      if ((right - left > 20000) or (bottom - top > 20000)) {
-         kt::Log log;
-         log.warning("%s set invalid clip dimensions: %.0f,%.0f,%.0f,%.0f", name.c_str(), left, top, right, bottom);
-         right = left;
-         bottom = top;
-      }
-   }
-};
-
-struct doc_edit {
-   int max_chars;
-   std::string name;
-   std::string on_enter, on_exit, on_change;
-   std::vector<std::pair<std::string, std::string>> args;
-   bool line_breaks;
-
-   doc_edit() : max_chars(-1), args(0), line_breaks(false) { }
-};
-
-struct bc_link;
-struct bc_cell;
-
-struct mouse_over {
-   std::string function; // name of function to call.
-   double top, left, bottom, right;
-   int element_id;
-};
-
-struct tablecol {
-   double preset_width = 0;
-   double min_width = 0;   // For assisting layout
-   double width = 0;
-   bool preset_width_rel = false;
 };
 
 //********************************************************************************************************************
@@ -1355,6 +1394,10 @@ class extDocument : public objDocument {
    inline void invalidate_text_width_cache() {
       WidthCacheGeneration++;
       if (!WidthCacheGeneration) WidthCacheGeneration = 1;
+   }
+
+   extDocument() {
+      unload_doc(this);
    }
 };
 

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -127,43 +127,6 @@ std::vector<sorted_segment> & extDocument::get_sorted_segments()
 
 struct layout; // Pre-def
 
-static ERR  activate_cell_edit(extDocument *, int, stream_char);
-static ERR  add_document_class(void);
-static int add_tabfocus(extDocument *, TT, BYTECODE);
-static void advance_tabfocus(extDocument *, int8_t);
-static void deactivate_edit(extDocument *, bool);
-static ERR  extract_script(extDocument *, std::string_view, objScript **, std::string &, std::string &);
-static void error_dialog(std::string_view, const std::string_view);
-static void error_dialog(std::string_view, ERR);
-static SEGINDEX find_segment(std::vector<doc_segment> &, stream_char, bool);
-static int  find_tabfocus(extDocument *, TT, BYTECODE);
-static ERR  flash_cursor(extDocument *, int64_t, int64_t);
-static int getutf8(CSTRING, int *);
-static ERR  insert_text(extDocument *, RSTREAM *, stream_char &, const std::string_view, bool);
-static ERR  insert_xml(extDocument *, RSTREAM *, objXML *, const objXML::TAGS &, int, STYLE = STYLE::NIL, IPF = IPF::NIL);
-static ERR  key_event(objVectorViewport *, KQ, KEY, int);
-static void layout_doc(extDocument *);
-static ERR  load_doc(extDocument *, std::string_view, bool, ULD = ULD::NIL);
-static void notify_disable_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
-static void notify_enable_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
-static void notify_focus_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
-static void notify_free_script_context(OBJECTPTR, ACTIONID, ERR, APTR);
-static void notify_lostfocus_viewport(OBJECTPTR, ACTIONID, ERR, APTR);
-static ERR  feedback_view(objVectorViewport *, FM);
-static void process_parameters(extDocument *, const std::string_view);
-static std::string_view read_unit(std::string_view, double &, bool &);
-static void redraw(extDocument *, bool);
-static ERR  report_event(extDocument *, DEF, entity *, KEYVALUE *);
-static void reset_cursor(extDocument *);
-static ERR  resolve_fontx_by_index(extDocument *, stream_char, double &);
-static int  safe_file_path(extDocument *, std::string_view);
-static void set_focus(extDocument *, int, CSTRING);
-static void show_bookmark(extDocument *, std::string_view);
-static std::string stream_to_string(RSTREAM &, stream_char, stream_char);
-static ERR  unload_doc(extDocument *, ULD = ULD::NIL);
-static bool valid_objectid(extDocument *, OBJECTID);
-static bool view_area(extDocument *, double, double, double, double);
-
 static ERR GET_WorkingPath(extDocument *, std::string_view &);
 
 #ifdef DBG_STREAM

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -390,16 +390,6 @@ exit:
    return error;
 }
 
-//********************************************************************************************************************
-
-static ERR IMAGE_Free(extImage *Self)
-{
-   if (Self->prvFile) { FreeResource(Self->prvFile); Self->prvFile = nullptr; }
-   if (Self->Bitmap)  { FreeResource(Self->Bitmap); Self->Bitmap = nullptr; }
-   if (Self->Mask)    { FreeResource(Self->Mask); Self->Mask = nullptr; }
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
 
 -ACTION-
@@ -494,13 +484,6 @@ static ERR IMAGE_Init(extImage *Self)
    }
 
    return ERR::NoSupport;
-}
-
-//********************************************************************************************************************
-
-static ERR IMAGE_NewObject(extImage *Self)
-{
-   return NewLocalObject(CLASSID::BITMAP, &Self->Bitmap);
 }
 
 //********************************************************************************************************************

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -12,4 +12,16 @@ class extImage : public objImage {
    objFile *prvFile;
    uint8_t Cached:1;
    uint8_t Queried:1;
+
+   ~extImage() {
+      if (prvFile) FreeResource(prvFile);
+      if (Bitmap)  FreeResource(Bitmap);
+      if (Mask)    FreeResource(Mask);
+   }
+
+   extImage() {
+      if (NewLocalObject(CLASSID::BITMAP, &Bitmap) != ERR::Okay) {
+         kt::Log().fatal(ERR::NewObject);
+      }
+   }
 };

--- a/src/image/image_def.c
+++ b/src/image/image_def.c
@@ -23,10 +23,8 @@ static ERR IMAGE_FreePlacement(extImage *Self) {
 
 static const struct ActionArray clImageActions[] = {
    { AC::Activate, IMAGE_Activate },
-   { AC::Free, IMAGE_Free },
    { AC::FreePlacement, IMAGE_FreePlacement },
    { AC::Init, IMAGE_Init },
-   { AC::NewObject, IMAGE_NewObject },
    { AC::NewPlacement, IMAGE_NewPlacement },
    { AC::Query, IMAGE_Query },
    { AC::Read, IMAGE_Read },

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -100,6 +100,7 @@ capabilities.
 #include <kotuku/modules/font.h>
 #include <kotuku/modules/display.h>
 #include <kotuku/modules/font.h>
+#include <kotuku/modules/tiri.h>
 #include <kotuku/modules/vector.h>
 #include <kotuku/strings.hpp>
 
@@ -615,49 +616,6 @@ static ERR SCINTILLA_Focus(extScintilla *Self)
    else return ERR::AccessObject;
 }
 
-//********************************************************************************************************************
-
-static ERR SCINTILLA_Free(extScintilla *Self, APTR)
-{
-   kt::Log log;
-
-   delete Self->API;
-   Self->API = nullptr;
-
-   if (Self->TimerID) { UpdateTimer(Self->TimerID, 0); Self->TimerID = 0; }
-
-   if ((Self->FocusID) and (Self->FocusID != Self->SurfaceID)) {
-
-      if (kt::ScopedObjectLock object(Self->FocusID, 500); object.granted()) {
-         UnsubscribeAction(*object, AC::NIL);
-      }
-   }
-
-   if (Self->SurfaceID) {
-      if (kt::ScopedObjectLock<objSurface> object(Self->SurfaceID, 500); object.granted()) {
-         object->removeCallback(C_FUNCTION(&draw_scintilla));
-         UnsubscribeAction(*object, AC::NIL);
-      }
-   }
-
-   /*if (Self->PointerLocked) {
-      RestoreCursor(PTR_DEFAULT, Self->UID);
-      Self->PointerLocked = FALSE;
-   }*/
-
-   if (Self->prvKeyEvent)  { UnsubscribeEvent(Self->prvKeyEvent); Self->prvKeyEvent = nullptr; }
-   if (Self->FileStream)   { FreeResource(Self->FileStream); Self->FileStream = nullptr; }
-   if (Self->Font)         { FreeResource(Self->Font);       Self->Font = nullptr; }
-   if (Self->BoldFont)     { FreeResource(Self->BoldFont);   Self->BoldFont = nullptr; }
-   if (Self->ItalicFont)   { FreeResource(Self->ItalicFont); Self->ItalicFont = nullptr; }
-   if (Self->BIFont)       { FreeResource(Self->BIFont);     Self->BIFont = nullptr; }
-
-   gfx::UnsubscribeInput(Self->InputHandle);
-
-   Self->~extScintilla();
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
 
 -METHOD-
@@ -981,48 +939,6 @@ static ERR SCINTILLA_InsertText(extScintilla *Self, struct sci::InsertText *Args
    SCICALL(SCI_BEGINUNDOACTION);
    SCICALL(SCI_INSERTTEXT, pos, Args->String.data());
    SCICALL(SCI_ENDUNDOACTION);
-   return ERR::Okay;
-}
-
-//*****************************************************************************
-
-static ERR SCINTILLA_NewObject(extScintilla *Self, APTR)
-{
-   if (!NewLocalObject(CLASSID::FONT, (OBJECTPTR *)&Self->Font)) {
-      Self->Font->setFace("courier:10");
-      Self->LeftMargin  = 4;
-      Self->RightMargin = 30;
-      Self->AutoIndent  = TRUE;
-      Self->TabWidth    = 8;
-      Self->AllowTabs   = FALSE;
-
-      Self->BkgdColour.Red   = 255;
-      Self->BkgdColour.Green = 255;
-      Self->BkgdColour.Blue  = 255;
-      Self->BkgdColour.Alpha = 255;
-
-      Self->LineHighlight.Red   = 240;
-      Self->LineHighlight.Green = 240;
-      Self->LineHighlight.Blue  = 255;
-      Self->LineHighlight.Alpha = 255;
-
-      Self->CursorColour.Red   = 0;
-      Self->CursorColour.Green = 0;
-      Self->CursorColour.Blue  = 0;
-      Self->CursorColour.Alpha = 255;
-
-      Self->SelectFore.Red   = 255;
-      Self->SelectFore.Green = 255;
-      Self->SelectFore.Blue  = 255;
-      Self->SelectFore.Alpha = 255;
-
-      Self->SelectBkgd.Red   = 0;
-      Self->SelectBkgd.Green = 0;
-      Self->SelectBkgd.Blue  = 180;
-      Self->SelectBkgd.Alpha = 255;
-   }
-   else return ERR::NewObject;
-
    return ERR::Okay;
 }
 
@@ -2121,7 +2037,7 @@ static void error_dialog(std::string_view Title, std::string_view Message, ERR E
       if (CheckResourceExists(dialog_id) IS ERR::True) return;
    }
 
-   OBJECTPTR dialog;
+   objTiri *dialog;
    if (!NewObject(CLASSID::TIRI, &dialog)) {
       dialog->setFields(fl::Name("scDialog"), fl::Owner(CurrentTaskID()), fl::Path("system:scripts/gui/dialog.tiri"));
 
@@ -2141,10 +2057,9 @@ static void error_dialog(std::string_view Title, std::string_view Message, ERR E
       else acSetKey(dialog, "message", Message);
 
       if ((!InitObject(dialog)) and (!acActivate(dialog))) {
-         kt::vector<std::string> *results;
-         int size;
-         if ((!dialog->get(FID_Results, results, size)) and (size > 0)) {
-            dialog_id = strtol((*results)[0].c_str(), nullptr, 0);
+         std::span<std::string> results;
+         if ((!dialog->getResults(results)) and (not results.empty())) {
+            dialog_id = svtonum<int>(results[0]);
          }
       }
    }
@@ -2403,6 +2318,41 @@ static ERR idle_timer(extScintilla *Self, int64_t Elapsed, int64_t CurrentTime)
 #include "pan_menu.cxx"
 #include "pan_surface.cxx"
 #include "pan_listbox.cxx"
+
+//********************************************************************************************************************
+
+extScintilla::~extScintilla() {
+   delete API;
+
+   if (TimerID) UpdateTimer(TimerID, 0);
+
+   if ((FocusID) and (FocusID != SurfaceID)) {
+      if (kt::ScopedObjectLock object(FocusID, 500); object.granted()) {
+         UnsubscribeAction(*object, AC::NIL);
+      }
+   }
+
+   if (SurfaceID) {
+      if (kt::ScopedObjectLock<objSurface> object(SurfaceID, 500); object.granted()) {
+         object->removeCallback(C_FUNCTION(&draw_scintilla));
+         UnsubscribeAction(*object, AC::NIL);
+      }
+   }
+
+   /*if (PointerLocked) {
+      RestoreCursor(PTR_DEFAULT, UID);
+      PointerLocked = FALSE;
+   }*/
+
+   if (prvKeyEvent) UnsubscribeEvent(prvKeyEvent);
+   if (FileStream)  FreeResource(FileStream);
+   if (Font)        FreeResource(Font);
+   if (BoldFont)    FreeResource(BoldFont);
+   if (ItalicFont)  FreeResource(ItalicFont);
+   if (BIFont)      FreeResource(BIFont);
+
+   gfx::UnsubscribeInput(InputHandle);
+}
 
 //********************************************************************************************************************
 

--- a/src/scintilla/class_scintilla_def.cxx
+++ b/src/scintilla/class_scintilla_def.cxx
@@ -7,7 +7,6 @@ static const struct FieldDef clScintillaEventFlags[] = {
    { "NewChar", 0x00000008 },
    { nullptr, 0 }
 };
-
 static const struct FieldDef clScintillaFlags[] = {
    { "Disabled", 0x00000001 },
    { "DetectLexer", 0x00000002 },
@@ -74,6 +73,11 @@ static ERR SCINTILLA_NewPlacement(extScintilla *Self) {
    return ERR::Okay;
 }
 
+static ERR SCINTILLA_FreePlacement(extScintilla *Self) {
+   Self->~extScintilla();
+   return ERR::Okay;
+}
+
 static const struct ActionArray clScintillaActions[] = {
    { AC::Clear, SCINTILLA_Clear },
    { AC::Clipboard, SCINTILLA_Clipboard },
@@ -82,10 +86,9 @@ static const struct ActionArray clScintillaActions[] = {
    { AC::Draw, SCINTILLA_Draw },
    { AC::Enable, SCINTILLA_Enable },
    { AC::Focus, SCINTILLA_Focus },
-   { AC::Free, SCINTILLA_Free },
+   { AC::FreePlacement, SCINTILLA_FreePlacement },
    { AC::Hide, SCINTILLA_Hide },
    { AC::Init, SCINTILLA_Init },
-   { AC::NewObject, SCINTILLA_NewObject },
    { AC::NewPlacement, SCINTILLA_NewPlacement },
    { AC::Redo, SCINTILLA_Redo },
    { AC::SaveToObject, SCINTILLA_SaveToObject },

--- a/src/scintilla/scintillakotuku.h
+++ b/src/scintilla/scintillakotuku.h
@@ -37,6 +37,27 @@ class extScintilla : public objScintilla {
    uint16_t HoldModify:1;
    uint16_t AllowTabs:1;
    uint8_t  ScrollLocked;
+
+   extScintilla() {
+      if (NewLocalObject(CLASSID::FONT, (OBJECTPTR *)&Font) != ERR::Okay) {
+         kt::Log().fatal(ERR::NewObject);
+      }
+
+      Font->setFace("courier:10");
+      LeftMargin  = 4;
+      RightMargin = 30;
+      AutoIndent  = TRUE;
+      TabWidth    = 8;
+      AllowTabs   = FALSE;
+
+      BkgdColour    = RGB8 { 255, 255, 255, 255 };
+      LineHighlight = RGB8 { 240, 240, 255, 255 };
+      CursorColour  = RGB8 { 0, 0, 0, 255 };
+      SelectFore    = RGB8 { 255, 255, 255, 255 };
+      SelectBkgd    = RGB8 { 0, 0, 180, 255 };
+   }
+
+   ~extScintilla();
 };
 
 // This class inherits from ScintillaBase which inherits from Editor.  Responsible for a lot of the editing code.

--- a/src/vector/filters/filter_source.cpp
+++ b/src/vector/filters/filter_source.cpp
@@ -36,6 +36,19 @@ class extSourceFX : public extFilterEffect {
 
    extSourceFX() {
       SourceType = VSF::NONE;
+      if ((Scene = objVectorScene::create::local(fl::Name("fx_src_scene"), fl::PageWidth(1), fl::PageHeight(1)))) {
+         if (objVectorViewport::create::global(fl::Name("fx_src_viewport"), fl::Owner(Scene->UID))) {
+            if ((Bitmap = objBitmap::create::local(fl::Name("fx_src_cache"),
+                  fl::Width(1),
+                  fl::Height(1),
+                  fl::BitsPerPixel(32),
+                  fl::Flags(BMF::ALPHA_CHANNEL|BMF::NO_DATA)))) {
+            }
+            else kt::Log().fatal(ERR::CreateObject);
+         }
+         else kt::Log().fatal(ERR::CreateObject);
+      }
+      else kt::Log().fatal(ERR::CreateObject);
    }
 
    ~extSourceFX() {
@@ -186,26 +199,6 @@ static ERR SOURCEFX_Init(extSourceFX *Self)
    Self->Scene->Viewport->setColourSpace(Self->Filter->ColourSpace);
 
    return ERR::Okay;
-}
-
-//********************************************************************************************************************
-
-static ERR SOURCEFX_NewObject(extSourceFX *Self)
-{
-   if ((Self->Scene = objVectorScene::create::local(fl::Name("fx_src_scene"), fl::PageWidth(1), fl::PageHeight(1)))) {
-      if (objVectorViewport::create::global(fl::Name("fx_src_viewport"), fl::Owner(Self->Scene->UID))) {
-         if ((Self->Bitmap = objBitmap::create::local(fl::Name("fx_src_cache"),
-               fl::Width(1),
-               fl::Height(1),
-               fl::BitsPerPixel(32),
-               fl::Flags(BMF::ALPHA_CHANNEL|BMF::NO_DATA)))) {
-            return ERR::Okay;
-         }
-         else return ERR::CreateObject;
-      }
-      else return ERR::CreateObject;
-   }
-   else return ERR::CreateObject;
 }
 
 /*********************************************************************************************************************

--- a/src/vector/filters/filter_source_def.c
+++ b/src/vector/filters/filter_source_def.c
@@ -14,7 +14,6 @@ static const struct ActionArray clSourceFXActions[] = {
    { AC::Draw, SOURCEFX_Draw },
    { AC::FreePlacement, SOURCEFX_FreePlacement },
    { AC::Init, SOURCEFX_Init },
-   { AC::NewObject, SOURCEFX_NewObject },
    { AC::NewPlacement, SOURCEFX_NewPlacement },
    { AC::NIL, nullptr }
 };

--- a/src/vector/painters/pattern.cpp
+++ b/src/vector/painters/pattern.cpp
@@ -77,20 +77,6 @@ static ERR VECTORPATTERN_Init(extVectorPattern *Self)
    return ERR::Okay;
 }
 
-//********************************************************************************************************************
-
-static ERR VECTORPATTERN_NewObject(extVectorPattern *Self)
-{
-   if (!NewLocalObject(CLASSID::VECTORSCENE, &Self->Scene)) {
-      if (!NewObject(CLASSID::VECTORVIEWPORT, &Self->Viewport)) {
-         SetOwner(Self->Viewport, Self->Scene);
-         return ERR::Okay;
-      }
-      else return ERR::NewObject;
-   }
-   else return ERR::NewObject;
-}
-
 /*********************************************************************************************************************
 
 -FIELD-

--- a/src/vector/painters/pattern_def.cpp
+++ b/src/vector/painters/pattern_def.cpp
@@ -39,7 +39,6 @@ static const struct ActionArray clVectorPatternActions[] = {
    { AC::Draw, VECTORPATTERN_Draw },
    { AC::FreePlacement, VECTORPATTERN_FreePlacement },
    { AC::Init, VECTORPATTERN_Init },
-   { AC::NewObject, VECTORPATTERN_NewObject },
    { AC::NewPlacement, VECTORPATTERN_NewPlacement },
    { AC::NIL, nullptr }
 };

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -631,6 +631,16 @@ class extVectorPattern : public objVectorPattern, public SceneDef {
 
    objBitmap *Bitmap;
 
+   extVectorPattern() {
+      if (!NewLocalObject(CLASSID::VECTORSCENE, &Scene)) {
+         if (!NewObject(CLASSID::VECTORVIEWPORT, &Viewport)) {
+            SetOwner(Viewport, Scene);
+         }
+         else kt::Log().fatal(ERR::NewObject);
+      }
+      else kt::Log().fatal(ERR::NewObject);
+   }
+
    ~extVectorPattern();
 };
 
@@ -955,6 +965,8 @@ class extVectorPolygon : public extVector {
 
    std::vector<VectorPoint> Points;
    bool Closed:1;      // Polygons are closed (TRUE) and Polylines are open (FALSE)
+
+   extVectorPolygon();
 };
 
 class extVectorPath : public extVector, public SceneDef {

--- a/src/vector/vectors/polygon.cpp
+++ b/src/vector/vectors/polygon.cpp
@@ -171,17 +171,6 @@ static ERR VECTORPOLYGON_MoveToPoint(extVectorPolygon *Self, struct acMoveToPoin
    return ERR::Okay;
 }
 
-//********************************************************************************************************************
-
-static ERR VECTORPOLYGON_NewObject(extVectorPolygon *Self)
-{
-   Self->GeneratePath = (void (*)(extVector *, agg::path_storage &))&generate_polygon;
-   Self->Closed       = true;
-   Self->Points.push_back({ 0, 0 }); // Two blank points are needed on construction in order to satisfy polyline requirements.
-   Self->Points.push_back({ 0, 0 });
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
 -ACTION-
 Resize: Resize the polygon by its width and height.
@@ -409,6 +398,15 @@ static ERR POLY_SET_Y2(extVectorPolygon *Self, Unit &Value)
    Self->Points[1].Y = Value;
    reset_path(Self);
    return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+extVectorPolygon::extVectorPolygon() {
+   GeneratePath = (void (*)(extVector *, agg::path_storage &))&generate_polygon;
+   Closed       = true;
+   Points.push_back({ 0, 0 }); // Two blank points are needed on construction in order to satisfy polyline requirements.
+   Points.push_back({ 0, 0 });
 }
 
 //********************************************************************************************************************

--- a/src/vector/vectors/polygon_def.cpp
+++ b/src/vector/vectors/polygon_def.cpp
@@ -14,7 +14,6 @@ static const struct ActionArray clVectorPolygonActions[] = {
    { AC::FreePlacement, VECTORPOLYGON_FreePlacement },
    { AC::Move, VECTORPOLYGON_Move },
    { AC::MoveToPoint, VECTORPOLYGON_MoveToPoint },
-   { AC::NewObject, VECTORPOLYGON_NewObject },
    { AC::NewPlacement, VECTORPOLYGON_NewPlacement },
    { AC::Resize, VECTORPOLYGON_Resize },
    { AC::NIL, nullptr }


### PR DESCRIPTION
* Initialised document, display pointer, image, Scintilla and vector state from placement constructors
* Replaced class NewObject and Free actions with constructor, destructor and FreePlacement hooks
* [Scintilla] Updated generated definitions for string-view method arguments