### PR TITLE
[SVG] Added VectorImage defs export

### DIFF
--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -354,7 +354,8 @@ static ERR SVG_SaveToObject(extSVG *Self, struct acSaveToObject *Args)
       // tree must be supplied via the Statement field at creation time.
 
       static const std::string root_doc = std::string(header) +
-         "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:kotuku=\"http://www.kotuku.dev/xmlns/svg\"/>";
+         "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" "
+         "xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:kotuku=\"http://www.kotuku.dev/xmlns/svg\"/>";
 
       auto xml = objXML::create { fl::Flags(XMF::NEW|XMF::READABLE), fl::Statement(root_doc) };
 

--- a/src/svg/save_svg.cpp
+++ b/src/svg/save_svg.cpp
@@ -176,6 +176,142 @@ static ERR save_svg_pattern(extSVG *Self, objXML *XML, objVectorPattern *Pattern
 
 //*********************************************************************************************************************
 
+static std::string save_aspect_ratio(ARF AspectRatio)
+{
+   if ((AspectRatio & ARF::NONE) != ARF::NIL) return "none";
+
+   std::string result;
+
+   if ((AspectRatio & ARF::X_MIN) != ARF::NIL) result = "xMin";
+   else if ((AspectRatio & ARF::X_MAX) != ARF::NIL) result = "xMax";
+   else result = "xMid";
+
+   if ((AspectRatio & ARF::Y_MIN) != ARF::NIL) result += "YMin";
+   else if ((AspectRatio & ARF::Y_MAX) != ARF::NIL) result += "YMax";
+   else result += "YMid";
+
+   if ((AspectRatio & ARF::SLICE) != ARF::NIL) result += " slice";
+   else result += " meet";
+
+   return result;
+}
+
+//*********************************************************************************************************************
+
+static bool external_image_path(std::string_view Path, std::string &Result)
+{
+   if (Path.empty() or Path.starts_with("data:") or Path.starts_with("temp:")) return false;
+
+   std::string resolved;
+   LOC type = LOC::NIL;
+   if ((ResolvePath(Path, RSF::NIL, &resolved) IS ERR::Okay) and
+       (AnalysePath(resolved, &type) IS ERR::Okay) and (type IS LOC::FILE)) {
+      Result.assign(Path);
+      return true;
+   }
+
+   return false;
+}
+
+//*********************************************************************************************************************
+
+static ERR encode_bitmap_png(objBitmap *Bitmap, std::string &Href)
+{
+   if (not Bitmap) return ERR::FieldNotSet;
+
+   objFile::create file = {
+      fl::Size(0),
+      fl::Flags(FL::BUFFER|FL::READ|FL::WRITE)
+   };
+   if (!file.ok()) return file.error;
+
+   objImage::create image(NF::LOCAL);
+   if (!image.ok()) return image.error;
+
+   if (auto owned_bitmap = image->Bitmap) FreeResource(owned_bitmap);
+   image->Bitmap = Bitmap;
+   image->Flags = PCF::NIL;
+
+   ERR error = image->saveImage(*file);
+   image->Bitmap = nullptr;
+   if (error != ERR::Okay) return error;
+
+   std::span<int8_t> data;
+   if ((error = file->getBuffer(data)) != ERR::Okay) return error;
+   if (data.empty()) return ERR::NoData;
+
+   std::vector<char> encoded((data.size() * 2) + 8);
+   kt::BASE64ENCODE state;
+
+   auto len = kt::Base64Encode(&state, std::span((const char *)data.data(), data.size()), encoded);
+   if (len <= 0) return ERR::NoData;
+
+   auto final_len = kt::Base64Encode(&state, {}, std::span(encoded.data() + len, encoded.size() - len));
+   if (final_len <= 0) return ERR::NoData;
+
+   Href = "data:image/png;base64,";
+   Href.reserve(Href.size() + size_t(len + final_len));
+
+   for (int64_t i=0; i < len + final_len; i++) {
+      if ((encoded[i] != '\n') and (encoded[i] != '\r') and (encoded[i] != 0)) Href.push_back(encoded[i]);
+   }
+
+   return ERR::Okay;
+}
+
+//*********************************************************************************************************************
+
+static ERR save_svg_image(objXML *XML, objVectorImage *Image, int Parent, std::string_view DefID)
+{
+   XTag *tag;
+   ERR error = XML->insertStatement(Parent, XMI::CHILD_END, "<image/>", &tag);
+   if (error != ERR::Okay) return error;
+
+   xml::NewAttrib(tag, "id", DefID);
+
+   objBitmap *bitmap;
+   if ((error = Image->getBitmap(bitmap)) != ERR::Okay) return error;
+   if (not bitmap) return ERR::FieldNotSet;
+
+   xml::NewAttrib(tag, "width", bitmap->Width);
+   xml::NewAttrib(tag, "height", bitmap->Height);
+
+   Unit unit;
+   if ((!error) and (!Image->getX(unit)) and unit.defined() and (double(unit) != 0)) set_dimension(tag, "x", unit);
+   if ((!error) and (!Image->getY(unit)) and unit.defined() and (double(unit) != 0)) set_dimension(tag, "y", unit);
+
+   VUNIT units;
+   if ((!error) and (!Image->getUnits(units))) {
+      switch(units) {
+         default:
+         case VUNIT::BOUNDING_BOX: xml::NewAttrib(tag, "units", "objectBoundingBox"); break;
+         case VUNIT::USERSPACE:    xml::NewAttrib(tag, "units", "userSpaceOnUse"); break;
+      }
+   }
+
+   ARF aspect_ratio;
+   if ((!error) and (!Image->getAspectRatio(aspect_ratio))) {
+      xml::NewAttrib(tag, "preserveAspectRatio", save_aspect_ratio(aspect_ratio));
+   }
+
+   std::string href;
+   objImage *source_image;
+   if ((!error) and (!Image->getImage(source_image)) and source_image) {
+      std::string_view path;
+      if ((!source_image->getPath(path)) and external_image_path(path, href)) {
+         xml::NewAttrib(tag, "xlink:href", href);
+         return ERR::Okay;
+      }
+   }
+
+   if ((error = encode_bitmap_png(bitmap, href)) != ERR::Okay) return error;
+   xml::NewAttrib(tag, "xlink:href", href);
+
+   return ERR::Okay;
+}
+
+//*********************************************************************************************************************
+
 static ERR save_vectorpath(extSVG *Self, objXML *XML, objVector *Vector, int Parent)
 {
    std::string path;
@@ -401,7 +537,7 @@ static ERR save_svg_defs(extSVG *Self, objXML *XML, objVectorScene *Scene, int P
             }
          }
          else if (def->classID() IS CLASSID::VECTORIMAGE) {
-            log.warning("VectorImage not supported.");
+            error = save_svg_image(XML, (objVectorImage *)def, def_index, key);
          }
          else if (def->classID() IS CLASSID::VECTORPATH) {
             error = save_svg_scan_def(Self, XML, (objVector *)def, def_index, key);

--- a/src/svg/tests/test_defs_export.tiri
+++ b/src/svg/tests/test_defs_export.tiri
@@ -3,13 +3,22 @@
    include 'svg'
    include 'vector'
 
+local glSVGFolder
 glFiles = array<string>
+
+@BeforeAll function setup(State:table)
+   glSVGFolder = State.folder
+end
 
 @AfterAll function removeFiles()
    for path in values(glFiles) do
       mSys.DeleteFile(path)
    end
 end
+
+----------------------------------------------------------------------------------------------------------------------
+
+glImagePath = <{ glSVGFolder .. 'basics/sign.png' }>
 
 function saveScene(Scene:obj, Path:str):str
    svg = obj.new('svg', { target=Scene })
@@ -38,6 +47,8 @@ function transitionStops()
       transitionStop(1.0, 'scale(2)')
    }
 end
+
+----------------------------------------------------------------------------------------------------------------------
 
 @Test function SavesClipDefWithMapKeyId()
    local scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
@@ -105,4 +116,43 @@ end
    assertContains(saved, 'id="text_transition"', 'Transition should use the scene def key')
    assertContains(saved, '<stop offset="0"', 'Transition definition should include XMLDef stop elements')
    assertContains(saved, 'transform="matrix(', 'Transition definition should include XMLDef transform matrices')
+end
+
+@Test function SavesVectorImageDefWithExistingPath()
+   local scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   local viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   local source = obj.new('image', { src=glImagePath, bitsPerPixel=32 })
+   local image = scene.new('VectorImage', { image=source, units=VUNIT_BOUNDING_BOX })
+
+   check scene.mtAddDef('sign_image', image)
+   viewport.new('VectorRectangle', { x=0, y=0, width=100, height=100, fill='url(#sign_image)' })
+
+   local saved = saveScene(scene, 'temp:svg_defs_image_path.svg')
+   assertContains(saved, '<image', 'Saved SVG should contain the image definition')
+   assertContains(saved, 'id="sign_image"', 'VectorImage should use the scene def key')
+   assertContains(saved, 'xlink:href=', 'VectorImage should export a source reference')
+   assertContains(saved, 'sign.png', 'VectorImage should preserve an existing source path')
+   assert(string.find(saved, 'data:image/png;base64,', 0, true) is nil, 'Existing image paths should not be embedded')
+end
+
+@Test function SavesVectorImageDefWithEmbeddedBitmapFallback()
+   local scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   local viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   local source = obj.new('image', { src=glImagePath, bitsPerPixel=32 })
+   local image = scene.new('VectorImage', { bitmap=source.bitmap, units=VUNIT_BOUNDING_BOX })
+
+   check scene.mtAddDef('embedded_image', image)
+   viewport.new('VectorRectangle', { x=0, y=0, width=100, height=100, fill='url(#embedded_image)' })
+
+   local saved = saveScene(scene, 'temp:svg_defs_image_embedded.svg')
+   assertContains(saved, '<image', 'Saved SVG should contain the image definition')
+   assertContains(saved, 'id="embedded_image"', 'Embedded VectorImage should use the scene def key')
+   assertContains(saved, 'xlink:href="data:image/png;base64,', 'VectorImage without a valid path should embed PNG data')
+
+   local loaded_scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   loaded_scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+   obj.new('svg', { target=loaded_scene, path='temp:svg_defs_image_embedded.svg' })
+   local err, loaded_image = loaded_scene.mtFindDef('embedded_image')
+   assert(err is ERR_Okay, 'Embedded VectorImage data should load back as a definition')
+   assert(loaded_image != nil, 'Embedded VectorImage definition should be available after reload')
 end

--- a/src/svg/tests/test_defs_export.tiri
+++ b/src/svg/tests/test_defs_export.tiri
@@ -130,6 +130,7 @@ end
    local saved = saveScene(scene, 'temp:svg_defs_image_path.svg')
    assertContains(saved, '<image', 'Saved SVG should contain the image definition')
    assertContains(saved, 'id="sign_image"', 'VectorImage should use the scene def key')
+   assertContains(saved, 'xmlns:xlink="http://www.w3.org/1999/xlink"', 'Saved SVG should declare the xlink namespace')
    assertContains(saved, 'xlink:href=', 'VectorImage should export a source reference')
    assertContains(saved, 'sign.png', 'VectorImage should preserve an existing source path')
    assert(string.find(saved, 'data:image/png;base64,', 0, true) is nil, 'Existing image paths should not be embedded')


### PR DESCRIPTION
* Exported VectorImage definitions as SVG image elements with path preservation and embedded PNG fallback
* Extended defs export tests to cover image path references and embedded bitmap reloads