### PR TITLE
[Vector] Renamed morph path support to guide paths

### DIFF
--- a/docs/xml/modules/classes/vector.xml
+++ b/docs/xml/modules/classes/vector.xml
@@ -310,7 +310,7 @@
     <field>
       <name>AppendPath</name>
       <comment>Experimental.  Append the path of the referenced vector during path generation.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>OBJECTPTR</type>
       <description>
 <p>The path of a vector object can be appended to another vector in real-time by making a reference to the former vector here.  The operation is completed immediately after the generation of the client vector's base path, prior to any transforms.</p>
@@ -459,6 +459,26 @@
     </field>
 
     <field>
+      <name>GuideFlags</name>
+      <comment>Optional flags that affect <fl>GuidePath</fl>.</comment>
+      <access read="R" write="S">Read/Set</access>
+      <type lookup="VMF">VMF</type>
+      <description>
+<types lookup="VMF"/>
+      </description>
+    </field>
+
+    <field>
+      <name>GuidePath</name>
+      <comment>Transform the vector to follow a target path specified here.</comment>
+      <access read="R" write="S">Read/Set</access>
+      <type>OBJECTPTR</type>
+      <description>
+<p>Setting the GuidePath to reference a path-generating vector will result in the source following the target path when rendered.  This works particularly well for text and shapes that follow a lengthy path.</p>
+      </description>
+    </field>
+
+    <field>
       <name>InnerJoin</name>
       <comment>Adjusts the handling of thickly stroked paths that cross back at the join.</comment>
       <access read="R" write="S">Read/Set</access>
@@ -506,7 +526,7 @@
     <field>
       <name>Mask</name>
       <comment>Reference a VectorClip object here to apply a clipping mask to the rendered vector.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>OBJECTPTR</type>
       <description>
 <p>A mask can be applied to a vector by setting the Mask field with a reference to a <class name="VectorClip">VectorClip</class> object.  Please refer to the <class name="VectorClip">VectorClip</class> class for further information.</p>
@@ -533,27 +553,6 @@
 <p>When two line segments meet at a sharp angle and miter joins have been specified in <fl>LineJoin</fl>, it is possible for the miter to extend far beyond the thickness of the line stroking the path. The MiterLimit imposes a limit on the ratio of the miter length to the <fl>StrokeWidth</fl>. When the limit is exceeded, the join is converted from a miter to a bevel.</p>
 <p>The ratio of miter length (distance between the outer tip and the inner corner of the miter) to <fl>StrokeWidth</fl> is directly related to the angle (theta) between the segments in user space by the formula: <code>MiterLength / StrokeWidth = 1 / sin ( theta / 2 )</code>.</p>
 <p>For example, a miter limit of 1.414 converts miters to bevels for theta less than 90 degrees, a limit of 4.0 converts them for theta less than approximately 29 degrees, and a limit of 10.0 converts them for theta less than approximately 11.5 degrees.</p>
-      </description>
-    </field>
-
-    <field>
-      <name>Morph</name>
-      <comment>Enables morphing of the vector to a target path.</comment>
-      <access read="G" write="S">Get/Set</access>
-      <type>OBJECTPTR</type>
-      <description>
-<p>If the Morph field is set to a Vector object that generates a path, the vector will be morphed to follow the target vector's path shape.  This works particularly well for text and shapes that follow a horizontal path that is much wider than it is tall.</p>
-<p>Squat shapes will fare poorly if morphed, so experimentation may be necessary to understand how the morph feature is best utilised.</p>
-      </description>
-    </field>
-
-    <field>
-      <name>MorphFlags</name>
-      <comment>Optional flags that affect morphing.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type lookup="VMF">VMF</type>
-      <description>
-<types lookup="VMF"/>
       </description>
     </field>
 
@@ -733,7 +732,7 @@ Z: Close Path
     <field>
       <name>Transition</name>
       <comment>Reference a VectorTransition object here to apply multiple transforms over the vector's path.</comment>
-      <access read="G" write="S">Get/Set</access>
+      <access read="R" write="S">Read/Set</access>
       <type>OBJECTPTR</type>
       <description>
 <p>A transition can be applied by setting this field with a reference to a <class name="VectorTransition">VectorTransition</class> object.  Please refer to the <class name="VectorTransition">VectorTransition</class> class for further information.</p>
@@ -867,7 +866,7 @@ Z: Close Path
       <const name="ROUND">The join is rounded.</const>
     </constants>
 
-    <constants lookup="VMF" comment="Morph flags">
+    <constants lookup="VMF" comment="Guide path flags">
       <const name="AUTO_SPACING">Applicable when used on <class name="VectorText">VectorText</class>, auto-spacing allows the spacing between glyphs to be shrunk or expanded along the target path so that they can produce a better fit.  The default is for the glyphs to conform to their original spacing requirements.</const>
       <const name="STRETCH">Applicable when used on <class name="VectorText">VectorText</class>, the stretch option converts glyph outlines into paths, and then all end points and control points will be adjusted to be along the perpendicular vectors from the path, thereby stretching and possibly warping the glyphs.  With this approach, connected glyphs, such as in cursive scripts, will maintain their connections.</const>
       <const name="X_MAX">Align the source so that it is morphed along the right of the target path.</const>

--- a/docs/xml/modules/classes/vectortext.xml
+++ b/docs/xml/modules/classes/vectortext.xml
@@ -13,7 +13,7 @@
     <category>Graphics</category>
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
-<p>To create text along a path, set the <class name="Vector" field="Morph">Vector.Morph</class> field with a reference to any <class name="Vector">Vector</class> object that generates a path.  The following extract illustrates the SVG equivalent of this feature:</p>
+<p>To create text along a path, set the <class name="Vector" field="GuidePath">Vector.GuidePath</class> field with a reference to any <class name="Vector">Vector</class> object that generates a path.  The following extract illustrates the SVG equivalent of this feature:</p>
 <pre>&lt;defs&gt;
   &lt;path id=&quot;myTextPath2&quot; d=&quot;M75,20 l100,0 l100,30 q0,100 150,100&quot;/&gt;
 &lt;/defs&gt;

