### PR TITLE
[Core] Replaced generic field access with generated accessors

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -179,7 +179,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -660,7 +660,8 @@ static ERR SOUND_Init(extSound *Self)
       else return log.warning(ERR::AccessObject);
    }
 
-   auto path = Self->get<std::string_view>(FID_Path);
+   std::string_view path;
+   Self->getPath(path);
    if (((Self->Flags & SDF::NEW) != SDF::NIL) or (path.empty())) {
       // If the sample is new or no path has been specified, create an audio sample from scratch (e.g. to record
       // audio to disk).
@@ -718,7 +719,9 @@ static ERR SOUND_Init(extSound *Self)
 
    // Setup the sound structure
 
-   Self->DataOffset = Self->File->get<int>(FID_Position);
+   int64_t file_position;
+   Self->File->getPosition(file_position);
+   Self->DataOffset = int(file_position);
 
    Self->Format         = WAVE.Format;
    Self->BytesPerSecond = WAVE.AvgBytesPerSecond;
@@ -765,7 +768,8 @@ static ERR SOUND_Init(extSound *Self)
       else return log.warning(ERR::AccessObject);
    }
 
-   auto path = Self->get<std::string_view>(FID_Path);
+   std::string_view path;
+   Self->getPath(path);
 
    if (((Self->Flags & SDF::NEW) != SDF::NIL) or (path.empty())) {
       log.msg("Sample created as new (without sample data).");
@@ -816,7 +820,9 @@ static ERR SOUND_Init(extSound *Self)
 
    // TODO Look for the cue chunk for loop information
 
-   pos = Self->File->get<int>(FID_Position);
+   int64_t file_position;
+   Self->File->getPosition(file_position);
+   pos = int(file_position);
 #if 0
    if (!find_chunk(Self->File.get(), "cue ")) {
       data_p += 32;
@@ -844,7 +850,9 @@ static ERR SOUND_Init(extSound *Self)
 
    fl::ReadLE(Self->File.get(), &Self->Length); // Length of audio data in this chunk
 
-   Self->DataOffset = Self->File->get<int>(FID_Position);
+   int64_t file_position;
+   Self->File->getPosition(file_position);
+   Self->DataOffset = int(file_position);
 
    Self->Format         = WAVE.Format;
    Self->BytesPerSecond = WAVE.AvgBytesPerSecond;

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -719,9 +719,9 @@ static ERR SOUND_Init(extSound *Self)
 
    // Setup the sound structure
 
-   int64_t file_position;
-   Self->File->getPosition(file_position);
-   Self->DataOffset = int(file_position);
+   int64_t file_pos;
+   Self->File->getPosition(file_pos);
+   Self->DataOffset = int(file_pos);
 
    Self->Format         = WAVE.Format;
    Self->BytesPerSecond = WAVE.AvgBytesPerSecond;
@@ -820,9 +820,9 @@ static ERR SOUND_Init(extSound *Self)
 
    // TODO Look for the cue chunk for loop information
 
-   int64_t file_position;
-   Self->File->getPosition(file_position);
-   pos = int(file_position);
+   int64_t file_pos;
+   Self->File->getPosition(file_pos);
+   pos = int(file_pos);
 #if 0
    if (!find_chunk(Self->File.get(), "cue ")) {
       data_p += 32;
@@ -850,9 +850,8 @@ static ERR SOUND_Init(extSound *Self)
 
    fl::ReadLE(Self->File.get(), &Self->Length); // Length of audio data in this chunk
 
-   int64_t file_position;
-   Self->File->getPosition(file_position);
-   Self->DataOffset = int(file_position);
+   Self->File->getPosition(file_pos);
+   Self->DataOffset = int(file_pos);
 
    Self->Format         = WAVE.Format;
    Self->BytesPerSecond = WAVE.AvgBytesPerSecond;

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -190,7 +190,9 @@ static ERR parse_file(extConfig *Self, std::string_view Path)
       objFile::create file = { fl::Path(current_path), fl::Flags(FL::READ|FL::APPROXIMATE) };
 
       if (file.ok()) {
-         auto filesize = file->get<int>(FID_Size);
+         int64_t file_size;
+         file->getSize(file_size);
+         int filesize = int(file_size);
 
          if (filesize > 0) {
             std::string data(filesize + 1, '\0');

--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -948,8 +948,9 @@ ERR LoadFile(const std::string_view &Path, LDF Flags, CacheFile **Cache)
    auto file = objFile::create { fl::Path(path), fl::Flags(FL::READ|FL::FILE) };
 
    if (file.ok()) {
-      auto file_size = file->get<int64_t>(FID_Size);
-      auto timestamp = file->get<int64_t>(FID_Timestamp);
+      int64_t file_size, timestamp;
+      file->getSize(file_size);
+      file->getTimestamp(timestamp);
 
       CacheFileIndex index(path, timestamp, file_size);
       std::shared_ptr<CacheLoadState> loading_state;

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -112,7 +112,9 @@ void clean_clipboard(void)
    if (not time.ok()) return;
 
    time->query();
-   int64_t now = time->get<int64_t>(FID_Timestamp) / 1000000LL;
+   int64_t timestamp;
+   time->getTimestamp(timestamp);
+   int64_t now = timestamp / 1000000LL;
    int64_t yesterday = now - (24 * 60LL * 60LL);
 
    DirInfo *dir;

--- a/src/display/display-driver.cpp
+++ b/src/display/display-driver.cpp
@@ -1394,7 +1394,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -746,8 +746,8 @@ ERR resize_layer(extSurface *Self, int X, int Y, int Width, int Height, int Insi
             return log.warning(ERR::Redimension);
          }
 
-         Width = display->get<int>(FID_Width);
-         Height = display->get<int>(FID_Height);
+         display->getWidth(Width);
+         display->getHeight(Height);
       }
       else return log.warning(ERR::AccessObject);
    }

--- a/src/display/win32/handlers.cpp
+++ b/src/display/win32/handlers.cpp
@@ -237,10 +237,11 @@ void CheckWindowSize(OBJECTID SurfaceID, int &Width, int &Height, int CurrentWid
    if ((Width IS CurrentWidth) and (Height IS CurrentHeight)) return;
 
    if (ScopedObjectLock<objSurface> surface(SurfaceID, 3000); surface.granted()) {
-      auto min_width  = surface->get<int>(FID_MinWidth);
-      auto min_height = surface->get<int>(FID_MinHeight);
-      auto max_width  = surface->get<int>(FID_MaxWidth);
-      auto max_height = surface->get<int>(FID_MaxHeight);
+      int min_width, min_height, max_width, max_height;
+      surface->getMinWidth(min_width);
+      surface->getMinHeight(min_height);
+      surface->getMaxWidth(max_width);
+      surface->getMaxHeight(max_height);
 
       if ((min_width > 0) and (Width < min_width))    Width  = min_width;
       if ((min_height > 0) and (Height < min_height)) Height = min_height;

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -114,10 +114,11 @@ static ERR feedback_view(objVectorViewport *View, FM Event)
    kt::Log log(__FUNCTION__);
    auto Self = (extDocument *)CurrentContext();
 
-   auto width  = View->get<double>(FID_ViewWidth);
-   auto height = View->get<double>(FID_ViewHeight);
-   if (not width) width = View->get<double>(FID_Width);
-   if (not height) height = View->get<double>(FID_Height);
+   double width, height;
+   View->getViewWidth(width);
+   View->getViewHeight(height);
+   if (not width)  { Unit w; View->getWidth(w);  width = w; }
+   if (not height) { Unit h; View->getHeight(h); height = h; }
 
    if ((Self->VPWidth IS width) and (Self->VPHeight IS height)) return ERR::Okay;
 
@@ -835,10 +836,10 @@ static ERR DOCUMENT_Init(extDocument *Self)
 
    SubscribeAction(Self->Viewport, AC::Free, C_FUNCTION(notify_free_viewport));
 
-   Self->VPWidth  = Self->Viewport->get<double>(FID_ViewWidth);
-   Self->VPHeight = Self->Viewport->get<double>(FID_ViewHeight);
-   if (not Self->VPWidth) Self->VPWidth = Self->Viewport->get<double>(FID_Width);
-   if (not Self->VPHeight) Self->VPHeight = Self->Viewport->get<double>(FID_Height);
+   Self->Viewport->getViewWidth(Self->VPWidth);
+   Self->Viewport->getViewHeight(Self->VPHeight);
+   if (not Self->VPWidth)  { Unit w; Self->Viewport->getWidth(w);  Self->VPWidth = w; }
+   if (not Self->VPHeight) { Unit h; Self->Viewport->getHeight(h); Self->VPHeight = h; }
 
    FRGB bkgd { 1.0, 1.0, 1.0, 1.0 };
    Self->Viewport->setFillColour(bkgd);

--- a/src/document/draw.cpp
+++ b/src/document/draw.cpp
@@ -867,7 +867,9 @@ void layout::gen_scene_graph(objVectorViewport *Viewport, std::vector<doc_segmen
 
                      txt.vector_text.push_back(vt);
 
-                     x_advance += vt->get<double>(FID_TextWidth);
+                     int text_width;
+                     vt->getTextWidth(text_width);
+                     x_advance += text_width;
                   }
                }
                break;

--- a/src/document/menu.cpp
+++ b/src/document/menu.cpp
@@ -200,12 +200,16 @@ void doc_menu::reposition(objVectorViewport *RelativeViewport)
 
    kt::ScopedObjectLock<objSurface> lk_surface(RelativeViewport->Scene->SurfaceID); // Window surface
    if (lk_surface.granted()) {
-      auto w_absx = lk_surface->get<double>(FID_AbsX);
-      auto w_absy = lk_surface->get<double>(FID_AbsY);
+      int w_absx, w_absy;
+      lk_surface->getAbsX(w_absx);
+      lk_surface->getAbsY(w_absy);
 
-      auto vp_absx = RelativeViewport->get<double>(FID_AbsX);
-      auto vp_absy = RelativeViewport->get<double>(FID_AbsY);
-      auto vp_height = RelativeViewport->get<double>(FID_Height);
+      int vp_absx, vp_absy;
+      RelativeViewport->getAbsX(vp_absx);
+      RelativeViewport->getAbsY(vp_absy);
+
+      Unit vp_height;
+      RelativeViewport->getHeight(vp_height);
 
       // Invert the menu position if it will drop off the display
 

--- a/src/document/scrollbar.cpp
+++ b/src/document/scrollbar.cpp
@@ -1,7 +1,7 @@
 
-static const char *glSliderBkgd = "rgb(225 225 225)";
-static const char *glSliderColour = "rgb(185 195 215)";
-static const char *glSliderHighlight = "rgb(245 175 155)";
+static CSTRING glSliderBkgd = "rgb(225 225 225)";
+static CSTRING glSliderColour = "rgb(185 195 215)";
+static CSTRING glSliderHighlight = "rgb(245 175 155)";
 
 //********************************************************************************************************************
 // Subscription to the slider's drag events.  Moving the page is all that is necessary; this
@@ -9,14 +9,18 @@ static const char *glSliderHighlight = "rgb(245 175 155)";
 
 static ERR slider_drag(objVectorViewport *Viewport, double X, double Y, double OriginX, double OriginY, scroll_mgr *Scroll)
 {
-   auto slider_height = Viewport->get<double>(FID_Height);
-   auto host_height = Scroll->m_vbar.m_slider_host->get<double>(FID_Height);
-   auto page_height = Scroll->m_page->get<double>(FID_Height);
-   auto view_height = Scroll->m_view->get<double>(FID_Height);
+   Unit slider_height, host_height, page_height, view_height, viewport_y;
+
+   Viewport->getHeight(slider_height);
+   Scroll->m_vbar.m_slider_host->getHeight(host_height);
+   Scroll->m_page->getHeight(page_height);
+   Scroll->m_view->getHeight(view_height);
 
    if (Y < 0) Y = 0;
    if (Y + slider_height > host_height) Y = host_height - slider_height;
-   if (Viewport->get<double>(FID_Y) IS Y) return ERR::Okay;
+
+   Viewport->getY(viewport_y);
+   if (viewport_y IS Y) return ERR::Okay;
 
    if ((Y != Scroll->m_vbar.m_slider_pos.offset) or (slider_height != Scroll->m_vbar.m_slider_pos.length)) {
       const double pct_pos = Y / (host_height - slider_height);
@@ -57,23 +61,31 @@ static ERR bkgd_input(objVectorViewport *Viewport, const InputEvent *Events, scr
    for (auto msg=Events; msg; msg=msg->Next) {
       if ((msg->Type IS JET::LMB) and (msg->Value > 0)) {
          if (Scroll->m_vbar.m_slider_host IS Viewport) {
-            auto slider_y = Scroll->m_vbar.m_slider_vp->get<double>(FID_Y);
-            auto slider_height = Scroll->m_vbar.m_slider_vp->get<double>(FID_Height);
+            Unit slider_y, slider_height, view_height;
+
+            Scroll->m_vbar.m_slider_vp->getY(slider_y);
+            Scroll->m_vbar.m_slider_vp->getHeight(slider_height);
+            Scroll->m_view->getHeight(view_height);
+
             if (msg->Y < slider_y) { // Scroll up?
-               Scroll->scroll_page(0, Scroll->m_view->get<double>(FID_Height) * 0.9);
+               Scroll->scroll_page(0, view_height * 0.9);
             }
             else if (msg->Y > slider_y + slider_height) { // Scroll down?
-               Scroll->scroll_page(0, -Scroll->m_view->get<double>(FID_Height) * 0.9);
+               Scroll->scroll_page(0, -view_height * 0.9);
             }
          }
          else if (Scroll->m_hbar.m_slider_host IS Viewport) {
-            auto slider_x = Scroll->m_vbar.m_slider_vp->get<double>(FID_X);
-            auto slider_width = Scroll->m_vbar.m_slider_vp->get<double>(FID_Width);
+            Unit slider_x, slider_width, view_width;
+
+            Scroll->m_vbar.m_slider_vp->getX(slider_x);
+            Scroll->m_vbar.m_slider_vp->getWidth(slider_width);
+            Scroll->m_view->getWidth(view_width);
+
             if (msg->X < slider_x) {
-               Scroll->scroll_page(Scroll->m_view->get<double>(FID_Width) * 0.9, 0);
+               Scroll->scroll_page(view_width * 0.9, 0);
             }
             else if (msg->X > slider_x + slider_width) {
-               Scroll->scroll_page(-Scroll->m_view->get<double>(FID_Width) * 0.9, 0);
+               Scroll->scroll_page(-view_width * 0.9, 0);
             }
          }
       }
@@ -87,13 +99,17 @@ static ERR bkgd_input(objVectorViewport *Viewport, const InputEvent *Events, scr
 
 static ERR view_path_changed(objVectorViewport *Viewport, FM Event, APTR EventObject, scroll_mgr *Scroll)
 {
-   auto p_x = Scroll->m_page->get<double>(FID_X);
-   auto p_y = Scroll->m_page->get<double>(FID_Y);
-   auto p_width  = Scroll->m_page->get<double>(FID_Width);
-   auto p_height = Scroll->m_page->get<double>(FID_Height);
+   Unit u_p_x, u_p_y, u_p_width, u_p_height, u_view_width, u_view_height;
 
-   auto view_width  = Scroll->m_view->get<double>(FID_Width);
-   auto view_height = Scroll->m_view->get<double>(FID_Height);
+   Scroll->m_page->getX(u_p_x);
+   Scroll->m_page->getY(u_p_y);
+   Scroll->m_page->getWidth(u_p_width);
+   Scroll->m_page->getHeight(u_p_height);
+   Scroll->m_view->getWidth(u_view_width);
+   Scroll->m_view->getHeight(u_view_height);
+
+   double p_x = u_p_x, p_y = u_p_y, p_width = u_p_width, p_height = u_p_height;
+   const double view_width = u_view_width, view_height = u_view_height;
 
    if (!Scroll->m_fixed_mode) {
       auto nw = Scroll->m_min_width;
@@ -142,9 +158,10 @@ static ERR page_movement(objVectorViewport *Viewport, const InputEvent *Events, 
 {
    for (auto ev = Events; ev; ev = ev->Next) {
       if (ev->Type IS JET::WHEEL) {
-         auto view_height = Scroll->m_view->get<double>(FID_Height);
-         auto page_height = Scroll->m_page->get<double>(FID_Height);
-         auto length = page_height - view_height;
+         Unit view_height, page_height;
+         Scroll->m_view->getHeight(view_height);
+         Scroll->m_page->getHeight(page_height);
+         double length = page_height - view_height;
          if (length > 0) {
             if (length > view_height) length = view_height;
             Scroll->scroll_page(0, -ev->Value * length * 0.06);
@@ -180,11 +197,12 @@ scroll_mgr::scroll_slider scroll_mgr::scroll_bar::calc_slider(double ViewLen, do
 
 void scroll_mgr::recalc_sliders_from_view()
 {
-   auto v_width  = m_view->get<double>(FID_Width);
-   auto v_height = m_view->get<double>(FID_Height);
+   Unit v_width, v_height, p_width, p_height;
 
-   auto p_width  = m_page->get<double>(FID_Width);
-   auto p_height = m_page->get<double>(FID_Height);
+   m_view->getWidth(v_width);
+   m_view->getHeight(v_height);
+   m_page->getWidth(p_width);
+   m_page->getHeight(p_height);
 
    if ((p_width > v_width) or (p_height > v_height)) {
       // Page exceeds the available view space, scrollbar is required.
@@ -194,9 +212,11 @@ void scroll_mgr::recalc_sliders_from_view()
 
          acMoveToFront(m_vbar.m_bar_vp);
 
-         auto s = m_vbar.calc_slider(v_height, p_height,
-            m_vbar.m_slider_host->get<double>(FID_Height),
-            -m_page->get<double>(FID_Y));
+         Unit host_height, page_y;
+         m_vbar.m_slider_host->getHeight(host_height);
+         m_page->getY(page_y);
+
+         auto s = m_vbar.calc_slider(v_height, p_height, host_height, -page_y);
 
          if ((s.offset != m_vbar.m_slider_pos.offset) or
              (s.length != m_vbar.m_slider_pos.length)) {
@@ -211,7 +231,11 @@ void scroll_mgr::recalc_sliders_from_view()
             }
             else {
                m_vbar.m_bar_vp->setVisibility(VIS::VISIBLE);
-               if (m_auto_adjust_view_size) m_view->setXOffset(m_vbar.m_slider_vp->get<double>(FID_Width));
+               if (m_auto_adjust_view_size) {
+                  Unit slider_width;
+                  m_vbar.m_slider_vp->getWidth(slider_width);
+                  m_view->setXOffset(slider_width);
+               }
                if (m_hbar.m_bar_vp) m_hbar.m_bar_vp->setXOffset(m_hbar.m_breadth);
             }
          }
@@ -296,10 +320,13 @@ void scroll_mgr::scroll_bar::clear()
 
 void scroll_mgr::scroll_page(double DeltaX, double DeltaY)
 {
-   const double current_y = m_page->get<double>(FID_Y);
+   Unit current_y, page_height, view_height;
+
+   m_page->getY(current_y);
+   m_page->getHeight(page_height);
+   m_view->getHeight(view_height);
+
    double y = current_y + DeltaY;
-   const double page_height = m_page->get<double>(FID_Height);
-   const double view_height = m_view->get<double>(FID_Height);
 
    if ((y > 0) or (page_height < view_height)) y = 0;
    else if (y + page_height < view_height) y = -page_height + view_height;
@@ -316,8 +343,14 @@ void scroll_mgr::scroll_page(double DeltaX, double DeltaY)
 void scroll_mgr::fix_page_size(double Width, double Height)
 {
    m_fixed_mode = true;
-   if (Width != m_page->get<double>(FID_Width)) m_page->setWidth(Width);
-   if (Height != m_page->get<double>(FID_Height)) m_page->setHeight(Height);
+
+   Unit page_width, page_height;
+
+   m_page->getWidth(page_width);
+   m_page->getHeight(page_height);
+
+   if (Width != page_width) m_page->setWidth(Width);
+   if (Height != page_height) m_page->setHeight(Height);
 }
 
 //********************************************************************************************************************
@@ -328,7 +361,9 @@ void scroll_mgr::dynamic_page_size(double NominalWidth, double MinWidth, double 
 
    if (NominalWidth < m_min_width) NominalWidth = m_min_width;
 
-   if (NominalWidth >= m_view->get<double>(FID_Width)) acResize(m_page, NominalWidth, Height, 0);
+   Unit view_width;
+   m_view->getWidth(view_width);
+   if (NominalWidth >= view_width) acResize(m_page, NominalWidth, Height, 0);
    else {
       m_page->setWidth(Unit(1.0, FD_SCALED));
       m_page->setHeight(Height);

--- a/src/document/ui.cpp
+++ b/src/document/ui.cpp
@@ -55,7 +55,9 @@ static ERR combo_feedback(objVectorViewport *Viewport, FM Event, OBJECTPTR Event
       }
    }
    else if ((Event IS FM::HAS_FOCUS) or (Event IS FM::CHILD_HAS_FOCUS)) {
-      combo->last_good_input = combo->input->get<std::string>(FID_String);
+      std::string_view input_string;
+      combo->input->getString(input_string);
+      combo->last_good_input = input_string;
       if (!combo->name.empty()) {
          Self->Vars[combo->name] = combo->last_good_input;
          if ((Self->EventMask & DEF::WIDGET_STATE) != DEF::NIL) {

--- a/src/font/font.cpp
+++ b/src/font/font.cpp
@@ -418,7 +418,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -582,7 +582,7 @@ static ERR HTTP_Activate(extHTTP *Self)
    Self->Flags        &= ~(HTF::MOVED|HTF::REDIRECTED);
 
    if ((Self->Socket) and (Self->Socket->State IS NTC::DISCONNECTED)) {
-      Self->Socket->set(FID_Feedback, (APTR)nullptr);
+      Self->Socket->setFeedback(FUNCTION{});
       FreeResource(Self->Socket);
       Self->Socket = nullptr;
       Self->SecurePath = true;
@@ -597,7 +597,7 @@ static ERR HTTP_Activate(extHTTP *Self)
    auto cleanup_activation_failure = [&]() {
       if (Self->flInput) { FreeResource(Self->flInput); Self->flInput = nullptr; }
       if (Self->Socket) {
-         Self->Socket->set(FID_Feedback, (APTR)nullptr);
+         Self->Socket->setFeedback(FUNCTION{});
          FreeResource(Self->Socket);
          Self->Socket = nullptr;
          Self->SecurePath = true;
@@ -734,7 +734,7 @@ static ERR HTTP_Activate(extHTTP *Self)
                if (!Self->Size) {
                   kt::ScopedObjectLock<Object> input(Self->InputObjectID, 3000);
                   if (input.granted()) {
-                     input->get(FID_Size, Self->ContentLength);
+                     Self->ContentLength = input->get<int64_t>(FID_Size);
                   }
                   else {
                      Self->Error = ERR::Lock;
@@ -889,9 +889,9 @@ static ERR HTTP_Activate(extHTTP *Self)
             (Self->Method IS HTM::PATCH)) {
             Self->Socket->setOutgoing(C_FUNCTION(socket_outgoing));
          }
-         else Self->Socket->set(FID_Outgoing, (APTR)nullptr);
+         else Self->Socket->setOutgoing(FUNCTION{});
       }
-      else Self->Socket->set(FID_Outgoing, (APTR)nullptr);
+      else Self->Socket->setOutgoing(FUNCTION{});
    }
 
    // Buffer the HTTP command string to the socket (will write on connect if we're not connected already).
@@ -969,7 +969,7 @@ static ERR HTTP_Deactivate(extHTTP *Self)
 
       if ((Self->Socket->State IS NTC::DISCONNECTED) or (Self->CurrentState IS HGS::TERMINATED)) {
          log.msg("Terminating socket (disconnected).");
-         Self->Socket->set(FID_Feedback, (APTR)nullptr);
+         Self->Socket->setFeedback(FUNCTION{});
          FreeResource(Self->Socket);
          Self->Socket = nullptr;
          Self->SecurePath = true;
@@ -984,7 +984,7 @@ static ERR HTTP_Deactivate(extHTTP *Self)
 extHTTP::~extHTTP()
 {
    if (Socket) {
-      Socket->set(FID_Feedback, (APTR)nullptr);
+      Socket->setFeedback(FUNCTION{});
       FreeResource(Socket);
    }
 

--- a/src/http/http_fields.cpp
+++ b/src/http/http_fields.cpp
@@ -379,7 +379,7 @@ static ERR SET_Location(extHTTP *Self, const std::string_view &Value)
       // Free the current socket if the entire URI changes
 
       if (Self->Socket) {
-         Self->Socket->set(FID_Feedback, (APTR)nullptr);
+         Self->Socket->setFeedback(FUNCTION{});
          FreeResource(Self->Socket);
          Self->Socket = nullptr;
       }

--- a/src/http/http_functions.cpp
+++ b/src/http/http_functions.cpp
@@ -137,7 +137,7 @@ static void socket_feedback(objNetSocket *Socket, NTC State, APTR Meta)
             // The HTTP socket was closed because the user is taking too long to authenticate with the dialog
             // window.  We will close the socket and create a new one once the user responds to the dialog.
 
-            Self->Socket->set(FID_Feedback, (APTR)nullptr);
+            Self->Socket->setFeedback(FUNCTION{});
             FreeResource(Socket);
             Self->Socket = nullptr;
             Self->SecurePath = true;
@@ -219,7 +219,8 @@ static ERR socket_outgoing(objNetSocket *Socket)
          log.warning("Input file read error: %s", GetErrorMsg(error));
       }
 
-      int64_t size = Self->flInput->get<int64_t>(FID_Size);
+      int64_t size = 0;
+      Self->flInput->getSize(size);
 
       if ((Self->flInput->Position IS size) or (client_bytes_written IS 0)) {
          log.trace("All file content read (%d bytes) - freeing file.", (int)size);

--- a/src/http/http_incoming.cpp
+++ b/src/http/http_incoming.cpp
@@ -251,7 +251,7 @@ static ERR read_incoming_header(extHTTP *Self, objNetSocket *Socket)
                   log.msg("MovedPermanently to %s", location.c_str());
 
                   if (auto active_socket = Self->Socket) {
-                     Self->Socket->set(FID_Feedback, (APTR)nullptr);
+                     Self->Socket->setFeedback(FUNCTION{});
                      Self->Socket = nullptr;
                      FreeResource(active_socket);
                   }

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -396,7 +396,8 @@ static ERR NETSOCKET_DataFeed(extNetSocket *Self, struct acDataFeed *Args)
       case DATA::FILE: { // File path
          auto file = objFile::create({ fl::Path(CSTRING(Args->Buffer)), fl::Flags(FL::READ) });
          if (file.ok()) {
-            auto size = file->get<size_t>(FID_Size);
+            int64_t size;
+            file->getSize(size);
             std::vector<int8_t> buf(size);
             if (!file->read(buf.data(), size)) {
                return acWrite(Self, buf.data(), size, nullptr);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -596,7 +596,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/regex/regex.cpp
+++ b/src/regex/regex.cpp
@@ -156,7 +156,7 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/svg/class_rsvg.cpp
+++ b/src/svg/class_rsvg.cpp
@@ -137,13 +137,14 @@ static ERR RSVG_Query(extRSVG *Self)
 
       // Check for fixed dimensions specified by the SVG.
 
-      auto view_width = view->get<int>(FID_Width);
-      auto view_height = view->get<int>(FID_Height);
+      Unit view_width, view_height;
+      ((objVectorViewport *)view)->getWidth(view_width);
+      ((objVectorViewport *)view)->getHeight(view_height);
 
       // If the SVG source doesn't specify fixed dimensions, automatically force rescaling to the display width and height.
 
-      if (not view_width)  view->set(FID_Width, Unit(1.0, FD_SCALED));
-      if (not view_height) view->set(FID_Height, Unit(1.0, FD_SCALED));
+      if (not view_width)  ((objVectorViewport *)view)->setWidth(Unit(1.0, FD_SCALED));
+      if (not view_height) ((objVectorViewport *)view)->setHeight(Unit(1.0, FD_SCALED));
 
       if ((Self->DisplayWidth > 0) and (Self->DisplayHeight > 0)) { // Client specified the display size?
          // Give the vector scene a target width and height.

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1386,13 +1386,15 @@ ParserResult<StmtNodePtr> AstBuilder::parse_compile_if()
             check_path = current_file.substr(0, last_sep + 1) + std::string(string_value);
          }
          else {
-            auto working_path = this->ctx.lua().script->get<std::string_view>(FID_WorkingPath);
+            std::string_view working_path;
+            this->ctx.lua().script->getWorkingPath(working_path);
             if (not working_path.empty()) check_path = std::string(working_path) + std::string(string_value);
             else check_path = std::string(string_value);
          }
       }
       else {
-         auto working_path = this->ctx.lua().script->get<std::string_view>(FID_WorkingPath);
+         std::string_view working_path;
+         this->ctx.lua().script->getWorkingPath(working_path);
          if (not working_path.empty()) check_path = std::string(working_path) + std::string(string_value);
          else check_path = std::string(string_value);
       }

--- a/src/tiri/jit/src/parser/parser_context.cpp
+++ b/src/tiri/jit/src/parser/parser_context.cpp
@@ -467,12 +467,14 @@ std::string ParserContext::resolve_lib_to_path(std::string_view &Library) const
             result = dir + result;
          }
          else { // Use script's working path as fallback
-            auto working_path = this->lua_state->script->get<std::string_view>(FID_WorkingPath);
+            std::string_view working_path;
+            this->lua_state->script->getWorkingPath(working_path);
             if (not working_path.empty()) result.insert(0, working_path.data(), working_path.size());
          }
       }
       else { // Use script's working path as fallback
-         auto working_path = this->lua_state->script->get<std::string_view>(FID_WorkingPath);
+         std::string_view working_path;
+         this->lua_state->script->getWorkingPath(working_path);
          if (not working_path.empty()) result.insert(0, working_path.data(), working_path.size());
       }
    }

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -314,7 +314,7 @@ static ERR MODExpunge(void)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/vector/scene/scene.cpp
+++ b/src/vector/scene/scene.cpp
@@ -518,8 +518,11 @@ static ERR VECTORSCENE_Init(extVectorScene *Self)
 
          if ((!Self->PageWidth) or (!Self->PageHeight)) {
             Self->Flags |= VPF::RESIZE;
-            Self->PageWidth = surface->get<int>(FID_Width);
-            Self->PageHeight = surface->get<int>(FID_Height);
+            Unit surface_width, surface_height;
+            surface->getWidth(surface_width);
+            surface->getHeight(surface_height);
+            Self->PageWidth = int(surface_width);
+            Self->PageHeight = int(surface_height);
          }
 
          SubscribeAction(*surface, AC::Redimension, C_FUNCTION(notify_redimension));

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -60,7 +60,6 @@ where large glyphs were oriented around sharp corners.  The process would look s
 
 const int DEFAULT_WEIGHT = 400;
 
-static FIELD FID_FreetypeFace;
 objConfig *glFontConfig = nullptr;
 
 //********************************************************************************************************************
@@ -2090,8 +2089,6 @@ static const FieldArray clTextFields[] = {
 
 static ERR init_text(void)
 {
-   FID_FreetypeFace = strihash("FreetypeFace");
-
    OBJECTID id;
    if (!FindObject("cfgSystemFonts", CLASSID::CONFIG, &id)) {
       glFontConfig = (objConfig *)GetObjectPtr(id);

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -46,15 +46,12 @@ void debug_tree(extVector *Vector, int &Level)
    Level++;
 
    for (auto v=Vector; v; v=(extVector *)v->Next) {
-      int dim = 0;
-      if (FindField(v, FID_Dimensions, nullptr)) v->get(strihash("Dimensions"), dim);
-
       if ((v->Class->BaseClassID IS CLASSID::VECTOR) and (v->Child)) {
          kt::Log blog(__FUNCTION__);
-         blog.branch(" #%d%s %s %s $%.8x", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim);
+         blog.branch(" #%d%s %s %s", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name);
          debug_tree((extVector *)v->Child, Level);
       }
-      else log.msg(" #%d%s %s %s $%.8x", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name, dim);
+      else log.msg(" #%d%s %s %s", v->UID, indent.get(), v->Class->ClassName.c_str(), v->Name);
    }
 
    Level--;

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -164,7 +164,7 @@ static ERR MODExpunge(void)
 
 static ERR MODOpen(OBJECTPTR Module)
 {
-   Module->set(FID_FunctionList, glFunctions);
+   ((objModule *)Module)->setFunctionList(glFunctions);
    return ERR::Okay;
 }
 

--- a/src/xquery/functions/func_documents.cpp
+++ b/src/xquery/functions/func_documents.cpp
@@ -28,7 +28,9 @@ namespace fs = std::filesystem;
    objFile::create file { fl::Path(URI), fl::Flags(FL::READ) };
    if (file.ok()) {
       std::string buffer;
-      buffer.resize(file->get<size_t>(FID_Size));
+      int64_t file_size;
+      file->getSize(file_size);
+      buffer.resize(file_size);
       if (not buffer.empty()) {
          size_t bytes_read = 0;
          if ((file->read(buffer.data(), buffer.size(), &bytes_read) != ERR::Okay) or

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -630,7 +630,7 @@ function buildFunctionTableOutput():str
       out ..= 'namespace ' .. glFunctionPrefix:lower() .. ' {\n'
    end
 
-   for k, func in ipairs(glFunctions) do
+   for _, func in ipairs(glFunctions) do
       if func.staticMacro?? and (func.status != 'private') then
          out ..= func.staticMacro() .. '\n'
       end


### PR DESCRIPTION
* Migrated staged module code to typed field getters and setters for files, viewports, sockets and module function tables
* [Document] Updated scrollbar sizing and movement logic to use Unit-aware viewport and page accessors
* [Tools] Ignored unused function table loop keys in IDL output generation