### PR TITLE
[Tiri] Recorded native array allocation and mutation in the JIT

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -227,7 +227,7 @@ static void append_integer(std::string &Result, int64_t Value)
 //   size: number of elements (must be non-negative)
 //   type: element type string ("char", "int16", "int", "int64", "float", "double", "string", "StructName")
 
-LJLIB_CF(array_new)
+LJLIB_CF(array_new)      LJLIB_REC(.)
 {
    GCarray *arr;
 
@@ -883,7 +883,7 @@ LJLIB_CF(array_last)
 //
 // Note: For string arrays with GC references, this also nullifies the references to allow garbage collection.
 
-LJLIB_CF(array_clear)
+LJLIB_CF(array_clear)      LJLIB_REC(.)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    if (arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
@@ -905,7 +905,7 @@ LJLIB_CF(array_clear)
 //
 // Note: External arrays and cached string arrays cannot grow and will raise an error.
 
-LJLIB_CF(array_resize)
+LJLIB_CF(array_resize)      LJLIB_REC(.)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    if (arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
@@ -955,7 +955,7 @@ LJLIB_CF(array_resize)
 //
 // Note: External arrays and cached string arrays cannot grow and will raise an error.
 
-LJLIB_CF(array_push)
+LJLIB_CF(array_push)      LJLIB_REC(.)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
    if (arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
@@ -1393,7 +1393,7 @@ LJLIB_CF(array_copy)
 //   start: starting index (0-based, default 0)
 //   len: number of bytes to extract (default: remaining bytes from start)
 
-LJLIB_CF(array_getString)
+LJLIB_CF(array_getString)      LJLIB_REC(.)
 {
    GCarray *arr = lj_lib_checkarray(L, 1);
 

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -22,6 +22,7 @@
 #define LUA_CORE
 
 #include <bit>
+#include <cstring>
 
 #include "lj_obj.h"
 #include "lj_err.h"
@@ -558,6 +559,188 @@ static bool array_elem_irtype(AET ElemType, IRType &ResultType)
 }
 
 //********************************************************************************************************************
+
+static bool array_elemtype_from_string(GCstr *TypeStr, AET *Result)
+{
+   CSTRING type_name = strdata(TypeStr);
+
+   if (TypeStr->len IS 3 and memcmp(type_name, "int", 3) IS 0) *Result = AET::INT32;
+   else if (TypeStr->len IS 4 and memcmp(type_name, "byte", 4) IS 0) *Result = AET::BYTE;
+   else if (TypeStr->len IS 4 and memcmp(type_name, "char", 4) IS 0) *Result = AET::BYTE;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "int16", 5) IS 0) *Result = AET::INT16;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "int64", 5) IS 0) *Result = AET::INT64;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "float", 5) IS 0) *Result = AET::FLOAT;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "double", 6) IS 0) *Result = AET::DOUBLE;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "string", 6) IS 0) *Result = AET::STR_GC;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "struct", 6) IS 0) *Result = AET::STRUCT;
+   else if (TypeStr->len IS 7 and memcmp(type_name, "pointer", 7) IS 0) *Result = AET::PTR;
+   else if (TypeStr->len IS 6 and memcmp(type_name, "object", 6) IS 0) *Result = AET::OBJECT;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "table", 5) IS 0) *Result = AET::TABLE;
+   else if (TypeStr->len IS 5 and memcmp(type_name, "array", 5) IS 0) *Result = AET::ARRAY;
+   else if (TypeStr->len IS 3 and memcmp(type_name, "any", 3) IS 0) *Result = AET::ANY;
+   else return false;
+
+   return true;
+}
+
+//********************************************************************************************************************
+// Record array.new(size, literal_type).  String-initialised byte arrays are left for the interpreter for now.
+
+static void recff_array_new(jit_State* J, RecordFFData* rd)
+{
+   TRef size_ref = J->base[0];
+   TRef type_ref = size_ref ? J->base[1] : 0;
+
+   if (!type_ref) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   if (not tvisnumber(&rd->argv[0])) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   if (not tvisstr(&rd->argv[1]) or not tref_isk(type_ref)) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   AET elem_type;
+   if (not array_elemtype_from_string(strV(&rd->argv[1]), &elem_type) or elem_type IS AET::PTR or
+       elem_type IS AET::STRUCT) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   size_ref = lj_opt_narrow_toint(J, size_ref);
+   emitir(IRTGI(IR_GE), size_ref, lj_ir_kint(J, 0));
+
+   J->base[0] = recff_ir_call_fixed(J, IRCALL_lj_arr_new_jit, size_ref, lj_ir_kint(J, int32_t(elem_type)),
+      TREF_NIL, TREF_NIL);
+}
+
+//********************************************************************************************************************
+// Record array.clear(receiver).
+
+static void recff_array_clear(jit_State* J, RecordFFData* rd)
+{
+   TRef array_ref = J->base[0];
+   if (tref_isarray(array_ref)) {
+      recff_ir_call_fixed(J, IRCALL_lj_arr_clear, array_ref, TREF_NIL, TREF_NIL, TREF_NIL);
+      J->base[0] = 0;
+      rd->nres = 0;
+   }  // else: Interpreter will throw.
+}
+
+//********************************************************************************************************************
+// Record array.resize(receiver, new_size).
+
+static void recff_array_resize(jit_State* J, RecordFFData* rd)
+{
+   TRef array_ref = J->base[0];
+   TRef size_ref = array_ref ? J->base[1] : 0;
+
+   if (tref_isarray(array_ref) and size_ref) {
+      if (not tvisnumber(&rd->argv[1])) {
+         recff_nyi(J, rd);
+         return;
+      }
+
+      size_ref = lj_opt_narrow_toint(J, size_ref);
+      J->base[0] = recff_ir_call_fixed(J, IRCALL_lj_arr_resize, array_ref, size_ref, TREF_NIL, TREF_NIL);
+   }  // else: Interpreter will throw.
+}
+
+//********************************************************************************************************************
+// Record array.getString(receiver, start, len).
+
+static void recff_array_getString(jit_State* J, RecordFFData* rd)
+{
+   TRef array_ref = J->base[0];
+   if (not tref_isarray(array_ref)) return;  // Interpreter will throw.
+
+   GCarray *arr = arrayV(&rd->argv[0]);
+   if (not (arr->elemtype IS AET::BYTE)) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   TRef elem_type_ref = emitir(IRT(IR_FLOAD, IRT_U8), array_ref, IRFL_ARRAY_ELEMTYPE);
+   emitir(IRTGI(IR_EQ), elem_type_ref, lj_ir_kint(J, int32_t(AET::BYTE)));
+
+   TRef start_ref = lj_ir_kint(J, 0);
+   if (J->base[1] and not tref_isnil(J->base[1])) {
+      if (not tvisnumber(&rd->argv[1])) {
+         recff_nyi(J, rd);
+         return;
+      }
+      start_ref = lj_opt_narrow_toint(J, J->base[1]);
+   }
+
+   TRef len_ref = lj_ir_kint(J, -1);
+   if (J->base[2] and not tref_isnil(J->base[2])) {
+      if (not tvisnumber(&rd->argv[2])) {
+         recff_nyi(J, rd);
+         return;
+      }
+      len_ref = lj_opt_narrow_toint(J, J->base[2]);
+      emitir(IRTGI(IR_GE), len_ref, lj_ir_kint(J, 0));
+   }
+
+   J->base[0] = recff_ir_call_fixed(J, IRCALL_lj_arr_getstring, array_ref, start_ref, len_ref, TREF_NIL);
+}
+
+//********************************************************************************************************************
+
+static bool array_push_recordable(GCarray *Array, cTValue *Val)
+{
+   switch (Array->elemtype) {
+      case AET::BYTE:
+         return tvisstr(Val) or tvisnumber(Val);
+      case AET::INT16:
+      case AET::INT32:
+      case AET::INT64:
+      case AET::FLOAT:
+      case AET::DOUBLE:
+         return tvisnumber(Val);
+      case AET::STR_GC:
+         return tvisstr(Val);
+      case AET::ANY:
+         return true;
+      default:
+         return false;
+   }
+}
+
+//********************************************************************************************************************
+// Record array.push(receiver, value).  Multi-value push falls back to the interpreter.
+
+static void recff_array_push(jit_State* J, RecordFFData* rd)
+{
+   TRef array_ref = J->base[0];
+   TRef val_ref = array_ref ? J->base[1] : 0;
+   if (not tref_isarray(array_ref) or not val_ref or J->base[2]) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   GCarray *arr = arrayV(&rd->argv[0]);
+   cTValue *val = &rd->argv[1];
+   if (not array_push_recordable(arr, val)) {
+      recff_nyi(J, rd);
+      return;
+   }
+
+   TRef elem_type_ref = emitir(IRT(IR_FLOAD, IRT_U8), array_ref, IRFL_ARRAY_ELEMTYPE);
+   emitir(IRTGI(IR_EQ), elem_type_ref, lj_ir_kint(J, int32_t(arr->elemtype)));
+
+   TRef tmp_ref = recff_tmpref(J, val_ref, IRTMPREF_IN1);
+   recff_ir_call_fixed(J, IRCALL_lj_arr_push1, array_ref, tmp_ref, TREF_NIL, TREF_NIL);
+   J->base[0] = emitir(IRTI(IR_FLOAD), array_ref, IRFL_ARRAY_LEN);
+}
+
+//********************************************************************************************************************
 // Record array.append(receiver, value) - the helper behind compound concatenation (..=).  Array receivers append in
 // place via lj_arr_push1(); string and number receivers concatenate to a string, mirroring BC_CAT recording.
 
