### PR TITLE
[Tiri] Harden runtime error handling

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -378,7 +378,7 @@ ERR create_tiri(void);
 void get_line(extTiri *, int, STRING, int);
 APTR get_meta(lua_State *Lua, int Arg, CSTRING);
 [[maybe_unused]] void hook_debug(lua_State *, lua_Debug *);
-ERR load_include(extTiri *, CSTRING);
+ERR load_include(extTiri *, std::string_view);
 int MAKESTRUCT(lua_State *);
 [[maybe_unused]] void make_any_array(lua_State *, int, std::string_view, int, CPTR);
 [[maybe_unused]] void make_array(lua_State *, AET, int = 0, CPTR = nullptr, std::string_view = {});

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1034,7 +1034,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_include_stmt()
             "Invalid module name; only alpha-numeric names shorter than 32 characters are permitted with include");
       }
 
-      if (auto error = load_include(this->ctx.lua().script, module_name.c_str()); error != ERR::Okay) {
+      if (auto error = load_include(this->ctx.lua().script, module_name); error != ERR::Okay) {
          std::string message;
          if (error IS ERR::FileNotFound) message = std::format("Requested include file '{}' does not exist", module_name);
          else message = std::format("Failed to process include file '{}': {}", module_name, GetErrorMsg(error));

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -186,7 +186,7 @@ void load_include_for_class(lua_State *Lua, objMetaClass *MetaClass)
    std::string_view module_name;
    // NOTE: Stick to the indirect get() method here because it otherwise crashes if the MetaClass table requires regeneration
    if (auto error = MetaClass->get(strhash("module"), module_name); !error) {
-      if (auto error = load_include(Lua->script, module_name.data()); error != ERR::Okay) {
+      if (auto error = load_include(Lua->script, module_name); error != ERR::Okay) {
          luaL_error(Lua, error,
             std::format("Failed to process module '{}' for class '{}'", module_name, MetaClass->ClassName));
       }

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -1022,7 +1022,10 @@ static ERR register_interfaces(extTiri *Self)
    reg_func_prototype("unsubscribeEvent", {}, { TiriType::Any });
    reg_func_prototype("MAKESTRUCT", { TiriType::Any }, { TiriType::Str });
 
-   load_include(Self, "core");
+   if (auto error = load_include(Self, "core"); error != ERR::Okay) {
+      log.error("Failed to process the core includes.");
+      return error;
+   }
 
 #ifndef NDEBUG
    int stack_delta = lua_gettop(Self->Lua) - stack_top;

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -35,6 +35,7 @@ For drag and drop operations, data can be requested from a source as follows:
 #include <kotuku/strings.hpp>
 #include <inttypes.h>
 #include <string_view>
+#include <mutex>
 
 #include "lib.h"
 #include "lauxlib.h"
@@ -285,13 +286,17 @@ static void key_event(evKey *, int, struct finput *);
    if ((function_type IS LUA_TFUNCTION) or (function_type IS LUA_TSTRING));
    else luaL_argerror(Lua, 4, "Function reference required.");
 
-   ERR error;
-   if (not modDisplay) {
-      kt::SwitchContext context(modTiri);
-      if ((error = objModule::load("display", &modDisplay, &DisplayBase)) != ERR::Okay) {
-         luaL_error(Lua, ERR::LoadModule);
+   ERR error = ERR::Okay;
+   {
+      static std::mutex display_load_lock;
+      const std::lock_guard<std::mutex> lock(display_load_lock);
+
+      if (not modDisplay) {
+         kt::SwitchContext context(modTiri);
+         error = objModule::load("display", &modDisplay, &DisplayBase);
       }
    }
+   if (error != ERR::Okay) luaL_error(Lua, ERR::LoadModule);
 
    log.msg("Surface: %d, Mask: $%.8x, Device: %d", object_id, int(mask), device_id);
 
@@ -445,7 +450,17 @@ static void focus_event(evFocus *Event, int Size, lua_State *Lua)
       return;
    }
 
-   log.traceBranch("Incoming focus event targeting #%d, focus lost from #%d.", Event->FocusList[0], Event->FocusList[Event->TotalWithFocus]);
+   if ((Event->TotalWithFocus > 0) and (Event->TotalLostFocus > 0)) {
+      log.traceBranch("Incoming focus event targeting #%d, focus lost from #%d.", Event->FocusList[0],
+         Event->FocusList[Event->TotalWithFocus]);
+   }
+   else if (Event->TotalWithFocus > 0) {
+      log.traceBranch("Incoming focus event targeting #%d.", Event->FocusList[0]);
+   }
+   else if (Event->TotalLostFocus > 0) {
+      log.traceBranch("Incoming focus event lost from #%d.", Event->FocusList[Event->TotalWithFocus]);
+   }
+   else log.traceBranch("Incoming focus event with no focus changes.");
 
    for (auto input=tiri->InputList; input; input=input->Next) {
       if (input->Mode != FIM_KEYBOARD) continue;

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -98,8 +98,9 @@ static int io_open(lua_State *Lua)
          case 'r': flags |= FL::READ; break;
          case 'w': flags |= FL::WRITE | FL::NEW; break;
          case 'a':
-            if (!AnalysePath(path, nullptr)) flags |= FL::WRITE;
-            else flags |= FL::WRITE | FL::NEW;
+            if (auto error = AnalysePath(path, nullptr); error IS ERR::Okay) flags |= FL::WRITE;
+            else if (error IS ERR::FileNotFound) flags |= FL::WRITE | FL::NEW;
+            else luaL_error(Lua, error, "Failed to analyse path: %s", path);
             seek_end = true;
             break;  // Append mode - will seek to end after open
          case '+': flags |= FL::READ | FL::WRITE; break;
@@ -107,15 +108,18 @@ static int io_open(lua_State *Lua)
    }
 
    if (auto file = objFile::create::local({ fl::Path(path), fl::Flags(flags) })) {
-      if (seek_end) file->seekEnd(0);
+      if (seek_end) {
+         if (auto error = file->seekEnd(0); error != ERR::Okay) {
+            FreeResource(file);
+            luaL_error(Lua, error, "Failed to seek to end of file: %s", path);
+         }
+      }
 
       push_file_handle(Lua, file);
-      return 1;
    }
-   else {
-      luaL_error(Lua, ERR::OpenFile);
-      return 0;
-   }
+   else luaL_error(Lua, ERR::OpenFile);
+
+   return 1;
 }
 
 //********************************************************************************************************************
@@ -151,8 +155,7 @@ static int io_close(lua_State *Lua)
       lua_pushboolean(Lua, 1);
       return 1;
    }
-
-   return 0;
+   else return 0;
 }
 
 //********************************************************************************************************************
@@ -407,10 +410,7 @@ static int io_lines(lua_State *Lua)
          lua_call(Lua, 0, 1);
       }
 
-      if (lua_isnil(Lua, -1)) {
-         luaL_error(Lua, ERR::InvalidState, "No default input file available");
-         return 0;
-      }
+      if (lua_isnil(Lua, -1)) luaL_error(Lua, ERR::InvalidState, "No default input file available");
 
       file_handle = check_file_handle(Lua, -1);
       handle_index = lua_gettop(Lua);
@@ -527,9 +527,14 @@ static int file_read(lua_State *Lua)
 
                   case 'a': { // Read entire file
                      auto current_pos = file->Position;
-                     file->seekEnd(0);
+                     if (auto error = file->seekEnd(0); error != ERR::Okay) {
+                        luaL_error(Lua, error, "Failed to seek to end of file");
+                     }
+
                      auto file_size = file->Position;
-                     file->seek(current_pos, SEEK::START);
+                     if (auto error = file->seek(current_pos, SEEK::START); error != ERR::Okay) {
+                        luaL_error(Lua, error, "Failed to restore file position");
+                     }
 
                      auto remaining = file_size - current_pos;
                      if (remaining > 0) {

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -41,17 +41,19 @@ constexpr size_t BUFFER_ELEMENT_SIZE = 16;
 constexpr size_t BUFFER_SIZE = MAX_MODULE_ARGS * BUFFER_ELEMENT_SIZE;
 constexpr size_t MAX_STRING_PREFIX_LENGTH = 200;
 struct CaseInsensitiveCompare {
-   bool operator()(const std::string &A, const std::string &B) const {
+   using is_transparent = void;
+
+   bool operator()(std::string_view A, std::string_view B) const {
       return std::lexicographical_compare(
          A.begin(), A.end(), B.begin(), B.end(),
-         [](char a, char b) { return std::tolower((unsigned char)a) < std::tolower((unsigned char)b); }
+         [](char CharA, char CharB) { return std::tolower((unsigned char)CharA) < std::tolower((unsigned char)CharB); }
       );
    }
 };
 
 static std::set<std::string, CaseInsensitiveCompare> glLoadedConstants; // Stores the names of modules that have loaded constants (system wide)
 
-[[nodiscard]] static CSTRING load_include_struct(extTiri *, CSTRING, std::string_view);
+[[nodiscard]] static ERR load_include_struct(extTiri *, CSTRING, std::string_view, CSTRING *);
 [[nodiscard]] static CSTRING load_include_constant(CSTRING, std::string_view);
 
 static int module_call(lua_State *);
@@ -251,7 +253,7 @@ static CSTRING load_include_constant(CSTRING Line, std::string_view Source)
 
 //********************************************************************************************************************
 
-static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
+static ERR process_module_defs(extTiri *Script, objModule *module, std::string_view Name)
 {
    if (auto root = (OBJECTPTR)module->Root) {
       struct ModHeader *header;
@@ -260,7 +262,9 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 
       if (auto idl = header->Definitions) {
          while ((idl) and (*idl)) {
-            if ((idl[0] IS 's') and (idl[1] IS '.')) idl = load_include_struct(Script, idl+2, Name);
+            if ((idl[0] IS 's') and (idl[1] IS '.')) {
+               if (auto error = load_include_struct(Script, idl+2, Name, &idl); error != ERR::Okay) return error;
+            }
             else if ((idl[0] IS 'c') and (idl[1] IS '.')) idl = load_include_constant(idl+2, Name);
             else idl = next_line(idl);
          }
@@ -274,7 +278,7 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 // For the 'include' statement.  Creates a temporary module object to process the definitions without formally opening
 // an interface.
 
-[[nodiscard]] ERR load_include(extTiri *Script, CSTRING Module)
+[[nodiscard]] ERR load_include(extTiri *Script, std::string_view Module)
 {
    ERR error = ERR::Okay;
 
@@ -289,7 +293,7 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 
    if (process_constants) {
       kt::Log log(__FUNCTION__);
-      log.branch("Definition: %s", Module);
+      log.branch("Definition: %.*s", int(Module.size()), Module.data());
 
       AdjustLogLevel(1);
 
@@ -299,7 +303,7 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 
       AdjustLogLevel(-1);
 
-      if (!error) glLoadedConstants.insert(Module);
+      if (!error) glLoadedConstants.emplace(Module);
    }
 
    return error;
@@ -309,8 +313,11 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 // Format: s.Name:typeField,...
 // TODO: This parses the struct definitions in advance - ideally we'd record the definition string and parse on first-use.
 
-[[nodiscard]] static CSTRING load_include_struct(extTiri *Script, CSTRING Line, std::string_view Source)
+[[nodiscard]] static ERR load_include_struct(extTiri *Script, CSTRING Line, std::string_view Source, CSTRING *NextLine)
 {
+   if (not NextLine) return ERR::NullArgs;
+   *NextLine = next_line(Line);
+
    int i;
    for (i=0; (Line[i] >= 0x20) and (Line[i] != ':'); i++);
 
@@ -323,18 +330,18 @@ static ERR process_module_defs(extTiri *Script, objModule *module, CSTRING Name)
 
       if ((Line[j] IS '\n') or (Line[j] IS '\r')) {
          std::string linebuf(Line, j);
-         make_struct(Script, name, linebuf.c_str());
          while ((Line[j] IS '\n') or (Line[j] IS '\r')) j++;
-         return Line + j;
+         *NextLine = Line + j;
+         return make_struct(Script, name, linebuf.c_str());
       }
       else {
-         make_struct(Script, name, Line);
-         return Line + j;
+         *NextLine = Line + j;
+         return make_struct(Script, name, Line);
       }
    }
    else {
       kt::Log(__FUNCTION__).warning("Malformed struct name in %.*s.", int(Source.size()), Source.data());
-      return next_line(Line);
+      return ERR::Syntax;
    }
 }
 

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -28,7 +28,7 @@ static ERR set_array_from_table(lua_State *Lua, OBJECTPTR Object, const Field *F
    if (Field->Flags & FD_INT) {
       kt::vector<int> values((size_t)total);
       for (lua_pushnil(Lua); lua_next(Lua, Values); lua_pop(Lua, 1)) {
-         int index = lua_tointeger(Lua, -2) - 1;
+         int index = lua_tointeger(Lua, -2);
          if ((index >= 0) and (index < total)) {
             values[index] = lua_tointeger(Lua, -1);
          }
@@ -38,7 +38,7 @@ static ERR set_array_from_table(lua_State *Lua, OBJECTPTR Object, const Field *F
    else if (Field->Flags & FD_STRING) {
       kt::vector<std::string> values((size_t)total);
       for (lua_pushnil(Lua); lua_next(Lua, Values); lua_pop(Lua, 1)) {
-         int index = lua_tointeger(Lua, -2) - 1;
+         int index = lua_tointeger(Lua, -2);
          if ((index >= 0) and (index < total)) {
             values[index] = lua_tostring(Lua, -1);
          }

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -28,9 +28,11 @@ static ERR set_array_from_table(lua_State *Lua, OBJECTPTR Object, const Field *F
    if (Field->Flags & FD_INT) {
       kt::vector<int> values((size_t)total);
       for (lua_pushnil(Lua); lua_next(Lua, Values); lua_pop(Lua, 1)) {
-         int index = lua_tointeger(Lua, -2);
-         if ((index >= 0) and (index < total)) {
-            values[index] = lua_tointeger(Lua, -1);
+         if (lua_type(Lua, -2) IS LUA_TNUMBER) {
+            int index = lua_tointeger(Lua, -2);
+            if ((index >= 0) and (index < total)) {
+               values[index] = lua_tointeger(Lua, -1);
+            }
          }
       }
       return Object->set(Field->FieldID, values);

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -245,8 +245,21 @@ static int processing_flush(lua_State *Lua)
 {
    Lua->script->clearFlag(NF::SIGNALLED);
    if (auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing")) {
-      for (auto &entry : *fp->Signals) {
-         entry.Object->clearFlag(NF::SIGNALLED);
+      if ((fp->SignalRefs) and (not fp->SignalRefs->empty())) {
+         for (auto ref : *fp->SignalRefs) {
+            lua_rawgeti(Lua, LUA_REGISTRYINDEX, ref);
+            if (lua_type(Lua, -1) IS LUA_TOBJECT) {
+               auto object = lua_toobject(Lua, -1);
+               if (auto obj = access_object(object)) {
+                  obj->clearFlag(NF::SIGNALLED);
+                  release_object(object);
+               }
+            }
+            lua_pop(Lua, 1);
+         }
+      }
+      else if ((fp->Signals) and (not fp->Signals->empty())) {
+         Lua->script->clearFlag(NF::SIGNALLED);
       }
    }
    return 0;

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -19,6 +19,7 @@ Examples:
 #include <string_view>
 #include <utility>
 #include <cctype>
+#include <mutex>
 
 #include "lauxlib.h"
 #include "lj_obj.h"
@@ -47,6 +48,9 @@ struct regex_callback {
 static ERR load_regex(void)
 {
 #ifndef KOTUKU_STATIC
+   static std::mutex regex_load_lock;
+   const std::lock_guard<std::mutex> lock(regex_load_lock);
+
    if (not modRegex) {
       kt::SwitchContext ctx(glTiriContext);
       if (objModule::load("regex", &modRegex, &RegexBase) != ERR::Okay) return ERR::InitModule;


### PR DESCRIPTION
* Propagate include processing failures from struct registration and module definitions
* Report file open, append and read seek failures through Tiri errors
* Guard lazy display and regex module loading against concurrent initialisation
* Clear processing signal flags through registry-held object references