### PR TITLE
[Tiri] Treat empty tables as empty in falsey checks

### DIFF
--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -785,7 +785,7 @@ function is_local_pair_in_range(Seconds:num, Nano:num, StartSeconds:num, StartNa
 end
 
 function resolver_name(Resolver:any):str
-   Resolver ??= tempus.resolve.compatible
+   Resolver ?= tempus.resolve.compatible
    return require_resolver(Resolver).name
 end
 
@@ -2050,7 +2050,7 @@ end
 @result ZonedDateTime value
 ]])
 function tempus.mtLocalDateTime:toZonedDateTime(Zone:table, Resolver:table):table
-   Resolver ??= tempus.resolve.compatible
+   Resolver ?= tempus.resolve.compatible
    return resolve_local_date_time(self, Zone, Resolver)
 end
 
@@ -2363,7 +2363,7 @@ end
 @result ZonedDateTime value
 ]])
 function tempus.mtZonedDateTime:withZoneSameLocal(Zone:table, Resolver:table):table
-   Resolver ??= tempus.resolve.compatible
+   Resolver ?= tempus.resolve.compatible
    return self:localDateTime():toZonedDateTime(Zone, Resolver)
 end
 
@@ -2375,8 +2375,7 @@ end
 zoned_date_time_with_local = function(Self:table, KV:table):table
    tempus._requireTable('fields', KV)
    fields = require_zoned_date_time(Self)
-   resolver = KV.resolver ?? tempus.resolve.compatible
-   return Self:localDateTime():withFields(KV):toZonedDateTime(fields.zone, resolver)
+   return Self:localDateTime():withFields(KV):toZonedDateTime(fields.zone, KV.resolver ? KV.resolver :> tempus.resolve.compatible)
 end
 
 tempus.mtZonedDateTime.withLocal = zoned_date_time_with_local
@@ -2809,7 +2808,7 @@ end
 @result LocalDateTime value
 ]])
 function tempus.mtClock:localDateTime(Zone:table):table
-   Zone ??= tempus.zone.local()
+   Zone ?= tempus.zone.local()
    require_zone(Zone)
 
    instant = self:instant()
@@ -2827,7 +2826,7 @@ end
 @result ZonedDateTime value
 ]])
 function tempus.mtClock:zonedDateTime(Zone:table):table
-   Zone ??= tempus.zone.local()
+   Zone ?= tempus.zone.local()
    return new_zoned_date_time(self:instant(), Zone)
 end
 
@@ -2880,7 +2879,7 @@ tempus.zonedDateTime.from = function(KV:table):table
    tempus._requireTable('zonedDateTime', KV)
    if KV.instant != nil then return new_zoned_date_time(KV.instant, KV.zone) end
    if KV.local_date_time != nil then
-      return KV.local_date_time:toZonedDateTime(KV.zone, KV.resolver ?? tempus.resolve.compatible)
+      return KV.local_date_time:toZonedDateTime(KV.zone, KV.resolver ? KV.resolver :> tempus.resolve.compatible)
    end
    raise ERR_InvalidValue, 'zonedDateTime.from requires instant or local_date_time.'
 end
@@ -2956,7 +2955,7 @@ tempus.resolve = {
 @result Instant value
 ]])
 tempus.now = function(Clock:table):table
-   Clock ??= tempus.clock.system()
+   Clock ?= tempus.clock.system()
    require_clock(Clock)
    return Clock:instant()
 end
@@ -2968,8 +2967,8 @@ end
 @result LocalDate value
 ]])
 tempus.today = function(Zone:table, Clock:table):table
