### PR TITLE
[Core] Made action subscriptions tolerate freed subscribers

### DIFF
--- a/docs/xml/modules/core.xml
+++ b/docs/xml/modules/core.xml
@@ -1842,7 +1842,7 @@ if (not OpenDir(path, RDF::FILE|RDF::FOLDER, &amp;info)) {
 }
 </pre>
 <p>The <code>Object</code> is the original subscription target, as-is the Action ID.  The Result is the error code that was generated at the end of the action call.  If this is not set to <code>ERR::Okay</code>, assume that the action did not have an effect on state.  The <code>Parameters</code> are the original arguments provided by the client - be aware that these can legitimately be <code>NULL</code> even if an action specifies a required parameter structure.  Notice that because subscriptions are context sensitive, <function>CurrentContext</function> can be used to get a reference to the object that initiated the subscription.</p>
-<p>To terminate an action subscription, use the <function>UnsubscribeAction</function> function.  Subscriptions are not resource tracked, so it is critical to match the original call with an unsubscription.</p>
+<p>To terminate an action subscription, use the <function>UnsubscribeAction</function> function.  Matching each subscription with an unsubscription remains good practice because it releases the subscription record immediately.  If a subscriber is freed without unsubscribing, the record degrades safely: the subscriber's object header is weakly pinned for the lifetime of the record, dispatch recognises the freed subscriber and skips the callback, and the stale record is swept once the notification pass completes.  Until that sweep occurs, the subscriber's header remains allocated in zombie form.</p>
     </description>
     <result type="ERR">
       <error code="Okay">Operation successful.</error>