--- a/docs/xml/modules/classes/vectortransition.xml
+++ b/docs/xml/modules/classes/vectortransition.xml
@@ -27,7 +27,7 @@
   &lt;rect fill=&quot;#ffffff&quot; width=&quot;100%&quot; height=&quot;100%&quot;/&gt;
   &lt;text x=&quot;3&quot; y=&quot;80&quot; font-size=&quot;19.6&quot; fill=&quot;navy&quot; transition=&quot;url(#hill)&quot;&gt;This text is morphed by a transition&lt;/text&gt;
 </pre>
-<p>Transitions are most effective when used in conjunction with the morph feature in the <class name="Vector">Vector</class> class.</p></description>
+<p>Transitions are most effective when used in conjunction with the <class name="Vector" field="GuidePath">Vector.GuidePath</class> feature.</p></description>
     <source>
       <file path="transformers/">transition.cpp</file>
     </source>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -314,7 +314,7 @@ enum class VTXF : uint32_t {
 
 DEFINE_ENUM_FLAG_OPERATORS(VTXF)
 
-// Morph flags
+// Guide path flags
 
 enum class VMF : uint32_t {
    NIL = 0,
@@ -4063,32 +4063,32 @@ class objVector : public Object {
    }
 
    inline ERR getFillRule(VFR &Value) noexcept {
-      Value = *((VFR *)(((int8_t *)this) + 336));
+      Value = *((VFR *)(((int8_t *)this) + 368));
       return ERR::Okay;
    }
 
    inline ERR getClipRule(VFR &Value) noexcept {
-      Value = *((VFR *)(((int8_t *)this) + 340));
+      Value = *((VFR *)(((int8_t *)this) + 372));
       return ERR::Okay;
    }
 
-   inline ERR getMorphFlags(VMF &Value) noexcept {
-      Value = *((VMF *)(((int8_t *)this) + 356));
+   inline ERR getGuideFlags(VMF &Value) noexcept {
+      Value = *((VMF *)(((int8_t *)this) + 388));
       return ERR::Okay;
    }
 
    inline ERR getLineJoin(VLJ &Value) noexcept {
-      Value = *((VLJ *)(((int8_t *)this) + 344));
+      Value = *((VLJ *)(((int8_t *)this) + 376));
       return ERR::Okay;
    }
 
    inline ERR getLineCap(VLC &Value) noexcept {
-      Value = *((VLC *)(((int8_t *)this) + 348));
+      Value = *((VLC *)(((int8_t *)this) + 380));
       return ERR::Okay;
    }
 
    inline ERR getInnerJoin(VIJ &Value) noexcept {
-      Value = *((VIJ *)(((int8_t *)this) + 352));
+      Value = *((VIJ *)(((int8_t *)this) + 384));
       return ERR::Okay;
    }
 
@@ -4112,6 +4112,26 @@ class objVector : public Object {
       return ERR::Okay;
    }
 
+   inline ERR getGuidePath(OBJECTPTR &Value) noexcept {
+      Value = *((OBJECTPTR *)(((int8_t *)this) + 336));
+      return ERR::Okay;
+   }
+
+   inline ERR getTransition(OBJECTPTR &Value) noexcept {
+      Value = *((OBJECTPTR *)(((int8_t *)this) + 344));
+      return ERR::Okay;
+   }
+
+   inline ERR getMask(OBJECTPTR &Value) noexcept {
+      Value = *((OBJECTPTR *)(((int8_t *)this) + 352));
+      return ERR::Okay;
+   }
+
+   inline ERR getAppendPath(OBJECTPTR &Value) noexcept {
+      Value = *((OBJECTPTR *)(((int8_t *)this) + 360));
+      return ERR::Okay;
+   }
+
    inline ERR getDashArray(std::span<double> &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
       auto get_field = (ERR (*)(APTR, std::span<double> &))field->GetValue;
@@ -4126,23 +4146,8 @@ class objVector : public Object {
       return error;
    }
 
-   inline ERR getMask(OBJECTPTR &Value) noexcept {
-      auto field = &this->Class->Dictionary[29];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getMorph(OBJECTPTR &Value) noexcept {
-      auto field = &this->Class->Dictionary[31];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getAppendPath(OBJECTPTR &Value) noexcept {
-      auto field = &this->Class->Dictionary[40];
-      return field->GetValue(this, &Value);
-   }
-
    inline ERR getSequence(std::string &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
+      auto field = &this->Class->Dictionary[16];
       SetObjectContext(this, field, AC::NIL);
       std::string_view view;
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
@@ -4156,17 +4161,12 @@ class objVector : public Object {
    }
 
    inline ERR getStrokeWidth(Unit &Value) noexcept {
-      auto field = &this->Class->Dictionary[22];
-      return field->GetValue(this, &Value);
-   }
-
-   inline ERR getTransition(OBJECTPTR &Value) noexcept {
-      auto field = &this->Class->Dictionary[38];
+      auto field = &this->Class->Dictionary[21];
       return field->GetValue(this, &Value);
    }
 
    inline ERR getTabOrder(int &Value) noexcept {
-      auto field = &this->Class->Dictionary[39];
+      auto field = &this->Class->Dictionary[38];
       return field->GetValue(this, &Value);
    }
 
@@ -4174,7 +4174,7 @@ class objVector : public Object {
    // Customised field setting
 
    inline ERR setNext(objVector * Value) noexcept {
-      auto field = &this->Class->Dictionary[25];
+      auto field = &this->Class->Dictionary[24];
       return field->WriteValue(this, field, 0x08000301, Value);
    }
 
@@ -4189,17 +4189,17 @@ class objVector : public Object {
    }
 
    inline ERR setFillOpacity(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[34];
-      return field->WriteValue(this, field, FD_DOUBLE, &Value);
-   }
-
-   inline ERR setOpacity(const double Value) noexcept {
       auto field = &this->Class->Dictionary[32];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
+   inline ERR setOpacity(const double Value) noexcept {
+      auto field = &this->Class->Dictionary[30];
+      return field->WriteValue(this, field, FD_DOUBLE, &Value);
+   }
+
    inline ERR setMiterLimit(const double Value) noexcept {
-      auto field = &this->Class->Dictionary[19];
+      auto field = &this->Class->Dictionary[18];
       return field->WriteValue(this, field, FD_DOUBLE, &Value);
    }
 
@@ -4214,7 +4214,7 @@ class objVector : public Object {
    }
 
    inline ERR setVisibility(const VIS Value) noexcept {
-      auto field = &this->Class->Dictionary[26];
+      auto field = &this->Class->Dictionary[25];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -4250,7 +4250,7 @@ class objVector : public Object {
    }
 
    inline ERR setFillRule(const VFR Value) noexcept {
-      auto field = &this->Class->Dictionary[24];
+      auto field = &this->Class->Dictionary[23];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -4259,18 +4259,18 @@ class objVector : public Object {
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
-   inline ERR setMorphFlags(const VMF Value) noexcept {
-      auto field = &this->Class->Dictionary[15];
+   inline ERR setGuideFlags(const VMF Value) noexcept {
+      auto field = &this->Class->Dictionary[36];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setLineJoin(const VLJ Value) noexcept {
-      auto field = &this->Class->Dictionary[30];
+      auto field = &this->Class->Dictionary[29];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
    inline ERR setLineCap(const VLC Value) noexcept {
-      auto field = &this->Class->Dictionary[21];
+      auto field = &this->Class->Dictionary[20];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -4295,8 +4295,28 @@ class objVector : public Object {
    }
 
    inline ERR setSID(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[20];
+      auto field = &this->Class->Dictionary[19];
       return field->WriteValue(this, field, 0x00804300, &Value);
+   }
+
+   inline ERR setGuidePath(OBJECTPTR Value) noexcept {
+      auto field = &this->Class->Dictionary[40];
+      return field->WriteValue(this, field, 0x08000301, Value);
+   }
+
+   inline ERR setTransition(OBJECTPTR Value) noexcept {
+      auto field = &this->Class->Dictionary[37];
+      return field->WriteValue(this, field, 0x08000301, Value);
+   }
+
+   inline ERR setMask(OBJECTPTR Value) noexcept {
+      auto field = &this->Class->Dictionary[28];
+      return field->WriteValue(this, field, 0x08000301, Value);
+   }
+
+   inline ERR setAppendPath(OBJECTPTR Value) noexcept {
+      auto field = &this->Class->Dictionary[39];
+      return field->WriteValue(this, field, 0x08000301, Value);
    }
 
    inline ERR setDashArray(std::span<const double> Value) noexcept {
@@ -4304,38 +4324,18 @@ class objVector : public Object {
       return field->WriteValue(this, field, 0x80101308, &Value);
    }
 
-   inline ERR setMask(OBJECTPTR Value) noexcept {
-      auto field = &this->Class->Dictionary[29];
-      return field->WriteValue(this, field, 0x08100309, Value);
-   }
-
-   inline ERR setMorph(OBJECTPTR Value) noexcept {
-      auto field = &this->Class->Dictionary[31];
-      return field->WriteValue(this, field, 0x08100309, Value);
-   }
-
-   inline ERR setAppendPath(OBJECTPTR Value) noexcept {
-      auto field = &this->Class->Dictionary[40];
-      return field->WriteValue(this, field, 0x08100309, Value);
-   }
-
    inline ERR setResizeEvent(const FUNCTION Value) noexcept {
-      auto field = &this->Class->Dictionary[18];
+      auto field = &this->Class->Dictionary[17];
       return field->WriteValue(this, field, FD_FUNCTION, &Value);
    }
 
    inline ERR setStrokeWidth(const Unit Value) noexcept {
-      auto field = &this->Class->Dictionary[22];
+      auto field = &this->Class->Dictionary[21];
       return field->WriteValue(this, field, FD_UNIT, &Value);
    }
 
-   inline ERR setTransition(OBJECTPTR Value) noexcept {
-      auto field = &this->Class->Dictionary[38];
-      return field->WriteValue(this, field, 0x08100309, Value);
-   }
-
    inline ERR setTabOrder(const int Value) noexcept {
-      auto field = &this->Class->Dictionary[39];
+      auto field = &this->Class->Dictionary[38];
       return field->WriteValue(this, field, FD_INT, &Value);
    }
 
@@ -4409,7 +4409,7 @@ class objVectorPath : public objVector {
    }
 
    inline ERR getSequence(std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
+      auto field = &this->Class->Dictionary[16];
       SetObjectContext(this, field, AC::NIL);
       auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
       auto error = get_field(this, Value);
@@ -4446,7 +4446,7 @@ class objVectorPath : public objVector {
    }
 
    inline ERR setSequence(const std::string_view &Value) noexcept {
-      auto field = &this->Class->Dictionary[17];
+      auto field = &this->Class->Dictionary[16];
       return field->WriteValue(this, field, 0x00804308, &Value);
    }
 

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -316,7 +316,7 @@ void svgState::process_shape_children(XTag &Tag, OBJECTPTR Vector) noexcept
          case SVF_animateTransform: proc_animate_transform(child, Vector); break;
          case SVF_animateMotion:    proc_animate_motion(child, Vector); break;
          case SVF_set:              proc_set(child, Tag, Vector); break;
-         case SVF_kotuku_morph:    proc_morph(child, Vector); break;
+         case SVF_kotuku_guidePath: proc_guide_path(child, Vector); break;
 
          case SVF_textPath:
             if (Vector->classID() IS CLASSID::VECTORTEXT) {
@@ -329,7 +329,7 @@ void svgState::process_shape_children(XTag &Tag, OBJECTPTR Vector) noexcept
                   else log.msg("Failed to retrieve content for <text> @ line %d", Tag.LineNo);
                }
 
-               proc_morph(child, Vector);
+               proc_guide_path(child, Vector);
             }
             break;
 
@@ -2421,16 +2421,16 @@ void svgState::proc_symbol(XTag &Tag) noexcept
 //********************************************************************************************************************
 // Most vector shapes can be morphed to the path of another vector.
 
-void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
+void svgState::proc_guide_path(XTag &Tag, OBJECTPTR Parent) noexcept
 {
    kt::Log log(__FUNCTION__);
 
    if ((!Parent) or (Parent->Class->BaseClassID != CLASSID::VECTOR)) {
-      log.traceWarning("Unable to apply morph to non-vector parent object.");
+      log.traceWarning("Unable to apply guidePath to non-vector parent object.");
       return;
    }
 
-   // Find the definition that is being referenced for the morph.
+   // Find the definition that is being referenced for the guide path.
 
    std::string offset;
    std::string ref;
@@ -2462,7 +2462,7 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
    }
 
    if (ref.empty()) {
-      log.warning("<morph> element @ line %d is missing a valid xlink:href attribute.", Tag.LineNo);
+      log.warning("<guidePath> element @ line %d is missing a valid xlink:href attribute.", Tag.LineNo);
       return;
    }
 
@@ -2501,7 +2501,7 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
       case SVF_kotuku_wave:   class_id = CLASSID::VECTORWAVE; break;
       case SVF_kotuku_shape:  class_id = CLASSID::VECTORSHAPE; break;
       default:
-         log.warning("Invalid reference '%s', '%s' is not recognised by <morph>.", ref.c_str(), tagref->name());
+         log.warning("Invalid reference '%s', '%s' is not recognised by <guidePath>.", ref.c_str(), tagref->name());
    }
 
    if ((flags & (VMF::Y_MIN|VMF::Y_MID|VMF::Y_MAX)) IS VMF::NIL) {
@@ -2514,9 +2514,9 @@ void svgState::proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept
       svgState state(Self);
       state.proc_shape(class_id, *tagref, Self->Scene, shape);
       auto parent_vector = (objVector *)Parent;
-      parent_vector->setMorph(shape);
+      parent_vector->setGuidePath(shape);
       if (transvector) parent_vector->setTransition(transvector);
-      parent_vector->setMorphFlags(flags);
+      parent_vector->setGuideFlags(flags);
       if (!Self->Cloning) Self->Scene->addDef(uri, shape);
    }
 }
@@ -3707,8 +3707,8 @@ ERR svgState::set_property(objVector *Vector, uint32_t Hash, XTag &Tag, const st
             case SVF_textLength: vt->setTextLength(SVGUnit(StrValue)); return ERR::Okay;
             // TextPath only
             //case SVF_startOffset: vt->set(FID_StartOffset, StrValue); return ERR::Okay;
-            //case SVF_method: // The default is align.  For 'stretch' mode, set VMF::STRETCH in MorphFlags
-            //                      vt->set(FID_MorphFlags, StrValue); return ERR::Okay;
+            //case SVF_method:      // The default is align.  For 'stretch' mode, set VMF::STRETCH in GuideFlags
+            //                      vt->set(FID_GuideFlags, StrValue); return ERR::Okay;
             //case SVF_spacing:     vt->set(FID_Spacing, StrValue); return ERR::Okay;
             //case SVF_xlink_href:  // Used for drawing text along a path.
             //   return ERR::Okay;

--- a/src/svg/save_svg.cpp
+++ b/src/svg/save_svg.cpp
@@ -744,36 +744,36 @@ static ERR save_svg_scan_std(extSVG *Self, objXML *XML, objVector *Vector, int T
       }
    }
 
-   OBJECTPTR morph_obj;
-   if ((!error) and (!Vector->getMorph(morph_obj)) and (morph_obj)) {
-      auto shape = (objVector *)morph_obj;
-      VMF morph_flags;
-      XTag *morph_tag;
-      error = XML->insertStatement(TagID, XMI::CHILD_END, "<kotuku:morph/>", &morph_tag);
+   OBJECTPTR guide_obj;
+   if ((!error) and (!Vector->getGuidePath(guide_obj)) and (guide_obj)) {
+      auto shape = (objVector *)guide_obj;
+      VMF guide_flags;
+      XTag *guide_tag;
+      error = XML->insertStatement(TagID, XMI::CHILD_END, "<kotuku:guidePath/>", &guide_tag);
 
       std::string_view shape_id;
       if ((!error) and (!shape->getSID(shape_id)) and not shape_id.empty()) {
          // NB: It is required that the shape has previously been registered as a definition, otherwise the url will refer to a dud tag.
          auto shape_ref = std::format("url(#{})", shape_id);
-         xml::NewAttrib(morph_tag, "xlink:href", shape_ref);
+         xml::NewAttrib(guide_tag, "xlink:href", shape_ref);
       }
 
-      if (!error) error = Vector->getMorphFlags(morph_flags);
+      if (!error) error = Vector->getGuideFlags(guide_flags);
 
-      if ((!error) and ((morph_flags & VMF::STRETCH) != VMF::NIL)) xml::NewAttrib(morph_tag, "method", "stretch");
-      if ((!error) and ((morph_flags & VMF::AUTO_SPACING) != VMF::NIL)) xml::NewAttrib(morph_tag, "spacing", "auto");
+      if ((!error) and ((guide_flags & VMF::STRETCH) != VMF::NIL)) xml::NewAttrib(guide_tag, "method", "stretch");
+      if ((!error) and ((guide_flags & VMF::AUTO_SPACING) != VMF::NIL)) xml::NewAttrib(guide_tag, "spacing", "auto");
 
-      if ((!error) and ((morph_flags & (VMF::X_MIN|VMF::X_MID|VMF::X_MAX|VMF::Y_MIN|VMF::Y_MID|VMF::Y_MAX)) != VMF::NIL)) {
+      if ((!error) and ((guide_flags & (VMF::X_MIN|VMF::X_MID|VMF::X_MAX|VMF::Y_MIN|VMF::Y_MID|VMF::Y_MAX)) != VMF::NIL)) {
          std::string align;
-         if ((morph_flags & VMF::X_MIN) != VMF::NIL) align = "xMin ";
-         else if ((morph_flags & VMF::X_MID) != VMF::NIL) align = "xMid ";
-         else if ((morph_flags & VMF::X_MAX) != VMF::NIL) align = "xMax ";
+         if ((guide_flags & VMF::X_MIN) != VMF::NIL) align = "xMin ";
+         else if ((guide_flags & VMF::X_MID) != VMF::NIL) align = "xMid ";
+         else if ((guide_flags & VMF::X_MAX) != VMF::NIL) align = "xMax ";
 
-         if ((morph_flags & VMF::Y_MIN) != VMF::NIL) align += "yMin";
-         else if ((morph_flags & VMF::Y_MID) != VMF::NIL) align += "yMid";
-         else if ((morph_flags & VMF::Y_MAX) != VMF::NIL) align += "yMax";
+         if ((guide_flags & VMF::Y_MIN) != VMF::NIL) align += "yMin";
+         else if ((guide_flags & VMF::Y_MID) != VMF::NIL) align += "yMid";
+         else if ((guide_flags & VMF::Y_MAX) != VMF::NIL) align += "yMax";
 
-         xml::NewAttrib(morph_tag, "align", align);
+         xml::NewAttrib(guide_tag, "align", align);
       }
 
       OBJECTPTR tv;

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -192,7 +192,7 @@ private:
    void proc_switch(XTag &, OBJECTPTR, objVector * &) noexcept;
    void proc_use(XTag &, OBJECTPTR) noexcept;
    void proc_clippath(XTag &) noexcept;
-   void proc_morph(XTag &Tag, OBJECTPTR Parent) noexcept;
+   void proc_guide_path(XTag &Tag, OBJECTPTR Parent) noexcept;
    ERR  proc_style(XTag &);
    void proc_symbol(XTag &Tag) noexcept;
    ERR  proc_conicgradient(const XTag &) noexcept;
@@ -418,7 +418,7 @@ static constexpr auto SVF_kerning             = strhash("kerning");
 static constexpr auto SVF_keyPoints           = strhash("keyPoints");
 static constexpr auto SVF_keySplines          = strhash("keySplines");
 static constexpr auto SVF_keyTimes            = strhash("keyTimes");
-static constexpr auto SVF_kotuku_morph        = strhash("kotuku:morph");
+static constexpr auto SVF_kotuku_guidePath    = strhash("kotuku:guidePath");
 static constexpr auto SVF_kotuku_pathTransition = strhash("kotuku:pathTransition");
 static constexpr auto SVF_kotuku_shape        = strhash("kotuku:shape");
 static constexpr auto SVF_kotuku_spiral       = strhash("kotuku:spiral");
@@ -620,7 +620,7 @@ static constexpr auto SVF_yChannelSelector = strhash("yChannelSelector");
 static constexpr auto SVF_yOffset          = strhash("yOffset");
 static constexpr auto SVF_z                = strhash("z");
 static constexpr auto SVF_zoomAndPan       = strhash("zoomAndPan");
-static constexpr auto SVF_morph            = strhash("morph");
+static constexpr auto SVF_guidePath        = strhash("guidePath");
 static constexpr auto SVF_pathTransition   = strhash("pathTransition");
 static constexpr auto SVF_shape            = strhash("shape");
 static constexpr auto SVF_wave             = strhash("wave");
@@ -683,7 +683,7 @@ static uint32_t svg_tag_hash(const XTag &Tag) noexcept
 
    if ((Tag.NamespaceID IS glKotukuNamespace) or (Tag.NamespaceID IS glKotukuSVGNamespace)) {
       switch (strhash(svg_local_name(Tag))) {
-         case SVF_morph:          return SVF_kotuku_morph;
+         case SVF_guidePath:      return SVF_kotuku_guidePath;
          case SVF_pathTransition: return SVF_kotuku_pathTransition;
          case SVF_shape:          return SVF_kotuku_shape;
          case SVF_spiral:         return SVF_kotuku_spiral;

--- a/src/svg/tests/paths/guidepath.svg
+++ b/src/svg/tests/paths/guidepath.svg
@@ -47,13 +47,13 @@
       <kotuku:spiral offset="30" loop-limit="3" step="0.1" cx="330" cy="280" fill="none" stroke-width="1" stroke="turquoise" opacity="0.2"/>
 
       <text x="330" y="280" font-size="20" fill="navy" font-family="Utopia">
-        <textPath xlink:href="#spiral" transition="url(#swirl)">This text is warped to fit a kotuku:spiral element.  You can morph text to fit any element that generates a shape, not just SVG path elements.  Transitions can also be used to scale and skew the path, as seen here.</textPath>
+        <textPath xlink:href="#spiral" transition="url(#swirl)">This text is warped to fit a kotuku:spiral element.  You can warp text to fit any element that generates a shape, not just SVG path elements.  Transitions can also be used to scale and skew the path, as seen here.</textPath>
       </text>
 
       <text x="10" y="350" font-size="20" fill="navy"></text>
 
       <kotuku:wave length="800" amplitude="15" frequency="50" stroke="red" stroke-width="1" fill="none" transition="url(#scale-and-skew)">
-        <kotuku:morph xlink:href="url(#wavespiral)" align="xMin yMid"/>
+        <kotuku:guidePath xlink:href="url(#wavespiral)" align="xMin yMid"/>
       </kotuku:wave>
     </g>
 

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -98,7 +98,7 @@ end
 @Test(name='CaseSensitiveNames') global function BasicsCaseSensitiveNames() hashTestSVG('basics/case-sensitive.svg', 0x61fc4322) end
 
 @Test global function Circles()         hashTestSVG('paths/circles.svg', 0xd91a717f) end
-@Test global function Morph()           hashTestSVG('paths/morph.svg', 0x22c9112b) end
+@Test global function GuidePath()       hashTestSVG('paths/guidepath.svg', 0x45b2e26a) end
 @Test global function EllipseVertices() hashTestSVG('paths/ellipse_vertices.svg', 0xa0a8e2df) end
 @Test global function Polygons()        hashTestSVG('paths/polygons.svg', 0x6e755c7b) end
 @Test global function Rough()           hashTestSVG('paths/rough_js.svg', 0xdb8d9130) end

--- a/src/vector/paths.cpp
+++ b/src/vector/paths.cpp
@@ -248,23 +248,23 @@ void gen_vector_path(extVector *Vector)
             }
          }
 
-         if ((Vector->Morph) and (Vector->Morph->Class->BaseClassID IS CLASSID::VECTOR)) {
-            if ((Vector->classID() IS CLASSID::VECTORTEXT) and ((Vector->MorphFlags & VMF::STRETCH) IS VMF::NIL)) {
-               // Do nothing for VectorText because it applies morph and transition effects during base path generation.
+         if ((Vector->GuidePath) and (Vector->GuidePath->Class->BaseClassID IS CLASSID::VECTOR)) {
+            if ((Vector->classID() IS CLASSID::VECTORTEXT) and ((Vector->GuideFlags & VMF::STRETCH) IS VMF::NIL)) {
+               // Do nothing for VectorText because it applies guidepath and transition effects during base path generation.
             }
             else {
-               auto morph = (extVector *)Vector->Morph;
+               auto guide = (extVector *)Vector->GuidePath;
 
-               if (morph->dirty()) gen_vector_path(morph);
+               if (guide->dirty()) gen_vector_path(guide);
 
-               if (morph->BasePath.total_vertices()) {
+               if (guide->BasePath.total_vertices()) {
                   double bx1, bx2, by1, by2;
 
-                  if ((Vector->MorphFlags & VMF::Y_MID) != VMF::NIL) {
+                  if ((Vector->GuideFlags & VMF::Y_MID) != VMF::NIL) {
                      bounding_rect_single(Vector->BasePath, 0, &bx1, &by1, &bx2, &by2);
                      Vector->BasePath.translate(0, -by1 - ((by2 - by1) * 0.5));
                   }
-                  else if ((Vector->MorphFlags & VMF::Y_MIN) != VMF::NIL) {
+                  else if ((Vector->GuideFlags & VMF::Y_MIN) != VMF::NIL) {
                      if (Vector->classID() != CLASSID::VECTORTEXT) {
                         bounding_rect_single(Vector->BasePath, 0, &bx1, &by1, &bx2, &by2);
                         Vector->BasePath.translate(0, -by1 -(by2 - by1));
@@ -278,11 +278,11 @@ void gen_vector_path(extVector *Vector)
                   }
 
                   agg::trans_single_path trans_path;
-                  morph->BasePath.approximation_scale(Vector->Transform.scale());
-                  trans_path.add_path(morph->BasePath);
+                  guide->BasePath.approximation_scale(Vector->Transform.scale());
+                  trans_path.add_path(guide->BasePath);
                   trans_path.preserve_x_scale(true); // The default is true.  Switching to false produces a lot of scrunching and extending
-                  if (morph->classID() IS CLASSID::VECTORPATH) { // Enforcing a fixed length along the path effectively causes a resize.
-                     if (((extVectorPath *)morph)->PathLength > 0) trans_path.base_length(((extVectorPath *)morph)->PathLength);
+                  if (guide->classID() IS CLASSID::VECTORPATH) { // Enforcing a fixed length along the path effectively causes a resize.
+                     if (((extVectorPath *)guide)->PathLength > 0) trans_path.base_length(((extVectorPath *)guide)->PathLength);
                   }
 
                   Vector->BasePath.transform(trans_path); // Apply manipulation to the base path.

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -1227,7 +1227,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
 
             if (not mView) {
                // Vector shapes not inside a viewport cannot be drawn (they may exist as definitions for other objects,
-               // e.g. as morph paths).
+               // e.g. as guide paths).
                return;
             }
 

--- a/src/vector/transformers/transition.cpp
+++ b/src/vector/transformers/transition.cpp
@@ -25,7 +25,7 @@ The following example illustrates the use of a transition in SVG:
   &lt;text x="3" y="80" font-size="19.6" fill="navy" transition="url(#hill)"&gt;This text is morphed by a transition&lt;/text&gt;
 </pre>
 
-Transitions are most effective when used in conjunction with the morph feature in the @Vector class.
+Transitions are most effective when used in conjunction with the @Vector.GuidePath feature.
 
 -END-
 

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -750,12 +750,16 @@ class extVector : public objVector {
    std::string FillString;
    std::string FilterString;
    std::string SID;
+   extVector           *GuidePath;
+   extVectorTransition *Transition;
+   extVectorClip       *ClipMask;
+   extVector           *AppendPath;
    VFR FillRule;
    VFR ClipRule;
    VLJ LineJoin;
    VLC LineCap;
    VIJ InnerJoin;
-   VMF MorphFlags;
+   VMF GuideFlags;
 
    extPainter Fill[2], Stroke;
    double FinalX, FinalY;         // Used by Viewport to define the target X,Y; also VectorText to position the text' final position.
@@ -772,10 +776,6 @@ class extVector : public objVector {
    std::unique_ptr<std::vector<KeyboardSubscription>> KeyboardSubscriptions;
    extVectorFilter     *Filter;
    extVectorViewport   *ParentView;
-   extVectorClip       *ClipMask;
-   extVectorTransition *Transition;
-   extVector           *Morph;
-   extVector           *AppendPath;
    std::unique_ptr<DashedStroke> DashArray;
    std::unique_ptr<ClipMaskCache> ClipCache;
    std::unique_ptr<filter_bitmap> IsolatedBuffer;

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -164,7 +164,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     "SECRET: Hide all characters from the UI by using generic symbols in place of glyphs.",
     "RASTER: Rasterise glyphs to a texture cache for very fast rendering.  This feature is not compatible with scalable graphics conventions.")
 
-  flags("VMF", { comment="Morph flags" },
+  flags("VMF", { comment="Guide path flags" },
     "STRETCH: Applicable when used on @VectorText, the stretch option converts glyph outlines into paths, and then all end points and control points will be adjusted to be along the perpendicular vectors from the path, thereby stretching and possibly warping the glyphs.  With this approach, connected glyphs, such as in cursive scripts, will maintain their connections.",
     "AUTO_SPACING: Applicable when used on @VectorText, auto-spacing allows the spacing between glyphs to be shrunk or expanded along the target path so that they can produce a better fit.  The default is for the glyphs to conform to their original spacing requirements.",
     "X_MIN: Align the source so that it is morphed along the left of the target path.",
@@ -767,7 +767,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     ~struct(FRGB) FillColour
     ~int(VFR) FillRule
     ~int(VFR) ClipRule
-    ~int(VMF) MorphFlags
+    ~int(VMF) GuideFlags
     ~int(VLJ) LineJoin
     ~int(VLC) LineCap
     ~int(VIJ) InnerJoin

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -3,7 +3,7 @@
 -CLASS-
 VectorText: Extends the Vector class with support for generating text.
 
-To create text along a path, set the @Vector.Morph field with a reference to any @Vector object that generates a path.  The
+To create text along a path, set the @Vector.GuidePath field with a reference to any @Vector object that generates a path.  The
 following extract illustrates the SVG equivalent of this feature:
 
 <pre>
@@ -48,7 +48,7 @@ textPath warping could be more accurate if the character angles were calculated 
 rather than the bottom left corner.  However, this would be more computationally intensive and only useful in situations
 where large glyphs were oriented around sharp corners.  The process would look something like this:
 
-+ Compute the (x,y) of the character's middle vertex in context of the morph path.
++ Compute the (x,y) of the character's middle vertex in context of the guide path.
 + Compute the angle from the middle vertex to the first vertex (start_x, start_y)
 + Compute the angle from the middle vertex to the last vertex (end_x, end_y)
 + Interpolate the two angles
@@ -1937,7 +1937,7 @@ void TextCursor::reset_vector(extVectorText *Vector) const
          // If the cursor X,Y lies outside of the parent viewport, offset the text so that it remains visible to
          // the user.
 
-         if ((not Vector->Morph) and (Vector->ParentView)) {
+         if ((not Vector->GuidePath) and (Vector->ParentView)) {
             auto p_width = Vector->ParentView->vpFixedWidth;
             double xo = 0;
             const double CURSOR_MARGIN = Vector->txFontSize * 0.5;

--- a/src/vector/vectors/text_path.cpp
+++ b/src/vector/vectors/text_path.cpp
@@ -205,26 +205,26 @@ static void generate_text(extVectorText *Vector, agg::path_storage &Path)
       return;
    }
 
-   auto morph = Vector->Morph;
+   auto guide = Vector->GuidePath;
    double start_x, start_y, end_vx, end_vy;
    double path_scale = 1.0;
-   if (morph) {
-      if ((Vector->MorphFlags & VMF::STRETCH) != VMF::NIL) {
+   if (guide) {
+      if ((Vector->GuideFlags & VMF::STRETCH) != VMF::NIL) {
          // In stretch mode, the standard morphing algorithm is used (see gen_vector_path())
-         morph = nullptr;
+         guide = nullptr;
       }
       else {
-         if (morph->dirty()) gen_vector_path(morph); // Regenerate the target path if necessary
+         if (guide->dirty()) gen_vector_path(guide); // Regenerate the target path if necessary
 
-         if (!morph->BasePath.total_vertices()) morph = nullptr;
+         if (!guide->BasePath.total_vertices()) guide = nullptr;
          else {
-            morph->BasePath.rewind(0);
-            morph->BasePath.vertex(0, &start_x, &start_y);
+            guide->BasePath.rewind(0);
+            guide->BasePath.vertex(0, &start_x, &start_y);
             end_vx = start_x;
             end_vy = start_y;
-            if (morph->PathLength > 0) {
-               path_scale = morph->PathLength / agg::path_length(morph->BasePath);
-               morph->BasePath.rewind(0);
+            if (guide->PathLength > 0) {
+               path_scale = guide->PathLength / agg::path_length(guide->BasePath);
+               guide->BasePath.rewind(0);
             }
          }
       }
@@ -259,7 +259,7 @@ static void generate_text(extVectorText *Vector, agg::path_storage &Path)
       FT_Set_Char_Size(pt.font->face, 0, dbl_to_int26p6(Vector->txFontSize), 72, 72);
    }
 
-   if (morph) {
+   if (guide) {
       // The scale_char transform is applied to each character to ensure that it is scaled to the path correctly.
 
       agg::trans_affine scale_char;
@@ -308,7 +308,7 @@ static void generate_text(extVectorText *Vector, agg::path_storage &Path)
             if (char_width > dist) {
                while (cmd != agg::path_cmd_stop) {
                   double current_x, current_y;
-                  cmd = morph->BasePath.vertex(&current_x, &current_y);
+                  cmd = guide->BasePath.vertex(&current_x, &current_y);
                   if (agg::is_vertex(cmd)) {
                      const double x = (current_x - end_vx), y = (current_y - end_vy);
                      const double vertex_dist = sqrt((x * x) + (y * y));
@@ -329,7 +329,7 @@ static void generate_text(extVectorText *Vector, agg::path_storage &Path)
 
             double tx = start_x, ty = start_y;
 
-            if (cmd != agg::path_cmd_stop) { // Advance (start_x,start_y) to the next point on the morph path.
+            if (cmd != agg::path_cmd_stop) { // Advance (start_x,start_y) to the next point on the guide path.
                angle = std::atan2(end_vy - start_y, end_vx - start_x);
 
                double x = end_vx - start_x, y = end_vy - start_y;

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -159,7 +159,7 @@ static void notify_free_transition(OBJECTPTR Object, ACTIONID ActionID, ERR Resu
 static void notify_free_morph(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 {
    auto Self = (extVector *)CurrentContext();
-   if ((Self->Morph) and (Object->UID IS Self->Morph->UID)) Self->Morph = nullptr;
+   if ((Self->GuidePath) and (Object->UID IS Self->GuidePath->UID)) Self->GuidePath = nullptr;
 }
 
 static void notify_free_clipmask(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
@@ -1033,12 +1033,6 @@ Note: Appended paths are not compliant with SVG and this feature is considered e
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_AppendPath(extVector *Self, extVector **Value)
-{
-   *Value = Self->AppendPath;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_AppendPath(extVector *Self, extVector *Value)
 {
    kt::Log log;
@@ -1538,12 +1532,6 @@ refer to the @VectorClip class for further information.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Mask(extVector *Self, extVectorClip **Value)
-{
-   *Value = Self->ClipMask;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_Mask(extVector *Self, extVectorClip *Value)
 {
    kt::Log log;
@@ -1610,39 +1598,26 @@ static ERR VECTOR_SET_MiterLimit(extVector *Self, double Value)
 
 /*********************************************************************************************************************
 -FIELD-
-Morph: Enables morphing of the vector to a target path.
+GuidePath: Transform the vector to follow a target path specified here.
 
-If the Morph field is set to a Vector object that generates a path, the vector will be morphed to follow the target
-vector's path shape.  This works particularly well for text and shapes that follow a horizontal path that is much wider
-than it is tall.
-
-Squat shapes will fare poorly if morphed, so experimentation may be necessary to understand how the morph feature is
-best utilised.
+Setting the GuidePath to reference a path-generating vector will result in the source following the target path when
+rendered.  This works particularly well for text and shapes that follow a lengthy path.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Morph(extVector *Self, extVector **Value)
-{
-   *Value = Self->Morph;
-   return ERR::Okay;
-}
-
-static ERR VECTOR_SET_Morph(extVector *Self, extVector *Value)
+static ERR VECTOR_SET_GuidePath(extVector *Self, extVector *Value)
 {
    kt::Log log;
 
-   if (!Value) {
-      if (Self->Morph) {
-         UnsubscribeAction(Self->Morph, AC::Free);
-         Self->Morph = nullptr;
-      }
+   if (not Value) {
+      if (Self->GuidePath) { UnsubscribeAction(Self->GuidePath, AC::Free); Self->GuidePath = nullptr; }
       return ERR::Okay;
    }
    else if (Value->Class->BaseClassID IS CLASSID::VECTOR) {
-      if (Self->Morph) UnsubscribeAction(Self->Morph, AC::Free);
+      if (Self->GuidePath) UnsubscribeAction(Self->GuidePath, AC::Free);
       if (Value->initialised()) { // The object must be initialised.
          SubscribeAction(Value, AC::Free, C_FUNCTION(notify_free_morph));
-         Self->Morph = Value;
+         Self->GuidePath = Value;
          mark_buffers_for_refresh(Self);
          return ERR::Okay;
       }
@@ -1654,15 +1629,15 @@ static ERR VECTOR_SET_Morph(extVector *Self, extVector *Value)
 /*********************************************************************************************************************
 
 -FIELD-
-MorphFlags: Optional flags that affect morphing.
+GuideFlags: Optional flags that affect #GuidePath.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_SET_MorphFlags(extVector *Self, VMF Value)
+static ERR VECTOR_SET_GuideFlags(extVector *Self, VMF Value)
 {
-    Self->MorphFlags = Value;
-    mark_buffers_for_refresh(Self);
-    return ERR::Okay;
+   Self->GuideFlags = Value;
+   mark_buffers_for_refresh(Self);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -1688,7 +1663,7 @@ static ERR VECTOR_SET_Next(extVector *Self, extVector *Value)
 {
    kt::Log log;
 
-   if ((!Value) or (Value IS Self)) return log.warning(ERR::InvalidValue);
+   if ((not Value) or (Value IS Self)) return log.warning(ERR::InvalidValue);
    if (Value->Class->BaseClassID != CLASSID::VECTOR) return log.warning(ERR::InvalidObject);
    if (Self->Owner != Value->Owner) return log.warning(ERR::UnsupportedOwner); // Owners must match
    if ((Self->Next IS Value) and (Value->Prev IS Self)) return ERR::Okay;
@@ -1788,7 +1763,7 @@ static ERR VECTOR_SET_Prev(extVector *Self, extVector *Value)
 {
    kt::Log log;
 
-   if ((!Value) or (Value IS Self)) return log.warning(ERR::InvalidValue);
+   if ((not Value) or (Value IS Self)) return log.warning(ERR::InvalidValue);
    if (Value->Class->BaseClassID != CLASSID::VECTOR) return log.warning(ERR::InvalidObject);
    if (Self->Owner != Value->Owner) return log.warning(ERR::UnsupportedOwner); // Owners must match
    if ((Self->Prev IS Value) and (Value->Next IS Self)) return ERR::Okay;
@@ -2145,17 +2120,11 @@ and @VectorWave are able to take full advantage of this feature.
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Transition(extVector *Self, extVectorTransition **Value)
-{
-   *Value = Self->Transition;
-   return ERR::Okay;
-}
-
 static ERR VECTOR_SET_Transition(extVector *Self, extVectorTransition *Value)
 {
    kt::Log log;
 
-   if (!Value) {
+   if (not Value) {
       if (Self->Transition) {
          UnsubscribeAction(Self->Transition, AC::Free);
          Self->Transition = nullptr;
@@ -2246,7 +2215,7 @@ extVector::~extVector() {
 
    if (ClipMask)   UnsubscribeAction(ClipMask, AC::Free);
    if (Transition) UnsubscribeAction(Transition, AC::Free);
-   if (Morph)      UnsubscribeAction(Morph, AC::Free);
+   if (GuidePath)  UnsubscribeAction(GuidePath, AC::Free);
    if (AppendPath) UnsubscribeAction(AppendPath, AC::Free);
 
    // Patch the nearest vectors that are linked to this one.
@@ -2336,23 +2305,23 @@ static const FieldArray clVectorFields[] = {
    { "Fill",         FDF_CPPSTRING|FDF_RW, nullptr, VECTOR_SET_Fill },
    { "Filter",       FDF_CPPSTRING|FDF_RW, nullptr, VECTOR_SET_Filter },
    { "SID",          FDF_CPPSTRING|FDF_RW },
+   { "GuidePath",    FDF_OBJECT|FDF_RW, nullptr, VECTOR_SET_GuidePath },
+   { "Transition",   FDF_OBJECT|FDF_RW, nullptr, VECTOR_SET_Transition },
+   { "Mask",         FDF_OBJECT|FDF_RW, nullptr, VECTOR_SET_Mask },
+   { "AppendPath",   FDF_OBJECT|FDF_RW, nullptr, VECTOR_SET_AppendPath },
    { "FillRule",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, VECTOR_SET_FillRule, &clVectorVFR },
    { "ClipRule",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, VECTOR_SET_ClipRule, &clVectorVFR },
    { "LineJoin",     FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_LineJoin, &clVectorVLJ },
    { "LineCap",      FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_LineCap, &clVectorVLC },
    { "InnerJoin",    FD_INT|FD_LOOKUP|FDF_RW,   nullptr, VECTOR_SET_InnerJoin, &clVectorVIJ },
-   { "MorphFlags",   FDF_INTFLAGS|FDF_RW,       nullptr, VECTOR_SET_MorphFlags, &clVectorVMF },
+   { "GuideFlags",   FDF_INTFLAGS|FDF_RW,       nullptr, VECTOR_SET_GuideFlags, &clVectorVMF },
    // Virtual fields
    { "DashArray",    FDF_VIRTUAL|FDF_ARRAY|FDF_DOUBLE|FD_RW|FDF_PURE, VECTOR_GET_DashArray, VECTOR_SET_DashArray },
    { "DisplayScale", FDF_VIRTUAL|FDF_DOUBLE|FDF_R,              VECTOR_GET_DisplayScale },
-   { "Mask",         FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Mask, VECTOR_SET_Mask },
-   { "Morph",        FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Morph, VECTOR_SET_Morph },
-   { "AppendPath",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_AppendPath, VECTOR_SET_AppendPath },
    { "ResizeEvent",  FDF_VIRTUAL|FDF_FUNCTION|FDF_W,            nullptr, VECTOR_SET_ResizeEvent },
    { "Sequence",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTOR_GET_Sequence },
    { "StrokeColour", FDF_VIRTUAL|FDF_STRUCT|FD_RW|FDF_PURE,     VECTOR_GET_StrokeColour, VECTOR_SET_StrokeColour, "FRGB" },
    { "StrokeWidth",  FDF_VIRTUAL|FDF_UNIT|FDF_RW|FDF_PURE,      VECTOR_GET_StrokeWidth, VECTOR_SET_StrokeWidth },
-   { "Transition",   FDF_VIRTUAL|FDF_OBJECT|FDF_RW|FDF_PURE,    VECTOR_GET_Transition, VECTOR_SET_Transition },
    { "FillColour",   FDF_VIRTUAL|FDF_STRUCT|FDF_RW|FDF_PURE,    VECTOR_GET_FillColour, VECTOR_SET_FillColour, "FRGB" },
    { "TabOrder",     FDF_VIRTUAL|FD_INT|FD_RW|FDF_PURE,         VECTOR_GET_TabOrder, VECTOR_SET_TabOrder },
    END_FIELD


### PR DESCRIPTION
* Replaced the Vector Morph and MorphFlags API with GuidePath and GuideFlags
* [SVG] Updated Kotuku SVG parsing, saving and fixture coverage for kotuku:guidePath
* [Doc] Regenerated vector API documentation and public vector header references