### PR TITLE
[Tiri] Added string list imports

### DIFF
--- a/apps/vuepoint.tiri
+++ b/apps/vuepoint.tiri
@@ -3,14 +3,9 @@
 A file viewer for recognised documents like SVG and RIPL
 --]]
 
-   import 'gui'
-   import 'gui/window'
-   import 'gui/divider'
-   import 'gui/fileview'
-   import 'gui/listview'
-   import 'gui/scrollbar'
-   import 'gui/filedialog'
+   import 'gui', 'gui/window', 'gui/divider', 'gui/fileview', 'gui/listview', 'gui/scrollbar', 'gui/filedialog'
    import 'options'
+
    include 'svg', 'image'
 
 CLASSID_IMAGE <const> = 'Image':hash()

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -102,6 +102,7 @@ private:
    ParserResult<StmtNodePtr> parse_raise();
    ParserResult<StmtNodePtr> parse_check();
    ParserResult<StmtNodePtr> parse_include_stmt();
+   ParserResult<ImportEntryPayload> parse_import_entry(const Token&, bool, bool * = nullptr);
    ParserResult<StmtNodePtr> parse_import();
    ParserResult<StmtNodePtr> parse_namespace();
    ParserResult<std::unique_ptr<BlockStmt>> parse_imported_file(std::string &, std::string_view, const Token& import_token);

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -482,7 +482,11 @@ struct StatementChildCounter {
 
    [[nodiscard]] inline size_t operator()(const ImportStmtPayload &Payload) const
    {
-      return block_child_count(Payload.inlined_body);
+      size_t total = 0;
+      for (const ImportEntryPayload &entry : Payload.entries) {
+         total += block_child_count(entry.inlined_body);
+      }
+      return total;
    }
 
    [[nodiscard]] inline size_t operator()(const WithStmtPayload &Payload) const
@@ -541,6 +545,7 @@ ExceptClause::~ExceptClause() = default;
 TryExceptPayload::~TryExceptPayload() = default;
 RaiseStmtPayload::~RaiseStmtPayload() = default;
 CheckStmtPayload::~CheckStmtPayload() = default;
+ImportEntryPayload::~ImportEntryPayload() = default;
 ImportStmtPayload::~ImportStmtPayload() = default;
 WithStmtPayload::~WithStmtPayload() = default;
 BlockStmt::~BlockStmt() = default;

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -878,7 +878,23 @@ struct CheckStmtPayload {
    ~CheckStmtPayload();
 };
 
-// Import statement payload: import 'library' - compile-time file inlining
+struct ImportEntryPayload {
+   ImportEntryPayload() = default;
+   ImportEntryPayload(const ImportEntryPayload&) = delete;
+   ImportEntryPayload& operator=(const ImportEntryPayload&) = delete;
+   ImportEntryPayload(ImportEntryPayload&&) noexcept = default;
+   ImportEntryPayload& operator=(ImportEntryPayload&&) noexcept = default;
+
+   std::optional<Identifier> namespace_name;  // The local variable name (alias or default)
+   std::string lib_path;                      // Resolved path to library file
+   std::string default_namespace;             // The declared namespace for _LIB lookup
+   std::unique_ptr<BlockStmt> inlined_body;   // Parsed content of imported file
+   uint8_t file_source_idx = 0;               // FileSource index for this imported file
+
+   ~ImportEntryPayload();
+};
+
+// Import statement payload: import 'library' [, 'library'...] - compile-time file inlining
 struct ImportStmtPayload {
    ImportStmtPayload() = default;
    ImportStmtPayload(const ImportStmtPayload&) = delete;
@@ -886,11 +902,7 @@ struct ImportStmtPayload {
    ImportStmtPayload(ImportStmtPayload&&) noexcept = default;
    ImportStmtPayload& operator=(ImportStmtPayload&&) noexcept = default;
 
-   std::optional<Identifier> namespace_name;  // The local variable name (alias or default)
-   std::string lib_path;                      // Resolved path to library file
-   std::string default_namespace;             // The declared namespace for _LIB lookup
-   std::unique_ptr<BlockStmt> inlined_body;   // Parsed content of imported file
-   uint8_t file_source_idx = 0;               // FileSource index for this imported file
+   std::vector<ImportEntryPayload> entries;
 
    ~ImportStmtPayload();
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -23,7 +23,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
 
       if (this->ctx.check(TokenKind::Enum)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "local enum declarations are not supported");
+            "Local enum declarations are not supported");
       }
 
       bool is_thunk = false;
@@ -98,7 +98,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_local()
          else {
             // Non-identifier expression in trailing position - this is an error
             return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier, this->ctx.tokens().current(),
-               "expected identifier after values in local declaration");
+               "Expected identifier after values in local declaration");
          }
       }
       // Remove the converted identifiers from the values list
