### PR TITLE
[Tiri] Report empty comments appended to variables

### DIFF
--- a/src/tiri/jit/src/debug/lj_errmsg.h
+++ b/src/tiri/jit/src/debug/lj_errmsg.h
@@ -143,6 +143,7 @@ ERRDEF(XLUNDEF,    "Undefined label " LUA_QS)
 ERRDEF(XLDUP,      "Duplicate label " LUA_QS)
 ERRDEF(XFSTR_EMPTY, "Empty interpolation in f-string")
 ERRDEF(XFSTR_BRACE, "Unclosed brace in f-string interpolation")
+ERRDEF(XEMPTYCOMMENT, "Empty comment appended to variable is not a decrement operation")
 ERRDEF(XNEST,       "Try blocks nested too deeply")
 ERRDEF(BADLIBRARY,  "Invalid library name; only alpha-numeric names are permitted with max 96 chars.")
 

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -67,6 +67,34 @@ namespace {
    constexpr bool is_sync_char(LexChar c) noexcept {
       return c IS ',' or c IS ';' or c IS '}' or c IS ')' or c IS ']';
    }
+
+   constexpr bool is_comment_blank(LexChar c) noexcept {
+      return c IS ' ' or c IS '\t' or c IS '\v' or c IS '\f';
+   }
+
+   [[nodiscard]] bool is_empty_short_comment(const LexState *State) noexcept {
+      if (State->c IS LEX_EOF) return true;
+
+      size_t offset = State->current_offset;
+      while (offset < State->source.size()) {
+         LexChar c = LexChar(uint8_t(State->source[offset]));
+         if (lex_iseol(c)) return true;
+         if (not is_comment_blank(c)) return false;
+         ++offset;
+      }
+
+      return true;
+   }
+
+   [[nodiscard]] bool is_empty_comment_appended_to_name(const LexState *State) noexcept {
+      if (State->tok != TK_name) return false;
+
+      size_t token_offset = State->pending_token_offset;
+      if (token_offset IS 0 or token_offset > State->source.size()) return false;
+
+      LexChar previous = LexChar(uint8_t(State->source[token_offset - 1]));
+      return lj_char_isident(previous) and is_empty_short_comment(State);
+   }
 } // anonymous namespace
 
 //********************************************************************************************************************
@@ -1189,6 +1217,11 @@ static LexToken lex_scan(LexState *State, TValue *tv)
                   lj_buf_reset(&State->sb);
                   continue;
                }
+            }
+
+            if (is_empty_comment_appended_to_name(State)) {
+               lj_lex_error(State, 0, ErrMsg::XEMPTYCOMMENT);
+               if (State->had_lex_error) continue;
             }
 
             // Short comment "--.*\n"

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -113,7 +113,7 @@ struct AstHarnessResult {
 
 //********************************************************************************************************************
 
-static AstHarnessResult build_ast_from_source(std::string_view source)
+static AstHarnessResult build_ast_from_source(std::string_view source, bool Diagnose = false)
 {
    AstHarnessResult result;
    result.state = std::make_unique<LuaStateHolder>();
@@ -124,6 +124,7 @@ static AstHarnessResult build_ast_from_source(std::string_view source)
    ctx.size = source.size();
 
    LexState lex(L, unit_reader, &ctx, "parser-unit", std::nullopt);
+   lex.diagnose_mode = Diagnose;
    FuncState& fs = lex.fs_init();
 
    ParserAllocator allocator = ParserAllocator::from(L);
@@ -389,6 +390,21 @@ static bool test_expression_list_entry_point(kt::Log &log)
    }
 
    return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_empty_comment_appended_to_variable(kt::Log &log)
+{
+   auto result = build_ast_from_source("value--\n", true);
+
+   for (const ParserDiagnostic &diagnostic : result.diagnostics) {
+      if (diagnostic.message IS "Empty comment appended to variable is not a decrement operation") return true;
+   }
+
+   log.error("expected empty appended comment diagnostic");
+   log_diagnostics(result.diagnostics, log);
+   return false;
 }
 
 //********************************************************************************************************************
@@ -1563,12 +1579,13 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 19> tests = { {
+   constexpr std::array<TestCase, 20> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
       { "expression_entry_point", test_expression_entry_point },
       { "expression_list_entry_point", test_expression_list_entry_point },
+      { "empty_comment_appended_to_variable", test_empty_comment_appended_to_variable },
       { "loop_ast", test_loop_ast },
       { "if_stmt_with_elseif_ast", test_if_stmt_with_elseif_ast },
       { "local_function_table_ast", test_local_function_table_ast },

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -30,6 +30,14 @@ end
    assert(diag.message != nil, "Diagnostic should have message")
 end
 
+@Test function ValidateEmptyCommentAppendedToVariableDiagnostic()
+   result = debug.validate("value--\n")
+   assert(result.success is false, "Appended empty comment should fail validation")
+   assert(#result.diagnostics > 0, "Should have diagnostics")
+   assert(result.diagnostics[0].message is 'Empty comment appended to variable is not a decrement operation',
+      'Should report the appended empty comment diagnostic')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Malformed type declarations and annotations
 


### PR DESCRIPTION
* Added a lexer diagnostic for empty short comments directly appended to identifier tokens
* Added parser unit and Flute coverage for debug.validate() reporting of value--