### PR TITLE
[IDL] Fixed class documentation reference tracking

### DIFF
--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -550,7 +550,7 @@
       <access read="G">Get</access>
       <type>STRING</type>
       <description>
-<p>The ResolvedPath will return a resolved copy of the <fl>Path</fl> string.  The resolved path will be in a format that is native to the host platform.  Please refer to the ~ResolvePath() function for further information.</p>
+<p>The ResolvedPath will return a resolved copy of the <fl>Path</fl> string.  The resolved path will be in a format that is native to the host platform.  Please refer to the <function module="Core">ResolvePath</function> function for further information.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/font.xml
+++ b/docs/xml/modules/classes/font.xml
@@ -412,15 +412,6 @@ external leading or descent.</li>
       <const name="VERTICAL">Align to vertical center</const>
     </constants>
 
-    <constants lookup="FMETA" comment="Result flags for the SelectFont() function.">
-      <const name="HIDDEN">The font should not appear in any named list shown to the user.</const>
-      <const name="HINT_INTERNAL">The Freetype hinter should be used.</const>
-      <const name="HINT_LIGHT">The light version of the Freetype hinter should be used.</const>
-      <const name="HINT_NORMAL">The hinting information provided by the font should be given preference.</const>
-      <const name="SCALED">The font is scalable (assume fixed otherwise).</const>
-      <const name="VARIABLE">This is a scalable font featuring variable metrics.</const>
-    </constants>
-
     <constants lookup="FTF" comment="Font flags">
       <const name="BASE_LINE">The Font's <fl>Y</fl> coordinate is the base line.</const>
       <const name="BOLD">Font is described as having a bold weight (read only).</const>
@@ -430,19 +421,6 @@ external leading or descent.</li>
 
   </types>
   <structs>
-    <struct name="FontList" comment="For GetList(), describes a system font.">
-      <field name="Next" type="struct FontList *">Pointer to the next entry in the list.</field>
-      <field name="Name" type="STRING">The name of the font face.</field>
-      <field name="Alias" type="STRING">Reference to another font Name if this is an alias.</field>
-      <field name="Points" type="INT" size="0">Pointer to an array of fixed point sizes supported by the font.</field>
-      <field name="Styles" type="STRING">Supported styles are listed here in CSV format.</field>
-      <field name="Axes" type="STRING">For variable fonts, lists all supported axis codes in CSV format</field>
-      <field name="Scalable" type="INT8"><code>TRUE</code> if the font is scalable.</field>
-      <field name="Variable" type="INT8"><code>TRUE</code> if the font has variable metrics.</field>
-      <field name="Hinting" type="HINT" lookup="HINT">Hinting options</field>
-      <field name="Hidden" type="INT8"><code>TRUE</code> if the font should be hidden from user font lists.</field>
-    </struct>
-
     <struct name="RGB8" comment="8-bit RGB colour value." typeName="RGB8">
       <field name="Red" type="UINT8">Red component value</field>
       <field name="Green" type="UINT8">Green component value</field>

--- a/docs/xml/modules/classes/gradientdistal.xml
+++ b/docs/xml/modules/classes/gradientdistal.xml
@@ -96,6 +96,17 @@ from zero before fading again, repeating until the parent area is filled.</li>
     </field>
 
   </fields>
+  <types>
+    <constants lookup="GFALL" comment="Gradient fall-off options.">
+      <const name="CLEAR">Disables the gradient.</const>
+      <const name="CUBIC">Cubic fall-off - very tight glow hugging the outline.</const>
+      <const name="LINEAR">Linear fall-off (even taper).</const>
+      <const name="OPAQUE">No fall-off.</const>
+      <const name="QUADRATIC">Quadratic fall-off - fast drop, thin tail — natural glow.</const>
+      <const name="SMOOTHSTEP">Smoothstep fall-off - S-curve; brightest, holds the inner half.</const>
+    </constants>
+
+  </types>
   <structs>
   </structs>
 </book>

--- a/docs/xml/modules/classes/mergefx.xml
+++ b/docs/xml/modules/classes/mergefx.xml
@@ -57,6 +57,20 @@
     </field>
 
   </fields>
+  <types>
+    <constants lookup="VSF" comment="Filter source types - these are used internally">
+      <const name="ALPHA">As for <code>GRAPHIC</code> except that only the alpha channel is used.</const>
+      <const name="BKGD">An image snapshot of the SVG document under the filter region at the time that the filter element was invoked.</const>
+      <const name="BKGD_ALPHA">As for <code>BKGD</code> but only the alpha channel is used.</const>
+      <const name="FILL">The value of the fill property on the target element for the filter effect.</const>
+      <const name="GRAPHIC">Represents the graphics elements that were the original input into the filter element.</const>
+      <const name="IGNORE">The filter does not require an input source.</const>
+      <const name="PREVIOUS">Use the previous effect as input, or source graphic if no previous effect.</const>
+      <const name="REFERENCE">This value is an assigned name for the filter primitive in the form of a custom-ident. If supplied, then graphics that result from processing this filter primitive can be referenced by an in attribute on a subsequent filter primitive within the same filter element. If no value is provided, the output will only be available for re-use as the implicit input into the next filter primitive if that filter primitive provides no value for its in attribute.</const>
+      <const name="STROKE">The value of the stroke property on the target element for the filter effect.</const>
+    </constants>
+
+  </types>
   <structs>
     <struct name="MergeSource" comment="Input source declaration for MergeFX">
       <field name="SourceType" type="VSF" lookup="VSF">The type of the required source.</field>

--- a/docs/xml/modules/classes/netclient.xml
+++ b/docs/xml/modules/classes/netclient.xml
@@ -64,6 +64,13 @@
     </field>
 
   </fields>