@@ -574,31 +757,7 @@ static void recff_array_append(jit_State* J, RecordFFData* rd)
       GCarray *arr = arrayV(&rd->argv[0]);
       cTValue *val = &rd->argv[1];
 
-      // Only record combinations that lj_arr_push1() implements with array.push() semantics.
-      bool supported;
-      switch (arr->elemtype) {
-         case AET::BYTE:
-            supported = tvisstr(val) or tvisnumber(val);
-            break;
-         case AET::INT16:
-         case AET::INT32:
-         case AET::INT64:
-         case AET::FLOAT:
-         case AET::DOUBLE:
-            supported = tvisnumber(val);
-            break;
-         case AET::STR_GC:
-            supported = tvisstr(val);
-            break;
-         case AET::ANY:
-            supported = true;
-            break;
-         default:
-            supported = false;
-            break;
-      }
-
-      if (not supported) {
+      if (not array_push_recordable(arr, val)) {
          recff_nyi(J, rd);
          return;
       }

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -208,9 +208,13 @@ typedef struct CCallInfo {
   _(FFI,        memset,            3,   S, PTR, 0) \
   _(FFI,        lj_vm_errno,       0,   S, INT, CCI_NOFPRCLOBBER) \
   /* Native array helpers */ \
+  _(ANY,        lj_arr_new_jit,    3,   A, ARRAY, CCI_L|CCI_T) \
   _(ANY,        lj_arr_getidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_setidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_push1,      3,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_clear,      2,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_resize,     3,   S, INT, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_getstring,  4,   S, STR, CCI_L|CCI_T) \
   /* Try-except exception handling */ \
   _(ANY,        lj_try_enter,      4,  FS, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -571,6 +571,12 @@ static AliasRet aa_fref(jit_State* J, IRIns* refa, IRIns* refb)
       return ALIAS_MAY;  //  Same field, possibly different object.
 }
 
+// True for C helpers that change an array's length or may reallocate its storage.
+static bool ircall_mutates_array(uint32_t CallId)
+{
+   return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_clear or CallId IS IRCALL_lj_arr_resize;
+}
+
 // Only the loads for mutable fields end up here (see FOLD).
 TRef lj_opt_fwd_fload(jit_State* J)
 {
@@ -579,13 +585,13 @@ TRef lj_opt_fwd_fload(jit_State* J)
    IRRef lim = oref;  //  Search limit.
    IRRef ref;
 
-   // Array-mutating C calls (array.append) update the length and may reallocate the storage.
+   // Array-mutating C calls update the length or may reallocate the storage.
    // Limit forwarding of these fields to below the most recent call (conservative across all arrays).
    if (fid IS IRFL_ARRAY_LEN or fid IS IRFL_ARRAY_STORAGE) {
       ref = J->chain[IR_CALLS];
       while (ref > lim) {
          IRIns* calls = IR(ref);
-         if (calls->op2 IS IRCALL_lj_arr_push1) {
+         if (ircall_mutates_array(calls->op2)) {
             lim = ref;
             break;
          }

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -352,3 +352,77 @@ extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Val)
    arr_store_elem(L, Array, idx, Val);
    Array->len = idx + 1;
 }
+
+//********************************************************************************************************************
+// Clear an array from a recorded trace.
+
+extern "C" void lj_arr_clear(lua_State *L, GCarray *Array)
+{
+   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+
+   lj_array_clear_range(Array, 0, Array->len);
+   Array->len = 0;
+}
+
+//********************************************************************************************************************
+// Resize an array from a recorded trace.
+
+extern "C" int32_t lj_arr_resize(lua_State *L, GCarray *Array, int32_t NewSize)
+{
+   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+   if (NewSize < 0) lj_err_msgv(L, ErrMsg::NUMRNG, "non-negative", "negative");
+
+   MSize target_len = MSize(NewSize);
+   MSize old_len = Array->len;
+
+   if (target_len > old_len) {
+      if (target_len > Array->capacity and not lj_array_grow(L, Array, target_len)) lj_err_msg(L, ErrMsg::ARREXT);
+
+      if (Array->elemtype IS AET::STR_GC or Array->elemtype IS AET::TABLE or
+          Array->elemtype IS AET::ARRAY or Array->elemtype IS AET::OBJECT or Array->elemtype IS AET::ANY) {
+         lj_array_clear_range(Array, old_len, target_len - old_len);
+      }
+      else {
+         void *start = (char*)Array->arraydata() + (old_len * Array->elemsize);
+         size_t bytes = (target_len - old_len) * Array->elemsize;
+         memset(start, 0, bytes);
+      }
+   }
+   else if (target_len < old_len) {
+      lj_array_clear_range(Array, target_len, old_len - target_len);
+   }
+
+   Array->len = target_len;
+   return int32_t(Array->len);
+}
+
+//********************************************************************************************************************
+// Extract a string from a byte array in a recorded trace.  Len -1 means "remaining from Start".
+
+extern "C" GCstr * lj_arr_getstring(lua_State *L, GCarray *Array, int32_t Start, int32_t Len)
+{
+   if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
+
+   int32_t count = Len;
+   if (Len IS -1) {
+      if (Start < 0 or MSize(Start) > Array->len) count = 0;
+      else count = int32_t(Array->len - MSize(Start));
+   }
+
+   if (Start < 0 or count < 0 or MSize(Start) > Array->len) lj_err_msg(L, ErrMsg::IDXRNG);
+
+   MSize start = MSize(Start);
+   MSize byte_count = MSize(count);
+   if (byte_count > Array->len - start) lj_err_msg(L, ErrMsg::IDXRNG);
+
+   CSTRING data = byte_count > 0 ? Array->get<const char>() + start : "";
+   return lj_str_new(L, data, byte_count);
+}
+
+//********************************************************************************************************************
+// Create an array from a recorded trace.  The recorder resolves and validates ElemType from a constant type literal.
+
+extern "C" GCarray * lj_arr_new_jit(lua_State *L, uint32_t Length, uint32_t ElemType)
+{
+   return lj_array_new(L, Length, AET(ElemType));
+}

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -23,6 +23,22 @@ extern "C" void lj_arr_setidx(lua_State *, GCarray *, int32_t idx, cTValue *);
 
 extern "C" void lj_arr_push1(lua_State *, GCarray *, cTValue *);
 
+// Clear an array from JIT traces.
+
+extern "C" void lj_arr_clear(lua_State *, GCarray *);
+
+// Resize an array from JIT traces.
+
+extern "C" int32_t lj_arr_resize(lua_State *, GCarray *, int32_t);
+
+// Extract a string from a byte array in JIT traces.
+
+extern "C" GCstr * lj_arr_getstring(lua_State *, GCarray *, int32_t, int32_t);
+
+// Create an array from JIT traces.
+
+extern "C" GCarray * lj_arr_new_jit(lua_State *, uint32_t, uint32_t);
+
 // Safe array get - returns nil for out-of-bounds instead of throwing error
 // Used by safe navigation operator (?[]) on arrays
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -634,6 +634,218 @@ end
    assert(ensure_trace(pairs) is true, "Expected array pairs to produce a JIT trace")
 end
 
+@Test(hotpath=80) function ArrayNewLiteralTypeTraces()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_new(Count)
+      local total = 0
+      for i = 1, Count do
+         local arr = array.new(i % 5, "int")
+         total += #arr
+      end
+      return total
+   end
+
+   local result = 0
+   for i = 1, 80 do
+      result = traced_array_new(10)
+   end
+
+   assert(result is 20, f"Expected recorded array.new() loop to total 20, got {result}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected array.new(size, literal_type) to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayClearTracesAndInvalidatesLength()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_clear(Count)
+      local arr = array<int> { 1, 2, 3, 4 }
+      local total = 0
+
+      for i = 1, Count do
+         total += #arr
+         arr:clear()
+         total += #arr
+         arr:push(i)
+      end
+
+      return total, #arr
+   end
+
+   local total = 0
+   local len = 0
+   for i = 1, 80 do
+      total, len = traced_array_clear(10)
+   end
+
+   assert(total is 13, f"Expected array.clear() length invalidation total 13, got {total}")
+   assert(len is 1, f"Expected final array length 1 after clear/push loop, got {len}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected array.clear() to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayResizeTracesAndInvalidatesLength()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_resize(Count)
+      local arr = array<int> { 7, 8 }
+      local total = 0
+      local result = 0
+
+      for i = 1, Count do
+         total += #arr
+         result = arr:resize((i % 4) + 1)
+         total += #arr
+      end
+
+      return total, result, #arr, arr[2]
+   end
+
+   local total = 0
+   local result = 0
+   local len = 0
+   local expanded_value = 0
+   for i = 1, 80 do
+      total, result, len, expanded_value = traced_array_resize(10)
+   end
+
+   assert(total is 49, f"Expected array.resize() length invalidation total 49, got {total}")
+   assert(result is 3, f"Expected final resize() result 3, got {result}")
+   assert(len is 3, f"Expected final array length 3 after resize loop, got {len}")
+   assert(expanded_value is 0, f"Expected grown array slot to be zero-filled, got {expanded_value}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected array.resize() to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayGetStringTracesWithRuntimeRemainingLength()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_get_string(Count)
+      local arr = array.new("abcdef")
+      local total = 0
+
+      for i = 1, Count do
+         arr:resize((i % 4) + 2)
+         total += #arr:getString(1)
+         total += #arr:getString(0, 1)
+      end
+
+      return total, #arr:getString(1)
+   end
+
+   local total = 0
+   local final_remaining = 0
+   for i = 1, 80 do
+      total, final_remaining = traced_array_get_string(10)
+   end
+
+   assert(total is 35, f"Expected array.getString() runtime remaining total 35, got {total}")
+   assert(final_remaining is 3, f"Expected final remaining string length 3, got {final_remaining}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected array.getString() to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayPushSingleValueTracesAndReturnsLength()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_push(Count)
+      local arr = array.new("")
+      local total = 0
+      local result = 0
+
+      for i = 1, Count do
+         result = arr:push("xy")
+         total += result
+      end
+
+      return total, result, #arr
+   end
+
+   local total = 0
+   local result = 0
+   local len = 0
+   for i = 1, 80 do
+      total, result, len = traced_array_push(10)
+   end
+
+   assert(total is 110, f"Expected array.push() length result total 110, got {total}")
+   assert(result is 20, f"Expected final push() result 20, got {result}")
+   assert(len is 20, f"Expected final array length 20 after push loop, got {len}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected single-value array.push() to produce a JIT trace")
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Test JIT recording of BC_OBGETF (object field get)
 -- Without JIT support, the trace recorder would abort with NYIBC (Not Yet Implemented Bytecode).

--- a/tools/benchmark/benchmark_string.tiri
+++ b/tools/benchmark/benchmark_string.tiri
@@ -23,14 +23,15 @@ global glStringBenchmarkSink = 0
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Goal: Build a string by concatenating multiple parts
+-- Goal: Build a string by concatenating multiple parts - big buffer version
 
-@Test function StringConcatenateMultiple()
+@Test function StringConcatBigBuffer()
    local a, b, c = "foo", "bar", "baz"
    local checksum = 0
-   for i in {0 to 10000} do
+   local result = ""
+   for i in {0 to 1000} do
       -- Concatenate literals
-      local result = "Hello" .. " " .. "World" .. "!"
+      result ..= "Hello" .. " " .. "World" .. "!"
 
       -- Concatenate with variables
       result ..= a .. b .. c
@@ -39,7 +40,7 @@ end
       result ..= "Part1" .. "-" .. "Part2" .. "-" .. "Part3" .. "-" .. "Part4"
 
       -- Concatenate numbers converted to strings
-      result = "Value: " .. tostring(i) .. ", Next: " .. tostring(i + 1)
+      result ..= "Value: " .. tostring(i) .. ", Next: " .. tostring(i + 1)
 
       -- Perform a real-work operation so that the result is used and not optimised away.
       checksum += #result
@@ -48,13 +49,63 @@ end
    glStringBenchmarkSink += checksum
 end
 
-@Test function StringConcatenateMultipleByteArray()
+@Test function StringConcatBigArray()
    local a, b, c = "foo", "bar", "baz"
-   local result = array<byte>
    local checksum = 0
-   for i in {0 to 10000} do
+   local result = array<byte>
+   for i in {0 to 1000} do
       -- Concatenate literals
-      result:clear()
+      result ..= "Hello" .. " " .. "World" .. "!"
+
+      -- Concatenate with variables
+      result ..= a .. b .. c
+
+      -- Build a longer string from parts
+      result ..= "Part1" .. "-" .. "Part2" .. "-" .. "Part3" .. "-" .. "Part4"
+
+      -- Concatenate numbers converted to strings
+      result ..= "Value: " .. tostring(i) .. ", Next: " .. tostring(i + 1)
+      checksum += #result
+   end
+
+   glStringBenchmarkSink += checksum
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Build a string by concatenating multiple parts - small buffer version
+
+@Test function StringConcatSmallBuffer()
+   local a, b, c = "foo", "bar", "baz"
+   local checksum = 0
+   for i in {0 to 1000} do
+      -- Concatenate literals
+      local result = ""
+      result ..= "Hello" .. " " .. "World" .. "!"
+
+      -- Concatenate with variables
+      result ..= a .. b .. c
+
+      -- Build a longer string from parts - parser could concat the RHS to a single string in advance
+      result ..= "Part1" .. "-" .. "Part2" .. "-" .. "Part3" .. "-" .. "Part4"
+
+      -- Concatenate numbers converted to strings
+      result ..= "Value: " .. tostring(i) .. ", Next: " .. tostring(i + 1)
+
+      -- Perform a real-work operation so that the result is used and not optimised away.
+      checksum += #result
+   end
+
+   glStringBenchmarkSink += checksum
+end
+
+@Test function StringConcatSmallArray()
+   local a, b, c = "foo", "bar", "baz"
+   local checksum = 0
+   local result = array<byte>
+   for i in {0 to 1000} do
+      result:clear() -- Maintains the array capacity
+
+      -- Concatenate literals
       result ..= "Hello" .. " " .. "World" .. "!"
 
       -- Concatenate with variables


### PR DESCRIPTION
* Added trace recorders and runtime helpers for array.new, clear, resize, push and getString
* Updated array length and storage forwarding around recorded mutating calls
* [Test] Covered recorded array operations and refreshed string concatenation benchmarks