### PR TITLE
[Document] Returned read content through std::string

### DIFF
--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -336,7 +336,7 @@
         <param type="DATA" name="Format" lookup="DATA">Set to <code>TEXT</code> to receive plain-text, <code>RAW</code> to receive the original byte-code, or <code>XML</code> to receive a textual XML serialisation of the stream.</param>
         <param type="INT" name="Start">An index in the document stream from which data will be extracted.</param>
         <param type="INT" name="End">An index in the document stream at which extraction will stop.</param>
-        <param type="STRING *" name="Result">The data is returned in this parameter as an allocated string.</param>
+        <param type="STRING *" name="Result">The data is returned in this parameter.</param>
       </input>
       <description>
 <p>The ReadContent() method extracts content from the document stream, covering a specific area.  It can return the data as a RIPL binary stream, translated into plain-text (control codes are removed), or serialised as an XML document describing the byte stream.</p>
@@ -346,12 +346,12 @@
       <result>
         <error code="Okay">Operation successful.</error>
         <error code="Args">Invalid arguments passed to function</error>
-        <error code="NoData">Operation successful, but no data was present for extraction.</error>
+        <error code="NoData">No data was extractable - applies to XML type only; other types return an empty string.</error>
         <error code="OutOfRange">The Start index is not within the stream.</error>
         <error code="AllocMemory">AllocMemory() failed to create a new memory block</error>
         <error code="NullArgs">Function call missing argument value(s)</error>
       </result>