+  <types>
+    <constants lookup="IPADDR" comment="Address types for the IPAddress structure.">
+      <const name="V4"/>
+      <const name="V6"/>
+    </constants>
+
+  </types>
   <structs>
     <struct name="IPAddress">
       <field name="Data" type="INT" size="4">128-bit array for supporting both V4 (32-bit host order) and V6 (8-bit byte order) IP addresses.</field>

--- a/docs/xml/modules/classes/netlookup.xml
+++ b/docs/xml/modules/classes/netlookup.xml
@@ -165,6 +165,11 @@
 
   </fields>
   <types>
+    <constants lookup="IPADDR" comment="Address types for the IPAddress structure.">
+      <const name="V4"/>
+      <const name="V6"/>
+    </constants>
+
     <constants lookup="NLF" comment="Options for NetLookup">
       <const name="NO_CACHE">Contact the name service and do not use the local DNS cache.</const>
     </constants>

--- a/docs/xml/modules/classes/netserver.xml
+++ b/docs/xml/modules/classes/netserver.xml
@@ -178,12 +178,28 @@
     </field>
 
   </fields>
-  <structs>
-    <struct name="IPAddress">
-      <field name="Data" type="INT" size="4">128-bit array for supporting both V4 (32-bit host order) and V6 (8-bit byte order) IP addresses.</field>
-      <field name="Type" type="IPADDR" lookup="IPADDR">Identifies the address Data value as a V4 or V6 address type.</field>
-      <field name="Port" type="INT">For UDP packets, identifies the client port number in host byte order.</field>
-    </struct>
+  <types>
+    <constants lookup="NSF" comment="NetSocket options">
+      <const name="BROADCAST">Enable broadcast (UDP only).</const>
+      <const name="DISABLE_SERVER_VERIFY">Disable SSL server certificate verification for client sockets (testing only).</const>
+      <const name="KEEP_ALIVE">Enable TCP keep-alive probes using operating system defaults.</const>
+      <const name="LOG_ALL">Print extra log messages.</const>
+      <const name="MULTI_CONNECT">Allow multiple connections from the same IP (NetServer only).</const>
+      <const name="SSL">Use Secure Sockets Layer for all communication.</const>
+      <const name="SYNCHRONOUS">Use synchronous (blocking) network calls.</const>
+      <const name="UDP">Use UDP (connectionless datagram protocol) instead of TCP.</const>
+    </constants>
 
+    <constants lookup="NTC" comment="NetSocket states">
+      <const name="CONNECTED">There is an active connection at present.</const>
+      <const name="CONNECTING">A connection is being established.</const>
+      <const name="DISCONNECTED">There is no connection.</const>
+      <const name="HANDSHAKING">An SSL connection is being established.</const>
+      <const name="MULTISTATE">A NetServer reports MULTISTATE because accepted ClientSocket objects track their own states.</const>
+      <const name="RESOLVING">The host name is being resolved.</const>
+    </constants>
+
+  </types>
+  <structs>
   </structs>
 </book>

--- a/docs/xml/modules/classes/netsocket.xml
+++ b/docs/xml/modules/classes/netsocket.xml
@@ -420,6 +420,11 @@ initially fill the internal write buffer, thereafter it will be called whenever 
 
   </fields>
   <types>
+    <constants lookup="IPADDR" comment="Address types for the IPAddress structure.">
+      <const name="V4"/>
+      <const name="V6"/>
+    </constants>
+
     <constants lookup="NSF" comment="NetSocket options">
       <const name="BROADCAST">Enable broadcast (UDP only).</const>
       <const name="DISABLE_SERVER_VERIFY">Disable SSL server certificate verification for client sockets (testing only).</const>

--- a/docs/xml/modules/classes/surface.xml
+++ b/docs/xml/modules/classes/surface.xml
@@ -762,48 +762,10 @@ the surface area first).</li>
 
   </fields>
   <types>
-    <constants lookup="BAF" comment="Instructions for basic graphics operations.">
-      <const name="BLEND">Enable alpha blending to the destination if the source supports an alpha channel.</const>
-      <const name="COPY">Special <function module="Display">CopyArea</function> option that avoids blending when the destination pixel is empty.</const>
-      <const name="DITHER">Perform dithering if the colour formats differ between the source and destination.</const>
-      <const name="FILL">For primitive operations such as <function module="Display">DrawRectangle</function>, this will fill the shape with a solid colour or texture.</const>
-      <const name="LINEAR">Use linear interpolation to improve the quality of alpha blending.</const>
-    </constants>
-
-    <constants lookup="BDF" comment="CopySurface() flags">
-      <const name="DITHER">Allow the use of dithering to improve image quality at a cost of speed.</const>
-      <const name="REDRAW">Redraw the surface before performing the copy operation.</const>
-    </constants>
-
-    <constants lookup="CRF" comment="Flags for the SetCursor() function.">
-      <const name="BUFFER">Use of the <code>BUFFER</code> option allows the cursor request to be buffered in the event that the cursor is locked at the time of calling the <function module="Display">SetCursor</function> function.  Use of this flag is highly recommended in most circumstances, but may not be used in conjunction with the <code>ANCHOR</code> option.</const>
-      <const name="LMB">Release the cursor after the left mouse button is held and released.</const>
-      <const name="MMB">Release the cursor after the middle mouse button is held and released.</const>
-      <const name="NO_BUTTONS">Set the cursor only on the condition that the user is not holding down any buttons.  <code>ERR::NothingDone</code> is returned if the user has a button held down.</const>
-      <const name="RESTRICT">Similar to the anchor option, but allows the pointer to move within the surface referred to by ObjectID.</const>
-      <const name="RMB">Release the cursor after the right mouse button is held and released.</const>
-    </constants>
-
-    <constants lookup="CSRF" comment="Flags for CopySurface().">
-      <const name="ALPHA">Enable alpha blending if the source is in 32-bit colour format with an alpha channel.</const>
-      <const name="CLIP">Enable clipping of the source coordinates.</const>
-      <const name="DEFAULT_FORMAT">Ignore the colour format defined in the source surface (if any) and generate a default format based on the <code>BitsPerPixel</code> value.</const>
-      <const name="OFFSET">Adjust X and Y coordinates by the offset values defined in the <class name="Surface" field="XOffset">Surface.XOffset</class> and <class name="Surface" field="YOffset">Surface.YOffset</class> fields.</const>
-      <const name="TRANSLUCENT">Perform a translucent copy operation, using the strength value specified in the <class name="Surface" field="Opacity">Surface.Opacity</class> field.</const>
-      <const name="TRANSPARENT">Enable transparent copying, whereby colours matching the source's <code>Colour</code> field will be ignored.</const>
-    </constants>
-
     <constants lookup="DRAG">
       <const name="ANCHOR">The surface is being dragged and the mouse pointer is anchored to the surface.</const>
       <const name="NONE">The surface is not being dragged.</const>
       <const name="NORMAL">The surface is being dragged.</const>
