### PR TITLE
[Tiri] Consolidated input cleanup and object dispatch paths

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -24,6 +24,7 @@ constexpr int SIZE_READ = 1024;
 #include "lj_frame.h"
 #include "lj_state.h"
 #include "lauxlib.h"
+#include "struct_def.h"
 
 using namespace kt;
 
@@ -58,12 +59,8 @@ extern MSGID glDelayedCallMsgID;
 //********************************************************************************************************************
 
 struct CaseInsensitiveHashView {
-   std::size_t operator()(std::string_view s) const noexcept {
-      std::size_t hash = 5381;
-      for (char c : s) {
-         hash = ((hash << 5) + hash) + std::tolower((unsigned char)c);
-      }
-      return hash;
+   std::size_t operator()(std::string_view String) const noexcept {
+      return kt::strihash(String);
    }
 };
 
@@ -152,16 +149,7 @@ static inline std::string_view lua_checkstringview(lua_State *L, int idx)
 
 inline uint32_t STRUCTHASH(CSTRING String)
 {
-   uint32_t hash = 5381;
-   uint8_t c;
-   while ((c = *String++)) {
-      if ((c >= 'A') and (c <= 'Z'));
-      else if ((c >= 'a') and (c <= 'z'));
-      else if ((c >= '0') and (c <= '9'));
-      else break;
-      hash = ((hash<<5) + hash) + c;
-   }
-   return hash;
+   return kt::strhash(struct_name_hash_prefix(String));
 }
 
 //********************************************************************************************************************
@@ -258,8 +246,6 @@ struct datarequest {
       TimeCreated = PreciseTime();
    }
 };
-
-#include "struct_def.h"
 
 //********************************************************************************************************************
 // Variable information captured during parsing when JOF::DIAGNOSE is enabled.

