### PR TITLE
[Core] Split filesystem class declarations into their own header

### DIFF
--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -11,7 +11,7 @@
     <id>4ca5c5b3</id>
     <idstring>FILE</idstring>
     <category>System</category>
-    <copyright>Paul Manias 1996-2026</copyright>
+    <copyright>Paul Manias © 1996-2026</copyright>
     <description>
 <p>The File class provides extensive support for file management and I/O.  The class supports the notion of individual file compression and file finding capabilities.  Since all File objects are tracked, there is no chance of the system leaving locked files behind after a program exits.  Folder management is also integrated into this class to ease the management of both file types.</p>
 <p>To read or write to a file, set the <fl>Path</fl> of the file as well as the correct I/O file flags before initialisation. See the <fl>Flags</fl> field for information on the available I/O flags.  Functionality for read and write operations is provided through the <action>Read</action> and <action>Write</action> actions.  The <action>Seek</action> action can be used to change the read/write position in a file.</p></description>
@@ -550,7 +550,7 @@
       <access read="G">Get</access>
       <type>STRING</type>
       <description>
-<p>The ResolvedPath will return a resolved copy of the <fl>Path</fl> string.  The resolved path will be in a format that is native to the host platform.  Please refer to the <function>ResolvePath</function> function for further information.</p>
+<p>The ResolvedPath will return a resolved copy of the <fl>Path</fl> string.  The resolved path will be in a format that is native to the host platform.  Please refer to the ~ResolvePath() function for further information.</p>
       </description>
     </field>
 
@@ -674,15 +674,5 @@
 
   </types>
   <structs>
-    <struct name="DateTime" comment="Generic structure for date-time management.">
-      <field name="Year" type="INT16">Year</field>
-      <field name="Month" type="INT8">Month 1 to 12</field>
-      <field name="Day" type="INT8">Day 1 to 31</field>
-      <field name="Hour" type="INT8">Hour 0 to 23</field>
-      <field name="Minute" type="INT8">Minute 0 to 59</field>
-      <field name="Second" type="INT8">Second 0 to 59</field>
-      <field name="TimeZone" type="INT8">TimeZone -13 to +13</field>
-    </struct>
-
   </structs>
 </book>

--- a/docs/xml/modules/classes/storagedevice.xml
+++ b/docs/xml/modules/classes/storagedevice.xml
@@ -11,7 +11,7 @@
     <id>b2355092</id>
     <idstring>STORAGEDEVICE</idstring>
     <category>System</category>
