### PR TITLE
[Tiri] Protect host registered globals from script overrides

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -781,7 +781,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
-   comparison_chaining reserved_keywords compile_if_import overflow
+   comparison_chaining reserved_keywords compile_if_import overflow protected_globals
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/lib/lib_init.cpp
+++ b/src/tiri/jit/src/lib/lib_init.cpp
@@ -11,6 +11,7 @@
 #include "lauxlib.h"
 #include "lualib.h"
 #include "lj_arch.h"
+#include "runtime/lj_tab.h"
 #include "runtime/lj_thunk.h"
 #include "runtime/lj_proto_registry.h"
 
@@ -66,3 +67,16 @@ extern void luaL_openlibs(lua_State* L)
    lua_setglobal(L, "_LIB");
 }
 
+extern void lua_protect_globals(lua_State* L)
+{
+   GCtab* globals = tabref(L->env);
+   Node* node = noderef(globals->node);
+
+   // The array part only represents integer keys.  Global names live in the hash part as string keys.
+   for (MSize i = 0; i <= globals->hmask; ++i) {
+      Node* entry = &node[i];
+      if (not tvisnil(&entry->val) and tvisstr(&entry->key)) {
+         strV(&entry->key)->flags |= STRFLAG_PROTECTED_GLOBAL;
+      }
+   }
+}

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -202,6 +202,7 @@ extern int   (lua_next) (lua_State *L, int idx);
 extern void  (lua_concat) (lua_State *L, int n);
 extern lua_Alloc (lua_getallocf) (lua_State *L, void **ud);
 extern void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
+extern void lua_protect_globals(lua_State *L);
 
 inline void lua_pop(lua_State *L, int N) { lua_settop(L, -(N)-1); }
 inline void lua_newtable(lua_State *L) { lua_createtable(L, 0, 0); }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -24,6 +24,50 @@ static bool contains_safe_nav_target(const ExprNode& Expr)
    }
 }
 
+static bool emit_identifier_name_is(GCstr *Name, std::string_view Text)
+{
+   return Name and std::string_view(strdata(Name), Name->len) IS Text;
+}
+
+static GCstr * emit_literal_string_key(const ExprNode &Expr)
+{
+   if (Expr.kind != AstNodeKind::LiteralExpr) return nullptr;
+   const auto &literal = std::get<LiteralValue>(Expr.data);
+   if (literal.kind != LiteralKind::String) return nullptr;
+   return literal.string_value;
+}
+
+static bool is_global_environment_reference(LexState &State, const ExprNode &Expr)
+{
+   if (Expr.kind != AstNodeKind::IdentifierExpr) return false;
+
+   const auto *name_ref = std::get_if<NameRef>(&Expr.data);
+   if (not name_ref or not emit_identifier_name_is(name_ref->identifier.symbol, "_G")) return false;
+
+   ExpDesc resolved;
+   State.var_lookup_symbol(name_ref->identifier.symbol, &resolved);
+   return resolved.k IS ExpKind::Global or resolved.k IS ExpKind::Unscoped;
+}
+
+static GCstr * protected_global_store_key(LexState &State, const ExprNode &Expr)
+{
+   GCstr *key = nullptr;
+
+   if (Expr.kind IS AstNodeKind::MemberExpr) {
+      const auto &payload = std::get<MemberExprPayload>(Expr.data);
+      if (payload.table and is_global_environment_reference(State, *payload.table)) key = payload.member.symbol;
+   }
+   else if (Expr.kind IS AstNodeKind::IndexExpr) {
+      const auto &payload = std::get<IndexExprPayload>(Expr.data);
+      if (payload.table and payload.index and is_global_environment_reference(State, *payload.table)) {
+         key = emit_literal_string_key(*payload.index);
+      }
+   }
+
+   if (key and ((key->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) return key;
+   return nullptr;
+}
+
 static void patch_safe_nav_skip_here(PreparedAssignment& Target, FuncState& State)
 {
    if (Target.safe_nav_skip.valid()) Target.safe_nav_skip.patch_to(BCPos(State.pc));
@@ -757,6 +801,14 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
       if (not node) {
          return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
             ParserErrorCode::InternalInvariant, "assignment target missing"));
+      }
+
+      if (GCstr *protected_name = protected_global_store_key(this->lex_state, *node)) {
+         return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
+            ParserErrorCode::OverrideProtectedGlobal,
+            std::format("cannot override built-in '{}'",
+               std::string_view(strdata(protected_name), protected_name->len)),
+            node->span));
       }
 
       PreparedAssignment prepared;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -68,6 +68,17 @@ static GCstr * protected_global_store_key(LexState &State, const ExprNode &Expr)
    return nullptr;
 }
 
