### PR TITLE
[Tiri] Correct LSP UTF-16 column handling

### DIFF
--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -113,15 +113,18 @@ function offsetToPosition(Content:str, Offset:num):table
    limit = Offset
    if limit > #Content then limit = #Content end
 
+   -- Character is reported as a UTF-16 column, so advance by whole UTF-8 sequences and count their unit width.
    while pos < limit do
       c = Content:sub(pos, pos + 1)
       if c is '\n' then
          line++
          character = 0
+         pos++
       else
-         character++
+         seq = utf8SequenceLength(Content:byte(pos))   -- :byte() is 0-based
+         character += (seq is 4) and 2 or 1
+         pos += seq
       end
-      pos++
    end
 
    return { line = line, character = character }
@@ -176,7 +179,10 @@ end
 
 function getStringAtPosition(Doc:table, Line:num, Character:num):table
    line_text = getLine(Doc, Line)
-   if not line_text or Character >= #line_text then return nil end
+   if not line_text then return nil end
+
+   byte_character = utf16ColToByteCol(line_text, Character)
+   if byte_character >= #line_text then return nil end
 
    pos = 0
    while pos < #line_text do
@@ -191,7 +197,7 @@ function getStringAtPosition(Doc:table, Line:num, Character:num):table
             if sc is '\\' and pos + 1 < #line_text then
                pos += 2
             elseif sc is quote then