-    <copyright>Paul Manias 1996-2026</copyright>
+    <copyright>Paul Manias © 1996-2026</copyright>
     <description>
 <p>The StorageDevice class returns metadata for mounted file system volumes.  Set <fl>Volume</fl> before initialisation to identify the volume to query.  If the volume name cannot be resolved, initialisation will fail.</p>
 <p>After initialisation, the read-only fields describe the resolved volume.  Values that depend on host or device support can remain unavailable; unknown byte counts are reported as <code>-1</code>, and <fl>DeviceID</fl> is empty if no identifier is available.</p></description>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -70,8 +70,6 @@ constexpr bool defined(T flags, T test_flag) noexcept {
 
 constexpr int RESOURCE_ID_OFFSET = -1;
 class objMetaClass;
-class objStorageDevice;
-class objFile;
 class objTask;
 class objThread;
 class objModule;
@@ -627,16 +625,6 @@ enum class THF : uint32_t {
 
 DEFINE_ENUM_FLAG_OPERATORS(THF)
 
-// Flags for the SetDate() file method.
-
-enum class FDT : int {
-   NIL = 0,
-   MODIFIED = 0,
-   CREATED = 1,
-   ACCESSED = 2,
-   ARCHIVED = 3,
-};
-
 // Options for SetVolume()
 
 enum class VOLUME : uint32_t {
@@ -671,29 +659,6 @@ enum class RSF : uint32_t {
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(RSF)
-
-// Flags for the File Watch() method.
-
-enum class MFF : uint32_t {
-   NIL = 0,
-   READ = 0x00000001,
-   MODIFY = 0x00000002,
-   WRITE = 0x00000002,
-   CREATE = 0x00000004,
-   DELETE = 0x00000008,
-   MOVED = 0x00000010,
-   RENAME = 0x00000010,
-   ATTRIB = 0x00000020,
-   OPENED = 0x00000040,
-   CLOSED = 0x00000080,
-   UNMOUNT = 0x00000100,
-   FOLDER = 0x00000200,
-   FILE = 0x00000400,
-   SELF = 0x00000800,
-   DEEP = 0x00001000,
-};
-
-DEFINE_ENUM_FLAG_OPERATORS(MFF)
 
 // Types for StrDatatype().
 
@@ -1177,6 +1142,39 @@ enum class FL : uint32_t {
 
 DEFINE_ENUM_FLAG_OPERATORS(FL)
 
+// Flags for the SetDate() file method.
+
+enum class FDT : int {
+   NIL = 0,
+   MODIFIED = 0,
+   CREATED = 1,
+   ACCESSED = 2,
+   ARCHIVED = 3,
+};
+
+// Flags for the File Watch() method.
+
+enum class MFF : uint32_t {
+   NIL = 0,
+   READ = 0x00000001,
+   MODIFY = 0x00000002,
+   WRITE = 0x00000002,
+   CREATE = 0x00000004,
+   DELETE = 0x00000008,
+   MOVED = 0x00000010,
+   RENAME = 0x00000010,
+   ATTRIB = 0x00000020,
+   OPENED = 0x00000040,
+   CLOSED = 0x00000080,
+   UNMOUNT = 0x00000100,
+   FOLDER = 0x00000200,
+   FILE = 0x00000400,
+   SELF = 0x00000800,
+   DEEP = 0x00001000,
+};
+
+DEFINE_ENUM_FLAG_OPERATORS(MFF)
+
 struct InputEvent {
    const struct InputEvent * Next;    // Next event in the chain
    double   Value;                    // The value associated with the Type
@@ -1502,8 +1500,7 @@ class FloatRect {
    constexpr double bottom() const noexcept { return Y + Height; }
 };
 
-}
-
+} // namespace
 
 struct OpenTag {
    TOI Tag;    // Tag identifier
@@ -2572,377 +2569,6 @@ inline bool Object::isDerived() { return Class->ClassID != Class->BaseClassID; }
 inline CLASSID Object::classID() { return Class->ClassID; }
 inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
 
-// StorageDevice class definition
-
-#define VER_STORAGEDEVICE (1.000000)
-
-class objStorageDevice : public Object {
-   public:
-   static constexpr CLASSID CLASS_ID = CLASSID::STORAGEDEVICE;
-   static constexpr CSTRING CLASS_NAME = "StorageDevice";
-
-   using create = kt::Create<objStorageDevice>;
-   objStorageDevice(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
-
-   DEVICE  DeviceFlags;   // These read-only flags identify the type of device and its features.
-   int64_t DeviceSize;    // Total storage capacity of the resolved volume, measured in bytes.
-   int64_t BytesFree;     // Amount of storage space available to the current user, measured in bytes.
-   int64_t BytesUsed;     // Amount of storage space in use, measured in bytes.
-   std::string DeviceID;  // Unique device identifier for the mounted volume, when available.
-   std::string Volume;    // The volume name of the device to query.
-
-   // Action stubs
-
-   inline ERR init() noexcept { return InitObject(this); }
-
-   // Customised field getting
-
-   inline ERR getDeviceFlags(DEVICE &Value) noexcept {
-      Value = this->DeviceFlags;
-      return ERR::Okay;
-   }
-
-   inline ERR getDeviceSize(int64_t &Value) noexcept {
-      Value = this->DeviceSize;
-      return ERR::Okay;
-   }
-
-   inline ERR getBytesFree(int64_t &Value) noexcept {
-      Value = this->BytesFree;
-      return ERR::Okay;
-   }
-
-   inline ERR getBytesUsed(int64_t &Value) noexcept {
-      Value = this->BytesUsed;
-      return ERR::Okay;
-   }
-
-   inline ERR getDevice(std::string_view &Value) noexcept {
-      Value = this->DeviceID;
-      return ERR::Okay;
-   }
-
-   inline ERR getVolume(std::string_view &Value) noexcept {
-      Value = this->Volume;
-      return ERR::Okay;
-   }
-
-
-   // Customised field setting
-
-   inline ERR setVolume(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(this, field, 0x00904500, &Value);
-   }
-
-};
-
-// File class definition
-
-#define VER_FILE (1.200000)
-
-// File methods
-
-namespace fl {
-struct StartStream { OBJECTID SubscriberID; FL Flags; int Length; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct StopStream { static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Delete { FUNCTION *Callback; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Move { std::string_view Dest; FUNCTION *Callback; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Copy { std::string_view Dest; FUNCTION *Callback; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct SetDate { int Year; int Month; int Day; int Hour; int Minute; int Second; FDT Type; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ReadLine { std::string *Result; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct BufferContent { static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Next { objFile *File; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct Watch { FUNCTION *Callback; MFF Flags; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-
-} // namespace
-
-class objFile : public Object {
-   public:
-   static constexpr CLASSID CLASS_ID = CLASSID::FILE;
-   static constexpr CSTRING CLASS_NAME = "File";
-
-   using create = kt::Create<objFile>;
-   objFile(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
-
-   int64_t  Position;   // The current read/write byte position in a file.
-   std::string Path;    // Specifies the location of a file or folder.
-   FL       Flags;      // File flags and options.
-   PERMIT   Permissions; // Manages the permissions of a file.
-   int8_t * Buffer;     // Points to the internal data buffer if the file content is held in memory.
-   int64_t  Size;       // The byte size of a file.
-   public:
-   inline std::string readLine() {
-      std::string str;
-      struct fl::ReadLine args { &str };
-      Action(fl::ReadLine::id, this, &args);
-      return str;
-   }
-
-   // Action stubs
-
-   inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
-      return Action(AC::DataFeed, this, &args);
-   }
-   inline ERR flush() noexcept { return Action(AC::Flush, this, nullptr); }
-   inline ERR init() noexcept { return InitObject(this); }
-   inline ERR query() noexcept { return Action(AC::Query, this, nullptr); }
-   template <class T, class U> ERR read(APTR Buffer, T Size, U *Result) noexcept {
-      static_assert(std::is_integral<U>::value, "Result value must be an integer type");
-      static_assert(std::is_integral<T>::value, "Size value must be an integer type");
-      const int bytes = (Size > 0x7fffffff) ? 0x7fffffff : Size;
-      struct acRead read = { (int8_t *)Buffer, bytes };
-      if (auto error = Action(AC::Read, this, &read); error IS ERR::Okay) {
-         *Result = U(read.Result);
-         return ERR::Okay;
-      }
-      else { *Result = 0; return error; }
-   }
-   template <class T> ERR read(APTR Buffer, T Size) noexcept {
-      static_assert(std::is_integral<T>::value, "Size value must be an integer type");
-      const int bytes = (Size > 0x7fffffff) ? 0x7fffffff : Size;
-      struct acRead read = { (int8_t *)Buffer, bytes };
-      return Action(AC::Read, this, &read);
-   }
-   inline ERR rename(std::string_view Name) noexcept {
-      struct acRename args = { Name };
-      return Action(AC::Rename, this, &args);
-   }
-   inline ERR reset() noexcept { return Action(AC::Reset, this, nullptr); }
-   inline ERR seek(double Offset, SEEK Position = SEEK::CURRENT) noexcept {
-      struct acSeek args = { Offset, Position };
-      return Action(AC::Seek, this, &args);
-   }
-   inline ERR seekStart(double Offset) noexcept { return seek(Offset, SEEK::START); }
-   inline ERR seekEnd(double Offset) noexcept { return seek(Offset, SEEK::END); }
-   inline ERR seekCurrent(double Offset) noexcept { return seek(Offset, SEEK::CURRENT); }
-   inline ERR write(CPTR Buffer, int Size, int *Result = nullptr) noexcept {
-      struct acWrite write = { (int8_t *)Buffer, Size };
-      if (auto error = Action(AC::Write, this, &write); error IS ERR::Okay) {
-         if (Result) *Result = write.Result;
-         return ERR::Okay;
-      }
-      else {
-         if (Result) *Result = 0;
-         return error;
-      }
-   }
-   inline ERR write(std::string Buffer, int *Result = nullptr) noexcept {
-      struct acWrite write = { (int8_t *)Buffer.c_str(), int(Buffer.size()) };
-      if (auto error = Action(AC::Write, this, &write); error IS ERR::Okay) {
-         if (Result) *Result = write.Result;
-         return ERR::Okay;
-      }
-      else {
-         if (Result) *Result = 0;
-         return error;
-      }
-   }
-   inline ERR startStream(OBJECTID SubscriberID, FL Flags, int Length) noexcept {
-      struct fl::StartStream args = { SubscriberID, Flags, Length };
-      return Action(AC(-1), this, &args);
-   }
-   inline ERR stopStream() noexcept {
-      return Action(AC(-2), this, nullptr);
-   }
-   inline ERR del(FUNCTION Callback) noexcept {
-      struct fl::Delete args = { &Callback };
-      return Action(AC(-3), this, &args);
-   }
-   inline ERR move(const std::string_view &Dest, FUNCTION Callback) noexcept {
-      struct fl::Move args = { Dest, &Callback };
-      return Action(AC(-4), this, &args);
-   }
-   inline ERR copy(const std::string_view &Dest, FUNCTION Callback) noexcept {
-      struct fl::Copy args = { Dest, &Callback };
-      return Action(AC(-5), this, &args);
-   }
-   inline ERR setDate(int Year, int Month, int Day, int Hour, int Minute, int Second, FDT Type) noexcept {
-      struct fl::SetDate args = { Year, Month, Day, Hour, Minute, Second, Type };
-      return Action(AC(-6), this, &args);
-   }
-   inline ERR readLine(std::string &Result) noexcept {
-      struct fl::ReadLine args = { &Result };
-      ERR error = Action(AC(-7), this, &args);
-      return error;
-   }
-   inline ERR bufferContent() noexcept {
-      return Action(AC(-8), this, nullptr);
-   }
-   inline ERR next(objFile ** File) noexcept {
-      struct fl::Next args = { (objFile *)0 };
-      ERR error = Action(AC(-9), this, &args);
-      if (File) *File = args.File;
-      return error;
-   }
-   inline ERR watch(FUNCTION Callback, MFF Flags) noexcept {
-      struct fl::Watch args = { &Callback, Flags };
-      return Action(AC(-10), this, &args);
-   }
-
-   // Customised field getting
-
-   inline ERR getPosition(int64_t &Value) noexcept {
-      Value = this->Position;
-      return ERR::Okay;
-   }
-
-   inline ERR getPath(std::string_view &Value) noexcept {
-      Value = this->Path;
-      return ERR::Okay;
-   }
-
-   inline ERR getFlags(FL &Value) noexcept {
-      Value = this->Flags;
-      return ERR::Okay;
-   }
-
-   inline ERR getPermissions(PERMIT &Value) noexcept {
-      auto field = &this->Class->Dictionary[19];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getBuffer(std::span<int8_t> &Value) noexcept {
-      auto field = &this->Class->Dictionary[12];
-      auto get_field = (ERR (*)(APTR, std::span<int8_t> &))field->GetValue;
-      return get_field(this, Value);
-   }
-
-   inline ERR getSize(int64_t &Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getDate(struct DateTime * &Value) noexcept {
-      auto field = &this->Class->Dictionary[10];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getCreated(struct DateTime * &Value) noexcept {
-      auto field = &this->Class->Dictionary[3];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getHandle(int64_t &Value) noexcept {
-      auto field = &this->Class->Dictionary[8];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getIcon(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[11];
-      SetObjectContext(this, field, AC::NIL);
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getResolvedPath(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[18];
-      SetObjectContext(this, field, AC::NIL);
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getTimestamp(int64_t &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getLink(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[15];
-      SetObjectContext(this, field, AC::NIL);
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getUser(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[14];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-   inline ERR getGroup(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[1];
-      SetObjectContext(this, field, AC::NIL);
-      auto error = field->GetValue(this, &Value);
-      RestoreObjectContext();
-      return error;
-   }
-
-
-   // Customised field setting
-
-   inline ERR setPosition(const int64_t Value) noexcept {
-      auto field = &this->Class->Dictionary[9];
-      return field->WriteValue(this, field, FD_INT64, &Value);
-   }
-
-   inline ERR setPath(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[5];
-      return field->WriteValue(this, field, 0x00804500, &Value);
-   }
-
-   inline ERR setFlags(const FL Value) noexcept {
-      auto field = &this->Class->Dictionary[2];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setPermissions(const PERMIT Value) noexcept {
-      auto field = &this->Class->Dictionary[19];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setSize(const int64_t Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
-      return field->WriteValue(this, field, FD_INT64, &Value);
-   }
-
-   inline ERR setDate(const struct DateTime & Value) noexcept {
-      auto field = &this->Class->Dictionary[10];
-      return field->WriteValue(this, field, FD_STRUCT, &Value);
-   }
-
-   inline ERR setLink(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[15];
-      return field->WriteValue(this, field, 0x00804308, &Value);
-   }
-
-   inline ERR setUser(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[14];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-   inline ERR setGroup(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[1];
-      return field->WriteValue(this, field, FD_INT, &Value);
-   }
-
-};
-
 struct ActionEntry {
    ERR (*PerformAction)(OBJECTPTR, APTR);     // Pointer to a custom action hook.
 };
@@ -3692,60 +3318,6 @@ struct evHotplug {
 }
 
 } // pf namespace
-
-namespace fl {
-
-// Read endian values from files and objects.
-
-template<class T> ERR ReadLE(OBJECTPTR Object, T *Result)
-{
-   uint8_t data[sizeof(T)];
-   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
-   if (!Action(AC::Read, Object, &read)) {
-      if (read.Result IS sizeof(T)) {
-         if constexpr (std::endian::native == std::endian::little) {
-            *Result = ((T *)data)[0];
-         }
-         else {
-            switch(sizeof(T)) {
-               case 2:  *Result = (data[1]<<8) | data[0]; break;
-               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
-               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
-               default: *Result = ((T *)data)[0];
-            }
-         }
-         return ERR::Okay;
-      }
-      else return ERR::Read;
-   }
-   else return ERR::Read;
-}
-
-template<class T> ERR ReadBE(OBJECTPTR Object, T *Result)
-{
-   uint8_t data[sizeof(T)];
-   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
-   if (!Action(AC::Read, Object, &read)) {
-      if (read.Result IS sizeof(T)) {
-         if constexpr (std::endian::native == std::endian::little) {
-            switch(sizeof(T)) {
-               case 2:  *Result = (data[1]<<8) | data[0]; break;
-               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
-               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
-               default: *Result = ((T *)data)[0];
-            }
-         }
-         else {
-            *Result = ((T *)data)[0];
-         }
-         return ERR::Okay;
-      }
-      else return ERR::Read;
-   }
-   else return ERR::Read;
-}
-
-} // fl namespace
 
 // Function construction (refer types.h)
 

--- a/include/kotuku/modules/filesystem.h
+++ b/include/kotuku/modules/filesystem.h
@@ -1,0 +1,435 @@
+#pragma once
+
+// Copyright: Paul Manias © 1996-2026
+// Generator: idl-c
+
+#include <kotuku/main.h>
+
+class objStorageDevice;
+class objFile;
+
+// StorageDevice class definition
+
+#define VER_STORAGEDEVICE (1.000000)
+
+class objStorageDevice : public Object {
+   public:
+   static constexpr CLASSID CLASS_ID = CLASSID::STORAGEDEVICE;
+   static constexpr CSTRING CLASS_NAME = "StorageDevice";
+
+   using create = kt::Create<objStorageDevice>;
+   objStorageDevice(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
+
+   DEVICE  DeviceFlags;   // These read-only flags identify the type of device and its features.
+   int64_t DeviceSize;    // Total storage capacity of the resolved volume, measured in bytes.
+   int64_t BytesFree;     // Amount of storage space available to the current user, measured in bytes.
+   int64_t BytesUsed;     // Amount of storage space in use, measured in bytes.
+   std::string DeviceID;  // Unique device identifier for the mounted volume, when available.
+   std::string Volume;    // The volume name of the device to query.
+
+   // Action stubs
+
+   inline ERR init() noexcept { return InitObject(this); }
+
+   // Customised field getting
+
+   inline ERR getDeviceFlags(DEVICE &Value) noexcept {
+      Value = this->DeviceFlags;
+      return ERR::Okay;
+   }
+
+   inline ERR getDeviceSize(int64_t &Value) noexcept {
+      Value = this->DeviceSize;
+      return ERR::Okay;
+   }
+
+   inline ERR getBytesFree(int64_t &Value) noexcept {
+      Value = this->BytesFree;
+      return ERR::Okay;
+   }
+
+   inline ERR getBytesUsed(int64_t &Value) noexcept {
+      Value = this->BytesUsed;
+      return ERR::Okay;
+   }
+
+   inline ERR getDevice(std::string_view &Value) noexcept {
+      Value = this->DeviceID;
+      return ERR::Okay;
+   }
+
+   inline ERR getVolume(std::string_view &Value) noexcept {
+      Value = this->Volume;
+      return ERR::Okay;
+   }
+
+
+   // Customised field setting
+
+   inline ERR setVolume(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[9];
+      return field->WriteValue(this, field, 0x00904500, &Value);
+   }
+
+};
+
+// File class definition
+
+#define VER_FILE (1.200000)
+
+// File methods
+
+namespace fl {
+struct StartStream { OBJECTID SubscriberID; FL Flags; int Length; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct StopStream { static const AC id = AC(-2); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Delete { FUNCTION *Callback; static const AC id = AC(-3); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Move { std::string_view Dest; FUNCTION *Callback; static const AC id = AC(-4); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Copy { std::string_view Dest; FUNCTION *Callback; static const AC id = AC(-5); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct SetDate { int Year; int Month; int Day; int Hour; int Minute; int Second; FDT Type; static const AC id = AC(-6); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ReadLine { std::string *Result; static const AC id = AC(-7); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct BufferContent { static const AC id = AC(-8); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Next { objFile *File; static const AC id = AC(-9); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct Watch { FUNCTION *Callback; MFF Flags; static const AC id = AC(-10); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+
+} // namespace
+
+class objFile : public Object {
+   public:
+   static constexpr CLASSID CLASS_ID = CLASSID::FILE;
+   static constexpr CSTRING CLASS_NAME = "File";
+
+   using create = kt::Create<objFile>;
+   objFile(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
+
+   int64_t  Position;   // The current read/write byte position in a file.
+   std::string Path;    // Specifies the location of a file or folder.
+   FL       Flags;      // File flags and options.
+   PERMIT   Permissions; // Manages the permissions of a file.
+   int8_t * Buffer;     // Points to the internal data buffer if the file content is held in memory.
+   int64_t  Size;       // The byte size of a file.
+   public:
+   inline std::string readLine() {
+      std::string str;
+      struct fl::ReadLine args { &str };
+      Action(fl::ReadLine::id, this, &args);
+      return str;
+   }
+
+   // Action stubs
+
+   inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+      return Action(AC::DataFeed, this, &args);
+   }
+   inline ERR flush() noexcept { return Action(AC::Flush, this, nullptr); }
+   inline ERR init() noexcept { return InitObject(this); }
+   inline ERR query() noexcept { return Action(AC::Query, this, nullptr); }
+   template <class T, class U> ERR read(APTR Buffer, T Size, U *Result) noexcept {
+      static_assert(std::is_integral<U>::value, "Result value must be an integer type");
+      static_assert(std::is_integral<T>::value, "Size value must be an integer type");
+      const int bytes = (Size > 0x7fffffff) ? 0x7fffffff : Size;
+      struct acRead read = { (int8_t *)Buffer, bytes };
+      if (auto error = Action(AC::Read, this, &read); error IS ERR::Okay) {
+         *Result = U(read.Result);
+         return ERR::Okay;
+      }
+      else { *Result = 0; return error; }
+   }
+   template <class T> ERR read(APTR Buffer, T Size) noexcept {
+      static_assert(std::is_integral<T>::value, "Size value must be an integer type");
+      const int bytes = (Size > 0x7fffffff) ? 0x7fffffff : Size;
+      struct acRead read = { (int8_t *)Buffer, bytes };
+      return Action(AC::Read, this, &read);
+   }
+   inline ERR rename(std::string_view Name) noexcept {
+      struct acRename args = { Name };
+      return Action(AC::Rename, this, &args);
+   }
+   inline ERR reset() noexcept { return Action(AC::Reset, this, nullptr); }
+   inline ERR seek(double Offset, SEEK Position = SEEK::CURRENT) noexcept {
+      struct acSeek args = { Offset, Position };
+      return Action(AC::Seek, this, &args);
+   }
+   inline ERR seekStart(double Offset) noexcept { return seek(Offset, SEEK::START); }
+   inline ERR seekEnd(double Offset) noexcept { return seek(Offset, SEEK::END); }
+   inline ERR seekCurrent(double Offset) noexcept { return seek(Offset, SEEK::CURRENT); }
+   inline ERR write(CPTR Buffer, int Size, int *Result = nullptr) noexcept {
+      struct acWrite write = { (int8_t *)Buffer, Size };
+      if (auto error = Action(AC::Write, this, &write); error IS ERR::Okay) {
+         if (Result) *Result = write.Result;
+         return ERR::Okay;
+      }
+      else {
+         if (Result) *Result = 0;
+         return error;
+      }
+   }
+   inline ERR write(std::string Buffer, int *Result = nullptr) noexcept {
+      struct acWrite write = { (int8_t *)Buffer.c_str(), int(Buffer.size()) };
+      if (auto error = Action(AC::Write, this, &write); error IS ERR::Okay) {
+         if (Result) *Result = write.Result;
+         return ERR::Okay;
+      }
+      else {
+         if (Result) *Result = 0;
+         return error;
+      }
+   }
+   inline ERR startStream(OBJECTID SubscriberID, FL Flags, int Length) noexcept {
+      struct fl::StartStream args = { SubscriberID, Flags, Length };
+      return Action(AC(-1), this, &args);
+   }
+   inline ERR stopStream() noexcept {
+      return Action(AC(-2), this, nullptr);
+   }
+   inline ERR del(FUNCTION Callback) noexcept {
+      struct fl::Delete args = { &Callback };
+      return Action(AC(-3), this, &args);
+   }
+   inline ERR move(const std::string_view &Dest, FUNCTION Callback) noexcept {
+      struct fl::Move args = { Dest, &Callback };
+      return Action(AC(-4), this, &args);
+   }
+   inline ERR copy(const std::string_view &Dest, FUNCTION Callback) noexcept {
+      struct fl::Copy args = { Dest, &Callback };
+      return Action(AC(-5), this, &args);
+   }
+   inline ERR setDate(int Year, int Month, int Day, int Hour, int Minute, int Second, FDT Type) noexcept {
+      struct fl::SetDate args = { Year, Month, Day, Hour, Minute, Second, Type };
+      return Action(AC(-6), this, &args);
+   }
+   inline ERR readLine(std::string &Result) noexcept {
+      struct fl::ReadLine args = { &Result };
+      ERR error = Action(AC(-7), this, &args);
+      return error;
+   }
+   inline ERR bufferContent() noexcept {
+      return Action(AC(-8), this, nullptr);
+   }
+   inline ERR next(objFile ** File) noexcept {
+      struct fl::Next args = { (objFile *)0 };
+      ERR error = Action(AC(-9), this, &args);
+      if (File) *File = args.File;
+      return error;
+   }
+   inline ERR watch(FUNCTION Callback, MFF Flags) noexcept {
+      struct fl::Watch args = { &Callback, Flags };
+      return Action(AC(-10), this, &args);
+   }
+
+   // Customised field getting
+
+   inline ERR getPosition(int64_t &Value) noexcept {
+      Value = this->Position;
+      return ERR::Okay;
+   }
+
+   inline ERR getPath(std::string_view &Value) noexcept {
+      Value = this->Path;
+      return ERR::Okay;
+   }
+
+   inline ERR getFlags(FL &Value) noexcept {
+      Value = this->Flags;
+      return ERR::Okay;
+   }
+
+   inline ERR getPermissions(PERMIT &Value) noexcept {
+      auto field = &this->Class->Dictionary[19];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getBuffer(std::span<int8_t> &Value) noexcept {
+      auto field = &this->Class->Dictionary[12];
+      auto get_field = (ERR (*)(APTR, std::span<int8_t> &))field->GetValue;
+      return get_field(this, Value);
+   }
+
+   inline ERR getSize(int64_t &Value) noexcept {
+      auto field = &this->Class->Dictionary[6];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getDate(struct DateTime * &Value) noexcept {
+      auto field = &this->Class->Dictionary[10];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getCreated(struct DateTime * &Value) noexcept {
+      auto field = &this->Class->Dictionary[3];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getHandle(int64_t &Value) noexcept {
+      auto field = &this->Class->Dictionary[8];
+      return field->GetValue(this, &Value);
+   }
+
+   inline ERR getIcon(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[11];
+      SetObjectContext(this, field, AC::NIL);
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getResolvedPath(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[18];
+      SetObjectContext(this, field, AC::NIL);
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getTimestamp(int64_t &Value) noexcept {
+      auto field = &this->Class->Dictionary[17];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getLink(std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[15];
+      SetObjectContext(this, field, AC::NIL);
+      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto error = get_field(this, Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getUser(int &Value) noexcept {
+      auto field = &this->Class->Dictionary[14];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+   inline ERR getGroup(int &Value) noexcept {
+      auto field = &this->Class->Dictionary[1];
+      SetObjectContext(this, field, AC::NIL);
+      auto error = field->GetValue(this, &Value);
+      RestoreObjectContext();
+      return error;
+   }
+
+
+   // Customised field setting
+
+   inline ERR setPosition(const int64_t Value) noexcept {
+      auto field = &this->Class->Dictionary[9];
+      return field->WriteValue(this, field, FD_INT64, &Value);
+   }
+
+   inline ERR setPath(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[5];
+      return field->WriteValue(this, field, 0x00804500, &Value);
+   }
+
+   inline ERR setFlags(const FL Value) noexcept {
+      auto field = &this->Class->Dictionary[2];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
+   inline ERR setPermissions(const PERMIT Value) noexcept {
+      auto field = &this->Class->Dictionary[19];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
+   inline ERR setSize(const int64_t Value) noexcept {
+      auto field = &this->Class->Dictionary[6];
+      return field->WriteValue(this, field, FD_INT64, &Value);
+   }
+
+   inline ERR setDate(const struct DateTime & Value) noexcept {
+      auto field = &this->Class->Dictionary[10];
+      return field->WriteValue(this, field, FD_STRUCT, &Value);
+   }
+
+   inline ERR setLink(const std::string_view &Value) noexcept {
+      auto field = &this->Class->Dictionary[15];
+      return field->WriteValue(this, field, 0x00804308, &Value);
+   }
+
+   inline ERR setUser(const int Value) noexcept {
+      auto field = &this->Class->Dictionary[14];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
+   inline ERR setGroup(const int Value) noexcept {
+      auto field = &this->Class->Dictionary[1];
+      return field->WriteValue(this, field, FD_INT, &Value);
+   }
+
+};
+
+namespace fl {
+
+// Read endian values from files and objects.
+
+template<class T> ERR ReadLE(OBJECTPTR Object, T *Result)
+{
+   uint8_t data[sizeof(T)];
+   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
+   if (!Action(AC::Read, Object, &read)) {
+      if (read.Result IS sizeof(T)) {
+         if constexpr (std::endian::native IS std::endian::little) {
+            *Result = ((T *)data)[0];
+         }
+         else {
+            switch(sizeof(T)) {
+               case 2:  *Result = (data[1]<<8) | data[0]; break;
+               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
+               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
+               default: *Result = ((T *)data)[0];
+            }
+         }
+         return ERR::Okay;
+      }
+      else return ERR::Read;
+   }
+   else return ERR::Read;
+}
+
+template<class T> ERR ReadBE(OBJECTPTR Object, T *Result)
+{
+   uint8_t data[sizeof(T)];
+   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
+   if (!Action(AC::Read, Object, &read)) {
+      if (read.Result IS sizeof(T)) {
+         if constexpr (std::endian::native IS std::endian::little) {
+            switch(sizeof(T)) {
+               case 2:  *Result = (data[1]<<8) | data[0]; break;
+               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
+               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
+               default: *Result = ((T *)data)[0];
+            }
+         }
+         else {
+            *Result = ((T *)data)[0];
+         }
+         return ERR::Okay;
+      }
+      else return ERR::Read;
+   }
+   else return ERR::Read;
+}
+
+} // fl namespace
+

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -95,6 +95,7 @@ For optimal results, choose the appropriate interface based on application requi
 
 #include <kotuku/main.h>
 #include <kotuku/modules/audio.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/config.h>
 #include <kotuku/modules/script.h>
 #include <kotuku/strings.hpp>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,16 +20,13 @@ set (FUNCTIONS  # Full paths are required for add_custom_command() dependencies 
    "${CMAKE_CURRENT_SOURCE_DIR}/fs_volumes.cpp")
 
 set (CORE_CLASSES
-   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_file.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_metaclass.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_module.cpp"
-   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_storagedevice.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_task.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_thread.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_time.cpp")
 
 SET (CORE_DEFS
-   "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_file_def.c"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_task_def.c"
    "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_thread_def.c")
 
@@ -38,10 +35,8 @@ if (KOTUKU_DEFS_AVAILABLE)
    set (CORE_OUTPUTS
       ${CORE_DEFS}
       "${DOCS}/modules/core.xml"
-      "${DOCS}/modules/classes/file.xml"
       "${DOCS}/modules/classes/metaclass.xml"
       "${DOCS}/modules/classes/module.xml"
-      "${DOCS}/modules/classes/storagedevice.xml"
       "${DOCS}/modules/classes/task.xml"
       "${DOCS}/modules/classes/thread.xml"
       "${DOCS}/modules/classes/time.xml"
@@ -117,6 +112,21 @@ idl_gen ("defs/compression.tdl"
       "${CMAKE_CURRENT_SOURCE_DIR}/defs/common.tdl"
       "${CMAKE_CURRENT_SOURCE_DIR}/compression/class_compression.cpp"
       "${CMAKE_CURRENT_SOURCE_DIR}/compression/class_compressed_stream.cpp")
+
+# File class
+
+idl_gen ("defs/filesystem.tdl"
+   NAME filesystem_defs
+   OUTPUT "${INCLUDE_OUTPUT}/modules/filesystem.h"
+   BYPRODUCTS
+      "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_file_def.c"
+      "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_storagedevice_def.c"
+      "${DOCS}/modules/classes/file.xml"
+      "${DOCS}/modules/classes/storagedevice.xml"
+   DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/defs/common.tdl"
+      "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_file.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/classes/class_storagedevice.cpp")
 
 if (NOT MSVC)
    # A bug in (MinGW?) GCC requires the following flag is applied to ensure that __packed__ works correctly.

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -189,6 +189,7 @@ struct rkWatchPath {
 #include "prototypes.h"
 #include <kotuku/modules/config.h>
 #include <kotuku/modules/script.h>
+#include <kotuku/modules/filesystem.h>
 
 using namespace kt;
 

--- a/src/core/defs/common.tdl
+++ b/src/core/defs/common.tdl
@@ -48,6 +48,29 @@
     "EXCLUDE_FOLDERS: Exclude folders when scanning this folder.",
     "VIRTUAL: Path is to a virtual device.")
 
+  enums("FDT", { type="int", start=0, comment="Flags for the SetDate() file method." },
+    "MODIFIED: The date on which the file was last modified.",
+    "CREATED: The date on which the file was created.  On some host platforms this datestamp may be read-only.",
+    "ACCESSED: The date on which the file was last accessed by a user or application.",
+    "ARCHIVED: The date on which the file was most recently archived.  Not supported by most filesystems.")
+
+  -- NB: The MFF flags are duplicated in the FileSystem's Win32 code if you're going to change these
+
+  flags("MFF", { comment="Flags for the File Watch() method." },
+    "READ: File was accessed (read).",
+    "MODIFY|WRITE: File modified via write or truncation.",
+    "CREATE: New file/link created or renamed in folder.",
+    "DELETE: Existing file deleted",
+    "MOVED|RENAME: Existing file moved or renamed.",
+    "ATTRIB: File permissions or datestamp changed.",
+    "OPENED: Existing file was opened.",
+    "CLOSED: An opened file has been closed.",
+    "UNMOUNT: Host filesystem was unmounted.",
+    "FOLDER: Folder identifier; if passed to @File.Watch() then indicates a preference for folder events only.",
+    "FILE: File identifier; if passed to @File.Watch() then indicates a preference for file events only.",
+    "SELF: Event applies to the monitored folder and not a contained item",
+    "DEEP: Receive notifications from sub-folders (Windows only).")
+
   struct("CompressionFeedback", { }, [[
     int(FDB) FeedbackID     # Set to one of the FDB event indicators
     int   Index             # Index of the current file

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -107,12 +107,6 @@ constexpr int RESOURCE_ID_OFFSET = -1;
   flags("THF", { comment="Thread flags" },
     "AUTO_FREE: Automatically destroy the Thread object when the user routine has completed.")
 
-  enums("FDT", { type="int", start=0, comment="Flags for the SetDate() file method." },
-    "MODIFIED: The date on which the file was last modified.",
-    "CREATED: The date on which the file was created.  On some host platforms this datestamp may be read-only.",
-    "ACCESSED: The date on which the file was last accessed by a user or application.",
-    "ARCHIVED: The date on which the file was most recently archived.  Not supported by most filesystems.")
-
   flags("VOLUME", { comment="Options for SetVolume()" },
     "REPLACE: If the volume already exists, all paths that are attached to it will be replaced with the new path setting.",
     "PRIORITY: If the volume already exists, the path will be inserted at the beginning of the path list so that it has priority over the others.",
@@ -129,23 +123,6 @@ constexpr int RESOURCE_ID_OFFSET = -1;
     "NO_DEEP_SCAN: Do not perform more than one iteration when resolving the source file path.",
     "PATH: Use the `PATH` environment variable to resolve the file name in the `Path` parameter.",
     "CASE_SENSITIVE: For use on host systems that use case-insensitive file systems such as Windows; this option checks that the discovered file is a case-sensitive match to the Path.")
-
-  -- NB: The MFF flags are duplicated in the FileSystem's Win32 code if you're going to change these
-
-  flags("MFF", { comment="Flags for the File Watch() method." },
-    "READ: File was accessed (read).",
-    "MODIFY|WRITE: File modified via write or truncation.",
-    "CREATE: New file/link created or renamed in folder.",
-    "DELETE: Existing file deleted",
-    "MOVED|RENAME: Existing file moved or renamed.",
-    "ATTRIB: File permissions or datestamp changed.",
-    "OPENED: Existing file was opened.",
-    "CLOSED: An opened file has been closed.",
-    "UNMOUNT: Host filesystem was unmounted.",
-    "FOLDER: Folder identifier; if passed to @File.Watch() then indicates a preference for folder events only.",
-    "FILE: File identifier; if passed to @File.Watch() then indicates a preference for file events only.",
-    "SELF: Event applies to the monitored folder and not a contained item",
-    "DEEP: Receive notifications from sub-folders (Windows only).")
 
   enums("STT", { type="int", start=1, comment="Types for StrDatatype()." },
     "NUMBER: The string represents a whole number.",
@@ -593,8 +570,7 @@ class FloatRect {
    constexpr double bottom() const noexcept { return Y + Height; }
 };
 
-}
-
+} // namespace
 ]==])
 
   struct('OpenTag', { comment='Tags for OpenInfo.Options' }, [[
@@ -1219,6 +1195,8 @@ typedef std::vector<obj_write> WRITE_TABLE;
   klass("Config")
   klass("Compression")
   klass("CompressedStream")
+  klass("File")
+  klass("StorageDevice")
 
   methods("MetaClass", "mc", {
     { id=1, name="FindField" }
@@ -1255,52 +1233,6 @@ inline bool Object::isDerived() { return Class->ClassID != Class->BaseClassID; }
 inline CLASSID Object::classID() { return Class->ClassID; }
 inline CLASSID Object::baseClassID() { return Class->BaseClassID; }
 ]])
-
-  klass("StorageDevice", { src="../classes/class_storagedevice.cpp", output="../classes/class_storagedevice_def.cpp" }, [[
-    large(DEVICE) DeviceFlags  # Flags identifying the type of media
-    large DeviceSize           # Size of the device
-    large BytesFree            # Bytes available to the user
-    large BytesUsed            # Bytes already used
-    string DeviceID            # A unique ID for the mounted device
-    string Volume              # The volume name of the device to query
-  ]])
-
-  methods("File", "Fl", {
-    { id=1,  name="StartStream" },
-    { id=2,  name="StopStream" },
-    { id=3,  name="Delete" },
-    { id=4,  name="Move" },
-    { id=5,  name="Copy" },
-    { id=6,  name="SetDate" },
-    { id=7,  name="ReadLine" },
-    { id=8,  name="BufferContent" },
-    { id=9,  name="Next" },
-    { id=10, name="Watch" }
-  })
-
-  klass("File", { version=1.2,
-    src="../classes/class_file.cpp",
-    output="../classes/class_file_def.c",
-    extended=true, references={ 'PERMIT' }
-  }, [[
-    large     Position  # The current read/write byte position in a file.
-    string    Path      # The file path.
-    int(FL)   Flags     # File flags and options.
-    int(PERMIT) Permissions
-    array(char) Buffer  # Points to the internal data buffer if the file content is held in memory.
-    large     Size      # The size of the file's content.
-    ~struct(DateTime) Date
-    ~struct(DateTime) Created
-  ]],
-  nil,
-  [[
-   inline std::string readLine() {
-      std::string str;
-      struct fl::ReadLine args { &str };
-      Action(fl::ReadLine::id, this, &args);
-      return str;
-   }
-  ]])
 
   struct("ActionEntry", { restrict='c', comment="For the Task Actions field." }, [[
      fptr(error obj ptr) PerformAction # Pointer to a custom action hook.
@@ -1496,60 +1428,6 @@ struct evHotplug {
 }
 
 } // pf namespace
-
-namespace fl {
-
-// Read endian values from files and objects.
-
-template<class T> ERR ReadLE(OBJECTPTR Object, T *Result)
-{
-   uint8_t data[sizeof(T)];
-   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
-   if (!Action(AC::Read, Object, &read)) {
-      if (read.Result IS sizeof(T)) {
-         if constexpr (std::endian::native == std::endian::little) {
-            *Result = ((T *)data)[0];
-         }
-         else {
-            switch(sizeof(T)) {
-               case 2:  *Result = (data[1]<<8) | data[0]; break;
-               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
-               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
-               default: *Result = ((T *)data)[0];
-            }
-         }
-         return ERR::Okay;
-      }
-      else return ERR::Read;
-   }
-   else return ERR::Read;
-}
-
-template<class T> ERR ReadBE(OBJECTPTR Object, T *Result)
-{
-   uint8_t data[sizeof(T)];
-   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
-   if (!Action(AC::Read, Object, &read)) {
-      if (read.Result IS sizeof(T)) {
-         if constexpr (std::endian::native == std::endian::little) {
-            switch(sizeof(T)) {
-               case 2:  *Result = (data[1]<<8) | data[0]; break;
-               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
-               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
-               default: *Result = ((T *)data)[0];
-            }
-         }
-         else {
-            *Result = ((T *)data)[0];
-         }
-         return ERR::Okay;
-      }
-      else return ERR::Read;
-   }
-   else return ERR::Read;
-}
-
-} // fl namespace
 
 // Function construction (refer types.h)
 

--- a/src/core/defs/filesystem.tdl
+++ b/src/core/defs/filesystem.tdl
@@ -1,0 +1,113 @@
+--$TIRI:Include
+
+header({ module="Core", copyright="Paul Manias © 1996-2026", timestamp=20240611 }, function()
+  c_include('<kotuku/main.h>')
+
+  restrict(function()
+    loadFile('./common.tdl')
+    loadFile(glPath .. 'common.tdl')
+  end)
+
+  klass("StorageDevice", { src="../classes/class_storagedevice.cpp", output="../classes/class_storagedevice_def.cpp" }, [[
+    large(DEVICE) DeviceFlags  # Flags identifying the type of media
+    large DeviceSize           # Size of the device
+    large BytesFree            # Bytes available to the user
+    large BytesUsed            # Bytes already used
+    string DeviceID            # A unique ID for the mounted device
+    string Volume              # The volume name of the device to query
+  ]])
+
+  methods("File", "Fl", {
+    { id=1,  name="StartStream" },
+    { id=2,  name="StopStream" },
+    { id=3,  name="Delete" },
+    { id=4,  name="Move" },
+    { id=5,  name="Copy" },
+    { id=6,  name="SetDate" },
+    { id=7,  name="ReadLine" },
+    { id=8,  name="BufferContent" },
+    { id=9,  name="Next" },
+    { id=10, name="Watch" }
+  })
+
+  klass("File", { version=1.2,
+    src="../classes/class_file.cpp",
+    output="../classes/class_file_def.c",
+    extended=true, references={ 'PERMIT' }
+  }, [[
+    large     Position  # The current read/write byte position in a file.
+    string    Path      # The file path.
+    int(FL)   Flags     # File flags and options.
+    int(PERMIT) Permissions
+    array(char) Buffer  # Points to the internal data buffer if the file content is held in memory.
+    large     Size      # The size of the file's content.
+    ~struct(DateTime) Date
+    ~struct(DateTime) Created
+  ]],
+  nil,
+  [[
+   inline std::string readLine() {
+      std::string str;
+      struct fl::ReadLine args { &str };
+      Action(fl::ReadLine::id, this, &args);
+      return str;
+   }
+  ]])
+
+  c_insert([[
+namespace fl {
+
+// Read endian values from files and objects.
+
+template<class T> ERR ReadLE(OBJECTPTR Object, T *Result)
+{
+   uint8_t data[sizeof(T)];
+   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
+   if (!Action(AC::Read, Object, &read)) {
+      if (read.Result IS sizeof(T)) {
+         if constexpr (std::endian::native IS std::endian::little) {
+            *Result = ((T *)data)[0];
+         }
+         else {
+            switch(sizeof(T)) {
+               case 2:  *Result = (data[1]<<8) | data[0]; break;
+               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
+               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
+               default: *Result = ((T *)data)[0];
+            }
+         }
+         return ERR::Okay;
+      }
+      else return ERR::Read;
+   }
+   else return ERR::Read;
+}
+
+template<class T> ERR ReadBE(OBJECTPTR Object, T *Result)
+{
+   uint8_t data[sizeof(T)];
+   struct acRead read = { .Buffer = data, .Length = sizeof(T) };
+   if (!Action(AC::Read, Object, &read)) {
+      if (read.Result IS sizeof(T)) {
+         if constexpr (std::endian::native IS std::endian::little) {
+            switch(sizeof(T)) {
+               case 2:  *Result = (data[1]<<8) | data[0]; break;
+               case 4:  *Result = (data[0]<<24)|(data[1]<<16)|(data[2]<<8)|(data[3]); break;
+               case 8:  *Result = ((int64_t)data[0]<<56)|((int64_t)data[1]<<48)|((int64_t)data[2]<<40)|((int64_t)data[3]<<32)|(data[4]<<24)|(data[5]<<16)|(data[6]<<8)|(data[7]); break;
+               default: *Result = ((T *)data)[0];
+            }
+         }
+         else {
+            *Result = ((T *)data)[0];
+         }
+         return ERR::Okay;
+      }
+      else return ERR::Read;
+   }
+   else return ERR::Read;
+}
+
+} // fl namespace
+]])
+
+end)

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -106,6 +106,7 @@ constexpr int BLEND_MIN_THRESHOLD = 1;
 #define SURFACE_READWRITE (SURFACE_READ|SURFACE_WRITE)
 
 #include <kotuku/modules/display.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/compression.h>
 #include <kotuku/modules/xml.h>
 #include <kotuku/modules/regex.h>

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -32,6 +32,7 @@ that is distributed with this package.  Please refer to it for further informati
 
 #include "defs/hashes.h"
 #include "../link/unicode.h"
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/script.h>
 #include <kotuku/modules/xquery.h>
 #include <atomic>

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -38,6 +38,7 @@ Google Fonts Knowledge page: https://fonts.google.com/knowledge
 #include <kotuku/main.h>
 #include <kotuku/modules/xml.h>
 #include <kotuku/modules/font.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/display.h>
 #include <kotuku/modules/config.h>
 

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -106,6 +106,7 @@ For information about the HTTP protocol, please refer to the official protocol w
 //#include <kotuku/modules/display.h>
 #include <kotuku/modules/network.h>
 #include <kotuku/modules/script.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/strings.hpp>
 #include "../link/base64.h"
 

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -39,6 +39,7 @@ rendered image size.
 #include <kotuku/main.h>
 #include <kotuku/modules/image.h>
 #include <kotuku/modules/display.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/strings.hpp>
 #include "../link/linear_rgb.h"
 

--- a/src/image_jpeg/jpeg.cpp
+++ b/src/image_jpeg/jpeg.cpp
@@ -14,6 +14,7 @@ related to this Package.  The original libjpeg source code can be obtained from 
 #include <kotuku/main.h>
 #include <kotuku/modules/image.h>
 #include <kotuku/modules/display.h>
+#include <kotuku/modules/filesystem.h>
 
 #include "../image/image.h"
 

--- a/src/mp3/mp3.cpp
+++ b/src/mp3/mp3.cpp
@@ -12,6 +12,7 @@ MP3: Sound class extension
 #define PRV_MP3
 #include <kotuku/main.h>
 #include <kotuku/modules/audio.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/mp3.h>
 #include <kotuku/strings.hpp>
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -28,6 +28,7 @@ sockets and HTTP, please refer to the @NetSocket, @NetServer and @HTTP classes.
 
 #include <kotuku/main.h>
 #include <kotuku/modules/network.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/script.h>
 #include <kotuku/strings.hpp>
 

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -24,6 +24,7 @@ https://www.w3.org/Graphics/SVG/Test/Overview.html
 #include <cfloat>
 #include <kotuku/main.h>
 #include <kotuku/modules/compression.h>
+#include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/xml.h>
 #include <kotuku/modules/vector.h>
 #include <kotuku/modules/display.h>

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -12,6 +12,7 @@ constexpr int SIZE_READ = 1024;
 #include <kotuku/strings.hpp>
 #include <kotuku/modules/regex.h>
 #include <kotuku/modules/tiri.h>
+#include <kotuku/modules/filesystem.h>
 #include <thread>
 #include <string_view>
 #include <span>

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -6,6 +6,7 @@
 #define PRV_TIRI_MODULE
 #include <kotuku/main.h>
 #include <kotuku/strings.hpp>
+#include <kotuku/modules/filesystem.h>
 #include <inttypes.h>
 
 #include "lauxlib.h"

--- a/src/xquery/functions/func_accessors.cpp
+++ b/src/xquery/functions/func_accessors.cpp
@@ -5,6 +5,7 @@
 // sequence-building helpers declared in xpath_functions.cpp.
 
 #include "accessor_support.h"
+
 //********************************************************************************************************************
 // base-uri() as xs:anyURI?
 // Returns the base URI for the specified node, or the context node if no argument is provided

--- a/src/xquery/functions/func_documents.cpp
+++ b/src/xquery/functions/func_documents.cpp
@@ -3,6 +3,7 @@
 
 #include "accessor_support.h"
 #include <filesystem>
+#include <kotuku/modules/filesystem.h>
 
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
* Added filesystem TDL and generated header for File and StorageDevice definitions
* Moved file event and date definitions into shared core IDL inputs
* Updated module sources to include the filesystem header where file APIs are used