### PR TITLE
[Vector] Store vector transforms in owned matrix lists

### DIFF
--- a/docs/xml/modules/classes/vector.xml
+++ b/docs/xml/modules/classes/vector.xml
@@ -110,6 +110,7 @@
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
+        <error code="NotFound">A search routine in this function failed</error>
         <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
       <tags>mutates-object, closes-handle</tags>
@@ -159,7 +160,6 @@
       </description>
       <result>
         <error code="Okay">Operation successful.</error>
-        <error code="AllocMemory">AllocMemory() failed to create a new memory block</error>
         <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
       <tags>mutates-object, object-owns-result, creates-resource</tags>
@@ -536,8 +536,8 @@
     <field>
       <name>Matrices</name>
       <comment>A linked list of transform matrices that have been applied to the vector.</comment>
-      <access read="R">Read</access>
-      <type>struct VectorMatrix *</type>
+      <access read="G">Get</access>
+      <type>struct VectorMatrix</type>
       <description>
 <p>All transforms that have been allocated via <function module="Vector">NewMatrix</function> can be read from the Matrices field.  Each transform is represented by the <st>VectorMatrix</st> structure, and are linked in the order in which they are added to the vector.</p>
 <struct lookup="VectorMatrix"/>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -3880,24 +3880,23 @@ class objVector : public Object {
    using create = kt::Create<objVector>;
    objVector(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
 
-   objVector * Child;                 // The first child vector, or NULL.
-   objVectorScene * Scene;            // Short-cut to the top-level VectorScene.
-   objVector * Next;                  // The next vector in the branch, or NULL.
-   objVector * Prev;                  // The previous vector in the branch, or NULL.
-   OBJECTPTR Parent;                  // The parent of the vector, or NULL if this is the top-most vector.
-   struct VectorMatrix * Matrices;    // A linked list of transform matrices that have been applied to the vector.
-   double    StrokeOpacity;           // Defines the opacity of the path stroke.
-   double    FillOpacity;             // The opacity to use when filling the vector.
-   double    Opacity;                 // Defines an overall opacity for the vector's graphics.
-   double    MiterLimit;              // Imposes a limit on the ratio of the miter length to the StrokeWidth.
-   double    InnerMiterLimit;         // Controls how far an inner stroke miter can extend at concave joins.
-   double    DashOffset;              // The distance into the dash pattern to start the dash.  Can be a negative number.
-   VIS       Visibility;              // Controls the visibility of a vector and its children.
-   VF        Flags;                   // Optional flags.
-   PTC       Cursor;                  // The mouse cursor to display when the pointer is within the vector's boundary.
-   RQ        PathQuality;             // Defines the quality of a path when it is rendered.
-   VCS       ColourSpace;             // Defines the colour space to use when blending the vector with a target bitmap's content.
-   int       PathTimestamp;           // This counter is modified each time the path is regenerated.
+   objVector * Child;         // The first child vector, or NULL.
+   objVectorScene * Scene;    // Short-cut to the top-level VectorScene.
+   objVector * Next;          // The next vector in the branch, or NULL.
+   objVector * Prev;          // The previous vector in the branch, or NULL.
+   OBJECTPTR Parent;          // The parent of the vector, or NULL if this is the top-most vector.
+   double    StrokeOpacity;   // Defines the opacity of the path stroke.
+   double    FillOpacity;     // The opacity to use when filling the vector.
+   double    Opacity;         // Defines an overall opacity for the vector's graphics.
+   double    MiterLimit;      // Imposes a limit on the ratio of the miter length to the StrokeWidth.
+   double    InnerMiterLimit; // Controls how far an inner stroke miter can extend at concave joins.
+   double    DashOffset;      // The distance into the dash pattern to start the dash.  Can be a negative number.
+   VIS       Visibility;      // Controls the visibility of a vector and its children.
+   VF        Flags;           // Optional flags.
+   PTC       Cursor;          // The mouse cursor to display when the pointer is within the vector's boundary.
+   RQ        PathQuality;     // Defines the quality of a path when it is rendered.
+   VCS       ColourSpace;     // Defines the colour space to use when blending the vector with a target bitmap's content.
+   int       PathTimestamp;   // This counter is modified each time the path is regenerated.
 
    // Action stubs
 
@@ -3987,11 +3986,6 @@ class objVector : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getMatrices(struct VectorMatrix * &Value) noexcept {
-      Value = this->Matrices;
-      return ERR::Okay;
-   }
-
    inline ERR getStrokeOpacity(double &Value) noexcept {
       Value = this->StrokeOpacity;
       return ERR::Okay;
@@ -4052,6 +4046,11 @@ class objVector : public Object {
       return ERR::Okay;
    }
 
+   inline ERR getMatrices(struct VectorMatrix * &Value) noexcept {
+      auto field = &this->Class->Dictionary[26];
+      return field->GetValue(this, &Value);
+   }
+
    inline ERR getStrokeColour(struct FRGB * &Value) noexcept {
       auto field = &this->Class->Dictionary[6];
       return field->GetValue(this, &Value);
@@ -4063,52 +4062,52 @@ class objVector : public Object {
    }
 
    inline ERR getFillRule(VFR &Value) noexcept {
-      Value = *((VFR *)(((int8_t *)this) + 376));
+      Value = *((VFR *)(((int8_t *)this) + 368));
       return ERR::Okay;
    }
 
    inline ERR getClipRule(VFR &Value) noexcept {
-      Value = *((VFR *)(((int8_t *)this) + 380));
+      Value = *((VFR *)(((int8_t *)this) + 372));
       return ERR::Okay;
    }
 
    inline ERR getGuideFlags(VMF &Value) noexcept {
-      Value = *((VMF *)(((int8_t *)this) + 396));
+      Value = *((VMF *)(((int8_t *)this) + 388));
       return ERR::Okay;
    }
 
    inline ERR getLineJoin(VLJ &Value) noexcept {
-      Value = *((VLJ *)(((int8_t *)this) + 384));
+      Value = *((VLJ *)(((int8_t *)this) + 376));
       return ERR::Okay;
    }
 
    inline ERR getLineCap(VLC &Value) noexcept {
-      Value = *((VLC *)(((int8_t *)this) + 388));
+      Value = *((VLC *)(((int8_t *)this) + 380));
       return ERR::Okay;
    }
 
    inline ERR getInnerJoin(VIJ &Value) noexcept {
-      Value = *((VIJ *)(((int8_t *)this) + 392));
+      Value = *((VIJ *)(((int8_t *)this) + 384));
       return ERR::Okay;
    }
 
    inline ERR getStroke(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + 216));
+      Value = *((std::string *)(((int8_t *)this) + 208));
       return ERR::Okay;
    }
 
    inline ERR getFill(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + 248));
+      Value = *((std::string *)(((int8_t *)this) + 240));
       return ERR::Okay;
    }
 
    inline ERR getFilter(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + 280));
