### PR TITLE
[Core] Tightened callback reference ownership

### DIFF
--- a/include/kotuku/system/types.h
+++ b/include/kotuku/system/types.h
@@ -75,10 +75,20 @@ struct FUNCTION {
    // The CALL::STDC constructor is managed by C_FUNCTION() in order to prevent problems with
    // implicit type conversion.
 
+   inline void disable() { Type = CALL::NIL; }
    inline void clear() { Type = CALL::NIL; Flags = 0; MetaValue = 0; Routine = nullptr; }
    inline bool isC() const { return Type IS CALL::STD_C; }
    inline bool isScript() const { return Type IS CALL::SCRIPT; }
    inline bool defined() const { return Type != CALL::NIL; }
+
+   inline bool releaseIfStale() {
+      if (stale()) {
+         unpin();
+         disable();
+         return true;
+      }
+      else return false;
+   }
 
    // Weak-pin management for stale callback detection; refer to the zombie object contract in objects.h.
    // Defined in modules/core.h once Object is complete.

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -18,6 +18,15 @@ inline BYTELEN &operator += (BYTELEN &a, BYTELEN b) { return (BYTELEN &)(((int &
 
 inline SAMPLE &operator -= (SAMPLE &a, SAMPLE b) { return (SAMPLE &)(((int &)a) -= ((int)b)); }
 
+inline void release_audio_callback(FUNCTION &Function)
+{
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
+}
+
 // Audio channel commands
 
 enum class CMD : int {

--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -24,16 +24,10 @@ Note: Support for audio recording is not currently available in this implementat
 
 #include "mixer_dispatch.h"
 
-static void deref_audio_callback(FUNCTION &Function)
-{
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
-}
-
 static void deref_audio_sample(AudioSample &Sample)
 {
-   deref_audio_callback(Sample.Callback);
-   deref_audio_callback(Sample.OnStop);
+   release_audio_callback(Sample.Callback);
+   release_audio_callback(Sample.OnStop);
 }
 
 #ifndef ALSA_ENABLED
@@ -260,6 +254,7 @@ ERR AUDIO_AddSample(extAudio *Self, struct snd::AddSample *Args)
    sample.SampleType   = Args->SampleFormat;
    sample.SampleLength = SAMPLE(Args->DataSize >> shift);
    sample.OnStop       = Args->OnStop;
+   if (sample.OnStop.defined()) sample.OnStop.pin();
 
    if (auto loop = Args->Loop) {
       sample.LoopMode     = loop->LoopMode;
@@ -285,7 +280,10 @@ ERR AUDIO_AddSample(extAudio *Self, struct snd::AddSample *Args)
    else if (!AllocMemory(Args->DataSize, MEM::DATA|MEM::NO_CLEAR, (APTR *)&sample.Data)) {
       copymem(Args->Data, sample.Data, Args->DataSize);
    }
-   else return log.warning(ERR::AllocMemory);
+   else {
+      deref_audio_sample(sample);
+      return log.warning(ERR::AllocMemory);
+   }
 
    Args->Result = idx;
    return ERR::Okay;
@@ -394,6 +392,8 @@ static ERR AUDIO_AddStream(extAudio *Self, struct snd::AddStream *Args)
    sample.StreamLength = BYTELEN((Args->SampleLength > 0) ? Args->SampleLength : 0x7fffffff); // 'Infinite' stream length
    sample.Callback     = Args->Callback;
    sample.OnStop       = Args->OnStop;
+   if (sample.Callback.defined()) sample.Callback.pin();
+   if (sample.OnStop.defined()) sample.OnStop.pin();
    sample.Stream       = true;
    sample.PlayPos      = BYTELEN(Args->PlayOffset);
 
@@ -412,6 +412,7 @@ static ERR AUDIO_AddStream(extAudio *Self, struct snd::AddStream *Args)
    }
 
    if (AllocMemory(buffer_len, MEM::DATA|MEM::NO_CLEAR, (APTR *)&sample.Data) != ERR::Okay) {
+      deref_audio_sample(sample);
       return ERR::AllocMemory;
    }
 

--- a/src/audio/class_sound.cpp
+++ b/src/audio/class_sound.cpp
@@ -85,7 +85,11 @@ static ERR win32_audio_stream(extSound *, int64_t, int64_t);
 
 static void sound_stopped_event(extSound *Self)
 {
-   if (Self->OnStop.isC()) {
+   if (Self->OnStop.stale()) {
+      Self->OnStop.unpin();
+      Self->OnStop.clear();
+   }
+   else if (Self->OnStop.isC()) {
       kt::SwitchContext context(Self->OnStop.Context);
       auto routine = (void (*)(extSound *, APTR))Self->OnStop.Routine;
       routine(Self, Self->OnStop.Meta);
@@ -496,7 +500,9 @@ static ERR SOUND_Activate(extSound *Self)
 
 static void notify_onstop_free(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 {
-   ((extSound *)CurrentContext())->OnStop.clear();
+   auto self = (extSound *)CurrentContext();
+   if (self->OnStop.defined()) self->OnStop.unpin();
+   self->OnStop.clear();
 }
 
 /*********************************************************************************************************************
@@ -1431,14 +1437,22 @@ static ERR SOUND_GET_OnStop(extSound *Self, FUNCTION * &Value)
 
 static ERR SOUND_SET_OnStop(extSound *Self, FUNCTION *Value)
 {
-   if (Value) {
+   if (Self->OnStop.defined()) {
       if (Self->OnStop.isScript()) UnsubscribeAction(Self->OnStop.Context, AC::Free);
+      Self->OnStop.unpin();
+      Self->OnStop.disable();
+   }
+
+   if (Value) {
       Self->OnStop = *Value;
-      if (Self->OnStop.isScript()) {
-         SubscribeAction(Self->OnStop.Context, AC::Free, C_FUNCTION(notify_onstop_free));
+      if (Self->OnStop.defined()) {
+         Self->OnStop.pin();
+         if (Self->OnStop.isScript()) {
+            SubscribeAction(Self->OnStop.Context, AC::Free, C_FUNCTION(notify_onstop_free));
+         }
       }
    }
-   else Self->OnStop.clear();
+
    return ERR::Okay;
 }
 
@@ -1662,9 +1676,10 @@ extSound::~extSound() {
    if (StreamTimer)   UpdateTimer(StreamTimer, 0);
    if (PlaybackTimer) UpdateTimer(PlaybackTimer, 0);
 
-   if (OnStop.isScript()) {
-      UnsubscribeAction(OnStop.Context, AC::Free);
-      OnStop.clear();
+   if (OnStop.defined()) {
+      if (OnStop.isScript()) UnsubscribeAction(OnStop.Context, AC::Free);
+      OnStop.unpin();
+      OnStop.disable();
    }
 
 #ifdef USE_WIN32_PLAYBACK

--- a/src/audio/functions.cpp
+++ b/src/audio/functions.cpp
@@ -140,6 +140,11 @@ void convert_samples(const InputType* input, int count, OutputType* output) {
 static void audio_stopped_event(extAudio &Audio, int SampleHandle)
 {
    auto &sample = Audio.Samples[SampleHandle];
+   if (sample.OnStop.stale()) {
+      release_audio_callback(sample.OnStop);
+      return;
+   }
+
    if (sample.OnStop.isC()) {
       kt::SwitchContext context(sample.OnStop.Context);
       auto routine = (void (*)(extAudio *, int, APTR))sample.OnStop.Routine;
@@ -155,6 +160,11 @@ static void audio_stopped_event(extAudio &Audio, int SampleHandle)
 
 static BYTELEN fill_stream_buffer(int Handle, AudioSample &Sample, int Offset)
 {
+   if (Sample.Callback.stale()) {
+      release_audio_callback(Sample.Callback);
+      return BYTELEN(0);
+   }
+
    if (Sample.Callback.isC()) {
       kt::SwitchContext context(Sample.Callback.Context);
       auto routine = (BYTELEN (*)(int, int, uint8_t *, int, APTR))Sample.Callback.Routine;

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -1631,9 +1631,16 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
             Self->prvWatch->Routine   = *Args->Callback;
             Self->prvWatch->Flags     = Args->Flags;
             Self->prvWatch->Routine.pin();
-            retained_callback = true;
 
             error = vd.WatchPath(Self);
+            if (error IS ERR::Okay) retained_callback = true;
+            else {
+               auto &func = Self->prvWatch->Routine;
+               if ((func.isScript()) and (not func.stale())) ((objScript *)func.Context)->derefProcedure(func);
+               func.unpin();
+               FreeResource(Self->prvWatch);
+               Self->prvWatch = nullptr;
+            }
          }
          else error = ERR::AllocMemory;
       }

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -158,12 +158,6 @@ static ERR GET_ResolvedPath(extFile *, std::string_view &);
 
 static ERR set_permissions(extFile *, PERMIT);
 
-static void deref_file_callback(FUNCTION &Function)
-{
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
-}
-
 /*********************************************************************************************************************
 -ACTION-
 Activate: Opens the file.  Performed automatically if `NEW`, `READ` or `WRITE` flags were specified on initialisation.
@@ -1575,6 +1569,11 @@ non-blocking, mutates-object, callback-held
 static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
 {
    kt::Log log;
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Args) and (Args->Callback) and (not retained_callback)) Args->Callback->consume();
+   });
 
    log.branch("%s, Flags: $%.8x", Self->Path.c_str(), (Args) ? int(Args->Flags) : 0);
 
@@ -1582,7 +1581,13 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
 
    if (Self->prvWatch) {
       auto id = Self->prvWatch->VirtualID;
-      deref_file_callback(Self->prvWatch->Routine);
+      auto &func = Self->prvWatch->Routine;
+
+      if ((func.isScript()) and (not func.stale())) {
+         ((objScript *)func.Context)->derefProcedure(func);
+      }
+      func.unpin();
+
       void (*ignore_file)(extFile *) = nullptr;
       {
          std::lock_guard<std::mutex> lock(glmVirtual);
@@ -1596,6 +1601,7 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
    }
 
    if ((not Args) or (not Args->Callback) or (Args->Flags IS MFF::NIL)) return ERR::Okay;
+   if (not Args->Callback->defined()) return log.warning(ERR::Args);
 
 #ifdef __linux__ // Initialise inotify if not done already.
 
@@ -1624,6 +1630,8 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
             Self->prvWatch->VirtualID = vd.VirtualID;
             Self->prvWatch->Routine   = *Args->Callback;
             Self->prvWatch->Flags     = Args->Flags;
+            Self->prvWatch->Routine.pin();
+            retained_callback = true;
 
             error = vd.WatchPath(Self);
          }

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -166,7 +166,8 @@ static void task_stdinput_callback(HOSTHANDLE FD, void *Task)
       buffer[0] = 0;
    }
 
-   if (Self->InputCallback.isC()) {
+   if (Self->InputCallback.stale()) clear_callback(Self->InputCallback);
+   else if (Self->InputCallback.isC()) {
       auto routine = (void (*)(extTask *, APTR, int, ERR, APTR))Self->InputCallback.Routine;
       routine(Self, buffer, bytes_read, error, Self->InputCallback.Meta);
    }
@@ -216,7 +217,8 @@ static int read_task_stdout(HOSTHANDLE FD, APTR Task)
       buffer[len] = 0;
 
       auto task = (extTask *)Task;
-      if (task->OutputCallback.isC()) {
+      if (task->OutputCallback.stale()) clear_callback(task->OutputCallback);
+      else if (task->OutputCallback.isC()) {
          auto routine = (void (*)(extTask *, APTR, int, APTR))task->OutputCallback.Routine;
          routine(task, buffer, len, task->OutputCallback.Meta);
       }
@@ -275,7 +277,8 @@ static int read_task_stderr(HOSTHANDLE FD, APTR Task)
       buffer[len] = 0;
 
       auto task = (extTask *)Task;
-      if (task->ErrorCallback.isC()) {
+      if (task->ErrorCallback.stale()) clear_callback(task->ErrorCallback);
+      else if (task->ErrorCallback.isC()) {
          auto routine = (void (*)(extTask *, APTR, int, APTR))task->ErrorCallback.Routine;
          routine(task, buffer, len, task->ErrorCallback.Meta);
       }
@@ -511,7 +514,8 @@ static void task_process_end(extTask *Task, int ReturnCode, bool Returned)
       Task->ReturnCodeSet = true;
    }
 
-   if (Task->ExitCallback.isC()) {
+   if (Task->ExitCallback.stale()) clear_callback(Task->ExitCallback);
+   else if (Task->ExitCallback.isC()) {
       auto routine = (void (*)(extTask *, APTR))Task->ExitCallback.Routine;
       routine(Task, Task->ExitCallback.Meta);
    }
@@ -618,7 +622,8 @@ static void task_process_end(WINHANDLE FD, extTask *Task)
 
    // Call ExitCallback, if specified
 
-   if (Task->ExitCallback.isC()) {
+   if (Task->ExitCallback.stale()) clear_callback(Task->ExitCallback);
+   else if (Task->ExitCallback.isC()) {
       auto routine = (void (*)(extTask *, APTR))Task->ExitCallback.Routine;
       routine(Task, Task->ExitCallback.Meta);
    }
@@ -1547,6 +1552,7 @@ static ERR TASK_Init(extTask *Self)
       FUNCTION call;
       call.Type = CALL::STD_C;
       call.Routine = (APTR)msg_action;
+      call.Context = Self;
       AddMsgHandler(MSGID::ACTION, &call, &handler);
       Self->MsgAction.reset(handler);
 
@@ -1992,8 +1998,11 @@ static ERR GET_ErrorCallback(extTask *Self, FUNCTION * &Value)
 
 static ERR SET_ErrorCallback(extTask *Self, FUNCTION *Value)
 {
-   if (Value) Self->ErrorCallback = *Value;
-   else Self->ErrorCallback.clear();
+   clear_callback(Self->ErrorCallback);
+   if (Value) {
+      Self->ErrorCallback = *Value;
+      if (Self->ErrorCallback.defined()) Self->ErrorCallback.pin();
+   }
    return ERR::Okay;
 }
 
@@ -2021,8 +2030,11 @@ static ERR GET_ExitCallback(extTask *Self, FUNCTION * &Value)
 
 static ERR SET_ExitCallback(extTask *Self, FUNCTION *Value)
 {
-   if (Value) Self->ExitCallback = *Value;
-   else Self->ExitCallback.clear();
+   clear_callback(Self->ExitCallback);
+   if (Value) {
+      Self->ExitCallback = *Value;
+      if (Self->ExitCallback.defined()) Self->ExitCallback.pin();
+   }
    return ERR::Okay;
 }
 
@@ -2079,7 +2091,9 @@ static ERR SET_InputCallback(extTask *Self, FUNCTION *Value)
       #elif _WIN32
       if (auto error = RegisterFD(winGetStdInput(), RFD::READ, &task_stdinput_callback, Self); !error) {
       #endif
+         clear_callback(Self->InputCallback);
          Self->InputCallback = *Value;
+         if (Self->InputCallback.defined()) Self->InputCallback.pin();
       }
       else return error;
    }
@@ -2089,7 +2103,7 @@ static ERR SET_InputCallback(extTask *Self, FUNCTION *Value)
       #else
       if (Self->InputCallback.defined()) RegisterFD(fileno(stdin), RFD::READ|RFD::REMOVE, &task_stdinput_callback, Self);
       #endif
-      Self->InputCallback.clear();
+      clear_callback(Self->InputCallback);
    }
 
    return ERR::Okay;
@@ -2120,8 +2134,11 @@ static ERR GET_OutputCallback(extTask *Self, FUNCTION * &Value)
 
 static ERR SET_OutputCallback(extTask *Self, FUNCTION *Value)
 {
-   if (Value) Self->OutputCallback = *Value;
-   else Self->OutputCallback.clear();
+   clear_callback(Self->OutputCallback);
+   if (Value) {
+      Self->OutputCallback = *Value;
+      if (Self->OutputCallback.defined()) Self->OutputCallback.pin();
+   }
    return ERR::Okay;
 }
 
@@ -2430,6 +2447,11 @@ extTask::~extTask()
    if (Platform) { winFreeProcess(Platform); Platform = nullptr; }
    if (InputCallback.defined()) RegisterFD(winGetStdInput(), RFD::READ|RFD::REMOVE, &task_stdinput_callback, this);
 #endif
+
+   clear_callback(ErrorCallback);
+   clear_callback(OutputCallback);
+   clear_callback(ExitCallback);
+   clear_callback(InputCallback);
 }
 
 //********************************************************************************************************************

--- a/src/core/classes/class_thread.cpp
+++ b/src/core/classes/class_thread.cpp
@@ -63,13 +63,19 @@ ERR msg_threadcallback(APTR Custom, int MsgID, int MsgType, APTR Message, int Ms
 
    log.branch("Executing completion callback for thread #%d", uid);
 
-   if (msg->Callback.isC()) {
+   if (msg->Callback.stale()) clear_callback(msg->Callback);
+   else if (msg->Callback.isC()) {
       auto callback = (void (*)(OBJECTID, APTR))msg->Callback.Routine;
       callback(uid, msg->Callback.Meta);
    }
    else if (msg->Callback.isScript()) {
       ScopedObjectLock script(msg->Callback.Context, 5000);
       if (script.granted()) sc::Call(msg->Callback, std::to_array<ScriptArg>({ { "Thread", uid, FD_OBJECTID } }));
+   }
+
+   if (msg->Callback.defined()) {
+      msg->Callback.unpin();
+      msg->Callback.clear();
    }
 
    // NB: Assume 'msg' is unstable after this point because the callback may have modified the message table.
@@ -144,6 +150,7 @@ static ERR THREAD_Activate(extThread *Self)
       Self->InterruptThreadID.store(GetThreadID(), std::memory_order_release);
 
       ThreadMessage msg = { .ThreadID = uid, .Callback = Self->Callback };
+      if (msg.Callback.defined()) msg.Callback.pin();
 
       {
          // Replace the default dummy context with one that pertains to the thread
@@ -151,6 +158,10 @@ static ERR THREAD_Activate(extThread *Self)
 
          if (StopToken.stop_requested()) {
             Self->Error = ERR::Cancelled;
+         }
+         else if (Self->Routine.stale()) {
+            clear_callback(Self->Routine);
+            Self->Error = ERR::Terminate;
          }
          else if (Self->Routine.isC()) {
             auto routine = (ERR (*)(extThread *, APTR))Self->Routine.Routine;
@@ -298,6 +309,26 @@ static ERR GET_Data(extThread *Self, std::span<uint8_t> &Value)
    return ERR::Okay;
 }
 
+static ERR SET_Callback(extThread *Self, FUNCTION *Value)
+{
+   clear_callback(Self->Callback);
+   if (Value) {
+      Self->Callback = *Value;
+      if (Self->Callback.defined()) Self->Callback.pin();
+   }
+   return ERR::Okay;
+}
+
+static ERR SET_Routine(extThread *Self, FUNCTION *Value)
+{
+   clear_callback(Self->Routine);
+   if (Value) {
+      Self->Routine = *Value;
+      if (Self->Routine.defined()) Self->Routine.pin();
+   }
+   return ERR::Okay;
+}
+
 /*********************************************************************************************************************
 
 -FIELD-
@@ -330,6 +361,9 @@ extThread::~extThread()
    }
 
    if (CPPThread) { delete CPPThread; CPPThread = nullptr; }
+
+   clear_callback(Callback);
+   clear_callback(Routine);
 }
 
 //********************************************************************************************************************
@@ -337,8 +371,8 @@ extThread::~extThread()
 #include "class_thread_def.c"
 
 static const FieldArray clFields[] = {
-   { "Callback",  FDF_FUNCTION|FDF_RW },
-   { "Routine",   FDF_FUNCTION|FDF_RW },
+   { "Callback",  FDF_FUNCTION|FDF_RW, nullptr, SET_Callback },
+   { "Routine",   FDF_FUNCTION|FDF_RW, nullptr, SET_Routine },
    { "Data",      FDF_ARRAY|FDF_BYTE|FDF_R|FDF_PURE, GET_Data },
    { "DataSize",  FDF_INT|FDF_R },
    { "Error",     FDF_INT|FDF_R },

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1391,3 +1391,14 @@ typename Container::const_iterator binary_search(const Container& container, con
     }
     return container.end();
 }
+
+//********************************************************************************************************************
+
+static void clear_callback(FUNCTION &Function)
+{
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
+}

--- a/src/core/lib_events.cpp
+++ b/src/core/lib_events.cpp
@@ -210,7 +210,10 @@ ERR SubscribeEvent(int64_t EventID, FUNCTION *Callback, APTR *Handle)
 
    if ((!Callback) or (!EventID) or (!Handle)) return ERR::NullArgs;
 
-   if (!Callback->isC()) return ERR::Args; // Currently only StdC callbacks are accepted.
+   if (!Callback->isC()) {
+      Callback->consume();
+      return ERR::Args; // Currently only StdC callbacks are accepted.
+   }
 
    auto gid = EVG(uint8_t(EventID>>56));
 

--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -725,7 +725,8 @@ blocking, callback-inlines
 
 ERR CopyFile(const std::string_view &Source, const std::string_view &Dest, FUNCTION *Callback)
 {
-   return fs_copy(Source, Dest, Callback, FALSE);
+   if (Callback) Callback->consume();
+   return fs_copy(Source, Dest, Callback, false);
 }
 
 /*********************************************************************************************************************
@@ -844,6 +845,8 @@ ERR DeleteFile(const std::string_view &Path, FUNCTION *Callback)
 {
    kt::Log log(__FUNCTION__);
 
+   if (Callback) Callback->consume();
+
    if (Path.empty()) return ERR::NullArgs;
 
    log.branch("%.*s", int(Path.size()), Path.data());
@@ -853,7 +856,7 @@ ERR DeleteFile(const std::string_view &Path, FUNCTION *Callback)
    std::string resolve;
    if (!ResolvePath(Path, RSF::NIL, &resolve)) {
       auto vd = get_fs(resolve);
-      if (vd.Delete) return vd.Delete(resolve, nullptr);
+      if (vd.Delete) return vd.Delete(resolve, Callback);
       else return ERR::NoSupport;
    }
    else return ERR::ResolvePath;
@@ -1132,10 +1135,12 @@ ERR MoveFile(const std::string_view &Source, const std::string_view &Dest, FUNCT
 {
    kt::Log log(__FUNCTION__);
 
+   if (Callback) Callback->consume();
+
    if ((Source.empty()) or (Dest.empty())) return ERR::NullArgs;
 
    log.branch("%.*s to %.*s", int(Source.size()), Source.data(), int(Dest.size()), Dest.data());
-   return fs_copy(Source, Dest, Callback, TRUE);
+   return fs_copy(Source, Dest, Callback, true);
 }
 
 /*********************************************************************************************************************

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -920,39 +920,60 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
    });
 
    if ((not Interval) or (not Callback)) return log.warning(ERR::NullArgs);
+   if (not Callback->defined()) return log.warning(ERR::Args);
    if (Interval < 0) return log.warning(ERR::Args);
 
    auto subscriber = tlContext.back().obj;
    if (subscriber->collecting()) return log.warning(ERR::InvalidState);
 
-   if (Callback->Type IS CALL::SCRIPT) log.msg(VLF::BRANCH|VLF::FUNCTION|VLF::DETAIL, "Interval: %.3fs", Interval);
+   if (Callback->isScript()) log.msg(VLF::BRANCH|VLF::FUNCTION|VLF::DETAIL, "Interval: %.3fs", Interval);
    else log.msg(VLF::BRANCH|VLF::FUNCTION|VLF::DETAIL, "Callback: %p, Interval: %.3fs", Callback->Routine, Interval);
 
    if (auto lock = std::unique_lock{glmTimer, 1000ms}) {
       auto usInterval = int64_t(Interval * 1000000.0); // Scale the interval to microseconds
+      auto subscribed = PreciseTime();
+      auto next_call = subscribed + usInterval;
+
       if (usInterval <= 40000) {
-         // TODO: Rapid timers should be synchronised with other existing timers to limit the number of
-         // interruptions that occur per second.
+         // Synchronise rapid timers that share an interval so the message loop can wake once for the group.
+         bool found_phase = false;
+         auto phase_call = next_call;
+
+         for (const auto &timer : glTimers) {
+            if ((timer.Interval != usInterval) or (timer.PendingInterval) or (timer.Routine.stale())) continue;
+
+            auto candidate = timer.NextCall;
+            if (candidate < next_call) {
+               auto cycles = ((next_call - candidate) + usInterval - 1) / usInterval;
+               candidate += cycles * usInterval;
+            }
+
+            if ((not found_phase) or (candidate < phase_call)) {
+               phase_call = candidate;
+               found_phase = true;
+            }
+         }
+
+         if (found_phase) next_call = phase_call;
       }
 
       auto it = glTimers.emplace(glTimers.end());
-      auto subscribed = PreciseTime();
       it->SubscriberID    = subscriber->UID;
       it->Interval        = usInterval;
       it->PendingInterval = 0;
       it->LastCall        = subscribed;
-      it->NextCall        = subscribed + usInterval;
+      it->NextCall        = next_call;
       it->Routine         = *Callback;
       it->Locked          = false;
       it->Cycle           = glTimerCycle - 1;
 
+      it->Routine.pin();
+
       if (subscriber->UID > 0) it->Subscriber = subscriber;
       else it->Subscriber = nullptr;
 
-      // For resource tracking purposes it is important for us to keep a record of the subscription so that
-      // we don't treat the object address as valid when it's been removed from the system.
-
-      subscriber->setFlag(NF::TIMER_SUB); // TODO: Use pin() instead?
+      // This flag lets object_free() cheaply detect and remove abandoned timer subscriptions.
+      subscriber->setFlag(NF::TIMER_SUB);
       if (Subscription) *Subscription = &*it;
       retained_callback = true;
       return ERR::Okay;
@@ -1016,12 +1037,17 @@ ERR UpdateTimer(APTR Subscription, double Interval)
          if (timer->Locked) {
             // A timer can't be removed during its execution, but we can nullify the function entry
             // and ProcessMessages() will automatically terminate it on the next cycle.
-            timer->Routine.Type = CALL::NIL;
+            if (timer->Routine.isScript() and (not timer->Routine.stale())) {
+               ((objScript *)timer->Routine.Context)->derefProcedure(timer->Routine);
+            }
+            if (timer->Routine.defined()) timer->Routine.unpin();
+            timer->Routine.clear();
             return log.warning(ERR::AlreadyLocked);
          }
 
          FUNCTION script_routine;
-         if (timer->Routine.isScript()) script_routine = timer->Routine;
+         if (timer->Routine.isScript() and (not timer->Routine.stale())) script_routine = timer->Routine;
+         if (timer->Routine.defined()) timer->Routine.unpin();
 
          for (auto it=glTimers.begin(); it != glTimers.end(); it++) {
             if (timer IS &(*it)) {

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -913,6 +913,11 @@ creates-resource, callback-held, blocking
 ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
 {
    kt::Log log(__FUNCTION__);
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Callback) and (not retained_callback)) Callback->consume();
+   });
 
    if ((not Interval) or (not Callback)) return log.warning(ERR::NullArgs);
    if (Interval < 0) return log.warning(ERR::Args);
@@ -949,6 +954,7 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
 
       subscriber->setFlag(NF::TIMER_SUB); // TODO: Use pin() instead?
       if (Subscription) *Subscription = &*it;
+      retained_callback = true;
       return ERR::Okay;
    }
    else return log.warning(ERR::SystemLocked);

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -59,7 +59,13 @@ static ERR msghandler_free(ResourceRecord &Resource, APTR Address)
    if (h->Next) h->Next->Prev = h->Prev;
    if (h->Prev) h->Prev->Next = h->Next;
 
-   if (h->Function.isScript()) ((objScript *)h->Function.Context)->derefProcedure(h->Function);
+   if (h->Function.defined()) {
+      if (h->Function.isScript() and (not h->Function.stale())) {
+         ((objScript *)h->Function.Context)->derefProcedure(h->Function);
+      }
+      h->Function.unpin();
+      h->Function.disable();
+   }
 
    return ERR::Terminate;
 }
@@ -150,6 +156,7 @@ ERR AddMsgHandler(MSGID MsgType, FUNCTION *Routine, MsgHandler **Handle)
       handler->Next     = nullptr;
       handler->MsgType  = MsgType;
       handler->Function = *Routine;
+      handler->Function.pin();
 
       if (!glMsgHandlers) glMsgHandlers = handler;
       else {
@@ -268,6 +275,10 @@ timer_cycle:
          for (auto timer=glTimers.begin(); timer != glTimers.end(); ) {
             if (current_time < timer->NextCall) { timer++; continue; }
             if (timer->Cycle IS glTimerCycle) { timer++; continue; }
+            if (timer->Routine.releaseIfStale()) {
+               timer = glTimers.erase(timer);
+               continue;
+            }
 
             int64_t elapsed = current_time - timer->LastCall;
 
@@ -322,9 +333,10 @@ timer_cycle:
             timer->Locked = false;
 
             if (error IS ERR::Terminate) {
-               if (timer->Routine.isScript()) {
+               if (timer->Routine.isScript() and (not timer->Routine.stale())) {
                   ((objScript *)timer->Routine.Context)->derefProcedure(timer->Routine);
                }
+               if (timer->Routine.defined()) timer->Routine.unpin();
 
                timer = glTimers.erase(timer);
             }
@@ -367,7 +379,8 @@ timer_cycle:
          for (auto hdl=glMsgHandlers; hdl; hdl=hdl->Next) {
             if ((hdl->MsgType IS MSGID::NIL) or (hdl->MsgType IS msg.Type)) {
                auto result = ERR::NoSupport;
-               if (hdl->Function.isC()) {
+               if (hdl->Function.stale()) continue;
+               else if (hdl->Function.isC()) {
                   auto msghandler = (ERR (*)(APTR, int, MSGID, APTR, int))hdl->Function.Routine;
                   if (msg.Size) result = msghandler(hdl->Function.Meta, msg.UID, msg.Type, msg.getBuffer(), msg.Size);
                   else result = msghandler(hdl->Function.Meta, msg.UID, msg.Type, nullptr, 0);

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -59,6 +59,8 @@ static ERR msghandler_free(ResourceRecord &Resource, APTR Address)
    if (h->Next) h->Next->Prev = h->Prev;
    if (h->Prev) h->Prev->Next = h->Next;
 
+   if (h->Function.isScript()) ((objScript *)h->Function.Context)->derefProcedure(h->Function);
+
    return ERR::Terminate;
 }
 
@@ -160,7 +162,10 @@ ERR AddMsgHandler(MSGID MsgType, FUNCTION *Routine, MsgHandler **Handle)
       if (Handle) *Handle = handler;
       return ERR::Okay;
    }
-   else return log.warning(ERR::AllocMemory);
+   else {
+      Routine->consume();
+      return log.warning(ERR::AllocMemory);
+   }
 }
 
 /*********************************************************************************************************************

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -29,6 +29,15 @@ static void async_wait_callback(OBJECTID, bool);
 //static ERR new_placement(CLASSID ClassID, NF Flags, OBJECTPTR Object);
 static ERR set_owner(OBJECTPTR, OBJECTPTR);
 
+static void release_owned_callback(FUNCTION &Function)
+{
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
+}
+
 // AsyncWait() state — guarded by glmAsyncWait.
 
 static std::atomic<int> glAsyncWaitCounter;
@@ -77,6 +86,9 @@ void stop_async_actions(void)
    // Clear any remaining queued actions (no callbacks are sent during shutdown).
    {
       std::lock_guard<std::mutex> lock(glmActionQueue);
+      for (auto &queue_ref : glActionQueues) {
+         for (auto &action : queue_ref.second) release_owned_callback(action.Callback);
+      }
       glActionQueues.clear();
       glActiveAsyncObjects.clear();
       glCancelledAsyncObjects.clear();
@@ -449,9 +461,10 @@ ERR object_free(ResourceRecord &Resource, Object *Object)
                if (it->SubscriberID IS Object->UID) {
                   log.warning("%s object #%d has an unfreed timer subscription, routine %p, interval %" PF64,
                      mc->ClassName.c_str(), Object->UID, &it->Routine, (long long)it->Interval);
-                  if (it->Routine.isScript() and (it->Routine.Context != Object)) {
+                  if (it->Routine.isScript() and (not it->Routine.stale()) and (it->Routine.Context != Object)) {
                      script_routines.emplace_back(it->Routine);
                   }
+                  if (it->Routine.defined()) it->Routine.unpin();
                   it = glTimers.erase(it);
                }
                else it++;
@@ -1131,6 +1144,7 @@ ERR AsyncAction(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters, FUNCTION *
    if (!error) {
       FUNCTION cb;
       if (Callback) cb = *Callback;
+      if (cb.defined()) cb.pin();
 
       // Check if an async action is already active for this object.  If so, queue the request
       // instead of spawning a competing thread.
@@ -1344,16 +1358,21 @@ ERR msg_threadaction(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgS
    auto msg = (ThreadActionMessage *)Message;
    if (not msg) return ERR::Okay;
 
-   if (msg->Callback.isC()) {
+   if (msg->Callback.stale()) {
+      release_owned_callback(msg->Callback);
+   }
+   else if (msg->Callback.isC()) {
       auto routine = (void (*)(ACTIONID, OBJECTPTR, ERR, APTR))msg->Callback.Routine;
       ScopedObjectLock obj(msg->ObjectID);
       if (obj.granted()) {
          routine(msg->ActionID, *obj, msg->Error, msg->Callback.Meta);
       }
       else routine(msg->ActionID, nullptr, ERR::DoesNotExist, msg->Callback.Meta);
+      release_owned_callback(msg->Callback);
    }
    else if (msg->Callback.isScript()) {
       auto script = msg->Callback.Context;
+      bool dereferenced = false;
       if (!LockObject(script, 5000)) {
          sc::Call(msg->Callback, std::to_array<ScriptArg>({
             { "ActionID", int(msg->ActionID) },
@@ -1365,9 +1384,15 @@ ERR msg_threadaction(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgS
          // Dereference the callback procedure to release the script registry reference.
          sc::DerefProcedure deref = { &msg->Callback };
          Action(sc::DerefProcedure::id, script, &deref);
+         dereferenced = true;
 
          ReleaseObject(script);
       }
+      if (dereferenced) {
+         if (msg->Callback.defined()) msg->Callback.unpin();
+         msg->Callback.clear();
+      }
+      else release_owned_callback(msg->Callback);
    }
 
    // Dispatch the next queued action for this object (if any).

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -1090,6 +1090,11 @@ copies-input, callback-held, blocking
 ERR AsyncAction(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters, FUNCTION *Callback)
 {
    kt::Log log(__FUNCTION__);
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Callback) and (not retained_callback)) Callback->consume();
+   });
 
    if ((ActionID IS AC::NIL) or (not Object)) return ERR::NullArgs;
 
@@ -1140,6 +1145,7 @@ ERR AsyncAction(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters, FUNCTION *
                .Parameters = std::move(param_buffer),
                .Callback   = cb
             });
+            retained_callback = true;
 
             log.trace("Queued action %d for object #%d (queue depth: %d)",
                int(ActionID), object_id, int(glActionQueues[object_id].size()));
@@ -1154,6 +1160,7 @@ ERR AsyncAction(ACTIONID ActionID, OBJECTPTR Object, APTR Parameters, FUNCTION *
       }
 
       launch_async_thread(Object, ActionID, argssize, std::move(param_buffer), cb);
+      retained_callback = true;
    }
 
    return error;
@@ -2744,7 +2751,10 @@ ERR SubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
 
    if ((not Object) or (not Callback)) return log.warning(ERR::NullArgs);
    if ((ActionID < AC::NIL) or (ActionID >= AC::END)) return log.warning(ERR::OutOfRange);
-   if (not Callback->isC()) return log.warning(ERR::Args);
+   if (not Callback->isC()) {
+      Callback->consume();
+      return log.warning(ERR::Args);
+   }
    if (Object->collecting()) return ERR::Okay;
 
    if (glSubReadOnly) {
@@ -2798,6 +2808,10 @@ blocking
 ERR UnsubscribeAction(OBJECTPTR Object, ACTIONID ActionID, FUNCTION *Callback)
 {
    kt::Log log(__FUNCTION__);
+
+   auto consume_callback = kt::Defer([&]() {
+      if (Callback) Callback->consume();
+   });
 
    if (not Object) return log.warning(ERR::NullArgs);
    if ((ActionID < AC::NIL) or (ActionID >= AC::END)) return log.warning(ERR::Args);

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -681,6 +681,7 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
          }
          Self->Callback[i].Object   = context;
          Self->Callback[i].Function = *Args->Callback;
+         Args->Callback->pin();
          retained_callback = true;
          return ERR::Okay;
       }

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -51,8 +51,11 @@ static ERR redraw_timer(extSurface *, int64_t, int64_t);
 
 static void deref_surface_callback(FUNCTION &Function)
 {
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.clear();
+   }
 }
 
 static void deref_surface_callback_range(SurfaceCallback *Callbacks, int Total)
@@ -678,6 +681,7 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
          }
          Self->Callback[i].Object   = context;
          Self->Callback[i].Function = *Args->Callback;
+         retained_callback = true;
          return ERR::Okay;
       }
       else if (Self->CallbackCount < Self->CallbackSize) {
@@ -720,6 +724,7 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
       SubscribeAction(Args->Callback->Context, AC::Free, C_FUNCTION(notify_free_callback));
    }
 
+   Args->Callback->pin();
    retained_callback = true;
    return ERR::Okay;
 }

--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -42,8 +42,8 @@ static ERR SET_Opacity(extSurface *, double);
 static ERR SET_XOffset(extSurface *, Unit &);
 static ERR SET_YOffset(extSurface *, Unit &);
 
-#define MOVE_VERTICAL   0x0001
-#define MOVE_HORIZONTAL 0x0002
+constexpr int MOVE_VERTICAL   = 0x0001;
+constexpr int MOVE_HORIZONTAL = 0x0002;
 
 static ERR consume_input_events(const InputEvent *, int);
 static void draw_region(extSurface *, extSurface *, extBitmap *);
@@ -631,8 +631,13 @@ mutates-object, callback-held
 static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
 {
    kt::Log log;
+   bool retained_callback = false;
 
    if ((!Args) or (!Args->Callback)) return log.warning(ERR::NullArgs);
+
+   auto consume_callback = kt::Defer([&]() {
+      if (Args->Callback and (not retained_callback)) Args->Callback->consume();
+   });
 
    OBJECTPTR context = ParentContext();
    OBJECTPTR call_context = nullptr;
@@ -715,6 +720,7 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
       SubscribeAction(Args->Callback->Context, AC::Free, C_FUNCTION(notify_free_callback));
    }
 
+   retained_callback = true;
    return ERR::Okay;
 }
 
@@ -1005,6 +1011,7 @@ extSurface::~extSurface()
       const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
       for (auto it = glWindowHooks.begin(); it != glWindowHooks.end();) {
          if (it->first.SurfaceID IS UID) {
+            release_display_callback(it->second);
             it = glWindowHooks.erase(it);
          }
          else it++;

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -578,6 +578,12 @@ extern std::recursive_mutex glFocusLock;
 extern std::recursive_mutex glSurfaceLock;
 extern std::recursive_mutex glInputLock;
 
+inline void release_display_callback(FUNCTION &Function)
+{
+   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
+   Function.clear();
+}
+
 // Thread-specific variables.
 
 extern thread_local int16_t tlNoDrawing, tlNoExpose, tlVolatileIndex;

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -580,8 +580,11 @@ extern std::recursive_mutex glInputLock;
 
 inline void release_display_callback(FUNCTION &Function)
 {
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
 }
 
 // Thread-specific variables.

--- a/src/display/lib_input.cpp
+++ b/src/display/lib_input.cpp
@@ -101,6 +101,11 @@ ERR SubscribeInput(FUNCTION *Callback, OBJECTID SurfaceFilter, JTYPE InputMask, 
 {
    static int counter = 1;
    kt::Log log(__FUNCTION__);
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Callback) and (not retained_callback)) Callback->consume();
+   });
 
    if ((!Callback) or (!Handle)) return log.warning(ERR::NullArgs);
 
@@ -117,6 +122,7 @@ ERR SubscribeInput(FUNCTION *Callback, OBJECTID SurfaceFilter, JTYPE InputMask, 
    };
 
    glInputCallbacks.emplace(*Handle, is);
+   retained_callback = true;
 
    return ERR::Okay;
 }
@@ -154,7 +160,10 @@ ERR UnsubscribeInput(int Handle)
 
    auto it = glInputCallbacks.find(Handle);
    if (it IS glInputCallbacks.end()) return log.warning(ERR::NotFound);
-   else glInputCallbacks.erase(it);
+   else {
+      release_display_callback(it->second.Callback);
+      glInputCallbacks.erase(it);
+   }
 
    return ERR::Okay;
 }

--- a/src/display/lib_input.cpp
+++ b/src/display/lib_input.cpp
@@ -122,6 +122,7 @@ ERR SubscribeInput(FUNCTION *Callback, OBJECTID SurfaceFilter, JTYPE InputMask, 
    };
 
    glInputCallbacks.emplace(*Handle, is);
+   Callback->pin();
    retained_callback = true;
 
    return ERR::Okay;
@@ -187,7 +188,27 @@ struct input_call {
    std::vector<InputEvent> events;
 
    input_call(int Handle, const InputCallback &Input) :
-      handle(Handle), surface_filter(Input.SurfaceFilter), input_mask(Input.InputMask), callback(Input.Callback) { }
+      handle(Handle), surface_filter(Input.SurfaceFilter), input_mask(Input.InputMask), callback(Input.Callback) {
+      if (callback.defined()) callback.pin();
+   }
+
+   ~input_call() {
+      if (callback.defined()) callback.unpin();
+   }
+
+   input_call(input_call &&Other) noexcept:
+      handle(Other.handle),
+      surface_filter(Other.surface_filter),
+      input_mask(Other.input_mask),
+      callback(Other.callback),
+      events(std::move(Other.events))
+   {
+      Other.callback.clear();
+   }
+
+   input_call(const input_call &) = delete;
+   input_call & operator=(const input_call &) = delete;
+   input_call & operator=(input_call &&) = delete;
 };
 
 static bool input_event_match(const InputEvent &Event, const input_call &Sub)
@@ -215,8 +236,15 @@ void input_event_loop(HOSTHANDLE FD, APTR Data) // Data is undefined
 
       input_buffer.reserve(glInputCallbacks.size());
 
-      for (const auto & [ handle, sub ] : glInputCallbacks) {
-         input_buffer.emplace_back(handle, sub);
+      for (auto it = glInputCallbacks.begin(); it != glInputCallbacks.end(); ) {
+         if (it->second.Callback.stale()) {
+            release_display_callback(it->second.Callback);
+            it = glInputCallbacks.erase(it);
+         }
+         else {
+            input_buffer.emplace_back(it->first, it->second);
+            it++;
+         }
       }
    }
 

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -835,10 +835,16 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
       log.traceBranch("Bitmap: %d, Count: %d", Bitmap->UID, Self->CallbackCount);
    #endif
 
-   for (int i=0; i < Self->CallbackCount; i++) {
+   for (int i=0; i < Self->CallbackCount; ) {
       Bitmap->Opacity = 255;
       auto &cb = Self->Callback[i].Function;
-      if (cb.isC()) {
+      if (cb.stale()) {
+         deref_surface_callback(cb);
+         for (int j=i; j < Self->CallbackCount-1; j++) Self->Callback[j] = Self->Callback[j+1];
+         Self->CallbackCount--;
+         continue;
+      }
+      else if (cb.isC()) {
          auto routine = (void (*)(APTR, extSurface *, objBitmap *, APTR))cb.Routine;
 
          #ifdef DBG_DRAW_ROUTINES
@@ -858,6 +864,7 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
             { "Bitmap",  Bitmap, FD_OBJECTPTR }
          }));
       }
+      i++;
    }
 
    Bitmap->Opacity = 255;
@@ -1541,6 +1548,7 @@ ERR WindowHook(OBJECTID SurfaceID, WH Event, FUNCTION *Callback)
    }
    else glWindowHooks[hook] = *Callback;
 
+   Callback->pin();
    retained_callback = true;
    return ERR::Okay;
 }

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -1525,11 +1525,23 @@ callback-held, does-not-take-ownership, blocking
 
 ERR WindowHook(OBJECTID SurfaceID, WH Event, FUNCTION *Callback)
 {
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Callback) and (not retained_callback)) Callback->consume();
+   });
+
    if ((!SurfaceID) or (Event IS WH::NIL) or (!Callback)) return ERR::NullArgs;
 
    const WinHook hook(SurfaceID, Event);
    const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
-   glWindowHooks[hook] = *Callback;
+   if (auto existing = glWindowHooks.find(hook); existing != glWindowHooks.end()) {
+      release_display_callback(existing->second);
+      existing->second = *Callback;
+   }
+   else glWindowHooks[hook] = *Callback;
+
+   retained_callback = true;
    return ERR::Okay;
 }
 

--- a/src/display/win32/handlers.cpp
+++ b/src/display/win32/handlers.cpp
@@ -325,7 +325,10 @@ void MsgWindowClose(OBJECTID SurfaceID)
 
          if (result IS ERR::Terminate) {
             const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
-            glWindowHooks.erase(hook);
+            if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
+               release_display_callback(it->second);
+               glWindowHooks.erase(it);
+            }
          }
          else if (result IS ERR::Cancelled) {
             log.msg("Window closure cancelled by client.");

--- a/src/display/win32/handlers.cpp
+++ b/src/display/win32/handlers.cpp
@@ -305,8 +305,15 @@ void MsgWindowClose(OBJECTID SurfaceID)
       {
          const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
          if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
-            func = it->second;
-            has_hook = true;
+            if (it->second.stale()) {
+               release_display_callback(it->second);
+               glWindowHooks.erase(it);
+            }
+            else {
+               func = it->second;
+               func.pin();
+               has_hook = true;
+            }
          }
       }
 
@@ -332,8 +339,11 @@ void MsgWindowClose(OBJECTID SurfaceID)
          }
          else if (result IS ERR::Cancelled) {
             log.msg("Window closure cancelled by client.");
+            if (func.defined()) func.unpin();
             return;
          }
+
+         if (func.defined()) func.unpin();
       }
 
       if (!CheckResourceExists(SurfaceID)) FreeResource(SurfaceID);

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -105,8 +105,15 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
                   {
                      const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
                      if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
-                        func = it->second;
-                        has_hook = true;
+                        if (it->second.stale()) {
+                           release_display_callback(it->second);
+                           glWindowHooks.erase(it);
+                        }
+                        else {
+                           func = it->second;
+                           func.pin();
+                           has_hook = true;
+                        }
                      }
                   }
 
@@ -132,8 +139,11 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
                      }
                      else if (result IS ERR::Cancelled) {
                         log.msg("Window closure cancelled by client.");
+                        if (func.defined()) func.unpin();
                         break;
                      }
+
+                     if (func.defined()) func.unpin();
                   }
 
                   log.msg("Freeing surface %d from display %d.", surface_id, display_id);

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -125,7 +125,10 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
 
                      if (result IS ERR::Terminate) {
                         const std::lock_guard<std::recursive_mutex> lock(glWindowHookLock);
-                        glWindowHooks.erase(hook);
+                        if (auto it = glWindowHooks.find(hook); it != glWindowHooks.end()) {
+                           release_display_callback(it->second);
+                           glWindowHooks.erase(it);
+                        }
                      }
                      else if (result IS ERR::Cancelled) {
                         log.msg("Window closure cancelled by client.");

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -227,6 +227,12 @@ mutates-object, callback-held
 
 static ERR DOCUMENT_AddListener(extDocument *Self, doc::AddListener *Args)
 {
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Args) and (Args->Function) and (not retained_callback)) Args->Function->consume();
+   });
+
    if ((not Args) or (Args->Trigger IS DRT::NIL) or (not Args->Function)) return ERR::NullArgs;
    if (not valid_trigger(Args->Trigger)) return ERR::OutOfRange;
 
@@ -236,6 +242,7 @@ static ERR DOCUMENT_AddListener(extDocument *Self, doc::AddListener *Args)
    }
 
    Self->Triggers[int(Args->Trigger)].push_back(*Args->Function);
+   retained_callback = true;
 
    // Scripts can't auto-remove listeners, so a Free subscription is necessary.  Functional
    // subscribers are expected to self-manage however.

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -242,6 +242,7 @@ static ERR DOCUMENT_AddListener(extDocument *Self, doc::AddListener *Args)
    }
 
    Self->Triggers[int(Args->Trigger)].push_back(*Args->Function);
+   Args->Function->pin();
    retained_callback = true;
 
    // Scripts can't auto-remove listeners, so a Free subscription is necessary.  Functional

--- a/src/document/class/fields.cpp
+++ b/src/document/class/fields.cpp
@@ -68,6 +68,7 @@ static ERR SET_EventCallback(extDocument *Self, FUNCTION *Value)
    if (Value) {
       deref_document_callback(Self->EventCallback);
       Self->EventCallback = *Value;
+      if (Self->EventCallback.defined()) Self->EventCallback.pin();
       if (subscribe_context) {
          SubscribeAction(Self->EventCallback.Context, AC::Free, C_FUNCTION(notify_free_script_context));
       }

--- a/src/document/document.cpp
+++ b/src/document/document.cpp
@@ -47,8 +47,11 @@ using CELL_ID = uint32_t;
 
 static void deref_document_callback(FUNCTION &Function)
 {
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
 }
 
 static void deref_document_callbacks(std::vector<FUNCTION> &Callbacks)

--- a/src/document/functions.cpp
+++ b/src/document/functions.cpp
@@ -1066,7 +1066,8 @@ static ERR report_event(extDocument *Self, DEF Event, entity *Entity, KEYVALUE *
       auto entity_id = Entity ? Entity->uid : 0;
       log.traceBranch("Event $%x -> Entity %d", int(Event), entity_id);
 
-      if (Self->EventCallback.isC()) {
+      if (Self->EventCallback.stale()) deref_document_callback(Self->EventCallback);
+      else if (Self->EventCallback.isC()) {
          auto routine = (ERR (*)(extDocument *, DEF, KEYVALUE *, entity *, APTR))Self->EventCallback.Routine;
          kt::SwitchContext context(Self->EventCallback.Context);
          result = routine(Self, Event, EventData, Entity, Self->EventCallback.Meta);

--- a/src/document/parsing.cpp
+++ b/src/document/parsing.cpp
@@ -3305,7 +3305,10 @@ void parser::tag_trigger(const tag_view &Tag)
       std::string args;
       if (!extract_script(Self, function_name, &script, function_name, args)) {
          if (!script->getProcedureID(function_name, &function_id)) {
+            bool subscribe_context = not has_script_free_callback(Self, script);
             Self->Triggers[int(trigger_code)].emplace_back(FUNCTION(script, function_id));
+            Self->Triggers[int(trigger_code)].back().pin();
+            if (subscribe_context) SubscribeAction(script, AC::Free, C_FUNCTION(notify_free_script_context));
          }
          else log_warning(&Tag, "doc.trigger-procedure-missing", attrib_name("function"),
             "Unable to resolve '{}' in script #{} to a function ID (the procedure may not exist).",

--- a/src/regex/regex.cpp
+++ b/src/regex/regex.cpp
@@ -541,6 +541,10 @@ ERR Search(Regex *Regex, const std::string_view &Text, RMATCH Flags, FUNCTION *C
 {
    kt::Log log(__FUNCTION__);
 
+   auto consume_callback = kt::Defer([&]() {
+      if (Callback) Callback->consume();
+   });
+
    if (not Regex) return log.warning(ERR::NullArgs);
 
    auto sr = ((extRegex *)Regex)->srell;

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -975,12 +975,9 @@ static int object_init(lua_State *Lua)
       report_action_error(Lua, def, "Init", error);
       lua_pushinteger(Lua, int(error));
       release_object(def);
-      return 1;
    }
-   else {
-      luaL_error(Lua, ERR::AccessObject);
-      return 0;
-   }
+   else luaL_error(Lua, ERR::AccessObject);
+   return 1;
 }
 
 //********************************************************************************************************************
@@ -1009,12 +1006,9 @@ static int object_with_lock(lua_State *Lua)
          return 0;
       }
       lua_pushvalue(Lua, 1); // Return the object
-      return 1;
    }
-   else {
-      luaL_argerror(Lua, 1, "Object expected for 'with' statement.");
-      return 0;
-   }
+   else luaL_argerror(Lua, 1, "Object expected for 'with' statement.");
+   return 1;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -569,25 +569,17 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
       struct_record *Def = nullptr;
 
       allocated_struct_ref() = default;
-      allocated_struct_ref(APTR InitData, struct_record *InitDef):
-         Data(InitData),
-         Def(InitDef)
-      {
-      }
+      allocated_struct_ref(APTR InitData, struct_record *InitDef): Data(InitData), Def(InitDef) { }
 
       allocated_struct_ref(const allocated_struct_ref &) = delete;
       allocated_struct_ref & operator=(const allocated_struct_ref &) = delete;
 
-      allocated_struct_ref(allocated_struct_ref &&Other) noexcept:
-         Data(Other.Data),
-         Def(Other.Def)
-      {
+      allocated_struct_ref(allocated_struct_ref &&Other) noexcept: Data(Other.Data), Def(Other.Def) {
          Other.Data = nullptr;
          Other.Def = nullptr;
       }
 
-      allocated_struct_ref & operator=(allocated_struct_ref &&Other) noexcept
-      {
+      allocated_struct_ref & operator=(allocated_struct_ref &&Other) noexcept {
          if (this != &Other) {
             release();
             Data = Other.Data;
@@ -602,8 +594,7 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
          release();
       }
 
-      void release()
-      {
+      void release() {
          if (Data) {
             if (Def) destroy_struct_cpp_strings(*Def, Data);
             FreeResource(Data);
@@ -678,15 +669,16 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
    FUNCTION func;
 
    // This guard owns the Lua registry reference for an FD_FUNCTION argument until the call is handed to the module.
-   // After that point, the module function is responsible for calling DerefProcedure() when it no longer needs it.
+   // After that point, the module function is responsible for calling DerefProcedure() when it no longer needs it,
+   // or alternatively marking the function as consumed.
 
    struct func_ref_guard {
       lua_State *Lua;
       FUNCTION  &Func;
       bool OwnsReference = true;
       ~func_ref_guard() {
-         if (OwnsReference) {
-            if (Func.isScript() and (Func.ProcedureID > 0)) luaL_unref(Lua, LUA_REGISTRYINDEX, Func.ProcedureID);
+         if (Func.isScript() and (Func.ProcedureID > 0)) {
+            if (OwnsReference or Func.consumed()) luaL_unref(Lua, LUA_REGISTRYINDEX, Func.ProcedureID);
          }
       }
    } func_guard{ Lua, func };
@@ -872,7 +864,8 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             return ERR::Args;
          }
 
-         // NOTE: The client is responsible for calling DerefProcedure() on the function reference when it is no longer needed.
+         // NOTE: The client is responsible for calling DerefProcedure() on the function reference when it is no longer needed,
+         // or it can mark the function as consumed.
 
          switch(lua_type(Lua, i)) {
             case LUA_TSTRING: { // Name of function to call

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -248,11 +248,13 @@ public:
 
 inline void release_callback(FUNCTION &Function)
 {
-   if (Function.isScript() and (not Function.Context->terminating())) {
-      ((objScript *)Function.Context)->derefProcedure(Function);
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.Context->terminating())) {
+         ((objScript *)Function.Context)->derefProcedure(Function);
+      }
+      Function.unpin();
+      Function.disable();
    }
-   Function.clear();
-   Function.Context->unpinWeak();
 }
 
 //********************************************************************************************************************
@@ -265,14 +267,6 @@ template <class T> inline void validate_object_link(T *&Link)
       Link->unpinWeak();
       Link = nullptr;
    }
-}
-
-//********************************************************************************************************************
-
-inline void deref_vector_callback(FUNCTION &Function)
-{
-   if (Function.isScript()) ((objScript *)Function.Context)->derefProcedure(Function);
-   Function.clear();
 }
 
 //********************************************************************************************************************

--- a/src/vector/vector_functions.cpp
+++ b/src/vector/vector_functions.cpp
@@ -889,6 +889,10 @@ callback-inlines, updates-seek-index
 
 ERR TracePath(APTR Path, FUNCTION *Callback, double Scale)
 {
+   auto consume_callback = kt::Defer([&]() {
+      if (Callback) Callback->consume();
+   });
+
    if ((not Path) or (not Callback)) return ERR::NullArgs;
 
    auto vector = (SimpleVector *)Path;

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -186,7 +186,6 @@ class extVectorText : public extVector {
    using create = kt::Create<extVectorText>;
 
    std::vector<TextLine> txLines;
-   FUNCTION txValidateInput;
    FUNCTION txOnChange;
    double txInlineSize; // Enables word-wrapping
    Unit txX = Unit(0), txY = Unit(0);
@@ -247,6 +246,7 @@ class extVectorText : public extVector {
       if (txDX)           FreeResource(txDX);
       if (txDY)           FreeResource(txDY);
       if (txKeyEvent)     UnsubscribeEvent(txKeyEvent);
+      release_callback(txOnChange);
 
       if (txFocusID) {
          if (kt::ScopedObjectLock<extVector> focus(txFocusID, 5000); focus.granted()) {
@@ -288,7 +288,8 @@ inline double get_kerning(FT_Face Face, int Glyph, int PrevGlyph)
 
 inline void report_change(extVectorText *Self)
 {
-   if (Self->txOnChange.isC()) {
+   if (Self->txOnChange.stale()) release_callback(Self->txOnChange);
+   else if (Self->txOnChange.isC()) {
       auto routine = (void (*)(extVectorText *))Self->txOnChange.Routine;
       kt::SwitchContext context(Self->txOnChange.Context);
       routine(Self);
@@ -671,11 +672,11 @@ static ERR TEXT_GET_OnChange(extVectorText *Self, FUNCTION * &Value)
 
 static ERR TEXT_SET_OnChange(extVectorText *Self, FUNCTION *Value)
 {
+   release_callback(Self->txOnChange);
    if (Value) {
-      if (Self->txOnChange.isScript()) UnsubscribeAction(Self->txOnChange.Context, AC::Free);
       Self->txOnChange = *Value;
+      if (Self->txOnChange.defined()) Self->txOnChange.pin();
    }
-   else Self->txOnChange.clear();
    return ERR::Okay;
 }
 

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -697,6 +697,11 @@ mutates-object, callback-held
 static ERR VECTOR_SubscribeFeedback(extVector *Self, struct vec::SubscribeFeedback *Args)
 {
    kt::Log log;
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Args) and (Args->Callback) and (not retained_callback)) Args->Callback->consume();
+   });
 
    if ((not Args) or (not Args->Callback)) return log.warning(ERR::NullArgs);
 
@@ -708,6 +713,7 @@ static ERR VECTOR_SubscribeFeedback(extVector *Self, struct vec::SubscribeFeedba
 
       Args->Callback->Context->pinWeak();
       Self->FeedbackSubscriptions->emplace_back(*Args->Callback, Args->Mask);
+      retained_callback = true;
    }
    else if (Self->FeedbackSubscriptions) { // Remove existing subscriptions for this callback
       for (auto it=Self->FeedbackSubscriptions->begin(); it != Self->FeedbackSubscriptions->end(); ) {
@@ -760,6 +766,11 @@ mutates-object, callback-held
 static ERR VECTOR_SubscribeInput(extVector *Self, struct vec::SubscribeInput *Args)
 {
    kt::Log log;
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Args) and (Args->Callback) and (not retained_callback)) Args->Callback->consume();
+   });
 
    // Refer to scene_input_events() for the origin of incoming input messages
 
@@ -786,6 +797,7 @@ static ERR VECTOR_SubscribeInput(extVector *Self, struct vec::SubscribeInput *Ar
       Self->InputMask |= mask;
       Args->Callback->Context->pinWeak();
       Self->InputSubscriptions->emplace_back(*Args->Callback, mask);
+      retained_callback = true;
       update_input_subscription_state(Self);
       mark_input_boundary_dirty(Self);
    }
@@ -840,6 +852,11 @@ mutates-object, callback-held
 static ERR VECTOR_SubscribeKeyboard(extVector *Self, struct vec::SubscribeKeyboard *Args)
 {
    kt::Log log;
+   bool retained_callback = false;
+
+   auto consume_callback = kt::Defer([&]() {
+      if ((Args) and (Args->Callback) and (not retained_callback)) Args->Callback->consume();
+   });
 
    if ((!Args) or (!Args->Callback)) return log.warning(ERR::NullArgs);
 
@@ -854,6 +871,7 @@ static ERR VECTOR_SubscribeKeyboard(extVector *Self, struct vec::SubscribeKeyboa
 
    Args->Callback->Context->pinWeak();
    Self->KeyboardSubscriptions->emplace_back(*Args->Callback);
+   retained_callback = true;
 
    return ERR::Okay;
 }

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -711,7 +711,7 @@ static ERR VECTOR_SubscribeFeedback(extVector *Self, struct vec::SubscribeFeedba
          if (not Self->FeedbackSubscriptions) return log.warning(ERR::AllocMemory);
       }
 
-      Args->Callback->Context->pinWeak();
+      Args->Callback->pin();
       Self->FeedbackSubscriptions->emplace_back(*Args->Callback, Args->Mask);
       retained_callback = true;
    }
@@ -795,7 +795,7 @@ static ERR VECTOR_SubscribeInput(extVector *Self, struct vec::SubscribeInput *Ar
       auto mask = Args->Mask;
 
       Self->InputMask |= mask;
-      Args->Callback->Context->pinWeak();
+      Args->Callback->pin();
       Self->InputSubscriptions->emplace_back(*Args->Callback, mask);
       retained_callback = true;
       update_input_subscription_state(Self);
@@ -869,7 +869,7 @@ static ERR VECTOR_SubscribeKeyboard(extVector *Self, struct vec::SubscribeKeyboa
 
    ((extVectorScene *)Self->Scene)->KeyboardSubscriptions.emplace(Self);
 
-   Args->Callback->Context->pinWeak();
+   Args->Callback->pin();
    Self->KeyboardSubscriptions->emplace_back(*Args->Callback);
    retained_callback = true;
 
@@ -1815,9 +1815,6 @@ any time.  The conventional means for monitoring the size and position of any ve
 static ERR VECTOR_SET_ResizeEvent(extVector *Self, FUNCTION *Value)
 {
    if (Value) {
-      auto context = Value->Context;
-      context->pinWeak();
-
       Self->ResizeSubscription = true;
       if ((Self->Scene) and (Self->ParentView)) {
          auto scene = (extVectorScene *)Self->Scene;
@@ -1826,6 +1823,7 @@ static ERR VECTOR_SET_ResizeEvent(extVector *Self, FUNCTION *Value)
             release_callback(existing->second);
          }
          subs[Self] = *Value;
+         if (subs[Self].defined()) subs[Self].pin();
       }
       else {
          const std::lock_guard<std::mutex> lock(glResizeLock);
@@ -1833,6 +1831,7 @@ static ERR VECTOR_SET_ResizeEvent(extVector *Self, FUNCTION *Value)
             release_callback(existing->second);
          }
          glResizeSubscriptions[Self] = *Value; // Save the subscription for initialisation.
+         if (glResizeSubscriptions[Self].defined()) glResizeSubscriptions[Self].pin();
       }
    }
    else if (Self->ResizeSubscription) {

--- a/src/vector/vectors/viewport.cpp
+++ b/src/vector/vectors/viewport.cpp
@@ -128,7 +128,7 @@ extVectorViewport::~extVectorViewport()
    }
 
    if (vpDragCallback.defined()) {
-      deref_vector_callback(vpDragCallback);
+      release_callback(vpDragCallback);
       subscribeInput(JTYPE::NIL, C_FUNCTION(drag_callback));
    }
 
@@ -360,11 +360,12 @@ static ERR VIEW_SET_DragCallback(extVectorViewport *Self, FUNCTION *Value)
          return ERR::Function;
       }
 
-      deref_vector_callback(Self->vpDragCallback);
+      release_callback(Self->vpDragCallback);
       Self->vpDragCallback = *Value;
+      if (Self->vpDragCallback.defined()) Self->vpDragCallback.pin();
    }
    else {
-      deref_vector_callback(Self->vpDragCallback);
+      release_callback(Self->vpDragCallback);
       Self->subscribeInput(JTYPE::NIL, C_FUNCTION(drag_callback));
    }
    return ERR::Okay;

--- a/src/xquery/eval/eval_context.cpp
+++ b/src/xquery/eval/eval_context.cpp
@@ -500,7 +500,12 @@ ERR XPathEvaluator::invoke_callback(XTag *Node, const XMLAttrib *Attribute, bool
       return ERR::Okay;
    }
 
-   if (query->Callback.isC()) {
+   if (query->Callback.stale()) {
+      query->Callback.unpin();
+      query->Callback.disable();
+      return ERR::Terminate;
+   }
+   else if (query->Callback.isC()) {
       auto routine = (ERR (*)(extXML *, int, CSTRING, APTR))query->Callback.Routine;
       return routine(xml, Node->ID, Attribute ? Attribute->Name.c_str() : nullptr, query->Callback.Meta);
    }

--- a/src/xquery/eval/eval_expression.cpp
+++ b/src/xquery/eval/eval_expression.cpp
@@ -271,6 +271,7 @@ static ERR resolve_variable_callback(XPathEvaluator &Evaluator, std::string_view
    XPathVal &OutValue, const XPathNode *ReferenceNode)
 {
    if (not Evaluator.query->ResolveVariable.defined()) return ERR::Search;
+   if (Evaluator.query->ResolveVariable.releaseIfStale()) return ERR::Search;
 
    std::string cache_key(Name);
 

--- a/src/xquery/eval/eval_values.cpp
+++ b/src/xquery/eval/eval_values.cpp
@@ -535,6 +535,11 @@ static std::optional<XPathVal> resolve_registered_function(XPathEvaluator &Evalu
    }
 
    if (callback IS Evaluator.query->RegisteredFunctions.end()) return std::nullopt;
+   if (callback->second.stale()) {
+      callback->second.unpin();
+      Evaluator.query->RegisteredFunctions.erase(callback);
+      return std::nullopt;
+   }
 
    std::vector<XPathValue> public_args;
    public_args.reserve(Args.size());

--- a/src/xquery/unit_tests.cpp
+++ b/src/xquery/unit_tests.cpp
@@ -162,7 +162,10 @@ static ERR registered_function_test_callback(objXQuery *Query, std::string_view 
 static bool compile_query_for_test(extXQuery &Query, std::string_view Statement, FUNCTION ResolveVariable = FUNCTION())
 {
    Query.Statement.assign(Statement);
+   if (Query.ResolveVariable.defined()) Query.ResolveVariable.unpin();
+   Query.ResolveVariable.disable();
    Query.ResolveVariable = ResolveVariable;
+   if (Query.ResolveVariable.defined()) Query.ResolveVariable.pin();
    Query.ParseResult = CompiledXQuery();
    Query.ModuleCache.reset();
    Query.ErrorMsg.clear();
@@ -722,6 +725,7 @@ static void test_registered_function_qname_normalisation()
       registered_function_test_context context;
       FUNCTION callback = C_FUNCTION(registered_function_test_callback, &context);
       query.RegisteredFunctions["ext:double"] = callback;
+      query.RegisteredFunctions["ext:double"].pin();
 
       XPathVal result;
       bool ok = evaluate_query_text(query,
@@ -747,6 +751,7 @@ static void test_registered_function_qname_normalisation()
       registered_function_test_context context;
       FUNCTION callback = C_FUNCTION(registered_function_test_callback, &context);
       query.RegisteredFunctions["double"] = callback;
+      query.RegisteredFunctions["double"].pin();
 
       XPathVal result;
       bool ok = evaluate_query_text(query,

--- a/src/xquery/xquery.cpp
+++ b/src/xquery/xquery.cpp
@@ -17,6 +17,7 @@ with the @XML class to provide a standards-compliant query engine with extensive
 *********************************************************************************************************************/
 
 #include <kotuku/modules/regex.h>
+#include <kotuku/modules/script.h>
 #include <kotuku/modules/module.h>
 #include "../link/unicode.h"
 #include "../xml/uri_utils.h"

--- a/src/xquery/xquery_class.cpp
+++ b/src/xquery/xquery_class.cpp
@@ -400,12 +400,27 @@ static ERR XQUERY_Evaluate(extXQuery *Self, struct xq::Evaluate *Args)
 
 //********************************************************************************************************************
 
+static void clear_xquery_callback(FUNCTION &Function)
+{
+   if (Function.defined()) {
+      if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);
+      Function.unpin();
+      Function.disable();
+   }
+}
+
+static void clear_registered_functions(extXQuery *Self)
+{
+   for (auto & [name, function] : Self->RegisteredFunctions) clear_xquery_callback(function);
+   Self->RegisteredFunctions.clear();
+}
+
+//********************************************************************************************************************
+
 extXQuery::~extXQuery()
 {
-   if (ResolveVariable.isScript()) {
-      UnsubscribeAction(ResolveVariable.Context, AC::Free);
-      ResolveVariable.clear();
-   }
+   clear_registered_functions(this);
+   clear_xquery_callback(ResolveVariable);
 }
 
 /*********************************************************************************************************************
@@ -642,7 +657,10 @@ static ERR XQUERY_RegisterFunction(extXQuery *Self, struct xq::RegisterFunction 
       return log.warning(ERR::NoSupport);
    }
 
-   Self->RegisteredFunctions[std::string(Args->FunctionName)] = *Args->Callback;
+   auto &function = Self->RegisteredFunctions[std::string(Args->FunctionName)];
+   clear_xquery_callback(function);
+   function = *Args->Callback;
+   function.pin();
    return ERR::Okay;
 }
 
@@ -721,12 +739,16 @@ static ERR XQUERY_Search(extXQuery *Self, struct xq::Search *Args)
 
    auto xml = (extXML *)Args->XML;
    Self->XML = xml;
-   if ((Args->Callback) and (Args->Callback->defined())) Self->Callback = *Args->Callback;
+   if ((Args->Callback) and (Args->Callback->defined())) {
+      Self->Callback = *Args->Callback;
+      Self->Callback.pin();
+   }
    else Self->Callback.Type = CALL::NIL;
    Self->ParseResult.error_msg.clear();
 
    auto clear_callback = kt::Defer([&]() {
-      Self->Callback.Type = CALL::NIL;
+      if (Self->Callback.defined()) Self->Callback.unpin();
+      Self->Callback.clear();
    });
 
    if ((Args->Index != 0) and (not xml)) {
@@ -900,9 +922,11 @@ static ERR SET_ResolveVariable(extXQuery *Self, FUNCTION *Value)
 {
    if (Value) {
       if (not Value->isC()) return ERR::NoSupport;
+      clear_xquery_callback(Self->ResolveVariable);
       Self->ResolveVariable = *Value;
+      Self->ResolveVariable.pin();
    }
-   else Self->ResolveVariable.clear();
+   else clear_xquery_callback(Self->ResolveVariable);
 
    return ERR::Okay;
 }


### PR DESCRIPTION
* Added consume guards for callbacks that are rejected, inlined, or only conditionally retained
* [Display] Released stored input and window hook callbacks when subscriptions are removed
* [Tiri] Unref consumed script function references after module calls