### PR TITLE
[Core] Typed field setter callbacks and archive resizing

### DIFF
--- a/docs/xml/modules/classes/metaclass.xml
+++ b/docs/xml/modules/classes/metaclass.xml
@@ -338,7 +338,7 @@
     <struct name="Field" comment="Used to describe the public fields of a class.">
       <field name="Arg" type="MAXINT">An option to complement the field type.  Can be a pointer or an integer value</field>
       <field name="GetValue" type="FUNCTION *" prototype="ERR (*GetValue)(APTR, APTR)">A virtual function that will retrieve the value for this field</field>
-      <field name="SetValue" type="APTR">A virtual function that will set the value for this field</field>
+      <field name="SetValue" type="FUNCTION *" prototype="ERR (*SetValue)(APTR, APTR)">A virtual function that will set the value for this field</field>
       <field name="WriteValue" type="FUNCTION *" prototype="ERR (*WriteValue)(OBJECTPTR, const struct Field *, int, const void *)">An internal function for writing to this field</field>
       <field name="Name" type="CSTRING">The English name for the field, e.g. <code>Width</code></field>
       <field name="FieldID" type="UINT">32-bit hash from fieldhash()</field>

--- a/docs/xml/modules/core.xml
+++ b/docs/xml/modules/core.xml
@@ -2527,7 +2527,7 @@ if (not OpenDir(path, RDF::FILE|RDF::FOLDER, &amp;info)) {
     <struct name="Field" comment="Used to describe the public fields of a class.">
       <field name="Arg" type="MAXINT">An option to complement the field type.  Can be a pointer or an integer value</field>
       <field name="GetValue" type="FUNCTION *" prototype="ERR (*GetValue)(APTR, APTR)">A virtual function that will retrieve the value for this field</field>
-      <field name="SetValue" type="APTR">A virtual function that will set the value for this field</field>
+      <field name="SetValue" type="FUNCTION *" prototype="ERR (*SetValue)(APTR, APTR)">A virtual function that will set the value for this field</field>
       <field name="WriteValue" type="FUNCTION *" prototype="ERR (*WriteValue)(OBJECTPTR, const struct Field *, int, const void *)">An internal function for writing to this field</field>
       <field name="Name" type="CSTRING">The English name for the field, e.g. <code>Width</code></field>
       <field name="FieldID" type="UINT">32-bit hash from fieldhash()</field>

--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -1446,7 +1446,7 @@ struct FileFeedback {
 struct Field {
    MAXINT   Arg;                                                              // An option to complement the field type.  Can be a pointer or an integer value
    ERR (*GetValue)(APTR, APTR);                                               // A virtual function that will retrieve the value for this field
-   APTR     SetValue;                                                         // A virtual function that will set the value for this field
+   ERR (*SetValue)(APTR, APTR);                                               // A virtual function that will set the value for this field
    ERR (*WriteValue)(OBJECTPTR, const struct Field *, int, const void *);     // An internal function for writing to this field
    CSTRING  Name;                                                             // The English name for the field, e.g. Width
    uint32_t FieldID;                                                          // 32-bit hash from fieldhash()

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -114,7 +114,7 @@ static const FieldDef CategoryTable[] = {
 static const std::vector<Field> glMetaFieldsPreset = {
    // If you adjust this table, remember to adjust the index numbers and the byte offsets into the structure.
    { 0, nullptr, nullptr, writeval_default, "ClassVersion",    strhash("classVersion"), glMetaClassVersionOffset, 0, FDF_DOUBLE|FDF_RI },
-   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_Fields, (APTR)SET_Fields, writeval_default, "Fields", strhash("fields"), glMetaFieldsOffset, 1, FDF_ARRAY|FD_STRUCT|FDF_RI },
+   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_Fields, (ERR (*)(APTR, APTR))SET_Fields, writeval_default, "Fields", strhash("fields"), glMetaFieldsOffset, 1, FDF_ARRAY|FD_STRUCT|FDF_RI },
    { MAXINT("Field"),      (ERR (*)(APTR, APTR))GET_Dictionary, nullptr, writeval_default, "Dictionary", strhash("dictionary"), glMetaDictionaryOffset, 2, FDF_ARRAY|FD_STRUCT|FDF_R },
    { 0, nullptr, nullptr, writeval_default, "ClassName",       strhash("className"),       glMetaClassNameOffset,        3,  FDF_CPPSTRING|FDF_RI|FDF_PURE },
    { 0, nullptr, nullptr, writeval_default, "FileExtension",   strhash("fileExtension"),   glMetaFileExtensionOffset,    4,  FDF_CPPSTRING|FDF_RI|FDF_PURE },
@@ -130,11 +130,11 @@ static const std::vector<Field> glMetaFieldsPreset = {
    { MAXINT(&CategoryTable), nullptr, nullptr, writeval_default, "Category",  strhash("category"), glMetaCategoryOffset, 14, FDF_INT|FDF_LOOKUP|FDF_RI },
    { 0, nullptr, nullptr, writeval_default, "PublicSize",      strhash("publicSize"),      glMetaPublicSizeOffset,       15, FDF_INT|FDF_RI },
    // Virtual fields
-   { MAXINT("MethodEntry"), (ERR (*)(APTR, APTR))GET_Methods, (APTR)SET_Methods, writeval_default, "Methods", strhash("methods"), sizeof(Object), 16, FDF_ARRAY|FD_STRUCT|FDF_RI },
-   { 0, nullptr, (APTR)SET_Actions,               writeval_default,   "Actions",           strhash("actions"),         sizeof(Object), 17, FDF_POINTER|FDF_I },
+   { MAXINT("MethodEntry"), (ERR (*)(APTR, APTR))GET_Methods, (ERR (*)(APTR, APTR))SET_Methods, writeval_default, "Methods", strhash("methods"), sizeof(Object), 16, FDF_ARRAY|FD_STRUCT|FDF_RI },
+   { 0, nullptr, (ERR (*)(APTR, APTR))SET_Actions,               writeval_default,   "Actions",           strhash("actions"),         sizeof(Object), 17, FDF_POINTER|FDF_I },
    { 0, (ERR (*)(APTR, APTR))GET_ActionTable, 0,  writeval_default,   "ActionTable",       strhash("actionTable"),     sizeof(Object), 18, FDF_ARRAY|FDF_POINTER|FDF_R },
    { 0, (ERR (*)(APTR, APTR))GET_Location, 0,     writeval_default,   "Location",          strhash("location"),        sizeof(Object), 19, FDF_CPPSTRING|FDF_R|FDF_PURE },
-   { 0, (ERR (*)(APTR, APTR))GET_ClassName, (APTR)SET_ClassName, writeval_default, "Name", strhash("name"),            sizeof(Object), 20, FDF_CPPSTRING|FDF_SYSTEM|FDF_RI|FDF_PURE },
+   { 0, (ERR (*)(APTR, APTR))GET_ClassName, (ERR (*)(APTR, APTR))SET_ClassName, writeval_default, "Name", strhash("name"),            sizeof(Object), 20, FDF_CPPSTRING|FDF_SYSTEM|FDF_RI|FDF_PURE },
    { 0, (ERR (*)(APTR, APTR))GET_Module, 0,       writeval_default,   "Module",            strhash("module"),          sizeof(Object), 21, FDF_CPPSTRING|FDF_R },
    { 0, (ERR (*)(APTR, APTR))GET_Objects, 0,      writeval_default,   "Objects",           strhash("objects"),         sizeof(Object), 22, FDF_ARRAY|FDF_INT|FDF_ALLOC|FDF_R },
    { MAXINT(CLASSID::METACLASS), (ERR (*)(APTR, APTR))GET_SubClasses, nullptr, writeval_default, "SubClasses", strhash("subClasses"), sizeof(Object), 23, FDF_ARRAY|FD_OBJECT|FDF_R },
@@ -913,7 +913,7 @@ static void field_setup(extMetaClass *Class)
                   }
 
                   if (Class->SubFields[i].SetField) {
-                     Class->FieldLookup[j].SetValue = Class->SubFields[i].SetField;
+                     Class->FieldLookup[j].SetValue = (ERR (*)(APTR, APTR))Class->SubFields[i].SetField;
                      if (Class->FieldLookup[j].Flags & (FDF_W|FDF_I));
                      else Class->FieldLookup[j].Flags |= FDF_W;
                   }
@@ -967,7 +967,7 @@ static void field_setup(extMetaClass *Class)
          Class->FieldLookup.push_back({
             .Arg        = 0,
             .GetValue   = (ERR (*)(APTR, APTR))&OBJECT_GetName,
-            .SetValue   = (APTR)&OBJECT_SetName,
+            .SetValue   = (ERR (*)(APTR, APTR))&OBJECT_SetName,
             .WriteValue = &writeval_default,
             .Name       = "Name",
             .FieldID    = strhash("name"),
@@ -981,7 +981,7 @@ static void field_setup(extMetaClass *Class)
          Class->FieldLookup.push_back({
             .Arg        = 0,
             .GetValue   = (ERR (*)(APTR, APTR))&OBJECT_GetOwner,
-            .SetValue   = (APTR)&OBJECT_SetOwner,
+            .SetValue   = (ERR (*)(APTR, APTR))&OBJECT_SetOwner,
             .WriteValue = &writeval_default,
             .Name       = "Owner",
             .FieldID    = strhash("owner"),
@@ -1111,7 +1111,7 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
    CSTRING field_type = nullptr;
    MAXINT field_arg = Source.Arg;
    auto get_field = (ERR (*)(APTR, APTR))Source.GetField;
-   auto set_field = Source.SetField;
+   auto set_field = (ERR (*)(APTR, APTR))Source.SetField;
    auto field_flags = Source.Flags;
 
    if ((Source.Flags & FD_SYNONYM) and ((Source.Flags & ~FD_SYNONYM) IS FD_VOID)) {

--- a/src/core/compression/class_compression.cpp
+++ b/src/core/compression/class_compression.cpp
@@ -1973,11 +1973,11 @@ static const FieldArray clFields[] = {
    { "MinOutputSize",    FDF_INT|FDF_R },
    { "WindowBits",       FDF_INT|FDF_RW, nullptr, SET_WindowBits },
    // Virtual fields
-   { "ArchiveName",      FDF_CPPSTRING|FDF_W,    nullptr, SET_ArchiveName },
-   { "Feedback",         FDF_FUNCTION|FDF_RW,    GET_Feedback, SET_Feedback },
-   { "Header",           FDF_POINTER|FDF_R,      GET_Header },
-   { "Size",             FDF_INT64|FDF_R,        GET_Size },
-   { "UncompressedSize", FDF_INT64|FDF_R,        GET_UncompressedSize },
+   { "ArchiveName",      FDF_CPPSTRING|FDF_W, nullptr, SET_ArchiveName },
+   { "Feedback",         FDF_FUNCTION|FDF_RW, GET_Feedback, SET_Feedback },
+   { "Header",           FDF_POINTER|FDF_R,   GET_Header },
+   { "Size",             FDF_INT64|FDF_R,     GET_Size },
+   { "UncompressedSize", FDF_INT64|FDF_R,     GET_UncompressedSize },
    END_FIELD
 };
 

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -440,7 +440,7 @@ static ERR remove_file(extCompression *Self, std::list<ZipFile>::iterator &File)
       if (acSeekStart(Self->FileIO, read_cursor) != ERR::Okay) return log.warning(ERR::Seek);
    }
 
-   Self->FileIO->set(strhash("size"), write_cursor);
+   Self->FileIO->setSize(write_cursor);
 
    // Adjust the offset of files that are ahead of this one
 
@@ -763,7 +763,7 @@ static void write_eof(extCompression *Self)
          wrb<uint32_t>(listoffset, tail + TAIL_FILELISTOFFSET);
          acWriteResult(Self->FileIO, tail, TAIL_LENGTH);
       }
-      else Self->FileIO->set(strhash("size"), 0);
+      else Self->FileIO->setSize(0);
 
       Self->CompressionCount = 0;
    }

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -687,10 +687,12 @@ class objTask;
   FileFeedback() : Size(0), Position(0), Path(nullptr), Dest(nullptr), FeedbackID(FBK::NIL) { }
   ]])
 
+  -- WriteValue signature is Object, *Field, Flags, *Value
+
   structdef("Field", { comment="Used to describe the public fields of a class." }, [[
     maxint Arg         # An option to complement the field type.  Can be a pointer or an integer value
     fptr(error ptr ptr) GetValue # A virtual function that will retrieve the value for this field
-    ptr SetValue       # A virtual function that will set the value for this field
+    fptr(error ptr ptr) SetValue # A virtual function that will set the value for this field
     fptr(error obj cstruct(*Field) int cptr) WriteValue # An internal function for writing to this field
     cstr Name          # The English name for the field, e.g. `Width`
     uint FieldID       # 32-bit hash from fieldhash()

--- a/src/core/lib_fields_write.cpp
+++ b/src/core/lib_fields_write.cpp
@@ -111,7 +111,7 @@ requires std::is_integral_v<T>
 }
 
 //********************************************************************************************************************
-// Used by some of the SetField() range of instructions.
+// Used by some of the SetField() and Create() range of instructions.
 
 ERR writeval_default(OBJECTPTR Object, const Field *Field, int flags, CPTR Data)
 {


### PR DESCRIPTION
* Typed Field SetValue entries as ERR callbacks across generated headers, metadata and documentation
* Used FileIO setSize() when resizing compression archives