### PR TITLE
[Tiri] Harden debug and struct reference handling

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -408,6 +408,7 @@ extern void register_async_class(lua_State *);
 void release_object(GCobject *);
 void new_module(lua_State *, objModule *);
 ERR struct_to_table(lua_State *, std::vector<lua_ref> &, struct struct_record &, CPTR);
+void unref_struct_references(lua_State *, std::vector<lua_ref> &);
 ERR table_to_struct(lua_State *, std::string_view, APTR *);
 void keyvalue_to_table(lua_State *, const KEYVALUE *);
 

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -562,6 +562,8 @@ ERR make_struct_ptr_array(lua_State *Lua, std::string_view StructName, int Eleme
          }
          Lua->top--;  // Pop the table
       }
+
+      unref_struct_references(Lua, ref);
    }
 
    return ERR::Okay;
@@ -601,6 +603,8 @@ void make_struct_array(lua_State *Lua, std::string_view StructName, int Elements
 
          Input = (int8_t *)Input + struct_stride;
       }
+
+      unref_struct_references(Lua, ref);
    }
 }
 
@@ -716,11 +720,14 @@ CSTRING code_reader(lua_State *Lua, void *Handle, size_t *Size)
 {
    auto handle = (code_reader_handle *)Handle;
    int result;
-   if (!acRead(handle->File, handle->Buffer, SIZE_READ, &result)) {
+   if (auto error = acRead(handle->File, handle->Buffer, SIZE_READ, &result); error IS ERR::Okay) {
       *Size = result;
       return (CSTRING)handle->Buffer;
    }
-   else return nullptr;
+   else {
+      kt::Log(__FUNCTION__).warning("Failed to read source chunk: %s", GetErrorMsg(error));
+      return nullptr;
+   }
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -522,7 +522,10 @@ static ERR TIRI_Init(extTiri *Self)
    if ((!error) and (Self->SaveCompiled = compile)) {
       DateTime *dt;
       if (!src_file->getDate(dt)) Self->CacheDate = *dt;
-      src_file->getPermissions(Self->CachePermissions);
+      Self->CachePermissions = PERMIT::NIL;
+      if (auto permissions_error = src_file->getPermissions(Self->CachePermissions); permissions_error != ERR::Okay) {
+         log.warning("Failed to read source permissions for cache file: %s", GetErrorMsg(permissions_error));
+      }
    }
 
    if (error != ERR::Okay) {

--- a/src/tiri/tiri_class_methods.cpp
+++ b/src/tiri/tiri_class_methods.cpp
@@ -118,7 +118,10 @@ static void emit_stack_trace(extTiri *Tiri, std::ostringstream &Buf, bool Compac
       int level = 1; // Start at 1 to skip the C function (mtDebugLog) itself
 
       while (lua_getstack(Tiri->Lua, level, &ar)) {
-         lua_getinfo(Tiri->Lua, "nSl", &ar);
+         if (not lua_getinfo(Tiri->Lua, "nSl", &ar)) {
+            level++;
+            continue;
+         }
 
          if (Compact) {
             Buf << "[" << level << "] ";
@@ -207,7 +210,7 @@ static void emit_upvalues_info(extTiri *Tiri, std::ostringstream &Buf, bool Comp
    lua_Debug ar;
    if (not lua_getstack(Tiri->Lua, 1, &ar)) return; // Level 1 = caller's frame
 
-   lua_getinfo(Tiri->Lua, "f", &ar);
+   if (not lua_getinfo(Tiri->Lua, "f", &ar)) return;
 
    if (not Compact) Buf <<"-UPVALUES-\n";
 
@@ -603,34 +606,35 @@ static ERR TIRI_DebugLog(extTiri *Self, struct sc::DebugLog *Args)
    if (opts.show_dump) {
       lua_Debug ar;
       if (lua_getstack(Self->Lua, 1, &ar)) {
-         lua_getinfo(Self->Lua, "Sln", &ar);
+         if (lua_getinfo(Self->Lua, "Sln", &ar)) {
+            if (not opts.compact) buf <<"-BINARY-\n";
 
-         if (not opts.compact) buf <<"-BINARY-\n";
+            if (lua_getinfo(Self->Lua, "f", &ar)) {
+               GCfunc *fn = funcV(Self->Lua->top - 1);
+               if (isluafunc(fn)) {
+                  std::vector<uint8_t> binary;
 
-         if (lua_getinfo(Self->Lua, "f", &ar)) {
-            GCfunc *fn = funcV(Self->Lua->top - 1);
-            if (isluafunc(fn)) {
-               std::vector<uint8_t> binary;
+                  if (lua_dump(Self->Lua, append_dump_chunk, &binary) IS 0) {
+                     if (not opts.compact) {
+                        CSTRING func_name = ar.name ? ar.name : "<anonymous>";
+                        buf << "Function: " << func_name << " (" << ar.short_src << ":" << ar.linedefined
+                            << "-" << ar.lastlinedefined << ")\n";
+                        buf << "Bytes: " << binary.size() << "\n";
+                     }
 
-               if (lua_dump(Self->Lua, append_dump_chunk, &binary) IS 0) {
-                  if (not opts.compact) {
-                     CSTRING func_name = ar.name ? ar.name : "<anonymous>";
-                     buf << "Function: " << func_name << " (" << ar.short_src << ":" << ar.linedefined
-                         << "-" << ar.lastlinedefined << ")\n";
-                     buf << "Bytes: " << binary.size() << "\n";
+                     append_hex_dump(binary, buf, opts.compact);
                   }
-
-                  append_hex_dump(binary, buf, opts.compact);
+                  else buf << "(failed to serialise bytecode)\n";
                }
-               else buf << "(failed to serialise bytecode)\n";
-            }
-            else buf << "(current frame is a C function; bytecode unavailable)\n";
+               else buf << "(current frame is a C function; bytecode unavailable)\n";
 
-            lua_pop(Self->Lua, 1);
+               lua_pop(Self->Lua, 1);
+            }
+            else buf << "(unable to inspect current frame)\n";
+
+            if (not opts.compact) buf <<"\n";
          }
          else buf << "(unable to inspect current frame)\n";
-
-         if (not opts.compact) buf <<"\n";
       }
       else {
          // No active frame - try to dump the main chunk if available

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -382,10 +382,8 @@ static int module_test(lua_State *Lua)
       lua_pushinteger(Lua, total);
       return 2;
    }
-   else {
-      luaL_argerror(Lua, 1, "Expected module.");
-      return 0;
-   }
+   else luaL_argerror(Lua, 1, "Expected module.");
+   return 0;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -111,7 +111,9 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
    // NB: Custom comparator will stop if a colon is encountered in StructName
    if (auto def = glStructs.find(StructName); def != glStructs.end()) {
       std::vector<lua_ref> ref;
-      return struct_to_table(Lua, ref, def->second, Address);
+      auto error = struct_to_table(Lua, ref, def->second, Address);
+      unref_struct_references(Lua, ref);
+      return error;
    }
    else if (StructName.starts_with("KeyValue")) {
       // A struct name of 'KeyValue' allows the KEYVALUE type to be used for building structures dynamically.
@@ -124,6 +126,17 @@ void destroy_struct_cpp_strings(const struct_record &StructDef, APTR Address)
       kt::Log().warning("Unknown struct name '%.*s' - use 'include' to load module definitions.", int(StructName.size()), StructName.data());
       return ERR::Search;
    }
+}
+
+//********************************************************************************************************************
+
+void unref_struct_references(lua_State *Lua, std::vector<lua_ref> &References)
+{
+   for (auto &rec : References) {
+      if ((rec.Ref != LUA_NOREF) and (rec.Ref != LUA_REFNIL)) luaL_unref(Lua, LUA_REGISTRYINDEX, rec.Ref);
+   }
+
+   References.clear();
 }
 
 //********************************************************************************************************************


### PR DESCRIPTION
* Released temporary registry references after struct table conversions
* Guarded debug frame and source cache metadata queries against failures
* Logged source chunk read failures during code loading