### PR TITLE
[XML] Added SIMD scanning acceleration

### DIFF
--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -31,6 +31,7 @@ that is distributed with this package.  Please refer to it for further informati
 #define PRV_SURFACE
 
 #include "defs/hashes.h"
+#include "../link/simd.h"
 #include "../link/unicode.h"
 #include <kotuku/modules/filesystem.h>
 #include <kotuku/modules/processes.h>

--- a/src/document/functions.cpp
+++ b/src/document/functions.cpp
@@ -613,6 +613,32 @@ static int getutf8(CSTRING Value, int *Unicode)
 }
 
 //********************************************************************************************************************
+// Scan forward from Str[Pos] to the first byte that is <= 0x20 (whitespace, control or newline), returning its
+// index or Str.size() if none is found.  This marks the end of a WORD run during tokenisation.  The SSE4.2 path
+// uses PCMPESTRI range matching to test 16 bytes per iteration; the scalar loop is retained as the tail handler
+// and as the fallback for non-x86 targets.  Bytes >= 0x80 (UTF-8 lead/continuation) are all > 0x20 and therefore
+// remain part of the word, matching the scalar semantics exactly.
+
+inline size_t scan_word_end(std::string_view Str, size_t Pos)
+{
+#ifdef KOTUKU_SSE42
+   // Range set {0x00..0x20}: PCMPESTRI reports the index of the first byte falling inside the range.  The
+   // explicit-length form is used so embedded null bytes are treated as ordinary word terminators.
+   const __m128i range = _mm_setr_epi8(0x00, 0x20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0);
+   constexpr int mode = _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES | _SIDD_POSITIVE_POLARITY | _SIDD_LEAST_SIGNIFICANT;
+
+   while (Pos + 16 <= Str.size()) {
+      __m128i block = _mm_loadu_si128((const __m128i *)(Str.data() + Pos));
+      int idx = _mm_cmpestri(range, 2, block, 16, mode);
+      if (idx < 16) return Pos + idx; // Found a byte <= 0x20 within this block
+      Pos += 16;
+   }
+#endif
+   while ((Pos < Str.size()) and (uint8_t(Str[Pos]) > 0x20)) Pos++;
+   return Pos;
+}
+
+//********************************************************************************************************************
 // Build the token list for a bc_text from its text string.  Tokens represent word, whitespace, and newline boundaries.
 // This avoids repeated byte-by-byte scanning during layout restarts.
 
