### PR TITLE
[Core] Updated derived file teardown handling

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2697,7 +2697,9 @@ class objFile : public Object {
    int64_t  Position;   // The current read/write byte position in a file.
    std::string Path;    // Specifies the location of a file or folder.
    FL       Flags;      // File flags and options.
+   PERMIT   Permissions; // Manages the permissions of a file.
    int8_t * Buffer;     // Points to the internal data buffer if the file content is held in memory.
+   int64_t  Size;       // The byte size of a file.
    public:
    inline std::string readLine() {
       std::string str;
@@ -2825,10 +2827,26 @@ class objFile : public Object {
       return ERR::Okay;
    }
 
+   inline ERR getPermissions(PERMIT &Value) noexcept {
+      auto field = &this->Class->Dictionary[19];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
    inline ERR getBuffer(std::span<int8_t> &Value) noexcept {
       auto field = &this->Class->Dictionary[12];
       auto get_field = (ERR (*)(APTR, std::span<int8_t> &))field->GetValue;
       return get_field(this, Value);
+   }
+
+   inline ERR getSize(int64_t &Value) noexcept {
+      auto field = &this->Class->Dictionary[6];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
    }
 
    inline ERR getDate(struct DateTime * &Value) noexcept {
@@ -2841,14 +2859,6 @@ class objFile : public Object {
 
    inline ERR getCreated(struct DateTime * &Value) noexcept {
       auto field = &this->Class->Dictionary[3];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getPermissions(PERMIT &Value) noexcept {
-      auto field = &this->Class->Dictionary[19];
       SetObjectContext(this, field, AC::NIL);
       auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
@@ -2874,14 +2884,6 @@ class objFile : public Object {
       SetObjectContext(this, field, AC::NIL);
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getSize(int64_t &Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
       RestoreObjectContext();
       return error;
    }
@@ -2937,11 +2939,6 @@ class objFile : public Object {
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
-   inline ERR setDate(const struct DateTime & Value) noexcept {
-      auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(this, field, FD_STRUCT, &Value);
-   }
-
    inline ERR setPermissions(const PERMIT Value) noexcept {
       auto field = &this->Class->Dictionary[19];
       return field->WriteValue(this, field, FD_INT, &Value);
@@ -2950,6 +2947,11 @@ class objFile : public Object {
    inline ERR setSize(const int64_t Value) noexcept {
       auto field = &this->Class->Dictionary[6];
       return field->WriteValue(this, field, FD_INT64, &Value);
+   }
+
+   inline ERR setDate(const struct DateTime & Value) noexcept {
+      auto field = &this->Class->Dictionary[10];
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
    }
 
    inline ERR setLink(const std::string_view &Value) noexcept {

--- a/src/core/classes/class_assets.cpp
+++ b/src/core/classes/class_assets.cpp
@@ -32,7 +32,7 @@ static bool glAssetManagerFree = false;
 constexpr int LEN_ASSETS = 7; // "assets:" length
 
 static ERR ASSET_Delete(objFile *, APTR);
-static ERR ASSET_Free(objFile *);
+static ERR ASSET_FreePlacement(objFile *);
 static ERR ASSET_Init(objFile *, APTR);
 static ERR ASSET_Move(objFile *, struct mtFileMove *);
 static ERR ASSET_Read(objFile *, struct acRead *);
@@ -52,13 +52,13 @@ static const FieldArray clFields[] = {
 };
 
 static const ActionArray clActions[] = {
-   { AC::Free,   ASSET_Free },
-   { AC::Init,   ASSET_Init },
-   { AC::Move,   ASSET_Move },
-   { AC::Read,   ASSET_Read },
-   { AC::Rename, ASSET_Rename },
-   { AC::Seek,   ASSET_Seek },
-   { AC::Write,  ASSET_Write },
+   { AC::FreePlacement, ASSET_FreePlacement },
+   { AC::Init,          ASSET_Init },
+   { AC::Move,          ASSET_Move },
+   { AC::Read,          ASSET_Read },
+   { AC::Rename,        ASSET_Rename },
+   { AC::Seek,          ASSET_Seek },
+   { AC::Write,         ASSET_Write },
    { 0, nullptr }
 };
 
@@ -83,7 +83,7 @@ static AAssetManager * get_asset_manager(void);
 
 //********************************************************************************************************************
 
-static bool is_asset_separator(char Value)
+inline bool is_asset_separator(char Value)
 {
    return (Value IS '/') or (Value IS '\\');
 }
@@ -216,21 +216,15 @@ static ERR ASSET_Delete(objFile *Self)
 
 //********************************************************************************************************************
 
-static ERR ASSET_Free(objFile *Self)
+static ERR ASSET_FreePlacement(objFile *Self)
 {
    if (auto prv = (prvFileAsset *)Self->DerivedPtr) {
-      if (prv->Asset) {
-         AAsset_close(prv->Asset);
-         prv->Asset = nullptr;
-      }
-
-      if (prv->Dir) {
-         AAssetDir_close(prv->Dir);
-         prv->Dir = nullptr;
-      }
+      if (prv->Asset) AAsset_close(prv->Asset);
+      if (prv->Dir) AAssetDir_close(prv->Dir);
+      // Let Free call FreeResource()
    }
 
-   return ERR::Okay;
+   return ERR::NothingDone;
 }
 
 //********************************************************************************************************************

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -2726,15 +2726,15 @@ static const FieldArray FileFields[] = {
    { "Path",         FDF_CPPSTRING|FDF_RI, nullptr, SET_Path },
    { "Src",          FDF_SYNONYM },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, SET_Flags, &clFileFlags },
+   { "Permissions",  FDF_INTFLAGS|FDF_RW, GET_Permissions, SET_Permissions, &clFilePERMIT },
    { "Buffer",       FDF_ARRAY|FDF_BYTE|FDF_R|FDF_PURE, GET_Buffer },
+   { "Size",         FDF_INT64|FDF_RW, GET_Size, SET_Size },
    // Virtual fields
    { "Date",         FDF_VIRTUAL|FDF_STRUCT|FDF_RW,        GET_Date, SET_Date, "DateTime" },
    { "Created",      FDF_VIRTUAL|FDF_STRUCT|FDF_R,         GET_Created, nullptr, "DateTime" },
    { "Handle",       FDF_VIRTUAL|FDF_INT64|FDF_R|FDF_PURE, GET_Handle },
    { "Icon",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_R,      GET_Icon },
-   { "Permissions",  FDF_VIRTUAL|FDF_INTFLAGS|FDF_RW,      GET_Permissions, SET_Permissions, &clFilePERMIT },
    { "ResolvedPath", FDF_VIRTUAL|FDF_CPPSTRING|FDF_R,      GET_ResolvedPath },
-   { "Size",         FDF_VIRTUAL|FDF_INT64|FDF_RW,         GET_Size, SET_Size },
    { "Timestamp",    FDF_VIRTUAL|FDF_INT64|FDF_R,          GET_Timestamp },
    { "Link",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW,     GET_Link, SET_Link },
    { "User",         FDF_VIRTUAL|FDF_INT|FDF_RW,           GET_User, SET_User },
@@ -2755,6 +2755,7 @@ extern ERR add_file_class(void)
       fl::Actions(clFileActions),
       fl::Methods(clFileMethods),
       fl::Fields(FileFields),
+      fl::PublicSize(sizeof(objFile)),
       fl::Size(sizeof(extFile)),
       fl::Path("modules:core"));
 

--- a/src/core/classes/class_file_def.c
+++ b/src/core/classes/class_file_def.c
@@ -20,6 +20,47 @@ static const struct FieldDef clFileFlags[] = {
    { nullptr, 0 }
 };
 
+static const struct FieldDef clFilePermissions[] = {
+   { "Read", 0x00000001 },
+   { "UserRead", 0x00000001 },
+   { "UserWrite", 0x00000002 },
+   { "Write", 0x00000002 },
+   { "Exec", 0x00000004 },
+   { "UserExec", 0x00000004 },
+   { "Delete", 0x00000008 },
+   { "User", 0x0000000f },
+   { "GroupRead", 0x00000010 },
+   { "GroupWrite", 0x00000020 },
+   { "GroupExec", 0x00000040 },
+   { "GroupDelete", 0x00000080 },
+   { "Group", 0x000000f0 },
+   { "OthersRead", 0x00000100 },
+   { "AllRead", 0x00000111 },
+   { "EveryoneRead", 0x00000111 },
+   { "OthersWrite", 0x00000200 },
+   { "AllWrite", 0x00000222 },
+   { "EveryoneWrite", 0x00000222 },
+   { "EveryoneReadwrite", 0x00000333 },
+   { "OthersExec", 0x00000400 },
+   { "AllExec", 0x00000444 },
+   { "EveryoneExec", 0x00000444 },
+   { "OthersDelete", 0x00000800 },
+   { "AllDelete", 0x00000888 },
+   { "EveryoneDelete", 0x00000888 },
+   { "Others", 0x00000f00 },
+   { "EveryoneAccess", 0x00000fff },
+   { "Hidden", 0x00001000 },
+   { "Archive", 0x00002000 },
+   { "Password", 0x00004000 },
+   { "Userid", 0x00008000 },
+   { "Groupid", 0x00010000 },
+   { "Inherit", 0x00020000 },
+   { "Offline", 0x00040000 },
+   { "Network", 0x00080000 },
+   { "Meta", 0x000c5000 },
+   { nullptr, 0 }
+};
+
 static const struct FieldDef clFilePERMIT[] = {
    { "Read", 0x00000001 },
    { "UserRead", 0x00000001 },

--- a/src/core/compression/class_archive.cpp
+++ b/src/core/compression/class_archive.cpp
@@ -16,15 +16,15 @@ ArchiveName for reference.  In the C++ example below, take note of the use of `u
 
 <pre>
 objCompression::create::untracked(
-   fl::Path("user:documents/myfile.zip"),
-   fl::ArchiveName("myfiles")
+   fl::Path('user:documents/myfile.zip'),
+   fl::ArchiveName('myfiles')
 );
 </pre>
 
 With the Compression object in place, opening files within the archive only requires the correct path
 reference.  The format is `archive:ArchiveName/path/to/file.ext` and the Tiri example below illustrates:
 
-`obj.new('file', { path='archive:myfiles/readme.txt', flags='!READ' })`
+`obj.new('file', { path='archive:myfiles/readme.txt', flags=FL_READ })`
 
 -END-
 
@@ -37,7 +37,7 @@ constexpr int LEN_ARCHIVE = 8; // "archive:" length
 struct prvFileArchive {
    ZipFile  Info;
    ZStream  Inflate;      // Streaming decompression state for the active archive entry
-   extFile  *FileStream;
+   objFile  *FileStream;
    extCompression *Archive;
    uint8_t  InputBuffer[SIZE_COMPRESSION_BUFFER];
    uint8_t  OutputBuffer[SIZE_COMPRESSION_BUFFER];
@@ -60,7 +60,7 @@ static ERR test_path(std::string &, RSF, LOC *);
 
 //********************************************************************************************************************
 
-static void reset_state(extFile *Self)
+static void reset_state(objFile *Self)
 {
    auto prv = (prvFileArchive *)Self->DerivedPtr;
 
@@ -73,7 +73,7 @@ static void reset_state(extFile *Self)
 
 //********************************************************************************************************************
 
-static ERR seek_to_item(extFile *Self)
+static ERR seek_to_item(objFile *Self)
 {
    auto prv = (prvFileArchive *)Self->DerivedPtr;
    if (prv->InvalidState) return ERR::InvalidState;
@@ -148,7 +148,7 @@ static extCompression * find_archive(std::string_view Path, std::string &FilePat
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Activate(extFile *Self)
+static ERR ARCHIVE_Activate(objFile *Self)
 {
    Log log;
 
@@ -160,7 +160,7 @@ static ERR ARCHIVE_Activate(extFile *Self)
 
    log.msg("Allocating file stream for item %s", prv->Info.Name.c_str());
 
-   if ((prv->FileStream = extFile::create::local(
+   if ((prv->FileStream = objFile::create::local(
       fl::Name("ArchiveFileStream"),
       fl::Path(prv->Archive->Path),
       fl::Flags(FL::READ)))) {
@@ -174,21 +174,19 @@ static ERR ARCHIVE_Activate(extFile *Self)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Free(extFile *Self)
+static ERR ARCHIVE_FreePlacement(objFile *Self)
 {
-   auto prv = (prvFileArchive *)Self->DerivedPtr;
-
-   if (prv) {
-      if (prv->FileStream) { FreeResource(prv->FileStream); prv->FileStream = nullptr; }
-      prv->~prvFileArchive();
+   if (auto prv = (prvFileArchive *)Self->DerivedPtr) {
+      if (FileStream) FreeResource(FileStream);
+      // Let Free call FreeResource()
    }
 
-   return ERR::Okay;
+   return ERR::NothingDone;
 }
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Init(extFile *Self)
+static ERR ARCHIVE_Init(objFile *Self)
 {
    Log log;
 
@@ -249,7 +247,7 @@ static ERR ARCHIVE_Init(extFile *Self)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Query(extFile *Self)
+static ERR ARCHIVE_Query(objFile *Self)
 {
    auto prv = (prvFileArchive *)(Self->DerivedPtr);
 
@@ -286,7 +284,7 @@ static ERR ARCHIVE_Query(extFile *Self)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
+static ERR ARCHIVE_Read(objFile *Self, struct acRead *Args)
 {
    Log log;
 
@@ -383,7 +381,7 @@ static ERR ARCHIVE_Read(extFile *Self, struct acRead *Args)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Seek(extFile *Self, struct acSeek *Args)
+static ERR ARCHIVE_Seek(objFile *Self, struct acSeek *Args)
 {
    Log log;
    int64_t pos;
@@ -416,7 +414,7 @@ static ERR ARCHIVE_Seek(extFile *Self, struct acSeek *Args)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_Write(extFile *Self, struct acWrite *Args)
+static ERR ARCHIVE_Write(objFile *Self, struct acWrite *Args)
 {
    Log log;
    return log.warning(ERR::NoSupport);
@@ -424,7 +422,7 @@ static ERR ARCHIVE_Write(extFile *Self, struct acWrite *Args)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_GET_Size(extFile *Self, int64_t *Value)
+static ERR ARCHIVE_GET_Size(objFile *Self, int64_t *Value)
 {
    if (auto prv = (prvFileArchive *)Self->DerivedPtr) {
       *Value = prv->Info.OriginalSize;
@@ -435,7 +433,7 @@ static ERR ARCHIVE_GET_Size(extFile *Self, int64_t *Value)
 
 //********************************************************************************************************************
 
-static ERR ARCHIVE_GET_Timestamp(extFile *Self, int64_t *Value)
+static ERR ARCHIVE_GET_Timestamp(objFile *Self, int64_t *Value)
 {
    if (auto prv = (prvFileArchive *)Self->DerivedPtr) {
       if (prv->Info.Timestamp) {
@@ -668,7 +666,7 @@ static ERR test_path(std::string &Path, RSF Flags, LOC *Type)
 
 static const ActionArray clArchiveActions[] = {
    { AC::Activate, ARCHIVE_Activate },
-   { AC::Free,     ARCHIVE_Free },
+   { AC::FreePlacement, ARCHIVE_FreePlacement },
    { AC::Init,     ARCHIVE_Init },
    { AC::Query,    ARCHIVE_Query },
    { AC::Read,     ARCHIVE_Read },

--- a/src/core/compression/class_archive.cpp
+++ b/src/core/compression/class_archive.cpp
@@ -178,7 +178,7 @@ static ERR ARCHIVE_FreePlacement(objFile *Self)
 {
    if (auto prv = (prvFileArchive *)Self->DerivedPtr) {
       if (prv->FileStream) FreeResource(prv->FileStream);
-      prv->~prvFileArchive()
+      prv->~prvFileArchive();
       // Let Free call FreeResource()
    }
 

--- a/src/core/compression/class_archive.cpp
+++ b/src/core/compression/class_archive.cpp
@@ -177,7 +177,8 @@ static ERR ARCHIVE_Activate(objFile *Self)
 static ERR ARCHIVE_FreePlacement(objFile *Self)
 {
    if (auto prv = (prvFileArchive *)Self->DerivedPtr) {
-      if (FileStream) FreeResource(FileStream);
+      if (prv->FileStream) FreeResource(prv->FileStream);
+      prv->~prvFileArchive()
       // Let Free call FreeResource()
    }
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -438,23 +438,25 @@ class extMetaClass : public objMetaClass {
 class extFile : public objFile {
    public:
    using create = kt::Create<extFile>;
+
    struct DateTime prvModified;
    struct DateTime prvCreated;
    std::string prvIcon;
    std::string prvLine;
    std::string prvResolvedPath;
+
    #ifdef __unix__
       std::string prvLink;
    #endif
-   int64_t Size;
+
    #ifdef _WIN32
       int  Stream;
    #else
       APTR  Stream;
    #endif
+
    struct rkWatchPath *prvWatch;
    struct DirInfo *prvList;
-   PERMIT Permissions;
    bool   isFolder;
    int    Handle;         // Native system file handle
 

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -1393,10 +1393,11 @@ inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
     large     Position  # The current read/write byte position in a file.
     string    Path      # The file path.
     int(FL)   Flags     # File flags and options.
+    int(PERMIT) Permissions
     array(char) Buffer  # Points to the internal data buffer if the file content is held in memory.
+    large     Size      # The size of the file's content.
     ~struct(DateTime) Date
     ~struct(DateTime) Created
-    ~int(PERMIT) Permissions
   ]],
   nil,
   [[

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -255,34 +255,28 @@ ERR object_free(ResourceRecord &Resource, Object *Object)
       // If the object wants to be warned when the free process is about to be executed, it will subscribe to the
       // FreeWarning action.  The process can be aborted by returning ERR::InUse.
 
+      bool in_use = false;
       if (mc->ActionTable[int(AC::FreeWarning)].PerformAction) {
-         if (mc->ActionTable[int(AC::FreeWarning)].PerformAction(Object, nullptr) IS ERR::InUse) {
-            if (Object->collecting()) {
-               // If the object is marked for deletion then it is not possible to avoid destruction (this prevents objects
-               // from locking up the shutdown process).
+         in_use = mc->ActionTable[int(AC::FreeWarning)].PerformAction(Object, nullptr) IS ERR::InUse;
+      }
 
-               log.msg("Object will be destroyed despite being in use.");
-            }
-            else {
-               if ((Object->Owner) and (Object->Owner->collecting())) Object->Owner = nullptr;
-               return ERR::InUse;
-            }
+      if (not in_use) {
+         // If prior check was for a derived class, call the base class
+         if ((mc->Base) and (mc->Base->ActionTable[int(AC::FreeWarning)].PerformAction)) {
+            in_use = mc->Base->ActionTable[int(AC::FreeWarning)].PerformAction(Object, nullptr) IS ERR::InUse;
          }
       }
 
-      if (mc->Base) { // Derived class detected, so call the base class
-         if (mc->Base->ActionTable[int(AC::FreeWarning)].PerformAction) {
-            if (mc->Base->ActionTable[int(AC::FreeWarning)].PerformAction(Object, nullptr) IS ERR::InUse) {
-               if (Object->collecting()) {
-                  // If the object is marked for deletion then it is not possible to avoid destruction (this prevents
-                  // objects from locking up the shutdown process).
-                  log.msg("Object will be destroyed despite being in use.");
-               }
-               else {
-                  if ((Object->Owner) and (Object->Owner->collecting())) Object->Owner = nullptr;
-                  return ERR::InUse;
-               }
-            }
+      if (in_use) {
+         if (Object->collecting()) {
+            // If the object is marked for deletion then it is not possible to avoid destruction (this prevents objects
+            // from locking up the shutdown process).
+
+            log.msg("Object will be destroyed despite being in use.");
+         }
+         else {
+            if ((Object->Owner) and (Object->Owner->collecting())) Object->Owner = nullptr;
+            return ERR::InUse;
          }
       }
 
@@ -298,18 +292,12 @@ ERR object_free(ResourceRecord &Resource, Object *Object)
 
       NotifySubscribers(Object, AC::Free, nullptr, ERR::Okay);
 
-      if (mc->ActionTable[int(AC::Free)].PerformAction) {  // Could be derived class or base-class
-         mc->ActionTable[int(AC::Free)].PerformAction(Object, nullptr);
-      }
-
-      if (mc->Base) { // Derived class detected, so call the base class
-         if (mc->Base->ActionTable[int(AC::Free)].PerformAction) {
-            mc->Base->ActionTable[int(AC::Free)].PerformAction(Object, nullptr);
-         }
-      }
-
       if (mc->ActionTable[int(AC::FreePlacement)].PerformAction) {
-         mc->ActionTable[int(AC::FreePlacement)].PerformAction(Object, nullptr);
+         if (mc->ActionTable[int(AC::FreePlacement)].PerformAction(Object, nullptr) IS ERR::NothingDone) {
+            if ((mc->Base) and (mc->Base->ActionTable[int(AC::FreePlacement)].PerformAction)) {
+               mc->Base->ActionTable[int(AC::FreePlacement)].PerformAction(Object, nullptr);
+            }
+         }
       }
       else if ((mc->Base) and (mc->Base->ActionTable[int(AC::FreePlacement)].PerformAction)) { // Fall-back to base class
          mc->Base->ActionTable[int(AC::FreePlacement)].PerformAction(Object, nullptr);

--- a/src/svg/class_rsvg.cpp
+++ b/src/svg/class_rsvg.cpp
@@ -18,10 +18,13 @@ class extRSVG : public extImage {
 public:
    // NB: Private variables aren't permitted for derived image classes
 
-   // Storing the SVG object in DerivedPtr avoids overhead and the Free function will automatically terminate it.
+   // Storing the SVG object in DerivedPtr avoids overhead
    inline objSVG * svg() { return (objSVG *)DerivedPtr; }
 
-   ~extRSVG() {}
+   ~extRSVG() {
+      // Manual termination required because Free's use of FreeResource treats DerivedPtr as a generic memory block.
+      if (DerivedPtr) { FreeResource(((objSVG *)DerivedPtr)->UID); DerivedPtr = nullptr; }
+   }
 
    extRSVG(objMetaClass *pClass, OBJECTID pUID) : extImage(pClass, pUID) { }
 };


### PR DESCRIPTION
* Moved File Size and Permissions into public File storage for derived classes
* Switched archive and Android asset file drivers to FreePlacement cleanup
* Updated object teardown to fall back to base FreePlacement handlers when requested
