### PR TITLE
[Tiri] Support byte array concat assignment

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2701,7 +2701,7 @@ static GCstr * array_concat_value(lua_State *L, cTValue *Value)
    return nullptr;
 }
 
-LJLIB_CF(array_append)
+LJLIB_CF(array_append)      LJLIB_REC(.)
 {
    TValue *left = lj_lib_checkany(L, 1);
    lj_lib_checkany(L, 2);

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -29,10 +29,13 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <string_view>
 #include <kotuku/strings.hpp>
 #include <kotuku/main.h>
 
 #define LJLIB_MODULE_array
+
+static constexpr std::string_view glArrayAppendHelperKey("\x1f" "array.append", 13);
 
 constexpr auto HASH_INT     = kt::strhash("int");
 constexpr auto HASH_BYTE    = kt::strhash("byte");
@@ -2828,6 +2831,13 @@ extern "C" int luaopen_array(lua_State *L)
 {
    LJ_LIB_REG(L, "array", array);
    // Stack: [..., array_lib_table]
+
+   // Compound concatenation lowers through this hidden key so rebinding the public array global cannot shadow it.
+   lua_getfield(L, -1, "append");
+   lua_pushlstring(L, glArrayAppendHelperKey.data(), glArrayAppendHelperKey.size());
+   lua_pushvalue(L, -2);
+   lua_rawset(L, LUA_GLOBALSINDEX);
+   lua_pop(L, 1);
 
    // Use the library table directly as the base metatable for arrays.
    // This allows lj_arr_get to find methods like concat, sort, etc. via direct table lookup.

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2668,6 +2668,27 @@ LJLIB_CF(array_clone)
 }
 
 //********************************************************************************************************************
+// Created exclusively for implementing array<byte> concatenation operations
+
+LJLIB_CF(array_append)      LJLIB_REC(.)
+{
+   TValue *left = lj_lib_checkany(L, 1);
+   lj_lib_checkany(L, 2);
+
+   if (tvisarray(left)) {
+      GCarray *arr = arrayV(left);
+      lj_cf_array_push(L);
+      setarrayV(L, L->base, arr);
+      L->top = L->base + 1;
+      return 1;
+   }
+
+   L->top = L->base + 2;
+   lua_concat(L, 2);
+   return 1;
+}
+
+//********************************************************************************************************************
 // __tostring metamethod.
 
 static int array_tostring(lua_State *L)
@@ -2699,24 +2720,6 @@ static GCstr * array_concat_value(lua_State *L, cTValue *Value)
    }
 
    return nullptr;
-}
-
-LJLIB_CF(array_append)      LJLIB_REC(.)
-{
-   TValue *left = lj_lib_checkany(L, 1);
-   lj_lib_checkany(L, 2);
-
-   if (tvisarray(left)) {
-      GCarray *arr = arrayV(left);
-      lj_cf_array_push(L);
-      setarrayV(L, L->base, arr);
-      L->top = L->base + 1;
-      return 1;
-   }
-
-   L->top = L->base + 2;
-   lua_concat(L, 2);
-   return 1;
 }
 
 static int array_concat_meta(lua_State *L)
@@ -2853,15 +2856,15 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_prototype("array", "of", { TiriType::Array }, { TiriType::Str }, FProtoFlags::Variadic);
    // Methods
    reg_iface_prototype("array", "table", { TiriType::Table }, { TiriType::Array });
-   reg_iface_prototype("array", "concat", { TiriType::Str },
-      { TiriType::Array, TiriType::Str, TiriType::Str, TiriType::Num, TiriType::Num });
+   reg_iface_prototype("array", "concat", { TiriType::Str }, { TiriType::Array, TiriType::Str, TiriType::Str, TiriType::Num, TiriType::Num });
    reg_iface_prototype("array", "contains", { TiriType::Bool }, { TiriType::Array, TiriType::Any });
    reg_iface_prototype("array", "first", { TiriType::Any }, { TiriType::Array, TiriType::Func });
    reg_iface_prototype("array", "last", { TiriType::Any }, { TiriType::Array, TiriType::Func });
    reg_iface_prototype("array", "clear", {}, { TiriType::Array });
    reg_iface_prototype("array", "resize", {}, { TiriType::Array, TiriType::Num });
    reg_iface_prototype("array", "push", {}, { TiriType::Array, TiriType::Any });