@@ -640,7 +666,7 @@ void bc_text::tokenise()
       }
       else {
          auto start = i;
-         while ((i < str.size()) and (unsigned(str[i]) > 0x20) and (str[i] != '\n')) i++;
+         i = scan_word_end(str, i);
          tokens.push_back({ uint16_t(start), uint16_t(i), -1, 0, text_token_kind::WORD });
       }
    }

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -55,3 +55,4 @@ flute_test (${MOD}_parsing "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xml_parsing.t
 flute_test (${MOD}_namespaces "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_namespaces.tiri")
 flute_test (${MOD}_variables "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_setvariable.tiri")
 flute_test (${MOD}_schema_validation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_schema_validation.tiri")
+flute_test (${MOD}_simd_scanning "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_simd_scanning.tiri")

--- a/src/xml/tests/test_simd_scanning.tiri
+++ b/src/xml/tests/test_simd_scanning.tiri
@@ -1,0 +1,111 @@
+-- SSE4.2 scanner boundary tests.
+--
+-- These tests exercise the SIMD-accelerated ParseState scanners (skipTo / skipWhitespace) in src/xml/xml.h, which
+-- process 16 bytes per iteration.  The cases below deliberately place delimiters, newlines and content boundaries
+-- around the 16-byte block boundary so that any divergence between the SIMD path and the scalar tail/fallback is
+-- caught.  The scanners must produce byte-identical parsing results and accurate line numbers regardless of length.
+
+   include 'xml'
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Attribute values that straddle the 16-byte SIMD block boundary must be captured exactly.  Lengths are chosen to
+-- land just below, on, and just above multiples of 16 (the skipTo('"') scan width).
+
+@Test function AttrValueBlockBoundaries()
+   for _, len in ipairs({ 1, 15, 16, 17, 31, 32, 33, 48, 100 }) do
+      local value = string.rep('a', len)
+      local xml = obj.new('xml', { statement = '<root attr="' .. value .. '"/>' })
+      assert(xml.tags, 'Parse failed for value length ' .. len)
+      local err, got = xml.mtGetAttrib(xml.tags[0].id, 'attr')
+      assert(err is ERR_Okay, 'GetAttrib failed for length ' .. len)
+      assert(got is value, 'Value mismatch at length ' .. len .. ': got "' .. tostring(got) .. '"')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Single-quoted values exercise the skipTo('\'') scan.  Mix in characters that must NOT terminate the scan early.
+
+@Test function SingleQuotedLongValue()
+   local value = 'the quick brown fox jumps over the lazy dog' -- 43 chars, spans multiple blocks
+   local xml = obj.new('xml', { statement = "<root attr='" .. value .. "'/>" })
+   local err, got = xml.mtGetAttrib(xml.tags[0].id, 'attr')
+   assert(err is ERR_Okay, 'GetAttrib failed for single-quoted value')
+   assert(got is value, 'Single-quoted value mismatch: got "' .. tostring(got) .. '"')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Long text content exercises skipTo('<').  Content longer than one SIMD block with a trailing tag must be captured
+-- in full, and the closing tag correctly located.
+
+@Test function LongContentRun()
+   local content = string.rep('X', 200)
+   local xml = obj.new('xml', { statement = '<root>' .. content .. '</root>' })
+   local children = xml.tags[0].children
+   assert(#children is 1, 'Expected single content node, got ' .. #children)
+   assert(children[0].attribs[0].value is content, 'Long content run not captured exactly')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- skipWhitespace SIMD path: a long whitespace run (> 16 bytes) between attributes must be skipped and both
+-- attributes parsed.  Newlines inside the run must be counted (validated separately below).
+
+@Test function LongWhitespaceRun()
+   local gap = string.rep(' ', 40)
+   local xml = obj.new('xml', { statement = '<root' .. gap .. 'a="1"' .. gap .. 'b="2"/>' })
+   local id = xml.tags[0].id
+   local e1, v1 = xml.mtGetAttrib(id, 'a')
+   local e2, v2 = xml.mtGetAttrib(id, 'b')
+   assert(e1 is ERR_Okay and v1 is '1', 'Attribute a not parsed across long whitespace')
+   assert(e2 is ERR_Okay and v2 is '2', 'Attribute b not parsed across long whitespace')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Line counting across SIMD blocks: the countNewlines() helper must tally every '\n' skipped in bulk.  A malformed
+-- tag placed after a known number of newlines should report the correct line in the error, proving the SIMD scanners
+-- kept the line counter accurate while skipping long runs.  We embed newlines inside a long content run (skipTo('<'))
+-- so the count crosses multiple 16-byte blocks.
+
+@Test function LineCountingAcrossBlocks()
+   -- Each <item> is preceded by a long comment padded with spaces so the newline that ends it is only reached after
+   -- the SIMD scanners have skipped whole 16-byte blocks.  Every item therefore sits on a precisely known line, and
+   -- tag.LineNo must reflect it.  A miscount in countNewlines() (or a scan that overruns a block) would shift these.
+   local parts = { '<root>' } -- source line 1
+   local expected = {}
+   for i = 1, 20 do
+      -- A comment wider than 16 bytes (its own source line), then the item on its own source line.  Comments are
+      -- stripped from the tree but still occupy a source line, so item i lands on source line (2*i + 1).
+      table.insert(parts, '<!-- padding-comment-' .. i .. '-with-extra-width -->')
+      table.insert(parts, '<item n="' .. i .. '"/>')
+      expected[i] = 2 * i + 1
+   end
+   table.insert(parts, '</root>')
+   local doc = table.concat(parts, '\n')
+
+   local xml = obj.new('xml', { statement = doc })
+   assert(xml.tags, 'Document with newline-laden padding should parse')
+
+   local items = xml.tags[0].children
+   local item_index = 0
+   for _, child in ipairs(items) do
+      if child.attribs[0].name is 'item' then
+         item_index = item_index + 1
+         assert(child.lineNo is expected[item_index],
+            'item ' .. item_index .. ' reported line ' .. tostring(child.lineNo) .. ', expected ' .. expected[item_index])
+      end
+   end
+   assert(item_index is 20, 'Expected to inspect 20 items, saw ' .. item_index)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Cross-check: a document parsed identically must yield identical serialised output irrespective of length, which
+-- would break if the SIMD scan over- or under-ran a block boundary.
+
+@Test function SerialisationStableAcrossLengths()
+   for _, len in ipairs({ 14, 16, 18, 34 }) do
+      local content = string.rep('z', len)
+      local xml = obj.new('xml', { statement = '<root><item>' .. content .. '</item></root>' })
+      local err, out = xml.mtSerialise(0, XMF_INCLUDE_SIBLINGS)
+      assert(err is ERR_Okay, 'Serialise failed at length ' .. len)
+      assert(string.find(out, content, 1, true), 'Serialised output missing content at length ' .. len)
+   end
+end

--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -14,11 +14,13 @@
 #include <ankerl/unordered_dense.h>
 
 #include "schema/schema_parser.h"
+#include "../link/simd.h"
 #include <kotuku/modules/xquery.h>
 
 #include <concepts>
 #include <ranges>
 #include <algorithm>
+#include <bit>
 
 // XML entity escape sequences
 constexpr std::string_view xml_entities[] = {
@@ -76,7 +78,36 @@ struct ParseState {
       return cursor.starts_with(str);
    }
 
+#ifdef KOTUKU_SSE42
+   // Count '\n' bytes in the leading Len bytes of Block (Len in 0..16).  Used to keep the line counter accurate as
+   // the SIMD scanners skip over blocks of text in bulk rather than one byte at a time.  The caller passes the
+   // block it has already loaded so the same 16 bytes are not read and compared twice per iteration.
+   static inline int countNewlines(__m128i Block, int Len) {
+      __m128i eq = _mm_cmpeq_epi8(Block, _mm_set1_epi8('\n'));
+      unsigned mask = unsigned(_mm_movemask_epi8(eq)) & ((1u << Len) - 1);
+      return int(std::popcount(mask));
+   }
+#endif
+
    inline void skipTo(char ch, int &line) {
+#ifdef KOTUKU_SSE42
+      // Advance 16 bytes per iteration until 'ch' is located, tallying any newlines that were skipped.  A plain
+      // SSE2 equality compare with a movemask locates the byte; every value (including embedded nulls) is treated
+      // as ordinary data, matching the scalar loop's behaviour.
+      const __m128i needle = _mm_set1_epi8(ch);
+      while (cursor.size() >= 16) {
+         __m128i block = _mm_loadu_si128((const __m128i *)cursor.data());
+         unsigned mask = unsigned(_mm_movemask_epi8(_mm_cmpeq_epi8(block, needle)));
+         if (mask) {
+            int idx = int(std::countr_zero(mask));
+            line += countNewlines(block, idx);
+            next(idx);
+            return;
+         }
+         line += countNewlines(block, 16);
+         next(16);
+      }
+#endif
       while ((not done()) and (current() != ch)) {
          if (current() == '\n') line++;
          next();
@@ -91,6 +122,27 @@ struct ParseState {
    }
 
    inline char skipWhitespace(int &line) {
+#ifdef KOTUKU_SSE42
+      // Find the first byte that is NOT whitespace/control (i.e. > 0x20), 16 bytes at a time.  An SSE2 unsigned
+      // compare is used here rather than a PCMPESTRI range scan because it has unambiguous semantics for every byte
+      // value (including embedded nulls) and no dependence on string-termination behaviour.  Bytes are biased by
+      // 0x80 so the signed _mm_cmpgt_epi8 acts as an unsigned '> 0x20' test.
+      const __m128i bias = _mm_set1_epi8((char)0x80);
+      const __m128i threshold = _mm_set1_epi8((char)(0x20 - 0x80)); // 0x20 biased into signed space
+      while (cursor.size() >= 16) {
+         __m128i block = _mm_loadu_si128((const __m128i *)cursor.data());
+         __m128i gt = _mm_cmpgt_epi8(_mm_sub_epi8(block, bias), threshold); // 0xFF where byte > 0x20
+         unsigned mask = unsigned(_mm_movemask_epi8(gt));
+         if (mask) {
+            int idx = int(std::countr_zero(mask));
+            line += countNewlines(block, idx);
+            next(idx);
+            return current();
+         }
+         line += countNewlines(block, 16);
+         next(16);
+      }
+#endif
       while ((not done()) and (uint8_t(current()) <= 0x20)) {
          if (current() == '\n') line++;
          next();

--- a/src/xml/xml_functions.cpp
+++ b/src/xml/xml_functions.cpp
@@ -453,9 +453,9 @@ static void extract_content(extXML *Self, TAGS &Tags, ParseState &State)
       auto end_ptr = State.cursor.data();
       auto ptr = content.cursor.data();
 
+      // Newlines in this span were already counted by skipTo() above; this loop only strips carriage returns.
       while (ptr < end_ptr) {
          char ch = *ptr++;
-         if (ch == '\n') ++Self->LineNo;
          if (ch != '\r') str.push_back(ch);
       }
 
@@ -707,20 +707,14 @@ static ERR parse_tag(extXML *Self, TAGS &Tags, ParseState &State)
          if (State.current() IS '"') {
             State.next();
             auto value_start = State.cursor.data();
-            while ((not State.done()) and (State.current() != '"')) {
-               if (State.current() IS '\n') Self->LineNo++;
-               State.next();
-            }
+            State.skipTo('"', Self->LineNo); // SSE4.2-accelerated scan to the closing quote
             val.assign(value_start, State.cursor.data() - value_start);
             if (State.current() IS '"') State.next();
          }
          else if (State.current() IS '\'') {
             State.next();
             auto value_start = State.cursor.data();
-            while ((not State.done()) and (State.current() != '\'')) {
-               if (State.current() IS '\n') Self->LineNo++;
-               State.next();
-            }
+            State.skipTo('\'', Self->LineNo);
             val.assign(value_start, State.cursor.data() - value_start);
             if (State.current() IS '\'') State.next();
          }


### PR DESCRIPTION
* Added SSE4.2 ParseState scanners for XML delimiter and whitespace runs while preserving line counts

* [Document] Added SIMD word-boundary scanning for text tokenisation

* [Test] Added Flute coverage for XML SIMD scanner block boundaries and line tracking