+static bool computed_global_environment_store(LexState &State, const ExprNode &Expr)
+{
+   if (Expr.kind != AstNodeKind::IndexExpr) return false;
+
+   const auto &payload = std::get<IndexExprPayload>(Expr.data);
+   if (not payload.table or not payload.index or
+      not is_global_environment_reference(State, *payload.table)) return false;
+
+   return emit_literal_string_key(*payload.index) IS nullptr;
+}
+
 static void patch_safe_nav_skip_here(PreparedAssignment& Target, FuncState& State)
 {
    if (Target.safe_nav_skip.valid()) Target.safe_nav_skip.patch_to(BCPos(State.pc));
@@ -801,6 +812,13 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
       if (not node) {
          return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
             ParserErrorCode::InternalInvariant, "assignment target missing"));
+      }
+
+      if (computed_global_environment_store(this->lex_state, *node)) {
+         return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
+            ParserErrorCode::OverrideProtectedGlobal,
+            "cannot override built-in through computed _G key",
+            node->span));
       }
 
       if (GCstr *protected_name = protected_global_store_key(this->lex_state, *node)) {

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -536,7 +536,15 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
 
    if (Payload.name.is_explicit_global and not Payload.name.segments.empty()) {
       GCstr *name = Payload.name.segments.front().symbol;
-      if (name) this->func_state.declared_globals.insert(name);
+      if (name) {
+         bool is_direct_global_store = Payload.name.segments.size() IS 1 and not Payload.name.method.has_value();
+         if (is_direct_global_store and ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
+            return ParserResult<IrEmitUnit>::failure(this->make_error(ParserErrorCode::OverrideProtectedGlobal,
+               std::format("cannot override built-in '{}'", std::string_view(strdata(name), name->len)),
+               Payload.name.segments.front().span));
+         }
+         this->func_state.declared_globals.insert(name);
+      }
    }
 
    // Check if this is a simple function name (not a path like foo.bar or method foo:bar)

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -17,6 +17,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       const Identifier& identifier = Payload.names[i];
       if (is_blank_symbol(identifier)) continue;
       if (GCstr *name = identifier.symbol) {
+         if ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
+            return ParserResult<IrEmitUnit>::failure(this->make_error(ParserErrorCode::OverrideProtectedGlobal,
+               std::format("cannot override built-in '{}'", std::string_view(strdata(name), name->len)),
+               identifier.span));
+         }
+
          this->func_state.declared_globals.insert(name);
 
          if (identifier.has_const) {

--- a/src/tiri/jit/src/parser/parser_diagnostics.cpp
+++ b/src/tiri/jit/src/parser/parser_diagnostics.cpp
@@ -65,6 +65,7 @@ static CSTRING error_code_name(ParserErrorCode Code)
       case ParserErrorCode::RecoverySkippedTokens:  return "Recovery skipped tokens";
       case ParserErrorCode::AssignToConstant:       return "Assign to constant";
       case ParserErrorCode::ConstRequiresInitialiser: return "Const requires initialiser";
+      case ParserErrorCode::OverrideProtectedGlobal: return "Override protected global";
       case ParserErrorCode::InvalidAssignment:       return "Invalid assignment";
       default: return "Unknown";
    }

--- a/src/tiri/jit/src/parser/parser_diagnostics.h
+++ b/src/tiri/jit/src/parser/parser_diagnostics.h
@@ -37,6 +37,7 @@ enum class ParserErrorCode : uint16_t {
    RecoverySkippedTokens,   // Info: tokens skipped during error recovery
    AssignToConstant,        // Cannot assign to a registered constant
    ConstRequiresInitialiser, // Const variable requires an initialiser
+   OverrideProtectedGlobal, // Cannot override a host pre-registered global
    InvalidAssignment        // Assignment form is syntactically valid but semantically forbidden
 };
 

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -45,6 +45,19 @@
    return result;
 }
 
+[[nodiscard]] static bool type_identifier_name_is(GCstr *Name, std::string_view Text)
+{
+   return Name and std::string_view(strdata(Name), Name->len) IS Text;
+}
+
+[[nodiscard]] static GCstr * type_literal_string_key(const ExprNode &Expr)
+{
+   if (Expr.kind != AstNodeKind::LiteralExpr) return nullptr;
+   const auto &literal = std::get<LiteralValue>(Expr.data);
+   if (literal.kind != LiteralKind::String) return nullptr;
+   return literal.string_value;
+}
+
 // Helper to check if type tracing is enabled
 
 [[nodiscard]] inline bool should_trace_types(lua_State *L)