-    </constants>
-
-    <constants lookup="DT" comment="Flags for GetDisplayType().">
-      <const name="GLES">The display is driven by OpenGLES.</const>
-      <const name="NATIVE">The display is native (supported by internal drivers).</const>
-      <const name="WINGDI">The display is driven by Microsoft Windows drivers.</const>
-      <const name="X11">The display is driven by the X Window System (X11, X.Org, XFree86)</const>
     </constants>
 
     <constants lookup="EXF" comment="Optional flags for the ExposeSurface() function.">
@@ -812,14 +774,6 @@ the surface area first).</li>
       <const name="CHILDREN">If set, all child surfaces that intersect with exposed region will be included in the expose operation.</const>
       <const name="REDRAW_VOLATILE">Redraw every volatile object that intersects with the expose region, including internal volatile children.</const>
       <const name="REDRAW_VOLATILE_OVERLAP">Only redraw volatile objects that obscure the expose region from a position outside of the target surface and its children.  Useful if no redrawing has occurred in the surface, but the surface has moved to a new position and the parents need to be redrawn.</const>
-    </constants>
-
-    <constants lookup="HOST">
-      <const name="STICK_TO_FRONT">The hosted display sticks to the front.</const>
-      <const name="TASKBAR">The hosted display is given a taskbar button.</const>
-      <const name="TRANSLUCENCE">Change the alpha channel level for the entire window.</const>
-      <const name="TRANSPARENT">Defines an RGB colour that is to be used as transparent.</const>
-      <const name="TRAY_ICON">All new displays are represented in the system tray when this option is active.</const>
     </constants>
 
     <constants lookup="JET" comment="JET constants are documented in GetInputEvent()">
@@ -933,81 +887,8 @@ the surface area first).</li>
       <const name="TASKBAR">Create a borderless (custom) window with taskbar representation.</const>
     </constants>
 
-    <constants lookup="WH" comment="Events for WindowHook()">
-      <const name="CLOSE"/>
-    </constants>
-
   </types>
   <structs>
