### PR TITLE
[Tiri] Preserve scoped shadowing of registered constants

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -781,7 +781,7 @@ set (TIRI_TESTS
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
-   comparison_chaining reserved_keywords compile_if_import overflow protected_globals
+   comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -254,8 +254,11 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
             return ParserResult<ExpDesc>::success(blank_expr);
          }
 
-         // Check if this is a registered constant - cannot assign to constants
-         if (lookup_constant(name_ref.identifier.symbol)) {
+         // Registered constants are immutable unless this target resolves to an explicit local/upvalue shadow.
+         ExpDesc resolved;
+         this->lex_state.var_lookup_symbol(name_ref.identifier.symbol, &resolved);
+         if (lookup_constant(name_ref.identifier.symbol) and
+             resolved.k != ExpKind::Local and resolved.k != ExpKind::Upval) {
             std::string var_name(strdata(name_ref.identifier.symbol), name_ref.identifier.symbol->len);
             std::string msg = "cannot assign to constant '" + var_name + "'";
             return ParserResult<ExpDesc>::failure(this->make_error(ParserErrorCode::AssignToConstant, msg));
@@ -544,6 +547,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
          if (is_direct_global_store and ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
             return ParserResult<IrEmitUnit>::failure(this->make_error(ParserErrorCode::OverrideProtectedGlobal,
                std::format("cannot override built-in '{}'", std::string_view(strdata(name), name->len)),
+               Payload.name.segments.front().span));
+         }
+         if (is_direct_global_store and lookup_constant(name)) {
+            return ParserResult<IrEmitUnit>::failure(this->make_error(ParserErrorCode::AssignToConstant,
+               std::format("cannot assign to constant '{}'", std::string_view(strdata(name), name->len)),
                Payload.name.segments.front().span));
          }
          this->func_state.declared_globals.insert(name);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -23,6 +23,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
                identifier.span));
          }
 
+         if (lookup_constant(name)) {
+            return ParserResult<IrEmitUnit>::failure(this->make_error(ParserErrorCode::AssignToConstant,
+               std::format("cannot assign to constant '{}'", std::string_view(strdata(name), name->len)),
+               identifier.span));
+         }
+
          this->func_state.declared_globals.insert(name);
 
          if (identifier.has_const) {

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -26,6 +26,8 @@
 
 inline const TiriConstant * lookup_constant(const GCstr *Name)
 {
+   if (not Name) return nullptr;
+
    std::shared_lock lock(glConstantMutex);
    auto it = glConstantRegistry.find(Name->hash);
    if (it != glConstantRegistry.end()) return &it->second;
@@ -1832,15 +1834,16 @@ ParserResult<ExpDesc> IrEmitter::emit_identifier_expr(const NameRef& reference, 
          "Cannot read blank identifier '_'"));
    }
 
-   // Check if this is a registered constant - substitute with literal value
-   if (auto constant = lookup_constant(reference.identifier.symbol)) {
-      ExpDesc expr(constant->to_number());
-      return ParserResult<ExpDesc>::success(expr);
-   }
-
-   // Normal variable lookup
    ExpDesc resolved;
    this->lex_state.var_lookup_symbol(reference.identifier.symbol, &resolved);
+
+   // Explicit local/upvalue shadows take precedence over registered constant substitution.
+   if (resolved.k != ExpKind::Local and resolved.k != ExpKind::Upval) {
+      if (auto constant = lookup_constant(reference.identifier.symbol)) {
+         ExpDesc expr(constant->to_number());
+         return ParserResult<ExpDesc>::success(expr);
+      }
+   }
 
    // If unscoped, check if this was explicitly declared as global
    if (resolved.k IS ExpKind::Unscoped) {

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -16,10 +16,12 @@
 #include "parser/type_checker.h"
 
 #include <format>
+#include <shared_mutex>
 
 #include <ankerl/unordered_dense.h>
 #include <kotuku/main.h>
 #include "parser/parser_context.h"
+#include "../../../defs.h"
 
 #ifdef INCLUDE_TIPS
 #include "parser/parser_tips.h"
@@ -48,6 +50,14 @@
 [[nodiscard]] static bool type_identifier_name_is(GCstr *Name, std::string_view Text)
 {
    return Name and std::string_view(strdata(Name), Name->len) IS Text;
+}
+
+[[nodiscard]] static bool type_is_registered_constant(GCstr *Name)
+{
+   if (not Name) return false;
+
+   std::shared_lock lock(glConstantMutex);
+   return glConstantRegistry.contains(Name->hash);
 }
 
 [[nodiscard]] static GCstr * type_literal_string_key(const ExprNode &Expr)
@@ -948,6 +958,16 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
          continue;
       }
 
+      if (type_is_registered_constant(name.symbol)) {
+         std::string_view name_view(strdata(name.symbol), name.symbol->len);
+         TypeDiagnostic diag;
+         diag.location = name.span;
+         diag.code = ParserErrorCode::AssignToConstant;
+         diag.message = std::format("cannot assign to constant '{}'", name_view);
+         this->diagnostics_.push_back(std::move(diag));
+         continue;
+      }
+
       InferredType inferred;
 
       // Explicit type annotation takes precedence
@@ -1045,6 +1065,14 @@ void TypeAnalyser::analyse_function_stmt(const FunctionStmtPayload &Payload)
          bool is_direct_global_store = Payload.name.segments.size() IS 1 and not Payload.name.method.has_value();
          if (is_direct_global_store and function_name and ((function_name->flags & STRFLAG_PROTECTED_GLOBAL) != 0)) {
             this->report_protected_global_override(function_name, function_location);
+         }
+         else if (is_direct_global_store and type_is_registered_constant(function_name)) {
+            std::string_view name_view(strdata(function_name), function_name->len);
+            TypeDiagnostic diag;
+            diag.location = function_location;
+            diag.code = ParserErrorCode::AssignToConstant;
+            diag.message = std::format("cannot assign to constant '{}'", name_view);
+            this->diagnostics_.push_back(std::move(diag));
          }
          else this->declare_global_function(function_name, function, function_location);
       }

