### PR TITLE
[Core] Store thread data as byte vector

### DIFF
--- a/docs/xml/modules/classes/thread.xml
+++ b/docs/xml/modules/classes/thread.xml
@@ -22,7 +22,7 @@
 objThread::create thread = { fl::Routine(thread_entry), fl::Flags(THF::AUTO_FREE) };
 if (thread.ok()) thread-&gt;activate();
 </pre>
-<p>To initialise the thread with data, call <method>SetData</method> prior to execution and read the <fl>Data</fl> field from within the thread routine.</p></description>
+<p>To initialise the thread with data, set <fl>Data</fl> prior to execution and read the <fl>Data</fl> field from within the thread routine.</p></description>
     <source>
       <file path="../classes/">class_thread.cpp</file>
     </source>
@@ -48,31 +48,6 @@ if (thread.ok()) thread-&gt;activate();
 
   </actions>
 
-  <methods>
-    <method>
-      <name>SetData</name>
-      <comment>Attaches data to the thread.</comment>
-      <prototype>ERR th::SetData(OBJECTPTR Object, APTR Data, INT Size)</prototype>
-      <tiriPrototype>err = SetData(Data:any, Size:num)</tiriPrototype>
-      <input>
-        <param type="APTR" name="Data">Pointer to the data buffer.</param>
-        <param type="INT" name="Size">Size of the data buffer.  If zero, the pointer is stored directly, with no copy operation taking place.</param>
-      </input>
-      <description>
-<p>Use the SetData() method prior to activating a thread so that it can be initialised with user data.  The thread will be able to read the data from the <fl>Data</fl> field.</p>
-<p>A copy of the provided data buffer will be stored with the thread object, so there is no need to retain the original data after this method has returned.  In some cases it may be desirable to store a direct pointer value and bypass the copy operation.  To do this, set the Size parameter to zero.</p>
-      </description>
-      <result>
-        <error code="Okay">Operation successful.</error>
-        <error code="Args">Invalid arguments passed to function</error>
-        <error code="AllocMemory">AllocMemory() failed to create a new memory block</error>
-        <error code="NullArgs">Function call missing argument value(s)</error>
-      </result>
-      <tags>mutates-object, copies-input</tags>
-    </method>
-
-  </methods>
-
   <fields>
     <field>
       <name>Callback</name>
@@ -87,19 +62,12 @@ if (thread.ok()) thread-&gt;activate();
 
     <field>
       <name>Data</name>
-      <comment>Pointer to initialisation data for the thread.</comment>
-      <access read="G">Get</access>
-      <type>APTR</type>
+      <comment>Storage for custom client data.</comment>
+      <access read="R" write="W">Read/Write</access>
+      <type>kt::vector&lt;int8_t&gt;</type>
       <description>
-<p>The Data field will point to a data buffer if the <method>SetData</method> method has previously been called to store data in the thread object.  It is paired with the <fl>DataSize</fl> field, which reflects the size of the data buffer.</p>
+<p>The Data field is a vector of bytes that can be used to store custom data for the thread.  There are no limits associated with its use, but care should be taken if both the thread and its creator can modify its content at any time.  Reserving the size of the vector in advance is recommended if the data is to be actively shared.</p>
       </description>
-    </field>
-
-    <field>
-      <name>DataSize</name>
-      <comment>The size of the buffer referenced in the Data field.</comment>
-      <access read="R">Read</access>
-      <type>INT</type>
     </field>
 
     <field>