-               if Character > start_pos and Character < pos then
+               if byte_character > start_pos and byte_character < pos then
                   return {
                      text = line_text:sub(start_pos + 1, pos),
                      quoteStart = start_pos,

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -9,7 +9,9 @@
 ----------------------------------------------------------------------------------------------------------------------
 -- Text Edit Helper
 
--- Convert line/character position to byte offset in document
+-- Convert line/character position to byte offset in document.  The LSP Character field counts UTF-16 code units,
+-- so it must be converted to bytes against the target line to stay aligned with multi-byte operators such as ≈.
+
 function positionToOffset(Content, Line, Character)
    offset = 0
    current_line = 0
@@ -22,8 +24,10 @@ function positionToOffset(Content, Line, Character)
       offset++
    end
 
-   -- Add character offset within the line
-   return offset + Character
+   -- Add the byte offset within the line, converting the UTF-16 column to bytes.
+   line_end = Content:find('\n', offset) or (#Content + 1)
+   line_text = Content:sub(offset, line_end)
+   return offset + utf16ColToByteCol(line_text, Character)
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -13,7 +13,10 @@ global function getTokenAtPosition(Doc:table, Line:num, Character:num):table
    -- context: 'identifier', 'method_call', 'field_access', 'module_call'
 
    lineText = getLine(Doc, Line)
-   if not lineText or Character >= #lineText then return nil end
+   if not lineText then return nil end
+
+   byte_character = utf16ColToByteCol(lineText, Character)
+   if byte_character >= #lineText then return nil end
 
    -- Helper to check if character is identifier-like
    function isIdent(C)
@@ -21,8 +24,8 @@ global function getTokenAtPosition(Doc:table, Line:num, Character:num):table
    end
 
    -- Find token boundaries
-   startCol = Character
-   endCol = Character
+   startCol = byte_character
+   endCol = byte_character
 
    -- Scan backwards to find token start
    while startCol > 0 do
@@ -83,8 +86,8 @@ global function getTokenAtPosition(Doc:table, Line:num, Character:num):table
    return {
       text     = token,
       object   = precedingIdent,
-      startCol = startCol,
-      endCol   = endCol,
+      startCol = byteColToUtf16Col(lineText, startCol),
+      endCol   = byteColToUtf16Col(lineText, endCol),
       context  = context
    }
 end

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -100,6 +100,68 @@ global function markLineIndex(Doc:table, LineNo:num)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- UTF-16 <-> UTF-8 column conversion
+--
+-- LSP positions count characters in UTF-16 code units, whilst Tiri strings are byte-indexed.  Multi-byte operators
+-- such as ≈, ≠, ≤, ≥ occupy three UTF-8 bytes but a single UTF-16 unit, so edits and diagnostics on lines that
+-- contain them drift unless the column is converted.  The helpers below operate on a single line's byte text and
+-- treat the byte offset as the 0-based start used elsewhere by :sub(pos, pos + 1).
+--
+-- A UTF-8 lead byte determines both the codepoint's byte length and its UTF-16 unit count:
+--    0x00-0x7F : 1 byte,  1 unit
+--    0xC0-0xDF : 2 bytes, 1 unit
+--    0xE0-0xEF : 3 bytes, 1 unit
+--    0xF0-0xF7 : 4 bytes, 2 units (encoded as a surrogate pair in UTF-16)
+
+-- Return the UTF-8 byte length implied by a lead byte (defaults to 1 for ASCII and stray continuation bytes).
+
+function utf8SequenceLength(LeadByte:num):num
+   if LeadByte >= 0xF0 then return 4
+   elseif LeadByte >= 0xE0 then return 3
+   elseif LeadByte >= 0xC0 then return 2
+   end
+   return 1
+end
+
+-- Convert a UTF-16 column within LineText into a 0-based byte column.  Columns beyond the end of the line clamp to
+-- the line's byte length so that edits appending past the final character remain well-defined.
+
+global function utf16ColToByteCol(LineText:str, Utf16Col:num):num
+   len = #LineText
+   byte_pos = 0
+   units = 0
+
+   while units < Utf16Col and byte_pos < len do
+      lead = LineText:byte(byte_pos)   -- :byte() is 0-based
+      seq = utf8SequenceLength(lead)
+      byte_pos += seq
+      units += (seq is 4) and 2 or 1
+   end
+
+   if byte_pos > len then byte_pos = len end
+   return byte_pos
+end
+
+-- Convert a 0-based byte column within LineText into a UTF-16 column.  Used when byte-based columns from the parser
+-- or tokeniser are reported back to the client.
+
+global function byteColToUtf16Col(LineText:str, ByteCol:num):num
+   len = #LineText
+   if ByteCol > len then ByteCol = len end
+   byte_pos = 0
+   units = 0
+
+   while byte_pos < ByteCol do
+      lead = LineText:byte(byte_pos)   -- :byte() is 0-based
+      seq = utf8SequenceLength(lead)
+      byte_pos += seq
+      units += (seq is 4) and 2 or 1
+   end
+
+   return units
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- LSP Symbol Kinds (subset used for Tiri)
 
 global SYMBOL_KIND = {
@@ -403,6 +465,11 @@ global function computeDiagnostics(Doc:table)
             start_col, end_col = computeErrorRange(Doc, diag.line, diag.column)
          end
 
+         -- The parser reports byte columns; convert to UTF-16 for the client.
+         diag_line = getLine(Doc, diag.line) or ''
+         start_col = byteColToUtf16Col(diag_line, start_col)
+         end_col = byteColToUtf16Col(diag_line, end_col)
+
          lsp_diags:push({
             range = {
                start = { line = diag.line, character = start_col },
@@ -424,6 +491,11 @@ global function computeDiagnostics(Doc:table)
          if end_col <= start_col+1 then
             start_col, end_col = computeErrorRange(Doc, tip.line, tip.column)
          end
+
+         -- The parser reports byte columns; convert to UTF-16 for the client.
+         tip_line = getLine(Doc, tip.line) or ''
+         start_col = byteColToUtf16Col(tip_line, start_col)
+         end_col = byteColToUtf16Col(tip_line, end_col)
 
          lsp_diags:push({
             range = {

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -19,6 +19,14 @@ rx_global_var   = <{ regex.new("^gl[A-Z]") }>
 rx_starts_upper = <{ regex.new("^[A-Z]") }>
 rx_all_upper    = <{ regex.new([[^[A-Z_]+$]]) }>
 
+-- Multi-byte (non-ASCII) operators recognised by the Tiri lexer, keyed by their UTF-8 byte sequence.  These are
+-- scanned byte-at-a-time by :sub(), so the tokeniser cannot match them with a single-character comparison and must
+-- look them up by their full sequence.  The value is the number of UTF-8 bytes the operator occupies.
+MULTIBYTE_OPERATORS = {
+   ['«'] = 2, ['»'] = 2, ['×'] = 2, ['÷'] = 2,
+   ['‥'] = 3, ['⁇'] = 3, ['≠'] = 3, ['≈'] = 3, ['≤'] = 3, ['≥'] = 3, ['↑'] = 3, ['▷'] = 3, ['⧺'] = 3
+}
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Semantic Token Encoder
 
@@ -278,8 +286,19 @@ global function tokenizeTiri(Source:str):array
       start_col = col
       start_pos = pos
 
+      -- Multi-byte operators (≈, ≠, ≤, ≥, «, », ×, ÷, ...).  :sub() is byte-indexed, so a single-byte comparison
+      -- can never match these; look up the full UTF-8 sequence and emit an operator token spanning its bytes.
+
+      op_bytes = (c:byte(0) or 0) >= 0x80 and (MULTIBYTE_OPERATORS[Source:sub(pos, pos + 3)] or
+         MULTIBYTE_OPERATORS[Source:sub(pos, pos + 2)]) or nil
+
+      if op_bytes then
+         addToken(line, col, op_bytes, 1, 0)  -- operator
+         pos += op_bytes
+         col += op_bytes
+
       -- Line comment: --
-      if c is '-' and pos + 1 < len and Source:sub(pos + 1, pos + 2) is '-' then
+      elseif c is '-' and pos + 1 < len and Source:sub(pos + 1, pos + 2) is '-' then
          comment_start = col
 
          -- Check for block comment --[[
@@ -705,10 +724,6 @@ global function tokenizeTiri(Source:str):array
             pos++
             col++
          end
-      elseif c is '≈' then -- approximate equality
-         addToken(line, col, 1, 1, 0)
-         pos++
-         col++
       elseif c is '&' then -- & bitwise AND
          addToken(line, col, 1, 1, 0)
          pos++
@@ -729,6 +744,29 @@ global function tokenizeTiri(Source:str):array
          pos++
          col++
       end
+   end
+
+   -- The scanner tracks byte columns, but the LSP wire format expects UTF-16 code units.  Convert each token's
+   -- start and length against its line so multi-byte operators (≈, ≠, ≤, ≥, ...) do not skew the highlighting of
+   -- everything that follows them on the same line.
+
+   line_starts = array<int>
+   line_starts:push(0)
+   scan = 0
+   while scan < len do
+      if Source:sub(scan, scan + 1) is '\n' then line_starts:push(scan + 1) end
+      scan++
+   end
+
+   for tok in values(tokens) do
+      line_start = line_starts[tok.line] or 0
+      line_end = Source:find('\n', line_start) or len
+      line_text = Source:sub(line_start, line_end)
+
+      byte_start = tok.char
+      byte_end = tok.char + tok.length
+      tok.char = byteColToUtf16Col(line_text, byte_start)
+      tok.length = byteColToUtf16Col(line_text, byte_end) - tok.char
    end
 
    return tokens

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -22,7 +22,10 @@ function signaturePositionToOffset(Doc:table, Position:table):num
       offset++
    end
 
-   offset += Position.character
+   -- Position.character counts UTF-16 code units; convert to bytes against the target line.
+   line_end = content:find('\n', offset) or (#content + 1)
+   line_text = content:sub(offset, line_end)
+   offset += utf16ColToByteCol(line_text, Position.character)
    if offset > #content then offset = #content end
    return offset
 end

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -158,6 +158,94 @@ test_data = f'{{"id":{i},"data":"test_data_{i}"}}'
    assert(#result.diagnostics is 0, 'LSP diagnostics should accept escaped braces in f-strings.')
 end
 
+@Test function MultiByteOperatorsReceiveSemanticTokens()
+   -- ≈, ≠, ≤, ≥ are three UTF-8 bytes but a single UTF-16 column.  The operator itself should be highlighted, and
+   -- the number following it must sit at the correct UTF-16 column rather than drifting by the operator's extra bytes.
+
+   source = '1.0 ≈ 2.0\n' ..   -- 3-byte operator
+      '1.0 ≠ 2.0\n' ..        -- 3-byte operator
+      '1.0 × 2.0\n'           -- 2-byte operator
+
+   tokens = tokenizeTiri(source)
+
+   -- The operator occupies UTF-16 column 4 with a width of one unit on every line.
+   for line = 0, 2 do
+      op = nil
+      for token in values(tokens) do
+         if token.line is line and token.char is 4 then op = token end
+      end
+      assert(op and op.type is 1, 'Multi-byte operator on line ' .. line .. ' should be highlighted as an operator.')
+      assert(op.length is 1, 'Multi-byte operator on line ' .. line .. ' should span one UTF-16 column.')
+   end
+
+   -- The trailing number aligns to UTF-16 column 6 on every line, independent of the operator's byte width.
+   for line = 0, 2 do
+      number = findToken(tokens, line, 6, '2.0')
+      assert(number and number.type is 5,
+         'Number after a multi-byte operator on line ' .. line .. ' should keep its UTF-16 alignment.')
+   end
+end
+
+@Test function MultiByteOperatorDiagnosticsUseCurrentParser()
+   doc = makeDoc('result = 1.0 ≈ 1.000001\n' ..
+      'unequal = 1.0 ≠ 2.0\n')
+   result = computeDiagnostics(doc)
+
+   assert(#result.diagnostics is 0, 'LSP diagnostics should accept multi-byte comparison operators.')
+end
+
+@Test function MultiByteOperatorHoverUsesUtf16Position()
+   doc = makeDoc('result = 1.0 ≈ value\n')
+   token = getTokenAtPosition(doc, 0, 15)
+
+   assert(token and token.text is 'value', 'Hover token extraction should convert UTF-16 columns to byte offsets.')
+   assert(token.startCol is 15, 'Hover token range should report the UTF-16 start column.')
+   assert(token.endCol is 20, 'Hover token range should report the UTF-16 end column.')
+end
+
+@Test function IncrementalEditAtEndOfLineUsesFullLineText()
+   uri = glSemanticTokensTestUri .. '#edit'
+   glDocuments[uri] = {
+      uri = uri,
+      languageId = 'tiri',
+      version = 1,
+      content = 'abc\n',
+      lineIndex = nil
+   }
+
+   server = {
+      _handlers = {},
+      verbose = false,
+      logMessage = function(Message) end
+   }
+   state = {
+      clientSocket = {
+         acWrite = function(Text) return ERR_Okay end
+      }
+   }
+
+   registerCoreHandlers(server)
+   server._handlers['textDocument/didChange']({
+      jsonrpc = '2.0',
+      params = {
+         textDocument = { uri = uri, version = 2 },
+         contentChanges = array<table> {
+            {
+               range = {
+                  start = { line = 0, character = 3 },
+                  ['end'] = { line = 0, character = 3 }
+               },
+               text = '!'
+            }
+         }
+      }
+   }, state)
+
+   assert(glDocuments[uri].content is 'abc!\n',
+      'Incremental edit at an end-of-line UTF-16 column should append after the final character.')
+   glDocuments[uri] = nil
+end
+
 @Test function ParserAnnotationHoverDocumentation()
    doc = makeDoc('value = @SourceFile\n')
    token = getTokenAtPosition(doc, 0, 10)


### PR DESCRIPTION
* Converted UTF-16 LSP positions to byte offsets for edits, signatures, hover and definitions
* Added semantic token coverage for multi-byte operators and end-of-line incremental edits