### PR TITLE
[Compression] Migrated Free action handling into the class destructor

### DIFF
--- a/docs/xml/modules/classes/compression.xml
+++ b/docs/xml/modules/classes/compression.xml
@@ -122,9 +122,9 @@ err = cmp.mtDecompressFile('*.def', 'temp:')
 <p>No meta-information is written to the stream, so the client will need a way to record the total number of bytes that have been output during the compression process. This value must be stored somewhere in order to decompress the stream correctly.  There is also no header information recorded to identify the type of algorithm used to compress the stream.  We recommend that the compression object's derived class ID is stored for future reference.</p>
 <p>The following C code illustrates a simple means of compressing a file to another file using a stream:</p>
 <pre>if (auto error = mtCompressStreamStart(compress); !error) {
-   int len;
-   int cmpsize = 0;
-   uint8_t input[4096];
+   LONG len;
+   LONG cmpsize = 0;
+   UBYTE input[4096];
    while (!(error = acRead(file, input, sizeof(input), &amp;len))) {
       if (!len) break; // No more data to read.
 

--- a/src/core/compression/class_compression.cpp
+++ b/src/core/compression/class_compression.cpp
@@ -182,6 +182,9 @@ static const int HEAD_NAMELEN        = 26;  // File name
 static const int HEAD_EXTRALEN       = 28;  // System specific information
 static const int HEAD_LENGTH         = 30;  // END
 
+class extCompression;
+static void write_eof(extCompression *);
+
 class extCompression : public objCompression {
    public:
    OBJECTPTR   FileIO;           // File input/output
@@ -206,6 +209,21 @@ class extCompression : public objCompression {
       Permissions      = PERMIT::NIL; // Inherit permissions by default. PERMIT::READ|PERMIT::WRITE|PERMIT::GROUP_READ|PERMIT::GROUP_WRITE;
       MinOutputSize    = (32 * 1024) + 2048; // Has to at least match the minimum 'window size' of each compression block, plus extra in case of overflow.  Min window size is typically 16k
       WindowBits       = MAX_WBITS; // If negative then you get raw compression when dealing with buffers and stream data, i.e. no header information
+   }
+
+   ~extCompression() {
+      // Before terminating anything, write the EOF signature (if modifications have been made).
+
+      write_eof(this);
+
+      if (ArchiveHash) remove_archive(this);
+
+      if (Feedback.isScript()) {
+         UnsubscribeAction(Feedback.Context, AC::Free);
+         Feedback.clear();
+      }
+
+      if (FileIO) FreeResource(FileIO);
    }
 };
 
@@ -784,9 +802,9 @@ The following C code illustrates a simple means of compressing a file to another
 
 <pre>
 if (auto error = mtCompressStreamStart(compress); !error) {
-   LONG len;
-   LONG cmpsize = 0;
-   UBYTE input[4096];
+   int len;
+   int cmpsize = 0;
+   uint8_t input[4096];
    while (!(error = acRead(file, input, sizeof(input), &len))) {
       if (!len) break; // No more data to read.
 
@@ -1666,29 +1684,6 @@ static ERR COMPRESSION_Flush(extCompression *Self)
 
 //********************************************************************************************************************
 
-static ERR COMPRESSION_Free(extCompression *Self)
-{
-   // Before terminating anything, write the EOF signature (if modifications have been made).
-
-   write_eof(Self);
-
-   if (Self->ArchiveHash)  {
-      remove_archive(Self);
-      Self->ArchiveHash = 0;
-   }
-
-   if (Self->Feedback.isScript()) {
-      UnsubscribeAction(Self->Feedback.Context, AC::Free);
-      Self->Feedback.clear();
-   }
-
-   if (Self->FileIO)       { FreeResource(Self->FileIO); Self->FileIO = nullptr; }
-
-   return ERR::Okay;
-}
-
-//********************************************************************************************************************
-
 static ERR COMPRESSION_Init(extCompression *Self)
 {
    kt::Log log;
@@ -1945,31 +1940,6 @@ static ERR COMPRESSION_Scan(extCompression *Self, struct cmp::Scan *Args)
 #include "compression_fields.cpp"
 #include "compression_func.cpp"
 
-static const FieldDef clPermissionFlags[] = {
-   { "Read",         PERMIT::READ },
-   { "Write",        PERMIT::WRITE },
-   { "Exec",         PERMIT::EXEC },
-   { "Executable",   PERMIT::EXEC },
-   { "Delete",       PERMIT::DELETE },
-   { "Hidden",       PERMIT::HIDDEN },
-   { "Archive",      PERMIT::ARCHIVE },
-   { "Password",     PERMIT::PASSWORD },
-   { "UserID",       PERMIT::USERID },
-   { "GroupID",      PERMIT::GROUPID },
-   { "OthersRead",   PERMIT::OTHERS_READ },
-   { "OthersWrite",  PERMIT::OTHERS_WRITE },
-   { "OthersExec",   PERMIT::OTHERS_EXEC },
-   { "OthersDelete", PERMIT::OTHERS_DELETE },
-   { "GroupRead",    PERMIT::GROUP_READ },
-   { "GroupWrite",   PERMIT::GROUP_WRITE },
-   { "GroupExec",    PERMIT::GROUP_EXEC },
-   { "GroupDelete",  PERMIT::GROUP_DELETE },
-   { "AllRead",      PERMIT::ALL_READ },
-   { "AllWrite",     PERMIT::ALL_WRITE },
-   { "AllExec",      PERMIT::ALL_EXEC },
-   { nullptr, 0 }
-};
-
 #include "class_compression_def.c"
 
 static const FieldArray clFields[] = {
@@ -1981,7 +1951,7 @@ static const FieldArray clFields[] = {
    { "CompressionLevel", FDF_INT|FDF_RW, nullptr, SET_CompressionLevel },
    { "Flags",            FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clCompressionFlags },
    { "SegmentSize",      FDF_INT|FDF_SYSTEM|FDF_RW },
-   { "Permissions",      FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clPermissionFlags },
+   { "Permissions",      FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clCompressionPermissions },
    { "MinOutputSize",    FDF_INT|FDF_R },
    { "WindowBits",       FDF_INT|FDF_RW, nullptr, SET_WindowBits },
    // Virtual fields

--- a/src/core/compression/class_compression_def.c
+++ b/src/core/compression/class_compression_def.c
@@ -94,7 +94,6 @@ static ERR COMPRESSION_FreePlacement(extCompression *Self) {
 
 static const struct ActionArray clCompressionActions[] = {
    { AC::Flush, COMPRESSION_Flush },
-   { AC::Free, COMPRESSION_Free },
    { AC::FreePlacement, COMPRESSION_FreePlacement },
    { AC::Init, COMPRESSION_Init },
    { AC::NewPlacement, COMPRESSION_NewPlacement },

--- a/src/core/compression/compression_fields.cpp
+++ b/src/core/compression/compression_fields.cpp
@@ -184,9 +184,7 @@ information that may identify the compressed data is not included in the total.
 static ERR GET_UncompressedSize(extCompression *Self, int64_t *Value)
 {
    int64_t size = 0;
-   for (auto &f : Self->Files) {
-      size += f.OriginalSize;
-   }
+   for (auto &f : Self->Files) size += f.OriginalSize;
    *Value = size;
    return ERR::Okay;
 }
@@ -209,12 +207,10 @@ To support GZIP decompression, please set the WindowBits value to 47.
 
 static ERR SET_WindowBits(extCompression *Self, int Value)
 {
-   kt::Log log;
-
    if (((Value >= 8) and (Value <= 15)) or ((Value >= -15) and (Value <= -8)) or
        (Value IS 15 + 32) or (Value IS 16 + 32)) {
       Self->WindowBits = Value;
       return ERR::Okay;
    }
-   else return log.warning(ERR::OutOfRange);
+   else return kt::Log().warning(ERR::OutOfRange);
 }


### PR DESCRIPTION
* Moved EOF write, archive removal, feedback unsubscription and FileIO teardown from COMPRESSION_Free into the extCompression destructor and dropped the AC::Free registration
* Switched the Permissions field to the generated clCompressionPermissions lookup table, removing the duplicate inline FieldDef array