### PR TITLE
[Core] Return allocated C++ string fields through std::string

### DIFF
--- a/docs/xml/modules/classes/vectorpath.xml
+++ b/docs/xml/modules/classes/vectorpath.xml
@@ -189,6 +189,7 @@ Z: Close Path
 <p>The use of lower case characters will indicate that the provided coordinates are relative (based on the coordinate of the previous command).</p>
 <p>To terminate a path without joining it to the first coordinate, omit the <code>Z</code> from the end of the sequence.</p>
       </description>
+      <tags>caller-owns-result</tags>
     </field>
 
     <field>

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -4232,10 +4232,10 @@ class objVectorPath : public objVector {
       return get_field(this, Value);
    }
 
-   inline ERR getSequence(std::string_view &Value) noexcept {
+   inline ERR getSequence(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[16];
       SetObjectContext(this, field, AC::NIL);
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
       auto error = get_field(this, Value);
       RestoreObjectContext();
       return error;
@@ -4271,7 +4271,7 @@ class objVectorPath : public objVector {
 
    inline ERR setSequence(const std::string_view &Value) noexcept {
       auto field = &this->Class->Dictionary[16];
-      return field->WriteValue(this, field, 0x00804308, &Value);
+      return field->WriteValue(this, field, 0x00804328, &Value);
    }
 
    inline ERR setX(const Unit Value) noexcept {

--- a/include/kotuku/modules/vector.h
+++ b/include/kotuku/modules/vector.h
@@ -782,15 +782,8 @@ class objVectorTransition : public Object {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[2];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1351,15 +1344,8 @@ class objGradient : public Object {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1475,15 +1461,8 @@ class objGradientLinear : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1567,15 +1546,8 @@ class objGradientRadial : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1659,15 +1631,8 @@ class objGradientConic : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1731,15 +1696,8 @@ class objGradientDiamond : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1793,15 +1751,8 @@ class objGradientContour : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1901,15 +1852,8 @@ class objGradientMesh : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -1983,15 +1927,8 @@ class objGradientDistal : public objGradient {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[8];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2243,15 +2180,8 @@ class objFilterEffect : public Object {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2370,15 +2300,8 @@ class objImageFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2437,15 +2360,8 @@ class objSourceFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2504,15 +2420,8 @@ class objBlurFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2567,15 +2476,8 @@ class objColourFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2645,15 +2547,8 @@ class objCompositeFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2768,15 +2663,8 @@ class objConvolveFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2887,15 +2775,8 @@ class objDisplacementFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -2959,15 +2840,8 @@ class objFloodFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3067,15 +2941,8 @@ class objLightingFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3150,15 +3017,8 @@ class objMergeFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3212,15 +3072,8 @@ class objMorphologyFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3279,15 +3132,8 @@ class objOffsetFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3374,15 +3220,8 @@ class objRemapFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3446,15 +3285,8 @@ class objTurbulenceFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3559,15 +3391,8 @@ class objWaveFunctionFX : public objFilterEffect {
 
    inline ERR getXMLDef(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[5];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -3773,15 +3598,8 @@ class objVectorFilter : public Object {
 
    inline ERR getEffectXML(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[15];
-      SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
-      RestoreObjectContext();
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       return error;
    }
 
@@ -4160,13 +3978,8 @@ class objVector : public Object {
    inline ERR getSequence(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[16];
       SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       RestoreObjectContext();
       return error;
    }

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -436,13 +436,8 @@ class objXML : public Object {
    inline ERR getStatement(std::string &Value) noexcept {
       auto field = &this->Class->Dictionary[10];
       SetObjectContext(this, field, AC::NIL);
-      std::string_view view;
-      auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;
-      auto error = get_field(this, view);
-      if (error IS ERR::Okay) {
-         Value.assign(view);
-         if (view.data()) FreeResource(GetMemoryID(view.data()));
-      }
+      auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+      auto error = get_field(this, Value);
       RestoreObjectContext();
       return error;
    }

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -589,6 +589,14 @@ struct alignas(8) Object { // Must be 64-bit aligned
             else return error;
          }
 
+         if ((flags & FD_STRING) and (flags & FD_ALLOC) and field->GetValue) {
+            if (not field->pure()) SetObjectContext(target, field, AC::NIL);
+            auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;
+            auto error = get_field(target, Value);
+            if (not field->pure()) RestoreObjectContext();
+            return error;
+         }
+
          int8_t field_value[sizeof(std::string_view)];
          auto fv = get_field_value(target, *field, field_value);
          APTR data = fv.second;

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -324,7 +324,10 @@ READ_TABLE * get_read_table(objMetaClass *Class)
             jmp.push_back(obj_read(hash, object_get_array, field_ptr));
          }
          else if (field.Flags & FD_STRUCT) jmp.push_back(obj_read(hash, object_get_struct, field_ptr));
-         else if (field.Flags & FD_STRING) jmp.push_back(obj_read(hash, object_get_string, field_ptr));
+         else if (field.Flags & FD_STRING) {
+            if (field.Flags & FD_ALLOC) jmp.push_back(obj_read(hash, object_get_cppstring, field_ptr));
+            else jmp.push_back(obj_read(hash, object_get_string, field_ptr));
+         }
          else if (field.Flags & FD_POINTER) {
             if (field.Flags & (FD_OBJECT|FD_LOCAL)) {
                jmp.push_back(obj_read(hash, object_get_object, field_ptr));

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -1,5 +1,7 @@
 // Refer: lib_object.cpp
 
+static int object_get_cppstring(lua_State *Lua, const obj_read &Handle, GCobject *Def);
+
 //********************************************************************************************************************
 
 static ERR lua_string_view(lua_State *Lua, int ValueIndex, std::string_view &Value)
@@ -452,7 +454,8 @@ static int object_get(lua_State *Lua)
             result = object_get_struct(Lua, obj_read(0, nullptr, (APTR)field), def);
          }
          else if (field->Flags & FD_STRING) {
-            result = object_get_string(Lua, obj_read(0, nullptr, (APTR)field), def);
+            if (field->Flags & FD_ALLOC) result = object_get_cppstring(Lua, obj_read(0, nullptr, (APTR)field), def);
+            else result = object_get_string(Lua, obj_read(0, nullptr, (APTR)field), def);
          }
          else if (field->Flags & FD_POINTER) {
             if (field->Flags & (FD_OBJECT|FD_LOCAL)) {
@@ -697,6 +700,24 @@ static int object_get_struct(lua_State *Lua, const obj_read &Handle, GCobject *D
       else {
          kt::Log(__FUNCTION__).warning("No struct name reference for field %s in class %s.", field->Name, obj->Class->ClassName.c_str());
          error = ERR::Failed;
+      }
+      release_object(Def);
+   }
+   else error = ERR::AccessObject;
+
+   Lua->CaughtError = error;
+   return error != ERR::Okay ? 0 : 1;
+}
+
+static int object_get_cppstring(lua_State *Lua, const obj_read &Handle, GCobject *Def)
+{
+   ERR error;
+   if (auto obj = access_object(Def)) {
+      auto field = (Field *)(Handle.Data);
+      std::string result;
+      if (!(error = obj->get(field->FieldID, result))) {
+         if (result.empty()) lua_pushnil(Lua);
+         else lua_pushlstring(Lua, result.data(), result.size());
       }
       release_object(Def);
    }

--- a/src/vector/filters/filter.cpp
+++ b/src/vector/filters/filter.cpp
@@ -709,7 +709,7 @@ is allocated and must be freed once no longer in use.
 
 *********************************************************************************************************************/
 
-static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, std::string_view &Value)
+static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, std::string &Value)
 {
    std::stringstream ss;
 
@@ -722,12 +722,8 @@ static ERR VECTORFILTER_GET_EffectXML(extVectorFilter *Self, std::string_view &V
       ss << "/>";
    }
 
-   auto cppstr = ss.str();
-   if (auto str = strclone(cppstr)) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = ss.str();
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -878,7 +874,7 @@ static const FieldArray clFilterFields[] = {
    { "ColourSpace",    FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorFilterColourSpace },
    { "AspectRatio",    FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clVectorFilterAspectRatio },
    // Virtual fields
-   { "EffectXML",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, VECTORFILTER_GET_EffectXML },
+   { "EffectXML",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, VECTORFILTER_GET_EffectXML },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_blur.cpp
+++ b/src/vector/filters/filter_blur.cpp
@@ -564,16 +564,12 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR BLURFX_GET_XMLDef(extBlurFX *Self, std::string_view &Value)
+static ERR BLURFX_GET_XMLDef(extBlurFX *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "feGaussianBlur stdDeviation=\"" << Self->SX << " " << Self->SY << "\"";
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -583,7 +579,7 @@ static ERR BLURFX_GET_XMLDef(extBlurFX *Self, std::string_view &Value)
 static const FieldArray clBlurFXFields[] = {
    { "SX",     FDF_DOUBLE|FDF_RW },
    { "SY",     FDF_DOUBLE|FDF_RW },
-   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, BLURFX_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, BLURFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_colourmatrix.cpp
+++ b/src/vector/filters/filter_colourmatrix.cpp
@@ -593,18 +593,14 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR COLOURFX_GET_XMLDef(extColourFX *Self, std::string_view &Value)
+static ERR COLOURFX_GET_XMLDef(extColourFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feColorMatrix";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -614,7 +610,7 @@ static ERR COLOURFX_GET_XMLDef(extColourFX *Self, std::string_view &Value)
 static const FieldArray clColourFXFields[] = {
    { "Mode",   FDF_INT|FDF_LOOKUP|FDF_RI,  nullptr, nullptr, &clColourFXCM },
    { "Values", FDF_VIRTUAL|FDF_DOUBLE|FDF_ARRAY|FDF_RI|FDF_PURE, COLOURFX_GET_Values, COLOURFX_SET_Values },
-   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,  COLOURFX_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE,  COLOURFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_composite.cpp
+++ b/src/vector/filters/filter_composite.cpp
@@ -776,14 +776,10 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR COMPOSITEFX_GET_XMLDef(extCompositeFX *Self, std::string_view &Value)
+static ERR COMPOSITEFX_GET_XMLDef(extCompositeFX *Self, std::string &Value)
 {
-   auto cppstr = std::string("feComposite");
-   if (auto str = strclone(cppstr)) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = std::string("feComposite");
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -796,7 +792,7 @@ static const FieldArray clCompositeFXFields[] = {
    { "K3",       FDF_DOUBLE|FDF_RW },
    { "K4",       FDF_DOUBLE|FDF_RW },
    { "Operator", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clCompositeFXOP },
-   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, COMPOSITEFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, COMPOSITEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_convolve.cpp
+++ b/src/vector/filters/filter_convolve.cpp
@@ -785,7 +785,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, std::string_view &Value)
+static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
@@ -845,12 +845,8 @@ static ERR CONVOLVEFX_GET_XMLDef(extConvolveFX *Self, std::string_view &Value)
 
    if (Self->PreserveAlpha) stream << " preserveAlpha=\"true\"";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -869,7 +865,7 @@ static const FieldArray clConvolveFXFields[] = {
    { "TargetY",       FDF_INT|FDF_RI,    nullptr, CONVOLVEFX_SET_TargetY },
    { "UnitX",         FDF_DOUBLE|FDF_RI, nullptr, CONVOLVEFX_SET_UnitX },
    { "UnitY",         FDF_DOUBLE|FDF_RI, nullptr, CONVOLVEFX_SET_UnitY },
-   { "XMLDef",        FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,  CONVOLVEFX_GET_XMLDef },
+   { "XMLDef",        FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE,  CONVOLVEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_displacement.cpp
+++ b/src/vector/filters/filter_displacement.cpp
@@ -233,18 +233,14 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, std::string_view &Value)
+static ERR DISPLACEMENTFX_GET_XMLDef(extDisplacementFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feDisplacement";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -256,7 +252,7 @@ static const FieldArray clDisplacementFXFields[] = {
    { "ResampleMethod", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXVSM },
    { "XChannel",  FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXCMP },
    { "YChannel",  FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clDisplacementFXCMP },
-   { "XMLDef",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, DISPLACEMENTFX_GET_XMLDef },
+   { "XMLDef",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, DISPLACEMENTFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_effect.cpp
+++ b/src/vector/filters/filter_effect.cpp
@@ -211,7 +211,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR FILTEREFFECT_GET_XMLDef(extFilterEffect *Self, std::string_view &Value)
+static ERR FILTEREFFECT_GET_XMLDef(extFilterEffect *Self, std::string &Value)
 {
    // Derived classes are expected to override this field
    return ERR::NoSupport;
@@ -231,7 +231,7 @@ static const FieldArray clFilterEffectFields[] = {
    { "Height",     FDF_UNIT|FDF_RW },
    { "SourceType", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clFilterEffectSourceType },
    { "MixType",    FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clFilterEffectMixType },
-   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, FILTEREFFECT_GET_XMLDef },
+   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, FILTEREFFECT_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_flood.cpp
+++ b/src/vector/filters/filter_flood.cpp
@@ -118,18 +118,14 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, std::string_view &Value)
+static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feFlood opacity=\"" << Self->Opacity << "\"";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -139,7 +135,7 @@ static ERR FLOODFX_GET_XMLDef(extFloodFX *Self, std::string_view &Value)
 static const FieldArray clFloodFXFields[] = {
    { "Colour",  FDF_STRUCT|FDF_RW, nullptr, FLOODFX_SET_Colour, "FRGB" },
    { "Opacity", FDF_DOUBLE|FDF_RW, nullptr, FLOODFX_SET_Opacity },
-   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, FLOODFX_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, FLOODFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_image.cpp
+++ b/src/vector/filters/filter_image.cpp
@@ -134,18 +134,14 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR IMAGEFX_GET_XMLDef(extImageFX *Self, std::string_view &Value)
+static ERR IMAGEFX_GET_XMLDef(extImageFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feImage";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -157,7 +153,7 @@ static const FieldArray clImageFXFields[] = {
    { "ResampleMethod", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clImageFXVSM },
    { "Bitmap",         FDF_OBJECT|FDF_R, nullptr, nullptr, CLASSID::BITMAP },
    { "Path",           FDF_VIRTUAL|FDF_CPPSTRING|FDF_RI, IMAGEFX_GET_Path, IMAGEFX_SET_Path },
-   { "XMLDef",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, IMAGEFX_GET_XMLDef },
+   { "XMLDef",         FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, IMAGEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_lighting.cpp
+++ b/src/vector/filters/filter_lighting.cpp
@@ -909,7 +909,7 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, std::string_view &Value)
+static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, std::string &Value)
 {
    std::stringstream stream;
    std::string type(Self->Type IS LT::DIFFUSE ? "feDiffuseLighting" : "feSpecularLighting");
@@ -917,12 +917,8 @@ static ERR LIGHTINGFX_GET_XMLDef(extLightingFX *Self, std::string_view &Value)
    // TODO
    stream << type;
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -937,7 +933,7 @@ static const FieldArray clLightingFXFields[] = {
    { "UnitX",    FDF_DOUBLE|FDF_RW, nullptr, LIGHTINGFX_SET_UnitX },
    { "UnitY",    FDF_DOUBLE|FDF_RW, nullptr, LIGHTINGFX_SET_UnitY },
    { "Type",     FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clLightingFXLT },
-   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, LIGHTINGFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, LIGHTINGFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_merge.cpp
+++ b/src/vector/filters/filter_merge.cpp
@@ -132,14 +132,10 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, std::string_view &Value)
+static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, std::string &Value)
 {
-   auto cppstr = std::string("feMerge");
-   if (auto str = strclone(cppstr)) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = std::string("feMerge");
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -148,7 +144,7 @@ static ERR MERGEFX_GET_XMLDef(extMergeFX *Self, std::string_view &Value)
 
 static const FieldArray clMergeFXFields[] = {
    { "SourceList", FDF_VIRTUAL|FDF_STRUCT|FDF_ARRAY|FDF_RW|FDF_PURE, MERGEFX_GET_SourceList, MERGEFX_SET_SourceList, "MergeSource" },
-   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, MERGEFX_GET_XMLDef },
+   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, MERGEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_morphology.cpp
+++ b/src/vector/filters/filter_morphology.cpp
@@ -262,7 +262,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, std::string_view &Value)
+static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
@@ -273,12 +273,8 @@ static ERR MORPHOLOGYFX_GET_XMLDef(extMorphologyFX *Self, std::string_view &Valu
 
    stream << "radius=\"" << Self->RadiusX << " " << Self->RadiusY << "\"";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -289,7 +285,7 @@ static const FieldArray clMorphologyFXFields[] = {
    { "RadiusX",  FDF_INT|FDF_RW, nullptr, MORPHOLOGYFX_SET_RadiusX },
    { "RadiusY",  FDF_INT|FDF_RW, nullptr, MORPHOLOGYFX_SET_RadiusY },
    { "Operator", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, nullptr, &clMorphologyFXMOP },
-   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, MORPHOLOGYFX_GET_XMLDef },
+   { "XMLDef",   FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, MORPHOLOGYFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_offset.cpp
+++ b/src/vector/filters/filter_offset.cpp
@@ -53,17 +53,13 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, std::string_view &Value)
+static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "feOffset dx=\"" << Self->XOffset << "\" dy=\"" << Self->YOffset << "\"";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -73,7 +69,7 @@ static ERR OFFSETFX_GET_XMLDef(extOffsetFX *Self, std::string_view &Value)
 static const FieldArray clOffsetFXFields[] = {
    { "XOffset", FDF_INT|FDF_RW },
    { "YOffset", FDF_INT|FDF_RW },
-   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, OFFSETFX_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, OFFSETFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_remap.cpp
+++ b/src/vector/filters/filter_remap.cpp
@@ -483,7 +483,7 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, std::string_view &Value)
+static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
@@ -495,12 +495,8 @@ static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, std::string_view &Value)
    stream << "<feFuncA/>";
    stream << "</feComponentTransfer>";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -508,7 +504,7 @@ static ERR REMAPFX_GET_XMLDef(extRemapFX *Self, std::string_view &Value)
 #include "filter_remap_def.c"
 
 static const FieldArray clRemapFXFields[] = {
-   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, REMAPFX_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, REMAPFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_source.cpp
+++ b/src/vector/filters/filter_source.cpp
@@ -289,14 +289,10 @@ XMLDef: Returns an SVG compliant XML string that describes the filter.
 
 *********************************************************************************************************************/
 
-static ERR SOURCEFX_GET_XMLDef(extSourceFX *Self, std::string_view &Value)
+static ERR SOURCEFX_GET_XMLDef(extSourceFX *Self, std::string &Value)
 {
-   auto cppstr = std::string("feImage");
-   if (auto str = strclone(cppstr)) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = std::string("feImage");
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -307,7 +303,7 @@ static const FieldArray clSourceFXFields[] = {
    { "AspectRatio", FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, SOURCEFX_SET_AspectRatio, &clAspectRatio },
    { "SourceName",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_I, nullptr, SOURCEFX_SET_SourceName },
    { "Source",      FDF_VIRTUAL|FDF_OBJECT|FDF_R|FDF_PURE, SOURCEFX_GET_Source, SOURCEFX_SET_Source, CLASSID::VECTOR },
-   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, SOURCEFX_GET_XMLDef },
+   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, SOURCEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_turbulence.cpp
+++ b/src/vector/filters/filter_turbulence.cpp
@@ -448,18 +448,14 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR TURBULENCEFX_GET_XMLDef(extTurbulenceFX *Self, std::string_view &Value)
+static ERR TURBULENCEFX_GET_XMLDef(extTurbulenceFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feTurbulence";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -473,7 +469,7 @@ static const FieldArray clTurbulenceFXFields[] = {
    { "Seed",    FDF_INT|FDF_RI,            nullptr, TURBULENCEFX_SET_Seed },
    { "Stitch",  FDF_INT|FDF_RI,            nullptr, TURBULENCEFX_SET_Stitch },
    { "Type",    FDF_INT|FDF_LOOKUP|FDF_RI, nullptr, TURBULENCEFX_SET_Type, &clTurbulenceFXTB },
-   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R,      TURBULENCEFX_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE,      TURBULENCEFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/filters/filter_wavefunction.cpp
+++ b/src/vector/filters/filter_wavefunction.cpp
@@ -329,18 +329,14 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 
 *********************************************************************************************************************/
 
-static ERR WAVEFUNCTIONFX_GET_XMLDef(extWaveFunctionFX *Self, std::string_view &Value)
+static ERR WAVEFUNCTIONFX_GET_XMLDef(extWaveFunctionFX *Self, std::string &Value)
 {
    std::stringstream stream;
 
    stream << "feWaveFunction";
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(stream.str())) {
-      Value = std::string_view{str, cppstr.size()};
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -356,7 +352,7 @@ static const FieldArray clWaveFunctionFXFields[] = {
    { "L",           FDF_INT|FDF_RW,              nullptr, WAVEFUNCTIONFX_SET_L },
    { "M",           FDF_INT|FDF_RW,              nullptr, WAVEFUNCTIONFX_SET_M },
    { "Resolution",  FDF_INT|FDF_RW,              nullptr, WAVEFUNCTIONFX_SET_Resolution },
-   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, WAVEFUNCTIONFX_GET_XMLDef },
+   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, WAVEFUNCTIONFX_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient.cpp
+++ b/src/vector/painters/gradient.cpp
@@ -556,18 +556,9 @@ The returned string does not include angle brackets, common gradient attributes,
 
 *********************************************************************************************************************/
 
-static ERR GRADIENT_GET_XMLDef(extGradient *, std::string_view &)
+static ERR GRADIENT_GET_XMLDef(extGradient *, std::string &)
 {
    return ERR::NoSupport;
-}
-
-static ERR gradient_xml_result(const std::string &String, std::string_view &Value)
-{
-   if (auto str = strclone(String)) {
-      Value = std::string_view{ str, String.size() };
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
 }
 
 static std::string gradient_xml_num(double Value)
@@ -623,7 +614,7 @@ static const FieldArray clGradientFields[] = {
    { "NumericID",    FDF_INT|FDF_RW,            nullptr, GRADIENT_SET_NumericID },
    // Virtual fields
    { "Transform",    FDF_VIRTUAL|FDF_CPPSTRING|FDF_W, nullptr, GRADIENT_SET_Transform },
-   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENT_GET_XMLDef },
+   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENT_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_conic.cpp
+++ b/src/vector/painters/gradient_conic.cpp
@@ -10,11 +10,6 @@ ramp forwards and then back again within each Span cycle, forming a triangular s
 `1.0` a single triangle spans the full turn: the ramp runs from start to end across the first half-turn and back to
 the start across the second.
 
--END-
-
-*********************************************************************************************************************/
-
-/*********************************************************************************************************************
 -FIELD-
 CX: The horizontal centre point of the gradient.
 
@@ -93,7 +88,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTCONIC_GET_XMLDef(extGradientConic *Self, std::string_view &Value)
+static ERR GRADIENTCONIC_GET_XMLDef(extGradientConic *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "conicGradient";
@@ -101,7 +96,8 @@ static ERR GRADIENTCONIC_GET_XMLDef(extGradientConic *Self, std::string_view &Va
    gradient_xml_attr(stream, "cy", Self->CY);
    gradient_xml_attr(stream, "r", Self->Radius);
    if (Self->Span != 1.0) gradient_xml_attr(stream, "span", Self->Span);
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -113,7 +109,7 @@ static const FieldArray clGradientConicFields[] = {
    { "CY",      FDF_UNIT|FDF_RW, nullptr, GRADIENTCONIC_SET_CY },
    { "Radius",  FDF_UNIT|FDF_RW, nullptr, GRADIENTCONIC_SET_Radius },
    { "Span",    FDF_DOUBLE|FDF_RW, nullptr, GRADIENTCONIC_SET_Span },
-   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTCONIC_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTCONIC_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_contour.cpp
+++ b/src/vector/painters/gradient_contour.cpp
@@ -62,13 +62,14 @@ static ERR GRADIENTCONTOUR_SET_Multiplier(extGradientContour *Self, double Value
    return ERR::Okay;
 }
 
-static ERR GRADIENTCONTOUR_GET_XMLDef(extGradientContour *Self, std::string_view &Value)
+static ERR GRADIENTCONTOUR_GET_XMLDef(extGradientContour *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "contourGradient";
    gradient_xml_attr(stream, "floor", Self->Floor);
    gradient_xml_attr(stream, "multiplier", Self->Multiplier);
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -78,7 +79,7 @@ static ERR GRADIENTCONTOUR_GET_XMLDef(extGradientContour *Self, std::string_view
 static const FieldArray clGradientContourFields[] = {
    { "Floor",      FDF_DOUBLE|FDF_RW, nullptr, GRADIENTCONTOUR_SET_Floor },
    { "Multiplier", FDF_DOUBLE|FDF_RW, nullptr, GRADIENTCONTOUR_SET_Multiplier },
-   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTCONTOUR_GET_XMLDef },
+   { "XMLDef",     FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTCONTOUR_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_diamond.cpp
+++ b/src/vector/painters/gradient_diamond.cpp
@@ -5,11 +5,6 @@ GradientDiamond: Diamond colour gradient paint server.
 
 GradientDiamond draws a square-shaped colour ramp from a centre point.
 
--END-
-
-*********************************************************************************************************************/
-
-/*********************************************************************************************************************
 -FIELD-
 CX: The horizontal centre point of the gradient.
 
@@ -67,14 +62,15 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTDIAMOND_GET_XMLDef(extGradientDiamond *Self, std::string_view &Value)
+static ERR GRADIENTDIAMOND_GET_XMLDef(extGradientDiamond *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "diamondGradient";
    gradient_xml_attr(stream, "cx", Self->CX);
    gradient_xml_attr(stream, "cy", Self->CY);
    gradient_xml_attr(stream, "r", Self->Radius);
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -85,7 +81,7 @@ static const FieldArray clGradientDiamondFields[] = {
    { "CX",      FDF_UNIT|FDF_RW, nullptr, GRADIENTDIAMOND_SET_CX },
    { "CY",      FDF_UNIT|FDF_RW, nullptr, GRADIENTDIAMOND_SET_CY },
    { "Radius",  FDF_UNIT|FDF_RW, nullptr, GRADIENTDIAMOND_SET_Radius },
-   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTDIAMOND_GET_XMLDef },
+   { "XMLDef",  FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTDIAMOND_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_distal.cpp
+++ b/src/vector/painters/gradient_distal.cpp
@@ -166,14 +166,15 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTDISTAL_GET_XMLDef(extGradientDistal *Self, std::string_view &Value)
+static ERR GRADIENTDISTAL_GET_XMLDef(extGradientDistal *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "distalGradient";
    gradient_xml_attr(stream, "floor", Self->Floor);
    gradient_xml_attr(stream, "multiplier", Self->Multiplier);
    if ((Self->Radius.defined()) and (Self->Radius > 0.0)) gradient_xml_attr(stream, "radius", Self->Radius);
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -187,7 +188,7 @@ static const FieldArray clGradientDistalFields[] = {
    { "InnerRadius", FDF_UNIT|FDF_RW, nullptr, GRADIENTDISTAL_SET_InnerRadius },
    { "InnerFall",   FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, GRADIENTDISTAL_SET_InnerFall, &clGradientDistalGFALL },
    { "OuterFall",   FDF_INT|FDF_LOOKUP|FDF_RW, nullptr, GRADIENTDISTAL_SET_OuterFall, &clGradientDistalGFALL },
-   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTDISTAL_GET_XMLDef },
+   { "XMLDef",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTDISTAL_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_linear.cpp
+++ b/src/vector/painters/gradient_linear.cpp
@@ -85,7 +85,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTLINEAR_GET_XMLDef(extGradientLinear *Self, std::string_view &Value)
+static ERR GRADIENTLINEAR_GET_XMLDef(extGradientLinear *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "linearGradient";
@@ -93,7 +93,8 @@ static ERR GRADIENTLINEAR_GET_XMLDef(extGradientLinear *Self, std::string_view &
    gradient_xml_attr(stream, "y1", Self->Y1);
    gradient_xml_attr(stream, "x2", Self->X2);
    gradient_xml_attr(stream, "y2", Self->Y2);
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -105,7 +106,7 @@ static const FieldArray clGradientLinearFields[] = {
    { "Y1", FDF_UNIT|FDF_RW, nullptr, GRADIENTLINEAR_SET_Y1 },
    { "X2", FDF_UNIT|FDF_RW, nullptr, GRADIENTLINEAR_SET_X2 },
    { "Y2", FDF_UNIT|FDF_RW, nullptr, GRADIENTLINEAR_SET_Y2 },
-   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTLINEAR_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTLINEAR_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_mesh.cpp
+++ b/src/vector/painters/gradient_mesh.cpp
@@ -268,9 +268,10 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTMESH_GET_XMLDef(extGradientMesh *, std::string_view &Value)
+static ERR GRADIENTMESH_GET_XMLDef(extGradientMesh *, std::string &Value)
 {
-   return gradient_xml_result("meshgradient", Value);
+   Value = "meshgradient";
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -287,7 +288,7 @@ static const FieldArray clGradientMeshFields[] = {
    { "Rows",         FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, GRADIENTMESH_GET_Rows, GRADIENTMESH_SET_Rows },
    { "Columns",      FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, GRADIENTMESH_GET_Columns, GRADIENTMESH_SET_Columns },
    { "Patches",      FDF_VIRTUAL|FDF_VECTOR|FDF_STRUCT|FDF_RW|FDF_PURE, GRADIENTMESH_GET_Patches, GRADIENTMESH_SET_Patches, "MeshPatchRecord" },
-   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTMESH_GET_XMLDef },
+   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTMESH_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/painters/gradient_radial.cpp
+++ b/src/vector/painters/gradient_radial.cpp
@@ -134,7 +134,7 @@ XMLDef: Returns an SVG compliant XML string that describes the effect.
 -END-
 *********************************************************************************************************************/
 
-static ERR GRADIENTRADIAL_GET_XMLDef(extGradientRadial *Self, std::string_view &Value)
+static ERR GRADIENTRADIAL_GET_XMLDef(extGradientRadial *Self, std::string &Value)
 {
    std::stringstream stream;
    stream << "radialGradient";
@@ -144,7 +144,8 @@ static ERR GRADIENTRADIAL_GET_XMLDef(extGradientRadial *Self, std::string_view &
    gradient_xml_attr(stream, "fy", Self->FY);
    gradient_xml_attr(stream, "r", Self->Radius);
    if (!Self->ContainFocal) stream << " focal=\"unbound\"";
-   return gradient_xml_result(stream.str(), Value);
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 //********************************************************************************************************************
@@ -159,7 +160,7 @@ static const FieldArray clGradientRadialFields[] = {
    { "Radius",       FDF_UNIT|FDF_RW, nullptr, GRADIENTRADIAL_SET_Radius },
    { "FocalRadius",  FDF_UNIT|FDF_RW, nullptr, GRADIENTRADIAL_SET_FocalRadius },
    { "ContainFocal", FDF_INT|FDF_RW, nullptr, GRADIENTRADIAL_SET_ContainFocal },
-   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, GRADIENTRADIAL_GET_XMLDef },
+   { "XMLDef",       FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, GRADIENTRADIAL_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/transformers/transition.cpp
+++ b/src/vector/transformers/transition.cpp
@@ -165,7 +165,7 @@ The returned XML defines the transition's stop list as `&lt;stop/&gt;` elements,
 
 *********************************************************************************************************************/
 
-static ERR TRANSITION_GET_XMLDef(extVectorTransition *Self, std::string_view &Value)
+static ERR TRANSITION_GET_XMLDef(extVectorTransition *Self, std::string &Value)
 {
    std::stringstream stream;
 
@@ -177,12 +177,8 @@ static ERR TRANSITION_GET_XMLDef(extVectorTransition *Self, std::string_view &Va
          << ")\"/>";
    }
 
-   auto cppstr = stream.str();
-   if (auto str = strclone(cppstr)) {
-      Value = std::string_view{ str, cppstr.size() };
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = stream.str();
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -231,14 +227,14 @@ static ERR TRANSITION_SET_Stops(extVectorTransition *Self, std::span<const Trans
 
 static const ActionArray clTransitionActions[] = {
    { AC::Free, TRANSITION_Free },
-   { AC::Init,          TRANSITION_Init },
+   { AC::Init, TRANSITION_Init },
    { AC::New,  TRANSITION_New },
    { AC::NIL, nullptr }
 };
 
 static const FieldArray clTransitionFields[] = {
    { "Stops", FDF_VIRTUAL|FDF_VECTOR|FDF_STRUCT|FDF_W, nullptr, TRANSITION_SET_Stops, "Transition" },
-   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R, TRANSITION_GET_XMLDef },
+   { "XMLDef", FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_R|FDF_PURE, TRANSITION_GET_XMLDef },
    END_FIELD
 };
 

--- a/src/vector/vectors/path.cpp
+++ b/src/vector/vectors/path.cpp
@@ -722,7 +722,7 @@ extVectorPath::extVectorPath(objMetaClass *ClassPtr, OBJECTID ObjectID) : extVec
 //********************************************************************************************************************
 
 static const FieldArray clPathFields[] = {
-   { "Sequence",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_RW, VECTOR_GET_Sequence, VECTORPATH_SET_Sequence },
+   { "Sequence",      FDF_VIRTUAL|FDF_CPPSTRING|FDF_ALLOC|FDF_RW, VECTOR_GET_Sequence, VECTORPATH_SET_Sequence },
    { "X",             FDF_VIRTUAL|FD_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, VECTORPATH_GET_X, VECTORPATH_SET_X },
    { "Y",             FDF_VIRTUAL|FD_UNIT|FDF_SCALED|FDF_RW|FDF_PURE, VECTORPATH_GET_Y, VECTORPATH_SET_Y },
    { "TotalCommands", FDF_VIRTUAL|FDF_INT|FDF_RW|FDF_PURE, VECTORPATH_GET_TotalCommands, VECTORPATH_SET_TotalCommands },

--- a/src/vector/vectors/vector.cpp
+++ b/src/vector/vectors/vector.cpp
@@ -1899,7 +1899,7 @@ of the previous command).
 
 *********************************************************************************************************************/
 
-static ERR VECTOR_GET_Sequence(extVector *Self, std::string_view &Value)
+static ERR VECTOR_GET_Sequence(extVector *Self, std::string &Value)
 {
    kt::Log log;
 
@@ -1973,15 +1973,8 @@ static ERR VECTOR_GET_Sequence(extVector *Self, std::string_view &Value)
       }
    }
 
-   auto out = seq.str();
-   if (out.length() > 0) {
-      if (auto str = strclone(out)) {
-         Value = std::string_view{str, out.length()};
-         return ERR::Okay;
-      }
-      else return ERR::AllocMemory;
-   }
-   else return ERR::NoData;
+   Value = seq.str();
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************

--- a/src/vector/vectors/wave.cpp
+++ b/src/vector/vectors/wave.cpp
@@ -14,8 +14,6 @@ Waves can be used in Kotuku's SVG implementation by using the &lt;kotuku:wave/&g
 
 -END-
 
-TODO: Allow the line cap and join styles to be configured when Thickness > 0 (currently fixed to ROUND).
-
 *********************************************************************************************************************/
 
 static void generate_wave(class extVectorWave *Vector, agg::path_storage &Path);

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -1982,16 +1982,13 @@ the base path for relative references.
 
 *********************************************************************************************************************/
 
-static ERR GET_Statement(extXML *Self, std::string_view &Value)
+static ERR GET_Statement(extXML *Self, std::string &Value)
 {
    kt::Log log;
 
    if (not Self->initialised()) {
-      if (CSTRING str = kt::strclone(Self->Statement)) {
-         Value = str;
-         return ERR::Okay;
-      }
-      else return ERR::AllocMemory;
+      Value = Self->Statement;
+      return ERR::Okay;
    }
 
    if (Self->Tags.empty()) return ERR::FieldNotSet;
@@ -2010,11 +2007,8 @@ static ERR GET_Statement(extXML *Self, std::string_view &Value)
    }
    else return log.warning(ERR::NoData); // NB: If there are tags, tag 0 should always exist, so this indicates a parsing issue
 
-   if (CSTRING str = kt::strclone(buffer.str())) {
-      Value = str;
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   Value = buffer.str();
+   return ERR::Okay;
 }
 
 static ERR SET_Statement(extXML *Self, const std::string_view &Value)

--- a/tools/idl/idl-c.tiri
+++ b/tools/idl/idl-c.tiri
@@ -5,8 +5,7 @@
 
    include 'core', 'xml'
 
-   import 'json'
-   import 'options'
+   import 'json', 'options'
 
    global glHeader = array<string>
    global glOutput = array<string>

--- a/tools/idl/include/output.tiri
+++ b/tools/idl/include/output.tiri
@@ -265,13 +265,8 @@ function outputGetValueCall(Field:table, FieldType:str, Indent:str)
       return
    elseif Field.flags has FD_STRING then
       if Field.flags has FD_ALLOC then
-         output(Indent .. 'std::string_view view;')
-         output(Indent .. 'auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;')
-         output(Indent .. 'auto error = get_field(this, view);')
-         output(Indent .. 'if (error IS ERR::Okay) {')
-         output(Indent .. '   Value.assign(view);')
-         output(Indent .. '   if (view.data()) FreeResource(GetMemoryID(view.data()));')
-         output(Indent .. '}')
+         output(Indent .. 'auto get_field = (ERR (*)(APTR, std::string &))field->GetValue;')
+         output(Indent .. 'auto error = get_field(this, Value);')
       else
          output(Indent .. 'auto get_field = (ERR (*)(APTR, std::string_view &))field->GetValue;')
          outputResult('get_field(this, Value);')


### PR DESCRIPTION
* Updated generated allocated string getters to call GetValue with std::string results directly
* Routed Tiri object reads for allocated string fields through the std::string object getter
* [Vector] Converted XML serialisation fields to return owned std::string values without strclone handoff