-   reg_iface_prototype("array", "append", { TiriType::Any }, { TiriType::Any, TiriType::Any });
+   // Private
+   // reg_iface_prototype("array", "append", { TiriType::Any }, { TiriType::Any, TiriType::Any });
    reg_iface_prototype("array", "pop", { TiriType::Any }, { TiriType::Array });
    reg_iface_prototype("array", "copy", {}, { TiriType::Array, TiriType::Num, TiriType::Num, TiriType::Num });
    reg_iface_prototype("array", "getString", { TiriType::Str }, { TiriType::Array, TiriType::Num, TiriType::Num });

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2701,6 +2701,24 @@ static GCstr * array_concat_value(lua_State *L, cTValue *Value)
    return nullptr;
 }
 
+LJLIB_CF(array_append)
+{
+   TValue *left = lj_lib_checkany(L, 1);
+   lj_lib_checkany(L, 2);
+
+   if (tvisarray(left)) {
+      GCarray *arr = arrayV(left);
+      lj_cf_array_push(L);
+      setarrayV(L, L->base, arr);
+      L->top = L->base + 1;
+      return 1;
+   }
+
+   L->top = L->base + 2;
+   lua_concat(L, 2);
+   return 1;
+}
+
 static int array_concat_meta(lua_State *L)
 {
    cTValue *left = L->base;
@@ -2843,6 +2861,7 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_prototype("array", "clear", {}, { TiriType::Array });
    reg_iface_prototype("array", "resize", {}, { TiriType::Array, TiriType::Num });
    reg_iface_prototype("array", "push", {}, { TiriType::Array, TiriType::Any });
+   reg_iface_prototype("array", "append", { TiriType::Any }, { TiriType::Any, TiriType::Any });
    reg_iface_prototype("array", "pop", { TiriType::Any }, { TiriType::Array });
    reg_iface_prototype("array", "copy", {}, { TiriType::Array, TiriType::Num, TiriType::Num, TiriType::Num });
    reg_iface_prototype("array", "getString", { TiriType::Str }, { TiriType::Array, TiriType::Num, TiriType::Num });

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -963,12 +963,54 @@ LJLIB_CF(array_push)
       return 1;
    }
 
+   MSize append_count = MSize(num_values);
+
+   if (arr->elemtype IS AET::BYTE) {
+      append_count = 0;
+      for (int i = 0; i < num_values; i++) {
+         int arg_idx = i + 2;
+         TValue *tv = L->base + arg_idx - 1;
+         MSize value_count;
+         if (tvisstr(tv)) value_count = strV(tv)->len;
+         else {
+            luaL_checkinteger(L, arg_idx);
+            value_count = 1;
+         }
+
+         if (value_count > (~MSize(0) - append_count)) lj_err_caller(L, ErrMsg::ARREXT);
+         append_count += value_count;
+      }
+   }
+
    // Ensure we have capacity for the new elements
-   MSize new_len = arr->len + MSize(num_values);
+   if (append_count > (~MSize(0) - arr->len)) lj_err_caller(L, ErrMsg::ARREXT);
+   MSize new_len = arr->len + append_count;
    if (new_len > arr->capacity) {
       if (not lj_array_grow(L, arr, new_len)) {
          lj_err_caller(L, ErrMsg::ARREXT);
       }
+   }
+
+   if (arr->elemtype IS AET::BYTE) {
+      MSize idx = arr->len;
+      for (int i = 0; i < num_values; i++) {
+         int arg_idx = i + 2;
+         TValue *tv = L->base + arg_idx - 1;
+
+         if (tvisstr(tv)) {
+            GCstr *str = strV(tv);
+            if (str->len > 0) memcpy(arr->get<uint8_t>() + idx, strdata(str), str->len);
+            idx += str->len;
+         }
+         else {
+            arr->get<uint8_t>()[idx] = uint8_t(luaL_checkinteger(L, arg_idx));
+            idx++;
+         }
+      }
+
+      arr->len = new_len;
+      setintV(L->top++, int32_t(arr->len));
+      return 1;
    }
 
    // Push each value
@@ -2644,7 +2686,7 @@ static int array_tostring(lua_State *L)
 }
 
 //********************************************************************************************************************
-// __concat metamethod.
+// __concat metamethod.  Produces a new string value from the combination of the LHS and RHS
 
 static GCstr * array_concat_value(lua_State *L, cTValue *Value)
 {

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -558,6 +558,77 @@ static bool array_elem_irtype(AET ElemType, IRType &ResultType)
 }
 
 //********************************************************************************************************************
