### PR TITLE
[codex] Optimise Tiri byte array append paths

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2773,18 +2773,14 @@ static void array_append_byte_pieces(lua_State *L, GCarray *Arr, int PieceCount)
       const ArrayAppendPiece &piece = pieces[i];
       if (piece.len IS 0) continue;
 
-      const char *source = nullptr;
       if (piece.kind IS ArrayAppendPiece::Kind::String) {
-         source = piece.data;
-         memcpy(dest_base + write_pos, source, piece.len);
+         memcpy(dest_base + write_pos, piece.data, piece.len);
       }
       else if (piece.kind IS ArrayAppendPiece::Kind::Scratch) {
-         source = scratch->b + piece.offset;
-         memcpy(dest_base + write_pos, source, piece.len);
+         memcpy(dest_base + write_pos, scratch->b + piece.offset, piece.len);
       }
       else {
-         source = piece.array->get<const char>();
-         memmove(dest_base + write_pos, source, piece.len);
+         memmove(dest_base + write_pos, piece.array->get<const char>(), piece.len);
       }
       write_pos += piece.len;
    }

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -29,6 +29,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <vector>
 #include <string_view>
 #include <kotuku/strings.hpp>
 #include <kotuku/main.h>
@@ -2673,20 +2674,136 @@ LJLIB_CF(array_clone)
 //********************************************************************************************************************
 // Created exclusively for implementing array<byte> concatenation operations
 
+struct ArrayAppendPiece {
+   enum class Kind : uint8_t {
+      String,
+      Scratch,
+      ByteArray
+   };
+
+   Kind kind = Kind::String;
+   const char *data = nullptr;
+   GCarray *array = nullptr;
+   MSize offset = 0;
+   MSize len = 0;
+};
+
+static void array_append_add_len(lua_State *L, MSize &Total, MSize Len)
+{
+   if (Len > (~MSize(0) - Total)) lj_err_caller(L, ErrMsg::ARREXT);
+   Total += Len;
+}
+
+static void array_append_push_number(lua_State *L, SBuf *Scratch, cTValue *Value, std::vector<ArrayAppendPiece> &Pieces,
+   MSize &Total)
+{
+   MSize offset = sbuflen(Scratch);
+   if (tvisint(Value)) lj_strfmt_putint(Scratch, intV(Value));
+   else lj_strfmt_putnum(Scratch, Value);
+
+   MSize len = sbuflen(Scratch) - offset;
+   Pieces.push_back({ ArrayAppendPiece::Kind::Scratch, nullptr, nullptr, offset, len });
+   array_append_add_len(L, Total, len);
+}
+
+static void array_append_push_piece(lua_State *L, cTValue *Value, std::vector<ArrayAppendPiece> &Pieces,
+   SBuf *Scratch, MSize &Total)
+{
+   if (tvisstr(Value)) {
+      GCstr *str = strV(Value);
+      Pieces.push_back({ ArrayAppendPiece::Kind::String, strdata(str), nullptr, 0, str->len });
+      array_append_add_len(L, Total, str->len);
+      return;
+   }
+
+   if (tvisnumber(Value)) {
+      array_append_push_number(L, Scratch, Value, Pieces, Total);
+      return;
+   }
+
+   if (tvisarray(Value)) {
+      GCarray *source = arrayV(Value);
+      if (source->elemtype IS AET::BYTE) {
+         Pieces.push_back({ ArrayAppendPiece::Kind::ByteArray, nullptr, source, 0, source->len });
+         array_append_add_len(L, Total, source->len);
+         return;
+      }
+   }
+
+   lj_err_optype(L, Value, ErrMsg::OPCAT);
+}
+
+static void array_append_byte_pieces(lua_State *L, GCarray *Arr, int PieceCount)
+{
+   if (Arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
+
+   SBuf *scratch = lj_buf_tmp_(L);
+   std::vector<ArrayAppendPiece> pieces;
+   pieces.reserve(size_t(PieceCount));
+
+   MSize append_len = 0;
+   for (int i = 0; i < PieceCount; i++) {
+      array_append_push_piece(L, L->base + i + 1, pieces, scratch, append_len);
+   }
+
+   if (append_len > (~MSize(0) - Arr->len)) lj_err_caller(L, ErrMsg::ARREXT);
+   MSize old_len = Arr->len;
+   MSize new_len = old_len + append_len;
+   if (new_len > Arr->capacity and not lj_array_grow(L, Arr, new_len)) lj_err_caller(L, ErrMsg::ARREXT);
+
+   uint8_t *dest_base = Arr->get<uint8_t>();
+   MSize write_pos = old_len;
+   for (const ArrayAppendPiece &piece : pieces) {
+      if (piece.len IS 0) continue;
+
+      const char *source = nullptr;
+      if (piece.kind IS ArrayAppendPiece::Kind::String) {
+         source = piece.data;
+         memcpy(dest_base + write_pos, source, piece.len);
+      }
+      else if (piece.kind IS ArrayAppendPiece::Kind::Scratch) {
+         source = scratch->b + piece.offset;
+         memcpy(dest_base + write_pos, source, piece.len);
+      }
+      else {
+         source = piece.array->get<const char>();
+         memmove(dest_base + write_pos, source, piece.len);
+      }
+      write_pos += piece.len;
+   }
+
+   Arr->len = new_len;
+}
+
+static void array_append_reduce_rhs(lua_State *L, int PieceCount)
+{
+   L->top = L->base + 1 + PieceCount;
+   if (PieceCount > 1) lua_concat(L, PieceCount);
+}
+
 LJLIB_CF(array_append)      LJLIB_REC(.)
 {
    TValue *left = lj_lib_checkany(L, 1);
-   lj_lib_checkany(L, 2);
+   int piece_count = lua_gettop(L) - 1;
+   if (piece_count < 1) lj_err_argv(L, 2, ErrMsg::NOVAL);
 
    if (tvisarray(left)) {
       GCarray *arr = arrayV(left);
+      if (arr->elemtype IS AET::BYTE) {
+         array_append_byte_pieces(L, arr, piece_count);
+         setarrayV(L, L->base, arr);
+         L->top = L->base + 1;
+         return 1;
+      }
+
+      array_append_reduce_rhs(L, piece_count);
       lj_cf_array_push(L);
       setarrayV(L, L->base, arr);
       L->top = L->base + 1;
       return 1;
    }
 
-   L->top = L->base + 2;
+   array_append_reduce_rhs(L, piece_count);
    lua_concat(L, 2);
    return 1;
 }

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -29,7 +29,6 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
-#include <vector>
 #include <string_view>
 #include <kotuku/strings.hpp>
 #include <kotuku/main.h>
@@ -2694,37 +2693,48 @@ static void array_append_add_len(lua_State *L, MSize &Total, MSize Len)
    Total += Len;
 }
 
-static void array_append_push_number(lua_State *L, SBuf *Scratch, cTValue *Value, std::vector<ArrayAppendPiece> &Pieces,
-   MSize &Total)
+static constexpr int max_array_append_stack_pieces = 16;
+
+static void array_append_store_piece(ArrayAppendPiece *Pieces, int &PieceCount, const ArrayAppendPiece &Piece)
+{
+   lj_assertX(PieceCount < max_array_append_stack_pieces, "array append stack piece overflow");
+   Pieces[PieceCount] = Piece;
+   PieceCount++;
+}
+
+static void array_append_push_number(lua_State *L, SBuf *Scratch, cTValue *Value, ArrayAppendPiece *Pieces,
+   int &PieceCount, MSize &Total)
 {
    MSize offset = sbuflen(Scratch);
    if (tvisint(Value)) lj_strfmt_putint(Scratch, intV(Value));
    else lj_strfmt_putnum(Scratch, Value);
 
    MSize len = sbuflen(Scratch) - offset;
-   Pieces.push_back({ ArrayAppendPiece::Kind::Scratch, nullptr, nullptr, offset, len });
+   array_append_store_piece(Pieces, PieceCount, { ArrayAppendPiece::Kind::Scratch, nullptr, nullptr, offset, len });
    array_append_add_len(L, Total, len);
 }
 