--- a/src/tiri/struct_def.h
+++ b/src/tiri/struct_def.h
@@ -32,6 +32,22 @@ struct struct_record {
 //********************************************************************************************************************
 // Structure names have their own handler due to the use of colons in struct references, i.e. "OfficialStruct:SomeName"
 
+[[nodiscard]] inline bool struct_name_hash_char(char Value) noexcept
+{
+   auto c = uint8_t(Value);
+   if ((c >= 'A') and (c <= 'Z')) return true;
+   else if ((c >= 'a') and (c <= 'z')) return true;
+   else if ((c >= '0') and (c <= '9')) return true;
+   else return false;
+}
+
+[[nodiscard]] inline std::string_view struct_name_hash_prefix(std::string_view Name) noexcept
+{
+   size_t length = 0;
+   while ((length < Name.size()) and (struct_name_hash_char(Name[length]))) length++;
+   return Name.substr(0, length);
+}
+
 struct struct_name {
    std::string name;
    struct_name(const std::string_view pName) {
@@ -53,28 +69,12 @@ struct struct_name {
 struct struct_hash { // Stops when an invalid character is encountered (typically a colon separator)
    using is_transparent = void; // Enables heterogeneous string_view lookups in std::unordered_map
 
-   std::size_t operator()(const struct_name &k) const {
-      uint32_t hash = 5381;
-      for (auto c : k.name) {
-         if ((c >= 'A') and (c <= 'Z'));
-         else if ((c >= 'a') and (c <= 'z'));
-         else if ((c >= '0') and (c <= '9'));
-         else break;
-         hash = ((hash<<5) + hash) + uint8_t(c);
-      }
-      return hash;
+   std::size_t operator()(const struct_name &Key) const {
+      return kt::strhash(struct_name_hash_prefix(Key.name));
    }
 
-   std::size_t operator()(const std::string_view k) const {
-      uint32_t hash = 5381;
-      for (auto c : k) {
-         if ((c >= 'A') and (c <= 'Z'));
-         else if ((c >= 'a') and (c <= 'z'));
-         else if ((c >= '0') and (c <= '9'));
-         else break;
-         hash = ((hash<<5) + hash) + uint8_t(c);
-      }
-      return hash;
+   std::size_t operator()(const std::string_view Key) const {
+      return kt::strhash(struct_name_hash_prefix(Key));
    }
 };
 

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -53,6 +53,16 @@ static void key_event(evKey *, int, struct finput *);
 
 //********************************************************************************************************************
 
+static void release_input_subscription(lua_State *Lua, struct finput *Input)
+{
+   if (Input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, Input->InputValue); Input->InputValue = 0; }
+   if (Input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, Input->Callback); Input->Callback = 0; }
+   if (Input->KeyEvent)    { UnsubscribeEvent(Input->KeyEvent); Input->KeyEvent = nullptr; }
+   if (Input->InputHandle) { gfx::UnsubscribeInput(Input->InputHandle); Input->InputHandle = 0; }
+}
+
+//********************************************************************************************************************
+
 [[nodiscard]] static ERR consume_input_events(const InputEvent *Events, int Handle)
 {
    kt::Log log(__FUNCTION__);
@@ -396,11 +406,7 @@ static void key_event(evKey *, int, struct finput *);
    kt::Log log("input.unsubscribe");
    log.traceBranch();
 
-   if (input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, input->InputValue); input->InputValue = 0; }
-   if (input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, input->Callback); input->Callback = 0; }
-   if (input->KeyEvent)    { UnsubscribeEvent(input->KeyEvent); input->KeyEvent = nullptr; }
-   if (input->InputHandle) { gfx::UnsubscribeInput(input->InputHandle); input->InputHandle = 0; }
-
+   release_input_subscription(Lua, input);
    input->Script = nullptr;
    input->Mode   = 0;
    return 0;
@@ -418,10 +424,7 @@ static void key_event(evKey *, int, struct finput *);
       log.traceBranch("Surface: %d, CallbackRef: %d, KeyEvent: %p", input->SurfaceID, input->Callback, input->KeyEvent);
 
       if (input->SurfaceID)   input->SurfaceID = 0;
-      if (input->InputHandle) { gfx::UnsubscribeInput(input->InputHandle); input->InputHandle = 0; }
-      if (input->InputValue)  { luaL_unref(Lua, LUA_REGISTRYINDEX, input->InputValue); input->InputValue = 0; }
-      if (input->Callback)    { luaL_unref(Lua, LUA_REGISTRYINDEX, input->Callback); input->Callback = 0; }
-      if (input->KeyEvent)    { UnsubscribeEvent(input->KeyEvent); input->KeyEvent = nullptr; }
+      release_input_subscription(Lua, input);
 
       if (Lua->script) { // Remove from the chain.
          auto tiri = Lua->script;

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -10,6 +10,20 @@ struct pending_function_arg {
 };
 
 //********************************************************************************************************************
+
+[[nodiscard]] inline ERR dispatch_action(GCobject *Def, ACTIONID ActionID, APTR Args, bool &Release)
+{
+   Release = false;
+
+   if (Def->ptr) return Action(ActionID, Def->ptr, Args);
+   else if (auto obj = access_object(Def)) {
+      Release = true;
+      return Action(ActionID, obj, Args);
+   }
+   else return ERR::AccessObject;
+}
+
+//********************************************************************************************************************
 // Lua C closure executed via calls to obj.acName()
 
 static int object_action_call_args(lua_State *Lua)
@@ -36,12 +50,7 @@ static int object_action_call_args(lua_State *Lua)
    }
 
    int results = 1;
-   if (obj_ref->ptr) error = Action(action_id, obj_ref->ptr, argbuffer.get());
-   else if (auto obj = access_object(obj_ref)) {
-      error = Action(action_id, obj, argbuffer.get());
-      release = true;
-   }
-   else error = ERR::AccessObject;
+   error = dispatch_action(obj_ref, action_id, argbuffer.get(), release);
 
    // NB: Even if an error is returned, always get the results (any results parameters are nullified prior to
    // function entry and the action can return results legitimately even if an error code is returned - e.g.
@@ -65,12 +74,7 @@ static int object_action_call(lua_State *Lua)
    ERR error;
    bool release = false;
 
-   if (def->ptr) error = Action(action_id, def->ptr, nullptr);
-   else if (auto obj = access_object(def)) {
-      error = Action(action_id, obj, nullptr);
-      release = true;
-   }
-   else error = ERR::AccessObject;
+   error = dispatch_action(def, action_id, nullptr, release);
 
    lua_pushinteger(Lua, int(error));
 
@@ -105,12 +109,7 @@ static int object_method_call_args(lua_State *Lua)
    int results = 1;
    bool release = false;
 
-   if (def->ptr) error = Action(method->MethodID, def->ptr, argbuffer.get());
-   else if (auto obj = access_object(def)) {
-      error = Action(method->MethodID, obj, argbuffer.get());
-      release = true;
-   }
-   else error = ERR::AccessObject;
+   error = dispatch_action(def, method->MethodID, argbuffer.get(), release);
 
    lua_pushinteger(Lua, int(error));
 
@@ -131,12 +130,7 @@ static int object_method_call(lua_State *Lua)
    bool release = false;
    auto method = (MethodEntry *)lua_touserdata(Lua, lua_upvalueindex(2));
 
-   if (def->ptr) error = Action(method->MethodID, def->ptr, nullptr);
-   else if (auto obj = access_object(def)) {
-      error = Action(method->MethodID, obj, nullptr);
-      release = true;
-   }
-   else error = ERR::AccessObject;
+   error = dispatch_action(def, method->MethodID, nullptr, release);
 
    lua_pushinteger(Lua, int(error));
 


### PR DESCRIPTION
* Shared input subscription release logic between explicit unsubscribe and garbage collection
* Shared object action and method dispatch through one access/release helper
* Reused standard string hash routines for case-insensitive and struct-name hashers