-      <tags>pure-query, caller-owns-result, null-terminated-result</tags>
+      <tags>pure-query, mutates-input</tags>
     </method>
 
     <method>

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -107,7 +107,7 @@ struct RemoveListener { int Trigger; FUNCTION *Function; static const AC id = AC
 struct ShowIndex { std::string_view Name; static const AC id = AC(-11); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct HideIndex { std::string_view Name; static const AC id = AC(-12); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct Edit { std::string_view Name; int Flags; static const AC id = AC(-13); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ReadContent { DATA Format; int Start; int End; STRING Result; static const AC id = AC(-14); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ReadContent { DATA Format; int Start; int End; std::string *Result; static const AC id = AC(-14); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -223,10 +223,9 @@ class objDocument : public Object {
       struct doc::Edit args = { Name, Flags };
       return Action(AC(-13), this, &args);
    }
-   inline ERR readContent(DATA Format, int Start, int End, STRING * Result) noexcept {
-      struct doc::ReadContent args = { Format, Start, End, (STRING)0 };
+   inline ERR readContent(DATA Format, int Start, int End, std::string &Result) noexcept {
+      struct doc::ReadContent args = { Format, Start, End, &Result };
       ERR error = Action(AC(-14), this, &args);
-      if (Result) *Result = args.Result;
       return error;
    }
 

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -1679,18 +1679,18 @@ resulting data.
 int(DATA) Format: Set to `TEXT` to receive plain-text, `RAW` to receive the original byte-code, or `XML` to receive a textual XML serialisation of the stream.
 int Start:  An index in the document stream from which data will be extracted.
 int End:    An index in the document stream at which extraction will stop.
-!str Result: The data is returned in this parameter as an allocated string.
+^&string Result: The data is returned in this parameter.
 
 -ERRORS-
 Okay
 NullArgs
 OutOfRange: The Start index is not within the stream.
+NoData: No data was extractable - applies to XML type only; other types return an empty string.
 Args
-NoData: Operation successful, but no data was present for extraction.
 AllocMemory
 
 -TAGS-
-pure-query, caller-owns-result, null-terminated-result
+pure-query
 
 *********************************************************************************************************************/
 
@@ -1698,9 +1698,7 @@ static ERR DOCUMENT_ReadContent(extDocument *Self, doc::ReadContent *Args)
 {
    kt::Log log(__FUNCTION__);
 
-   if (not Args) return log.warning(ERR::NullArgs);
-
-   Args->Result = nullptr;
+   if ((not Args) or (not Args->Result)) return log.warning(ERR::NullArgs);
 
    if ((Args->Start < 0) or (Args->Start >= std::ssize(Self->Stream))) return log.warning(ERR::OutOfRange);
    if (Args->End <= Args->Start) return log.warning(ERR::Args);
@@ -1719,21 +1717,13 @@ static ERR DOCUMENT_ReadContent(extDocument *Self, doc::ReadContent *Args)
          }
       }
 
-      auto str = buffer.str();
-      if (str.empty()) return ERR::NoData;
-      if ((Args->Result = strclone(str))) return ERR::Okay;
-      else return log.warning(ERR::AllocMemory);
+      *Args->Result = std::move(buffer).str();
+      return ERR::Okay;
    }
    else if (Args->Format IS DATA::RAW) {
-      STRING output;
       auto size = (end - Args->Start) * INDEX(sizeof(stream_code));
-      if (!AllocMemory(size + 1, MEM::NO_CLEAR, (APTR *)&output)) {
-         copymem(Self->Stream.data.data() + Args->Start, output, size);
-         output[size] = 0;
-         Args->Result = output;
-         return ERR::Okay;
-      }
-      else return log.warning(ERR::AllocMemory);
+      Args->Result->assign((CSTRING)(Self->Stream.data.data() + Args->Start), size);
+      return ERR::Okay;
    }
    else if (Args->Format IS DATA::XML) {
       std::ostringstream buffer;
@@ -1750,9 +1740,8 @@ static ERR DOCUMENT_ReadContent(extDocument *Self, doc::ReadContent *Args)
 
       if (not has_content) return ERR::NoData;
 
-      auto str = buffer.str();
-      if ((Args->Result = strclone(str))) return ERR::Okay;
-      else return log.warning(ERR::AllocMemory);
+      *Args->Result = std::move(buffer).str();
+      return ERR::Okay;
    }
    else return log.warning(ERR::Args);
 }
@@ -1932,10 +1921,10 @@ static ERR DOCUMENT_SaveToObject(extDocument *Self, struct acSaveToObject *Args)
 
    log.branch("Destination: %d", Args->Dest->UID);
 
-   doc::ReadContent read = { DATA::XML, 0, int(Self->Stream.size()), nullptr };
+   std::string result;
+   doc::ReadContent read = { DATA::XML, 0, int(Self->Stream.size()), &result };
    if (auto error = DOCUMENT_ReadContent(Self, &read); !error) {
-      error = acWrite(Args->Dest, read.Result, strlen(read.Result), nullptr);
-      FreeResource(read.Result);
+      error = acWrite(Args->Dest, result.data(), result.size(), nullptr);
       if (!error) return ERR::Okay;
       else return log.warning(ERR::Write);
    }

--- a/src/document/class/document_def.c
+++ b/src/document/class/document_def.c
@@ -34,7 +34,7 @@ FDEF maRemoveListener[] = { { "Trigger", FD_INT }, { "Function", FD_FUNCTIONPTR 
 FDEF maShowIndex[] = { { "Name", FDF_CPPSTRING }, { 0, 0 } };
 FDEF maHideIndex[] = { { "Name", FDF_CPPSTRING }, { 0, 0 } };
 FDEF maEdit[] = { { "Name", FDF_CPPSTRING }, { "Flags", FD_INT }, { 0, 0 } };
-FDEF maReadContent[] = { { "Format", FD_INT }, { "Start", FD_INT }, { "End", FD_INT }, { "Result", FD_RESULT|FD_STR|FD_ALLOC }, { 0, 0 } };
+FDEF maReadContent[] = { { "Format", FD_INT }, { "Start", FD_INT }, { "End", FD_INT }, { "Result", FD_RESULT|FD_MUTABLE|FDF_CPPSTRING }, { 0, 0 } };
 
 static const struct MethodEntry clDocumentMethods[] = {
    { AC(-1), (APTR)DOCUMENT_FeedParser, "FeedParser", maFeedParser, sizeof(struct doc::FeedParser) },


### PR DESCRIPTION
* Updated ReadContent to fill caller-provided std::string results instead of allocated C strings
* Updated SaveToObject and generated method metadata for mutable string result handling