### PR TITLE
[Tiri] Replaced debug.validate flags string with a symbols option in …

### DIFF
--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -113,7 +113,7 @@ Function annotations are parsed in the C++ parser and can follow two different p
 - Runtime registration: `src/parser/ir_emitter/emit_function.cpp` and `src/lib/lib_debug.cpp` emit
   `debug.anno.set(func, "...", source, name)` for annotated functions so runtime code can inspect annotations.
 - Parser metadata extraction: `src/parser/parser_symbols.cpp`, `src/parser/parser_symbols.h` and
-  `src/lib/lib_debug.cpp` build the `debug.validate(Source, "symbols").symbols` table for LSP and documentation
+  `src/lib/lib_debug.cpp` build the `debug.validate(Source, { symbols = true }).symbols` table for LSP and documentation
   tooling.
 
 ### Runtime Annotation Registration
@@ -135,10 +135,10 @@ payloads in `debug.anno`.  Tooling paths that need the payload must enable `SCF:
 
 ### Parser Symbol Extraction
 
-`debug.validate(Source, "symbols")` is the public extraction path for parser-provided symbol and documentation metadata.
+`debug.validate(Source, { symbols = true })` is the public extraction path for parser-provided symbol and documentation metadata.
 In `LJLIB_CF(debug_validate)`:
 
-1. The `"symbols"` flag temporarily sets `L->script->Flags |= SCF::PROCESS_DOC`.
+1. The `symbols` option temporarily sets `L->script->Flags |= SCF::PROCESS_DOC`.
 2. `lua_load()` parses the source in diagnose mode.
 3. `collect_parser_symbols()` is called after AST construction from `parser.cpp`.
 4. `push_symbol_metadata()` converts `L->parser_symbols` into a Tiri table named `symbols`.

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -26,7 +26,7 @@
 //   debug.setHook([hook, mask [, count]]) - Sets the debug hook
 //   debug.getHook()             - Returns the current hook settings
 //   debug.traceback([msg [, level]]) - Returns a traceback string
-//   debug.validate(code [, flags]) - Parses code and returns diagnostics without execution
+//   debug.validate(code [, options]) - Parses code and returns diagnostics without execution
 //   debug.locality(name [, level]) - Returns locality of a variable: "local", "upvalue", "global", or "nil"
 //   debug.anno.get(func)        - Returns annotation entry for a function
 //   debug.anno.set(func, annotations [, source [, name]]) - Sets annotations for a function
@@ -1189,23 +1189,22 @@ LJLIB_CF(debug_validate)
 {
    CSTRING statement = luaL_checkstring(L, 1);
 
-   // The optional second argument may be a flags string (deprecated), or an options table accepting 'flags' and 'path'
-   // values.  A 'path' enables relative import resolution against the source file's directory (used by the LSP).
+   // The optional second argument may be an options table.  The 'symbols' boolean
+   // enables parser symbol extraction, and 'path' enables relative import resolution against the source file's
+   // directory (used by the LSP).
 
-   std::string flags;
    std::string source_path;
+   bool include_symbols = false;
    if (lua_istable(L, 2)) {
-      lua_getfield(L, 2, "flags");
-      if (CSTRING f = lua_tostring(L, -1)) flags.assign(f);
+      lua_getfield(L, 2, "symbols");
+      bool has_symbols_option = not lua_isnil(L, -1);
+      if (has_symbols_option) include_symbols = lua_toboolean(L, -1);
       lua_pop(L, 1);
 
       lua_getfield(L, 2, "path");
       if (CSTRING p = lua_tostring(L, -1)) source_path.assign(p);
       lua_pop(L, 1);
    }
-   else if (CSTRING f = luaL_optstring(L, 2, "")) flags.assign(f);
-
-   bool include_symbols = flags.find("symbols") != std::string_view::npos;
 
    // The chunk name carries the source path through to the parser so that relative imports ('./lib') resolve
    // against the document's directory.  Use a literal chunk name so validation of unsaved or stale LSP buffers does

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -471,6 +471,16 @@ end
    assert(result.success is true, "Valid function definition should succeed")
 end
 
+@Test function ValidateSymbolsOption()
+   code = "function symbolOption(Value: str):str return Value end"
+
+   result = debug.validate(code, { symbols = true })
+   assert(result.success is true, "Valid symbols option code should succeed")
+   assert(result.symbols != nil, "symbols=true should include a symbols table")
+   assert(#result.symbols is 1, "Expected one symbol with symbols=true")
+   assert(result.symbols[0].name is "symbolOption", "Expected symbolOption symbol")
+end
+
 @Test function ValidateSymbolsWithDocAnnotation()
    code = [=[
       @Doc(text=[[
@@ -490,7 +500,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Valid documented function should succeed")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
@@ -523,7 +533,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Valid compact documented function should succeed")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
@@ -561,7 +571,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Valid compact inferred result docs should succeed")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
@@ -591,7 +601,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Valid compact unknown result docs should succeed")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
@@ -617,7 +627,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Annotated function assignment should parse")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)
@@ -638,7 +648,7 @@ end
       end
    ]=]
 
-   result = debug.validate(code, "symbols")
+   result = debug.validate(code, { symbols = true })
    assert(result.success is true, "Valid global function expression should succeed")
    assert(result.symbols != nil, "symbols option should include a symbols table")
    assert(#result.symbols is 1, "Expected one symbol, got " .. #result.symbols)

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -196,7 +196,7 @@ function hoverGetDocumentSymbols(Doc:table):array
 
    local result
    try
-      result = debug.validate(Doc.content, { flags = 'symbols', path = lspUriToPath(Doc.uri) })
+      result = debug.validate(Doc.content, { symbols = true, path = lspUriToPath(Doc.uri) })
    except ex
       result = nil
    end
@@ -343,7 +343,7 @@ global function resolveHoverContent(TokenInfo, Doc)
       return formatBuiltinHover(token, glDefs.builtins[token])
    end
 
-   -- Check current-document functions parsed by debug.validate(..., 'symbols')
+   -- Check current-document functions parsed by debug.validate(..., { symbols = true })
    document_hover = resolveDocumentSymbolHover(TokenInfo, Doc)
    if document_hover then return document_hover end
 

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -346,7 +346,7 @@ function signatureGetDocumentSymbols(Doc:table):array
 
    local result
    try
-      result = debug.validate(Doc.content, { flags = 'symbols', path = lspUriToPath(Doc.uri) })
+      result = debug.validate(Doc.content, { symbols = true, path = lspUriToPath(Doc.uri) })
    except ex
       result = nil
    end


### PR DESCRIPTION
…the options table

* Removed the deprecated flags string parameter in favour of a 'symbols' boolean in the options table
* [Test] Added ValidateSymbolsOption coverage and migrated existing tests to the new options form
* [Doc] Updated AGENTS.md, LSP hover and signature callers to use { symbols = true }