-    <struct name="BitmapSurface" typeName="BITMAPSURFACE">
-      <field name="Data" type="APTR">Pointer to the bitmap graphics data.</field>
-      <field name="Width" type="INT16">Pixel width of the bitmap.</field>
-      <field name="Height" type="INT16">Pixel height of the bitmap.</field>
-      <field name="LineWidth" type="INT">The distance between bitmap lines, measured in bytes.</field>
-      <field name="BitsPerPixel" type="UINT8">The number of bits per pixel (8, 15, 16, 24, 32).</field>
-      <field name="BytesPerPixel" type="UINT8">The number of bytes per pixel (1, 2, 3, 4).</field>
-      <field name="Opacity" type="UINT8">Opacity level of the source if <code>CSRF::TRANSLUCENT</code> is used.</field>
-      <field name="Version" type="UINT8">Version of this structure.</field>
-      <field name="Colour" type="INT">Colour index to use if <code>CSRF::TRANSPARENT</code> is used.</field>
-      <field name="Clip" type="struct ClipRectangle">A clipping rectangle will restrict drawing operations to this region if <code>CSRF::CLIP</code> is used.</field>
-      <field name="XOffset" type="INT16">Offset all X coordinate references by the given value.</field>
-      <field name="YOffset" type="INT16">Offset all Y coordinate references by the given value.</field>
-      <field name="Format" type="struct ColourFormat">The colour format of this bitmap's pixels, or alternatively use <code>CSRF::DEFAULT_FORMAT</code>.</field>
-    </struct>
-
-    <struct name="ColourFormat" typeName="COLOURFORMAT">
-      <field name="RedShift" type="UINT8">Right shift value for red (15/16 bit formats only)</field>
-      <field name="GreenShift" type="UINT8">Right shift value for green</field>
-      <field name="BlueShift" type="UINT8">Right shift value for blue</field>
-      <field name="AlphaShift" type="UINT8">Right shift value for alpha</field>
-      <field name="RedMask" type="UINT8">Unshifted mask value for red (ranges from 0x00 to 0xff)</field>
-      <field name="GreenMask" type="UINT8">Unshifted mask value for green</field>
-      <field name="BlueMask" type="UINT8">Unshifted mask value for blue</field>
-      <field name="AlphaMask" type="UINT8">Unshifted mask value for alpha</field>
-      <field name="RedPos" type="UINT8">Left shift/positional value for red</field>
-      <field name="GreenPos" type="UINT8">Left shift/positional value for green</field>
-      <field name="BluePos" type="UINT8">Left shift/positional value for blue</field>
-      <field name="AlphaPos" type="UINT8">Left shift/positional value for alpha</field>
-      <field name="BitsPerPixel" type="UINT8">Number of bits per pixel for this format.</field>
-    </struct>
-
-    <struct name="CursorInfo">
-      <field name="Width" type="INT">Maximum cursor width for custom cursors</field>
-      <field name="Height" type="INT">Maximum cursor height for custom cursors</field>
-      <field name="Flags" type="INT">Currently unused</field>
-      <field name="BitsPerPixel" type="INT16">Preferred bits-per-pixel setting for custom cursors</field>
-    </struct>
-
-    <struct name="DisplayInfo">
-      <field name="PixelFormat" type="struct PixelFormat">The colour format to use for each pixel.</field>
-      <field name="MinRefresh" type="FLOAT">Minimum refresh rate</field>
-      <field name="MaxRefresh" type="FLOAT">Maximum refresh rate</field>
-      <field name="RefreshRate" type="FLOAT">Recommended refresh rate</field>
-      <field name="Display" type="OBJECTID">Object ID related to the display</field>
-      <field name="AccelFlags" type="ACF" lookup="ACF">Flags describing supported hardware features.</field>
-      <field name="Flags" type="SCR" lookup="SCR">Display flags</field>
-      <field name="AmtColours" type="INT">Total number of supported colours.</field>
-      <field name="Index" type="INT">Display mode ID (internal)</field>
-      <field name="HDensity" type="INT">Horizontal pixel density per inch.</field>
-      <field name="VDensity" type="INT">Vertical pixel density per inch.</field>
-      <field name="HostedX" type="INT">Horizontal display position in virtual desktop coordinates</field>
-      <field name="HostedY" type="INT">Vertical display position in virtual desktop coordinates</field>
-      <field name="MonitorX" type="INT">Horizontal position of the monitor, relative to the primary monitor</field>
-      <field name="MonitorY" type="INT">Vertical position of the monitor, relative to the primary monitor</field>
-      <field name="MonitorWidth" type="INT">Pixel width of the monitor</field>
-      <field name="MonitorHeight" type="INT">Pixel height of the monitor</field>
-      <field name="VirtualX" type="INT">Horizontal position of the complete desktop spanning all monitors</field>
-      <field name="VirtualY" type="INT">Vertical position of the complete desktop spanning all monitors</field>
-      <field name="VirtualWidth" type="INT">Width of the complete desktop spanning all monitors</field>
-      <field name="VirtualHeight" type="INT">Height of the complete desktop spanning all monitors</field>
-      <field name="PhysicalWidth" type="INT">Width in millimeters, 0 if unknown</field>
-      <field name="PhysicalHeight" type="INT">Height in millimeters, 0 if unknown</field>
-      <field name="Width" type="INT16">Pixel width of the display bitmap</field>
-      <field name="Height" type="INT16">Pixel height of the display bitmap</field>
-      <field name="BitsPerPixel" type="INT16">Bits per pixel</field>
-      <field name="BytesPerPixel" type="INT16">Bytes per pixel</field>
-    </struct>
-
     <struct name="InputEvent">
       <field name="Next" type="const struct InputEvent *">Next event in the chain</field>
       <field name="Value" type="DOUBLE">The value associated with the Type</field>
@@ -1022,24 +903,6 @@ the surface area first).</li>
       <field name="Type" type="JET" lookup="JET">JET constant that describes the event</field>
       <field name="Flags" type="JTYPE" lookup="JTYPE">Broad descriptors for the given <code>Type</code> (see <code>JTYPE</code> flags).  Automatically defined when delivered to the pointer object</field>
       <field name="Mask" type="JTYPE" lookup="JTYPE">Mask to use for checking against subscribers</field>
-    </struct>
-
-    <struct name="SurfaceInfo" typeName="SURFACEINFO">
-      <field name="Data" type="APTR">Bitmap data memory ID</field>
-      <field name="ParentID" type="OBJECTID">Object that contains the surface area</field>
-      <field name="BitmapID" type="OBJECTID">Surface bitmap buffer</field>
-      <field name="DisplayID" type="OBJECTID">Refers to the display if this object is at root level</field>
-      <field name="Flags" type="RNF" lookup="RNF">Surface flags</field>
-      <field name="X" type="INT">Horizontal coordinate</field>
-      <field name="Y" type="INT">Vertical coordinate</field>
-      <field name="Width" type="INT">Width of the surface area</field>
-      <field name="Height" type="INT">Height of the surface area</field>
-      <field name="AbsX" type="INT">Absolute X coordinate</field>
-      <field name="AbsY" type="INT">Absolute Y coordinate</field>
-      <field name="Level" type="INT16">Branch level within the tree</field>
-      <field name="BitsPerPixel" type="INT8">Bits per pixel of the bitmap</field>
-      <field name="BytesPerPixel" type="INT8">Bytes per pixel of the bitmap</field>
-      <field name="LineWidth" type="INT">Line width of the bitmap, in bytes</field>
     </struct>
 
   </structs>

--- a/docs/xml/modules/classes/vectorpath.xml
+++ b/docs/xml/modules/classes/vectorpath.xml
@@ -222,6 +222,30 @@ Z: Close Path
     </field>
 
   </fields>
+  <types>
+    <constants lookup="PE">
+      <const name="Arc"/>
+      <const name="ArcRel"/>
+      <const name="ClosePath"/>
+      <const name="Curve"/>
+      <const name="CurveRel"/>
+      <const name="HLine"/>
+      <const name="HLineRel"/>
+      <const name="Line"/>
+      <const name="LineRel"/>
+      <const name="Move"/>
+      <const name="MoveRel"/>
+      <const name="QuadCurve"/>
+      <const name="QuadCurveRel"/>
+      <const name="QuadSmooth"/>
+      <const name="QuadSmoothRel"/>
+      <const name="Smooth"/>
+      <const name="SmoothRel"/>
+      <const name="VLine"/>
+      <const name="VLineRel"/>
+    </constants>
+
+  </types>
   <structs>
     <struct name="PathCommand" comment="Base structure for path commands.">
       <field name="Type" type="PE" lookup="PE">The command type</field>