@@ -99,6 +112,9 @@ private:
    void analyse_function_payload(const FunctionExprPayload &, GCstr *Name = nullptr);
    void analyse_expression(const ExprNode &);
    void analyse_call_expr(const CallExprPayload &);
+   [[nodiscard]] bool is_global_environment_reference(const ExprNode &) const;
+   [[nodiscard]] GCstr * protected_global_store_key(const ExprNode &) const;
+   void report_protected_global_override(GCstr *, SourceSpan);
 
    // Argument type checking for function calls
    void check_arguments(const FunctionExprPayload &, const CallExprPayload &);
@@ -648,6 +664,11 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
       if (not target_ptr) continue;
       const auto &target = *target_ptr;
 
+      if (GCstr *protected_name = this->protected_global_store_key(target)) {
+         this->report_protected_global_override(protected_name, target.span);
+         continue;
+      }
+
       // Check local and global variable assignments
       if (target.kind IS AstNodeKind::IdentifierExpr) {
          auto *name_ref = std::get_if<NameRef>(&target.data);
@@ -905,6 +926,11 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
       const auto &name = Payload.names[i];
       if (not name.symbol) continue;
 
+      if ((name.symbol->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
+         this->report_protected_global_override(name.symbol, name.span);
+         continue;
+      }
+
       InferredType inferred;
 
       // Explicit type annotation takes precedence
@@ -999,7 +1025,11 @@ void TypeAnalyser::analyse_function_stmt(const FunctionStmtPayload &Payload)
       if (not Payload.name.segments.empty()) {
          function_name = Payload.name.segments.back().symbol;
          function_location = Payload.name.segments.back().span;
-         this->declare_global_function(function_name, function, function_location);
+         bool is_direct_global_store = Payload.name.segments.size() IS 1 and not Payload.name.method.has_value();
+         if (is_direct_global_store and function_name and ((function_name->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
+            this->report_protected_global_override(function_name, function_location);
+         }
+         else this->declare_global_function(function_name, function, function_location);
       }
       else if (Payload.name.method) {
          function_name = Payload.name.method->symbol;
@@ -1009,6 +1039,46 @@ void TypeAnalyser::analyse_function_stmt(const FunctionStmtPayload &Payload)
    }
 
    if (function) this->analyse_function_payload(*function, function_name);
+}
+
+bool TypeAnalyser::is_global_environment_reference(const ExprNode &Expr) const
+{
+   if (Expr.kind != AstNodeKind::IdentifierExpr) return false;
+
+   const auto *name_ref = std::get_if<NameRef>(&Expr.data);
+   if (not name_ref or not type_identifier_name_is(name_ref->identifier.symbol, "_G")) return false;
+
+   return not this->resolve_identifier(name_ref->identifier.symbol).has_value();
+}
+
+GCstr * TypeAnalyser::protected_global_store_key(const ExprNode &Expr) const
+{
+   GCstr *key = nullptr;
+
+   if (Expr.kind IS AstNodeKind::MemberExpr) {
+      const auto &payload = std::get<MemberExprPayload>(Expr.data);
+      if (payload.table and this->is_global_environment_reference(*payload.table)) key = payload.member.symbol;
+   }
+   else if (Expr.kind IS AstNodeKind::IndexExpr) {
+      const auto &payload = std::get<IndexExprPayload>(Expr.data);
+      if (payload.table and payload.index and this->is_global_environment_reference(*payload.table)) {
+         key = type_literal_string_key(*payload.index);
+      }
+   }
+
+   if (key and ((key->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) return key;
+   return nullptr;
+}
+
+void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Location)
+{
+   if (not Name) return;
+
+   TypeDiagnostic diag;
+   diag.location = Location;
+   diag.code = ParserErrorCode::OverrideProtectedGlobal;
+   diag.message = std::format("cannot override built-in '{}'", std::string_view(strdata(Name), Name->len));
+   this->diagnostics_.push_back(std::move(diag));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -114,7 +114,9 @@ private:
    void analyse_call_expr(const CallExprPayload &);
    [[nodiscard]] bool is_global_environment_reference(const ExprNode &) const;
    [[nodiscard]] GCstr * protected_global_store_key(const ExprNode &) const;
+   [[nodiscard]] bool computed_global_environment_store(const ExprNode &) const;
    void report_protected_global_override(GCstr *, SourceSpan);
+   void report_computed_global_environment_store(SourceSpan);
 
    // Argument type checking for function calls
    void check_arguments(const FunctionExprPayload &, const CallExprPayload &);
@@ -664,6 +666,11 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
       if (not target_ptr) continue;
       const auto &target = *target_ptr;
 
+      if (this->computed_global_environment_store(target)) {
+         this->report_computed_global_environment_store(target.span);
+         continue;
+      }
+
       if (GCstr *protected_name = this->protected_global_store_key(target)) {
          this->report_protected_global_override(protected_name, target.span);
          continue;
@@ -1070,6 +1077,17 @@ GCstr * TypeAnalyser::protected_global_store_key(const ExprNode &Expr) const
    return nullptr;
 }
 
+bool TypeAnalyser::computed_global_environment_store(const ExprNode &Expr) const
+{
+   if (Expr.kind != AstNodeKind::IndexExpr) return false;
+
+   const auto &payload = std::get<IndexExprPayload>(Expr.data);
+   if (not payload.table or not payload.index or
+      not this->is_global_environment_reference(*payload.table)) return false;
+
+   return type_literal_string_key(*payload.index) IS nullptr;
+}
+
 void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Location)
 {
    if (not Name) return;
@@ -1078,6 +1096,15 @@ void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Loca
    diag.location = Location;
    diag.code = ParserErrorCode::OverrideProtectedGlobal;
    diag.message = std::format("cannot override built-in '{}'", std::string_view(strdata(Name), Name->len));
+   this->diagnostics_.push_back(std::move(diag));
+}
+
+void TypeAnalyser::report_computed_global_environment_store(SourceSpan Location)
+{
+   TypeDiagnostic diag;
+   diag.location = Location;
+   diag.code = ParserErrorCode::OverrideProtectedGlobal;
+   diag.message = "cannot override built-in through computed _G key";
    this->diagnostics_.push_back(std::move(diag));
 }
 

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -436,11 +436,14 @@ typedef uint32_t StrID;      //  String ID.
 typedef struct GCstr {
    GCHeader;           // 16-bit aligned
    uint8_t reserved;   // Used by lexer for fast lookup of reserved words.
-   uint8_t flags;      // Currently unused, but available for marking strings in relation to the thing they represent
+   uint8_t flags;      // STRFLAG_* bits that mark parser/runtime properties of interned names.
    StrID sid;          // Interned string ID.
    LuaStrHash hash;    // Hash of string.
    MSize len;          // Size of string.
 } GCstr;
+
+// GCstr::flags bits.  Bit 0x01 is STRF_MUTABLE_BUFFER in lj_str.h.
+inline constexpr uint8_t STRFLAG_PROTECTED_GLOBAL = 0x02;  // Name of a host pre-registered global
 
 inline GCstr* strref(GCRef r) noexcept;  // Defined after GCobj
 

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -384,25 +384,17 @@ end
    assert(store.label is 'xy', 'field string ..= should still concatenate and store a string')
 end
 
-@Test function ArrayConcatAssignmentIgnoresShadowedArrayGlobal()
-   saved_array = array
+@Test function ArrayConcatAssignmentIgnoresShadowedArrayLocal()
    store = { buf = array<byte>, label = 'x' }
 
-   global array = {}
+   local array = {}
 
-   try
-      store.label ..= 'y'
-      store.buf ..= 'Hi'
-      store.buf ..= 33
+   store.label ..= 'y'
+   store.buf ..= 'Hi'
+   store.buf ..= 33
 
-      assert(store.label is 'xy', 'field string ..= should not call the shadowed array global')
-      assert(store.buf:getString() is 'Hi33', 'field byte array ..= should still use the internal append helper')
-   except e
-      global array = saved_array
-      error(e)
-   success
-      global array = saved_array
-   end
+   assert(store.label is 'xy', 'field string ..= should not call the shadowed array local')
+   assert(store.buf:getString() is 'Hi33', 'field byte array ..= should still use the internal append helper')
 end
 
 @Test function ArrayConcatAssignmentOnTypedLocals()

--- a/src/tiri/tests/test_protected_globals.tiri
+++ b/src/tiri/tests/test_protected_globals.tiri
@@ -40,6 +40,19 @@ end
    assert_activation_fails([[_G['tostring'] = 5]], "_G['tostring'] assignment")
 end
 
+@Test function RejectsGlobalEnvironmentComputedIndexAssignment()
+   assert_activation_fails([[local k = 'tostring'; _G[k] = 5]], "_G[k] assignment")
+end
+
+@Test function AllowsComputedIndexAssignmentToLocalNamedGlobalEnvironment()
+   assert_activation_succeeds([[
+      local _G = {}
+      local k = 'tostring'
+      _G[k] = 5
+      assert(_G.tostring is 5)
+   ]], 'local _G computed index assignment')
+end
+
 @Test function RejectsProtectedNameInMultiTargetGlobalDeclaration()
    assert_activation_fails([[global a, tostring = 1, 2]], 'multi-target global declaration')
 end
@@ -83,4 +96,3 @@ end
       assert(myThing is 2)
    ]], 'script-created global reassignment')
 end
-

--- a/src/tiri/tests/test_protected_globals.tiri
+++ b/src/tiri/tests/test_protected_globals.tiri
@@ -1,0 +1,86 @@
+-- Flute regression tests for protected host-registered global names.
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath() end
+
+function assert_activation_fails(Statement:str, Message:str)
+   local script = obj.new('tiri', { statement = Statement })
+   local err = script.acActivate()
+
+   assert(err != ERR_Okay, Message .. ' should fail activation')
+   assert(script.error != ERR_Okay, Message .. ' should set a script error')
+   assert(string.find(script.errorMessage, 'cannot override built-in') != nil,
+      Message .. ' should report the protected-global diagnostic, got: ' .. tostring(script.errorMessage))
+end
+
+function assert_activation_succeeds(Statement:str, Message:str)
+   local script = obj.new('tiri', { statement = Statement })
+   local err = script.acActivate()
+
+   assert(err is ERR_Okay, Message .. ' should activate successfully: ' .. tostring(script.errorMessage))
+end
+
+@Test function RejectsGlobalDeclarationOfBuiltinFunction()
+   assert_activation_fails([[global tostring = 5]], 'global tostring assignment')
+end
+
+@Test function RejectsGlobalFunctionDeclarationOfBuiltinFunction()
+   assert_activation_fails([[global function tostring() end]], 'global tostring function declaration')
+end
+
+@Test function RejectsGlobalDeclarationOfInterfaceTable()
+   assert_activation_fails([[global table = {}]], 'global table assignment')
+end
+
+@Test function RejectsGlobalEnvironmentMemberAssignment()
+   assert_activation_fails([[_G.tostring = 5]], '_G.tostring assignment')
+end
+
+@Test function RejectsGlobalEnvironmentLiteralIndexAssignment()
+   assert_activation_fails([[_G['tostring'] = 5]], "_G['tostring'] assignment")
+end
+
+@Test function RejectsProtectedNameInMultiTargetGlobalDeclaration()
+   assert_activation_fails([[global a, tostring = 1, 2]], 'multi-target global declaration')
+end
+
+@Test function AllowsPlainLocalShadowOfBuiltin()
+   assert_activation_succeeds([[
+      tostring = 5
+      local copy = tostring
+      assert(copy is 5)
+   ]], 'plain local shadow')
+end
+
+@Test function AllowsExplicitLocalShadowReadingBuiltinFirst()
+   assert_activation_succeeds([[
+      local original = tostring
+      local tostring = original
+      assert(type(tostring) is 'function')
+   ]], 'local shadow from builtin')
+end
+
+@Test function AllowsLocalFunctionShadowOfBuiltin()
+   assert_activation_succeeds([[
+      function tostring()
+         return 'local'
+      end
+      assert(tostring() is 'local')
+   ]], 'local function shadow')
+end
+
+@Test function AllowsUnregisteredGlobalDeclaration()
+   assert_activation_succeeds([[
+      global myThing = 1
+      assert(myThing is 1)
+   ]], 'unregistered global declaration')
+end
+
+@Test function AllowsScriptCreatedGlobalReassignment()
+   assert_activation_succeeds([[
+      global myThing = 1
+      myThing = 2
+      assert(myThing is 2)
+   ]], 'script-created global reassignment')
+end
+

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -612,6 +612,7 @@ static ERR TIRI_Query(extTiri *Self)
          SetName(core, "mSys");
          new_module(Self->Lua, core);
          lua_setglobal(Self->Lua, "mSys");
+         lua_protect_globals(Self->Lua);
       }
       else {
          log.warning("Failed to create module object.");


### PR DESCRIPTION
* Added protected global name marking after Tiri state initialisation
* Added parser and type-analysis diagnostics for overriding built-in globals
* Added Flute coverage for protected globals and updated compound shadowing coverage