--- a/src/tiri/tests/test_constant_shadowing.tiri
+++ b/src/tiri/tests/test_constant_shadowing.tiri
@@ -1,0 +1,105 @@
+-- Flute regression tests for scoped shadowing of registry-backed constants.
+
+global glConstantShadowCounter = 0
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath() end
+
+function assert_activation_fails(Statement:str, Message:str)
+   local script = obj.new('tiri', { statement = Statement })
+   local err = script.acActivate()
+
+   assert(err != ERR_Okay, Message .. ' should fail activation')
+   assert(script.error != ERR_Okay, Message .. ' should set a script error')
+   assert(string.find(script.errorMessage, 'cannot assign to constant') != nil,
+      Message .. ' should report the constant-assignment diagnostic, got: ' .. tostring(script.errorMessage))
+end
+
+@Test function AllowsLocalShadowOfConstant()
+   local ERR_Okay = ''
+   assert(ERR_Okay is '', 'Local shadow should take precedence over the registered constant')
+end
+
+@Test function ShadowIsBlockScoped()
+   do
+      local ERR_Okay = 'shadow'
+      assert(ERR_Okay is 'shadow', 'Block-local shadow should be read inside its block')
+   end
+
+   assert(ERR_Okay is 0, 'Unshadowed reads after the block should fold to the registered constant')
+end
+
+@Test function ShadowCapturedByClosure()
+   local capture
+
+   do
+      local ERR_Okay = 'captured'
+      capture = function()
+         return ERR_Okay
+      end
+   end
+
+   assert(capture() is 'captured', 'Closure should capture the local shadow')
+end
+
+@Test function AllowsParameterShadowOfConstant()
+   local function use_constant_name(ERR_Okay)
+      return ERR_Okay
+   end
+
+   assert(use_constant_name('x') is 'x', 'Parameter shadow should be read as a normal parameter')
+end
+
+@Test function AllowsReassignmentOfShadow()
+   local ERR_Okay = 1
+   ERR_Okay = 2
+   ERR_Okay += 1
+   ERR_Okay++
+
+   assert(ERR_Okay is 4, 'Plain, compound, and update assignment should mutate the local shadow')
+end
+
+@Test function RejectsPlainAssignmentToConstant()
+   assert_activation_fails([[ERR_Okay = 5]], 'plain assignment to registered constant')
+end
+
+@Test function RejectsGlobalDeclarationOfConstant()
+   assert_activation_fails([[global ERR_Okay = 5]], 'global declaration of registered constant')
+end
+
+@Test function RejectsGlobalFunctionDeclarationOfConstant()
+   assert_activation_fails([[global function ERR_Okay() end]], 'global function declaration named after registered constant')
+end
+
+@Test function UnshadowedConstantStillFolds()
+   assert(ERR_Okay is 0, 'Unshadowed registered constant should still fold to its numeric value')
+end
+
+@Test function EnumMemberShadow()
+   glConstantShadowCounter++
+   local prefix = 'SHADOW_ENUM_' .. tostring(glConstantShadowCounter)
+
+   exec(string.format([[
+enum %s {
+   VALUE = 7,
+}
+
+do
+   local %s_VALUE = 'shadow'
+   assert(%s_VALUE is 'shadow')
+end
+
+assert(%s_VALUE is 7)
+]], prefix, prefix, prefix, prefix))
+end
+
+@Test function ForLoopVariableCanShadowConstant()
+   local sum = 0
+
+   for ERR_Okay = 1, 3 do
+      sum += ERR_Okay
+   end
+
+   assert(sum is 6, 'For-loop variable should shadow the registered constant in the loop body')
+   assert(ERR_Okay is 0, 'Unshadowed reads after the loop should fold to the registered constant')
+end

--- a/tools/rsakey.tiri
+++ b/tools/rsakey.tiri
@@ -78,7 +78,7 @@ function signFiles(DestPath:str)
       input.acSeek(0, 0)
 
       check mSSL.VerifySig(input, 0, glPublicKey, "sha256", sig)
-      print("Verification passed.") end
+      print("Verification passed.")
    else
       print("Failed to generate signature: " .. mSys.GetErrorMsg(err));
    end

--- a/tools/rsakey.tiri
+++ b/tools/rsakey.tiri
@@ -71,15 +71,14 @@ function signFiles(DestPath:str)
    if (err is ERR_Okay) and (sig != nil) then
       if glSigFile?? then
          print("Saving signature to " .. glSigFile)
-         local sigfile = obj.new("file", { path=glSigFile, flags=FL_NEW|FL_WRITE } )
+         sigfile = obj.new("file", { path=glSigFile, flags=FL_NEW|FL_WRITE } )
          sigfile.acWrite(sig)
       end
 
       input.acSeek(0, 0)
 
-      err = mSSL.VerifySig(input, 0, glPublicKey, "sha256", sig)
-      if (err != ERR_Okay) then print("Verification failed.")
-      else print("Verification passed.") end
+      check mSSL.VerifySig(input, 0, glPublicKey, "sha256", sig)
+      print("Verification passed.") end
    else
       print("Failed to generate signature: " .. mSys.GetErrorMsg(err));
    end


### PR DESCRIPTION
* Let local variables, upvalues, parameters, and loop variables take precedence over registered constant folding
* Reject global declarations and direct global functions that assign to registered constants
* Added Flute coverage for constant shadowing and constant assignment diagnostics
* [Script] Updated rsakey signature verification to use checked verification flow