--- a/docs/xml/modules/classes/vectorviewport.xml
+++ b/docs/xml/modules/classes/vectorviewport.xml
@@ -291,11 +291,6 @@
 
   </fields>
   <types>
-    <constants lookup="ARC" comment="Options for drawing arcs.">
-      <const name="LARGE">The arc will take the longest available drawing path rather than the shortest.</const>
-      <const name="SWEEP">Inverts the default behaviour in generating the arc path (go clockwise).</const>
-    </constants>
-
     <constants lookup="ARF" comment="Aspect ratios control alignment, scaling and clipping.">
       <const name="MEET">Aspect ratio is preserved. The entire viewbox will be visible in the viewport.  The viewbox is scaled up as much as possible.</const>
       <const name="NONE">Scale the viewbox to match the size of the viewport.  Aspect ratio is not preserved.</const>
@@ -317,31 +312,5 @@
 
   </types>
   <structs>
-    <struct name="FontMetrics" comment="Font metrics, measured in pixels relative to the display">
-      <field name="Height" type="INT">Full font height equivalent to <code>Ascent (cap-height) + Descent (gutter)</code>.  Does NOT include accents.</field>
-      <field name="LineSpacing" type="INT">Vertical advance from one line to the next.  Includes coverage for accents and additional whitespace.</field>
-      <field name="Ascent" type="INT">Height from the baseline to the top (cap-height) of the font.  Does NOT include accents.</field>
-      <field name="Descent" type="INT">Height from the baseline to the bottom of the font (gutter)</field>
-    </struct>
-
-    <struct name="VectorMatrix" comment="Vector transformation matrix.">
-      <field name="Next" type="struct VectorMatrix *">The next transform in the list.</field>
-      <field name="Vector" type="objVector *">The vector associated with the transform.</field>
-      <field name="ScaleX" type="DOUBLE">Matrix value A</field>
-      <field name="ShearY" type="DOUBLE">Matrix value B</field>
-      <field name="ShearX" type="DOUBLE">Matrix value C</field>
-      <field name="ScaleY" type="DOUBLE">Matrix value D</field>
-      <field name="TranslateX" type="DOUBLE">Matrix value E</field>
-      <field name="TranslateY" type="DOUBLE">Matrix value F</field>
-      <field name="Tag" type="INT">An optional tag value defined by the client for matrix identification.</field>
-    </struct>
-
-    <struct name="VectorPainter" comment="Deserialised painter information; compliant with SVG painter definitions.">
-      <field name="Pattern" type="objVectorPattern *">A <class name="VectorPattern">VectorPattern</class> object, suitable for pattern based fills.</field>
-      <field name="Image" type="objVectorImage *">A <class name="VectorImage">VectorImage</class> object, suitable for image fills.</field>
-      <field name="Gradient" type="objGradient *">A <class name="Gradient">Gradient</class> object, suitable for gradient fills.</field>
-      <field name="Colour" type="struct FRGB">A single RGB colour definition, suitable for block colour fills.  Colour values are unclamped to support all possible colour spaces.</field>
-    </struct>
-
   </structs>
 </book>

--- a/docs/xml/modules/classes/vectorwave.xml
+++ b/docs/xml/modules/classes/vectorwave.xml
@@ -141,7 +141,7 @@
       <access read="R" write="S">Read/Set</access>
       <type>UNIT</type>
       <description>
-<p>Specifying a thickness value will create a wave that forms a filled shape, rather than the default of a stroked path. The thickness (diameter) of the wave is determined by the provided value.  If defined as a percentage, the value is resolved against the normalised diagonal of the parent viewport, matching the scaling rule used for #StrokeWidth. Thickness is not compatible with the <fl>Close</fl> option, and takes precedence over it.</p>
+<p>Specifying a thickness value will create a wave that forms a filled shape, rather than the default of a stroked path. The thickness (diameter) of the wave is determined by the provided value.  If defined as a percentage, the value is resolved against the normalised diagonal of the parent viewport, matching the scaling rule used for <class name="Vector" field="StrokeWidth">Vector.StrokeWidth</class>. Thickness is not compatible with the <fl>Close</fl> option, and takes precedence over it.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -811,21 +811,16 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       <const name="UPDATE_ONLY">SetAttrib will find the target attribute and update it.  It is not possible to rename the attribute when using this technique.  <code>ERR::Search</code> is returned if the attribute cannot be found.</const>
     </constants>
 
-    <constants lookup="XPVT" comment="Type descriptors for XPathValue">
-      <const name="Array"/>
-      <const name="Boolean"/>
-      <const name="Date"/>
-      <const name="DateTime"/>
-      <const name="Map"/>
-      <const name="NodeSet"/>
-      <const name="Number"/>
-      <const name="String"/>
-      <const name="Time"/>
-    </constants>
-
     <constants lookup="XSF" comment="Options for the Sort method.">
       <const name="CHECK_SORT">Tells the algorithm to check for a 'sort' attribute in each analysed tag and if found, the algorithm will use that as the sort value instead of that indicated in the <code>Attrib</code> field.</const>
       <const name="DESC">Sort in descending order.</const>
+    </constants>
+
+    <constants lookup="XTF" comment="Standard flags for XTag.">
+      <const name="CDATA">Tag represents <code>CDATA</code>.</const>
+      <const name="COMMENT">Tag represents a comment of the format <code>&lt;!-- Comment --&gt;</code>.</const>
+      <const name="INSTRUCTION">Tag represents an instruction of the format <code>&lt;?xml?&gt;</code>.</const>
+      <const name="NOTATION">Tag represents a notation of the format <code>&lt;!XML&gt;</code>.</const>
     </constants>
 
   </types>