-static void array_append_push_piece(lua_State *L, cTValue *Value, std::vector<ArrayAppendPiece> &Pieces,
+static void array_append_push_piece(lua_State *L, cTValue *Value, ArrayAppendPiece *Pieces, int &PieceCount,
    SBuf *Scratch, MSize &Total)
 {
    if (tvisstr(Value)) {
       GCstr *str = strV(Value);
-      Pieces.push_back({ ArrayAppendPiece::Kind::String, strdata(str), nullptr, 0, str->len });
+      array_append_store_piece(Pieces, PieceCount, { ArrayAppendPiece::Kind::String, strdata(str), nullptr, 0,
+         str->len });
       array_append_add_len(L, Total, str->len);
       return;
    }
 
    if (tvisnumber(Value)) {
-      array_append_push_number(L, Scratch, Value, Pieces, Total);
+      array_append_push_number(L, Scratch, Value, Pieces, PieceCount, Total);
       return;
    }
 
    if (tvisarray(Value)) {
       GCarray *source = arrayV(Value);
       if (source->elemtype IS AET::BYTE) {
-         Pieces.push_back({ ArrayAppendPiece::Kind::ByteArray, nullptr, source, 0, source->len });
+         array_append_store_piece(Pieces, PieceCount, { ArrayAppendPiece::Kind::ByteArray, nullptr, source, 0,
+            source->len });
          array_append_add_len(L, Total, source->len);
          return;
       }
@@ -2737,13 +2747,19 @@ static void array_append_byte_pieces(lua_State *L, GCarray *Arr, int PieceCount)
 {
    if (Arr->flags & ARRAY_READONLY) lj_err_caller(L, ErrMsg::ARRRO);
 
+   if (PieceCount > max_array_append_stack_pieces) {
+      L->top = L->base + 1 + PieceCount;
+      lua_concat(L, PieceCount);
+      PieceCount = 1;
+   }
+
    SBuf *scratch = lj_buf_tmp_(L);
-   std::vector<ArrayAppendPiece> pieces;
-   pieces.reserve(size_t(PieceCount));
+   ArrayAppendPiece pieces[max_array_append_stack_pieces];
+   int piece_count = 0;
 
    MSize append_len = 0;
    for (int i = 0; i < PieceCount; i++) {
-      array_append_push_piece(L, L->base + i + 1, pieces, scratch, append_len);
+      array_append_push_piece(L, L->base + i + 1, pieces, piece_count, scratch, append_len);
    }
 
    if (append_len > (~MSize(0) - Arr->len)) lj_err_caller(L, ErrMsg::ARREXT);
@@ -2753,7 +2769,8 @@ static void array_append_byte_pieces(lua_State *L, GCarray *Arr, int PieceCount)
 
    uint8_t *dest_base = Arr->get<uint8_t>();
    MSize write_pos = old_len;
-   for (const ArrayAppendPiece &piece : pieces) {
+   for (int i = 0; i < piece_count; i++) {
+      const ArrayAppendPiece &piece = pieces[i];
       if (piece.len IS 0) continue;
 
       const char *source = nullptr;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -713,6 +713,27 @@ static bool array_push_recordable(GCarray *Array, cTValue *Val)
    }
 }
 
+static int recff_arg_count(jit_State *J)
+{
+   return int(J->L->top - J->L->base);
+}
+
+static TRef recff_concat_tostr(jit_State *J, TRef Value)
+{
+   if (tref_isnumber(Value)) {
+      return emitir(IRT(IR_TOSTR, IRT_STR), Value, tref_isnum(Value) ? IRTOSTR_NUM : IRTOSTR_INT);
+   }
+   return Value;
+}
+
+static bool recff_is_number_str_args(jit_State *J, int Start, int Stop)
+{
+   for (int i = Start; i < Stop; i++) {
+      if (not tref_isnumber_str(J->base[i])) return false;
+   }
+   return true;
+}
+
 //********************************************************************************************************************
 // Record array.push(receiver, value).  Multi-value push falls back to the interpreter.
 
@@ -741,45 +762,78 @@ static void recff_array_push(jit_State* J, RecordFFData* rd)
 }
 
 //********************************************************************************************************************
-// Record array.append(receiver, value) - the helper behind compound concatenation (..=).  Array receivers append in
-// place via lj_arr_push1(); string and number receivers concatenate to a string, mirroring BC_CAT recording.
+// Record array.append(receiver, value, ...) - the helper behind compound concatenation (..=).
+
+static bool recff_byte_array_append_piece_recordable(cTValue *Value, TRef Piece)
+{
+   return (tvisstr(Value) and tref_isstr(Piece)) or tvisnumber(Value);
+}
 
 static void recff_array_append(jit_State* J, RecordFFData* rd)
 {
    TRef left = J->base[0];
-   TRef right = left ? J->base[1] : 0;
-   if (!right) {
+   int arg_count = left ? recff_arg_count(J) : 0;
+   if (arg_count < 2) {
       recff_nyi(J, rd);
       return;
    }
 
    if (tref_isarray(left)) {
       GCarray *arr = arrayV(&rd->argv[0]);
-      cTValue *val = &rd->argv[1];
-
-      if (not array_push_recordable(arr, val)) {
-         recff_nyi(J, rd);
-         return;
-      }
 
       // Guard the element type so the trace only runs for arrays matching the recorded semantics.
       TRef et_ref = emitir(IRT(IR_FLOAD, IRT_U8), left, IRFL_ARRAY_ELEMTYPE);
       emitir(IRTGI(IR_EQ), et_ref, lj_ir_kint(J, int32_t(arr->elemtype)));
 
-      TRef tmp_ref = recff_tmpref(J, right, IRTMPREF_IN1);
-      recff_ir_call_fixed(J, IRCALL_lj_arr_push1, left, tmp_ref, TREF_NIL, TREF_NIL);
+      if (arr->elemtype IS AET::BYTE) {
+         for (int i = 1; i < arg_count; i++) {
+            cTValue *val = &rd->argv[i];
+            TRef piece = J->base[i];
+            if (not recff_byte_array_append_piece_recordable(val, piece)) {
+               recff_nyi(J, rd);
+               return;
+            }
+         }
+
+         for (int i = 1; i < arg_count; i++) {
+            cTValue *val = &rd->argv[i];
+            TRef piece = J->base[i];
+            if (tvisstr(val) and tref_isstr(piece)) {
+               recff_ir_call_fixed(J, IRCALL_lj_arr_putstr, left, piece, TREF_NIL, TREF_NIL);
+            }
+            else if (tvisnumber(val)) {
+               TRef tmp_ref = recff_tmpref(J, piece, IRTMPREF_IN1);
+               recff_ir_call_fixed(J, IRCALL_lj_arr_putnumtv, left, tmp_ref, TREF_NIL, TREF_NIL);
+            }
+         }
+      }
+      else {
+         if (arg_count != 2 or not array_push_recordable(arr, &rd->argv[1])) {
+            recff_nyi(J, rd);
+            return;
+         }
+
+         TRef tmp_ref = recff_tmpref(J, J->base[1], IRTMPREF_IN1);
+         recff_ir_call_fixed(J, IRCALL_lj_arr_push1, left, tmp_ref, TREF_NIL, TREF_NIL);
+      }
+
       J->base[0] = left;  // append() returns the receiver array.
    }
-   else if (tref_isnumber_str(left) and tref_isnumber_str(right)) {
-      if (tref_isnumber(left)) {
-         left = emitir(IRT(IR_TOSTR, IRT_STR), left, tref_isnum(left) ? IRTOSTR_NUM : IRTOSTR_INT);
-      }
-      if (tref_isnumber(right)) {
-         right = emitir(IRT(IR_TOSTR, IRT_STR), right, tref_isnum(right) ? IRTOSTR_NUM : IRTOSTR_INT);
-      }
+   else if (tref_isnumber_str(left) and recff_is_number_str_args(J, 1, arg_count)) {
       TRef hdr = recff_bufhdr(J);
-      TRef tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), hdr, left);
-      tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, right);
+      TRef rhs = recff_concat_tostr(J, J->base[1]);
+
+      if (arg_count > 2) {
+         TRef rhs_tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), hdr, rhs);
+         for (int i = 2; i < arg_count; i++) {
+            rhs_tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), rhs_tr, recff_concat_tostr(J, J->base[i]));
+         }
+         rhs = emitir(IRTG(IR_BUFSTR, IRT_STR), rhs_tr, hdr);
+         hdr = recff_bufhdr(J);
+      }
+
+      TRef tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), hdr, recff_concat_tostr(J, left));
+      tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, rhs);
       J->base[0] = emitir(IRTG(IR_BUFSTR, IRT_STR), tr, hdr);
    }
    else {

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -766,7 +766,18 @@ static void recff_array_push(jit_State* J, RecordFFData* rd)
 
 static bool recff_byte_array_append_piece_recordable(cTValue *Value, TRef Piece)
 {
-   return (tvisstr(Value) and tref_isstr(Piece)) or tvisnumber(Value);
+   return (tvisstr(Value) and tref_isstr(Piece)) or (tvisnumber(Value) and tref_isnumber(Piece));
+}
+
+static void recff_byte_array_append_piece(jit_State *J, TRef ArrayRef, cTValue *Value, TRef Piece)
+{
+   if (tvisstr(Value) and tref_isstr(Piece)) {
+      recff_ir_call_fixed(J, IRCALL_lj_arr_putstr, ArrayRef, Piece, TREF_NIL, TREF_NIL);
+   }
+   else {
+      TRef tmp_ref = recff_tmpref(J, Piece, IRTMPREF_IN1);
+      recff_ir_call_fixed(J, IRCALL_lj_arr_putnumtv, ArrayRef, tmp_ref, TREF_NIL, TREF_NIL);
+   }
 }
 
 static void recff_array_append(jit_State* J, RecordFFData* rd)
@@ -795,16 +806,17 @@ static void recff_array_append(jit_State* J, RecordFFData* rd)
             }
          }
 