@@ -200,7 +200,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
          else {
             // Non-identifier expression in trailing position - this is an error
             return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedIdentifier, this->ctx.tokens().current(),
-               "expected identifier after values in global declaration");
+               "Expected identifier after values in global declaration");
          }
       }
       // Remove the converted identifiers from the values list
@@ -227,13 +227,13 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
 
       if (this->ctx.check(TokenKind::Comma)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "extern wildcard cannot be combined with named symbols");
+            "Extern wildcard cannot be combined with named symbols");
       }
 
       if (this->ctx.check(TokenKind::Equals) or
             token_to_assignment_op(this->ctx.tokens().current().kind()).has_value()) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "extern declarations cannot have an initialiser");
+            "Extern declarations cannot have an initialiser");
       }
 
       auto stmt = std::make_unique<StmtNode>(AstNodeKind::ExternStmt, extern_token.span());
@@ -248,7 +248,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
 
    if (this->ctx.check(TokenKind::Equals) or token_to_assignment_op(this->ctx.tokens().current().kind()).has_value()) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "extern declarations cannot have an initialiser");
+         "Extern declarations cannot have an initialiser");
    }
 
    for (const Identifier &identifier : names.value_ref()) {
@@ -260,7 +260,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_extern()
       if (identifier.type != TiriType::Unknown or identifier.has_const or identifier.has_close) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
             Token::from_span(identifier.span, TokenKind::Identifier),
-            "extern declarations cannot have type annotations or attributes");
+            "Extern declarations cannot have type annotations or attributes");
       }
    }
 
@@ -321,13 +321,13 @@ ParserResult<int64_t> AstBuilder::parse_enum_integer_literal()
 
    if (not token.is(TokenKind::Number)) {
       return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
-         "enum values must be integer literals");
+         "Enum values must be integer literals");
    }
 
    double number_value = token.payload().as_number();
    if (not std::isfinite(number_value) or std::trunc(number_value) != number_value) {
       return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
-         "enum values must be integer literals");
+         "Enum values must be integer literals");
    }
 
    double signed_value = number_value * double(sign);
@@ -335,7 +335,7 @@ ParserResult<int64_t> AstBuilder::parse_enum_integer_literal()
    constexpr double max_value = double(std::numeric_limits<int64_t>::max());
    if (signed_value < min_value or signed_value > max_value) {
       return this->fail<int64_t>(ParserErrorCode::UnexpectedToken, token,
-         "enum integer literal is out of range");
+         "Enum integer literal is out of range");
    }
 
    this->ctx.tokens().advance();
@@ -346,7 +346,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
 {
    if (not this->at_top_level()) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "enum declarations are only allowed at top-level scope");
+         "Enum declarations are only allowed at top-level scope");
    }
 
    Token enum_token = this->ctx.tokens().current();
@@ -359,17 +359,17 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
    GCstr *prefix_symbol = prefix_token.value_ref().identifier();
    if (not is_uppercase_enum_name(prefix_symbol)) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, prefix_token.value_ref(),
-         "declare enum prefixes in uppercase only");
+         "Declare enum prefixes in uppercase only");
    }
 
    if (this->ctx.check(TokenKind::Colon)) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "enum prefixes cannot use a type annotation");
+         "Enum prefixes cannot use a type annotation");
    }
 
    if (is_prefixed_attribute_token(this->ctx.tokens())) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-         "enum prefixes cannot use <const> or <close> attributes");
+         "Enum prefixes cannot use <const> or <close> attributes");
    }
 
    auto open_brace = this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);
@@ -383,7 +383,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
    while (not this->ctx.check(TokenKind::RightBrace)) {
       if (this->ctx.check(TokenKind::EndOfFile)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedEndOfFile, enum_token,
-            "unterminated enum declaration");
+            "Unterminated enum declaration");
       }
 
       auto member_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
@@ -392,14 +392,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
       GCstr *member_symbol = member_token.value_ref().identifier();
       if (not is_uppercase_enum_name(member_symbol)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
-            "declare enum members in uppercase only");
+            "Declare enum members in uppercase only");
       }
 
       std::string member(strdata(member_symbol), member_symbol->len);
       for (const std::string &existing : members) {
          if (existing IS member) {
             return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
-               "duplicate enum member '" + member + "'");
+               "Duplicate enum member '" + member + "'");
          }
       }
       members.push_back(member);
@@ -414,7 +414,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
       constants.push_back(EnumConstantDecl{ prefix + "_" + member, value, member_token.value_ref().span() });
       if (value IS std::numeric_limits<int64_t>::max()) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, member_token.value_ref(),
-            "enum value overflow");
+            "Enum value overflow");
       }
       next_value = value + 1;
 