@@ -833,12 +828,6 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <struct name="XMLAttrib" typeName="XMLATTRIB">
       <field name="Name" type="STRING">Name of the attribute</field>
       <field name="Value" type="STRING">Value of the attribute</field>
-    </struct>
-
-    <struct name="XPathValue" typeName="XPATHVALUE">
-      <field name="Type" type="XPVT" lookup="XPVT">Identifies the type of value stored</field>
-      <field name="NumberValue" type="DOUBLE">Defined if the type is Number or Boolean</field>
-      <field name="StringValue" type="STRING">Defined if the type is String</field>
     </struct>
 
     <struct name="XTag" typeName="XTAG">

--- a/docs/xml/modules/classes/xquery.xml
+++ b/docs/xml/modules/classes/xquery.xml
@@ -400,6 +400,33 @@ if (query.ok()) {
       <const name="USER_DEFINED">Include user-defined status in the inspection result.</const>
     </constants>
 
+    <constants lookup="XPVT" comment="Type descriptors for XPathValue">
+      <const name="Array"/>
+      <const name="Boolean"/>
+      <const name="Date"/>
+      <const name="DateTime"/>
+      <const name="Map"/>
+      <const name="NodeSet"/>
+      <const name="Number"/>
+      <const name="String"/>
+      <const name="Time"/>
+    </constants>
+
+    <constants lookup="XQF" comment="Flags indicating the features of a compiled XQuery expression.">
+      <const name="BASE_URI_DECLARED">Static base URI declared.</const>
+      <const name="BOUNDARY_PRESERVE">Boundary-space preserve mode.</const>
+      <const name="CONSTRUCTION_PRESERVE">Construction preserve mode.</const>
+      <const name="DEFAULT_COLLATION_DECLARED">Default collation declared.</const>
+      <const name="DEFAULT_ELEMENT_NS">Default element namespace declared.</const>
+      <const name="DEFAULT_FUNCTION_NS">Default function namespace declared.</const>
+      <const name="HAS_PROLOG">The XQuery declares a prolog.</const>
+      <const name="HAS_WILDCARD_TESTS">Wildcard name tests present.</const>
+      <const name="LIBRARY_MODULE">Prolog declares a module namespace (library module).</const>
+      <const name="MODULE_IMPORTS">One or more module imports are declared.</const>
+      <const name="ORDERING_UNORDERED">Ordering mode is unordered.</const>
+      <const name="XPATH">The expression is an XPath location string.</const>
+    </constants>
+
   </types>
   <structs>
   </structs>

--- a/include/kotuku/modules/audio.h
+++ b/include/kotuku/modules/audio.h
@@ -730,4 +730,3 @@ extern ERR MixStartSequence(objAudio *Audio, int Handle);
 extern ERR MixEndSequence(objAudio *Audio, int Handle);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/include/kotuku/modules/backstage.h
+++ b/include/kotuku/modules/backstage.h
@@ -9,4 +9,3 @@
 #define MODVERSION_BACKSTAGE (1)
 
 #include <kotuku/modules/network.h>
-

--- a/include/kotuku/modules/compression.h
+++ b/include/kotuku/modules/compression.h
@@ -356,4 +356,3 @@ class objCompressedStream : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/config.h
+++ b/include/kotuku/modules/config.h
@@ -222,4 +222,3 @@ class objConfig : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -1987,22 +1987,22 @@ inline ERR DeregisterFD(HOSTHANDLE Handle) {
 
 inline APTR GetResourcePtr(RES ID) { return (APTR)(MAXINT)GetResource(ID); }
 
-[[nodiscard]] constexpr inline const char* to_cstring(const char* A) { return A; }
-[[nodiscard]] inline const char* to_cstring(const std::string &A) { return A.c_str(); }
+[[nodiscard]] constexpr inline CSTRING to_cstring(CSTRING A) { return A; }
+[[nodiscard]] inline CSTRING to_cstring(const std::string &A) { return A.c_str(); }
 
 #ifndef PRV_CORE_DATA
 // These overloaded functions can't be used in the Core as they will confuse the compiler in key areas.
 
 inline ERR SubscribeAction(OBJECTPTR Object, AC Action, FUNCTION Callback) {
-   return SubscribeAction(Object,Action,&Callback);
+   return SubscribeAction(Object, Action, &Callback);
 }
 
 inline ERR SubscribeEvent(int64_t Event, FUNCTION Callback, APTR *Handle) {
-   return SubscribeEvent(Event,&Callback,Handle);
+   return SubscribeEvent(Event, &Callback, Handle);
 }
 
 inline ERR SubscribeTimer(double Interval, FUNCTION Callback, APTR *Subscription) {
-   return SubscribeTimer(Interval,&Callback,Subscription);
+   return SubscribeTimer(Interval, &Callback, Subscription);
 }
 
 // This template leverages pcObject to be the preferred entry point for any Object type or derivation.

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -413,4 +413,3 @@ constexpr FieldValue EventMask(DEF Value) { return FieldValue(strhash("eventMask
 constexpr FieldValue Flags(DCF Value) { return FieldValue(strhash("flags"), int(Value)); }
 
 }
-

--- a/include/kotuku/modules/filesystem.h
+++ b/include/kotuku/modules/filesystem.h
@@ -432,4 +432,3 @@ template<class T> ERR ReadBE(OBJECTPTR Object, T *Result)
 }
 
 } // fl namespace
-

--- a/include/kotuku/modules/font.h
+++ b/include/kotuku/modules/font.h
@@ -481,4 +481,3 @@ extern ERR SelectFont(const std::string_view &Name, const std::string_view &Styl
 extern ERR ResolveFamilyName(const std::string_view &String, std::string_view *Result);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/include/kotuku/modules/http.h
+++ b/include/kotuku/modules/http.h
@@ -560,4 +560,3 @@ class objHTTP : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/lzma.h
+++ b/include/kotuku/modules/lzma.h
@@ -96,4 +96,3 @@ class objLZMAStream : public objCompressedStream {
    }
 
 };
-

--- a/include/kotuku/modules/module.h
+++ b/include/kotuku/modules/module.h
@@ -60,6 +60,7 @@ struct ModHeader {
       Root          = nullptr;
    }
 };
+
 // Module class definition
 
 #define VER_MODULE (1.000000)

--- a/include/kotuku/modules/mp3.h
+++ b/include/kotuku/modules/mp3.h
@@ -62,4 +62,3 @@ class objMP3 : public objSound {
    // Customised field setting
 
 };
-

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -993,4 +993,3 @@ extern uint32_t LongToHost(uint32_t Value);
 extern ERR SetSSL(objNetSocket *NetSocket, const std::string_view &Command, const std::string_view &Value);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/include/kotuku/modules/processes.h
+++ b/include/kotuku/modules/processes.h
@@ -383,4 +383,3 @@ class objThread : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/regex.h
+++ b/include/kotuku/modules/regex.h
@@ -85,5 +85,3 @@ namespace rx {
 }
 } // namespace rx
 #endif