-         for (int i = 1; i < arg_count; i++) {
-            cTValue *val = &rd->argv[i];
-            TRef piece = J->base[i];
-            if (tvisstr(val) and tref_isstr(piece)) {
-               recff_ir_call_fixed(J, IRCALL_lj_arr_putstr, left, piece, TREF_NIL, TREF_NIL);
+         if (arg_count IS 2) {
+            cTValue *val = &rd->argv[1];
+            TRef piece = J->base[1];
+            recff_byte_array_append_piece(J, left, val, piece);
+         }
+         else {
+            TRef buf_ref = recff_bufhdr(J);
+            for (int i = 1; i < arg_count; i++) {
+               buf_ref = emitir(IRTG(IR_BUFPUT, IRT_PGC), buf_ref, recff_concat_tostr(J, J->base[i]));
             }
-            else if (tvisnumber(val)) {
-               TRef tmp_ref = recff_tmpref(J, piece, IRTMPREF_IN1);
-               recff_ir_call_fixed(J, IRCALL_lj_arr_putnumtv, left, tmp_ref, TREF_NIL, TREF_NIL);
-            }
+            recff_ir_call_fixed(J, IRCALL_lj_arr_putsbuf, left, buf_ref, TREF_NIL, TREF_NIL);
          }
       }
       else {

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -214,8 +214,6 @@ typedef struct CCallInfo {
   _(ANY,        lj_arr_push1,      3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_putstr,     3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_putsbuf,    3,   S, NIL, CCI_L|CCI_T) \
-  _(ANY,        lj_arr_putint,     3,   S, NIL, CCI_L|CCI_T) \
-  _(ANY,        lj_arr_putnum,     3,   S, NIL, XA_FP|CCI_L|CCI_T) \
   _(ANY,        lj_arr_putnumtv,   3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_clear,      2,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_resize,     3,   S, INT, CCI_L|CCI_T) \

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -213,6 +213,7 @@ typedef struct CCallInfo {
   _(ANY,        lj_arr_setidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_push1,      3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_putstr,     3,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_putsbuf,    3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_putint,     3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_putnum,     3,   S, NIL, XA_FP|CCI_L|CCI_T) \
   _(ANY,        lj_arr_putnumtv,   3,   S, NIL, CCI_L|CCI_T) \

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -212,6 +212,10 @@ typedef struct CCallInfo {
   _(ANY,        lj_arr_getidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_setidx,     4,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_push1,      3,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_putstr,     3,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_putint,     3,   S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_arr_putnum,     3,   S, NIL, XA_FP|CCI_L|CCI_T) \
+  _(ANY,        lj_arr_putnumtv,   3,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_clear,      2,   S, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_arr_resize,     3,   S, INT, CCI_L|CCI_T) \
   _(ANY,        lj_arr_getstring,  4,   S, STR, CCI_L|CCI_T) \

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -575,8 +575,7 @@ static AliasRet aa_fref(jit_State* J, IRIns* refa, IRIns* refb)
 static bool ircall_mutates_array(uint32_t CallId)
 {
    return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_putstr or CallId IS IRCALL_lj_arr_putsbuf or
-      CallId IS IRCALL_lj_arr_putint or CallId IS IRCALL_lj_arr_putnum or CallId IS IRCALL_lj_arr_putnumtv or
-      CallId IS IRCALL_lj_arr_clear or CallId IS IRCALL_lj_arr_resize;
+      CallId IS IRCALL_lj_arr_putnumtv or CallId IS IRCALL_lj_arr_clear or CallId IS IRCALL_lj_arr_resize;
 }
 
 // Only the loads for mutable fields end up here (see FOLD).

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -574,7 +574,9 @@ static AliasRet aa_fref(jit_State* J, IRIns* refa, IRIns* refb)
 // True for C helpers that change an array's length or may reallocate its storage.
 static bool ircall_mutates_array(uint32_t CallId)
 {
-   return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_clear or CallId IS IRCALL_lj_arr_resize;
+   return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_putstr or CallId IS IRCALL_lj_arr_putint or
+      CallId IS IRCALL_lj_arr_putnum or CallId IS IRCALL_lj_arr_putnumtv or CallId IS IRCALL_lj_arr_clear or
+      CallId IS IRCALL_lj_arr_resize;
 }
 
 // Only the loads for mutable fields end up here (see FOLD).

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -574,9 +574,9 @@ static AliasRet aa_fref(jit_State* J, IRIns* refa, IRIns* refb)
 // True for C helpers that change an array's length or may reallocate its storage.
 static bool ircall_mutates_array(uint32_t CallId)
 {
-   return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_putstr or CallId IS IRCALL_lj_arr_putint or
-      CallId IS IRCALL_lj_arr_putnum or CallId IS IRCALL_lj_arr_putnumtv or CallId IS IRCALL_lj_arr_clear or
-      CallId IS IRCALL_lj_arr_resize;
+   return CallId IS IRCALL_lj_arr_push1 or CallId IS IRCALL_lj_arr_putstr or CallId IS IRCALL_lj_arr_putsbuf or
+      CallId IS IRCALL_lj_arr_putint or CallId IS IRCALL_lj_arr_putnum or CallId IS IRCALL_lj_arr_putnumtv or
+      CallId IS IRCALL_lj_arr_clear or CallId IS IRCALL_lj_arr_resize;
 }
 
 // Only the loads for mutable fields end up here (see FOLD).

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1677,14 +1677,27 @@ static TRef rec_array_method_lookup(jit_State *J, RecordIndex* ix)
    cTValue *method = lj_tab_getstr(mt, key);
    if (not method or not tvisfunc(method)) return 0;
 
+   RecordIndex mix;
    TRef mtref = ir.fload_tab(ix->tab, IRFL_ARRAY_META);
    if (using_base_mt) {
       int basemt_offset = GG_OFS(g.gcroot) + int((GCROOT_BASEMT + ~LJ_TARRAY) * sizeof(GCRef));
       ir.guard_eq(mtref, ir.knull(IRT_TAB), IRT_TAB);
-      ir.guard_eq(lj_ir_ggfload(J, IRT_TAB, basemt_offset), lj_ir_ktab(J, mt), IRT_TAB);
+      mix.tab = lj_ir_ggfload(J, IRT_TAB, basemt_offset);
+      ir.guard_eq(mix.tab, lj_ir_ktab(J, mt), IRT_TAB);
    }
-   else ir.guard_eq(mtref, lj_ir_ktab(J, mt), IRT_TAB);
-   return lj_ir_kgc(J, gcV(method), IRT_FUNC);
+   else {
+      mix.tab = mtref;
+      ir.guard_eq(mix.tab, lj_ir_ktab(J, mt), IRT_TAB);
+   }
+
+   settabV(J->L, &mix.tabv, mt);
+   setstrV(J->L, &mix.keyv, key);
+   mix.key = ix->key;
+   mix.val = 0;
+   mix.idxchain = 0;
+   TRef method_ref = lj_record_idx(J, &mix);
+   ir.guard_eq(method_ref, lj_ir_kfunc(J, funcV(method)), IRT_FUNC);
+   return method_ref;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1657,6 +1657,37 @@ static int nommstr(jit_State *J, TRef key)
 }
 
 //********************************************************************************************************************
+// Record array method lookup for method-form calls.
+
+static TRef rec_array_method_lookup(jit_State *J, RecordIndex* ix)
+{
+   if (ix->val or not tref_isarray(ix->tab) or not tref_isstr(ix->key) or not tref_isk(ix->key)) return 0;
+
+   IRBuilder ir(J);
+   GCarray *arr = arrayV(&ix->tabv);
+   GCtab *mt = tabref(arr->metatable);
+   bool using_base_mt = false;
+   if (not mt) {
+      mt = tabref(basemt_it(J2G(J), LJ_TARRAY));
+      using_base_mt = true;
+   }
+   if (not mt) return 0;
+
+   GCstr *key = ir_kstr(IR(tref_ref(ix->key)));
+   cTValue *method = lj_tab_getstr(mt, key);
+   if (not method or not tvisfunc(method)) return 0;
+
+   TRef mtref = ir.fload_tab(ix->tab, IRFL_ARRAY_META);
+   if (using_base_mt) {
+      int basemt_offset = GG_OFS(g.gcroot) + int((GCROOT_BASEMT + ~LJ_TARRAY) * sizeof(GCRef));
+      ir.guard_eq(mtref, ir.knull(IRT_TAB), IRT_TAB);
+      ir.guard_eq(lj_ir_ggfload(J, IRT_TAB, basemt_offset), lj_ir_ktab(J, mt), IRT_TAB);
+   }
+   else ir.guard_eq(mtref, lj_ir_ktab(J, mt), IRT_TAB);
+   return lj_ir_kgc(J, gcV(method), IRT_FUNC);
+}
+
+//********************************************************************************************************************
 // Record indexed load/store.
 
 TRef lj_record_idx(jit_State *J, RecordIndex* ix)
@@ -1669,6 +1700,7 @@ TRef lj_record_idx(jit_State *J, RecordIndex* ix)
    while (not tref_istab(ix->tab)) {  // Handle non-table lookup.
       // Never call raw lj_record_idx() on non-table.
       lj_assertJ(ix->idxchain != 0, "bad usage");
+      if (TRef method = rec_array_method_lookup(J, ix)) return method;
       if (not lj_record_mm_lookup(J, ix, ix->val ? MM_newindex : MM_index)) lj_trace_err(J, LJ_TRERR_NOMM);
 
 handlemm:

--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -122,7 +122,7 @@ static void trace_abort_restore_retry_stack(jit_State *J, CSTRING Path)
 void lj_trace_err(jit_State *J, TraceError e)
 {
 #ifdef LUA_USE_ASSERT
-   kt::Log(__FUNCTION__).msg("Aborting JIT trace.");
+   kt::Log(__FUNCTION__).msg("Aborting JIT trace.  Error: %d", int(e));
 #endif
 
    // Mark that we're aborting trace recording. This flag survives through Windows SEH unwinding
@@ -152,7 +152,7 @@ void lj_trace_err(jit_State *J, TraceError e)
 void lj_trace_err_info(jit_State *J, TraceError e)
 {
 #ifdef LUA_USE_ASSERT
-   kt::Log(__FUNCTION__).msg("Aborting JIT trace.");
+   kt::Log(__FUNCTION__).msg("Aborting JIT trace.  Error: %d", int(e));
 #endif
 
    J->abort_in_progress = true; // Mark that we're aborting trace recording.

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -589,6 +589,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          }
 
          node = std::move(expressions.front());
+         node->is_grouped = true;
          break;
       }
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -606,6 +606,7 @@ struct ChooseExprPayload {
 struct ExprNode {
    AstNodeKind kind = AstNodeKind::LiteralExpr;
    SourceSpan span{};
+   bool is_grouped = false;
    std::variant<LiteralValue, NameRef, VarArgExprPayload, UnaryExprPayload,
       UpdateExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
       PresenceExprPayload, PipeExprPayload, CallExprPayload, MemberExprPayload,

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -140,6 +140,87 @@ static void fold_adjacent_concat_literals(LexState *State, const std::vector<con
    flush_folded_concat_literal_run(State, FoldedOperands, FoldedNodes, run, run_text);
 }
 
+static const VarInfo * array_append_find_local(const FuncState &State, GCstr *Name)
+{
+   if (not Name) return nullptr;
+
+   for (int32_t slot = int32_t(State.varmap.size()) - 1; slot >= 0; --slot) {
+      const VarInfo &info = State.var_get(slot);
+      GCstr *name = strref(info.name);
+      if (name IS Name) return &info;
+   }
+
+   return nullptr;
+}
+
+static TiriType array_append_identifier_type(const FuncState &State, const NameRef &Reference)
+{
+   if (const VarInfo *info = array_append_find_local(State, Reference.identifier.symbol)) return info->fixed_type;
+   return Reference.identifier.type;
+}
+
+static TiriType array_append_call_result_type(const FuncState &State, const CallExprPayload &Call)
+{
+   if (Call.result_type != TiriType::Unknown) return Call.result_type;
+
+   const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+   if (not direct or not direct->callable) return TiriType::Unknown;
+
+   if (direct->callable->kind IS AstNodeKind::IdentifierExpr) {
+      const auto *name_ref = std::get_if<NameRef>(&direct->callable->data);
+      if (name_ref and name_ref->identifier.symbol) {
+         if (const VarInfo *info = array_append_find_local(State, name_ref->identifier.symbol)) {
+            return info->result_types[0];
+         }
+         if (auto proto = get_func_prototype_by_hash(name_ref->identifier.symbol->hash)) return proto->first_result();
+      }
+   }
+   else if (direct->callable->kind IS AstNodeKind::MemberExpr) {
+      const auto *member = std::get_if<MemberExprPayload>(&direct->callable->data);
+      if (member and member->table and member->table->kind IS AstNodeKind::IdentifierExpr and member->member.symbol) {
+         const auto *iface = std::get_if<NameRef>(&member->table->data);
+         if (iface and iface->identifier.symbol) {
+            if (array_append_find_local(State, iface->identifier.symbol)) return TiriType::Unknown;
+            if (auto proto = get_prototype_by_hash(iface->identifier.symbol->hash, member->member.symbol->hash)) {
+               return proto->first_result();
+            }
+         }
+      }
+   }
+
+   return TiriType::Unknown;
+}
+
+static bool array_append_piece_can_skip_concat(const FuncState &State, const ExprNode &Expr)
+{
+   if (Expr.kind IS AstNodeKind::LiteralExpr) {
+      const auto &literal = std::get<LiteralValue>(Expr.data);
+      return literal.kind IS LiteralKind::String or literal.kind IS LiteralKind::Number;
+   }
+
+   TiriType type = TiriType::Unknown;
+   if (Expr.kind IS AstNodeKind::IdentifierExpr) {
+      type = array_append_identifier_type(State, std::get<NameRef>(Expr.data));
+   }
+   else if (Expr.kind IS AstNodeKind::CallExpr) {
+      type = array_append_call_result_type(State, std::get<CallExprPayload>(Expr.data));
+   }
+   else {
+      type = infer_expression_type(Expr);
+   }
+
+   return type IS TiriType::Str or type IS TiriType::Num or type IS TiriType::Array;
+}
+
+static bool array_append_pieces_can_skip_concat(const FuncState &State, const std::vector<const ExprNode *> &Pieces)
+{
+   for (const ExprNode *piece : Pieces) {
+      if (not piece or not array_append_piece_can_skip_concat(State, *piece)) return false;
+   }
+
+   return true;
+}
+
 //********************************************************************************************************************
 // Emit bytecode for a plain assignment, storing values into one or more target lvalues.  NB: This generic function
 // exists over the local/global specific implementations because of the need to handle complex scenarios
@@ -428,7 +509,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
       std::vector<const ExprNode *> folded_append_pieces;
       fold_adjacent_concat_literals(this->func_state.ls, append_pieces, folded_append_pieces, folded_append_nodes);
 
-      if (folded_append_pieces.size() > max_flattened_append_pieces) {
+      if (folded_append_pieces.size() > max_flattened_append_pieces or
+         not array_append_pieces_can_skip_concat(this->func_state, folded_append_pieces)) {
          auto list = this->emit_expression_list(values, count);
          if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -55,6 +55,91 @@ static GCstr * array_append_helper_key(LexState *State)
    return State->keepstr(key);
 }
 
+static void collect_concat_operands(const ExprNode &Expr, std::vector<const ExprNode *> &Operands)
+{
+   if (not Expr.is_grouped and Expr.kind IS AstNodeKind::BinaryExpr) {
+      const auto &payload = std::get<BinaryExprPayload>(Expr.data);
+      if (payload.op IS AstBinaryOperator::Concat and payload.left and payload.right) {
+         collect_concat_operands(*payload.left, Operands);
+         collect_concat_operands(*payload.right, Operands);
+         return;
+      }
+   }
+
+   Operands.push_back(&Expr);
+}
+
+static SourceSpan concat_literal_run_span(const ExprNode &Start, const ExprNode &End)
+{
+   SourceSpan span = Start.span;
+   span.offset = End.span.offset;
+   span.line = End.span.line;
+   span.column = End.span.column;
+   return span;
+}
+
+static bool append_concat_literal_piece(LexState *State, const ExprNode &Expr, std::string &Text)
+{
+   if (not (Expr.kind IS AstNodeKind::LiteralExpr)) return false;
+
+   const auto &literal = std::get<LiteralValue>(Expr.data);
+   switch (literal.kind) {
+      case LiteralKind::String:
+         if (not literal.string_value) return false;
+         Text.append(strdata(literal.string_value), literal.string_value->len);
+         return true;
+
+      case LiteralKind::Number: {
+         TValue value;
+         setnumV(&value, literal.number_value);
+         GCstr *number_text = lj_strfmt_number(State->L, &value);
+         Text.append(strdata(number_text), number_text->len);
+         return true;
+      }
+
+      default:
+         return false;
+   }
+}
+
+static void flush_folded_concat_literal_run(LexState *State, std::vector<const ExprNode *> &FoldedOperands,
+   std::vector<ExprNodePtr> &FoldedNodes, std::vector<const ExprNode *> &Run, std::string &RunText)
+{
+   if (Run.empty()) return;
+
+   if (Run.size() IS 1) {
+      FoldedOperands.push_back(Run.front());
+   }
+   else {
+      SourceSpan span = concat_literal_run_span(*Run.front(), *Run.back());
+      GCstr *folded = State->keepstr(std::string_view(RunText.data(), RunText.size()));
+      FoldedNodes.push_back(make_literal_expr(span, LiteralValue::string(folded)));
+      FoldedOperands.push_back(FoldedNodes.back().get());
+   }
+
+   Run.clear();
+   RunText.clear();
+}
+
+static void fold_adjacent_concat_literals(LexState *State, const std::vector<const ExprNode *> &Operands,
+   std::vector<const ExprNode *> &FoldedOperands, std::vector<ExprNodePtr> &FoldedNodes)
+{
+   std::vector<const ExprNode *> run;
+   std::string run_text;
+
+   for (const ExprNode *operand : Operands) {
+      if (append_concat_literal_piece(State, *operand, run_text)) {
+         run.push_back(operand);
+         continue;
+      }
+
+      flush_folded_concat_literal_run(State, FoldedOperands, FoldedNodes, run, run_text);
+      FoldedOperands.push_back(operand);
+   }
+
+   flush_folded_concat_literal_run(State, FoldedOperands, FoldedNodes, run, run_text);
+}
+
 //********************************************************************************************************************
 // Emit bytecode for a plain assignment, storing values into one or more target lvalues.  NB: This generic function
 // exists over the local/global specific implementations because of the need to handle complex scenarios
@@ -320,6 +405,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
    const bool use_append_helper = mapped.value() IS BinOpr::Concat and not direct_known_non_array;
 
    if (use_append_helper) {
+      if (values.size() != 1) {
+         return assignment_value_count_error(this, values,
+            "compound assignment expects exactly one RHS value");
+      }
+
       ExpDesc append_func;
       append_func.init(ExpKind::Global, 0);
       append_func.u.sval = array_append_helper_key(this->func_state.ls);
@@ -331,16 +421,28 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
 
       this->materialise_to_next_reg(working, "array append compound receiver");
 
-      auto list = this->emit_expression_list(values, count);
-      if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
+      static constexpr size_t max_flattened_append_pieces = 16;
+      std::vector<const ExprNode *> append_pieces;
+      collect_concat_operands(*values.front(), append_pieces);
+      std::vector<ExprNodePtr> folded_append_nodes;
+      std::vector<const ExprNode *> folded_append_pieces;
+      fold_adjacent_concat_literals(this->func_state.ls, append_pieces, folded_append_pieces, folded_append_nodes);
 
-      if (count != 1) {
-         return assignment_value_count_error(this, values,
-            "compound assignment expects exactly one RHS value");
+      if (folded_append_pieces.size() > max_flattened_append_pieces) {
+         auto list = this->emit_expression_list(values, count);
+         if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
+
+         rhs = list.value_ref();
+         this->materialise_to_next_reg(rhs, "array compound append argument");
       }
-
-      rhs = list.value_ref();
-      this->materialise_to_next_reg(rhs, "array compound append argument");
+      else {
+         for (const ExprNode *piece : folded_append_pieces) {
+            auto piece_result = this->emit_expression(*piece);
+            if (not piece_result.ok()) return ParserResult<IrEmitUnit>::failure(piece_result.error_ref());
+            ExpDesc piece_expr = piece_result.value_ref();
+            this->materialise_to_next_reg(piece_expr, "array compound append piece");
+         }
+      }
 
       ExpDesc result;
       result.init(ExpKind::Call, bcemit_ABC(&this->func_state, BC_CALL, call_base, 2,

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1292,6 +1292,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_numeric_for_stmt(const NumericForStmtPa
       FuncScope visible_scope;
       ScopeGuard guard(fs, &visible_scope, FuncScopeFlag::None);
       this->lex_state.var_add(1);
+      fs->var_get(base.raw() + FORL_EXT).fixed_type = TiriType::Num;
       RegisterAllocator allocator(fs);
       allocator.reserve(BCReg(1));
       std::array<BlockBinding, 1> loop_bindings{};

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -15,6 +15,7 @@
 #include "lj_debug.h"
 #include "lj_tab.h"
 #include "lj_proto_registry.h"
+#include "lj_strfmt.h"
 #include "../parse_internal.h"
 #include "../parse_value.h"
 #include "../token_types.h"

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -379,6 +379,14 @@ extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
 }
 
 //********************************************************************************************************************
+// Append the bytes currently held by a string buffer to a byte array from a recorded trace.
+
+extern "C" void lj_arr_putsbuf(lua_State *L, GCarray *Array, SBuf *Buf)
+{
+   lj_arr_append_bytes(L, Array, Buf->b, sbuflen(Buf));
+}
+
+//********************************************************************************************************************
 // Append an integer formatted with concat/tostring semantics to a byte array from a recorded trace.
 
 extern "C" void lj_arr_putint(lua_State *L, GCarray *Array, int32_t Value)

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -387,24 +387,6 @@ extern "C" void lj_arr_putsbuf(lua_State *L, GCarray *Array, SBuf *Buf)
 }
 
 //********************************************************************************************************************
-// Append an integer formatted with concat/tostring semantics to a byte array from a recorded trace.
-
-extern "C" void lj_arr_putint(lua_State *L, GCarray *Array, int32_t Value)
-{
-   SBuf *sb = lj_strfmt_putint(lj_buf_tmp_(L), Value);
-   lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
-}
-
-//********************************************************************************************************************
-// Append a number formatted with concat/tostring semantics to a byte array from a recorded trace.
-
-extern "C" void lj_arr_putnum(lua_State *L, GCarray *Array, double Value)
-{
-   SBuf *sb = lj_strfmt_putfnum(lj_buf_tmp_(L), STRFMT_G14, Value);
-   lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
-}
-
-//********************************************************************************************************************
 // Append a number TValue formatted with concat/tostring semantics to a byte array from a recorded trace.
 
 extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)

--- a/src/tiri/jit/src/runtime/lj_vmarray.cpp
+++ b/src/tiri/jit/src/runtime/lj_vmarray.cpp
@@ -11,10 +11,13 @@
 #include "lj_meta.h"
 #include "lj_array.h"
 #include "lj_str.h"
+#include "lj_strfmt.h"
+#include "lj_buf.h"
 #include "lj_vmarray.h"
 #include "lj_vm.h"
 #include "lj_frame.h"
 
+#include <cstring>
 #include <string>
 
 //********************************************************************************************************************
@@ -351,6 +354,58 @@ extern "C" void lj_arr_push1(lua_State *L, GCarray *Array, cTValue *Val)
    if (idx + 1 > Array->capacity and not lj_array_grow(L, Array, idx + 1)) lj_err_msg(L, ErrMsg::ARREXT);
    arr_store_elem(L, Array, idx, Val);
    Array->len = idx + 1;
+}
+
+//********************************************************************************************************************
+
+static void lj_arr_append_bytes(lua_State *L, GCarray *Array, const char *Data, MSize Len)
+{
+   if (Array->flags & ARRAY_READONLY) lj_err_msg(L, ErrMsg::ARRRO);
+   if (not (Array->elemtype IS AET::BYTE)) lj_err_msg(L, ErrMsg::ARRSTR);
+   if (Len > (~MSize(0) - Array->len)) lj_err_msg(L, ErrMsg::ARREXT);
+
+   MSize new_len = Array->len + Len;
+   if (new_len > Array->capacity and not lj_array_grow(L, Array, new_len)) lj_err_msg(L, ErrMsg::ARREXT);
+   if (Len > 0) memcpy((uint8_t*)Array->arraydata() + Array->len, Data, Len);
+   Array->len = new_len;
+}
+
+//********************************************************************************************************************
+// Append string bytes to a byte array from a recorded trace.
+
+extern "C" void lj_arr_putstr(lua_State *L, GCarray *Array, GCstr *Str)
+{
+   lj_arr_append_bytes(L, Array, strdata(Str), Str->len);
+}
+
+//********************************************************************************************************************
+// Append an integer formatted with concat/tostring semantics to a byte array from a recorded trace.
+
+extern "C" void lj_arr_putint(lua_State *L, GCarray *Array, int32_t Value)
+{
+   SBuf *sb = lj_strfmt_putint(lj_buf_tmp_(L), Value);
+   lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
+}
+
+//********************************************************************************************************************
+// Append a number formatted with concat/tostring semantics to a byte array from a recorded trace.
+
+extern "C" void lj_arr_putnum(lua_State *L, GCarray *Array, double Value)
+{
+   SBuf *sb = lj_strfmt_putfnum(lj_buf_tmp_(L), STRFMT_G14, Value);
+   lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
+}
+
+//********************************************************************************************************************
+// Append a number TValue formatted with concat/tostring semantics to a byte array from a recorded trace.
+
+extern "C" void lj_arr_putnumtv(lua_State *L, GCarray *Array, cTValue *Value)
+{
+   SBuf *sb;
+   if (tvisint(Value)) sb = lj_strfmt_putint(lj_buf_tmp_(L), intV(Value));
+   else if (tvisnum(Value)) sb = lj_strfmt_putfnum(lj_buf_tmp_(L), STRFMT_G14, numV(Value));
+   else lj_err_msg(L, ErrMsg::BADVAL);
+   lj_arr_append_bytes(L, Array, sb->b, sbuflen(sb));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -25,6 +25,8 @@ extern "C" void lj_arr_push1(lua_State *, GCarray *, cTValue *);
 
 extern "C" void lj_arr_putstr(lua_State *, GCarray *, GCstr *);
 
+extern "C" void lj_arr_putsbuf(lua_State *, GCarray *, SBuf *);
+
 extern "C" void lj_arr_putint(lua_State *, GCarray *, int32_t);
 
 extern "C" void lj_arr_putnum(lua_State *, GCarray *, double);

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -23,6 +23,14 @@ extern "C" void lj_arr_setidx(lua_State *, GCarray *, int32_t idx, cTValue *);
 
 extern "C" void lj_arr_push1(lua_State *, GCarray *, cTValue *);
 
+extern "C" void lj_arr_putstr(lua_State *, GCarray *, GCstr *);
+
+extern "C" void lj_arr_putint(lua_State *, GCarray *, int32_t);
+
+extern "C" void lj_arr_putnum(lua_State *, GCarray *, double);
+
+extern "C" void lj_arr_putnumtv(lua_State *, GCarray *, cTValue *);
+
 // Clear an array from JIT traces.
 
 extern "C" void lj_arr_clear(lua_State *, GCarray *);

--- a/src/tiri/jit/src/runtime/lj_vmarray.h
+++ b/src/tiri/jit/src/runtime/lj_vmarray.h
@@ -27,10 +27,6 @@ extern "C" void lj_arr_putstr(lua_State *, GCarray *, GCstr *);
 
 extern "C" void lj_arr_putsbuf(lua_State *, GCarray *, SBuf *);
 
-extern "C" void lj_arr_putint(lua_State *, GCarray *, int32_t);
-
-extern "C" void lj_arr_putnum(lua_State *, GCarray *, double);
-
 extern "C" void lj_arr_putnumtv(lua_State *, GCarray *, cTValue *);
 
 // Clear an array from JIT traces.

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -34,6 +34,29 @@ function folded_boundary_append_call_shape(Value)
    return result
 end
 
+function folded_tostring_append_call_shape(Value: num)
+   local result = array<byte>
+   result ..= 'Value: ' .. tostring(Value) .. ', Next: ' .. tostring(Value + 1)
+   return result
+end
+
+function shadowed_tostring_append_call_shape()
+   local mt = {
+      __concat = function(A, B)
+         if type(A) is 'table' then return A.val .. B end
+         return A .. B.val
+      end
+   }
+   local tostring = function(Value)
+      return setmetatable({ val = Value }, mt)
+   end
+   local result = array<byte>
+
+   result ..= 'Value: ' .. tostring('local')
+
+   return result
+end
+
 @Test function CompoundAssignment()
    value = 5
    value += 3
@@ -422,8 +445,26 @@ end
    result = folded_boundary_append_call_shape('X')
 
    assert(result:getString() is 'abXc12d', 'literal runs should fold across dynamic operand boundaries')
-   assert(max_call_c_operand(folded_boundary_append_call_shape) is 5,
-      'dynamic boundaries should leave one receiver plus three append pieces in the call C operand')
+   assert(max_call_c_operand(folded_boundary_append_call_shape) is 3,
+      'unknown dynamic concat pieces should emit one concatenated RHS for the append helper')
+end
+
+@Test function ArrayConcatAssignmentFlattensRegisteredStringCalls()
+   result = folded_tostring_append_call_shape(4)
+
+   assert(result:getString() is 'Value: 4, Next: 5',
+      'registered string-returning calls should append through concat-flattened byte array pieces')
+   assert(max_call_c_operand(folded_tostring_append_call_shape) is 6,
+      'registered string-returning calls should remain flattened in the append helper call')
+end
+
+@Test function ArrayConcatAssignmentHonoursShadowedStringCalls()
+   result = shadowed_tostring_append_call_shape()
+
+   assert(result:getString() is 'Value: local',
+      'shadowed string-returning builtin names should preserve RHS __concat semantics')
+   assert(max_call_c_operand(shadowed_tostring_append_call_shape) is 3,
+      'shadowed string-returning builtin names should emit one concatenated RHS for the append helper')
 end
 
 @Test function ArrayConcatAssignmentFormatsNumbersAsTextOverFlattenCap()
@@ -473,6 +514,21 @@ end
    result ..= 'A' .. source .. 'D'
 
    assert(result:getString() is 'ABCD', 'flattened byte array concat should accept byte-array RHS operands')
+end
+
+@Test function ArrayConcatAssignmentPreservesRhsMetamethodConcat()
+   mt = {
+      __concat = function(A, B)
+         if type(A) is 'table' then return A.val .. B end
+         return A .. B.val
+      end
+   }
+   obj = setmetatable({ val = 'data' }, mt)
+   result = array<byte>
+
+   result ..= 'prefix_' .. obj
+
+   assert(result:getString() is 'prefix_data', 'byte array concat assignment should preserve RHS __concat semantics')
 end
 
 @Test function ArrayConcatAssignmentSelfAppendUsesOriginalBytes()

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -434,6 +434,27 @@ end
    assert(result:getString() is 'a65bcdefghijklmno6.5', 'over-cap concat fallback should still format numbers as text')
 end
 
+@Test function ArrayAppendDirectOverflowAcceptsByteArrayPieces()
+   result = array<byte>
+   source = array<byte> { 88, 89 }
+
+   array.append(result, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+      source, 12, 'q')
+
+   assert(result:getString() is 'abcdefghijklmnopXY12q',
+      'direct byte array append overflow should reduce RHS and append the resulting bytes')
+end
+
+@Test function ArrayAppendDirectOverflowSnapshotsSelfOperand()
+   result = array.new('xy')
+
+   array.append(result, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+      result, 'q')
+
+   assert(result:getString() is 'xyabcdefghijklmnopxyq',
+      'direct byte array append overflow should snapshot self operands before mutation')
+end
+
 @Test function ArrayConcatAssignmentPreservesParenthesisedGroup()
    a = 'a'
    b = 'b'

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -3,6 +3,37 @@
 @BeforeEach(hotpath=true)
 function enforce_hotpath() end
 
+function max_call_c_operand(Func)
+   local info = jit.util.funcInfo(Func, 0)
+   local largest: any = nil
+
+   for pc = 0, info.byteCodes - 1 do
+      local ins = jit.util.funcBC(Func, pc)
+      if ins != nil and (ins & 255) is 76 then
+         local operand_count = (ins >> 16) & 255
+         if largest is nil then
+            largest = operand_count
+         elseif operand_count > largest then
+            largest = operand_count
+         end
+      end
+   end
+
+   return largest
+end
+
+function folded_constant_append_call_shape()
+   local result = array<byte>
+   result ..= 'Part1' .. '-' .. 'Part2' .. '-' .. 'Part3' .. '-' .. 'Part4'
+   return result
+end
+
+function folded_boundary_append_call_shape(Value)
+   local result = array<byte>
+   result ..= 'a' .. 'b' .. Value .. 'c' .. 12 .. 'd'
+   return result
+end
+
 @Test function CompoundAssignment()
    value = 5
    value += 3
@@ -305,14 +336,14 @@ end
    arr ..= 'AB'
    arr ..= 67
 
-   assert(#arr is 3, 'array byte ..= should append to the array')
-   assert(arr:getString() is 'ABC', 'array byte ..= should append string bytes and numeric bytes')
+   assert(#arr is 4, 'array byte ..= should append numeric RHS using concat formatting')
+   assert(arr:getString() is 'AB67', 'array byte ..= should append numbers as text')
 
    source = array<byte> { 0, 68 }
    arr ..= source:getString()
-   expected = 'ABC' .. source:getString()
+   expected = 'AB67' .. source:getString()
 
-   assert(#arr is 5, 'array byte ..= should preserve embedded NUL bytes')
+   assert(#arr is 6, 'array byte ..= should preserve embedded NUL bytes')
    assert(arr:getString() is expected, 'array byte ..= should preserve the full appended byte string')
 
    result = arr .. '!'
@@ -326,7 +357,7 @@ end
    store.buf ..= 33
    store.label ..= 'y'
 
-   assert(store.buf:getString() is 'Hi!', 'field byte array ..= should mutate the stored array')
+   assert(store.buf:getString() is 'Hi33', 'field byte array ..= should mutate the stored array with concat semantics')
    assert(store.label is 'xy', 'field string ..= should still concatenate and store a string')
 end
 
@@ -342,7 +373,7 @@ end
       store.buf ..= 33
 
       assert(store.label is 'xy', 'field string ..= should not call the shadowed array global')
-      assert(store.buf:getString() is 'Hi!', 'field byte array ..= should still use the internal append helper')
+      assert(store.buf:getString() is 'Hi33', 'field byte array ..= should still use the internal append helper')
    except e
       global array = saved_array
       error(e)
@@ -356,13 +387,96 @@ end
    buf ..= 'Hi'
    buf ..= 33
 
-   assert(#buf is 3, 'typed local byte array ..= should append to the array')
-   assert(buf:getString() is 'Hi!', 'typed local byte array ..= should append string bytes and numeric bytes')
+   assert(#buf is 4, 'typed local byte array ..= should append to the array')
+   assert(buf:getString() is 'Hi33', 'typed local byte array ..= should append numeric RHS as text')
 
    local text = 'x'
    text ..= 42
 
    assert(text is 'x42', 'typed local string ..= should accept a numeric RHS')
+end
+
+@Test function ArrayConcatAssignmentFlattensConstantChain()
+   result = array<byte>
+   result ..= 'a' .. 'b' .. 'c'
+
+   assert(result:getString() is 'abc', 'flattened constant concat chain should append all pieces')
+end
+
+@Test function ArrayConcatAssignmentFormatsNumbersAsText()
+   result = array<byte>
+   result ..= 'a' .. 65 .. 6.5
+
+   assert(result:getString() is 'a656.5', 'flattened byte array concat should format numbers as text')
+end
+
+@Test function ArrayConcatAssignmentFoldsAdjacentConstantsBeforeAppend()
+   result = folded_constant_append_call_shape()
+
+   assert(result:getString() is 'Part1-Part2-Part3-Part4', 'constant concat pieces should fold before byte append')
+   assert(max_call_c_operand(folded_constant_append_call_shape) is 3,
+      'folded constant concat should emit one receiver and one RHS piece in the call C operand')
+end
+
+@Test function ArrayConcatAssignmentFoldsLiteralRunsAcrossDynamicBoundary()
+   result = folded_boundary_append_call_shape('X')
+
+   assert(result:getString() is 'abXc12d', 'literal runs should fold across dynamic operand boundaries')
+   assert(max_call_c_operand(folded_boundary_append_call_shape) is 5,
+      'dynamic boundaries should leave one receiver plus three append pieces in the call C operand')
+end
+
+@Test function ArrayConcatAssignmentFormatsNumbersAsTextOverFlattenCap()
+   result = array<byte>
+   result ..= 'a' .. 65 .. 'b' .. 'c' .. 'd' .. 'e' .. 'f' .. 'g' .. 'h' ..
+      'i' .. 'j' .. 'k' .. 'l' .. 'm' .. 'n' .. 'o' .. 6.5
+
+   assert(result:getString() is 'a65bcdefghijklmno6.5', 'over-cap concat fallback should still format numbers as text')
+end
+
+@Test function ArrayConcatAssignmentPreservesParenthesisedGroup()
+   a = 'a'
+   b = 'b'
+   c = 'c'
+   result = array<byte>
+
+   result ..= (a .. b) .. c
+
+   assert(result:getString() is 'abc', 'parenthesised concat group should remain one operand and preserve result')
+end
+
+@Test function ArrayConcatAssignmentAcceptsByteArrayOperand()
+   result = array<byte>
+   source = array<byte> { 66, 67 }
+
+   result ..= 'A' .. source .. 'D'
+
+   assert(result:getString() is 'ABCD', 'flattened byte array concat should accept byte-array RHS operands')
+end
+
+@Test function ArrayConcatAssignmentSelfAppendUsesOriginalBytes()
+   result = array.new('ab')
+
+   result ..= result
+
+   assert(result:getString() is 'abab', 'byte array self append should copy the original RHS bytes')
+end
+
+@Test function ArrayConcatAssignmentDynamicStringReceiver()
+   local receiver: any = 'start'
+
+   receiver ..= '-' .. 'end'
+
+   assert(receiver is 'start-end', 'dynamic string receiver should keep string concat semantics')
+end
+
+@Test function ArrayConcatAssignmentNonByteArrayPushesSingleConcatResult()
+   result = array<string>
+
+   result ..= 'a' .. 'b'
+
+   assert(#result is 1, 'non-byte array concat assignment should push one concatenated value')
+   assert(result[0] is 'ab', 'non-byte array concat assignment should preserve CAT-then-push behaviour')
 end
 
 @Test function ArrayConcatAssignmentUsesFirstReturn()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -74,6 +74,30 @@ function count_trace_opcode(TraceNo, Info, Opcode)
    return count
 end
 
+function count_jit_traces(MaxTraceNo)
+   local count = 0
+   for trace_no = 1, MaxTraceNo do
+      if jit.util.traceInfo(trace_no) != nil then count++ end
+   end
+   return count
+end
+
+function run_array_method_trace(Workload, Count)
+   jit.off()
+   local expected = Workload(Count)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local result = nil
+   for i = 1, 80 do
+      result = Workload(Count)
+   end
+
+   return expected, result, count_jit_traces(30)
+end
+
 function traced_clamp_sum(Count)
    local total = 0
    for i = 1, Count do
@@ -100,6 +124,56 @@ function constant_target(Value)
       return Value + offset, label
    end
    return offset, label
+end
+
+function array_method_clear_workload(Count)
+   local result = array.new("")
+
+   for i = 1, Count do
+      result:clear()
+      array.push(result, "clear")
+   end
+
+   return array.getString(result)
+end
+
+function array_method_resize_workload(Count)
+   local result = array.new("abcdef")
+
+   for i = 1, Count do
+      result:resize(0)
+      array.push(result, "resize")
+   end
+
+   return array.getString(result)
+end
+
+function array_method_push_workload(Count)
+   local result = array.new("")
+
+   for i = 1, Count do
+      result:push("push")
+   end
+
+   return array.getString(result)
+end
+
+function array_unknown_method_workload(Count)
+   local arr = array<int> { 1, 2, 3 }
+   local total = 0
+
+   for i = 1, Count do
+      total += arr[0]
+      if i is Count then arr:missingPhaseOneMethod() end
+   end
+
+   return total
+end
+
+function array_clear_then_push(Array)
+   Array:clear()
+   array.push(Array, "base")
+   return array.getString(Array)
 end
 
 function jit_regex_failure_convert(Value:any, Param:table):any
@@ -634,6 +708,94 @@ end
    assert(ensure_trace(pairs) is true, "Expected array pairs to produce a JIT trace")
 end
 
+@Test(hotpath=80) function ArrayMethodClearLookupTraces()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   local expected, result, trace_count = run_array_method_trace(array_method_clear_workload, 12)
+
+   assert(result is expected, f"Expected traced array:clear() result '{expected}', got '{result}'")
+   assert(trace_count > 0, "Expected array:clear() method lookup to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayMethodResizeLookupTraces()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   local expected, result, trace_count = run_array_method_trace(array_method_resize_workload, 12)
+
+   assert(result is expected, f"Expected traced array:resize() result '{expected}', got '{result}'")
+   assert(trace_count > 0, "Expected array:resize() method lookup to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayMethodPushLookupTraces()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   local expected, result, trace_count = run_array_method_trace(array_method_push_workload, 12)
+
+   assert(result is expected, f"Expected traced array:push() result '{expected}', got '{result}'")
+   assert(trace_count > 0, "Expected array:push() method lookup to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayUnknownMethodStillRaises()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local saw_error = false
+   local message = ""
+
+   for i = 1, 80 do
+      try
+         array_unknown_method_workload(6)
+      except e
+         saw_error = true
+         message = e.message ?? tostring(e)
+      end
+   end
+
+   assert(saw_error is true, "Unknown array method should still raise an error")
+   assert(message:find("call") != nil or message:find("index") != nil,
+      f"Unknown array method should raise a call/index error, got '{message}'")
+end
+
+@Test(hotpath=80) function ArrayMethodMetatableOverrideExitsTrace()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local arr = array.new("")
+   local result = ""
+
+   for i = 1, 80 do
+      result = array_clear_then_push(arr)
+   end
+
+   assert(result is "base", f"Expected base array method result before override, got '{result}'")
+   assert(count_jit_traces(30) > 0, "Expected base-metatable array method call to produce a JIT trace")
+
+   debug.setMetatable(arr, {
+      clear = function(Self)
+         array.resize(Self, 0)
+         array.push(Self, "override")
+      end
+   })
+
+   result = array_clear_then_push(arr)
+   assert(result is "overridebase", f"Expected overridden clear method to be honoured, got '{result}'")
+
+   debug.setMetatable(arr, nil)
+   jit.flush()
+
+   for i = 1, 80 do
+      result = array_clear_then_push(arr)
+   end
+
+   assert(result is "base", f"Expected nil array metatable to fall back to base methods, got '{result}'")
+   assert(count_jit_traces(30) > 0, "Expected nil array metatable fallback to produce a JIT trace")
+end
+
 @Test(hotpath=80) function ArrayNewLiteralTypeTraces()
    cached_trace_no = nil
    cached_trace_info = nil
@@ -844,6 +1006,46 @@ end
    end
 
    assert(trace_found is true, "Expected single-value array.push() to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayAppendFlattenedConcatChainTraces()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_append_concat(Count)
+      local arr = array<byte>
+
+      for i = 1, Count do
+         arr ..= "a" .. 65 .. "b" .. 6.5
+      end
+
+      return arr:getString(), #arr
+   end
+
+   local final = ""
+   local len = 0
+   for i = 1, 80 do
+      final, len = traced_array_append_concat(10)
+   end
+
+   assert(final is "a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5a65b6.5",
+      f"Expected flattened append result repeated 10 times, got {final}")
+   assert(len is 70, f"Expected flattened append result length 70, got {len}")
+
+   local trace_found = false
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         trace_found = true
+         break
+      end
+   end
+
+   assert(trace_found is true, "Expected flattened array append chain to produce a JIT trace")
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -4,7 +4,12 @@ local glCfg
 local ir_min <const> = 50  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_max <const> = 51  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_xstore <const> = 78  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+local ir_bufput <const> = 86
+local ir_bufstr <const> = 87
 local ir_calln <const> = 95  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+local ir_calla <const> = 96
+local ir_calll <const> = 97
+local ir_calls <const> = 98
 
 @BeforeAll
 function SetupJitTests()
@@ -80,6 +85,11 @@ function count_jit_traces(MaxTraceNo)
       if jit.util.traceInfo(trace_no) != nil then count++ end
    end
    return count
+end
+
+function count_trace_calls(TraceNo, Info)
+   return count_trace_opcode(TraceNo, Info, ir_calln) + count_trace_opcode(TraceNo, Info, ir_calla) +
+      count_trace_opcode(TraceNo, Info, ir_calll) + count_trace_opcode(TraceNo, Info, ir_calls)
 end
 
 function run_array_method_trace(Workload, Count)
@@ -1046,6 +1056,52 @@ end
    end
 
    assert(trace_found is true, "Expected flattened array append chain to produce a JIT trace")
+end
+
+@Test(hotpath=80) function ArrayAppendMultiPieceConcatUsesBufferTrace()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   function traced_array_append_dynamic(Count)
+      local arr = array<byte>
+
+      for i = 1, Count do
+         arr ..= "x" .. i .. "y"
+      end
+
+      return arr:getString(), #arr
+   end
+
+   local final = ""
+   local len = 0
+   for i = 1, 80 do
+      final, len = traced_array_append_dynamic(10)
+   end
+
+   assert(final is "x1yx2yx3yx4yx5yx6yx7yx8yx9yx10y",
+      f"Expected buffered append trace result, got {final}")
+   assert(len is 31, f"Expected buffered append trace length 31, got {len}")
+
+   local buffer_trace_found = false
+   for trace_no = 1, 30 do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         local bufput_count = count_trace_opcode(trace_no, info, ir_bufput)
+         if bufput_count > 0 then
+            buffer_trace_found = true
+            assert(count_trace_opcode(trace_no, info, ir_bufstr) is 0,
+               "array append buffer trace should append the buffer without interning it")
+            assert(count_trace_calls(trace_no, info) <= 2,
+               "multi-piece array append should not record one mutating call per piece")
+         end
+      end
+   end
+
+   assert(buffer_trace_found is true, "Expected multi-piece array append to record buffer IR")
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -806,6 +806,77 @@ end
    assert(count_jit_traces(30) > 0, "Expected nil array metatable fallback to produce a JIT trace")
 end
 
+@Test(hotpath=80) function ArrayMethodInstanceSlotMutationExitsTrace()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local arr = array.new("")
+   local mt = {
+      clear = function(Self)
+         array.resize(Self, 0)
+         array.push(Self, "first")
+      end
+   }
+   debug.setMetatable(arr, mt)
+
+   local result = ""
+   for i = 1, 80 do
+      result = array_clear_then_push(arr)
+   end
+
+   assert(result is "firstbase", f"Expected first instance method result before mutation, got '{result}'")
+   assert(count_jit_traces(30) > 0, "Expected per-instance array method call to produce a JIT trace")
+
+   mt.clear = function(Self)
+      array.resize(Self, 0)
+      array.push(Self, "second")
+   end
+
+   try
+      result = array_clear_then_push(arr)
+      assert(result is "secondbase", f"Expected mutated instance method to be honoured, got '{result}'")
+   except e
+      debug.setMetatable(arr, nil)
+      error(e)
+   end
+
+   debug.setMetatable(arr, nil)
+end
+
+@Test(hotpath=80) function ArrayMethodBaseSlotMutationExitsTrace()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local arr = array.new("")
+   local base_mt = debug.getMetatable(arr)
+   local original_clear = base_mt.clear
+   local result = ""
+
+   for i = 1, 80 do
+      result = array_clear_then_push(arr)
+   end
+
+   assert(result is "base", f"Expected base method result before mutation, got '{result}'")
+   assert(count_jit_traces(30) > 0, "Expected base array method call to produce a JIT trace")
+
+   base_mt.clear = function(Self)
+      array.resize(Self, 0)
+      array.push(Self, "patched")
+   end
+
+   try
+      result = array_clear_then_push(arr)
+      assert(result is "patchedbase", f"Expected mutated base method to be honoured, got '{result}'")
+   except e
+      base_mt.clear = original_clear
+      error(e)
+   end
+
+   base_mt.clear = original_clear
+end
+
 @Test(hotpath=80) function ArrayNewLiteralTypeTraces()
    cached_trace_no = nil
    cached_trace_info = nil

--- a/tools/benchmark/benchmark_string.tiri
+++ b/tools/benchmark/benchmark_string.tiri
@@ -71,6 +71,23 @@ end
    glStringBenchmarkSink += checksum
 end
 
+-- This is the standard Lua trick for concatenating strings in a loop.
+
+@Test function StringConcatBigTable()
+   local a, b, c = "foo", "bar", "baz"
+   local checksum = 0
+   local result = {}
+   for i in {0 to 1000} do
+      table.insert(result, "Hello" .. " " .. "World" .. "!")
+      table.insert(result, a .. b .. c)
+      table.insert(result, "Part1" .. "-" .. "Part2" .. "-" .. "Part3" .. "-" .. "Part4")
+      table.insert(result, "Value: " .. tostring(i) .. ", Next: " .. tostring(i + 1))
+   end
+
+   concat_result = table.concat(result)
+   glStringBenchmarkSink += #concat_result
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Build a string by concatenating multiple parts - small buffer version
 


### PR DESCRIPTION
## Summary

This PR implements the Tiri byte-array concat and append regression fixes from `docs/plans/tiri_array_regression_fixes.md`.

It records multi-piece byte-array append traces through a string buffer and one mutating array call, avoiding per-piece mutating IRCALLs and avoiding `BUFSTR` interning. It also removes the interpreter hot-path `std::vector<ArrayAppendPiece>` allocation by using a fixed 16-entry stack buffer for flattened append pieces, with direct `array.append()` overflow reducing the RHS before mutation so self-aliasing remains correct.

## Impact

Array-heavy concat workloads keep the Phase 3 traced shape while the interpreter path loses its per-statement heap allocation. Direct `array.append()` calls with more than 16 RHS values continue to support strings, numbers, byte arrays, and self references.

## Validation

- `cmake --build build/wsl-agents --target tiri origo_cmd --parallel`
- `cmake --install build/wsl-agents`
- `build/wsl-agents-install/origo tools/flute.tiri file=src/tiri/tests/test_compound.tiri --log-warning` - 47/47 passed
- `build/wsl-agents-install/origo tools/flute.tiri file=src/tiri/tests/test_jit.tiri --log-warning`
- `ctest --build-config Debug --test-dir build/wsl-agents --output-on-failure -R tiri` - 82/82 passed
- `build/wsl-agents-install/origo tools/benchmark/probe_string_concat_small.tiri count=1000 calls=50 --log-warning` - `small_array` retained `bufstr=0`, `calls=6`, `perCall=0.479ms`