@@ -423,7 +423,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
       }
       if (not this->ctx.check(TokenKind::RightBrace)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
-            "expected ',' or '}' in enum declaration");
+            "Expected ',' or '}' in enum declaration");
       }
    }
 
@@ -432,7 +432,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
 
    if (constants.empty()) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, StartToken,
-         "enum declarations must contain at least one member");
+         "Enum declarations must contain at least one member");
    }
 
    std::string duplicate_name;
@@ -461,7 +461,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_enum(const Token &StartToken)
    if (not duplicate_name.empty()) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
          Token::from_span(duplicate_span, TokenKind::Identifier),
-         "duplicate enum constant '" + duplicate_name + "'");
+         "Duplicate enum constant '" + duplicate_name + "'");
    }
 
    return ParserResult<StmtNodePtr>::success(nullptr);
@@ -490,7 +490,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_function_stmt()
    if (this->ctx.match(TokenKind::Colon).ok()) {
       if (is_thunk) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "thunk functions do not support method syntax");
+            "Thunk functions do not support method syntax");
       }
       method = true;
       auto seg = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
@@ -794,13 +794,13 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
          }
          else {
             return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken,
-               attribute.value_ref(), "unknown try attribute, expected 'trace'");
+               attribute.value_ref(), "Unknown try attribute, expected 'trace'");
          }
       }
 
       if (not this->ctx.lex_opt('>')) {
          return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken,
-            this->ctx.tokens().current(), "expected '>' after try attribute");
+            this->ctx.tokens().current(), "Expected '>' after try attribute");
       }
    }
 
@@ -822,7 +822,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
       if (has_catch_all) {
          // Error: catch-all must be last
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
-            "catch-all 'except' must be the last clause");
+            "Catch-all 'except' must be the last clause");
       }
 
       Token except_token = this->ctx.tokens().current();
@@ -850,7 +850,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
          if (unexpected.span().line IS except_token.span().line) {
             GCstr *ident = unexpected.identifier();
             return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, unexpected,
-               "expected 'when' or newline after 'except', not '" + std::string(strdata(ident), ident->len) + "'");
+               "Expected 'when' or newline after 'except', not '" + std::string(strdata(ident), ident->len) + "'");
          }
       }
 
@@ -862,7 +862,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
          Token next_token = this->ctx.tokens().current();
          if (next_token.span().line != when_token.span().line) {
             return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, when_token,
-               "expected error code(s) after 'when' on the same line");
+               "Expected error code(s) after 'when' on the same line");
          }
 
          // Parse error code filter(s): when ERR_A or when ERR_A, ERR_B
@@ -879,7 +879,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_try()
             Token code_token = this->ctx.tokens().current();
             if (code_token.span().line != when_token.span().line) {
                return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, comma_token,
-                  "expected error code after ',' on the same line as 'when'");
+                  "Expected error code after ',' on the same line as 'when'");
             }
 
             auto next_code = this->parse_expression();
@@ -1018,26 +1018,26 @@ ParserResult<StmtNodePtr> AstBuilder::parse_include_stmt()
    while (true) {
       Token name_token = this->ctx.tokens().current();
       if (not name_token.is(TokenKind::String)) {
-         const char *message = first_item ? "include module name must be a string literal" :
+         const char *message = first_item ? "Include module name must be a string literal" :
             "'include' list items must be string literals";
          return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, name_token, message);
       }
 
       GCstr *name_str = name_token.payload().as_string();
       if (not name_str) {
-         return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, name_token, "invalid include module name");
+         return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, name_token, "Invalid include module name");
       }
 
       std::string module_name(strdata(name_str), name_str->len);
       if (not include_module_name_is_valid(module_name)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token,
-            "invalid module name; only alpha-numeric names shorter than 32 characters are permitted with include");
+            "Invalid module name; only alpha-numeric names shorter than 32 characters are permitted with include");
       }
 
       if (auto error = load_include(this->ctx.lua().script, module_name.c_str()); error != ERR::Okay) {
          std::string message;
-         if (error IS ERR::FileNotFound) message = std::format("requested include file '{}' does not exist", module_name);
-         else message = std::format("failed to process include file '{}': {}", module_name, GetErrorMsg(error));
+         if (error IS ERR::FileNotFound) message = std::format("Requested include file '{}' does not exist", module_name);
+         else message = std::format("Failed to process include file '{}': {}", module_name, GetErrorMsg(error));
 
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token, std::move(message));
       }
@@ -1053,7 +1053,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_include_stmt()
 }
 
 //********************************************************************************************************************
-// Parses import statements: import 'library' [as alias]
+// Parses one import list entry.
 //
 // The import statement is a compile-time feature that reads and parses the referenced file, inlining its content as
 // statements executed within the current scope.