-   Zone ??= tempus.zone.local()
-   Clock ??= tempus.clock.system()
+   Zone ?= tempus.zone.local()
+   Clock ?= tempus.clock.system()
    require_zone(Zone)
    require_clock(Clock)
    return Clock:today(Zone)

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -75,7 +75,7 @@ Operand suffixes: V=variable slot, S=string const, N=number const, P=primitive (
 | `ISF` | D | Skip next if R(D) is falsey |
 | `ISTYPE` | A D | Assert R(A) is type D (debug) |
 | `ISNUM` | A D | Assert R(A) is number (debug) |
-| `ISEMPTYARR` | A | R(A) is empty array → execute next JMP; else skip JMP |
+| `ISEMPTYARR` | A | R(A) is an empty array or table → execute next JMP; else skip JMP |
 
 #### Unary Ops
 | Opcode | Format | Description |
@@ -405,7 +405,7 @@ AGETV   dest, arr, i     ; Load element at variable index i
 
 ### 6.2 Ternary Operators (`cond ? true_val :> false_val`, `cond ?? true_val :> false_val`)
 - Only one branch executes. The standard `? :>` form matches `if` falsey semantics: only `nil` and `false` branch to the false value.
-- The extended `?? :>` form uses the same extended falsey set as `??`: `nil`, `false`, numeric zero, empty string, and empty array.
+- The extended `?? :>` form uses the same extended falsey set as `??`: `nil`, `false`, numeric zero, empty string, and empty collections.
 - `IrEmitter::emit_ternary_expr` places both branches so the selected branch materialises into a single result register. Each branch frees temporaries before convergence, and `freereg` is patched back to guarantee a single-slot result.
 - Example sketch:
   ```
@@ -420,16 +420,16 @@ end:
   ```
 
 ### 6.3 Presence Operator (`x?`) – Extended Falsey Check
-- Falsey set: `nil`, `false`, numeric zero, empty string, empty array. If operand is in this set, result is `false` and RHS (if any) is skipped.
+- Falsey set: `nil`, `false`, numeric zero, empty string, empty arrays, and empty tables. If operand is in this set, result is `false` and RHS (if any) is skipped.
 - Emission: chain `BC_ISEQP`/`BC_ISEQN`/`BC_ISEQS`/`BC_ISEMPTYARR` comparisons, each followed by a `JMP` to the falsey path. A matching equality branches to that path; non-matching comparisons fall through to the next check. If all checks fall through (truthy value), execution continues past the chain.
 - Jump lists patch the falsey exit after the chain; truthy fallthrough sets the result and collapses `freereg`.
-- `BC_ISEMPTYARR` is used to check if the value is a native array with length zero. Semantics: if `R(A)` is an array with `len == 0`, execute the following `JMP` (falsey); otherwise skip the `JMP` (truthy - either not an array or non-empty array).
+- `BC_ISEMPTYARR` is used to check if the value is an empty collection. Semantics: if `R(A)` is a native array with `len == 0` or a table with no entries, execute the following `JMP` (falsey); otherwise skip the `JMP` (truthy).
 
 ### 6.4 If-Empty Operator (`lhs ?? rhs`) – Short-Circuiting with Extended Falsey Semantics
-- Evaluate `lhs`; if it is nil/false/0/""/empty array, evaluate `rhs` and return it; otherwise return `lhs` without touching `rhs`.
+- Evaluate `lhs`; if it is nil/false/0/""/empty array/empty table, evaluate `rhs` and return it; otherwise return `lhs` without touching `rhs`.
 - Implemented in `IrEmitter::emit_if_empty_expr` plus helper routines in `operator_emitter.cpp`. The compare chain mirrors the presence operator: a matching falsey value branches to RHS evaluation; a truthy value falls through all checks and skips RHS entirely.
 - The result register is the original `lhs` slot; RHS evaluation reuses it and collapses `freereg` afterward to avoid leaked arguments or vararg tails.
-- Uses `BC_ISEMPTYARR` to check for empty arrays as part of the extended falsey semantics. If `R(A)` is a native array with `len == 0`, the following `JMP` is executed (falsey path); otherwise the `JMP` is skipped (truthy path).
+- Uses `BC_ISEMPTYARR` to check for empty arrays and tables as part of the extended falsey semantics. If `R(A)` is a native array with `len == 0` or a table with no entries, the following `JMP` is executed (falsey path); otherwise the `JMP` is skipped (truthy path).
 
 ## 7. Register Semantics and Multi-Value Behaviour
 ### 7.1 Register Lifetimes, `freereg`, and `nactvar`
@@ -580,7 +580,7 @@ Enables type inference for untyped functions, allowing the VM to optimize subseq
 - `ExpKind`: parser expression classification (`VNONRELOC`, `VRELOCABLE`, `VCALL`, etc.).
 
 ### Control Flow
-- Extended falsey: `nil`, `false`, numeric zero, empty string, empty array.
+- Extended falsey: `nil`, `false`, numeric zero, empty string, empty arrays, empty tables.
 - Short-circuit: using compare+`JMP` so RHS executes only when needed.
 - Cheat sheet: `ISEQ*`/`ISNE*`/`IS*` comparisons — true skips next, false executes next; `and` skips RHS on falsey, `or` skips RHS on truthy; `x?` and `lhs ?? rhs` use chained equality tests with shared jump lists; ternary writes result back into the condition register with one branch skipped.
 

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -281,7 +281,7 @@ typedef enum {
    BC_ISF     = 15,
    BC_ISTYPE  = 16,
    BC_ISNUM   = 17,
-   BC_ISEMPTYARR = 18,  // Check if RA is an empty array (for ?? operator)
+   BC_ISEMPTYARR = 18,  // Check if RA is an empty array or table (for ?? operator)
 
    // Unary ops (19-22)
    BC_MOV     = 19,

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2688,19 +2688,26 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_ISEMPTYARR:
-    // Check if RA is an empty array. Used by ?? operator for extended falsey semantics.
-    // If RA is an array with len==0, execute the following JMP (value is falsey).
-    // Otherwise, skip the following JMP (value is truthy - not an array or non-empty).
+    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
+    // Empty collections execute the following JMP (value is falsey); all other values skip it.
     |  // RA = src, followed by JMP with RC = target
     |  ldr CARG1, [BASE, RA, lsl #3]
     |  add PC, PC, #8			// Advance past following JMP (64-bit BCIns)
     |  asr ITYPE, CARG1, #47
     |  cmn ITYPE, #-LJ_TARRAY
-    |  bne >1				// Not an array - skip JMP (truthy)
+    |  beq >2
+    |  cmn ITYPE, #-LJ_TTAB
+    |  bne >1				// Not a collection - skip JMP (truthy)
+    |  and CARG1, CARG1, #LJ_GCVMASK
+    |  bl extern lj_tab_empty
+    |  cbz CRET1w, >1			// Non-empty table - skip JMP (truthy)
+    |  b >3				// Empty table - execute JMP (falsey)
+    |2:
     |  and CARG1, CARG1, #LJ_GCVMASK
     |  ldr TMP0w, ARRAY:CARG1->len
     |  cbnz TMP0w, >1			// Non-empty array - skip JMP (truthy)
-    |  // Empty array - execute JMP (falsey)
+    |3:
+    |  // Empty collection - execute JMP (falsey)
     |  ldrh RCw, [PC, #-6]		// Load RD from JMP at [PC-8+OFS_RD]
     |  add PC, PC, RC, lsl #3		// Branch target: PC + RD*8
     |  sub PC, PC, #0x40000		// Subtract BCBIAS_J*8

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -3909,26 +3909,42 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_ISEMPTYARR:
-    // Check if RA is an empty array. Used by ?? operator for extended falsey semantics.
-    // If RA is an array with len==0, execute the following JMP (value is falsey).
-    // Otherwise, skip the following JMP (value is truthy - not an array or non-empty).
+    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
+    // Empty collections execute the following JMP (value is falsey); all other values skip it.
     |  // RA = src*8, followed by JMP with RD = target
     |  lwzx TMP0, BASE, RA		// Load type tag
     |   ld INS, 0(PC)                      // Load full 64-bit instruction (next JMP)
     |   addi PC, PC, 8			// Advance past following JMP (64-bit)
     |  checkarray TMP0
-    |  bne >1				// Not an array - skip JMP (truthy)
-    |.if GPR64
+    |  beq >2
+    |  checktab TMP0
+    |  bne >1				// Not a collection - skip JMP (truthy)
+    |  mr SAVE0, INS
+|.if GPR64
+    |  ldx CARG1, BASE, RA
+    |  clrldi CARG1, CARG1, 17
+|.else
+    |  add CARG1, BASE, RA
+    |  lwz CARG1, 4(CARG1)
+|.endif
+    |  bl extern lj_tab_empty
+    |  mr INS, SAVE0
+    |  cmpwi CRET1, 0
+    |  beq >1				// Non-empty table - skip JMP (truthy)
+    |  b >3				// Empty table - execute JMP (falsey)
+    |2:
+|.if GPR64
     |  ldx TMP1, BASE, RA		// Load full value for pointer
     |  clrldi TMP1, TMP1, 17		// Clear type tag bits
-    |.else
+|.else
     |  add TMP1, BASE, RA
     |  lwz TMP1, 4(TMP1)		// Load pointer (lo word)
     |.endif
     |  lwz TMP2, ARRAY:TMP1->len
     |  cmpwi TMP2, 0
     |  bne >1				// Non-empty array - skip JMP (truthy)
-    |  // Empty array - execute JMP (falsey)
+    |3:
+    |  // Empty collection - execute JMP (falsey)
     |  decode_RD8 TMP0, INS
     |  addis TMP0, TMP0, -(BCBIAS_J*8 >> 16)
     |  add PC, PC, TMP0

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3285,20 +3285,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_ISEMPTYARR:
-    // Check if RA is an empty array. Used by ?? operator for extended falsey semantics.
-    // If RA is an array with len==0, execute the following JMP (value is falsey).
-    // Otherwise, skip the following JMP (value is truthy - not an array or non-empty).
+    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
+    // Empty collections execute the following JMP (value is falsey); all other values skip it.
     |  ins_AD  // RA = src, followed by JMP with RD = target
     |  mov RB, [BASE+RA*8]
     |  mov ITYPE, RB
     |  add PC, 8        // Advance past following JMP
     |  sar ITYPE, 47
     |  cmp ITYPEd, LJ_TARRAY
-    |  jne >1        // Not an array - skip JMP (truthy)
+    |  je >2
+    |  cmp ITYPEd, LJ_TTAB
+    |  jne >1        // Not a collection - skip JMP (truthy)
+    |  mov CARG1, RB
+    |  cleartp CARG1
+    |  mov RB, BASE
+    |  call extern lj_tab_empty
+    |  mov BASE, RB
+    |  test RDd, RDd
+    |  jz >1         // Non-empty table - skip JMP (truthy)
+    |  jmp >3        // Empty table - execute JMP (falsey)
+    |2:
     |  cleartp RB
     |  cmp dword ARRAY:RB->len, 0
     |  jne >1        // Non-empty array - skip JMP (truthy)
-    |  // Empty array - execute JMP (falsey)
+    |3:
+    |  // Empty collection - execute JMP (falsey)
     |  movzx RDd, PC_RD
     |  branchPC RD
     |1:           // Fallthrough - skip the JMP

--- a/src/tiri/jit/src/lib/lib_table.cpp
+++ b/src/tiri/jit/src/lib/lib_table.cpp
@@ -281,15 +281,7 @@ LJLIB_CF(table_empty)
       return 1;
    }
 
-   if (lj_tab_len(t) != 0) {
-      setboolV(L->top - 1, 0);
-      return 1;
-   }
-
-   TValue key, kv[2];
-   setnilV(&key);
-   if (lj_tab_next(t, &key, kv)) setboolV(L->top - 1, 0);  //  Found at least one entry.
-   else setboolV(L->top - 1, 1);  //  Confirmed empty.
+   setboolV(L->top - 1, lj_tab_empty(t));
 
    return 1;
 }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3170,9 +3170,9 @@ void lj_record_ins(jit_State *J)
       break;
 
    case BC_ISEMPTYARR: {
-      // Empty array check for ?? operator.
+      // Empty collection check for ?? operator.
       // If value is an array, we must guard on its length being 0 or non-zero.
-      // For non-array types, type specialisation suffices (they are always truthy for this check).
+      // Table emptiness needs full traversal, so leave that path to the interpreter.
       if (bc_a(pc[1]) < J->maxslot) J->maxslot = bc_a(pc[1]);  // Shrink used slots.
       if (tref_isarray(ra)) {
          // Load array length and compare to 0
@@ -3188,7 +3188,10 @@ void lj_record_ins(jit_State *J)
          emitir(IRTG(is_empty ? IR_EQ : IR_NE, IRT_INT), arrlen, zero);
          rec_comp_fixup(J, J->pc, !is_empty);
       }
-      // For non-arrays, no additional guard needed - type specialisation handles it
+      else if (tref_istab(ra)) {
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      }
+      // For other non-arrays, no additional guard needed - type specialisation handles it
       break;
    }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -343,7 +343,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
 }
 
 //********************************************************************************************************************
-// Emit bytecode for an if-empty assignment (??=), assigning only if the target is nil, false, 0, or empty string.
+// Emit bytecode for an if-empty assignment (??=), assigning only if the target is nil, false, 0, empty string, or
+// an empty collection.
 
 ParserResult<IrEmitUnit> IrEmitter::emit_if_empty_assignment(PreparedAssignment target, const ExprNodeList& values)
 {
@@ -389,8 +390,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_if_empty_assignment(PreparedAssignment 
    ExpressionValue lhs_value(&this->func_state, working);
    auto lhs_reg = lhs_value.discharge_to_any_reg(allocator);
 
+   FalseyJumpOptions options;
+   options.include_empty_array = true;
    ControlFlowEdge falsey_edge = emit_falsey_jumps(
-      this->func_state, this->lex_state, this->control_flow, lhs_reg, FalseyJumpOptions{});
+      this->func_state, this->lex_state, this->control_flow, lhs_reg, options);
 
    // Safe-nav targets may already carry a skip edge from target preparation. Those jumps bypass this
    // whole conditional-assignment block. The checks below are only for the terminal lvalue once the
@@ -468,7 +471,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_if_nil_assignment(PreparedAssignment ta
    ExpressionValue lhs_value(&this->func_state, working);
    auto lhs_reg = lhs_value.discharge_to_any_reg(allocator);
 
-   // Only check for nil (simpler and faster than ??= which checks nil, false, 0, and empty string)
+   // Only check for nil (simpler and faster than ??= which checks nil, false, 0, empty strings, and empty
+   // collections).
    FalseyJumpOptions nil_only;
    nil_only.include_false = false;
    nil_only.include_zero = false;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -60,10 +60,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpressionValue lhs_value(&this->func_state, global_var);
       auto lhs_reg = lhs_value.discharge_to_any_reg(allocator);
 
-      // Emit checks for empty values: nil, false, 0, ""
+      // Emit checks for empty values: nil, false, 0, "", and empty collections.
 
+      FalseyJumpOptions options;
+      options.include_empty_array = true;
       ControlFlowEdge falsey_edge = emit_falsey_jumps(
-         this->func_state, this->lex_state, this->control_flow, lhs_reg, FalseyJumpOptions{});
+         this->func_state, this->lex_state, this->control_flow, lhs_reg, options);
 
       // Skip assignment if not empty
 

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -833,7 +833,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_expression_stmt(const ExpressionStmtPay
 }
 
 //********************************************************************************************************************
-// Emit bytecode for a conditional shorthand statement (executes body only for falsey values like nil, false, 0, or empty string).
+// Emit bytecode for a conditional shorthand statement (executes body only for falsey values like nil, false, 0,
+// empty strings, or empty collections).
 
 ParserResult<IrEmitUnit> IrEmitter::emit_conditional_shorthand_stmt(const ConditionalShorthandStmtPayload &Payload)
 {
@@ -2040,7 +2041,7 @@ ParserResult<ExpDesc> IrEmitter::emit_comparison_chain_expr(const ComparisonChai
 }
 //********************************************************************************************************************
 // IF_EMPTY (lhs ?? rhs) with conditional RHS emission for proper short-circuit semantics
-// Similar to ternary but with extended falsey checks (nil, false, 0, "")
+// Similar to ternary but with extended falsey checks (nil, false, 0, "", empty collections)
 
 ParserResult<ExpDesc> IrEmitter::emit_if_empty_expr(ExpDesc lhs, const ExprNode& rhs_ast)
 {

--- a/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
@@ -1112,7 +1112,7 @@ void OperatorEmitter::prepare_if_empty(ExprValue left)
    ExpDesc* left_desc = left.raw();
 
    // IF_EMPTY short-circuit: if left is truthy, skip RHS and return left
-   // Extended falsey: nil, false, 0, "" (all trigger RHS evaluation)
+   // Extended falsey: nil, false, 0, "", empty collections (all trigger RHS evaluation)
 
    // Discharge left operand
    ExpressionValue left_val(this->func_state, *left_desc);
@@ -1315,7 +1315,7 @@ void OperatorEmitter::complete_concat(ExprValue left, ExpDesc right)
 
 //********************************************************************************************************************
 // Presence check operator (x?)
-// Returns boolean: true if value is truthy, false if falsey (nil, false, 0, "")
+// Returns boolean: true if value is truthy, false if falsey (nil, false, 0, "", empty collections)
 
 void OperatorEmitter::emit_presence_check(ExprValue operand)
 {

--- a/src/tiri/jit/src/parser/ir_emitter/operator_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/operator_emitter.h
@@ -12,7 +12,7 @@
 //
 // EXTENDED FALSEY SEMANTICS:
 // Tiri's falsey semantics differ from standard Lua:
-// - Falsey values: nil, false, 0 (numeric zero), "" (empty string)
+// - Falsey values: nil, false, 0 (numeric zero), "" (empty string), and empty collections
 // - All other values are truthy
 // - This affects the ?? (if-empty) operator and ? (presence check) operator
 // - Use ExpDesc::is_falsey() for compile-time constant checks
@@ -90,7 +90,7 @@ public:
 
    // Presence check operator (x?)
    // Emits bytecode to check if value is truthy (extended falsey semantics)
-   // Returns boolean: true if truthy, false if falsey (nil, false, 0, "")
+   // Returns boolean: true if truthy, false if falsey (nil, false, 0, "", empty collections)
    void emit_presence_check(ExprValue operand);
 
 private:

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -264,7 +264,7 @@ struct ExpDesc {
    [[nodiscard]] inline bool is_any_indexed() const { return this->k IS ExpKind::Indexed or this->k IS ExpKind::IndexedArray or this->k IS ExpKind::SafeIndexedArray; }
    [[nodiscard]] inline bool is_register() const { return this->k IS ExpKind::Local or this->k IS ExpKind::NonReloc; }
 
-   // Extended falsey check (nil, false, 0, "")
+   // Extended falsey check (nil, false, 0, ""; empty collections are runtime-only)
    // Supports Tiri's extended falsey semantics for ?? operator
    [[nodiscard]] bool is_falsey() const;
 

--- a/src/tiri/jit/src/parser/value_categories.cpp
+++ b/src/tiri/jit/src/parser/value_categories.cpp
@@ -12,6 +12,7 @@
 // - false is falsey
 // - 0 (numeric zero) is falsey
 // - "" (empty string) is falsey
+// Empty table and array values are handled by runtime checks.
 // All other values are truthy
 
 bool ExpDesc::is_falsey() const

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -645,6 +645,18 @@ int lj_tab_next(GCtab* t, cTValue* key, TValue* o)
 }
 
 //********************************************************************************************************************
+// Return true if the table has no array or hash entries.
+
+int lj_tab_empty(GCtab* t)
+{
+   if (lj_tab_len(t) != 0) return 0;
+
+   TValue key, kv[2];
+   setnilV(&key);
+   return lj_tab_next(t, &key, kv) IS 0;
+}
+
+//********************************************************************************************************************
 // Table length calculation
 
 // 0-based: length = last_index + 1 (e.g., last element at index 2 → length 3)

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -111,6 +111,7 @@ LJ_FUNC TValue* lj_tab_set(lua_State* L, GCtab* t, cTValue* key);
 
 LJ_FUNC uint32_t lj_tab_keyindex(GCtab* t, cTValue* key);
 LJ_FUNCA int lj_tab_next(GCtab* t, cTValue* key, TValue* o);
+LJ_FUNCA int lj_tab_empty(GCtab* t);
 LJ_FUNCA MSize lj_tab_len(GCtab* t);
 #if LJ_HASJIT
 LJ_FUNC MSize lj_tab_len_hint(GCtab* t, size_t hint);

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -44,6 +44,10 @@ end
    empty ??= 'fallback'
    assert(empty is 'fallback', 'empty string should trigger ??= assignment')
 
+   local empty_table: any = { }
+   empty_table ??= 'fallback table'
+   assert(empty_table is 'fallback table', 'empty table should trigger ??= assignment')
+
    store = { retries = 0, label = 'ready', slots = { '' } }
    store.retries ??= 3
    assert(store.retries is 3, 'table field ??= should assign when falsey')
@@ -77,7 +81,7 @@ end
 end
 
 -- Tests for the ?= (if-nil) operator - only assigns when LHS is nil
--- Unlike ??= which checks for all falsey values (nil, false, 0, ""),
+-- Unlike ??= which checks for all falsey values (nil, false, 0, "", empty collections),
 -- ?= only checks for nil, making it simpler and faster.
 
 @Test function IfNilAssignment()
@@ -399,6 +403,11 @@ end
    global gEmptyVar = ''
    global gEmptyVar ??= 'from empty'
    assert(gEmptyVar is 'from empty', 'global ??= should assign when value is empty string')
+
+   -- Test global ??= assigns when value is an empty table
+   global gEmptyTableVar = { }
+   global gEmptyTableVar ??= 'from empty table'
+   assert(gEmptyTableVar is 'from empty table', 'global ??= should assign when value is an empty table')
 end
 
 @Test function GlobalIfEmptyWithFunctionCall()

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -1,4 +1,4 @@
--- Flute tests for the ?? operator (if-empty: nil, false, 0, "")
+-- Flute tests for the ?? operator (if-empty: nil, false, 0, "", empty collections)
 
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
@@ -93,6 +93,10 @@ end
    t = { a=1, b=2, c=3}
    v = t ?? 'Nothing'
    assert(v['a'] is 1, "Failed table case: expected table, got '" .. tostring(v) .. "'")
+
+   empty = { }
+   v = empty ?? 'Nothing'
+   assert(v is 'Nothing', "Failed empty table case: expected fallback, got '" .. tostring(v) .. "'")
 
    v = 'x' ?? { 'Nothing' }
    assert(v is 'x', "Failed table case: expected table, got '" .. tostring(v) .. "'")
@@ -406,6 +410,28 @@ end
    single = array<int, 1>
    v = single ?? 'default'
    assert(v is single, "Array with one element should be truthy")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Table falsey tests: empty tables are considered falsey
+
+@Test function EmptyTable()
+   empty = { }
+   v = empty ?? 'default'
+   assert(v is 'default', "Empty table should be falsey: expected 'default', got '" .. tostring(v) .. "'")
+end
+
+@Test function NonEmptyTable()
+   filled = { value = 1 }
+   v = filled ?? 'default'
+   assert(v is filled, "Non-empty table should be truthy: expected table, got '" .. tostring(v) .. "'")
+end
+
+@Test function ClearedTable()
+   cleared = { value = 1 }
+   cleared.value = nil
+   v = cleared ?? 'default'
+   assert(v is 'default', "Cleared table should be falsey: expected 'default', got '" .. tostring(v) .. "'")
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_if_empty_guard.tiri
+++ b/src/tiri/tests/test_if_empty_guard.tiri
@@ -56,7 +56,7 @@ end
    empty = { }
    named = { name = 'table' }
 
-   assert(describeTable(empty) is 'present', "Empty table should pass the shorthand guard")
+   assert(describeTable(empty) is 'empty', "Empty table should trigger the shorthand return")
    assert(describeTable(named) is 'table', "Non-empty table should pass the shorthand guard")
 end
 

--- a/src/tiri/tests/test_presence.tiri
+++ b/src/tiri/tests/test_presence.tiri
@@ -1,5 +1,5 @@
 -- Flute tests for the postfix ?? operator (presence check)
--- Returns boolean: true if value is truthy, false if falsey (nil, false, 0, "")
+-- Returns boolean: true if value is truthy, false if falsey (nil, false, 0, "", empty collections)
 
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
@@ -261,7 +261,6 @@ end
       {val = -1, name = "negative number"},
       {val = 0.5, name = "fractional number"},
       {val = true, name = "boolean true"},
-      {val = {}, name = "empty table"},
       {val = {x=1}, name = "non-empty table"}
    }
    for _, tc in ipairs(test_cases) do
@@ -276,7 +275,8 @@ end
       {val = nil, name = "nil"},
       {val = false, name = "false"},
       {val = 0, name = "zero"},
-      {val = "", name = "empty string"}
+      {val = "", name = "empty string"},
+      {val = {}, name = "empty table"}
    }
    for _, tc in ipairs(test_cases) do
       result = (tc.val)??
@@ -354,6 +354,22 @@ end
    assert((int_filled??) is true, "Non-empty int array should return true")
 end
 
+@Test function EmptyTablePresence()
+   local empty = { }
+   assert((empty??) is false, "Empty table should return false for ??")
+end
+
+@Test function NonEmptyTablePresence()
+   local named = { name = "table" }
+   assert((named??) is true, "Non-empty table should return true for ??")
+end
+
+@Test function TableClearedToEmptyPresence()
+   local value = { name = "table" }
+   value.name = nil
+   assert((value??) is false, "Table with all entries cleared should return false for ??")
+end
+
 @Test function ArrayInComprehensiveFalseyList()
    -- Verify arrays are now included in the falsey value set
    test_cases = {
@@ -362,10 +378,12 @@ end
       {val = 0, name = "zero", expected = false},
       {val = "", name = "empty string", expected = false},
       {val = array<int>, name = "empty array", expected = false},
+      {val = {}, name = "empty table", expected = false},
       {val = true, name = "true", expected = true},
       {val = 1, name = "one", expected = true},
       {val = "test", name = "non-empty string", expected = true},
-      {val = array<int, 3>, name = "non-empty array", expected = true}
+      {val = array<int, 3>, name = "non-empty array", expected = true},
+      {val = { name = "table" }, name = "non-empty table", expected = true}
    }
    for _, tc in ipairs(test_cases) do
       result = (tc.val)??


### PR DESCRIPTION
* Extended if-empty and presence bytecode/runtime checks to treat empty tables as empty collections
* Updated Tempus value wrappers and nil-only defaults to preserve valid opaque values under the new semantics
* Added Flute coverage for empty table behaviour across if-empty, if-empty assignment, shorthand guards and presence checks