### PR TITLE
[Tiri] Allow trace event callbacks to grow the stack

### DIFF
--- a/src/tiri/jit/src/lj_trace.cpp
+++ b/src/tiri/jit/src/lj_trace.cpp
@@ -883,25 +883,28 @@ void lj_trace_ins(jit_State *J, const BCIns *pc)
    J->pc = pc;
    J->fn = curr_func(J->L);
    J->pt = isluafunc(J->fn) ? funcproto(J->fn) : nullptr;
-   TValue *base_before = J->L->base;
-   TValue *top_before = J->L->top;
+   ptrdiff_t base_before = savestack(J->L, J->L->base);
+   ptrdiff_t top_before = savestack(J->L, J->L->top);
 
    while (true) {
       if (lj_vm_cpcall(J->L, nullptr, (void *)J, trace_state) IS 0) break;
       J->state = TraceState::ERR;
    }
 
-   if (not (J->L->base IS base_before) or not (J->L->top IS top_before)) {
-      log.msg("Stack changed.  Base: %p→%p, Top: %p→%p, State: %d", base_before, J->L->base, top_before, J->L->top, (int)J->state);
+   TValue *expected_base = restorestack(J->L, base_before);
+   TValue *expected_top = restorestack(J->L, top_before);
+   if (not (J->L->base IS expected_base) or not (J->L->top IS expected_top)) {
+      log.msg("Stack changed.  Base: %p→%p, Top: %p→%p, State: %d",
+         expected_base, J->L->base, expected_top, J->L->top, (int)J->state);
 #ifdef LUA_USE_ASSERT
       lj_assertJ(J->state IS TraceState::ERR or J->state IS TraceState::IDLE, "trace recorder mutated stack");
 #endif
       if (J->state IS TraceState::ERR or J->state IS TraceState::IDLE) {
          // try-except may have changed the stack, this stabilises it.  Ideally this
          // doesn't happen in practice, hence the assert above.
-         log.msg("Restoring stack: base=%p, top=%p", (void*)base_before, (void*)top_before);
-         J->L->base = base_before;
-         J->L->top = top_before;
+         log.msg("Restoring stack: base=%p, top=%p", (void*)expected_base, (void*)expected_top);
+         J->L->base = expected_base;
+         J->L->top = expected_top;
       }
    }
 }

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -680,6 +680,25 @@ Areas for investigation:
    assert(trace_events > 0, "Trace handler should run at least once")
 end
 
+@Test(hotpath=1000) function JitAttachTraceEventAllocatingHandler()
+   cached_trace_no = nil
+   cached_trace_info = nil
+
+   records = {}
+   trace_events = 0
+   function trace_handler(TraceNo, Reason)
+      records[trace_events] = "trace:" .. tostring(TraceNo) .. ":" .. tostring(Reason)
+      trace_events++
+   end
+
+   jit.attach(trace_handler, "trace")
+   build_trace()
+   jit.attach(trace_handler)
+
+   assert(trace_events > 0, "Allocating trace handler should run at least once")
+   assert(records[0] != nil, "Allocating trace handler should record its first event")
+end
+
 @Test(hotpath=100) function ArrayIteratorTraces()
    cached_trace_no = nil
    cached_trace_info = nil


### PR DESCRIPTION
* Track recorder stack positions as offsets so VM event callbacks can relocate the Lua stack without tripping mutation assertions
* Add a JIT trace event regression with an allocating handler