@@ -1061,29 +1061,26 @@ ParserResult<StmtNodePtr> AstBuilder::parse_include_stmt()
 // When using 'as alias' syntax, the imported library must declare a namespace. The alias creates a local const variable
 // that references _LIB['namespace'] for convenient access to the library exports.
 
-ParserResult<StmtNodePtr> AstBuilder::parse_import()
+ParserResult<ImportEntryPayload> AstBuilder::parse_import_entry(const Token &ImportToken, bool AllowAlias,
+   bool *UsedAlias)
 {
    kt::Log log(__FUNCTION__);
 
-   Token import_token = this->ctx.tokens().current();
-
-   // Import statements must be at the top level of the script
-
-   if (not this->at_top_level()) {
-      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, import_token, "Use of 'import' is not permitted inside function blocks");
-   }
-
-   this->ctx.tokens().advance();  // consume 'import'
+   if (UsedAlias) *UsedAlias = false;
 
    // Require a string literal for the library path
 
    Token path_token = this->ctx.tokens().current();
    if (not path_token.is(TokenKind::String)) {
-      return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, path_token, "Import path must be a string literal");
+      const char *message = AllowAlias ? "Import path must be a string literal" :
+         "Import list items must be string literals";
+      return this->fail<ImportEntryPayload>(ParserErrorCode::ExpectedToken, path_token, message);
    }
 
    GCstr *path_str = path_token.payload().as_string();
-   if (not path_str) return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, path_token, "Invalid import path");
+   if (not path_str) {
+      return this->fail<ImportEntryPayload>(ParserErrorCode::ExpectedToken, path_token, "Invalid import path");
+   }
 
    std::string_view mod_name(strdata(path_str), path_str->len);
    this->ctx.tokens().advance();  // consume string
@@ -1096,13 +1093,20 @@ ParserResult<StmtNodePtr> AstBuilder::parse_import()
    Token as_token;
    if (this->ctx.check(TokenKind::AsToken)) {
       as_token = this->ctx.tokens().current();
+
+      if (not AllowAlias) {
+         return this->fail<ImportEntryPayload>(ParserErrorCode::UnexpectedToken, as_token,
+            "Import lists do not support 'as' aliases");
+      }
+
       this->ctx.tokens().advance();  // consume 'as'
 
       auto alias_result = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
-      if (not alias_result.ok()) return ParserResult<StmtNodePtr>::failure(alias_result.error_ref());
+      if (not alias_result.ok()) return ParserResult<ImportEntryPayload>::failure(alias_result.error_ref());
 
       alias = make_identifier(alias_result.value_ref());
       alias->has_const = true;  // Namespace alias is const
+      if (UsedAlias) *UsedAlias = true;
    }
 
    std::string path = this->ctx.resolve_lib_to_path(mod_name);
@@ -1110,13 +1114,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_import()
    // Check for circular import
 
    if (this->ctx.is_importing(path)) {
-      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, import_token, "Circular import detected: " + path);
+      return this->fail<ImportEntryPayload>(ParserErrorCode::UnexpectedToken, ImportToken,
+         "Circular import detected: " + path);
    }
 
    // Parse the imported file
 
-   auto imported_body = this->parse_imported_file(path, mod_name, import_token);
-   if (not imported_body.ok()) return ParserResult<StmtNodePtr>::failure(imported_body.error_ref());
+   auto imported_body = this->parse_imported_file(path, mod_name, ImportToken);
+   if (not imported_body.ok()) return ParserResult<ImportEntryPayload>::failure(imported_body.error_ref());
 
    // Look up the FileSource index and namespace for this import (registered during parse_imported_file)
 
@@ -1132,8 +1137,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_import()
    // If using 'as' alias, the library must declare a namespace
 
    if (alias and default_ns.empty()) {
-      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, as_token,
-         std::string("cannot use 'as' alias: library '") + std::string(mod_name) + "' does not declare a namespace");
+      return this->fail<ImportEntryPayload>(ParserErrorCode::UnexpectedToken, as_token,
+         std::string("Cannot use 'as' alias: library '") + std::string(mod_name) + "' does not declare a namespace");
    }
 
    // Determine final namespace name (alias takes precedence)
@@ -1142,29 +1147,63 @@ ParserResult<StmtNodePtr> AstBuilder::parse_import()
    if (alias) final_ns = std::string(strdata(alias->symbol), alias->symbol->len);
    else if (not default_ns.empty()) final_ns = default_ns;
 
