### PR TITLE
[Tiri] Resolve thunk argument types for native calls

### DIFF
--- a/src/tiri/jit/src/debug/lj_errmsg.h
+++ b/src/tiri/jit/src/debug/lj_errmsg.h
@@ -161,8 +161,6 @@ ERRDEF(ARREXT,  "Cannot grow external or cached string array")
 // Object errors.
 ERRDEF(OBJFREED, "Object has been freed")
 
-ERRDEF(THUNKEX,  "Thunk threw an exception on resolution")
-
 #undef ERRDEF
 
 /* Detecting unused error messages:

--- a/src/tiri/jit/src/lib/lib.cpp
+++ b/src/tiri/jit/src/lib/lib.cpp
@@ -304,29 +304,19 @@ GCtab * lj_lib_checktab(lua_State *L, int Arg)
 }
 
 //********************************************************************************************************************
-// Helper function to check argument is an object (nil not accepted)
+// Helper function to check argument is an object (nil not accepted).  Throws error unless CanThrow is false
 
-GCobject * lj_lib_checkobject(lua_State *L, int Arg)
+GCobject * lj_lib_checkobject(lua_State *L, int Arg, bool CanThrow)
 {
-   TValue *o = L->base + Arg - 1;
-   if (o < L->top) {
-      if (lj_is_thunk(o)) { // Resolve thunk if present
-         TValue *resolved = lj_thunk_resolve(L, udataV(o));
-         o = L->base + Arg - 1; // Stack may have moved, recalculate o
-         copyTV(L, o, resolved); // Replace thunk with resolved value
-      }
-
-      if (tvisobject(o)) [[likely]] return objectV(o);
-   }
-
-   lj_err_argt(L, Arg, LUA_TOBJECT);
-   return nullptr; // unreachable
+   auto result = lj_lib_optobject(L, Arg, false);
+   if ((not result) and (CanThrow)) lj_err_argt(L, Arg, LUA_TOBJECT);
+   return result;
 }
 
 //********************************************************************************************************************
-// Helper function to check optional object argument (may be nil, but non-objects throw an error)
+// Helper function to check optional object argument (may be nil, but non-objects throw an error unless CanThrow is false)
 
-GCobject * lj_lib_optobject(lua_State *L, int Arg)
+GCobject * lj_lib_optobject(lua_State *L, int Arg, bool CanThrow)
 {
    TValue *o = L->base + Arg - 1;
    if (o < L->top and not tvisnil(o)) {
@@ -337,15 +327,15 @@ GCobject * lj_lib_optobject(lua_State *L, int Arg)
       }
 
       if (tvisobject(o)) return objectV(o);
-      else lj_err_argt(L, Arg, LUA_TOBJECT);
+      else if (CanThrow) lj_err_argt(L, Arg, LUA_TOBJECT);
    }
    return nullptr;
 }
 
 //********************************************************************************************************************
-// Helper function to check argument is an array
+// Helper function to check argument is an array and performs thunk resolution
 
-GCarray * lj_lib_checkarray(lua_State *L, int Arg)
+GCarray * lj_lib_checkarray(lua_State *L, int Arg, bool Required)
 {
    TValue *o = L->base + Arg - 1;
    if (o < L->top) {
@@ -358,8 +348,8 @@ GCarray * lj_lib_checkarray(lua_State *L, int Arg)
       if (tvisarray(o)) [[likely]] return arrayV(o);
    }
 
-   lj_err_argt(L, Arg, LUA_TARRAY);
-   return nullptr;  //  unreachable
+   if (Required) lj_err_argt(L, Arg, LUA_TARRAY);
+   return nullptr;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lib/lib.h
+++ b/src/tiri/jit/src/lib/lib.h
@@ -42,9 +42,9 @@ extern GCtab *     lj_lib_checktab(lua_State *, int);
 extern GCtab *     lj_lib_checktabornil(lua_State *, int);
 extern int         lj_lib_checkopt(lua_State *, int, int def, const char* lst);
 extern GCarray *   lj_lib_optarray(lua_State *L, int);
-extern GCarray *   lj_lib_checkarray(lua_State *, int);
-extern GCobject *  lj_lib_optobject(lua_State *L, int);
-extern GCobject *  lj_lib_checkobject(lua_State *, int);
+extern GCobject *  lj_lib_optobject(lua_State *L, int, bool = true);
+extern GCobject *  lj_lib_checkobject(lua_State *, int, bool = true);
+extern GCarray *   lj_lib_checkarray(lua_State *, int, bool = true);
 
 // Avoid including lj_frame.h.
 #define lj_lib_upvalue(L, n) (&gcval(L->base-2)->fn.c.upvalue[(n)-1])

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -155,12 +155,6 @@ extern TValue * resolve_index(lua_State *L, int idx)
 static cTValue * resolve_index_const(lua_State *L, int idx)
 {
    if (idx <= LUA_REGISTRYINDEX) return index2adr(L, idx);  // Pseudo-indices can't be thunks
-
-   // For positive indices, check if slot exists before attempting resolution
-   if (idx > 0) {
-      TValue *o = L->base + (idx - 1);
-      if (o >= L->top) return niltv(L);  // Slot doesn't exist, return nil
-   }
    return resolve_index(L, idx);
 }
 
@@ -338,6 +332,27 @@ extern void lua_pushvalue(lua_State *L, int idx)
 extern int lua_type(lua_State *L, int idx)
 {
    cTValue* o = index2adr(L, idx);
+   if (tvisnumber(o)) return LUA_TNUMBER;
+   else if (o IS niltv(L)) return LUA_TNONE;
+   else {  // Magic internal/external tag conversion. ORDER LJ_T
+      uint32_t t = ~itype(o);
+      // Lookup table: position 13 = LUA_TARRAY (11)
+      int tt = (int)((U64x(b75a06, 98042110) >> 4 * t) & 15u);
+      lj_assertL(tt != LUA_TNIL or tvisnil(o), "bad tag conversion");
+      return tt;
+   }
+}
+
+//********************************************************************************************************************
+// Get the type, performing thunk resolution first.
+//
+// Note: Resolving the thunk type in advance can be an anti-pattern, normally you shouldn't perform the resolution
+// until you're ready to read the value.
+
+extern int lua_resolved_type(lua_State *L, int idx)
+{
+   cTValue *o = resolve_index_const(L, idx);
+
    if (tvisnumber(o)) return LUA_TNUMBER;
    else if (o IS niltv(L)) return LUA_TNONE;
    else {  // Magic internal/external tag conversion. ORDER LJ_T

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -137,15 +137,18 @@ extern TValue * resolve_index(lua_State *L, int idx)
       // Set flag to prevent infinite recursion
 
       L->resolving_thunk = 1;
-      TValue *result = lj_thunk_resolve(L, ud);
+      TValue *result = lj_thunk_resolve_protected(L, ud);
       L->resolving_thunk = 0;
 
       o = restorestack(L, slot_offset); // Restore slot pointer (stack may have been reallocated)
 
-      // If resolution failed (e.g., error in thunk function), return the original slot
-      // which still contains the thunk userdata - let caller handle the error
+      // If resolution failed (e.g., error in thunk function), propagate the original error now that the
+      // recursion flag has been cleared.  The error value was left just above the restored stack top.
 
-      if (not result) return o;
+      if (not result) {
+         L->top++;
+         lj_err_run(L);
+      }
 
       copyTV(L, o, result); // Copy resolved value to stack slot for consistency
       return o;
@@ -365,6 +368,53 @@ extern int lua_resolved_type(lua_State *L, int idx)
       lj_assertL(tt != LUA_TNIL or tvisnil(o), "bad tag conversion");
       return tt;
    }
+}
+
+//********************************************************************************************************************
+// Resolve any thunks in the positive stack slot range [idx, idx+count-1] in place, without raising Lua errors.
+// Returns 0 on success, otherwise the index of the first slot whose thunk raised an error during resolution.
+// On failure the failing slot is overwritten with the error value (anchoring it against GC), so the caller can
+// retrieve the error message with lua_tostring() on the returned index.
+//
+// Intended for C code that must not be interrupted by a long jump (e.g. RAII scopes); resolving all argument
+// slots up-front means subsequent lua_tostring(), lua_tonumber() etc. calls are plain slot reads.
+
+extern int lua_resolve_thunks(lua_State *L, int idx, int count)
+{
+   if (L->resolving_thunk) return 0;  // Nested resolution is prohibited; downstream reads will skip thunks too
+
+   for (int n = idx; n < idx + count; n++) {
+      TValue *o = L->base + (n - 1);
+      if (o >= L->top) break;  // Remaining slots don't exist
+      if (not lj_is_thunk(o)) continue;
+
+      GCudata *ud = udataV(o);
+      ThunkPayload *payload = thunk_payload(ud);
+
+      if (payload->resolved) {
+         copyTV(L, o, &payload->cached_value);
+         continue;
+      }
+
+      ptrdiff_t slot_offset = savestack(L, o); // Track slot position (may move during resolution)
+
+      L->resolving_thunk = 1;
+      TValue *result = lj_thunk_resolve_protected(L, ud);
+      L->resolving_thunk = 0;
+
+      o = restorestack(L, slot_offset);
+
+      if (not result) {
+         // Anchor the error value (left just above the stack top) in the failing argument slot so that it
+         // remains GC-safe while the caller reports it.
+         copyTV(L, o, L->top);
+         return n;
+      }
+
+      copyTV(L, o, result);
+   }
+
+   return 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -125,9 +125,12 @@ extern TValue * resolve_index(lua_State *L, int idx)
       GCudata *ud = udataV(o);
       ThunkPayload *payload = thunk_payload(ud);
 
-      // If already resolved, just return the cached value pointer
+      // If already resolved, refresh the stack slot so resolved type checks stay consistent with raw slot reads.
 
-      if (payload->resolved) return &payload->cached_value;
+      if (payload->resolved) {
+         copyTV(L, o, &payload->cached_value);
+         return o;
+      }
 
       ptrdiff_t slot_offset = savestack(L, o); // Track slot position (may move during resolution)
 
@@ -152,7 +155,7 @@ extern TValue * resolve_index(lua_State *L, int idx)
 
 // Const variant for read-only access - resolves but returns const pointer
 
-static cTValue * resolve_index_const(lua_State *L, int idx)
+inline cTValue * resolve_index_const(lua_State *L, int idx)
 {
    if (idx <= LUA_REGISTRYINDEX) return index2adr(L, idx);  // Pseudo-indices can't be thunks
    return resolve_index(L, idx);

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -110,6 +110,7 @@ extern int (lua_iscfunction) (lua_State *L, int idx);
 extern int (lua_isuserdata) (lua_State *L, int idx);
 extern int (lua_type) (lua_State *L, int idx);
 extern int lua_resolved_type(lua_State *L, int idx);
+extern int lua_resolve_thunks(lua_State *L, int idx, int count);
 extern const char *(lua_typename) (lua_State *L, int tp);
 
 extern int (lua_equal) (lua_State *L, int idx1, int idx2);

--- a/src/tiri/jit/src/lua.h
+++ b/src/tiri/jit/src/lua.h
@@ -109,6 +109,7 @@ extern int (lua_isstring) (lua_State *L, int idx);
 extern int (lua_iscfunction) (lua_State *L, int idx);
 extern int (lua_isuserdata) (lua_State *L, int idx);
 extern int (lua_type) (lua_State *L, int idx);
+extern int lua_resolved_type(lua_State *L, int idx);
 extern const char *(lua_typename) (lua_State *L, int tp);
 
 extern int (lua_equal) (lua_State *L, int idx1, int idx2);

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -57,7 +57,10 @@ void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type)
 }
 
 //********************************************************************************************************************
-// Resolve a thunk if not already resolved.
+// Resolve a thunk if not already resolved.  This protected variant never raises a Lua error; a nullptr result
+// indicates that the deferred function threw an exception.  In that case the stack is restored to its original
+// state and the error value is left in the unreferenced slot at *L->top - callers wanting to preserve or
+// propagate it must copy or re-push it before performing any further stack operations.
 //
 // IMPORTANT: Callers from VM assembler code (e.g., lj_meta_equal_thunk) must use
 // VMHelperGuard to ensure L->top is valid before calling this function.
@@ -68,7 +71,7 @@ void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type)
 // boundary, which would cause snapshot_framelinks() to fail when it encounters the
 // protected C frame created by lua_pcall.
 
-TValue* lj_thunk_resolve(lua_State *L, GCudata *thunk_udata)
+TValue* lj_thunk_resolve_protected(lua_State *L, GCudata *thunk_udata)
 {
    ThunkPayload *payload = thunk_payload(thunk_udata);
 
@@ -113,9 +116,11 @@ TValue* lj_thunk_resolve(lua_State *L, GCudata *thunk_udata)
    // Restore base in case stack was reallocated
    L->base = restorestack(L, base_offset);
 
-   if (status != 0) { // Error occurred - restore stack and propagate
+   if (status != 0) {
+      // Error occurred - restore the stack and report the failure to the caller.  The error value pushed by
+      // lua_pcall() sits in the slot at the restored L->top, where the caller can retrieve it immediately.
       L->top = restorestack(L, top_offset);
-      lj_err_msg(L, ErrMsg::THUNKEX);
+      return nullptr;
    }
 
    TValue *result = L->top - 1;
@@ -133,6 +138,19 @@ TValue* lj_thunk_resolve(lua_State *L, GCudata *thunk_udata)
    }
 
    return &payload->cached_value;
+}
+
+//********************************************************************************************************************
+// Throwing variant of thunk resolution - propagates the original error if the deferred function fails.
+
+TValue* lj_thunk_resolve(lua_State *L, GCudata *thunk_udata)
+{
+   TValue *result = lj_thunk_resolve_protected(L, thunk_udata);
+   if (not result) {
+      L->top++;  // Re-expose the error value left just above the stack top
+      lj_err_run(L);
+   }
+   return result;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_thunk.h
+++ b/src/tiri/jit/src/runtime/lj_thunk.h
@@ -14,8 +14,12 @@ LJ_FUNC void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type);
 // Resolve a thunk if not already resolved
 // thunk_udata: The thunk userdata (must be UDTYPE_THUNK)
 // Returns: Pointer to resolved value (either cached or newly evaluated)
+// The throwing variant propagates the deferred function's error as a Lua error if it fails.  The protected
+// variant returns nullptr instead, guaranteeing that no long jump occurs; the error value is left in the
+// unreferenced slot at *L->top for the caller to copy or re-push immediately.
 
 LJ_FUNC TValue * lj_thunk_resolve(lua_State *L, GCudata *thunk_udata);
+LJ_FUNC TValue * lj_thunk_resolve_protected(lua_State *L, GCudata *thunk_udata);
 
 // Get the current value of a thunk (resolved value if resolved, thunk itself if not)
 // o: TValue that might be a thunk

--- a/src/tiri/tests/test_thunks.tiri
+++ b/src/tiri/tests/test_thunks.tiri
@@ -500,3 +500,33 @@ end
    assert(r2 is 42, "Second access should return 42")
    assert(r5 is 84, "Multiplication should work with cached value")
 end
+
+----------------------------------------------------------------------------------------------------------------------
+-- A thunk argument that raises an error during native call argument building must surface as a catchable script
+-- exception, and thunk resolution must continue to function afterwards.
+
+@Test function ThunkArgumentException()
+   thunk bad():str
+      error('boom')
+   end
+
+   thunk good():str
+      return 'disasm'
+   end
+
+   script = obj.new('tiri', { statement = 'x = 1' })
+   script.acActivate()
+
+   caught_msg = nil
+   try
+      script.mtDebugLog(bad())
+   except e
+      caught_msg = e.message ?? tostring(e)
+   end
+   assert(caught_msg != nil, 'Expected an exception from the erroring thunk argument')
+   assert(string.find(caught_msg, 'boom') != nil, 'Original thunk error should be propagated, got: ' .. caught_msg)
+
+   -- Resolution must not be left disabled by the earlier failure
+   err = script.mtDebugLog(good())
+   assert(err is 0, 'Post-error thunk argument failed with error ' .. err)
+end

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -728,11 +728,11 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
          j += sizeof(APTR);
       }
       else if (Args[i].Type & FD_INT) {
-         if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
+         if (type IS LUA_TOBJECT) {
             if (auto obj = lj_lib_optobject(Lua, n, false)) {
                ((int *)(ArgBuffer + j))[0] = obj->uid;
             }
-            else return fail_arg(n, "Unable to convert usertype to an integer.");
+            else return fail_arg(n, "Failed to read object type.");
          }
          else if (type IS LUA_TBOOLEAN) {
             auto value = lua_toboolean(Lua, n);
@@ -744,7 +744,10 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
             }
             ((int *)(ArgBuffer + j))[0] = value;
          }
-         else if (type != LUA_TNIL) {
+         else if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
+            return fail_arg(n, "Unable to convert usertype to an integer.");
+         }
+         else if (type != LUA_TNIL) { // Attempt numeric conversion
             auto value = lua_tointeger(Lua, n);
             if ((Args[i].Type & FD_BUFSIZE) and buffer_capacity_known) {
                if (not check_buffer_size_arg(value, buffer_capacity)) {
@@ -757,7 +760,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
          else if (Args[i].Type & (FD_BUFSIZE|FD_ARRAYSIZE)) {
             buffer_capacity_known = false; // Do not alter as the FD_BUFFER support would have managed it
          }
-         else ((int *)(ArgBuffer + j))[0] = 0;
+         else ((int *)(ArgBuffer + j))[0] = 0; // Value is nil
          //log.trace("Arg: %s, Value: %d / $%.8x", Args[i].Name, ((int *)(ArgBuffer + j))[0], ((int *)(ArgBuffer + j))[0]);
          j += sizeof(int);
       }

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -440,6 +440,8 @@ inline bool check_buffer_size_arg(int64_t Size, size_t Capacity)
    return (Size >= 0) and (uint64_t(Size) <= uint64_t(Capacity));
 }
 
+// Long jumps are not permitted (interferes with RAII cleanup)
+
 ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int ArgsSize, int8_t *ArgBuffer,
    int *ResultCount, int &ErrorArg, CSTRING &ErrorMsg)
 {
@@ -524,7 +526,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
          continue;
       }
 
-      int type = (top > 0) ? lua_type(Lua, n) : LUA_TNIL;
+      int type = (top > 0) ? lua_resolved_type(Lua, n) : LUA_TNIL;
 
       //log.trace("Processing arg %s, type $%.8x", Args[i].Name, Args[i].Type);
 
@@ -532,7 +534,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
          j = ALIGN64(j);
          if (type != LUA_TARRAY) return fail_arg(n, "Array required.");
 
-         auto array = lua_toarray(Lua, n);
+         auto array = lua_toarray(Lua, n); // Safe (confirmed array type)
          if (Args[i].Type & FD_CPP) {
             APTR vector = nullptr;
             auto error = copy_cpp_array_arg(Args[i].Type, array, &vector);
@@ -561,7 +563,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
          if (type IS LUA_TARRAY) {
             //log.trace("Arg: %s, Value: Buffer (Source is Memory)", Args[i].Name);
 
-            auto array = lua_toarray(Lua, n);
+            auto array = lua_toarray(Lua, n); // Safe (confirmed array type)
             ((APTR *)(ArgBuffer + j))[0] = array->arraydata();
             j += sizeof(APTR);
 
@@ -647,17 +649,14 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
                j += sizeof(CSTRING);
             }
          }
-         else {
-            return fail_arg(n, "String required.");
-         }
+         else return fail_arg(n, "String required.");
 
          //log.trace("Arg: %s, Value: %s", Args[i].Name, ((STRING *)(ArgBuffer + j))[0]);
-
       }
       else if (Args[i].Type & FD_PTR) {
          j = ALIGN64(j);
          if (Args[i].Type & FD_OBJECT) {
-            if (auto obj_ref = lj_lib_optobject(Lua, n)) {
+            if (auto obj_ref = lj_lib_optobject(Lua, n, false)) { // Performs thunk resolution
                OBJECTPTR ptr_obj;
                if (obj_ref->ptr) {
                   ((OBJECTPTR *)(ArgBuffer + j))[0] = obj_ref->ptr;
@@ -671,7 +670,8 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
                   ((OBJECTPTR *)(ArgBuffer + j))[0] = nullptr;
                }
             }
-            else ((OBJECTPTR *)(ArgBuffer + j))[0] = nullptr;
+            else if (type IS LUA_TNIL) ((OBJECTPTR *)(ArgBuffer + j))[0] = nullptr;
+            else return fail_arg(n, "Object required.");
          }
          else if (Args[i].Type & FD_FUNCTION) {
             if ((type IS LUA_TSTRING) or (type IS LUA_TFUNCTION)) {
@@ -729,7 +729,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
       }
       else if (Args[i].Type & FD_INT) {
          if ((type IS LUA_TUSERDATA) or (type IS LUA_TLIGHTUSERDATA)) {
-            if (auto obj = lj_lib_checkobject(Lua, n)) {
+            if (auto obj = lj_lib_optobject(Lua, n, false)) {
                ((int *)(ArgBuffer + j))[0] = obj->uid;
             }
             else return fail_arg(n, "Unable to convert usertype to an integer.");

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -440,7 +440,8 @@ inline bool check_buffer_size_arg(int64_t Size, size_t Capacity)
    return (Size >= 0) and (uint64_t(Size) <= uint64_t(Capacity));
 }
 
-// Long jumps are not permitted (interferes with RAII cleanup)
+// Long jumps are not permitted (interferes with RAII cleanup).  Thunk arguments are resolved up-front under
+// error protection so that later stack reads can never raise a Lua error mid-function.
 
 ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int ArgsSize, int8_t *ArgBuffer,
    int *ResultCount, int &ErrorArg, CSTRING &ErrorMsg)
@@ -450,6 +451,15 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
    int top = lua_gettop(Lua);
 
    log.traceBranch("%d, %p, Top: %d", ArgsSize, ArgBuffer, top);
+
+   if (top > 0) {
+      if (int failed = lua_resolve_thunks(Lua, 1, top)) {
+         ErrorArg = failed;
+         ErrorMsg = lua_tostring(Lua, failed);  // Error value is anchored in the failed slot
+         if (not ErrorMsg) ErrorMsg = "Exception in thunk argument.";
+         return ERR::Exception;
+      }
+   }
 
    clearmem(ArgBuffer, ArgsSize);
 


### PR DESCRIPTION
* Added a thunk-resolving type query that preserves pseudo-index handling
* Made object and array argument helpers support non-throwing validation
* Converted object argument building to return structured type errors instead of long-jumping