### PR TITLE
[SVG] Refactored RSVG as a derived class of extImage using placement …

### DIFF
--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -1401,6 +1401,7 @@ static ERR create_image_class(void)
       fl::Icon("filetypes/image"),
       fl::Actions(clImageActions),
       fl::Fields(clFields),
+      fl::PublicSize(0),
       fl::Size(sizeof(extImage)),
       fl::Path(MOD_PATH));
 

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -1,3 +1,4 @@
+// This class is visible to derived classes as they need access to internal fields
 
 class extImage : public objImage {
    public:

--- a/src/svg/class_rsvg.cpp
+++ b/src/svg/class_rsvg.cpp
@@ -12,19 +12,24 @@ handling of both standard (.svg) and compressed (.svgz) SVG files.
 
 *********************************************************************************************************************/
 
-// SVG renderer for the Image class
-
 #include "../image/image.h"
+
+class extRSVG : public extImage {
+   public:
+   class objSVG *SVG = nullptr;
+
+   ~extRSVG() {
+      if (SVG) FreeResource(SVG);
+   }
+
+   extRSVG(objMetaClass *pClass, OBJECTID pUID) : extImage(pClass, pUID) { }
+};
 
 //********************************************************************************************************************
 
-static ERR RSVG_Activate(extImage *Self)
+static ERR RSVG_Activate(extRSVG *Self)
 {
-   prvSVG *prv;
-   if (not (prv = (prvSVG *)Self->DerivedPtr)) return ERR::NotInitialised;
-
-   ERR error;
-   if ((error = acQuery(Self)) != ERR::Okay) return error;
+   if (auto error = acQuery(Self); error != ERR::Okay) return error;
 
    auto bmp = Self->Bitmap;
    if (!bmp->initialised()) {
@@ -32,23 +37,21 @@ static ERR RSVG_Activate(extImage *Self)
    }
 
    gfx::DrawRectangle(bmp, 0, 0, bmp->Width, bmp->Height, 0, BAF::FILL); // Black background
-   prv->SVG->render(bmp, 0, 0, bmp->Width, bmp->Height);
+   Self->SVG->render(bmp, 0, 0, bmp->Width, bmp->Height);
    return ERR::Okay;
 }
 
 //********************************************************************************************************************
 
-static ERR RSVG_Free(extImage *Self)
+static ERR RSVG_FreePlacement(extRSVG *Self)
 {
-   if (auto prv = (prvSVG *)Self->DerivedPtr) {
-      if (prv->SVG) { FreeResource(prv->SVG); prv->SVG = nullptr; }
-   }
+   Self->~extRSVG();
    return ERR::Okay;
 }
 
 //********************************************************************************************************************
 
-static ERR RSVG_Init(extImage *Self)
+static ERR RSVG_Init(extRSVG *Self)
 {
    kt::Log log;
    std::string_view path;
@@ -73,31 +76,34 @@ static ERR RSVG_Init(extImage *Self)
 
    Self->Flags |= PCF::SCALABLE;
 
-   if (!AllocMemory(sizeof(prvSVG), MEM::DATA, &Self->DerivedPtr)) {
-      if ((Self->Flags & PCF::LAZY) != PCF::NIL) return ERR::Okay;
-      return acActivate(Self);
-   }
-   else return ERR::AllocMemory;
+   if ((Self->Flags & PCF::LAZY) != PCF::NIL) return ERR::Okay;
+   return acActivate(Self);
 }
 
 //********************************************************************************************************************
 
-static ERR RSVG_Query(extImage *Self)
+static ERR RSVG_NewPlacement(extRSVG *Self)
+{
+   new (Self) extRSVG(Self->Class, Self->UID);
+   return ERR::Okay;
+}
+
+//********************************************************************************************************************
+
+static ERR RSVG_Query(extRSVG *Self)
 {
    kt::Log log;
-   prvSVG *prv;
    objBitmap *bmp;
 
-   if (not (prv = (prvSVG *)Self->DerivedPtr)) return ERR::NotInitialised;
    if (not (bmp = Self->Bitmap)) return log.warning(ERR::ObjectCorrupt);
 
    if (Self->Queried) return ERR::Okay;
    Self->Queried = TRUE;
 
-   if (not prv->SVG) {
+   if (not Self->SVG) {
       std::string_view path;
       if (!Self->getPath(path)) {
-         if ((prv->SVG = objSVG::create::local(fl::Path(path)))) {
+         if ((Self->SVG = objSVG::create::local(fl::Path(path)))) {
          }
          else return log.warning(ERR::CreateObject);
       }
@@ -106,7 +112,7 @@ static ERR RSVG_Query(extImage *Self)
 
    objVectorScene *scene;
    ERR error;
-   if ((!(error = prv->SVG->getScene(scene))) and (scene)) {
+   if ((!(error = Self->SVG->getScene(scene))) and (scene)) {
       if ((Self->Flags & PCF::FORCE_ALPHA_32) != PCF::NIL) {
          bmp->Flags |= BMF::ALPHA_CHANNEL;
          bmp->BitsPerPixel  = 32;
@@ -168,26 +174,23 @@ static ERR RSVG_Query(extImage *Self)
 
 //********************************************************************************************************************
 
-static ERR RSVG_Resize(extImage *Self, struct acResize *Args)
+static ERR RSVG_Resize(extRSVG *Self, struct acResize *Args)
 {
-   prvSVG *prv;
-   if (not (prv = (prvSVG *)Self->DerivedPtr)) return ERR::NotInitialised;
-
    if (not Args) return ERR::NullArgs;
 
-   if (prv->SVG) {
+   if (Self->SVG) {
       if (!Self->Bitmap->initialised()) {
          if (InitObject(Self->Bitmap) != ERR::Okay) return ERR::Init;
       }
 
       if (!Action(AC::Resize, Self->Bitmap, Args)) {
          objVectorScene *scene;
-         if ((!prv->SVG->getScene(scene)) and (scene)) {
+         if ((!Self->SVG->getScene(scene)) and (scene)) {
             scene->setPageWidth(Self->Bitmap->Width);
             scene->setPageHeight(Self->Bitmap->Height);
 
             gfx::DrawRectangle(Self->Bitmap, 0, 0, Self->Bitmap->Width, Self->Bitmap->Height, 0, BAF::FILL);
-            acDraw(prv->SVG);
+            acDraw(Self->SVG);
          }
          else return ERR::GetField;
 
@@ -201,11 +204,12 @@ static ERR RSVG_Resize(extImage *Self, struct acResize *Args)
 //********************************************************************************************************************
 
 static const ActionArray clActions[] = {
-   { AC::Activate, RSVG_Activate },
-   { AC::Free,     RSVG_Free },
-   { AC::Init,     RSVG_Init },
-   { AC::Query,    RSVG_Query },
-   { AC::Resize,   RSVG_Resize },
+   { AC::Activate,      RSVG_Activate },
+   { AC::FreePlacement, RSVG_FreePlacement },
+   { AC::Init,          RSVG_Init },
+   { AC::NewPlacement,  RSVG_NewPlacement },
+   { AC::Query,         RSVG_Query },
+   { AC::Resize,        RSVG_Resize },
    { AC::NIL, nullptr }
 };
 
@@ -221,6 +225,7 @@ static ERR init_rsvg(void)
       fl::FileExtension("svg|svgz"),
       fl::FileDescription("SVG image"),
       fl::Actions(clActions),
+      fl::Size(sizeof(extRSVG)),
       fl::Path(MOD_PATH));
 
    return clRSVG ? ERR::Okay : ERR::AddClass;

--- a/src/svg/class_rsvg.cpp
+++ b/src/svg/class_rsvg.cpp
@@ -15,12 +15,13 @@ handling of both standard (.svg) and compressed (.svgz) SVG files.
 #include "../image/image.h"
 
 class extRSVG : public extImage {
-   public:
-   class objSVG *SVG = nullptr;
+public:
+   // NB: Private variables aren't permitted for derived image classes
 
-   ~extRSVG() {
-      if (SVG) FreeResource(SVG);
-   }
+   // Storing the SVG object in DerivedPtr avoids overhead and the Free function will automatically terminate it.
+   inline objSVG * svg() { return (objSVG *)DerivedPtr; }
+
+   ~extRSVG() {}
 
    extRSVG(objMetaClass *pClass, OBJECTID pUID) : extImage(pClass, pUID) { }
 };
@@ -29,15 +30,18 @@ class extRSVG : public extImage {
 
 static ERR RSVG_Activate(extRSVG *Self)
 {
+   kt::Log log;
+   log.branch();
+
    if (auto error = acQuery(Self); error != ERR::Okay) return error;
 
    auto bmp = Self->Bitmap;
-   if (!bmp->initialised()) {
+   if (not bmp->initialised()) {
       if (InitObject(bmp) != ERR::Okay) return ERR::Init;
    }
 
    gfx::DrawRectangle(bmp, 0, 0, bmp->Width, bmp->Height, 0, BAF::FILL); // Black background
-   Self->SVG->render(bmp, 0, 0, bmp->Width, bmp->Height);
+   Self->svg()->render(bmp, 0, 0, bmp->Width, bmp->Height);
    return ERR::Okay;
 }
 
@@ -54,8 +58,8 @@ static ERR RSVG_FreePlacement(extRSVG *Self)
 static ERR RSVG_Init(extRSVG *Self)
 {
    kt::Log log;
-   std::string_view path;
 
+   std::string_view path;
    Self->getPath(path);
 
    if (path.empty() or ((Self->Flags & PCF::NEW) != PCF::NIL)) {
@@ -100,10 +104,10 @@ static ERR RSVG_Query(extRSVG *Self)
    if (Self->Queried) return ERR::Okay;
    Self->Queried = TRUE;
 
-   if (not Self->SVG) {
+   if (not Self->svg()) {
       std::string_view path;
       if (!Self->getPath(path)) {
-         if ((Self->SVG = objSVG::create::local(fl::Path(path)))) {
+         if ((Self->DerivedPtr = objSVG::create::local(fl::Path(path)))) {
          }
          else return log.warning(ERR::CreateObject);
       }
@@ -112,7 +116,7 @@ static ERR RSVG_Query(extRSVG *Self)
 
    objVectorScene *scene;
    ERR error;
-   if ((!(error = Self->SVG->getScene(scene))) and (scene)) {
+   if ((!(error = Self->svg()->getScene(scene))) and (scene)) {
       if ((Self->Flags & PCF::FORCE_ALPHA_32) != PCF::NIL) {
          bmp->Flags |= BMF::ALPHA_CHANNEL;
          bmp->BitsPerPixel  = 32;
@@ -178,19 +182,19 @@ static ERR RSVG_Resize(extRSVG *Self, struct acResize *Args)
 {
    if (not Args) return ERR::NullArgs;
 
-   if (Self->SVG) {
-      if (!Self->Bitmap->initialised()) {
+   if (Self->svg()) {
+      if (not Self->Bitmap->initialised()) {
          if (InitObject(Self->Bitmap) != ERR::Okay) return ERR::Init;
       }
 
       if (!Action(AC::Resize, Self->Bitmap, Args)) {
          objVectorScene *scene;
-         if ((!Self->SVG->getScene(scene)) and (scene)) {
+         if ((!Self->svg()->getScene(scene)) and (scene)) {
             scene->setPageWidth(Self->Bitmap->Width);
             scene->setPageHeight(Self->Bitmap->Height);
 
             gfx::DrawRectangle(Self->Bitmap, 0, 0, Self->Bitmap->Width, Self->Bitmap->Height, 0, BAF::FILL);
-            acDraw(Self->SVG);
+            acDraw(Self->svg());
          }
          else return ERR::GetField;
 

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -41,10 +41,6 @@ JUMPTABLE_VECTOR
 static OBJECTPTR clSVG = nullptr, clRSVG = nullptr, modDisplay = nullptr, modVector = nullptr, modImage = nullptr;
 static double glDisplayHDPI = 96, glDisplayVDPI = 96, glDisplayDPI = 96;
 
-struct prvSVG { // Private variables for RSVG
-   class objSVG *SVG;
-};
-
 struct svgInherit {
    OBJECTPTR Object;
    std::string ID;


### PR DESCRIPTION
…construction

* Replaced the prvSVG/DerivedPtr allocation pattern with an extRSVG class that holds the SVG object directly and frees it via a destructor
* Migrated RSVG to NewPlacement/FreePlacement actions, dropping the legacy AC::Free hook
* [Image] Exposed extImage to derived classes via PublicSize(0) so RSVG can inherit its internal fields