-
-

--- a/include/kotuku/modules/svg.h
+++ b/include/kotuku/modules/svg.h
@@ -189,4 +189,3 @@ class objSVG : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/time.h
+++ b/include/kotuku/modules/time.h
@@ -165,4 +165,3 @@ class objTime : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/tiri.h
+++ b/include/kotuku/modules/tiri.h
@@ -111,4 +111,3 @@ namespace ti {
 extern ERR SetVariable(objTiri *Script, const std::string_view &Name, int Type, ...);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -5921,4 +5921,3 @@ template <kt::NumericOrScale T> FieldValue RoundX(T Value) { return FieldValue(s
 template <kt::NumericOrScale T> FieldValue RoundY(T Value) { return FieldValue(strhash("roundY"), Value); }
 
 }
-

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -685,4 +685,3 @@ extern ERR XValueToString(const struct XPathValue *Value, std::string *Result);
 extern ERR XValueNodes(struct XPathValue *Value, kt::vector<XTag *> *Result);
 } // namespace
 #endif // KOTUKU_STATIC
-

--- a/include/kotuku/system/errors.h
+++ b/include/kotuku/system/errors.h
@@ -240,4 +240,3 @@ enum class ERR : int32_t {
 constexpr bool operator!(ERR Error) noexcept {
    return not int(Error);
 }
-

--- a/include/kotuku/system/registry.h
+++ b/include/kotuku/system/registry.h
@@ -117,4 +117,3 @@ enum class CLASSID : uint32_t {
    XQUERY = 0x58128f50UL,
    LZMASTREAM = 0xea1b1936UL,
 };
-

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -2450,7 +2450,7 @@ static ERR SET_Position(extFile *Self, int64_t Value)
 ResolvedPath: Returns a resolved copy of the Path string.
 
 The ResolvedPath will return a resolved copy of the #Path string.  The resolved path will be in a format that is native
-to the host platform.  Please refer to the ~ResolvePath() function for further information.
+to the host platform.  Please refer to the ~Core.ResolvePath() function for further information.
 
 *********************************************************************************************************************/
 

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -828,22 +828,22 @@ inline ERR DeregisterFD(HOSTHANDLE Handle) {
 
 inline APTR GetResourcePtr(RES ID) { return (APTR)(MAXINT)GetResource(ID); }
 
-[[nodiscard]] constexpr inline const char* to_cstring(const char* A) { return A; }
-[[nodiscard]] inline const char* to_cstring(const std::string &A) { return A.c_str(); }
+[[nodiscard]] constexpr inline CSTRING to_cstring(CSTRING A) { return A; }
+[[nodiscard]] inline CSTRING to_cstring(const std::string &A) { return A.c_str(); }
 
 #ifndef PRV_CORE_DATA
 // These overloaded functions can't be used in the Core as they will confuse the compiler in key areas.
 
 inline ERR SubscribeAction(OBJECTPTR Object, AC Action, FUNCTION Callback) {
-   return SubscribeAction(Object,Action,&Callback);
+   return SubscribeAction(Object, Action, &Callback);
 }
 
 inline ERR SubscribeEvent(int64_t Event, FUNCTION Callback, APTR *Handle) {
-   return SubscribeEvent(Event,&Callback,Handle);
+   return SubscribeEvent(Event, &Callback, Handle);
 }
 
 inline ERR SubscribeTimer(double Interval, FUNCTION Callback, APTR *Subscription) {
-   return SubscribeTimer(Interval,&Callback,Subscription);
+   return SubscribeTimer(Interval, &Callback, Subscription);
 }
 
 // This template leverages pcObject to be the preferred entry point for any Object type or derivation.

--- a/src/document/defs/hashes.h
+++ b/src/document/defs/hashes.h
@@ -160,4 +160,3 @@
 #define HASH_xml_raw 0x39cabf6bUL
 #define HASH_xml_translate 0x985de42aUL
 #define HASH_y 0x5b57dc90UL
-

--- a/src/tiri/hashes.h
+++ b/src/tiri/hashes.h
@@ -73,4 +73,3 @@
 #define HASH_LOCK 0x9f36c619
 #define HASH_INIT 0x680cc731
 #define HASH_STATE 0x66db68df
-

--- a/src/vector/vectors/wave.cpp
+++ b/src/vector/vectors/wave.cpp
@@ -466,7 +466,7 @@ Thickness: Expands the diameter of the wave to the specified value to produce a 
 
 Specifying a thickness value will create a wave that forms a filled shape, rather than the default of a stroked path.
 The thickness (diameter) of the wave is determined by the provided value.  If defined as a percentage, the value is
-resolved against the normalised diagonal of the parent viewport, matching the scaling rule used for #StrokeWidth.
+resolved against the normalised diagonal of the parent viewport, matching the scaling rule used for @Vector.StrokeWidth.
 Thickness is not compatible with the #Close option, and takes precedence over it.
 
 *********************************************************************************************************************/

--- a/tools/idl/include/client_functions.tiri
+++ b/tools/idl/include/client_functions.tiri
@@ -848,7 +848,11 @@ global function klass(Name, Options:table, Spec, Private, Custom)
    end
    cl.references = { }
 
+   restore_refs = glActiveRefs
    global glActiveRefs = cl.references
+   defer
+      glActiveRefs = restore_refs
+   end
 
    if type(cl.src) is 'string' then cl.src = { cl.src } end -- Convert string to an array of strings
 
@@ -881,6 +885,7 @@ global function klass(Name, Options:table, Spec, Private, Custom)
          for v in values(Options.references) do
             if glCustomTypes[v]?? then
                cdef = cdef .. outputLookup(cl.name .. v, glCustomTypes[v].list)
+               cl.references['TYPE:' .. v] = true
                glCustomTypes[v].restrict = nil
             elseif glStructures[v]?? then
                cl.references['STRUCT:' .. v] = true

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -415,6 +415,26 @@ setAction('Write', {
 })
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Structures can reference custom lookup tables through their fields.  Record those lookups before <types> output is
+-- produced so struct documentation does not contain dangling lookup attributes.
+
+function collectStructureTypeReferences(References:table, IncludeAll:bool)
+   References ?! return
+
+   for struct in values(glStructures) do
+      if struct.restrict?? then
+         -- Don't publish restricted structures or their support types.
+      elseif IncludeAll or References['STRUCT:' .. struct.name] then
+         for f in values(struct.fields) do
+            if f.lookup and glCustomTypes[f.lookup] then
+               References['TYPE:' .. f.lookup] ?= 'struct:' .. struct.name
+            end
+         end
+      end
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
 
 global function saveDocuments()
    -- Save module functions, if any
@@ -423,6 +443,7 @@ global function saveDocuments()
    if not outPath:endsWith('/') then outPath ..= '/' end
 
    if glFunctions?? then
+      collectStructureTypeReferences(glReferences, true)
       out = docModuleHeader()
       for _, func in ipairs(glFunctions) do
          out ..= docFunction(func)
@@ -447,6 +468,7 @@ global function saveDocuments()
 
          if cl.meta then
             try
+               collectStructureTypeReferences(cl.references, false)
                out = docClass(cl) .. docTypes(cl.references) .. docStructures(cl.references) .. '</book>\n'
                fl = obj.new('file', { flags = FL_WRITE|FL_NEW, path = f'{outPath}classes/{className:lower()}.xml' } )
                print(f'Saving XML class documentation to "{fl.path}"')
@@ -613,11 +635,11 @@ global function substituteReferences(String:str, Class:table):str
          if glStructures[lookup].restrict is 'c' then
             return lookup .. whitespace
          else
-            Class?.references['STRUCT:' .. lookup] = 1
+            Class?.references['STRUCT:' .. lookup] = 'doc-ref'
             return f'<st>{lookup}</st>{whitespace}'
          end
       elseif glCustomTypes[lookup] then
-         Class?.references['TYPE:' .. lookup] = 1
+         Class?.references['TYPE:' .. lookup] = 'doc-ref'
          return f'<lk>{lookup}</lk>{whitespace}'
       else
          print('Unrecognised struct or constant "!' .. lookup .. '"')
@@ -1177,7 +1199,7 @@ global function docFunction(Function)
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Output custom types - flags, enumerators etc
+-- Output custom types - flags, enumerators etc, used for both module and class output.
 
 global function docTypes(References:table)
    out = ''

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -676,5 +676,7 @@ global function saveOutput()
       end
    end
 
+   if content:endsWith('\n\n') then content = content:sub(0, -3) end
+
    saveIfModified(outPath, content, 'C header output')
 end

--- a/tools/idl/include/types.tiri
+++ b/tools/idl/include/types.tiri
@@ -329,7 +329,7 @@ global function cType(Value:table, Origin:str):table
          Value.type = Value.isClass ? ('class ' .. struct) :> ('struct ' .. struct)
 
          if glStructures[struct] then
-            glActiveRefs['STRUCT:' .. struct] = 1
+            glActiveRefs['STRUCT:' .. struct] = 'type-ref'
 
             if glStructures[struct].version then
                Value.type = Value.type .. 'V' .. glStructures[struct].version
@@ -375,7 +375,7 @@ global function cType(Value:table, Origin:str):table
          Value.type = 'struct ' .. struct
 
          if glStructures[struct] then
-            glActiveRefs['STRUCT:' .. struct] = 1
+            glActiveRefs['STRUCT:' .. struct] = 'type-ref'
 
             if glStructures[struct].version then
                Value.type = Value.type .. 'V' .. glStructures[struct].version
@@ -453,7 +453,7 @@ global function cType(Value:table, Origin:str):table
          Value.lookup   = prefix
 
          if glCustomTypes[prefix] then
-            glActiveRefs['TYPE:' .. prefix] = 1
+            glActiveRefs['TYPE:' .. prefix] = 'type-ref'
          else
             print('Unknown custom type "' .. prefix .. '"')
          end
@@ -487,7 +487,7 @@ global function cType(Value:table, Origin:str):table
          Value.lookup = prefix
 
          if glCustomTypes[prefix] then
-            glActiveRefs['TYPE:' .. prefix] = 1
+            glActiveRefs['TYPE:' .. prefix] = 'type-ref'
             if glCustomTypes[prefix].type then -- Strongly typed
                Value.type = prefix
             end


### PR DESCRIPTION
* Record explicit custom type references for class documentation output
* Add struct lookup collection before type documentation emission to avoid dangling XML lookup references
* Regenerate affected headers and XML documentation