+      Value = *((std::string *)(((int8_t *)this) + 272));
       return ERR::Okay;
    }
 
    inline ERR getSID(std::string_view &Value) noexcept {
-      Value = *((std::string *)(((int8_t *)this) + 312));
+      Value = *((std::string *)(((int8_t *)this) + 304));
       return ERR::Okay;
    }
 
@@ -4885,67 +4884,67 @@ class objVectorWave : public objVector {
    // Customised field getting
 
    inline ERR getFrequencyEnd(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 1056));
-      return ERR::Okay;
-   }
-
-   inline ERR getNoise(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 1072));
-      return ERR::Okay;
-   }
-
-   inline ERR getEnvelope(WVE &Value) noexcept {
-      Value = *((WVE *)(((int8_t *)this) + 1088));
-      return ERR::Okay;
-   }
-
-   inline ERR getClose(WVC &Value) noexcept {
-      Value = *((WVC *)(((int8_t *)this) + 1092));
-      return ERR::Okay;
-   }
-
-   inline ERR getType(WVT &Value) noexcept {
-      Value = *((WVT *)(((int8_t *)this) + 1096));
-      return ERR::Okay;
-   }
-
-   inline ERR getX(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 968));
-      return ERR::Okay;
-   }
-
-   inline ERR getY(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 984));
-      return ERR::Okay;
-   }
-
-   inline ERR getLength(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1000));
-      return ERR::Okay;
-   }
-
-   inline ERR getAmplitude(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1016));
-      return ERR::Okay;
-   }
-
-   inline ERR getThickness(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1032));
-      return ERR::Okay;
-   }
-
-   inline ERR getFrequency(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 1048));
-      return ERR::Okay;
-   }
-
-   inline ERR getDecay(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1064));
       return ERR::Okay;
    }
 
-   inline ERR getPhase(double &Value) noexcept {
+   inline ERR getNoise(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1080));
+      return ERR::Okay;
+   }
+
+   inline ERR getEnvelope(WVE &Value) noexcept {
+      Value = *((WVE *)(((int8_t *)this) + 1096));
+      return ERR::Okay;
+   }
+
+   inline ERR getClose(WVC &Value) noexcept {
+      Value = *((WVC *)(((int8_t *)this) + 1100));
+      return ERR::Okay;
+   }
+
+   inline ERR getType(WVT &Value) noexcept {
+      Value = *((WVT *)(((int8_t *)this) + 1104));
+      return ERR::Okay;
+   }
+
+   inline ERR getX(Unit &Value) noexcept {
+      Value = *((Unit *)(((int8_t *)this) + 976));
+      return ERR::Okay;
+   }
+
+   inline ERR getY(Unit &Value) noexcept {
+      Value = *((Unit *)(((int8_t *)this) + 992));
+      return ERR::Okay;
+   }
+
+   inline ERR getLength(Unit &Value) noexcept {
+      Value = *((Unit *)(((int8_t *)this) + 1008));
+      return ERR::Okay;
+   }
+
+   inline ERR getAmplitude(Unit &Value) noexcept {
+      Value = *((Unit *)(((int8_t *)this) + 1024));
+      return ERR::Okay;
+   }
+
+   inline ERR getThickness(Unit &Value) noexcept {
+      Value = *((Unit *)(((int8_t *)this) + 1040));
+      return ERR::Okay;
+   }
+
+   inline ERR getFrequency(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1056));
+      return ERR::Okay;
+   }
+
+   inline ERR getDecay(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1072));
+      return ERR::Okay;
+   }
+
+   inline ERR getPhase(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1088));
       return ERR::Okay;
    }
 
@@ -5280,62 +5279,62 @@ class objVectorShape : public objVector {
    // Customised field getting
 
    inline ERR getM(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 968));
-      return ERR::Okay;
-   }
-
-   inline ERR getN1(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 976));
       return ERR::Okay;
    }
 
-   inline ERR getN2(double &Value) noexcept {
+   inline ERR getN1(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 984));
       return ERR::Okay;
    }
 
-   inline ERR getN3(double &Value) noexcept {
+   inline ERR getN2(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 992));
       return ERR::Okay;
    }
 
-   inline ERR getA(double &Value) noexcept {
+   inline ERR getN3(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1000));
       return ERR::Okay;
    }
 
-   inline ERR getB(double &Value) noexcept {
+   inline ERR getA(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1008));
       return ERR::Okay;
    }
 
-   inline ERR getPhi(double &Value) noexcept {
+   inline ERR getB(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1016));
       return ERR::Okay;
    }
 
+   inline ERR getPhi(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1024));
+      return ERR::Okay;
+   }
+
    inline ERR getVertices(int &Value) noexcept {
-      Value = *((int *)(((int8_t *)this) + 1024));
-      return ERR::Okay;
-   }
-
-   inline ERR getSpiral(int &Value) noexcept {
-      Value = *((int *)(((int8_t *)this) + 1028));
-      return ERR::Okay;
-   }
-
-   inline ERR getRepeat(int &Value) noexcept {
       Value = *((int *)(((int8_t *)this) + 1032));
       return ERR::Okay;
    }
 
-   inline ERR getClose(int &Value) noexcept {
+   inline ERR getSpiral(int &Value) noexcept {
       Value = *((int *)(((int8_t *)this) + 1036));
       return ERR::Okay;
    }
 
-   inline ERR getMod(int &Value) noexcept {
+   inline ERR getRepeat(int &Value) noexcept {
       Value = *((int *)(((int8_t *)this) + 1040));
+      return ERR::Okay;
+   }
+
+   inline ERR getClose(int &Value) noexcept {
+      Value = *((int *)(((int8_t *)this) + 1044));
+      return ERR::Okay;
+   }
+
+   inline ERR getMod(int &Value) noexcept {
+      Value = *((int *)(((int8_t *)this) + 1048));
       return ERR::Okay;
    }
 
@@ -5453,37 +5452,37 @@ class objVectorSpiral : public objVector {
    // Customised field getting
 
    inline ERR getSpacing(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 968));
-      return ERR::Okay;
-   }
-
-   inline ERR getOffset(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 976));
       return ERR::Okay;
    }
 