-   // Create ImportStmtPayload
-
-   auto stmt = std::make_unique<StmtNode>(AstNodeKind::ImportStmt, import_token.span());
-   ImportStmtPayload payload;
-   payload.lib_path = path;
-   payload.inlined_body = std::move(imported_body.value_ref());
+   ImportEntryPayload entry;
+   entry.lib_path = path;
+   entry.inlined_body = std::move(imported_body.value_ref());
 
    if (file_idx.has_value()) {
-      payload.file_source_idx = file_idx.value();
+      entry.file_source_idx = file_idx.value();
    }
 
    // If we have a namespace (either from alias or default), set up the namespace binding
    if (not final_ns.empty()) {
       Identifier ns_id;
       ns_id.symbol = lj_str_new(L, final_ns.c_str(), final_ns.size());
-      ns_id.span = import_token.span();
+      ns_id.span = ImportToken.span();
       ns_id.has_const = true;
-      payload.namespace_name = std::move(ns_id);
-      payload.default_namespace = default_ns;  // Store original for _LIB lookup
+      entry.namespace_name = std::move(ns_id);
+      entry.default_namespace = default_ns;  // Store original for _LIB lookup
    }
 
-   stmt->data = std::move(payload);
+   return ParserResult<ImportEntryPayload>::success(std::move(entry));
+}
 
+//********************************************************************************************************************
+// Parses import statements: import 'library' [, 'library'...] [as alias for single imports only]
+
+ParserResult<StmtNodePtr> AstBuilder::parse_import()
+{
+   Token import_token = this->ctx.tokens().current();
+
+   // Import statements must be at the top level of the script
+
+   if (not this->at_top_level()) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, import_token,
+         "Use of 'import' is not permitted inside function blocks");
+   }
+
+   this->ctx.tokens().advance();  // consume 'import'
+
+   ImportStmtPayload payload;
+
+   bool first_used_alias = false;
+   auto first_entry = this->parse_import_entry(import_token, true, &first_used_alias);
+   if (not first_entry.ok()) return ParserResult<StmtNodePtr>::failure(first_entry.error_ref());
+   payload.entries.push_back(std::move(first_entry.value_ref()));
+
+   if (this->ctx.check(TokenKind::Comma) and first_used_alias) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "Import lists do not support 'as' aliases");
+   }
+
+   while (this->ctx.match(TokenKind::Comma).ok()) {
+      auto entry = this->parse_import_entry(import_token, false);
+      if (not entry.ok()) return ParserResult<StmtNodePtr>::failure(entry.error_ref());
+      payload.entries.push_back(std::move(entry.value_ref()));
+   }
+
+   auto stmt = std::make_unique<StmtNode>(AstNodeKind::ImportStmt, import_token.span());
+   stmt->data = std::move(payload);
    return ParserResult<StmtNodePtr>::success(std::move(stmt));
 }
 
@@ -1194,7 +1233,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_namespace()
    Token name_token = this->ctx.tokens().current();
    if (not name_token.is(TokenKind::String)) {
       return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, name_token,
-         "namespace name must be a string literal");
+         "Namespace name must be a string literal");
    }
 
    GCstr *name_str = name_token.payload().as_string();

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -332,28 +332,28 @@ ParserResult<IrEmitUnit> IrEmitter::emit_check_stmt(const CheckStmtPayload &Payl
 }
 
 //********************************************************************************************************************
-// Emit bytecode for import statement: import 'path' [as alias]
+// Emit bytecode for one import entry.
 //
-// The import statement inlines the content of the referenced file at compile time.
+// The import entry inlines the content of the referenced file at compile time.
 // The inlined_body block is emitted as if its statements were written directly at the import location.
 // This creates a new scope for the imported content to provide some isolation.
 //
 // When namespace_name is set (from 'as alias' or module's default namespace), emits:
 //   local <namespace_name> <const> = _LIB['<default_namespace>']
 