--- a/include/kotuku/modules/processes.h
+++ b/include/kotuku/modules/processes.h
@@ -324,13 +324,6 @@ class objTask : public Object {
 
 #define VER_THREAD (1.000000)
 
-// Thread methods
-
-namespace th {
-struct SetData { APTR Data; int Size; static const AC id = AC(-1); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-
-} // namespace
-
 class objThread : public Object {
    public:
    static constexpr CLASSID CLASS_ID = CLASSID::THREAD;
@@ -339,22 +332,17 @@ class objThread : public Object {
    using create = kt::Create<objThread>;
    objThread(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
 
-   FUNCTION Callback;    // This function will be called when the thread finishes.
-   FUNCTION Routine;     // This function will be called when the thread starts.
-   APTR     Data;        // Pointer to initialisation data for the thread.
-   int      DataSize;    // The size of the buffer referenced in the Data field.
-   ERR      Error;       // Reflects the error code returned by the thread routine.
-   THF      Flags;       // Optional flags can be defined here.
+   FUNCTION Callback;          // This function will be called when the thread finishes.
+   FUNCTION Routine;           // This function will be called when the thread starts.
+   kt::vector<int8_t> Data;    // Storage for custom client data.
+   ERR      Error;             // Reflects the error code returned by the thread routine.
+   THF      Flags;             // Optional flags can be defined here.
 
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
    inline ERR deactivate() noexcept { return Action(AC::Deactivate, this, nullptr); }
    inline ERR init() noexcept { return InitObject(this); }
-   inline ERR setData(APTR Data, int Size) noexcept {
-      struct th::SetData args = { Data, Size };
-      return Action(AC(-1), this, &args);
-   }
 
    // Customised field getting
 
@@ -368,14 +356,9 @@ class objThread : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getData(std::span<APTR> &Value) noexcept {
-      auto field = &this->Class->Dictionary[6];
-      auto get_field = (ERR (*)(APTR, std::span<APTR> &))field->GetValue;
-      return get_field(this, Value);
-   }
-
-   inline ERR getDataSize(int &Value) noexcept {
-      Value = this->DataSize;
+   inline ERR getData(std::span<int8_t> &Value) noexcept {
+      auto ktv = (kt::vector<int8_t> *)(((int8_t *)this) + 160);
+      Value = std::span<int8_t>(ktv->data(), ktv->size());
       return ERR::Okay;
    }
 
@@ -398,8 +381,13 @@ class objThread : public Object {
    }
 
    inline ERR setRoutine(const FUNCTION Value) noexcept {
-      auto field = &this->Class->Dictionary[10];
+      auto field = &this->Class->Dictionary[9];
       return field->WriteValue(this, field, FD_FUNCTION, &Value);
+   }
+
+   inline ERR setData(const kt::vector<int8_t> &Value) noexcept {
+      this->Data = Value;
+      return ERR::Okay;
    }
 
    inline ERR setFlags(const THF Value) noexcept {

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -50,16 +50,21 @@
 #define FDF_FIELDTYPES  (FD_INT|FD_DOUBLE|FD_INT64|FD_POINTER|FD_UNIT|FD_BYTE|FD_ARRAY|FD_FUNCTION)
 
 //********************************************************************************************************************
-// For testing if type T can be matched to an FD flag.  All integral types are mapped by size so that types without
-// an explicit branch (e.g. uint32_t, int16_t) cannot fall through to the pointer/struct default.
+// For testing if type T can be matched to an FD flag.  Integral types are mapped by storage width so that typed spans
+// match byte, word, int and large field definitions.
 
 template <class T> [[nodiscard]] constexpr int FIELD_TYPECHECK() {
-   if constexpr (std::is_same_v<T, double>) return FD_DOUBLE;
-   else if constexpr (std::is_same_v<T, float>) return FD_FLOAT;
-   else if constexpr (std::is_integral_v<T>) return (sizeof(T) > 4) ? FD_INT64 : FD_INT;
-   else if constexpr (std::is_same_v<T, std::string>) return FD_STRING|FD_CPP;
-   else if constexpr (std::is_same_v<T, CSTRING> or std::is_same_v<T, STRING>) return FD_STRING;
-   else if constexpr (std::is_same_v<T, OBJECTPTR> or std::is_same_v<T, APTR>) return FD_PTR;
+   using field_type = std::remove_cvref_t<T>;
+
+   if constexpr (std::is_same_v<field_type, double>) return FD_DOUBLE;
+   else if constexpr (std::is_same_v<field_type, float>) return FD_FLOAT;
+   else if constexpr (std::is_integral_v<field_type> and (sizeof(field_type) IS sizeof(int8_t))) return FD_BYTE;
+   else if constexpr (std::is_integral_v<field_type> and (sizeof(field_type) IS sizeof(int16_t))) return FD_WORD;
+   else if constexpr (std::is_integral_v<field_type> and (sizeof(field_type) IS sizeof(int64_t))) return FD_INT64;
+   else if constexpr (std::is_integral_v<field_type>) return FD_INT;
+   else if constexpr (std::is_same_v<field_type, std::string>) return FD_STRING|FD_CPP;
+   else if constexpr (std::is_same_v<field_type, CSTRING> or std::is_same_v<field_type, STRING>) return FD_STRING;
+   else if constexpr (std::is_same_v<field_type, OBJECTPTR> or std::is_same_v<field_type, APTR>) return FD_PTR;
    else return FD_PTR|FD_STRUCT|FD_STRING;
 }
 

--- a/src/core/classes/class_thread.cpp
+++ b/src/core/classes/class_thread.cpp
@@ -22,7 +22,7 @@ objThread::create thread = { fl::Routine(thread_entry), fl::Flags(THF::AUTO_FREE
 if (thread.ok()) thread->activate();
 </pre>
 
-To initialise the thread with data, call #SetData() prior to execution and read the #Data field from within the
+To initialise the thread with data, set #Data prior to execution and read the #Data field from within the
 thread routine.
 
 -END-
@@ -224,65 +224,10 @@ static ERR THREAD_FreeWarning(extThread *Self)
 {
    if (!Self->Active) return ERR::Okay;
    else {
-      kt::Log log;
-      log.detail("Thread is still running, marking for auto termination.");
+      kt::Log().detail("Thread is still running, marking for auto termination.");
       Self->Flags |= THF::AUTO_FREE;
       return ERR::InUse;
    }
-}
-
-/*********************************************************************************************************************
-
--METHOD-
-SetData: Attaches data to the thread.
-
-Use the SetData() method prior to activating a thread so that it can be initialised with user data.  The thread will be
-able to read the data from the #Data field.
-
-A copy of the provided data buffer will be stored with the thread object, so there is no need to retain the original
-data after this method has returned.  In some cases it may be desirable to store a direct pointer value and bypass the
-copy operation.  To do this, set the Size parameter to zero.
-
--INPUT-
-buf(ptr) Data: Pointer to the data buffer.
-bufsize Size: Size of the data buffer.  If zero, the pointer is stored directly, with no copy operation taking place.
-
--ERRORS-
-Okay
-NullArgs
-Args
-AllocMemory
-
--TAGS-
-mutates-object, copies-input
--END-
-
-*********************************************************************************************************************/
-
-static ERR THREAD_SetData(extThread *Self, struct th::SetData *Args)
-{
-   kt::Log log;
-
-   if ((!Args) or (!Args->Data)) return log.warning(ERR::NullArgs);
-   if (Args->Size < 0) return log.warning(ERR::Args);
-
-   if (Self->Data) {
-      FreeResource(Self->Data);
-      Self->Data = nullptr;
-      Self->DataSize = 0;
-   }
-
-   if (!Args->Size) { // If no size is provided, we simply copy the provided pointer.
-      Self->Data = Args->Data;
-      Self->DataSize = 0;
-      return ERR::Okay;
-   }
-   else if (!AllocMemory(Args->Size, MEM::DATA, &Self->Data)) {
-      Self->DataSize = Args->Size;
-      copymem(Args->Data, Self->Data, Args->Size);
-      return ERR::Okay;
-   }
-   else return log.warning(ERR::AllocMemory);
 }
 
 /*********************************************************************************************************************
@@ -296,18 +241,13 @@ callback will be executed in the context of the main program loop to minimise re
 The prototype for the callback routine is `void Callback(objThread *Thread)`.
 
 -FIELD-
-Data: Pointer to initialisation data for the thread.
+Data: Storage for custom client data.
 
-The Data field will point to a data buffer if the #SetData() method has previously been called to store data in
-the thread object.  It is paired with the #DataSize field, which reflects the size of the data buffer.
+The Data field is a vector of bytes that can be used to store custom data for the thread.  There are no limits
+associated with its use, but care should be taken if both the thread and its creator can modify its content at any
+time.  Reserving the size of the vector in advance is recommended if the data is to be actively shared.
 
 *********************************************************************************************************************/
-
-static ERR GET_Data(extThread *Self, std::span<uint8_t> &Value)
-{
-   Value = std::span<uint8_t>((uint8_t *)Self->Data, Self->DataSize);
-   return ERR::Okay;
-}
 
 static ERR SET_Callback(extThread *Self, FUNCTION *Value)
 {
@@ -319,20 +259,7 @@ static ERR SET_Callback(extThread *Self, FUNCTION *Value)
    return ERR::Okay;
 }
 
-static ERR SET_Routine(extThread *Self, FUNCTION *Value)
-{
-   clear_callback(Self->Routine);
-   if (Value) {
-      Self->Routine = *Value;
-      if (Self->Routine.defined()) Self->Routine.pin();
-   }
-   return ERR::Okay;
-}
-
 /*********************************************************************************************************************
-
--FIELD-
-DataSize: The size of the buffer referenced in the Data field.
 
 -FIELD-
 Error: Reflects the error code returned by the thread routine.
@@ -352,14 +279,18 @@ finished processing, the resulting error code will be stored in the thread objec
 
 *********************************************************************************************************************/
 
+static ERR SET_Routine(extThread *Self, FUNCTION *Value)
+{
+   clear_callback(Self->Routine);
+   if (Value) {
+      Self->Routine = *Value;
+      if (Self->Routine.defined()) Self->Routine.pin();
+   }
+   return ERR::Okay;
+}
+
 extThread::~extThread()
 {
-   if ((Data) and (DataSize > 0)) {
-      FreeResource(Data);
-      Data = nullptr;
-      DataSize = 0;
-   }
-
    if (CPPThread) { delete CPPThread; CPPThread = nullptr; }
 
    clear_callback(Callback);
@@ -373,8 +304,7 @@ extThread::~extThread()
 static const FieldArray clFields[] = {
    { "Callback",  FDF_FUNCTION|FDF_RW, nullptr, SET_Callback },
    { "Routine",   FDF_FUNCTION|FDF_RW, nullptr, SET_Routine },
-   { "Data",      FDF_ARRAY|FDF_BYTE|FDF_R|FDF_PURE, GET_Data },
-   { "DataSize",  FDF_INT|FDF_R },
+   { "Data",      FDF_VECTOR|FDF_BYTE|FDF_RW },
    { "Error",     FDF_INT|FDF_R },
    { "Flags",     FDF_INT|FDF_RI, nullptr, nullptr, &clThreadFlags },
    END_FIELD
@@ -389,7 +319,6 @@ extern ERR add_thread_class(void)
       fl::Name("Thread"),
       fl::Category(CCF::SYSTEM),
       fl::Actions(clThreadActions),
-      fl::Methods(clThreadMethods),
       fl::Fields(clFields),
       fl::Size(sizeof(extThread)),
       fl::Path("modules:core"));

--- a/src/core/classes/class_thread_def.c
+++ b/src/core/classes/class_thread_def.c
@@ -5,13 +5,6 @@ static const struct FieldDef clThreadFlags[] = {
    { nullptr, 0 }
 };
 
-FDEF maSetData[] = { { "Data", FD_BUFFER|FD_PTR }, { "Size", FD_INT|FD_BUFSIZE }, { 0, 0 } };
-
-static const struct MethodEntry clThreadMethods[] = {
-   { AC(-1), (APTR)THREAD_SetData, "SetData", maSetData, sizeof(struct th::SetData) },
-   { AC::NIL, 0, 0, 0, 0 }
-};
-
 static ERR THREAD_New(extThread *Self) {
    new (Self) extThread(Self->Class, Self->UID);
    return ERR::Okay;

--- a/src/core/defs/processes.tdl
+++ b/src/core/defs/processes.tdl
@@ -43,15 +43,10 @@ header({ module="Core", copyright="Paul Manias © 1996-2026", timestamp=20240611
     ~array(struct(ActionEntry)) Actions
   ]])
 
-  methods("Thread", "Th", {
-    { id=1, name="SetData" }
-  })
-
   klass("Thread", { src="../classes/class_thread.cpp", output="../classes/class_thread_def.c", extended=true }, [[
     func  Callback     # This function will be called when the thread finishes
     func  Routine      # This function will be called when the thread starts
-    ptr   Data         # User data pointer
-    int   DataSize     # Size of user data
+    vector(char) Data  # User data
     error Error        # Error code returned by the thread on completion
     int(THF) Flags     # Optional flags
   ]])

--- a/src/core/lib_fields_write.cpp
+++ b/src/core/lib_fields_write.cpp
@@ -488,11 +488,11 @@ static ERR set_or_write_vector(OBJECTPTR Object, const Field *Field, int Flags, 
          }
          else if (Field->Flags & FD_BYTE) {
             if (not (Flags & FD_BYTE)) return ERR::SetValueNotArray;
-            return assign_vector_field<uint8_t>(Object, Field, Data);
+            return assign_vector_field<int8_t>(Object, Field, Data);
          }
          else if (Field->Flags & FD_WORD) {
             if (not (Flags & FD_WORD)) return ERR::SetValueNotArray;
-            return assign_vector_field<uint16_t>(Object, Field, Data);
+            return assign_vector_field<int16_t>(Object, Field, Data);
          }
          else if (Field->Flags & FD_INT) {
             if (not (Flags & FD_INT)) return ERR::SetValueNotArray;
@@ -547,10 +547,10 @@ static ERR set_or_write_array(OBJECTPTR Object, const Field *Field, int Flags, C
          // All std::span instantiations share the same {pointer, count} layout, so the element count can be read
          // through any concrete element type.  The per-element width is derived from Flags.
 
-         auto span = (const std::span<const uint8_t> *)Data;
+         auto span = (const std::span<const int8_t> *)Data;
          size_t element_size;
-         if (Flags & FD_BYTE) element_size = sizeof(uint8_t);
-         else if (Flags & FD_WORD) element_size = sizeof(uint16_t);
+         if (Flags & FD_BYTE) element_size = sizeof(int8_t);
+         else if (Flags & FD_WORD) element_size = sizeof(int16_t);
          else if (Flags & FD_INT) element_size = sizeof(int);
          else if (Flags & (FD_INT64|FD_DOUBLE)) element_size = sizeof(double);
          else if (Flags & FD_POINTER) element_size = sizeof(APTR);


### PR DESCRIPTION
* Replaced Thread SetData and DataSize with a writable byte vector field
* Improved field type checks for byte and word spans