+// Record array.append(receiver, value) - the helper behind compound concatenation (..=).  Array receivers append in
+// place via lj_arr_push1(); string and number receivers concatenate to a string, mirroring BC_CAT recording.
+
+static void recff_array_append(jit_State* J, RecordFFData* rd)
+{
+   TRef left = J->base[0];
+   TRef right = left ? J->base[1] : 0;
+   if (!right) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   if (tref_isarray(left)) {
+      GCarray *arr = arrayV(&rd->argv[0]);
+      cTValue *val = &rd->argv[1];
+
+      // Only record combinations that lj_arr_push1() implements with array.push() semantics.
+      bool supported;
+      switch (arr->elemtype) {
+         case AET::BYTE:
+            supported = tvisstr(val) or tvisnumber(val);
+            break;
+         case AET::INT16:
+         case AET::INT32:
+         case AET::INT64:
+         case AET::FLOAT:
+         case AET::DOUBLE:
+            supported = tvisnumber(val);
+            break;
+         case AET::STR_GC:
+            supported = tvisstr(val);
+            break;
+         case AET::ANY:
+            supported = true;
+            break;
+         default:
+            supported = false;
+            break;
+      }
+
+      if (not supported) {
+         recff_nyi(J, rd);
+         return;
+      }
+
+      // Guard the element type so the trace only runs for arrays matching the recorded semantics.
+      TRef et_ref = emitir(IRT(IR_FLOAD, IRT_U8), left, IRFL_ARRAY_ELEMTYPE);
+      emitir(IRTGI(IR_EQ), et_ref, lj_ir_kint(J, int32_t(arr->elemtype)));
+
+      TRef tmp_ref = recff_tmpref(J, right, IRTMPREF_IN1);
+      recff_ir_call_fixed(J, IRCALL_lj_arr_push1, left, tmp_ref, TREF_NIL, TREF_NIL);
+      J->base[0] = left;  // append() returns the receiver array.
+   }
+   else if (tref_isnumber_str(left) and tref_isnumber_str(right)) {
+      if (tref_isnumber(left)) {
+         left = emitir(IRT(IR_TOSTR, IRT_STR), left, tref_isnum(left) ? IRTOSTR_NUM : IRTOSTR_INT);
+      }
+      if (tref_isnumber(right)) {
+         right = emitir(IRT(IR_TOSTR, IRT_STR), right, tref_isnum(right) ? IRTOSTR_NUM : IRTOSTR_INT);
+      }
+      TRef hdr = recff_bufhdr(J);
+      TRef tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), hdr, left);
+      tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, right);
+      J->base[0] = emitir(IRTG(IR_BUFSTR, IRT_STR), tr, hdr);
+   }
+   else {
+      recff_nyi(J, rd);  // Tables and objects with __concat metamethods fall back to the interpreter.
+   }
+}
+
+//********************************************************************************************************************
 
 static void recff_ipairs_aux(jit_State* J, RecordFFData* rd)
 {

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -210,6 +210,7 @@ typedef struct CCallInfo {
   /* Native array helpers */ \
   _(ANY,        lj_arr_getidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_setidx,     4,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_push1,      3,   S, NIL, CCI_L|CCI_T) \
   /* Try-except exception handling */ \
   _(ANY,        lj_try_enter,      4,  FS, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -579,6 +579,20 @@ TRef lj_opt_fwd_fload(jit_State* J)
    IRRef lim = oref;  //  Search limit.
    IRRef ref;
 
+   // Array-mutating C calls (array.append) update the length and may reallocate the storage.
+   // Limit forwarding of these fields to below the most recent call (conservative across all arrays).
+   if (fid IS IRFL_ARRAY_LEN or fid IS IRFL_ARRAY_STORAGE) {
+      ref = J->chain[IR_CALLS];
+      while (ref > lim) {
+         IRIns* calls = IR(ref);
+         if (calls->op2 IS IRCALL_lj_arr_push1) {
+            lim = ref;
+            break;
+         }
+         ref = calls->prev;
+      }
+   }
+
    // Search for conflicting stores.
    ref = J->chain[IR_FSTORE];
    while (ref > oref) {

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -298,8 +298,57 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
    TableOperandCopies copies = allocator.duplicate_table_operands(target.storage);
    ExpDesc working = copies.duplicated;
 
+   auto finish_compound_assignment = [&]() {
+      register_guard.release_to(register_guard.saved());
+      allocator.release(copies.reserved);
+      release_prepared_assignment(allocator, this->func_state, target);
+      this->func_state.reset_freereg();
+      register_guard.adopt_saved(BCReg(this->func_state.freereg));
+      return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+   };
+
    ExpDesc rhs;
-      if (mapped.value() IS BinOpr::Concat) {
+   const bool direct_known_non_array = (target.storage.k IS ExpKind::Local or target.storage.k IS ExpKind::Upval) and
+      not (target.storage.result_type IS TiriType::Array or target.storage.result_type IS TiriType::Unknown or
+         target.storage.result_type IS TiriType::Any);
+   const bool use_append_helper = mapped.value() IS BinOpr::Concat and not direct_known_non_array;
+
+   if (use_append_helper) {
+      ExpDesc append_func;
+      append_func.init(ExpKind::Global, 0);
+      append_func.u.sval = this->func_state.ls->keepstr("array");
+      this->materialise_to_next_reg(append_func, "array append interface");
+
+      ExpDesc append_key(this->func_state.ls->keepstr("append"));
+      expr_index(&this->func_state, &append_func, &append_key);
+      this->materialise_to_next_reg(append_func, "array append helper");
+
+      RegisterAllocator call_allocator(&this->func_state);
+      call_allocator.reserve(BCReg(1));
+      auto call_base = BCReg(append_func.u.s.info);
+
+      this->materialise_to_next_reg(working, "array append compound receiver");
+
+      auto list = this->emit_expression_list(values, count);
+      if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
+
+      if (count != 1) {
+         return assignment_value_count_error(this, values,
+            "compound assignment expects exactly one RHS value");
+      }
+
+      rhs = list.value_ref();
+      this->materialise_to_next_reg(rhs, "array compound append argument");
+
+      ExpDesc result;
+      result.init(ExpKind::Call, bcemit_ABC(&this->func_state, BC_CALL, call_base, 2,
+         this->func_state.freereg - call_base - 1));
+      result.u.s.aux = call_base;
+      if (target.storage.result_type IS TiriType::Array) result.result_type = TiriType::Array;
+
+      bcemit_store(&this->func_state, &target.storage, &result);
+   }
+   else if (mapped.value() IS BinOpr::Concat) {
       ExpDesc infix = working;
       // CONCAT compound assignment: use OperatorEmitter for BC_CAT chaining
       this->operator_emitter.prepare_concat(ExprValue(&infix));
@@ -334,12 +383,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
       bcemit_store(&this->func_state, &target.storage, &infix);
    }
 
-   register_guard.release_to(register_guard.saved());
-   allocator.release(copies.reserved);
-   release_prepared_assignment(allocator, this->func_state, target);
-   this->func_state.reset_freereg();
-   register_guard.adopt_saved(BCReg(this->func_state.freereg));
-   return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+   return finish_compound_assignment();
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -49,6 +49,12 @@ static ParserResult<IrEmitUnit> assignment_value_count_error(
       ParserError(ParserErrorCode::InternalInvariant, Token::from_span(span, TokenKind::Unknown), Message));
 }
 
+static GCstr * array_append_helper_key(LexState *State)
+{
+   static constexpr std::string_view key("\x1f" "array.append", 13);
+   return State->keepstr(key);
+}
+
 //********************************************************************************************************************
 // Emit bytecode for a plain assignment, storing values into one or more target lvalues.  NB: This generic function
 // exists over the local/global specific implementations because of the need to handle complex scenarios
@@ -316,11 +322,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
    if (use_append_helper) {
       ExpDesc append_func;
       append_func.init(ExpKind::Global, 0);
-      append_func.u.sval = this->func_state.ls->keepstr("array");
-      this->materialise_to_next_reg(append_func, "array append interface");
-
-      ExpDesc append_key(this->func_state.ls->keepstr("append"));
-      expr_index(&this->func_state, &append_func, &append_key);
+      append_func.u.sval = array_append_helper_key(this->func_state.ls);
       this->materialise_to_next_reg(append_func, "array append helper");
 
       RegisterAllocator call_allocator(&this->func_state);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -692,6 +692,14 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             if (existing->primary IS TiriType::Any) continue; // 'any' accepts everything including nil
             if (value_type.primary IS TiriType::Nil) continue;  // Nil is always allowed as a "clear" operation
 
+            if (Payload.op IS AssignmentOperator::Concat) {
+               // Compound concatenation (..=) on an array target appends in place via array.append(),
+               // preserving the array type; the RHS is validated by push() at runtime.
+               if (existing->primary IS TiriType::Array) continue;
+               // Concatenating a number onto a string target still yields a string.
+               if (existing->primary IS TiriType::Str and value_type.primary IS TiriType::Num) continue;
+            }
+
             if (value_type.primary != TiriType::Any and value_type.primary != existing->primary) {
                // Type mismatch
                TypeDiagnostic diag;

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -327,3 +327,28 @@ extern "C" void lj_arr_setidx(lua_State *L, GCarray *Array, int32_t Idx, cTValue
    if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
    arr_store_elem(L, Array, uint32_t(Idx), Val);
 }
+
+//********************************************************************************************************************
+// Append a single value to an array.  Called from JIT traces when recording array.append(), mirroring the semantics
+// of array.push() for one value.  Byte arrays accept strings, appending their bytes verbatim.
+
+extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Val)
+{
+   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+
+   if (Array->elemtype IS AET::BYTE and tvisstr(Val)) {
+      GCstr *str = strV(Val);
+      if (str->len > (~MSize(0) - Array->len)) lj_err_msg(L, ErrMsg::ARREXT);
+      MSize new_len = Array->len + str->len;
+      if (new_len > Array->capacity and not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+      if (str->len > 0) memcpy((uint8_t*)Array->arraydata() + Array->len, strdata(str), str->len);
+      Array->len = new_len;
+      return;
+   }
+
+   MSize idx = Array->len;
+   if (idx IS ~MSize(0)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (idx + 1 > Array->capacity and not lj_array_grow(L, Array, idx + 1)) lj_err_msg(L, ErrMsg::ARREXT);
+   arr_store_elem(L, Array, idx, Val);
+   Array->len = idx + 1;
+}

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -19,6 +19,10 @@ extern "C" [[nodiscard]] int lj_arr_set(lua_State *, cTValue *, cTValue *, cTVal
 extern "C" void lj_arr_getidx(lua_State *, GCarray *, int32_t idx, TValue *);
 extern "C" void lj_arr_setidx(lua_State *, GCarray *, int32_t idx, cTValue *);
 
+// Append a single value to an array (array.append() semantics), called from JIT traces
+
+extern "C" void lj_arr_push1(lua_State *, GCarray *, cTValue *);
+
 // Safe array get - returns nil for out-of-bounds instead of throwing error
 // Used by safe navigation operator (?[]) on arrays
 

--- a/src/tiri/tests/test_array_manip.tiri
+++ b/src/tiri/tests/test_array_manip.tiri
@@ -92,6 +92,36 @@ end
    assert(arr:getString() is 'ABCD', 'getString should return ABCD')
 end
 
+@Test function ArrayPushByteString()
+   empty = array<byte>
+   len = empty:push('')
+   assert(len is 0, 'push() should accept an empty string without growing a byte array')
+   assert(#empty is 0, 'Empty string push should leave a fresh byte array empty')
+
+   arr = array<byte>
+   len = arr:push('AB', 67, '', 'D')
+
+   assert(len is 4, 'push() should count string bytes and numeric byte values')
+   assert(#arr is 4, 'Byte array length should be 4 after string push')
+   assert(arr:getString() is 'ABCD', 'String values should append their bytes sequentially')
+
+   source = array<byte> { 88, 0, 89 }
+   len = arr:push(source:getString())
+   expected = 'ABCD' .. source:getString()
+
+   assert(len is 7, 'push() should preserve embedded NUL bytes when appending strings')
+   assert(arr:getString() is expected, 'Byte array string push should preserve embedded NUL bytes')
+   assert(#arr:getString() is 7, 'Byte array string push should preserve the full byte length')
+end
+
+@Test function ArrayPushCharString()
+   arr = array<char>
+   len = arr:push('Hi', 33)
+
+   assert(len is 3, 'char array push() should append string bytes and numeric byte values')
+   assert(tostring(arr) is 'Hi!', "char array push() should produce 'Hi!'")
+end
+
 @Test function ArrayPushString()
    arr = array<string>
    arr:push('hello')

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -330,6 +330,20 @@ end
    assert(store.label is 'xy', 'field string ..= should still concatenate and store a string')
 end
 
+@Test function ArrayConcatAssignmentOnTypedLocals()
+   local buf = array<byte>
+   buf ..= 'Hi'
+   buf ..= 33
+
+   assert(#buf is 3, 'typed local byte array ..= should append to the array')
+   assert(buf:getString() is 'Hi!', 'typed local byte array ..= should append string bytes and numeric bytes')
+
+   local text = 'x'
+   text ..= 42
+
+   assert(text is 'x42', 'typed local string ..= should accept a numeric RHS')
+end
+
 @Test function ArrayConcatAssignmentUsesFirstReturn()
    function byte_tail()
       return 'Z', 'ignored'

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -330,6 +330,27 @@ end
    assert(store.label is 'xy', 'field string ..= should still concatenate and store a string')
 end
 
+@Test function ArrayConcatAssignmentIgnoresShadowedArrayGlobal()
+   saved_array = array
+   store = { buf = array<byte>, label = 'x' }
+
+   global array = {}
+
+   try
+      store.label ..= 'y'
+      store.buf ..= 'Hi'
+      store.buf ..= 33
+
+      assert(store.label is 'xy', 'field string ..= should not call the shadowed array global')
+      assert(store.buf:getString() is 'Hi!', 'field byte array ..= should still use the internal append helper')
+   except e
+      global array = saved_array
+      error(e)
+   success
+      global array = saved_array
+   end
+end
+
 @Test function ArrayConcatAssignmentOnTypedLocals()
    local buf = array<byte>
    buf ..= 'Hi'

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -300,6 +300,53 @@ end
    assert(text is 'abc', '..= should concatenate with function result')
 end
 
+@Test function ArrayConcatAssignmentMutates()
+   arr = array<byte>
+   arr ..= 'AB'
+   arr ..= 67
+
+   assert(#arr is 3, 'array byte ..= should append to the array')
+   assert(arr:getString() is 'ABC', 'array byte ..= should append string bytes and numeric bytes')
+
+   source = array<byte> { 0, 68 }
+   arr ..= source:getString()
+   expected = 'ABC' .. source:getString()
+
+   assert(#arr is 5, 'array byte ..= should preserve embedded NUL bytes')
+   assert(arr:getString() is expected, 'array byte ..= should preserve the full appended byte string')
+
+   result = arr .. '!'
+   assert(result is expected .. '!', 'plain array concat should still return a string')
+   assert(arr:getString() is expected, 'plain array concat should not mutate the array')
+end
+
+@Test function ArrayConcatAssignmentOnFields()
+   store = { buf = array<byte>, label = 'x' }
+   store.buf ..= 'Hi'
+   store.buf ..= 33
+   store.label ..= 'y'
+
+   assert(store.buf:getString() is 'Hi!', 'field byte array ..= should mutate the stored array')
+   assert(store.label is 'xy', 'field string ..= should still concatenate and store a string')
+end
+
+@Test function ArrayConcatAssignmentUsesFirstReturn()
+   function byte_tail()
+      return 'Z', 'ignored'
+   end
+
+   arr = array<byte>
+   arr ..= byte_tail()
+
+   assert(arr:getString() is 'Z', 'array byte ..= should use only the first function result')
+
+   nums = array<int> { 1, 2 }
+   nums ..= 3
+
+   assert(#nums is 3, 'array int ..= should push one value')
+   assert(nums[2] is 3, 'array int ..= should append the numeric value')
+end
+
 @Test function RegisterIndexPreservedAcrossRHS()
    t = { 10, 20, 30 }
    i = 0


### PR DESCRIPTION
## Summary

This PR extends Tiri array append behaviour and concat assignment handling:

* Allows `array<byte>:push()` to append string data safely, including overflow checks and empty-string handling.
* Makes `..=` mutate array LHS values through `array.append()` while preserving normal string concat behaviour for non-array receivers.
* Adds JIT recording for traced `array.append()` calls with a single-value `lj_arr_push1()` helper and conservative forwarding around array length/storage mutation.
* Adds focused compound-assignment coverage for byte arrays, typed locals, fields, and first-result RHS handling.

## Validation

* Built Tiri in WSL: `cmake --build build/wsl-agents --target tiri --parallel`
* Ran focused compound tests with the built runtime: `build/wsl-agents/release/origo tools/flute.tiri file=src/tiri/tests/test_compound.tiri --log-warning`
* Ran focused array manipulation tests with the built runtime: `build/wsl-agents/release/origo tools/flute.tiri file=src/tiri/tests/test_array_manip.tiri --log-warning`

Note: the workspace currently has unrelated unstaged/untracked local files that are not part of this PR.