-ParserResult<IrEmitUnit> IrEmitter::emit_import_stmt(const ImportStmtPayload &Payload)
+ParserResult<IrEmitUnit> IrEmitter::emit_import_entry(const ImportEntryPayload &Entry)
 {
    FuncState *fs = &this->func_state;
    lua_State *L = this->lex_state.L;
 
    // If there's a body, emit the inlined content first
-   if (Payload.inlined_body) {
+   if (Entry.inlined_body) {
       // Temporarily switch to the imported file's FileSource index
       // so that prototypes created for functions in the import get the correct file_source_idx
       uint8_t saved_file_index = this->lex_state.current_file_index;
-      this->lex_state.current_file_index = Payload.file_source_idx;
+      this->lex_state.current_file_index = Entry.file_source_idx;
 
-      auto result = this->emit_block(*Payload.inlined_body, FuncScopeFlag::None);
+      auto result = this->emit_block(*Entry.inlined_body, FuncScopeFlag::None);
 
       // Restore the parent file's index
       this->lex_state.current_file_index = saved_file_index;
@@ -362,9 +362,9 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_stmt(const ImportStmtPayload &Pa
    }
 
    // If namespace_name is set, emit: local <name> <const> = _LIB['<default_namespace>']
-   if (Payload.namespace_name) {
-      const Identifier &ns_id = *Payload.namespace_name;
-      const std::string &default_ns = Payload.default_namespace;
+   if (Entry.namespace_name) {
+      const Identifier &ns_id = *Entry.namespace_name;
+      const std::string &default_ns = Entry.default_namespace;
 
       if (default_ns.empty()) {
          return ParserResult<IrEmitUnit>::failure(this->make_error(
@@ -399,6 +399,19 @@ ParserResult<IrEmitUnit> IrEmitter::emit_import_stmt(const ImportStmtPayload &Pa
       // Update binding table
       this->update_local_binding(ns_id.symbol, BCReg(fs->varmap.size() - 1));
       fs->reset_freereg();
+   }
+
+   return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+}
+
+//********************************************************************************************************************
+// Emit bytecode for import statement: import 'path' [, 'path'...]
+
+ParserResult<IrEmitUnit> IrEmitter::emit_import_stmt(const ImportStmtPayload &Payload)
+{
+   for (const ImportEntryPayload &entry : Payload.entries) {
+      auto result = this->emit_import_entry(entry);
+      if (not result.ok()) return result;
    }
 
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -177,6 +177,7 @@ private:
    ParserResult<IrEmitUnit> emit_try_except_stmt(const TryExceptPayload& payload);
    ParserResult<IrEmitUnit> emit_raise_stmt(const RaiseStmtPayload& payload, const SourceSpan& span);
    ParserResult<IrEmitUnit> emit_check_stmt(const CheckStmtPayload& payload, const SourceSpan& span);
+   ParserResult<IrEmitUnit> emit_import_entry(const ImportEntryPayload& entry);
    ParserResult<IrEmitUnit> emit_import_stmt(const ImportStmtPayload& payload);
    ParserResult<IrEmitUnit> emit_with_stmt(const WithStmtPayload& payload);
    ParserResult<IrEmitUnit> emit_assignment_stmt(const AssignmentStmtPayload& payload);

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -305,7 +305,7 @@ end
    try
       exec([[enum DUP_ENUM { ONE, ONE }]])
    except ex
-      assert(ex.message:find('duplicate enum member'), f'Error should mention duplicate enum member: {ex.message}')
+      assert(ex.message:find('Duplicate enum member'), f'Error should mention duplicate enum member: {ex.message}')
       return
    end
    error('Duplicate enum member should fail')
@@ -318,7 +318,7 @@ enum DUP_REG_ENUM { ONE }
 enum DUP_REG_ENUM { ONE }
 ]])
    except ex
-      assert(ex.message:find('duplicate enum constant'), f'Error should mention duplicate enum constant: {ex.message}')
+      assert(ex.message:find('Duplicate enum constant'), f'Error should mention duplicate enum constant: {ex.message}')
       return
    end
    error('Duplicate registered enum constant should fail')

--- a/src/tiri/tests/test_import.tiri
+++ b/src/tiri/tests/test_import.tiri
@@ -1,8 +1,26 @@
 
-   import './compile_if_helper'
-   import './import_parent/child'
+   import './compile_if_helper', './import_parent/child'
 
 extern on_windows, on_linux, on_osx, debug_on, debug_off
+
+function assert_valid(Source:str, Context:str)
+   local result = debug.validate(Source)
+
+   assert(type(result) is 'table', Context .. ': debug.validate() should return a table')
+   assert(result.success is true, Context .. ': source should validate successfully')
+end
+
+function assert_invalid(Source:str, ExpectedMessage:str, Context:str)
+   local result = debug.validate(Source)
+
+   assert(type(result) is 'table', Context .. ': debug.validate() should return a table')
+   assert(result.success is false, Context .. ': source should fail validation')
+   assert(type(result.diagnostics) is 'table', Context .. ': diagnostics should be returned')
+   assert(#result.diagnostics > 0, Context .. ': at least one diagnostic should be reported')
+   assert(string.find(result.diagnostics[0].message, ExpectedMessage, 0, true) != nil,
+      Context .. ': diagnostic should contain "' .. ExpectedMessage .. '", got: ' ..
+      tostring(result.diagnostics[0].message))
+end
 
 @Test function ImportBasic()
    assert(helper_message is "Hello from imported module!",
@@ -31,4 +49,53 @@ end
    assert(parent_import_value() is 73, "Expected parent import function to remain available")
    assert(child_parent_message is "Loaded through parent-relative import from child",
       f"Expected child import message, got '{child_parent_message}'")
+end
+
+@Test function ImportListNamespaceLocals()
+   assert_valid([[
+      import 'json', 'options'
+
+      local encoded = json.encode({ ['ok'] = true })
+      local parser = options({ args = {} })
+      assert(type(encoded) is 'string')
+      assert(type(parser.getUsage()) is 'string')
+   ]], 'import list namespace locals')
+end
+
+@Test function DuplicateImportListEntryIsAccepted()
+   assert_valid([[
+      import 'json', 'json'
+
+      local encoded = json.encode({ ['value'] = 1 })
+      assert(type(encoded) is 'string')
+   ]], 'duplicate import list entry')
+end
+
+@Test function SingleAliasedImportStillWorks()
+   assert_valid([[
+      import 'json' as jsonLib
+
+      local encoded = jsonLib.encode({ ['aliased'] = true })
+      assert(type(encoded) is 'string')
+   ]], 'single import alias')
+end
+
+@Test function ImportListAliasesAreRejected()
+   assert_invalid([[import 'json' as jsonLib, 'options']], "import lists do not support 'as' aliases",
+      'alias on first list item')
+   assert_invalid([[import 'json', 'options' as optionsLib]], "import lists do not support 'as' aliases",
+      'alias on later list item')
+end
+
+@Test function MalformedImportListsAreRejected()
+   assert_invalid([[import 'json',]], 'import list items must be string literals', 'trailing comma')
+   assert_invalid([[import 'json', name]], 'import list items must be string literals', 'non-string list item')
+end
+
+@Test function ImportInsideFunctionRemainsRejected()
+   assert_invalid([[
+      function invalid_import()
+         import 'json'
+      end
+   ]], "Use of 'import' is not permitted inside function blocks", 'import inside function')
 end

--- a/src/tiri/tests/test_import.tiri
+++ b/src/tiri/tests/test_import.tiri
@@ -81,15 +81,15 @@ end
 end
 
 @Test function ImportListAliasesAreRejected()
-   assert_invalid([[import 'json' as jsonLib, 'options']], "import lists do not support 'as' aliases",
+   assert_invalid([[import 'json' as jsonLib, 'options']], "Import lists do not support 'as' aliases",
       'alias on first list item')
-   assert_invalid([[import 'json', 'options' as optionsLib]], "import lists do not support 'as' aliases",
+   assert_invalid([[import 'json', 'options' as optionsLib]], "Import lists do not support 'as' aliases",
       'alias on later list item')
 end
 
 @Test function MalformedImportListsAreRejected()
-   assert_invalid([[import 'json',]], 'import list items must be string literals', 'trailing comma')
-   assert_invalid([[import 'json', name]], 'import list items must be string literals', 'non-string list item')
+   assert_invalid([[import 'json',]], 'Import list items must be string literals', 'trailing comma')
+   assert_invalid([[import 'json', name]], 'Import list items must be string literals', 'non-string list item')
 end
 
 @Test function ImportInsideFunctionRemainsRejected()

--- a/src/tiri/tests/test_include_list.tiri
+++ b/src/tiri/tests/test_include_list.tiri
@@ -56,7 +56,7 @@ end
 @Test function MalformedIncludeListsAreRejected()
    assert_invalid([[include 'core',]], "'include' list items must be string literals", 'trailing comma')
    assert_invalid([[include 'core', name]], "'include' list items must be string literals", 'non-string item')
-   assert_invalid([[include '']], 'invalid module name', 'empty module name')
+   assert_invalid([[include '']], 'Invalid module name', 'empty module name')
 end
 
 @Test function UnrelatedParenlessCallsDoNotGainCommaLists()

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -1016,9 +1016,7 @@ static ERR register_interfaces(extTiri *Self)
    reg_func_prototype("arg", { TiriType::Any }, { TiriType::Str, TiriType::Any });
    reg_func_prototype("loadFile", {}, { TiriType::Str }, FProtoFlags::Variadic);
    reg_func_prototype("exec", {}, { TiriType::Str }, FProtoFlags::Variadic);
-   reg_func_prototype("getExecutionState", { TiriType::Table }, {});
    reg_func_prototype("print", {}, {}, FProtoFlags::Variadic);
-   reg_func_prototype("require", { TiriType::Table }, { TiriType::Str });
    reg_func_prototype("msg", {}, { TiriType::Str }, FProtoFlags::Variadic);
    reg_func_prototype("subscribeEvent", { TiriType::Num, TiriType::Any }, { TiriType::Str, TiriType::Func });
    reg_func_prototype("unsubscribeEvent", {}, { TiriType::Any });

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -8,7 +8,10 @@ rx_def_decl           <const> = <{ regex.new([[\b(local|global)\s+([A-Za-z_][A-Z
 rx_def_assign_func    <const> = <{ regex.new([[\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^\)]*)\)]]) }>
 rx_def_assign         <const> = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]]) }>
 rx_def_param          <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
-rx_def_loader_before  <const> = <{ regex.new([[\b(import|require|include)\s*(?:\(\s*)?$]]) }>
+rx_def_loader_before  <const> = <{ regex.new(
+   [[\b(import|require|include)\s*(?:\(\s*)?]] ..
+   [[(?:(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*,\s*)*$]]
+) }>
 rx_def_obj_new_before <const> = <{ regex.new([[obj\.new\s*\(\s*$]]) }>
 rx_def_obj_new        <const> = <{ regex.new([=[([A-Za-z_][A-Za-z0-9_]*)\s*=\s*obj\.new\s*\(\s*['"]([^'"]+)['"]]=], regex.DOT_ALL) }>
 rx_def_action_prefix  <const> = <{ regex.new([=[^ac[A-Z]]=]) }>
@@ -204,6 +207,7 @@ function getStringAtPosition(Doc:table, Line:num, Character:num):table
                      text = line_text:sub(start_pos + 1, pos),
                      quoteStart = start_pos,
                      quoteEnd = pos,
+                     line = Line,
                      before = line_text:sub(0, start_pos)
                   }
                end
@@ -219,11 +223,29 @@ function getStringAtPosition(Doc:table, Line:num, Character:num):table
    return nil
 end
 
+function getLoaderKeywordBeforeString(Doc:table, StringInfo:table):str
+   prefix = StringInfo.before
+   line_no = StringInfo.line
+
+   while line_no >= 0 do
+      keyword = rx_def_loader_before.extract(prefix)
+      if keyword then return keyword end
+
+      if line_no is 0 then break end
+      line_no -= 1
+      previous_line = getLine(Doc, line_no)
+      previous_line ?! break
+      prefix = previous_line .. '\n' .. prefix
+   end
+
+   return nil
+end
+
 function getLoaderStringAtPosition(Doc:table, Position:table):table
    string_info = getStringAtPosition(Doc, Position.line, Position.character)
    string_info ?! return nil
 
-   keyword = rx_def_loader_before.extract(string_info.before)
+   keyword = getLoaderKeywordBeforeString(Doc, string_info)
    keyword ?! return nil
 
    string_info.keyword = keyword

--- a/tools/tiri_lsp/include/lsp_defs.tiri
+++ b/tools/tiri_lsp/include/lsp_defs.tiri
@@ -210,7 +210,10 @@ glKeywords = {
    ['extern'] = {
       comment = 'Declares that a symbol is supplied externally and should be resolved as a global.'
    },
-   ['import'] = { comment = 'Inlines a Tiri script library at parse time. Use ./ or ../ for local libraries.' },
+   ['import'] = {
+      comment = 'Inlines one or more Tiri script libraries at parse time. List entries must be string literals; ' ..
+         'use ./ or ../ for local libraries. The as alias form is only valid for single imports.'
+   },
    ['as'] = { comment = 'Introduces a local alias for an imported library namespace.' },
 
    -- Pattern matching

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -88,6 +88,18 @@ end
    assertUriContains(locations, '/scripts/gui/window.tiri', 'Nested import should resolve to SDK script')
 end
 
+@Test function ImportListScriptResolution()
+   doc = makeDoc("import 'json', 'options'\n")
+   locations = resolveDefinition(doc, { line = 0, character = 17 })
+   assertUriContains(locations, '/scripts/options.tiri', 'Second import list item should resolve to SDK script')
+end
+
+@Test function WrappedImportListScriptResolution()
+   doc = makeDoc("import 'json',\n   'options'\n")
+   locations = resolveDefinition(doc, { line = 1, character = 6 })
+   assertUriContains(locations, '/scripts/options.tiri', 'Wrapped import list item should resolve to SDK script')
+end
+
 @Test function ImportParentRelativeScriptResolution()
    doc = makeDoc("import '../server'\n")
    locations = resolveDefinition(doc, { line = 0, character = 11 })

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -86,6 +86,20 @@ end
    assert(import_path and import_path.type is 4, 'Parent-relative import path should remain a string token.')
 end
 
+@Test function ImportListPathsReceiveSemanticTokens()
+   source = "import 'json',\n   'options'\n"
+
+   tokens = tokenizeTiri(source)
+
+   import_keyword = findToken(tokens, 0, 0, 'import')
+   first_path = findToken(tokens, 0, 7, "'json'")
+   second_path = findToken(tokens, 1, 3, "'options'")
+
+   assert(import_keyword and import_keyword.type is 0, 'import list keyword should be highlighted as a keyword.')
+   assert(first_path and first_path.type is 4, 'First import list path should remain a string token.')
+   assert(second_path and second_path.type is 4, 'Wrapped import list path should remain a string token.')
+end
+
 @Test function ExternKeywordReceivesSemanticTokens()
    source = 'extern runTest, assertEqId\n'
 


### PR DESCRIPTION
* Added comma-separated import parsing and direct emission for ordered import entries
* [LSP] Resolved import list targets across wrapped lines and updated import keyword help
* [Test] Covered import lists, alias rejection and LSP import-list handling
* Removed stale getExecutionState and require interface prototypes