### PR TITLE
[Build] Added SSE4.2 SIMD baseline for x86 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,6 +588,24 @@ else ()
 #   set (KOTUKU_ARCH "-m32")
 endif ()
 
+# --------------------------------------------------------------------------------------------------------------------
+# SIMD baseline.  SSE4.2 is the mandatory floor for all x86/x86-64 builds (guaranteed on any 64-bit CPU from ~2008
+# onwards).  This unlocks SSE4.2 intrinsics for scalar codegen and lets the compiler auto-vectorise with the full
+# SSE1-4.2 instruction set.  AVX2 remains an opt-in, per-function path gated by simd_has_avx2() at run time -- see
+# src/link/simd.h.  Non-x86 targets (ARM/AArch64, Apple Silicon) are unaffected.
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64|i[3-6]86|x86)")
+   if (MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # MSVC has no /arch:SSE4.2 flag (its /arch jumps SSE2 -> AVX) and SSE4.2 intrinsics are always available
+      # without a flag, so no compile option is required to guarantee the baseline for the MSVC toolchain.
+      message (STATUS "SIMD baseline: SSE4.2 (MSVC intrinsics available unconditionally)")
+   else ()
+      # GCC/Clang (including clang-cl) require an explicit flag to raise the baseline above SSE2.
+      message (STATUS "SIMD baseline: SSE4.2 (-msse4.2)")
+      add_compile_options ("-msse4.2")
+   endif ()
+endif ()
+
 if (KOTUKU_VLOG)
    add_compile_definitions ("_DEBUG")
 endif ()

--- a/src/link/simd.h
+++ b/src/link/simd.h
@@ -1,8 +1,9 @@
 #pragma once
 
-// SSE2 availability detection, shared by modules that implement SIMD rendering paths.  SSE2 is guaranteed on
-// all x86-64 targets and on 32-bit MSVC builds compiled with /arch:SSE2 or better.  Code must guard its SIMD
-// paths with KOTUKU_SSE2 and fall back to scalar routines on other architectures.
+// SIMD availability detection, shared by modules that implement SIMD rendering paths.  SSE4.2 is the mandatory
+// baseline for all x86/x86-64 Kotuku builds (see the SIMD baseline block in the root CMakeLists.txt), which in
+// turn guarantees SSE2.  Both are therefore always defined on x86 targets, but code should still guard its SIMD
+// paths with KOTUKU_SSE2 / KOTUKU_SSE42 and fall back to scalar routines on other architectures (e.g. ARM).
 
 #if defined(__SSE2__)
    #define KOTUKU_SSE2 1
@@ -14,8 +15,22 @@
    #endif
 #endif
 
+// SSE4.2 is guaranteed by the build baseline.  GCC/Clang expose __SSE4_2__ when compiled with -msse4.2; MSVC has
+// no equivalent predefined macro but always provides the SSE4.2 intrinsics, so on the MSVC toolchain the baseline
+// is implied wherever SSE2 is present.
+
+#if defined(__SSE4_2__)
+   #define KOTUKU_SSE42 1
+#elif defined(KOTUKU_SSE2) and defined(_MSC_VER) and !defined(__clang__)
+   #define KOTUKU_SSE42 1
+#endif
+
 #ifdef KOTUKU_SSE2
 #include <emmintrin.h>
+#endif
+
+#ifdef KOTUKU_SSE42
+#include <nmmintrin.h>
 #endif
 
 // AVX2 kernels are compiled per-function wherever the toolchain allows it: MSVC permits AVX2


### PR DESCRIPTION
* Added an x86 CMake baseline that enables SSE4.2 for GCC and Clang builds
* Updated shared SIMD feature detection to expose KOTUKU_SSE42 and include SSE4.2 intrinsics