-   inline ERR getStep(double &Value) noexcept {
+   inline ERR getOffset(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 984));
       return ERR::Okay;
    }
 
-   inline ERR getLoopLimit(double &Value) noexcept {
+   inline ERR getStep(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 992));
       return ERR::Okay;
    }
 
+   inline ERR getLoopLimit(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1000));
+      return ERR::Okay;
+   }
+
    inline ERR getRadius(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1000));
+      Value = *((Unit *)(((int8_t *)this) + 1008));
       return ERR::Okay;
    }
 
    inline ERR getCX(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1016));
+      Value = *((Unit *)(((int8_t *)this) + 1024));
       return ERR::Okay;
    }
 
    inline ERR getCY(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1032));
+      Value = *((Unit *)(((int8_t *)this) + 1040));
       return ERR::Okay;
    }
 
@@ -5584,27 +5583,27 @@ class objVectorEllipse : public objVector {
    // Customised field getting
 
    inline ERR getCX(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 968));
+      Value = *((Unit *)(((int8_t *)this) + 976));
       return ERR::Okay;
    }
 
    inline ERR getCY(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 984));
+      Value = *((Unit *)(((int8_t *)this) + 992));
       return ERR::Okay;
    }
 
    inline ERR getRadiusX(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1000));
+      Value = *((Unit *)(((int8_t *)this) + 1008));
       return ERR::Okay;
    }
 
    inline ERR getRadiusY(Unit &Value) noexcept {
-      Value = *((Unit *)(((int8_t *)this) + 1016));
+      Value = *((Unit *)(((int8_t *)this) + 1024));
       return ERR::Okay;
    }
 
    inline ERR getVertices(int &Value) noexcept {
-      Value = *((int *)(((int8_t *)this) + 1032));
+      Value = *((int *)(((int8_t *)this) + 1040));
       return ERR::Okay;
    }
 
@@ -5708,7 +5707,7 @@ class objVectorViewport : public objVector {
    // Customised field getting
 
    inline ERR getAspectRatio(ARF &Value) noexcept {
-      Value = *((ARF *)(((int8_t *)this) + 1008));
+      Value = *((ARF *)(((int8_t *)this) + 1016));
       return ERR::Okay;
    }
 
@@ -5718,37 +5717,37 @@ class objVectorViewport : public objVector {
    }
 
    inline ERR getOverflowX(VOF &Value) noexcept {
-      Value = *((VOF *)(((int8_t *)this) + 1012));
+      Value = *((VOF *)(((int8_t *)this) + 1020));
       return ERR::Okay;
    }
 
    inline ERR getOverflowY(VOF &Value) noexcept {
-      Value = *((VOF *)(((int8_t *)this) + 1016));
+      Value = *((VOF *)(((int8_t *)this) + 1024));
       return ERR::Okay;
    }
 
    inline ERR getBuffer(OBJECTPTR &Value) noexcept {
-      Value = *((OBJECTPTR *)(((int8_t *)this) + 968));
+      Value = *((OBJECTPTR *)(((int8_t *)this) + 976));
       return ERR::Okay;
    }
 
    inline ERR getViewX(double &Value) noexcept {
-      Value = *((double *)(((int8_t *)this) + 976));
-      return ERR::Okay;
-   }
-
-   inline ERR getViewY(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 984));
       return ERR::Okay;
    }
 
-   inline ERR getViewWidth(double &Value) noexcept {
+   inline ERR getViewY(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 992));
       return ERR::Okay;
    }
 
