### PR TITLE
[Network] Return AddressToStr results through string output

### DIFF
--- a/docs/xml/modules/core.xml
+++ b/docs/xml/modules/core.xml
@@ -1522,7 +1522,7 @@ kotuku:images/      kotuku:documents    kotuku:documents (Existing documents fol
     <input>
       <param type="STRVIEW" name="Path">The path to be resolved.</param>
       <param type="RSF" name="Flags" lookup="RSF">Optional flags.</param>
-      <param type="STRING *" name="Result">Must point to a <code>std::string</code> variable so that the resolved path can be stored.  If <code>NULL</code>, ResolvePath() will work as normal and return a valid error code without the result string.  The value is unchanged if the error code is not <code>ERR::Okay</code>.</param>
+      <param type="STRING *" name="Result">Refer to a string variable so that the resolved path can be stored.  If <code>NULL</code>, ResolvePath() will work as normal and return a valid error code without the result string.  The value is unchanged if the error code is not <code>ERR::Okay</code>.</param>
     </input>
     <description>
 <p>This function will convert a file path to its resolved form, according to the host system.  For example, a Linux system might resolve <code>drive1:documents/readme.txt</code> to <code>/documents/readme.txt</code>.  A Windows system might resolve the path to <code>c:\documents\readme.txt</code>.</p>
@@ -1530,7 +1530,7 @@ kotuku:images/      kotuku:documents    kotuku:documents (Existing documents fol
 <p>If the path can be resolved to more than one file, ResolvePath() will attempt to discover the correct path by checking the validity of each possible location.  For instance, if resolving a path of <code>user:document.txt</code> and the <code>user:</code> volume refers to both <code>system:users/joebloggs/</code> and <code>system:users/default/</code>, the routine will check both directories for the existence of the <code>document.txt</code> file to determine the correct location.  This approach can be problematic if the intent is to create a new file, in which case <code>RSF::NO_FILE_CHECK</code> will circumvent it.</p>
 <p>When checking the file location, ResolvePath() requires an exact match to the provided file name.  If the file name can be approximated (i.e. the file extension can be ignored) then use the <code>RSF::APPROXIMATE</code> flag.</p>
 <p>To resolve the location of executable programs on Unix systems, use the <code>RSF::PATH</code> flag.  This uses the <code>PATH</code> environment variable to resolve the file name specified in the <code>Path</code> parameter.</p>
-<p>The resolved path will be copied to the <code>std::string</code> provided in the <code>Result</code> parameter.  This will overwrite any existing content in the string.</p>
+<p>The resolved path will be copied to the string provided in the <code>Result</code> parameter.  This will overwrite any existing content in the string.</p>
 <types lookup="RSF"/>
 <p>If the path resolves to a virtual drive, it may not be possible to confirm whether the target file exists if the virtual driver does not support this check.  This is common when working with network drives.</p>
     </description>

--- a/docs/xml/modules/network.xml
+++ b/docs/xml/modules/network.xml
@@ -28,16 +28,19 @@
   <function>
     <name>AddressToStr</name>
     <comment>Converts an IPAddress structure to an IPAddress in dotted string form.</comment>
-    <prototype>CSTRING net::AddressToStr(struct IPAddress * IPAddress)</prototype>
-    <tiriPrototype>str = AddressToStr(IPAddress:any)</tiriPrototype>
-    <tags>caller-owns-result, creates-resource, null-terminated-result, nullable-result</tags>
+    <prototype>ERR net::AddressToStr(struct IPAddress * IPAddress, STRING * Result)</prototype>
+    <tiriPrototype>err, Result:str = AddressToStr(IPAddress:any)</tiriPrototype>
+    <tags>mutates-input</tags>
     <input>
       <param type="struct IPAddress *" name="IPAddress">A pointer to the IPAddress structure.</param>
+      <param type="STRING *" name="Result">Must point to a <code>std::string</code> variable so that the resolved address can be stored.</param>
     </input>
     <description>
-<p>Converts an IPAddress structure to a string containing the IPAddress in dotted format.  Please free the resulting string with <function>FreeResource</function> once it is no longer required.</p>
+<p>Converts an IPAddress structure to a string containing the IPAddress in dotted format.</p>
     </description>
-    <result type="CSTRING">The IP address is returned as an allocated string.</result>
+    <result type="ERR">
+      <error code="Okay">The IPAddress was converted successfully.</error>
+    </result>
   </function>
 
   <function>

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -962,7 +962,7 @@ inline ERR nsCreate(objNetSocket **NewNetSocketOut, OBJECTID ListenerID, APTR Cl
 struct NetworkBase {
 #ifndef KOTUKU_STATIC
    ERR (*_StrToAddress)(const std::string_view &String, struct IPAddress *Address);
-   CSTRING (*_AddressToStr)(struct IPAddress *IPAddress);
+   ERR (*_AddressToStr)(struct IPAddress *IPAddress, std::string *Result);
    uint32_t (*_HostToShort)(uint32_t Value);
    uint32_t (*_HostToLong)(uint32_t Value);
    uint32_t (*_ShortToHost)(uint32_t Value);
@@ -975,7 +975,7 @@ struct NetworkBase {
 extern struct NetworkBase *NetworkBase;
 namespace net {
 inline ERR StrToAddress(const std::string_view &String, struct IPAddress *Address) { return NetworkBase->_StrToAddress(String,Address); }
-inline CSTRING AddressToStr(struct IPAddress *IPAddress) { return NetworkBase->_AddressToStr(IPAddress); }
+inline ERR AddressToStr(struct IPAddress *IPAddress, std::string *Result) { return NetworkBase->_AddressToStr(IPAddress,Result); }
 inline uint32_t HostToShort(uint32_t Value) { return NetworkBase->_HostToShort(Value); }
 inline uint32_t HostToLong(uint32_t Value) { return NetworkBase->_HostToLong(Value); }
 inline uint32_t ShortToHost(uint32_t Value) { return NetworkBase->_ShortToHost(Value); }
@@ -985,7 +985,7 @@ inline ERR SetSSL(objNetSocket *NetSocket, const std::string_view &Command, cons
 #else
 namespace net {
 extern ERR StrToAddress(const std::string_view &String, struct IPAddress *Address);
-extern CSTRING AddressToStr(struct IPAddress *IPAddress);
+extern ERR AddressToStr(struct IPAddress *IPAddress, std::string *Result);
 extern uint32_t HostToShort(uint32_t Value);
 extern uint32_t HostToLong(uint32_t Value);
 extern uint32_t ShortToHost(uint32_t Value);

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -1536,7 +1536,12 @@ function serverIncoming(self, ClientSocket)
 
       -- Get client IP for rate limiting
       local ip = ClientSocket.client?.ip
-      state.ip = ip and mNet.AddressToStr(ip) or 'unknown'
+      if ip then
+         err, ip_str = mNet.AddressToStr(ip)
+         state.ip = (err is ERR_Okay) ? ip_str :> 'unknown'
+      else
+         state.ip = 'unknown'
+      end
 
       -- Check rate limit
       if not checkRateLimit(self, state.ip) then

--- a/scripts/net/proxyserver.tiri
+++ b/scripts/net/proxyserver.tiri
@@ -637,7 +637,8 @@ end
 function getClientIP(ClientSocket:obj):str
    local ip = ClientSocket.client?.ip
    if ip then
-      return mNet.AddressToStr(ip) or 'unknown'
+      err, ip = mNet.AddressToStr(ip)
+      return ip ?? 'unknown'
    end
 
    return 'unknown'

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -400,7 +400,7 @@ struct virtual_drive {
    ERR (*IdentifyFile)(std::string_view, CLASSID *, CLASSID *);
    ERR (*CreateFolder)(std::string_view, PERMIT);
    ERR (*SameFile)(std::string_view, std::string_view);
-   ERR (*ReadLink)(std::string_view, STRING *);
+   ERR (*ReadLink)(std::string_view, std::string &);
    ERR (*CreateLink)(std::string_view, std::string_view);
    inline bool is_default() const { return VirtualID IS 0; }
    inline bool is_virtual() const { return VirtualID != 0; }
@@ -1136,7 +1136,7 @@ ERR fs_getdeviceinfo(std::string_view, objStorageDevice *);
 void fs_ignore_file(class extFile *);
 ERR fs_makedir(std::string_view, PERMIT);
 ERR fs_opendir(DirInfo *);
-ERR fs_readlink(std::string_view, STRING *);
+ERR fs_readlink(std::string_view, std::string &);
 ERR fs_rename(std::string_view, std::string_view);
 ERR fs_samefile(std::string_view, std::string_view);
 ERR fs_scandir(DirInfo *);

--- a/src/core/fs_resolution.cpp
+++ b/src/core/fs_resolution.cpp
@@ -63,7 +63,7 @@ name can be approximated (i.e. the file extension can be ignored) then use the `
 To resolve the location of executable programs on Unix systems, use the `RSF::PATH` flag.  This uses the `PATH`
 environment variable to resolve the file name specified in the `Path` parameter.
 
-The resolved path will be copied to the `std::string` provided in the `Result` parameter.  This will overwrite any
+The resolved path will be copied to the string provided in the `Result` parameter.  This will overwrite any
 existing content in the string.
 
 <types lookup="RSF"/>
@@ -74,7 +74,7 @@ virtual driver does not support this check.  This is common when working with ne
 -INPUT-
 strview Path: The path to be resolved.
 int(RSF) Flags: Optional flags.
-^&string Result: Must point to a `std::string` variable so that the resolved path can be stored.  If `NULL`, ResolvePath() will work as normal and return a valid error code without the result string.  The value is unchanged if the error code is not `ERR::Okay`.
+^&string Result: Refer to a string variable so that the resolved path can be stored.  If `NULL`, ResolvePath() will work as normal and return a valid error code without the result string.  The value is unchanged if the error code is not `ERR::Okay`.
 
 -ERRORS-
 Okay:        The `Path` was resolved.

--- a/src/core/lib_filesystem.cpp
+++ b/src/core/lib_filesystem.cpp
@@ -2050,8 +2050,8 @@ ERR fs_copydir(std::string &Source, std::string &Dest, FileFeedback *Feedback, F
                   else if (result IS FFR::SKIP) continue;
                }
 
-               STRING link;
-               if (!(error = vsrc.ReadLink(Source, &link))) {
+               std::string link;
+               if (!(error = vsrc.ReadLink(Source, link))) {
                   DeleteFile(Dest, nullptr);
                   error = vdest.CreateLink(Dest, link);
                }
@@ -2144,13 +2144,13 @@ PERMIT get_parent_permissions(std::string_view Path, int *UserID, int *GroupID)
 
 //********************************************************************************************************************
 
-ERR fs_readlink(std::string_view Source, STRING *Link)
+ERR fs_readlink(std::string_view Source, std::string &Link)
 {
 #ifdef __unix__
    char buffer[512];
    if (int i = readlink(Source.data(), buffer, sizeof(buffer)-1); i != -1) {
       buffer[i] = 0;
-      *Link = strclone(buffer);
+      Link.assign(buffer);
       return ERR::Okay;
    }
    else return ERR::SystemCall;

--- a/src/network/module_def.c
+++ b/src/network/module_def.c
@@ -2,7 +2,7 @@
 
 namespace net {
 extern ERR StrToAddress(const std::string_view & String, struct IPAddress * Address);
-extern CSTRING AddressToStr(struct IPAddress * IPAddress);
+extern ERR AddressToStr(struct IPAddress * IPAddress, std::string * Result);
 extern uint32_t HostToShort(uint32_t Value);
 extern uint32_t HostToLong(uint32_t Value);
 extern uint32_t ShortToHost(uint32_t Value);
@@ -14,7 +14,7 @@ extern ERR SetSSL(objNetSocket * NetSocket, const std::string_view & Command, co
 #define FDEF static const struct FunctionField
 #endif
 
-FDEF argsAddressToStr[] = { { "Result", FD_RESULT|FD_STR|FD_ALLOC }, { "IPAddress:IPAddress", FD_PTR|FD_STRUCT }, { 0, 0 } };
+FDEF argsAddressToStr[] = { { "Error", FD_INT|FD_ERROR }, { "IPAddress:IPAddress", FD_PTR|FD_STRUCT }, { "Result", FD_RESULT|FD_MUTABLE|FDF_CPPSTRING }, { 0, 0 } };
 FDEF argsHostToLong[] = { { "Result", FD_INT|FD_UNSIGNED }, { "Value", FD_INT|FD_UNSIGNED }, { 0, 0 } };
 FDEF argsHostToShort[] = { { "Result", FD_INT|FD_UNSIGNED }, { "Value", FD_INT|FD_UNSIGNED }, { 0, 0 } };
 FDEF argsLongToHost[] = { { "Result", FD_INT|FD_UNSIGNED }, { "Value", FD_INT|FD_UNSIGNED }, { 0, 0 } };

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -82,10 +82,9 @@ static bool same_client_ip(const IPAddress &Left, const IPAddress &Right)
 static std::string client_ip_label(const IPAddress &Address)
 {
    IPAddress printable = client_identity(Address);
-   CSTRING value = net::AddressToStr(&printable);
-   std::string label = value ? value : "<invalid>";
-   if (value) FreeResource((APTR)value);
-   return label;
+   std::string value;
+   if (net::AddressToStr(&printable, &value) != ERR::Okay) value = "<invalid>";
+   return value;
 }
 
 //********************************************************************************************************************

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -666,34 +666,35 @@ namespace net {
 -FUNCTION-
 AddressToStr: Converts an IPAddress structure to an IPAddress in dotted string form.
 
-Converts an IPAddress structure to a string containing the IPAddress in dotted format.  Please free the resulting
-string with <function>FreeResource</> once it is no longer required.
+Converts an IPAddress structure to a string containing the IPAddress in dotted format.
 
 -INPUT-
 struct(IPAddress) IPAddress: A pointer to the IPAddress structure.
+^&string Result: Must point to a `std::string` variable so that the resolved address can be stored.
 
--RESULT-
-!cstr: The IP address is returned as an allocated string.
-
--TAGS-
-caller-owns-result, creates-resource, null-terminated-result, nullable-result
+-ERRORS-
+Okay: The IPAddress was converted successfully.
 
 *********************************************************************************************************************/
 
-CSTRING AddressToStr(IPAddress *Address)
+ERR AddressToStr(IPAddress *Address, std::string *Result)
 {
    kt::Log log(__FUNCTION__);
 
-   if (!Address) return nullptr;
+   if ((not Address) or (not Result)) return log.warning(ERR::NullArgs);
 
    if ((Address->Type IS IPADDR::V4) or (Address->Type IS IPADDR::V6)) {
       char buffer[46]; // 46 bytes is sufficient for both IPv4 and IPv6 addresses.
       auto result = network_platform().address_to_string(*Address, buffer, sizeof(buffer));
-      return result ? kt::strclone(result) : nullptr;
+      if (result) {
+         Result->assign(result);
+         return ERR::Okay;
+      }
+      else return ERR::InvalidData;
    }
    else {
       log.warning("Unsupported address type: %d", int(Address->Type));
-      return nullptr;
+      return ERR::InvalidType;
    }
 }
 

--- a/src/network/tests/test_ipv6.tiri
+++ b/src/network/tests/test_ipv6.tiri
@@ -36,12 +36,9 @@ glPort = 8089
             logOutput('Parsed successfully as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
 
             -- Test conversion back to string
-            result_str = mNet.AddressToStr(addr)
-            if result_str then
-               logOutput('Converted back to: ' .. result_str)
-            else
-               error('Failed to convert back to string')
-            end
+            err, result_str = mNet.AddressToStr(addr)
+            check err
+            logOutput('Converted back to: ' .. result_str)
          else
             error('Failed to parse ' .. addr_str .. ': ' .. mSys.GetErrorMsg(err))
          end
@@ -137,7 +134,8 @@ end
          if (Error is ERR_Okay) and addresses then
             logOutput('[DNS] Resolved ' .. tostring(Lookup.hostName) .. ' to ' .. #addresses .. ' addresses:')
             for i, addr in ipairs(addresses) do
-               addr_str = mNet.AddressToStr(addr)
+               err, addr_str = mNet.AddressToStr(addr)
+               check err
                type_str = (addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'
                logOutput(i .. '. ' .. (addr_str or 'unknown') .. ' (' .. type_str .. ')')
             end
@@ -180,10 +178,8 @@ end
          logOutput('    Correctly identified as ' .. ((addr.type is IPADDR_V6) and 'IPv6' or 'IPv4'))
 
          -- Test round-trip conversion
-         converted = mNet.AddressToStr(addr)
-         if not converted then
-            error('Round-trip conversion failed')
-         end
+         err, converted = mNet.AddressToStr(addr)
+         check err
       else
          error('Incorrect type identification')
       end

--- a/src/network/tests/test_udp_basic.tiri
+++ b/src/network/tests/test_udp_basic.tiri
@@ -5,6 +5,8 @@ UDP Basic Communication Test
    include 'network'
    mNet ?= mod.load('network')
 
+extern logOutput
+
 glBasePort = 19800  -- Base port for UDP tests
 glTestTimeout = 3.0
 
@@ -33,7 +35,8 @@ glTestTimeout = 3.0
 
          if (bytesRead > 0) then
             local msg = sv_buffer:sub(0, bytesRead)
-            logOutput('[UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
+            local err, ip = mNet.AddressToStr(sv_source)
+            logOutput('[UDP Server] Received: "' .. msg .. '" from ' .. ip .. ':' .. sv_source.port)
             assert(msg:startsWith('Hello UDP Server'), 'Unexpected message received')
 
             -- Echo back a response
@@ -55,7 +58,8 @@ glTestTimeout = 3.0
 
          if (bytesRead > 0) then
             local msg = cl_buffer:sub(0, bytesRead)
-            logOutput('[UDP Client] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(cl_source) .. ':' .. cl_source.port)
+            local err, ip = mNet.AddressToStr(cl_source)
+            logOutput('[UDP Client] Received: "' .. msg .. '" from ' .. ip .. ':' .. cl_source.port)
             assert(msg:startsWith('Hello UDP Client'), 'Unexpected response received')
             client_received = true
             Socket.acSignal()

--- a/src/network/tests/test_udp_broadcast_multicast.tiri
+++ b/src/network/tests/test_udp_broadcast_multicast.tiri
@@ -106,7 +106,8 @@ end
          err, read_len = Socket.mtRecvFrom(source, buffer)
          if err is ERR_Okay and read_len > 0 then
             local msg = buffer:sub(0, read_len)
-            logOutput('[Broadcast Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
+            local err, ip = mNet.AddressToStr(source)
+            logOutput('[Broadcast Server] Received: "' .. msg .. '" from ' .. ip .. ':' .. source.port)
             if (msg:startsWith('Broadcast Test')) then
                bcast_recv = true
                Socket.acSignal()

--- a/src/network/tests/test_udp_ipv6.tiri
+++ b/src/network/tests/test_udp_ipv6.tiri
@@ -29,7 +29,8 @@ glTestTimeout = 3.0
 
          if bytesRead > 0 then
             local msg = buffer:getString(0, bytesRead)
-            logOutput('[IPv6 UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(sv_source) .. ':' .. sv_source.port)
+            local err, ip = mNet.AddressToStr(sv_source)
+            logOutput('[IPv6 UDP Server] Received: "' .. msg .. '" from ' .. ip .. ':' .. sv_source.port)
             assert(msg:startsWith('Hello IPv6'), 'Unexpected message received')
             msg_recv = true
             Socket.acSignal()
@@ -79,7 +80,8 @@ end
 
          if bytesRead > 0 then
             local msg = buffer:getString(0, bytesRead)
-            logOutput('[Dual-Stack UDP Server] Received: "' .. msg .. '" from ' .. mNet.AddressToStr(source) .. ':' .. source.port)
+            local err, ip = mNet.AddressToStr(source)
+            logOutput('[Dual-Stack UDP Server] Received: "' .. msg .. '" from ' .. ip .. ':' .. source.port)
 
             if msg:endsWith('IPv4') then
                ipv4Received = true


### PR DESCRIPTION
* Converted AddressToStr to return ERR and write to a std::string result buffer
* [Script] Updated network scripts and Flute tests to handle the new AddressToStr result pair
* [Core] Changed symbolic link reads to use std::string output storage