@@ -1960,6 +1960,7 @@ if (not OpenDir(path, RDF::FILE|RDF::FOLDER, &amp;info)) {
     <description>
 <p>The UnsubscribeAction() function will terminate subscriptions made by <function>SubscribeAction</function>.  The removal of subscriptions is context sensitive, so the context of the original <function>SubscribeAction</function> call must be matched by UnsubscribeAction().</p>
 <p>To terminate multiple subscriptions in a single call, set the <code>Action</code> parameter to zero.</p>
+<p>Unsubscribing releases the subscription record (and the weak pin it holds on the subscriber) immediately.  A subscriber that is freed without unsubscribing is tolerated - its remaining records are swept lazily the next time each subscribed action is dispatched - but explicit unsubscription remains the recommended practice.</p>
     </description>
     <result type="ERR">
       <error code="Okay">Operation successful.</error>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -2304,6 +2304,6 @@ inline CSTRING Object::className() { return Class->ClassName.c_str(); }
 // Weak-pin management for callback holders (refer to the zombie object contract in objects.h).  A pinned
 // Context header remains readable after termination, allowing stale() to be tested lazily at invoke time.
 
-inline void FUNCTION::pin() { if (Context) Context->pinWeak(); }
-inline void FUNCTION::unpin() { if (Context) Context->unpinWeak(); }
-inline bool FUNCTION::stale() const { return defined() and (Context) and (Context->terminating()); }
+inline void FUNCTION::pin() { Context->pinWeak(); }
+inline void FUNCTION::unpin() { Context->unpinWeak(); }
+inline bool FUNCTION::stale() const { return defined() and (Context->terminating()); }

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -193,13 +193,13 @@ struct alignas(8) Object { // Must be 64-bit aligned
    APTR     CreatorMeta;         // The creator of the object is permitted to store a custom data pointer here.
    struct Object *Owner;         // The owner of this object
    std::atomic_uint64_t NotifyFlags; // Action subscription flags - space for 64 actions max
-   int8_t   ActionDepth;         // Debug builds only: Incremented each time an action or method is called on the object
-   std::atomic_char Queue;       // Counter of locks attained by LockObject(); decremented by ReleaseObject(); not stable by design (see lock())
-   std::atomic_char SleepQueue;  // For the use of LockObject() only
-   std::atomic<uint16_t> RefCount; // Packed pin counters: low byte strong pins, high byte weak pins.  NB: This is not a locking mechanism!
+   std::atomic<uint32_t> RefCount; // Packed pin counters: low byte strong pins, upper 24 bits weak pins.  NB: This is not a locking mechanism!
    OBJECTID UID;                 // Unique object identifier
    std::atomic<uint32_t> Flags;  // Object NF flags
    std::atomic_int ThreadID;     // Managed by locking functions.  Atomic due to volatility.
+   int8_t   ActionDepth;         // Debug builds only: Incremented each time an action or method is called on the object
+   std::atomic_char Queue;       // Counter of locks attained by LockObject(); decremented by ReleaseObject(); not stable by design (see lock())
+   std::atomic_char SleepQueue;  // For the use of LockObject() only
    char Name[MAX_NAME_LEN];      // The name of the object.  NOTE: This value can be adjusted to ensure that the struct is always 8-bit aligned.
 
    Object(objMetaClass *ClassPtr, OBJECTID ObjectID) noexcept :
@@ -208,13 +208,13 @@ struct alignas(8) Object { // Must be 64-bit aligned
       CreatorMeta(nullptr),
       Owner(nullptr),
       NotifyFlags(0),
-      ActionDepth(0),
-      Queue(0),
-      SleepQueue(0),
       RefCount(0),
       UID(ObjectID),
       Flags(0),
       ThreadID(0),
+      ActionDepth(0),
+      Queue(0),
+      SleepQueue(0),
       Name("") { }
 
    Object() = delete;
@@ -229,7 +229,7 @@ struct alignas(8) Object { // Must be 64-bit aligned
    inline void setFlag(NF pFlag) { Flags.fetch_or(uint32_t(pFlag), std::memory_order_relaxed); }
    inline void clearFlag(NF pFlag) { Flags.fetch_and(~uint32_t(pFlag), std::memory_order_relaxed); }
 
-   // Two tiers of pinning are packed into RefCount: the low byte counts strong pins and the high byte counts weak
+   // Two tiers of pinning are packed into RefCount: the low byte counts strong pins and the upper 24 bits count weak
    // pins.  Both tiers keep the object's header block allocated after termination (zombie mode) until every pin is
    // released; only the header fields Flags and RefCount remain valid at that point, and pin holders may only test
    // NF::FREE and unpin.  Placement objects cannot be pinned because the Core does not own their memory block.
@@ -241,8 +241,8 @@ struct alignas(8) Object { // Must be 64-bit aligned
    // Weak pins - pinWeak()/unpinWeak() - never impede termination and exist purely for stale-reference detection,
    // e.g. callback subscriptions.  A weak pin on an ancestor cannot deadlock its destruction.
 
-   static constexpr uint16_t STRONG_PINS = 0x0001; // RefCount increment per strong pin
-   static constexpr uint16_t WEAK_PINS   = 0x0100; // RefCount increment per weak pin
+   static constexpr uint32_t STRONG_PINS = 0x00000001; // RefCount increment per strong pin
+   static constexpr uint32_t WEAK_PINS   = 0x00000100; // RefCount increment per weak pin
 
    inline void pin() {
       #ifndef NDEBUG
@@ -263,7 +263,7 @@ struct alignas(8) Object { // Must be 64-bit aligned
       // Saturate at zero; a plain load-check-decrement would allow two racing threads to underflow the counter.
       auto ref_count = RefCount.load(std::memory_order_relaxed);
       while ((ref_count & 0xff) > 0) {
-         if (RefCount.compare_exchange_weak(ref_count, uint16_t(ref_count - STRONG_PINS), std::memory_order_acq_rel,
+         if (RefCount.compare_exchange_weak(ref_count, ref_count - STRONG_PINS, std::memory_order_acq_rel,
                std::memory_order_relaxed)) {
             if ((ref_count IS STRONG_PINS) and defined(NF::ZOMBIE)) {
                ReleaseZombie(this);
@@ -288,7 +288,7 @@ struct alignas(8) Object { // Must be 64-bit aligned
          kt::Log("pinWeak").warning("Pinning placement object #%d (%s) is unsupported.", UID, className());
          DEBUG_BREAK
       }
-      if ((ref_count >> 8) >= 254) {
+      if ((ref_count >> 8) >= 0xfffffe) {
          kt::Log("pinWeak").warning("Weak pin overflow risk for object #%d (%s), count: %d", UID, className(), ref_count >> 8);
          DEBUG_BREAK
       }
@@ -300,7 +300,7 @@ struct alignas(8) Object { // Must be 64-bit aligned
       // Saturate at zero on the weak byte; see unpin() for rationale.
       auto ref_count = RefCount.load(std::memory_order_relaxed);
       while ((ref_count >> 8) > 0) {
-         if (RefCount.compare_exchange_weak(ref_count, uint16_t(ref_count - WEAK_PINS), std::memory_order_acq_rel,
+         if (RefCount.compare_exchange_weak(ref_count, ref_count - WEAK_PINS, std::memory_order_acq_rel,
                std::memory_order_relaxed)) {
             if ((ref_count IS WEAK_PINS) and defined(NF::ZOMBIE)) ReleaseZombie(this);
             return;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -238,6 +238,7 @@ flute_test (core_compression "tests/test_compression.tiri")
 flute_test (core_config "tests/test_config.tiri")
 flute_test (core_messages "tests/test_messages.tiri")
 flute_test (core_time "tests/test_time.tiri")
+flute_test (core_subscriber_lifetimes "tests/test_subscriber_lifetimes.tiri")
 
 if (INSTALL_TESTS)
    # Windows-compatible tests

--- a/src/core/compression/compression_fields.cpp
+++ b/src/core/compression/compression_fields.cpp
@@ -73,7 +73,7 @@ static ERR SET_Feedback(extCompression *Self, FUNCTION *Value)
    if (Self->Feedback.defined()) Self->Feedback.unpin();
    if (Value) {
       Self->Feedback = *Value;
-      Self->Feedback.pin();
+      if (Self->Feedback.defined()) Self->Feedback.pin();
    }
    else Self->Feedback.clear();
    return ERR::Okay;

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -341,14 +341,44 @@ using OBJECTLOOKUP = ankerl::unordered_dense::map<uint32_t, std::vector<Object *
 using ACTION_CALLBACK = void (*)(OBJECTPTR, ACTIONID, ERR, APTR, APTR);
 
 struct ActionSubscription {
-   OBJECTPTR Subscriber; // The object that initiated the subscription
+   OBJECTPTR Subscriber;  // The object that initiated the subscription; weakly pinned for the record's lifetime
    OBJECTID SubscriberID; // Required for sanity checks on subscriber still existing.
    FUNCTION Callback;
+   bool Stale;            // Marked at dispatch time if the subscriber has been freed; swept lazily afterwards
 
-   ActionSubscription() : Subscriber(nullptr), SubscriberID(0), Callback() { }
+   // Each record owns a weak pin on its subscriber so that the header remains readable after termination
+   // (zombie mode), allowing dispatch to test NF::FREE lazily instead of dereferencing freed memory.  Records
+   // are move-only because they live by value in vectors; a moved-from record surrenders pin ownership so
+   // that reallocation and erasure cannot double-unpin.
+
+   ActionSubscription() : Subscriber(nullptr), SubscriberID(0), Callback(), Stale(false) { }
 
    ActionSubscription(OBJECTPTR pContext, FUNCTION pCallback) :
-      Subscriber(pContext), SubscriberID(pContext->UID), Callback(pCallback) { }
+      Subscriber(pContext), SubscriberID(pContext->UID), Callback(pCallback), Stale(false) {
+      Subscriber->pinWeak();
+   }
+
+   ~ActionSubscription() { if (Subscriber) Subscriber->unpinWeak(); }
+
+   ActionSubscription(ActionSubscription &&Other) noexcept :
+      Subscriber(Other.Subscriber), SubscriberID(Other.SubscriberID), Callback(Other.Callback), Stale(Other.Stale) {
+      Other.Subscriber = nullptr;
+   }
+
+   ActionSubscription & operator=(ActionSubscription &&Other) noexcept {
+      if (this != &Other) {
+         if (Subscriber) Subscriber->unpinWeak();
+         Subscriber   = Other.Subscriber;
+         SubscriberID = Other.SubscriberID;
+         Callback     = Other.Callback;
+         Stale        = Other.Stale;
+         Other.Subscriber = nullptr;
+      }
+      return *this;
+   }
+
+   ActionSubscription(const ActionSubscription &) = delete;
+   ActionSubscription & operator=(const ActionSubscription &) = delete;
 };
 
 struct virtual_drive {

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -100,11 +100,13 @@ struct subscription {
 struct unsubscription {
    OBJECTID ObjectID;
    ACTIONID ActionID;
+   OBJECTID SubscriberID; // The context current at the time of the deferred call; the drain runs under a different context.
    FUNCTION Callback;
    bool Filtered;
 
-   unsubscription(OBJECTID pObject, ACTIONID pAction, FUNCTION *pCallback) :
-      ObjectID(pObject), ActionID(pAction), Callback(pCallback ? *pCallback : FUNCTION{}), Filtered(pCallback) { }
+   unsubscription(OBJECTID pObject, ACTIONID pAction, FUNCTION *pCallback, OBJECTID pSubscriber) :
+      ObjectID(pObject), ActionID(pAction), SubscriberID(pSubscriber),
+      Callback(pCallback ? *pCallback : FUNCTION{}), Filtered(pCallback) { }
 };
 
 static std::recursive_mutex glSubLock; // Guards glSubscriptions; same-thread delayed queues are thread-local.
@@ -118,6 +120,29 @@ static ankerl::unordered_dense::set<OBJECTPTR> glZombies;
 constexpr uint64_t notify_bit(ACTIONID Id) { return 1ULL << (int(Id) & 63); }
 
 static void free_children(OBJECTPTR Object);
+static void unsubscribe_from_object(OBJECTPTR Object, ACTIONID ActionID, OBJECTID Subscriber, FUNCTION *Callback);
+
+//********************************************************************************************************************
+// Erases subscription records that dispatch marked as stale (subscriber freed without unsubscribing).  Record
+// destruction releases the weak pin, which may in turn release the subscriber's zombie header.  The caller must
+// hold glSubLock and glSubReadOnly must have returned to zero.
+
+static void sweep_stale_subscriptions(OBJECTPTR Object, ACTIONID ActionID)
+{
+   auto obj_it = glSubscriptions.find(Object->UID);
+   if (obj_it IS glSubscriptions.end()) return;
+
+   auto action_it = obj_it->second.find(int(ActionID));
+   if (action_it IS obj_it->second.end()) return;
+
+   std::erase_if(action_it->second, [](const ActionSubscription &Sub) { return Sub.Stale; });
+
+   if (action_it->second.empty()) {
+      Object->NotifyFlags.fetch_and(~notify_bit(ActionID), std::memory_order::relaxed);
+      obj_it->second.erase(action_it);
+      if (obj_it->second.empty()) glSubscriptions.erase(obj_it);
+   }
+}
 
 //********************************************************************************************************************
 // Applies subscription changes that were queued while glSubscriptions was in a read-only state.  The caller must
@@ -127,7 +152,12 @@ static void drain_delayed_subscriptions(OBJECTPTR Object)
 {
    if (not glDelayedSubscribe.empty()) { // Check if SubscribeAction() was called during the notification process
       for (auto &entry : glDelayedSubscribe) {
-         glSubscriptions[entry.ObjectID][int(entry.ActionID)].emplace_back(entry.Callback.Context, entry.Callback);
+         // The queue holds a weak pin on the subscriber context, so staleness can be tested safely here.  A
+         // context freed between queueing and the drain is dropped instead of being registered.
+         if (not entry.Callback.stale()) {
+            glSubscriptions[entry.ObjectID][int(entry.ActionID)].emplace_back(entry.Callback.Context, entry.Callback);
+         }
+         entry.Callback.unpin();
       }
       glDelayedSubscribe.clear();
    }
@@ -135,11 +165,11 @@ static void drain_delayed_subscriptions(OBJECTPTR Object)
    if (not glDelayedUnsubscribe.empty()) {
       for (auto &entry : glDelayedUnsubscribe) {
          auto callback = entry.Filtered ? &entry.Callback : nullptr;
-         if (Object->UID IS entry.ObjectID) UnsubscribeAction(Object, entry.ActionID, callback);
+         if (Object->UID IS entry.ObjectID) unsubscribe_from_object(Object, entry.ActionID, entry.SubscriberID, callback);
          else {
             OBJECTPTR obj;
             if (!AccessObject(entry.ObjectID, 3000, &obj)) {
-               UnsubscribeAction(obj, entry.ActionID, callback);
+               unsubscribe_from_object(obj, entry.ActionID, entry.SubscriberID, callback);
                ReleaseObject(obj);
             }
          }
@@ -907,10 +937,17 @@ ERR Action(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters)
       std::lock_guard<std::recursive_mutex> lock(glSubLock);
 
       glSubReadOnly++;
+      bool stale_found = false;
 
       if (auto it = glSubscriptions.find(Object->UID); it != glSubscriptions.end()) {
          if (it->second.contains(int(ActionID))) {
             for (auto &list : it->second[int(ActionID)]) {
+               if ((not list.Subscriber) or (list.Subscriber->terminating())) {
+                  // The subscriber was freed without unsubscribing; mark the record for the lazy sweep.
+                  list.Stale = true;
+                  stale_found = true;
+                  continue;
+               }
                #ifndef NDEBUG
                // Locked subscribers can sometimes warrant investigation
                if ((int(ActionID) > 0) and list.Subscriber->locked()) {
@@ -927,7 +964,10 @@ ERR Action(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters)
 
       glSubReadOnly--;
 
-      if (not glSubReadOnly) drain_delayed_subscriptions(Object);
+      if (not glSubReadOnly) {
+         if (stale_found) sweep_stale_subscriptions(Object, ActionID);
+         drain_delayed_subscriptions(Object);
+      }
    }
 
 #ifndef NDEBUG
@@ -2281,8 +2321,14 @@ void NotifySubscribers(OBJECTPTR Object, ACTIONID ActionID, APTR Parameters, ERR
 
    if ((object_it != glSubscriptions.end()) and (action_it != object_it->second.end()) and (not action_it->second.empty())) {
       glSubReadOnly++; // Prevents changes to glSubscriptions while we're processing it.
+      bool stale_found = false;
       for (auto &sub : action_it->second) {
-         if (sub.Subscriber) {
+         if ((not sub.Subscriber) or (sub.Subscriber->terminating())) {
+            // The subscriber was freed without unsubscribing; mark the record for the lazy sweep.
+            sub.Stale = true;
+            stale_found = true;
+         }
+         else {
             kt::SwitchContext ctx(sub.Subscriber);
             auto callback = (ACTION_CALLBACK)sub.Callback.Routine;
             callback(Object, ActionID, ErrorCode, Parameters, sub.Callback.Meta);
@@ -2290,7 +2336,10 @@ void NotifySubscribers(OBJECTPTR Object, ACTIONID ActionID, APTR Parameters, ERR
       }
       glSubReadOnly--;
 
-      if (not glSubReadOnly) drain_delayed_subscriptions(Object);
+      if (not glSubReadOnly) {
+         if (stale_found) sweep_stale_subscriptions(Object, ActionID);
+         drain_delayed_subscriptions(Object);
+      }
    }
    else {
       log.warning("Unstable subscription flags discovered for object #%d, action %d", Object->UID, int(ActionID));
@@ -2666,8 +2715,12 @@ state.  The `Parameters` are the original arguments provided by the client - be 
 `NULL` even if an action specifies a required parameter structure.  Notice that because subscriptions are context
 sensitive, ~CurrentContext() can be used to get a reference to the object that initiated the subscription.
 
-To terminate an action subscription, use the ~UnsubscribeAction() function.  Subscriptions are not resource tracked,
-so it is critical to match the original call with an unsubscription.
+To terminate an action subscription, use the ~UnsubscribeAction() function.  Matching each subscription with an
+unsubscription remains good practice because it releases the subscription record immediately.  If a subscriber is
+freed without unsubscribing, the record degrades safely: the subscriber's object header is weakly pinned for the
+lifetime of the record, dispatch recognises the freed subscriber and skips the callback, and the stale record is
+swept once the notification pass completes.  Until that sweep occurs, the subscriber's header remains allocated in
+zombie form.
 
 -INPUT-
 obj Object: The target object.
@@ -2695,7 +2748,10 @@ ERR SubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
    if (Object->collecting()) return ERR::Okay;
 
    if (glSubReadOnly) {
+      // Weakly pin the subscriber context so that the drain can test for staleness safely; another callback in
+      // the same notification pass could free the subscriber before the queue is processed.
       glDelayedSubscribe.emplace_back(Object->UID, ActionID, *Callback);
+      Callback->pin();
       Object->NotifyFlags.fetch_or(notify_bit(ActionID), std::memory_order::relaxed);
    }
    else {
@@ -2718,6 +2774,10 @@ subscriptions is context sensitive, so the context of the original ~SubscribeAct
 UnsubscribeAction().
 
 To terminate multiple subscriptions in a single call, set the `Action` parameter to zero.
+
+Unsubscribing releases the subscription record (and the weak pin it holds on the subscriber) immediately.  A
+subscriber that is freed without unsubscribing is tolerated - its remaining records are swept lazily the next time
+each subscribed action is dispatched - but explicit unsubscription remains the recommended practice.
 
 -INPUT-
 obj Object: The object that you are unsubscribing from.
@@ -2743,25 +2803,36 @@ ERR UnsubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
    if ((ActionID < AC::NIL) or (ActionID >= AC::END)) return log.warning(ERR::Args);
 
    if (glSubReadOnly) {
-      glDelayedUnsubscribe.emplace_back(Object->UID, ActionID, Callback);
+      // Capture the current context now; the delayed queue is drained under the notifier's context, which
+      // would otherwise be matched as the subscriber.
+      glDelayedUnsubscribe.emplace_back(Object->UID, ActionID, Callback, tlContext.back().obj->UID);
       return ERR::Okay;
    }
 
    std::lock_guard<std::recursive_mutex> lock(glSubLock);
+   unsubscribe_from_object(Object, ActionID, tlContext.back().obj->UID, Callback);
+   return ERR::Okay;
+}
 
+//********************************************************************************************************************
+// Shared erase path for UnsubscribeAction() and the delayed-unsubscribe replay, which must supply the subscriber
+// that was current when the deferred call was made.  The caller must hold glSubLock.  Record destruction releases
+// the weak pin held on the subscriber.
+
+static void unsubscribe_from_object(OBJECTPTR Object, ACTIONID ActionID, OBJECTID Subscriber, FUNCTION *Callback)
+{
    if (ActionID IS AC::NIL) { // Unsubscribe all actions associated with the subscriber.
       if (glSubscriptions.contains(Object->UID)) {
-         OBJECTID subscriber = tlContext.back().obj->UID;
          bool need_restart = true;
          while (need_restart) {
             need_restart = false;
             for (auto & [action, list] : glSubscriptions[Object->UID]) {
                if (Callback) {
-                  std::erase_if(list, [subscriber, Callback](const auto &sub) {
-                     return (sub.SubscriberID IS subscriber) and sub.Callback.identical(*Callback);
+                  std::erase_if(list, [Subscriber, Callback](const auto &sub) {
+                     return (sub.SubscriberID IS Subscriber) and sub.Callback.identical(*Callback);
                   });
                }
-               else std::erase_if(list, [subscriber](const auto &sub) { return sub.SubscriberID IS subscriber; });
+               else std::erase_if(list, [Subscriber](const auto &sub) { return sub.SubscriberID IS Subscriber; });
 
                if (list.empty()) {
                   Object->NotifyFlags.fetch_and(~notify_bit(ACTIONID(action)), std::memory_order::relaxed);
@@ -2781,14 +2852,13 @@ ERR UnsubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
       }
    }
    else if ((glSubscriptions.contains(Object->UID)) and (glSubscriptions[Object->UID].contains(int(ActionID)))) {
-      auto subscriber = tlContext.back().obj->UID;
       auto &list = glSubscriptions[Object->UID][int(ActionID)];
       if (Callback) {
-         std::erase_if(list, [subscriber, Callback](const auto &sub) {
-            return (sub.SubscriberID IS subscriber) and sub.Callback.identical(*Callback);
+         std::erase_if(list, [Subscriber, Callback](const auto &sub) {
+            return (sub.SubscriberID IS Subscriber) and sub.Callback.identical(*Callback);
          });
       }
-      else std::erase_if(list, [subscriber](const auto &sub) { return sub.SubscriberID IS subscriber; });
+      else std::erase_if(list, [Subscriber](const auto &sub) { return sub.SubscriberID IS Subscriber; });
 
       if (list.empty()) {
          Object->NotifyFlags.fetch_and(~notify_bit(ActionID), std::memory_order::relaxed);
@@ -2799,6 +2869,4 @@ ERR UnsubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
          else glSubscriptions[Object->UID].erase(int(ActionID));
       }
    }
-
-   return ERR::Okay;
 }

--- a/src/core/tests/test_subscriber_lifetimes.tiri
+++ b/src/core/tests/test_subscriber_lifetimes.tiri
@@ -1,0 +1,78 @@
+-- Verifies subscriber lifetime safety in the core action subscription machinery.  Subscription records weakly pin
+-- their subscriber, so a subscriber freed without unsubscribing must be skipped at dispatch and swept lazily -
+-- without crashing on the stale context and without disturbing other live subscribers.  Unsubscribing from within
+-- a notification callback must also be honoured once the notification pass completes.
+
+-- A sub-script subscribes to an action on the target and is then freed.  Firing the action must not invoke the
+-- stale callback; the first pass sweeps the record lazily and the second confirms stability.
+
+@Test function StaleScriptSubscriberIsDiscarded()
+   target = obj.new('config', { name='sub_lifetime_target' })
+
+   sub_script = obj.new('tiri', { statement=[[
+      local target = obj.find('sub_lifetime_target')
+      assert(target != nil, 'Sub-script could not find the target object')
+      target.subscribe('refresh', function(UID, Args)
+         error('An action callback fired for a freed script context')
+      end)
+   ]] })
+
+   check sub_script.acActivate()
+   sub_script.free()
+   sub_script = nil
+
+   target.acRefresh()
+   target.acRefresh()
+end
+
+-- With a freed subscriber ahead of a live one in the subscription list, the stale record's lazy removal must not
+-- disturb delivery to the live subscriber.
+
+@Test function LiveSubscriberSurvivesStaleRemoval()
+   target = obj.new('config', { name='sub_lifetime_live' })
+
+   sub_script = obj.new('tiri', { statement=[[
+      local target = obj.find('sub_lifetime_live')
+      assert(target != nil, 'Sub-script could not find the target object')
+      target.subscribe('refresh', function(UID, Args)
+         error('An action callback fired for a freed script context')
+      end)
+   ]] })
+
+   check sub_script.acActivate()
+
+   local count = 0
+   target.subscribe('refresh', function(UID, Args)
+      count++
+   end)
+
+   sub_script.free()
+   sub_script = nil
+
+   target.acRefresh()
+   assert(count is 1, 'Live subscriber did not receive the notification after stale record removal')
+
+   target.acRefresh()
+   assert(count is 2, 'Live subscriber stopped receiving notifications on subsequent events')
+
+   target.unsubscribe('refresh')
+end
+
+-- An unsubscribe call made from inside a notification callback is deferred until the pass completes; it must
+-- remove the caller's own record and not linger or affect other subscribers.
+
+@Test function UnsubscribeDuringNotificationIsHonoured()
+   target = obj.new('config')
+
+   local one_shot = 0
+   target.subscribe('refresh', function(UID, Args)
+      one_shot++
+      target.unsubscribe('refresh')
+   end)
+
+   target.acRefresh()
+   assert(one_shot is 1, 'The one-shot callback did not fire on the first notification')
+
+   target.acRefresh()
+   assert(one_shot is 1, 'The one-shot callback fired again despite unsubscribing during notification')
+end

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -702,7 +702,7 @@ static ERR SET_RequestHandler(objClipboard *Self, FUNCTION *Value)
    if (Self->RequestHandler.defined()) Self->RequestHandler.unpin();
    if (Value) {
       Self->RequestHandler = *Value;
-      Self->RequestHandler.pin();
+      if (Self->RequestHandler.defined()) Self->RequestHandler.pin();
    }
    else Self->RequestHandler.clear();
    return ERR::Okay;

--- a/src/network/class_netlookup.cpp
+++ b/src/network/class_netlookup.cpp
@@ -448,7 +448,7 @@ static ERR SET_Callback(extNetLookup *Self, FUNCTION *Value)
    clear_callback_function(Self->Callback);
    if (Value) {
       Self->Callback = *Value;
-      Self->Callback.pin();
+      if (Self->Callback.defined()) Self->Callback.pin();
    }
 
    return ERR::Okay;

--- a/src/network/netsocket/netsocket_fields.cpp
+++ b/src/network/netsocket/netsocket_fields.cpp
@@ -62,7 +62,7 @@ static ERR SET_Feedback(extNetSocket *Self, FUNCTION *Value)
    clear_callback_function(Self->Feedback);
    if (Value) {
       Self->Feedback = *Value;
-      Self->Feedback.pin();
+      if (Self->Feedback.defined()) Self->Feedback.pin();
    }
 
    return ERR::Okay;
@@ -104,7 +104,7 @@ static ERR SET_Incoming(extNetSocket *Self, FUNCTION *Value)
    clear_callback_function(Self->Incoming);
    if (Value) {
       Self->Incoming = *Value;
-      Self->Incoming.pin();
+      if (Self->Incoming.defined()) Self->Incoming.pin();
    }
    return ERR::Okay;
 }
@@ -176,15 +176,17 @@ static ERR SET_Outgoing(extNetSocket *Self, FUNCTION *Value)
 
    clear_callback_function(Self->Outgoing);
    Self->Outgoing = *Value;
-   Self->Outgoing.pin();
+   if (Self->Outgoing.defined()) {
+      Self->Outgoing.pin();
 
-   if (Self->initialised()) {
-      if ((Self->Handle.is_valid()) and (Self->State IS NTC::CONNECTED)) {
-         // Setting the Outgoing field after connectivity is established will put the socket into streamed write mode.
+      if (Self->initialised()) {
+         if ((Self->Handle.is_valid()) and (Self->State IS NTC::CONNECTED)) {
+            // Setting the Outgoing field after connectivity is established will put the socket into streamed write mode.
 
-         network_platform().register_write(Self->Handle, &netsocket_outgoing, Self);
+            network_platform().register_write(Self->Handle, &netsocket_outgoing, Self);
+         }
+         else log.trace("Will not listen for socket-writes (no socket handle, or state %d != NTC::CONNECTED).", Self->State);
       }
-      else log.trace("Will not listen for socket-writes (no socket handle, or state %d != NTC::CONNECTED).", Self->State);
    }
 
    return ERR::Okay;

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -1751,7 +1751,7 @@ static ERR SET_EventCallback(extScintilla *Self, FUNCTION *Value)
    if (Self->EventCallback.defined()) Self->EventCallback.unpin();
    if (Value) {
       Self->EventCallback = *Value;
-      Self->EventCallback.pin();
+      if (Self->EventCallback.defined()) Self->EventCallback.pin();
    }
    else Self->EventCallback.clear();
    return ERR::Okay;

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -491,7 +491,7 @@ static ERR SET_FrameCallback(extSVG *Self, FUNCTION *Value)
    if (Self->FrameCallback.defined()) Self->FrameCallback.unpin();
    if (Value) {
       Self->FrameCallback = *Value;
-      Self->FrameCallback.pin();
+      if (Self->FrameCallback.defined()) Self->FrameCallback.pin();
    }
    else Self->FrameCallback.clear();
    return ERR::Okay;


### PR DESCRIPTION
* Weakly pinned subscriber records and swept stale callbacks after notification dispatch
* Preserved deferred unsubscription context while draining subscription queues
* Added subscriber lifetime coverage for stale records and notification-time unsubscribe