### PR TITLE
[Tiri] Resolve relative imports during parser validation

### DIFF
--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -1075,15 +1075,6 @@ function append_metadata(Lines:array, Parser:table)
       Lines:push('')
       Lines:push(Parser.epilog)
    end
-
-   if Parser.copyright then
-      Lines:push('')
-      Lines:push(Parser.copyright)
-   end
-
-   if Parser.license then
-      Lines:push(Parser.license)
-   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1208,9 +1208,10 @@ LJLIB_CF(debug_validate)
    bool include_symbols = flags.find("symbols") != std::string_view::npos;
 
    // The chunk name carries the source path through to the parser so that relative imports ('./lib') resolve
-   // against the document's directory.  Prefixing with '@' marks it as a file path (Lua source-naming convention).
+   // against the document's directory.  Use a literal chunk name so validation of unsaved or stale LSP buffers does
+   // not register the buffer path as a real FileSource entry.
 
-   std::string chunk_name = source_path.empty() ? std::string("=validate") : (std::string("@") + source_path);
+   std::string chunk_name = source_path.empty() ? std::string("=validate") : (std::string("=") + source_path);
 
    lua_newtable(L); // Create result table
 

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1002,7 +1002,7 @@ LJLIB_CF(debug_traceback)
 }
 
 //********************************************************************************************************************
-// debug.validate(statement [, flags]) - Parse code and return diagnostics without execution
+// debug.validate(statement [, options]) - Parse code and return diagnostics without execution
 //
 // Returns a table with:
 //   success     - boolean: true if no errors
@@ -1022,9 +1022,9 @@ LJLIB_CF(debug_traceback)
 //     category  - hint category (e.g., "performance", "code-quality")
 //     message   - human-readable improvement suggestion
 //
