### PR TITLE
[Cleanup] Replaced manual buffers with RAII containers

### DIFF
--- a/src/origo/gui/origo.cpp
+++ b/src/origo/gui/origo.cpp
@@ -71,7 +71,7 @@ extern "C" void program(void)
    glTask = CurrentTask();
    bool time       = false;
    int winhandle  = 0;
-   STRING procedure  = nullptr;
+   std::string procedure;
    STRING scriptfile = nullptr;
    int width      = 0;
    int height     = 0;
@@ -114,14 +114,8 @@ extern "C" void program(void)
             }
          }
          else if (iequals(Args[i], "--procedure")) {
-            if (procedure) { FreeResource(procedure); procedure = nullptr; }
-
             if (Args[i+1]) {
-               for (j=0; Args[i+1][j]; j++);
-               if (!AllocMemory(j+1, MEM::STRING|MEM::NO_CLEAR, &procedure)) {
-                  for (j=0; Args[i+1][j]; j++) procedure[j] = Args[i+1][j];
-                  procedure[j] = 0;
-               }
+               procedure = Args[i+1];
                i++;
             }
          }
@@ -191,7 +185,6 @@ exit:
       }
    }
 
-   if (procedure) { FreeResource(procedure); procedure = nullptr; }
    if (scriptfile) { FreeResource(scriptfile); scriptfile = nullptr; }
 
    if (glDirectory) {

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -1123,16 +1123,9 @@ static ERR SCINTILLA_SaveToObject(extScintilla *Self, struct acSaveToObject *Arg
 
    log.branch("To: %d, Size: %d", Args->Dest->UID, len);
 
-   ERR error;
-   APTR buffer;
-   if (!AllocMemory(len+1, MEM::STRING|MEM::NO_CLEAR, &buffer)) {
-      SCICALL(SCI_GETTEXT, len+1, (const char *)buffer);
-      error = acWrite(Args->Dest, buffer, len, nullptr);
-      FreeResource(buffer);
-   }
-   else error = ERR::AllocMemory;
-
-   return error;
+   std::vector<char> buffer(len+1);
+   SCICALL(SCI_GETTEXT, buffer.size(), (const char *)buffer.data());
+   return acWrite(Args->Dest, buffer.data(), len, nullptr);
 }
 
 /*********************************************************************************************************************
@@ -2081,20 +2074,16 @@ static ERR load_file(extScintilla *Self, std::string_view Path)
       else if (!file->getSize(size)) {
          if (size > 0) {
             if (size < 1024 * 1024 * 10) {
-               if (!AllocMemory(size+1, MEM::STRING|MEM::NO_CLEAR, (APTR *)&str)) {
-                  if (!file->read(str, size, &len)) {
-                     str[len] = 0;
-                     SCICALL(SCI_SETTEXT, str);
-                     SCICALL(SCI_EMPTYUNDOBUFFER);
-                     error = ERR::Okay;
+               std::vector<char> str(size);
+               if (!file->read(str.data(), size, &len)) {
+                  str[len] = 0;
+                  SCICALL(SCI_SETTEXT, str);
+                  SCICALL(SCI_EMPTYUNDOBUFFER);
+                  error = ERR::Okay;
 
-                     calc_longest_line(Self);
-                  }
-                  else error = ERR::Read;
-
-                  FreeResource(str);
+                  calc_longest_line(Self);
                }
-               else error = ERR::AllocMemory;
+               else error = ERR::Read;
             }
             else error = ERR::BufferOverflow;
          }

--- a/src/scintilla/class_scintilla_ext.cxx
+++ b/src/scintilla/class_scintilla_ext.cxx
@@ -327,27 +327,22 @@ void ScintillaKTK::Paste()
          if (file.ok()) {
             int64_t len, size;
             if ((!file->getSize(size)) and (size > 0)) {
-               STRING buffer;
-               if (!AllocMemory(size, MEM::STRING, (APTR *)&buffer)) {
-                  if (!file->read(buffer, size, &len)) {
-                     pdoc->BeginUndoAction();
+               std::vector<char> buffer(size);
+               if (!file->read(buffer.data(), size, &len)) {
+                  pdoc->BeginUndoAction();
 
-                        ClearSelection();
-                        pdoc->InsertString(CurrentPosition(), (char *)buffer, len);
-                        SetEmptySelection(CurrentPosition() + len);
+                     ClearSelection();
+                     pdoc->InsertString(CurrentPosition(), (char *)buffer.data(), len);
+                     SetEmptySelection(CurrentPosition() + len);
 
-                     pdoc->EndUndoAction();
+                  pdoc->EndUndoAction();
 
-                     NotifyChange();
-                     Redraw();
+                  NotifyChange();
+                  Redraw();
 
-                     calc_longest_line(scintilla);
-                  }
-                  else error_dialog("Paste Error", "Failed to read data from the clipboard file.", ERR::Okay);
-
-                  FreeResource(buffer);
+                  calc_longest_line(scintilla);
                }
-               else error_dialog("Paste Error", nullptr, ERR::AllocMemory);
+               else error_dialog("Paste Error", "Failed to read data from the clipboard file.", ERR::Okay);
             }
          }
          else error_dialog("Paste Error", std::format("Failed to load clipboard file \"{}\"", files[0]), ERR::Okay);

--- a/src/svg/parser.cpp
+++ b/src/svg/parser.cpp
@@ -2100,21 +2100,16 @@ static ERR load_pic(extSVG *Self, std::string Path, objImage **Image, Unit Width
             kt::BASE64DECODE state;
             clearmem(&state, sizeof(state));
 
-            uint8_t *output;
-            if (!AllocMemory(val.size(), MEM::DATA|MEM::NO_CLEAR, (APTR *)&output)) {
-               int64_t written;
-               if (!(error = kt::Base64Decode(&state, val, output, &written))) {
-                  Path = "temp:svg.img";
-                  if ((file = objFile::create::local(fl::Path(Path), fl::Flags(FL::NEW|FL::WRITE)))) {
-                     int result;
-                     file->write(output, written, &result);
-                  }
-                  else error = ERR::File;
+            std::vector<uint8_t> output(val.size());
+            int64_t written;
+            if (!(error = kt::Base64Decode(&state, val, output.data(), &written))) {
+               Path = "temp:svg.img";
+               if ((file = objFile::create::local(fl::Path(Path), fl::Flags(FL::NEW|FL::WRITE)))) {
+                  int result;
+                  file->write(output.data(), written, &result);
                }
-
-               FreeResource(output);
+               else error = ERR::File;
             }
-            else error = ERR::AllocMemory;
          }
          else error = ERR::StringFormat;
       }

--- a/src/vector/vectors/text.cpp
+++ b/src/vector/vectors/text.cpp
@@ -196,8 +196,8 @@ class extVectorText : public extVector {
    double txStartOffset; // TODO
    double txSpacing; // TODO
    double txXOffset, txYOffset; // X,Y adjustment for ensuring that the cursor is visible.
-   double *txDX, *txDY; // A series of spacing adjustments that apply on a per-character level.
-   double *txRotate;  // A series of angles that will rotate each individual character.
+   std::vector<double> txDX, txDY; // A series of spacing adjustments that apply on a per-character level.
+   std::vector<double> txRotate; // A series of angles that will rotate each individual character.
    objFont *txBitmapFont;
    objBitmap *txAlphaBitmap; // Host for the bitmap font texture
    extVectorImage *txBitmapImage;
@@ -212,7 +212,6 @@ class extVectorText : public extVector {
    OBJECTID txShapeSubtractID; // Subtract this shape from the path defined by shape-inside
    int  txTotalLines;
    int  txLineLimit, txCharLimit;
-   int  txTotalRotate, txTotalDX, txTotalDY;
    int  txWeight; // 100 - 300 (Light), 400 (Normal), 700 (Bold), 900 (Boldest)
    ALIGN txAlignFlags;
    VTXF  txFlags;
@@ -243,8 +242,6 @@ class extVectorText : public extVector {
 
       if (txBitmapImage)  FreeResource(txBitmapImage);
       if (txAlphaBitmap)  FreeResource(txAlphaBitmap);
-      if (txDX)           FreeResource(txDX);
-      if (txDY)           FreeResource(txDY);
       if (txKeyEvent)     UnsubscribeEvent(txKeyEvent);
       release_callback(txOnChange);
 
@@ -600,24 +597,16 @@ else (b) no extra shift along the x-axis occurs.
 
 static ERR TEXT_GET_DX(extVectorText *Self, std::span<double> &Array)
 {
-   Array = std::span<double>(Self->txDX, Self->txTotalDX);
+   Array = std::span<double>(Self->txDX.data(), Self->txDX.size());
    return ERR::Okay;
 }
 
 static ERR TEXT_SET_DX(extVectorText *Self, std::span<const double> &Array)
 {
-   if (Self->txDX) { FreeResource(Self->txDX); Self->txDX = nullptr; Self->txTotalDX = 0; }
-
-   if ((Array.data()) and (Array.size() > 0)) {
-      if (!AllocMemory(sizeof(double) * Array.size(), MEM::DATA, (APTR *)&Self->txDX)) {
-         copymem(Array.data(), Self->txDX, Array.size() * sizeof(double));
-         Self->txTotalDX = Array.size();
-         reset_path(Self);
-         return ERR::Okay;
-      }
-      else return ERR::AllocMemory;
-   }
-   else return ERR::Okay;
+   if ((not Array.data()) or Array.empty()) Self->txDX.clear();
+   else Self->txDX.assign(Array.begin(), Array.end());
+   reset_path(Self);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -630,24 +619,16 @@ This field follows the same rules described in #DX.
 
 static ERR TEXT_GET_DY(extVectorText *Self, std::span<double> &Array)
 {
-   Array = std::span<double>(Self->txDY, Self->txTotalDY);
+   Array = std::span<double>(Self->txDY.data(), Self->txDY.size());
    return ERR::Okay;
 }
 
 static ERR TEXT_SET_DY(extVectorText *Self, std::span<const double> &Array)
 {
-   if (Self->txDY) { FreeResource(Self->txDY); Self->txDY = nullptr; Self->txTotalDY = 0; }
-
-   if ((Array.data()) and (Array.size() > 0)) {
-      if (!AllocMemory(sizeof(double) * Array.size(), MEM::DATA, (APTR *)&Self->txDY)) {
-         copymem(Array.data(), Self->txDY, Array.size() * sizeof(double));
-         Self->txTotalDY = Array.size();
-         reset_path(Self);
-         return ERR::Okay;
-      }
-      else return ERR::AllocMemory;
-   }
-   else return ERR::Okay;
+   if ((not Array.data()) or Array.empty()) Self->txDY.clear();
+   else Self->txDY.assign(Array.begin(), Array.end());
+   reset_path(Self);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -1180,21 +1161,16 @@ and is supplemental to any rotation due to text on a path and to 'glyph-orientat
 
 static ERR TEXT_GET_Rotate(extVectorText *Self, std::span<double> &Array)
 {
-   Array = std::span<double>(Self->txRotate, Self->txTotalRotate);
+   Array = std::span<double>(Self->txRotate.data(), Self->txRotate.size());
    return ERR::Okay;
 }
 
 static ERR TEXT_SET_Rotate(extVectorText *Self, std::span<const double> &Array)
 {
-   if (Self->txRotate) { FreeResource(Self->txRotate); Self->txRotate = nullptr; Self->txTotalRotate = 0; }
-
-   if (!AllocMemory(sizeof(double) * Array.size(), MEM::DATA, (APTR *)&Self->txRotate)) {
-      copymem(Array.data(), Self->txRotate, Array.size() * sizeof(double));
-      Self->txTotalRotate = Array.size();
-      reset_path(Self);
-      return ERR::Okay;
-   }
-   else return ERR::AllocMemory;
+   if ((not Array.data()) or Array.empty()) Self->txRotate.clear();
+   else Self->txRotate.assign(Array.begin(), Array.end());
+   reset_path(Self);
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************


### PR DESCRIPTION
* [Origo] Replaced procedure argument allocation with std::string storage
* [Scintilla] Replaced temporary text buffers with std::vector storage
* [SVG] Replaced base64 decode scratch allocation with std::vector storage
* [Vector] Converted VectorText DX, DY and Rotate arrays to std::vector-backed fields