-   inline ERR getViewHeight(double &Value) noexcept {
+   inline ERR getViewWidth(double &Value) noexcept {
       Value = *((double *)(((int8_t *)this) + 1000));
+      return ERR::Okay;
+   }
+
+   inline ERR getViewHeight(double &Value) noexcept {
+      Value = *((double *)(((int8_t *)this) + 1008));
       return ERR::Okay;
    }
 

--- a/src/document/ui.cpp
+++ b/src/document/ui.cpp
@@ -1279,31 +1279,30 @@ static ERR inputevent_button(objVectorViewport *Viewport, const InputEvent *Even
 
             // Scale the button viewport down a little bit to indicate that it's been clicked.
 
-            if (!button->viewport->Matrices) {
-               VectorMatrix *matrix;
-               button->viewport->newMatrix(&matrix, false);
-            }
+            VectorMatrix *matrix = nullptr;
+            button->viewport->getMatrices(matrix);
+            if (not matrix) button->viewport->newMatrix(&matrix, false);
 
-            Unit width;
+            Unit width, height;
             button->viewport->getWidth(width);
-            Unit height;
             button->viewport->getHeight(height);
 
-            if (auto m = button->viewport->Matrices) {
+            if (matrix) {
                const auto SCALE = 0.95;
-               m->TranslateX -= double(width) * 0.5;
-               m->TranslateY -= double(height) * 0.5;
-               vec::Scale(m, SCALE, SCALE);
-               m->TranslateX += double(width) * 0.5;
-               m->TranslateY += double(height) * 0.5;
-               vec::FlushMatrix(button->viewport->Matrices);
+               matrix->TranslateX -= double(width) * 0.5;
+               matrix->TranslateY -= double(height) * 0.5;
+               vec::Scale(matrix, SCALE, SCALE);
+               matrix->TranslateX += double(width) * 0.5;
+               matrix->TranslateY += double(height) * 0.5;
+               vec::FlushMatrix(matrix);
             }
          }
          else {
-            if (!button->alt_fill.empty()) button->viewport->setFill(button->fill);
+            if (not button->alt_fill.empty()) button->viewport->setFill(button->fill);
 
-            if (button->viewport->Matrices) {
-               vec::ResetMatrix(button->viewport->Matrices);
+            VectorMatrix *m = nullptr;
+            if ((button->viewport->getMatrices(m) IS ERR::Okay) and m) {
+               vec::ResetMatrix(m);
             }
          }
 

--- a/src/svg/anim_timing.cpp
+++ b/src/svg/anim_timing.cpp
@@ -153,7 +153,7 @@ static ERR animation_timer(extSVG *SVG, int64_t TimeElapsed, int64_t CurrentTime
 
       VectorMatrix *m = nullptr;
       if (vt.transforms.front()->additive IS ADD::REPLACE) {
-         for (m = vector->Matrices; (m); m=m->Next) {
+         for (vector->getMatrices(m); (m); m=m->Next) {
             if ((unsigned int)m->Tag IS MTAG_SVG_TRANSFORM) {
                double d = 1.0 / (m->ScaleX * m->ScaleY - m->ShearY * m->ShearX);
 

--- a/src/svg/anim_value.cpp
+++ b/src/svg/anim_value.cpp
@@ -296,8 +296,9 @@ void anim_value::set_value(objVector &Vector)
             // Special case: SVG groups don't have an (x,y) position, but can declare one in the form of a
             // transform.  Refer to xtag_use() for a working example as to why.
 
-            VectorMatrix *m;
-            for (m=Vector.Matrices; (m) and ((uint32_t)m->Tag != MTAG_SVG_TRANSFORM); m=m->Next);
+            VectorMatrix *m = nullptr;
+            Vector.getMatrices(m);
+            for (; (m) and ((uint32_t)m->Tag != MTAG_SVG_TRANSFORM); m=m->Next);
 
             if (!m) {
                Vector.newMatrix(&m, false);
@@ -314,8 +315,9 @@ void anim_value::set_value(objVector &Vector)
 
       case SVF_y: {
          if (Vector.Class->ClassID IS CLASSID::VECTORGROUP) {
-            VectorMatrix *m;
-            for (m=Vector.Matrices; (m) and ((uint32_t)m->Tag != MTAG_SVG_TRANSFORM); m=m->Next);
+            VectorMatrix *m = nullptr;
+            Vector.getMatrices(m);
+            for (; (m) and ((uint32_t)m->Tag != MTAG_SVG_TRANSFORM); m=m->Next);
 
             if (!m) {
                Vector.newMatrix(&m, false);

--- a/src/svg/tests/paths/wave.svg
+++ b/src/svg/tests/paths/wave.svg
@@ -16,18 +16,18 @@
   <rect fill="#FFFFFF" width="100%" height="100%"/>
   <switch>
     <g requiredExtensions="http://www.kotuku.dev/TR/Kotuku/1.0">
-      <kotuku:wave fill="green" y="5%" length="100%" decay="0.5" amplitude="8%" close="top" frequency="6"/>
-      <kotuku:wave fill="none" y="5%" stroke="url(#helix)" stroke-width="16" length="100%" decay="0.5" amplitude="8%" frequency="6"/>
+      <kotuku:wave fill="green" y="5%" length="100%" decay="0.2" amplitude="8%" close="top" frequency="6"/>
+      <kotuku:wave fill="none" y="5%" stroke="url(#helix)" stroke-width="16" length="100%" decay="0.2" amplitude="8%" frequency="6"/>
 
       <kotuku:wave fill="red" stroke="red" x="0" y="85%" length="100%" amplitude="15%" close="bottom" frequency="4"/>
 
-      <kotuku:wave type="triangle" fill="turquoise" thickness="20" x="0" y="50%" length="100%" amplitude="100" frequency="9" fill-opacity="0.5"/>
+      <kotuku:wave type="triangle" fill="turquoise" thickness="20" x="0" y="50%" length="100%" amplitude="100" frequency="9" fill-opacity="0.5" stroke-linejoin="miter" stroke-linecap="miter"/>
       <kotuku:wave type="triangle" fill="none" stroke="url(#chain)" stroke-width="12" x="0" y="50%" length="100%" amplitude="100" frequency="9"/>
 
       <!-- This example utilises the stroke-width as opposed to thickness -->
-      <kotuku:wave fill="none" stroke="url(#LinearGradient)" stroke-width="40" x="0" y="25%" length="105%" amplitude="100" decay="-2" frequency="8"/>
+      <kotuku:wave fill="none" stroke="url(#LinearGradient)" stroke-width="40" x="0" y="25%" length="105%" amplitude="100" decay="-2" frequency="8" frequencyEnd="20"/>
 
-      <kotuku:wave fill="yellow" thickness="6" type="sawtooth" stroke="black" frequency="16" x="0" y="70%" length="100%" amplitude="20"/>
+      <kotuku:wave fill="yellow" thickness="6" type="sawtooth" stroke="black" frequency="16" x="0" y="70%" length="100%" amplitude="20" stroke-linejoin="miter" stroke-linecap="miter"/>
     </g>
 
     <text x="50%" y="50%" fill="black" font-family="Arial, sans-serif" font-size="48" text-anchor="middle" dominant-baseline="middle">Requires Kotuku framework</text>

--- a/src/svg/tests/test_defs_export.tiri
+++ b/src/svg/tests/test_defs_export.tiri
@@ -212,5 +212,5 @@ end
    assertNear(wave.noise, 0.75, 'VectorWave noise should parse from SVG')
 
    local saved = saveScene(scene, 'temp:svg_wave_noise.svg')
-   assertContains(saved, 'noise=', 'Saved SVG should include VectorWave noise')
+   assertContains(saved, 'noise=', 'Saved SVG should include VectorWave noise, got ' .. saved)
 end

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -98,7 +98,7 @@ end
 @Test(name='CaseSensitiveNames') global function BasicsCaseSensitiveNames() hashTestSVG('basics/case-sensitive.svg', 0x61fc4322) end
 
 @Test global function Circles()         hashTestSVG('paths/circles.svg', 0xd91a717f) end
-@Test global function GuidePath()       hashTestSVG('paths/guidepath.svg', 0x45b2e26a) end
+@Test global function GuidePath()       hashTestSVG('paths/guidepath.svg', 0x12a16220) end
 @Test global function EllipseVertices() hashTestSVG('paths/ellipse_vertices.svg', 0xa0a8e2df) end
 @Test global function Polygons()        hashTestSVG('paths/polygons.svg', 0x6e755c7b) end
 @Test global function Rough()           hashTestSVG('paths/rough_js.svg', 0xdb8d9130) end
@@ -108,7 +108,7 @@ end
 @Test global function SuperShapes()     hashTestSVG('paths/supershapes.svg', 0x07dc5ee7) end
 @Test global function SuperSpiral()     hashTestSVG('paths/superspiral.svg', 0x87dd0122) end
 @Test global function Transitions()     hashTestSVG('paths/transitions.svg', 0x801a2fb0) end
-@Test global function Wave()            hashTestSVG('paths/wave.svg', 0xea7f93b8) end
+@Test global function Wave()            hashTestSVG('paths/wave.svg', 0x2c07e1c2) end
 @Test global function W3Paths01()       hashTestSVG('paths/w3-paths-data-01-t.svg', 0x7fdb0e82) end
 @Test global function W3Paths02()       hashTestSVG('paths/w3-paths-data-02-t.svg', 0xb100cbc6) end
 @Test global function W3Paths03()       hashTestSVG('paths/w3-paths-data-03-f.svg', 0x0100b85b) end

--- a/src/vector/agg/include/agg_rasterizer_outline_aa.h
+++ b/src/vector/agg/include/agg_rasterizer_outline_aa.h
@@ -46,21 +46,17 @@ namespace agg
         }
     };
 
-
-    //----------------------------------------------------------outline_aa_join_e
     enum outline_aa_join_e
     {
-        outline_no_join,             //-----outline_no_join
-        outline_miter_join,          //-----outline_miter_join
-        outline_round_join,          //-----outline_round_join
-        outline_miter_accurate_join  //-----outline_accurate_join
+        outline_no_join,
+        outline_miter_join,
+        outline_round_join,
+        outline_miter_accurate_join
     };
 
-    //=======================================================rasterizer_outline_aa
     template<class Renderer, class Coord=line_coord> class rasterizer_outline_aa
     {
     private:
-        //------------------------------------------------------------------------
         struct draw_vars
         {
             unsigned idx;
@@ -88,7 +84,6 @@ namespace agg
         {}
         void attach(Renderer& ren) { m_ren = &ren; }
 
-        //------------------------------------------------------------------------
         void line_join(outline_aa_join_e join)
         {
             m_line_join = m_ren->accurate_join_only() ?
@@ -97,80 +92,54 @@ namespace agg
         }
         bool line_join() const { return m_line_join; }
 
-        //------------------------------------------------------------------------
         void round_cap(bool v) { m_round_cap = v; }
         bool round_cap() const { return m_round_cap; }
 
-        //------------------------------------------------------------------------
         void move_to(int x, int y)
         {
             m_src_vertices.modify_last(vertex_type(m_start_x = x, m_start_y = y));
         }
 
-        //------------------------------------------------------------------------
         void line_to(int x, int y)
         {
             m_src_vertices.add(vertex_type(x, y));
         }
 
-        //------------------------------------------------------------------------
         void move_to_d(double x, double y)
         {
             move_to(Coord::conv(x), Coord::conv(y));
         }
 
-        //------------------------------------------------------------------------
         void line_to_d(double x, double y)
         {
             line_to(Coord::conv(x), Coord::conv(y));
         }
 
-        //------------------------------------------------------------------------
         void render(bool close_polygon);
 
-        //------------------------------------------------------------------------
-        void add_vertex(double x, double y, unsigned cmd)
-        {
-            if(is_move_to(cmd))
-            {
-                render(false);
-                move_to_d(x, y);
+        void add_vertex(double x, double y, unsigned cmd) {
+            if (is_move_to(cmd)) {
+               render(false);
+               move_to_d(x, y);
             }
-            else
-            {
-                if(is_end_poly(cmd))
-                {
-                    render(is_closed(cmd));
-                    if(is_closed(cmd))
-                    {
-                        move_to(m_start_x, m_start_y);
-                    }
+            else {
+                if (is_end_poly(cmd)) {
+                   render(is_closed(cmd));
+                   if (is_closed(cmd)) move_to(m_start_x, m_start_y);
                 }
-                else
-                {
-                    line_to_d(x, y);
-                }
+                else line_to_d(x, y);
             }
         }
 
-        //------------------------------------------------------------------------
         template<class VertexSource>
-        void add_path(VertexSource& vs, unsigned path_id=0)
-        {
-            double x;
-            double y;
-
+        void add_path(VertexSource& vs, unsigned path_id=0) {
+            double x, y;
             unsigned cmd;
             vs.rewind(path_id);
-            while(!is_stop(cmd = vs.vertex(&x, &y)))
-            {
-                add_vertex(x, y, cmd);
-            }
+            while(!is_stop(cmd = vs.vertex(&x, &y))) add_vertex(x, y, cmd);
             render(false);
         }
 
-
-        //------------------------------------------------------------------------
         template<class VertexSource, class ColorStorage, class PathId>
         void render_all_paths(VertexSource& vs,
                               const ColorStorage& colors,

--- a/src/vector/filters/filter_source.cpp
+++ b/src/vector/filters/filter_source.cpp
@@ -146,16 +146,19 @@ static ERR SOURCEFX_Draw(extSourceFX *Self, struct acDraw *Args)
       Self->Scene->Viewport->setAspectRatio(Self->AspectRatio);
 
       agg::trans_affine &t = filter->ClientVector->Transform;
-      VectorMatrix matrix;
-      matrix.Vector = Self->Scene->Viewport;
-      matrix.ScaleX = t.sx;
-      matrix.ShearY = t.shy;
-      matrix.ShearX = t.shx;
-      matrix.ScaleY = t.sy;
+      auto viewport = (extVectorViewport *)Self->Scene->Viewport;
+
+      // Temporarily inject the client's transform as the viewport's sole matrix for the duration of the render.
+
+      viewport->Matrices.clear();
+      auto &matrix = viewport->Matrices.emplace_back();
+      matrix.Vector     = Self->Scene->Viewport;
+      matrix.ScaleX     = t.sx;
+      matrix.ShearY     = t.shy;
+      matrix.ShearX     = t.shx;
+      matrix.ScaleY     = t.sy;
       matrix.TranslateX = t.tx;
       matrix.TranslateY = t.ty;
-
-      ((extVectorViewport *)Self->Scene->Viewport)->Matrices = &matrix;
 
       auto save_parent = Self->Source->Parent;
       auto const save_next = Self->Source->Next;
@@ -175,7 +178,7 @@ static ERR SOURCEFX_Draw(extSourceFX *Self, struct acDraw *Args)
       Self->Scene->Viewport->Child = nullptr;
       Self->Source->Parent = save_parent;
       Self->Source->Next   = save_next;
-      ((extVectorViewport *)Self->Scene->Viewport)->Matrices = nullptr;
+      viewport->Matrices.clear();
       mark_dirty(Self->Source, RC::DIRTY);
    }
 

--- a/src/vector/painters/gradient.cpp
+++ b/src/vector/painters/gradient.cpp
@@ -407,6 +407,7 @@ static ERR GRADIENT_SET_Matrices(extGradient *Self, const std::span<const Vector
    if (Value) {
       Self->Matrices.assign(Value->begin(), Value->end());
 
+      // Chain the next and prev pointers
       VectorMatrix *prev = nullptr;
       for (auto &matrix : Self->Matrices) {
          matrix.Vector = nullptr;

--- a/src/vector/paths.cpp
+++ b/src/vector/paths.cpp
@@ -170,7 +170,7 @@ void gen_vector_path(extVector *Vector)
 
       Vector->Transform.reset();
 
-      for (auto t=Vector->Matrices; t; t=t->Next) {
+      for (auto t=Vector->matrices(); t; t=t->Next) {
          Vector->Transform.multiply(t->ScaleX, t->ShearY, t->ShearX, t->ScaleY, t->TranslateX, t->TranslateY);
       }
 
@@ -231,11 +231,11 @@ void gen_vector_path(extVector *Vector)
          if (Vector->AppendPath) {
             if (Vector->AppendPath->dirty()) gen_vector_path(Vector->AppendPath);
 
-            if (Vector->AppendPath->Matrices) {
+            if (not Vector->AppendPath->Matrices.empty()) {
                agg::trans_affine trans;
                trans.tx += Vector->AppendPath->FinalX;
                trans.ty += Vector->AppendPath->FinalY;
-               for (auto t=Vector->AppendPath->Matrices; t; t=t->Next) {
+               for (auto t=&Vector->AppendPath->Matrices.front(); t; t=t->Next) {
                   trans.multiply(t->ScaleX, t->ShearY, t->ShearX, t->ScaleY, t->TranslateX, t->TranslateY);
                }
 
@@ -309,7 +309,7 @@ void gen_vector_path(extVector *Vector)
          Vector->Dirty = (Vector->Dirty & (~RC::TRANSFORM)) | RC::FINAL_PATH;
       }
 
-      if (Vector->Matrices) {
+      if (not Vector->Matrices.empty()) {
          double scale = Vector->Transform.scale();
          if (scale > 1.0) Vector->BasePath.angle_tolerance(0.2); // Set in radians.  The less this value is, the more accurate it will be at sharp turns.
          else Vector->BasePath.angle_tolerance(0);
@@ -404,7 +404,7 @@ void apply_parent_transforms(extVector *Start, agg::trans_affine &AGGTransform)
             }
          }
 
-         for (auto t=node->Matrices; t; t=t->Next) {
+         for (auto t=node->matrices(); t; t=t->Next) {
             AGGTransform.multiply(t->ScaleX, t->ShearY, t->ShearX, t->ScaleY, t->TranslateX, t->TranslateY);
          }
 
@@ -417,7 +417,7 @@ void apply_parent_transforms(extVector *Start, agg::trans_affine &AGGTransform)
 
          AGGTransform.tx += node->FinalX;
          AGGTransform.ty += node->FinalY;
-         for (auto t=node->Matrices; t; t=t->Next) {
+         for (auto t=node->matrices(); t; t=t->Next) {
             AGGTransform.multiply(t->ScaleX, t->ShearY, t->ShearX, t->ScaleY, t->TranslateX, t->TranslateY);
          }
       }

--- a/src/vector/scene/scene_clipping.cpp
+++ b/src/vector/scene/scene_clipping.cpp
@@ -339,7 +339,7 @@ void SceneRenderer::ClipBuffer::draw_bounding_box(SceneRenderer &Render)
    set_viewport_fixed_bounds(m_clip->Viewport, shape_bounds.left, shape_bounds.top,
       shape_bounds.width(), shape_bounds.height());
 
-   if (!set_render_transform(m_clip->Viewport, build_matrix_transform(m_shape->Matrices))) {
+   if (!set_render_transform(m_clip->Viewport, build_matrix_transform(m_shape->matrices()))) {
       clip_viewport->vpClipConfiguring = false;
       return;
    }

--- a/src/vector/scene/scene_draw.cpp
+++ b/src/vector/scene/scene_draw.cpp
@@ -29,12 +29,14 @@ static void set_render_matrix(VectorMatrix &Matrix, const agg::trans_affine &Tra
 
 static bool set_render_transform(objVectorViewport *Viewport, const agg::trans_affine &Transform)
 {
-   if (not Viewport->Matrices) {
+   auto vp = (extVectorViewport *)Viewport;
+
+   if (not vp->matrices()) {
       if (Viewport->newMatrix(nullptr, false) != ERR::Okay) return false;
    }
 
-   if (not render_matrix_matches(*Viewport->Matrices, Transform)) {
-      set_render_matrix(*Viewport->Matrices, Transform);
+   if (not render_matrix_matches(*vp->matrices(), Transform)) {
+      set_render_matrix(*vp->matrices(), Transform);
       mark_dirty(Viewport, RC::TRANSFORM);
    }
 
@@ -933,7 +935,7 @@ void SceneRenderer::draw_vectors(extVector *CurrentVector, VectorState &ParentSt
       }
 
       #ifdef DBG_DRAW
-         log.traceBranch("%s: #%d, Matrices: %p", get_name(shape), shape->UID, shape->Matrices);
+         log.traceBranch("%s: #%d, Matrices: %p", get_name(shape), shape->UID, shape->matrices());
       #endif
 
       if (mBitmap->ColourSpace IS CS::LINEAR_RGB) state.mLinearRGB = true; // The target bitmap's colour space has priority if linear.

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -10,6 +10,7 @@ template<class... Args> void DBG_TRANSFORM(Args...) {
 }
 
 #include <array>
+#include <list>
 #include <memory>
 #include <vector>
 #include <unordered_set>
@@ -788,6 +789,7 @@ class extVector : public objVector {
    double FinalX, FinalY;         // Used by Viewport to define the target X,Y; also VectorText to position the text' final position.
    TClipRectangle<double> Bounds; // Must be calculated by GeneratePath() and called from calc_full_boundary()
    Unit StrokeWidth;
+   std::list<VectorMatrix> Matrices;
    agg::path_storage BasePath;
    agg::trans_affine Transform;   // Final transform.  Accumulated from the Matrix list during path generation.
 
@@ -841,6 +843,8 @@ class extVector : public objVector {
    double fixed_stroke_width();
 
    inline bool dirty() { return (Dirty & RC::DIRTY) != RC::NIL; }
+
+   inline VectorMatrix * matrices() { return Matrices.empty() ? nullptr : &Matrices.front(); }
 
    inline bool is_stroked() {
       return (StrokeWidth > 0) and
@@ -1411,16 +1415,16 @@ inline static void reset_final_path(objVector *Vector)
 template <class T>
 inline static void apply_transforms(const T &Vector, agg::trans_affine &AGGTransform)
 {
-   if constexpr (std::is_pointer_v<std::decay_t<decltype(Vector.Matrices)>>) {
-      // Linked-list storage (objVector, viewports and patterns)
-      for (auto t=Vector.Matrices; t; t=t->Next) {
-         AGGTransform.multiply(t->ScaleX, t->ShearY, t->ShearX, t->ScaleY, t->TranslateX, t->TranslateY);
-      }
-   }
-   else { // Contiguous kt::vector storage
-      for (auto &t : Vector.Matrices) {
-         AGGTransform.multiply(t.ScaleX, t.ShearY, t.ShearX, t.ScaleY, t.TranslateX, t.TranslateY);
-      }
+   // extVector-derived shapes store their transforms in a std::list (Matrices); gradients and patterns use a
+   // contiguous kt::vector (Matrices).  Both are range-iterable, so the storage is selected at compile time.
+
+   auto &store = [&]() -> auto & {
+      if constexpr (requires { Vector.Matrices; }) return Vector.Matrices;
+      else return Vector.Matrices;
+   }();
+
+   for (auto &t : store) {
+      AGGTransform.multiply(t.ScaleX, t.ShearY, t.ShearX, t.ScaleY, t.TranslateX, t.TranslateY);
    }
 }
 

--- a/src/vector/vector.tdl
+++ b/src/vector/vector.tdl
@@ -750,7 +750,6 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     obj(Vector) Next        # The next vector in the branch, or `NULL`.
     obj(Vector) Prev        # The previous vector in the branch, or `NULL`.
     obj Parent              # The parent vector, or `NULL` if this is the top-most vector.
-    struct(*VectorMatrix) Matrices # A list of transform matrices to apply to the vector.
     double StrokeOpacity    # Defines the opacity of the path stroke.
     double FillOpacity      # The opacity to use when filling the vector.
     double Opacity          # An overall opacity value for the vector.
@@ -763,6 +762,7 @@ module({ name='Vector', copyright='Paul Manias © 2010-2026', version=1.0, times
     int(RQ)  PathQuality    # Defines the quality of rendered path outlines.
     int(VCS) ColourSpace    # Desired colour space to use when blending colours.
     int      PathTimestamp  # This counter is modified each time the path is regenerated.
+    ~struct(VectorMatrix) Matrices
     ~struct(FRGB) StrokeColour
     ~struct(FRGB) FillColour
     ~int(VFR) FillRule

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -31,6 +31,18 @@ static std::mutex glResizeLock;
 
 static ERR VECTOR_Push(extVector *, struct vec::Push *);
 
+static void rebuild_matrix_links(extVector *Self)
+{
+   VectorMatrix *prev = nullptr;
+
+   for (auto &matrix : Self->Matrices) {
+      matrix.Vector = Self;
+      matrix.Next = nullptr;
+      if (prev) prev->Next = &matrix;
+      prev = &matrix;
+   }
+}
+
 //********************************************************************************************************************
 // For the use of the VectorScene's Debug() method.
 
@@ -228,6 +240,7 @@ struct(*VectorMatrix) Matrix: Reference to the structure that requires removal.
 -ERRORS-
 Okay:
 NullArgs:
+NotFound:
 
 -TAGS-
 mutates-object, closes-handle
@@ -238,24 +251,17 @@ static ERR VECTOR_FreeMatrix(extVector *Self, struct vec::FreeMatrix *Args)
 {
    if ((!Args) or (!Args->Matrix)) return ERR::NullArgs;
 
-   // Clean up the linked list
+   for (auto matrix = Self->Matrices.begin(); matrix != Self->Matrices.end(); ++matrix) {
+      if (&*matrix IS Args->Matrix) {
+         Self->Matrices.erase(matrix);
+         rebuild_matrix_links(Self);
 
-   if (Self->Matrices IS Args->Matrix) {
-      Self->Matrices = Args->Matrix->Next;
-   }
-   else {
-      for (auto t = Self->Matrices; t; t=t->Next) {
-         if (t->Next IS Args->Matrix) {
-            t->Next = Args->Matrix->Next;
-            break;
-         }
+         mark_dirty(Self, RC::TRANSFORM);
+         return ERR::Okay;
       }
    }
 
-   FreeResource(Args->Matrix);
-
-   mark_dirty(Self, RC::TRANSFORM);
-   return ERR::Okay;
+   return ERR::NotFound;
 }
 
 /*********************************************************************************************************************
@@ -463,7 +469,6 @@ int End: If `true`, the matrix priority is lowered by inserting it at the end of
 -ERRORS-
 Okay:
 NullArgs:
-AllocMemory
 
 -TAGS-
 mutates-object, object-owns-result, creates-resource
@@ -472,35 +477,25 @@ mutates-object, object-owns-result, creates-resource
 
 static ERR VECTOR_NewMatrix(extVector *Self, struct vec::NewMatrix *Args)
 {
-   if (!Args) return ERR::NullArgs;
+   if (not Args) return ERR::NullArgs;
 
-   VectorMatrix *transform;
-   if (!AllocMemory(sizeof(VectorMatrix), MEM::DATA|MEM::NO_CLEAR, (APTR *)&transform)) {
-      transform->Vector = Self;
-      transform->ScaleX = 1.0;
-      transform->ScaleY = 1.0;
-      transform->ShearX = 0;
-      transform->ShearY = 0;
-      transform->TranslateX = 0;
-      transform->TranslateY = 0;
+   Args->Transform = nullptr;
 
-      if ((Args->End) and (Self->Matrices)) {
-         transform->Next   = nullptr;
-         VectorMatrix *last = Self->Matrices;
-         while (last->Next) last = last->Next;
-         last->Next = transform;
-      }
-      else { // Insert transform at the start of the list.
-         transform->Next = Self->Matrices;
-         Self->Matrices = transform;
-      }
-
-      Args->Transform = transform;
-
-      mark_dirty(Self, RC::TRANSFORM);
-      return ERR::Okay;
+   if (Args->End) {
+      Self->Matrices.emplace_back();
+      Args->Transform = &Self->Matrices.back();
    }
-   else return ERR::AllocMemory;
+   else {
+      Self->Matrices.emplace_front();
+      Args->Transform = &Self->Matrices.front();
+   }
+
+   Args->Transform->Vector = Self;
+
+   rebuild_matrix_links(Self);
+
+   mark_dirty(Self, RC::TRANSFORM);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -1563,6 +1558,17 @@ represented by the !VectorMatrix structure, and are linked in the order in which
 
 !VectorMatrix
 
+*********************************************************************************************************************/
+
+static ERR VECTOR_GET_Matrices(extVector *Self, struct VectorMatrix * &Value)
+{
+   if (Self->Matrices.empty()) Value = nullptr;
+   else Value = &Self->Matrices.front();
+   return ERR::Okay;
+}
+
+/*********************************************************************************************************************
+
 -FIELD-
 MiterLimit: Imposes a limit on the ratio of the miter length to the StrokeWidth.
 
@@ -2318,14 +2324,6 @@ extVector::~extVector() {
          glResizeSubscriptions.erase(this);
       }
    }
-
-   if (Matrices) {
-      VectorMatrix *next;
-      for (auto t=Matrices; t; t=next) {
-         next = t->Next;
-         FreeResource(t);
-      }
-   }
 }
 
 //********************************************************************************************************************
@@ -2338,7 +2336,6 @@ static const FieldArray clVectorFields[] = {
    { "Next",            FDF_OBJECT|FD_RW, nullptr, VECTOR_SET_Next, CLASSID::VECTOR },
    { "Prev",            FDF_OBJECT|FD_RW, nullptr, VECTOR_SET_Prev, CLASSID::VECTOR },
    { "Parent",          FDF_OBJECT|FD_R },
-   { "Matrices",        FDF_POINTER|FDF_STRUCT|FDF_R, nullptr, nullptr, "VectorMatrix" },
    { "StrokeOpacity",   FDF_DOUBLE|FDF_RW, nullptr, VECTOR_SET_StrokeOpacity },
    { "FillOpacity",     FDF_DOUBLE|FDF_RW, nullptr, VECTOR_SET_FillOpacity },
    { "Opacity",         FDF_DOUBLE|FD_RW, nullptr, VECTOR_SET_Opacity },
@@ -2369,6 +2366,7 @@ static const FieldArray clVectorFields[] = {
    // Virtual fields
    { "DashArray",    FDF_VIRTUAL|FDF_ARRAY|FDF_DOUBLE|FD_RW|FDF_PURE, VECTOR_GET_DashArray, VECTOR_SET_DashArray },
    { "DisplayScale", FDF_VIRTUAL|FDF_DOUBLE|FDF_R,              VECTOR_GET_DisplayScale },
+   { "Matrices",     FDF_VIRTUAL|FDF_POINTER|FDF_STRUCT|FDF_R|FDF_PURE, VECTOR_GET_Matrices, nullptr, "VectorMatrix" },
    { "ResizeEvent",  FDF_VIRTUAL|FDF_FUNCTION|FDF_W,            nullptr, VECTOR_SET_ResizeEvent },
    { "Sequence",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTOR_GET_Sequence },
    { "StrokeColour", FDF_VIRTUAL|FDF_STRUCT|FD_RW|FDF_PURE,     VECTOR_GET_StrokeColour, VECTOR_SET_StrokeColour, "FRGB" },

--- a/src/vector/vectors/wave.cpp
+++ b/src/vector/vectors/wave.cpp
@@ -41,6 +41,9 @@ class extVectorWave : public extVector {
 
    extVectorWave(objMetaClass *ClassPtr, OBJECTID ObjectID) : extVector(ClassPtr, ObjectID) {
       GeneratePath = (void (*)(extVector *, agg::path_storage &))&generate_wave;
+      LineJoin  = VLJ::ROUND;  // Rounds the outer (convex) side of sharp peaks
+      InnerJoin = VIJ::ROUND;  // Absorbs the inner (concave) side, preventing cross-over
+      LineCap   = VLC::ROUND;
    }
 
    void apply_wave_thickness(agg::path_storage &Path, double Thickness, double ApproxScale, double Length,
@@ -429,9 +432,9 @@ void extVectorWave::apply_wave_thickness(agg::path_storage &Path, double Thickne
 
    agg::conv_stroke<agg::path_storage> stroke(centreline);
    stroke.width(Thickness);
-   stroke.line_join(VLJ::ROUND);  // Rounds the outer (convex) side of sharp peaks
-   stroke.inner_join(VIJ::ROUND); // Absorbs the inner (concave) side, preventing cross-over
-   stroke.line_cap(VLC::ROUND);
+   stroke.line_join(this->LineJoin);  // Rounds the outer (convex) side of sharp peaks
+   stroke.inner_join(this->InnerJoin); // Absorbs the inner (concave) side, preventing cross-over
+   stroke.line_cap(this->LineCap);
    stroke.approximation_scale(ApproxScale > 0.0 ? ApproxScale : 1.0);
 
    if (wave_needs_resolve(Length, Amplitude, Thickness, Frequency, FrequencyEnd)) {


### PR DESCRIPTION
* Replaced heap-allocated vector transform chains with object-owned list storage and virtual Matrices access
* Updated SVG animation, filters, scene drawing and document input paths for the new matrix access pattern
* [SVG] Added wave export coverage and refreshed wave rendering expectations
* [Vector] Allowed wave thickness joins and caps to follow vector style fields