-// Optional flags parameter (string, reserved for future use):
-//   "s" - syntax only (default, just parse)
-//   "t" - include type checking (future)
+// The optional second argument may be an options table for richer control:
+//   flags - a string of comma/space separated flags (e.g. "symbols" to include parsed symbol metadata)
+//   path  - the source file path, enabling relative imports ('./lib') to resolve against its directory
 
 static CSTRING diagnostic_code_name(ParserErrorCode Code)
 {
@@ -1188,8 +1188,29 @@ static void push_symbol_metadata(lua_State *L, const ParserSymbolCollection *Sym
 LJLIB_CF(debug_validate)
 {
    CSTRING statement = luaL_checkstring(L, 1);
-   CSTRING flags = luaL_optstring(L, 2, "");
-   bool include_symbols = flags and std::string_view(flags).find("symbols") != std::string_view::npos;
+
+   // The optional second argument may be a flags string (deprecated), or an options table accepting 'flags' and 'path'
+   // values.  A 'path' enables relative import resolution against the source file's directory (used by the LSP).
+
+   std::string flags;
+   std::string source_path;
+   if (lua_istable(L, 2)) {
+      lua_getfield(L, 2, "flags");
+      if (CSTRING f = lua_tostring(L, -1)) flags.assign(f);
+      lua_pop(L, 1);
+
+      lua_getfield(L, 2, "path");
+      if (CSTRING p = lua_tostring(L, -1)) source_path.assign(p);
+      lua_pop(L, 1);
+   }
+   else if (CSTRING f = luaL_optstring(L, 2, "")) flags.assign(f);
+
+   bool include_symbols = flags.find("symbols") != std::string_view::npos;
+
+   // The chunk name carries the source path through to the parser so that relative imports ('./lib') resolve
+   // against the document's directory.  Prefixing with '@' marks it as a file path (Lua source-naming convention).
+
+   std::string chunk_name = source_path.empty() ? std::string("=validate") : (std::string("@") + source_path);
 
    lua_newtable(L); // Create result table
 
@@ -1201,7 +1222,7 @@ LJLIB_CF(debug_validate)
    if (include_symbols) L->script->Flags |= SCF::PROCESS_DOC;
    if (L->parser_symbols) { delete L->parser_symbols; L->parser_symbols = nullptr; }
 
-   int parse_result = lua_load(L, std::string_view(statement, strlen(statement)), "=validate");
+   int parse_result = lua_load(L, std::string_view(statement, strlen(statement)), chunk_name.c_str());
 
    L->script->JitOptions = old_options;  // Restore options
    L->script->Flags = old_flags;
@@ -1557,7 +1578,7 @@ extern int luaopen_debug(lua_State *L)
    reg_iface_prototype("debug", "setHook", {}, { TiriType::Func, TiriType::Str, TiriType::Num });
    reg_iface_prototype("debug", "getHook", { TiriType::Func, TiriType::Str, TiriType::Num }, {});
    reg_iface_prototype("debug", "traceback", { TiriType::Str }, { TiriType::Str, TiriType::Num });
-   reg_iface_prototype("debug", "validate", { TiriType::Table }, { TiriType::Str, TiriType::Str });
+   reg_iface_prototype("debug", "validate", { TiriType::Table }, { TiriType::Str, TiriType::Any });
    reg_iface_prototype("debug", "locality", { TiriType::Str }, { TiriType::Str, TiriType::Num });
 
    // Register debug.anno interface prototypes

--- a/src/tiri/jit/src/parser/parser_context.cpp
+++ b/src/tiri/jit/src/parser/parser_context.cpp
@@ -416,9 +416,18 @@ std::string ParserContext::resolve_lib_to_path(std::string_view &Library) const
    int slash_count = 0;
 
    bool local = false;
+   std::string parent_prefix;
    if (Library.starts_with("./")) { // Local libraries are permitted if the name starts with "./" and otherwise adheres to path rules
       local = true;
       Library.remove_prefix(2);
+   }
+   else {
+      while (Library.starts_with("../")) {
+         local = true;
+         parent_prefix.append("../");
+         Library.remove_prefix(3);
+         slash_count++;
+      }
    }
 
    size_t i;
@@ -436,7 +445,8 @@ std::string ParserContext::resolve_lib_to_path(std::string_view &Library) const
       return "";
    }
 
-   std::string result(Library);
+   std::string result(parent_prefix);
+   result.append(Library);
 
    // Prepend the base path
 

--- a/src/tiri/tests/import_parent/child.tiri
+++ b/src/tiri/tests/import_parent/child.tiri
@@ -1,0 +1,3 @@
+import '../import_parent_helper'
+
+global child_parent_message = parent_import_message .. " from child"

--- a/src/tiri/tests/import_parent_helper.tiri
+++ b/src/tiri/tests/import_parent_helper.tiri
@@ -1,0 +1,5 @@
+global parent_import_message = "Loaded through parent-relative import"
+
+global function parent_import_value()
+   return 73
+end

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -400,6 +400,34 @@ function hasTipMessage(Result, Message)
    return false
 end
 
+function hasDiagnosticMessage(Result, Message)
+   if not Result.diagnostics then return false end
+   for diagnostic in values(Result.diagnostics) do
+      if diagnostic.message and diagnostic.message:find(Message) then return true end
+   end
+   return false
+end
+
+@Test function ValidatePathDoesNotRegisterFileSource()
+   err, missing_path = mSys.ResolvePath('temp:debug_validate_lsp_missing.tiri', RSF_NO_FILE_CHECK)
+   assert(err is ERR_Okay, 'Failed to resolve temporary missing file path')
+   mSys.DeleteFile(missing_path)
+
+   err, importer_path = mSys.ResolvePath('temp:debug_validate_lsp_importer.tiri', RSF_NO_FILE_CHECK)
+   assert(err is ERR_Okay, 'Failed to resolve temporary importer path')
+
+   primed = debug.validate('buffer_only = true', { path = missing_path })
+   assert(primed.success is true, 'Initial buffer validation should succeed')
+
+   for source in values(debug.fileSources()) do
+      assert(source.path != missing_path, 'debug.validate(path) should not register the buffer path as a FileSource')
+   end
+
+   imported = debug.validate("import './debug_validate_lsp_missing'\nmissing_value = true", { path = importer_path })
+   assert(imported.success is false, 'Missing imported file should not be hidden by an earlier buffer validation')
+   assert(hasDiagnosticMessage(imported, 'Cannot open imported file'), 'Expected missing imported file diagnostic')
+end
+
 @Test function ValidateChooseWithoutElseTip()
    message = "Choose expression has no else branch; unmatched values evaluate to nil"
    result = debug.validate([[

--- a/src/tiri/tests/test_import.tiri
+++ b/src/tiri/tests/test_import.tiri
@@ -1,5 +1,6 @@
 
    import './compile_if_helper'
+   import './import_parent/child'
 
 @Test function ImportBasic()
    assert(helper_message is "Hello from imported module!",
@@ -20,4 +21,12 @@ end
 
 @Test function DebugMode()
    assert(debug_on or debug_off, "Debug state flags not set.")
+end
+
+@Test function ParentRelativeImport()
+   assert(parent_import_message is "Loaded through parent-relative import",
+      f"Expected parent import message, got '{parent_import_message}'")
+   assert(parent_import_value() is 73, "Expected parent import function to remain available")
+   assert(child_parent_message is "Loaded through parent-relative import from child",
+      f"Expected child import message, got '{child_parent_message}'")
 end

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -411,13 +411,14 @@ function resolveScriptImport(Doc:table, Name:str):table
    doc_path = lspUriToPath(Doc.uri)
    base_path = getParentPath(doc_path)
    script_name = Name:endsWith('.tiri') and Name or (Name .. '.tiri')
+   local_import = Name:startsWith('./') or Name:startsWith('../')
 
-   if Name:startsWith('./') or Name:startsWith('../') then
+   if local_import then
       candidates:push(base_path .. script_name)
+   else
+      candidates:push('sdk:scripts/' .. script_name)
+      candidates:push('scripts:' .. script_name)
    end
-
-   candidates:push('sdk:scripts/' .. script_name)
-   candidates:push('scripts:' .. script_name)
 
    for candidate in values(candidates) do
       resolved = resolveExistingPath(candidate)

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -207,7 +207,8 @@ glKeywords = {
    -- Variables
    ['local'] = { comment = 'Declares a local variable (block-scoped).' },
    ['global'] = { comment = 'Declares a global variable.' },
-   ['import'] = { comment = 'Loads a Tiri module into the current scope.' },
+   ['import'] = { comment = 'Inlines a Tiri script library at parse time. Use ./ or ../ for local libraries.' },
+   ['as'] = { comment = 'Introduces a local alias for an imported library namespace.' },
 
    -- Pattern matching
    ['choose'] = { comment = 'Pattern matching expression (switch-like).' },

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -196,7 +196,7 @@ function hoverGetDocumentSymbols(Doc:table):array
 
    local result
    try
-      result = debug.validate(Doc.content, 'symbols')
+      result = debug.validate(Doc.content, { flags = 'symbols', path = lspUriToPath(Doc.uri) })
    except ex
       result = nil
    end

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -256,7 +256,7 @@ global FLUID_KEYWORDS = {
    ['choose'] = true, ['from'] = true, ['when'] = true,
 
    -- Declarations
-   ['function'] = true, ['local'] = true, ['global'] = true, ['thunk'] = true, ['import'] = true,
+   ['function'] = true, ['local'] = true, ['global'] = true, ['thunk'] = true, ['import'] = true, ['as'] = true,
 
    -- Special
    ['defer'] = true, ['catch'] = true, ['raise'] = true, ['check'] = true
@@ -444,7 +444,9 @@ end
 
 @Doc(text="Compute diagnostics for a document using debug.validate()")
 global function computeDiagnostics(Doc:table)
-   result = debug.validate(Doc.content)
+   -- Pass the document's file path so relative imports ('./lib') resolve against its directory rather than the
+   -- LSP server's working directory.
+   result = debug.validate(Doc.content, { path = lspUriToPath(Doc.uri) })
 
    lsp_diags = array<table>
 

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -346,7 +346,7 @@ function signatureGetDocumentSymbols(Doc:table):array
 
    local result
    try
-      result = debug.validate(Doc.content, 'symbols')
+      result = debug.validate(Doc.content, { flags = 'symbols', path = lspUriToPath(Doc.uri) })
    except ex
       result = nil
    end

--- a/tools/tiri_lsp/tests/relative_symbol_helper.tiri
+++ b/tools/tiri_lsp/tests/relative_symbol_helper.tiri
@@ -1,0 +1,1 @@
+global relative_symbol_helper_value = 1

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -87,6 +87,24 @@ end
    assertUriContains(locations, '/scripts/gui/window.tiri', 'Nested import should resolve to SDK script')
 end
 
+@Test function ImportParentRelativeScriptResolution()
+   doc = makeDoc("import '../server'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 11 })
+   assertUriContains(locations, '/tools/tiri_lsp/server.tiri', 'Parent-relative import should resolve from document path')
+end
+
+@Test function ImportAliasScriptResolution()
+   doc = makeDoc("import 'json' as jsonLib\n")
+   locations = resolveDefinition(doc, { line = 0, character = 9 })
+   assertUriContains(locations, '/scripts/json.tiri', 'Aliased import should still resolve its script target')
+end
+
+@Test function ExplicitLocalImportDoesNotFallbackToSdk()
+   doc = makeDoc("import './json'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 10 })
+   assert(not locations, 'Explicit local import should not fall back to SDK script resolution')
+end
+
 @Test function IncludeModuleResolution()
    doc = makeDoc("include 'network'\n")
    locations = resolveDefinition(doc, { line = 0, character = 10 })

--- a/tools/tiri_lsp/tests/test_hover.tiri
+++ b/tools/tiri_lsp/tests/test_hover.tiri
@@ -124,6 +124,30 @@ result = greet|('Ada')
    assertContains(hover, '`Name: str` - Person to greet', 'Call hover should include parameter documentation.')
 end
 
+@Test function DocAnnotatedFunctionCallHoverAfterRelativeImport()
+   hover, token = hoverAt([=[
+import './relative_symbol_helper'
+
+@Doc(text=[[
+   Returns a local greeting.
+
+   -INPUT-
+   Name: Person to greet
+]])
+function localGreeting(Name: str):str
+   return Name
+end
+
+result = local|Greeting('Ada')
+]=])
+
+   assert(token and token.text is 'localGreeting', 'Hover should identify the function call after a relative import.')
+   assertContains(hover, 'localGreeting(Name: str):str',
+      'Relative imports should not stop parser symbols from feeding hover.')
+   assertContains(hover, 'Returns a local greeting.',
+      'Hover should include @Doc text after a relative import.')
+end
+
 @Test function AssignedFunctionExpressionHover()
    hover, token = hoverAt([=[
 global greetGlobal = function(Name: str):str

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -69,6 +69,20 @@ end
    assert((function_name.modifiers & 4) != 0, '@FunctionName should be marked readonly.')
 end
 
+@Test function ImportKeywordAndAliasReceiveSemanticTokens()
+   source = "import '../server' as serverLib\n"
+
+   tokens = tokenizeTiri(source)
+
+   import_keyword = findToken(tokens, 0, 0, 'import')
+   alias_keyword = findToken(tokens, 0, 19, 'as')
+   import_path = findToken(tokens, 0, 7, "'../server'")
+
+   assert(import_keyword and import_keyword.type is 0, 'import should be highlighted as a keyword.')
+   assert(alias_keyword and alias_keyword.type is 0, 'import alias keyword should be highlighted as a keyword.')
+   assert(import_path and import_path.type is 4, 'Parent-relative import path should remain a string token.')
+end
+
 @Test function RangeSeparatorsReceiveContextualSemanticTokens()
    source = 'range_value = {0 to 5}\n' ..
       'range_value = {0 into 5}\n' ..

--- a/tools/tiri_lsp/tests/test_signature_help.tiri
+++ b/tools/tiri_lsp/tests/test_signature_help.tiri
@@ -111,6 +111,33 @@ result = greet('Ada', |)
       'Second parameter should include @Doc text.')
 end
 
+@Test function DocAnnotatedFunctionSignatureAfterRelativeImport()
+   help = signatureAt([=[
+import './relative_symbol_helper'
+
+@Doc(text=[[
+   Returns a local greeting.
+
+   -INPUT-
+   Name: Person to greet
+   Count: Number of greetings
+]])
+function localGreeting(Name: str, Count: num):str
+   return Name
+end
+
+result = localGreeting('Ada', |)
+]=])
+
+   signature = firstSignature(help)
+   assertContains(signature.label, 'localGreeting(Name: str, Count: num):str',
+      'Relative imports should not stop parser symbols from feeding signature help.')
+   assert(signature.documentation.value is 'Returns a local greeting.',
+      'Signature docs should survive relative import parsing.')
+   assert(signature.parameters[1].label is 'Count: num',
+      'Second parameter should remain available after a relative import.')
+end
+
 @Test function MixedTypedAndUntypedParameters()
    help = signatureAt([=[
 function mix(Untyped, Flag: bool)

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -197,7 +197,11 @@
             },
             {
                "name": "keyword.other.import.tiri",
-               "match": "\\b(require|include|using)\\b"
+               "match": "\\b(import|require|include)\\b"
+            },
+            {
+               "name": "keyword.other.alias.tiri",
+               "match": "\\b(as)\\b"
             },
             {
                "name": "support.function.builtin.tiri",


### PR DESCRIPTION
* Added path-aware debug.validate() options and parent-relative script import resolution
* [LSP] Resolved imports and parser symbols from the active document path for diagnostics, definitions, hover and signature help
* [Test] Covered parent-relative imports, import aliases and LSP symbol extraction after relative imports
* [Script] Stopped options help metadata from appending copyright and licence text