### PR TITLE
[Audio] Switched audio buffers to vector-backed storage

### DIFF
--- a/src/audio/alsa.cpp
+++ b/src/audio/alsa.cpp
@@ -9,7 +9,6 @@ static void free_alsa(extAudio *Self)
    if (Self->sndlog) { snd_output_close(Self->sndlog); Self->sndlog = nullptr; }
    if (Self->Handle) { snd_pcm_close(Self->Handle); Self->Handle = nullptr; }
    if (Self->MixHandle) { snd_mixer_close(Self->MixHandle); Self->MixHandle = nullptr; }
-   if (Self->AudioBuffer) { FreeResource(Self->AudioBuffer); Self->AudioBuffer = nullptr; }
 }
 
 //********************************************************************************************************************
@@ -329,64 +328,56 @@ static ERR init_audio(extAudio *Self)
    // Note that ALSA reports the audio buffer size in samples, not bytes
 
    snd_pcm_hw_params_get_buffer_size(hwparams, &buffersize);
-   Self->AudioBufferSize = BYTELEN(buffersize);
+   auto buf_size = BYTELEN(buffersize);
 
-   if (Self->Stereo) Self->AudioBufferSize = BYTELEN(Self->AudioBufferSize<<1);
-   Self->AudioBufferSize = BYTELEN(Self->AudioBufferSize * (Self->BitDepth/8));
+   if (Self->Stereo) buf_size = BYTELEN(buf_size<<1);
+   buf_size = BYTELEN(buf_size * (Self->BitDepth/8));
 
-   log.msg("Total Periods: %d, Period Size: %d, Buffer Size: %d (bytes)", Self->Periods, Self->PeriodSize, Self->AudioBufferSize);
+   log.msg("Total Periods: %d, Period Size: %d, Buffer Size: %d (bytes)", Self->Periods, Self->PeriodSize, buf_size);
 
-   // Allocate a buffer that we will use for audio output
+   Self->AudioBuffer.resize(buf_size);
+   if ((Self->Flags & ADF::SYSTEM_WIDE) != ADF::NIL) {
+      log.msg("Applying user configured volumes.");
 
-   if (Self->AudioBuffer) { FreeResource(Self->AudioBuffer); Self->AudioBuffer = nullptr; }
+      auto oldctl = Self->Volumes;
+      Self->Volumes = volctl;
 
-   if (!AllocMemory(Self->AudioBufferSize, MEM::DATA, (APTR *)&Self->AudioBuffer)) {
-      if ((Self->Flags & ADF::SYSTEM_WIDE) != ADF::NIL) {
-         log.msg("Applying user configured volumes.");
-
-         auto oldctl = Self->Volumes;
-         Self->Volumes = volctl;
-
-         for (int i=0; i < (int)volctl.size(); i++) {
-            int j;
-            for (j=0; j < (int)oldctl.size(); j++) {
-               if (volctl[i].Name == oldctl[j].Name) {
-                  setvol.Index   = i;
-                  setvol.Name    = std::string_view{};
-                  setvol.Flags   = SVF::NIL;
-                  setvol.Channel = -1;
-                  setvol.Volume  = oldctl[j].Channels[0];
-                  if ((oldctl[j].Flags & VCF::MUTE) != VCF::NIL) setvol.Flags |= SVF::MUTE;
-                  else setvol.Flags |= SVF::UNMUTE;
-                  Action(snd::SetVolume::id, Self, &setvol);
-                  break;
-               }
-            }
-
-            // If the user has no volume defined for a mixer, set our own.
-
-            if (j IS (int)oldctl.size()) {
+      for (int i=0; i < std::ssize(volctl); i++) {
+         int j;
+         for (j=0; j < std::ssize(oldctl); j++) {
+            if (volctl[i].Name == oldctl[j].Name) {
                setvol.Index   = i;
                setvol.Name    = std::string_view{};
                setvol.Flags   = SVF::NIL;
                setvol.Channel = -1;
-               setvol.Volume  = 0.8;
+               setvol.Volume  = oldctl[j].Channels[0];
+               if ((oldctl[j].Flags & VCF::MUTE) != VCF::NIL) setvol.Flags |= SVF::MUTE;
+               else setvol.Flags |= SVF::UNMUTE;
                Action(snd::SetVolume::id, Self, &setvol);
+               break;
             }
          }
-      }
-      else {
-         log.msg("Skipping preset volumes.");
-         Self->Volumes = volctl;
-      }
 
-      // Free existing volume measurements and apply the information that we read from alsa.
+         // If the user has no volume defined for a mixer, set our own.
 
-      Self->Handle = pcmhandle;
+         if (j IS std::ssize(oldctl)) {
+            setvol.Index   = i;
+            setvol.Name    = std::string_view{};
+            setvol.Flags   = SVF::NIL;
+            setvol.Channel = -1;
+            setvol.Volume  = 0.8;
+            Action(snd::SetVolume::id, Self, &setvol);
+         }
+      }
    }
    else {
-      return log.warning(ERR::AllocMemory);
+      log.msg("Skipping preset volumes.");
+      Self->Volumes = volctl;
    }
+
+   // Free existing volume measurements and apply the information that we read from alsa.
+
+   Self->Handle = pcmhandle;
 
    return ERR::Okay;
 }

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -67,12 +67,12 @@ typedef struct _GUID {
 } GUID;
 
 typedef struct WAVEFormat {
-   int16_t Format;               // Type of WAVE data in the chunk: RAW or ADPCM
-   int16_t Channels;             // Number of channels, 1=mono, 2=stereo
-   int Frequency;            // Playback frequency
-   int AvgBytesPerSecond;    // Channels * SamplesPerSecond * (BitsPerSample / 8)
-   int16_t BlockAlign;           // Channels * (BitsPerSample / 8)
-   int16_t BitsPerSample;        // Bits per sample
+   int16_t Format;            // Type of WAVE data in the chunk: RAW or ADPCM
+   int16_t Channels;          // Number of channels, 1=mono, 2=stereo
+   int Frequency;             // Playback frequency
+   int AvgBytesPerSecond;     // Channels * SamplesPerSecond * (BitsPerSample / 8)
+   int16_t BlockAlign;        // Channels * (BitsPerSample / 8)
+   int16_t BitsPerSample;     // Bits per sample
    int16_t ExtraLength;
 } WAVEFORMATEX;
 
@@ -90,7 +90,7 @@ struct PlatformData { void *Void; };
 struct AudioSample {
    FUNCTION Callback;     // For feeding audio streams.
    FUNCTION OnStop;       // Called when playback stops.
-   uint8_t *  Data;         // Pointer to the sample data.
+   std::vector<uint8_t> Data; // Sample data.
    SAMPLE   Loop1Start;   // Start of the first loop
    SAMPLE   Loop1End;     // End of the first loop
    SAMPLE   Loop2Start;   // Start of the second loop
@@ -105,7 +105,6 @@ struct AudioSample {
    bool     Stream;       // True if this is a stream
 
    AudioSample() {
-      Data     = nullptr;
       Stream   = false;
       clear();
    }
@@ -115,11 +114,9 @@ struct AudioSample {
    }
 
    void clear() {
-      if (Data) FreeResource(Data);
-
       Callback.clear();
       OnStop.clear();
-      Data         = nullptr;
+      std::vector<uint8_t>().swap(Data);
       SampleLength = SAMPLE(0);
       Loop1Start   = SAMPLE(0);
       Loop1End     = SAMPLE(0);
@@ -233,22 +230,20 @@ class extAudio : public objAudio {
    std::vector<VolumeCtl> Volumes;
    std::vector<MixTimer> MixTimers;
    AudioConfig MixConfig;
-   APTR  MixBuffer;
+   std::vector<float> MixBuffer;
    APTR  TaskRemovedHandle;
    APTR  UserLoginHandle;
    #ifdef _WIN32
       uint8_t  PlatformData[128];  // Data area for holding platform/hardware specific information
    #endif
    #ifdef ALSA_ENABLED
-      uint8_t *AudioBuffer;
+      std::vector<uint8_t> AudioBuffer;
       snd_pcm_t    *Handle;
       snd_mixer_t  *MixHandle;
       snd_output_t *sndlog;
-      BYTELEN AudioBufferSize;    // Buffer size measured in bytes
    #endif
    double  MasterVolume;
    TIMER   Timer;
-   BYTELEN MixBufferSize;
    SAMPLE  MixElements;
    int     MaxChannels;    // Recommended maximum mixing channels for Sound class
    std::string Device;

--- a/src/audio/class_audio.cpp
+++ b/src/audio/class_audio.cpp
@@ -52,7 +52,7 @@ inline double extAudio::MixerLag() {
          // Windows uses a split buffer technique, so the write cursor is always 1/2 a buffer ahead.
          mixerLag = MIX_INTERVAL + (double(MixElements>>1) / double(OutputRate));
       #elif ALSA_ENABLED
-         mixerLag = MIX_INTERVAL + (AudioBufferSize / DriverBitSize) / double(OutputRate);
+         mixerLag = MIX_INTERVAL + (double(AudioBuffer.size()) / double(DriverBitSize)) / double(OutputRate);
       #endif
       log.trace("Mixer lag: %.2f", mixerLag);
    }
@@ -100,7 +100,6 @@ object can perform configuration operations but cannot process audio samples.
 
 -ERRORS-
 Okay: Hardware activation completed successfully.
-AllocMemory: Failed to allocate internal mixing buffers.
 Failed: Hardware device unavailable or driver initialisation failed.
 
 *********************************************************************************************************************/
@@ -134,48 +133,43 @@ static ERR AUDIO_Activate(extAudio *Self)
 
    const int mixbitsize = Self->Stereo ? sizeof(float) * 2 : sizeof(float);
 
-   Self->MixBufferSize = BYTELEN((int((mixbitsize * Self->OutputRate) * (MIX_INTERVAL * 1.5)) + 15) & (~15));
-   Self->MixElements   = SAMPLE(Self->MixBufferSize / mixbitsize);
+   auto mix_buffer_size = BYTELEN((int((mixbitsize * Self->OutputRate) * (MIX_INTERVAL * 1.5)) + 15) & (~15));
+   Self->MixBuffer.resize(mix_buffer_size / sizeof(float));
+   Self->MixElements = SAMPLE(mix_buffer_size / mixbitsize);
 
-   if (!AllocMemory(Self->MixBufferSize, MEM::DATA, &Self->MixBuffer)) {
-      // Configure the mixing system
+   // Configure the mixing system
 
-      bool use_interpolation = (Self->Flags & ADF::OVER_SAMPLING) != ADF::NIL;
-      Self->MixConfig = AudioConfig(Self->Stereo, use_interpolation);
+   bool use_interpolation = (Self->Flags & ADF::OVER_SAMPLING) != ADF::NIL;
+   Self->MixConfig = AudioConfig(Self->Stereo, use_interpolation);
 
-      #ifdef _WIN32
-         WAVEFORMATEX wave = {
-            .Format            = int16_t((Self->BitDepth IS 32) ? WAVE_FLOAT : WAVE_RAW),
-            .Channels          = int16_t(Self->Stereo ? 2 : 1),
-            .Frequency         = 44100,
-            .AvgBytesPerSecond = 44100 * Self->DriverBitSize,
-            .BlockAlign        = Self->DriverBitSize,
-            .BitsPerSample     = int16_t(Self->BitDepth),
-            .ExtraLength       = 0
-         };
+   #ifdef _WIN32
+      WAVEFORMATEX wave = {
+         .Format            = int16_t((Self->BitDepth IS 32) ? WAVE_FLOAT : WAVE_RAW),
+         .Channels          = int16_t(Self->Stereo ? 2 : 1),
+         .Frequency         = 44100,
+         .AvgBytesPerSecond = 44100 * Self->DriverBitSize,
+         .BlockAlign        = Self->DriverBitSize,
+         .BitsPerSample     = int16_t(Self->BitDepth),
+         .ExtraLength       = 0
+      };
 
-         if (auto strerr = sndCreateBuffer(Self, &wave, Self->MixBufferSize, 0x7fffffff, (PlatformData *)Self->PlatformData, TRUE)) {
-            log.warning(strerr);
-            Self->Initialising = false;
-            return ERR::Failed;
-         }
+      if (auto strerr = sndCreateBuffer(Self, &wave, mix_buffer_size, 0x7fffffff, (PlatformData *)Self->PlatformData, TRUE)) {
+         log.warning(strerr);
+         Self->Initialising = false;
+         return ERR::Failed;
+      }
 
-         if (sndPlay((PlatformData *)Self->PlatformData, TRUE, 0)) {
-            Self->Initialising = false;
-            return log.warning(ERR::Failed);
-         }
-      #endif
+      if (sndPlay((PlatformData *)Self->PlatformData, TRUE, 0)) {
+         Self->Initialising = false;
+         return log.warning(ERR::Failed);
+      }
+   #endif
 
-      // Note: The audio feed is managed by audio_timer() and is not started until an audio playback command
-      // is executed by the client.
+   // Note: The audio feed is managed by audio_timer() and is not started until an audio playback command
+   // is executed by the client.
 
-      Self->Initialising = false;
-      return ERR::Okay;
-   }
-   else {
-      Self->Initialising = false;
-      return log.warning(ERR::AllocMemory);
-   }
+   Self->Initialising = false;
+   return ERR::Okay;
 }
 
 /*********************************************************************************************************************
@@ -242,7 +236,7 @@ ERR AUDIO_AddSample(extAudio *Self, struct snd::AddSample *Args)
 
    int idx;
    for (idx=1; idx < std::ssize(Self->Samples); idx++) {
-      if (!Self->Samples[idx].Data) break;
+      if (Self->Samples[idx].Data.empty()) break;
    }
 
    if (idx >= std::ssize(Self->Samples)) Self->Samples.resize(std::ssize(Self->Samples)+10);
@@ -275,14 +269,11 @@ ERR AUDIO_AddSample(extAudio *Self, struct snd::AddSample *Args)
    }
 
    if ((sample.SampleType IS SFM::NIL) or (Args->DataSize <= 0) or (!Args->Data)) {
-      sample.Data = nullptr;
-   }
-   else if (!AllocMemory(Args->DataSize, MEM::DATA|MEM::NO_CLEAR, (APTR *)&sample.Data)) {
-      copymem(Args->Data, sample.Data, Args->DataSize);
+      sample.Data.clear();
    }
    else {
-      deref_audio_sample(sample);
-      return log.warning(ERR::AllocMemory);
+      sample.Data.resize(Args->DataSize);
+      copymem(Args->Data, sample.Data.data(), Args->DataSize);
    }
 
    Args->Result = idx;
@@ -365,7 +356,7 @@ static ERR AUDIO_AddStream(extAudio *Self, struct snd::AddStream *Args)
 
    int idx;
    for (idx=1; idx < std::ssize(Self->Samples); idx++) {
-      if (!Self->Samples[idx].Data) break;
+      if (Self->Samples[idx].Data.empty()) break;
    }
 
    if (idx >= std::ssize(Self->Samples)) Self->Samples.resize(std::ssize(Self->Samples)+10);
@@ -380,7 +371,11 @@ static ERR AUDIO_AddStream(extAudio *Self, struct snd::AddStream *Args)
    else buffer_len = MAX_STREAM_BUFFER; // Use the recommended amount of buffer space
 
    #ifdef ALSA_ENABLED
-      if (buffer_len < Self->AudioBufferSize) log.warning("Warning: Buffer length of %d is less than audio buffer size of %d.", buffer_len, Self->AudioBufferSize);
+      auto audio_buffer_size = int(Self->AudioBuffer.size());
+      if (buffer_len < audio_buffer_size) {
+         log.warning("Warning: Buffer length of %d is less than audio buffer size of %d.",
+            buffer_len, audio_buffer_size);
+      }
    #endif
 
    // Setup the audio sample
@@ -411,11 +406,7 @@ static ERR AUDIO_AddStream(extAudio *Self, struct snd::AddStream *Args)
       if (sample.Loop2Start IS sample.Loop2End) sample.Loop2Type = LTYPE::NIL;
    }
 
-   if (AllocMemory(buffer_len, MEM::DATA|MEM::NO_CLEAR, (APTR *)&sample.Data) != ERR::Okay) {
-      deref_audio_sample(sample);
-      return ERR::AllocMemory;
-   }
-
+   sample.Data.resize(buffer_len);
    Args->Result = idx;
    return ERR::Okay;
 }
@@ -525,8 +516,6 @@ static ERR AUDIO_Deactivate(extAudio *Self)
 
 #ifdef ALSA_ENABLED
    free_alsa(Self);
-   //if (Self->MixHandle) { snd_mixer_close(Self->MixHandle); Self->MixHandle = NULL; }
-   //if (Self->Handle) { snd_pcm_close(Self->Handle); Self->Handle = 0; }
 #endif
 
    return ERR::Okay;
@@ -1464,8 +1453,6 @@ extAudio::~extAudio() {
    glSoundChannels.erase(UID);
 
    acDeactivate(this);
-
-   if (MixBuffer) FreeResource(MixBuffer);
 
 #ifdef ALSA_ENABLED
 

--- a/src/audio/commands.cpp
+++ b/src/audio/commands.cpp
@@ -403,7 +403,7 @@ ERR MixPlay(objAudio *Audio, int Handle, int Position)
 
    auto bitpos = SAMPLE(Position >> sample_shift(sample.SampleType));
 
-   if (!sample.Data) { // The sample reference must be valid and not stale.
+   if (sample.Data.empty()) { // The sample reference must be valid and not stale.
       log.warning("On channel %d, referenced sample %d is unconfigured.", Handle, channel->SampleHandle);
       return ERR::Failed;
    }
@@ -634,7 +634,7 @@ ERR MixSample(objAudio *Audio, int Handle, int SampleIndex)
    if ((idx <= 0) or (idx >= (int)((extAudio *)Audio)->Samples.size())) {
       return log.warning(ERR::OutOfRange);
    }
-   else if (!((extAudio *)Audio)->Samples[idx].Data) {
+   else if (((extAudio *)Audio)->Samples[idx].Data.empty()) {
       log.warning("Sample #%d refers to a dead sample.", idx);
       return ERR::Failed;
    }

--- a/src/audio/functions.cpp
+++ b/src/audio/functions.cpp
@@ -168,13 +168,13 @@ static BYTELEN fill_stream_buffer(int Handle, AudioSample &Sample, int Offset)
    if (Sample.Callback.isC()) {
       kt::SwitchContext context(Sample.Callback.Context);
       auto routine = (BYTELEN (*)(int, int, uint8_t *, int, APTR))Sample.Callback.Routine;
-      return routine(Handle, Offset, Sample.Data, Sample.SampleLength<<sample_shift(Sample.SampleType), Sample.Callback.Meta);
+      return routine(Handle, Offset, Sample.Data.data(), Sample.SampleLength<<sample_shift(Sample.SampleType), Sample.Callback.Meta);
    }
    else if (Sample.Callback.isScript()) {
       const auto args = std::to_array<ScriptArg>({
          { "Handle", Handle },
          { "Offset", Offset },
-         { "Buffer", Sample.Data, FD_BUFFER },
+         { "Buffer", Sample.Data.data(), FD_BUFFER },
          { "Length", Sample.SampleLength<<sample_shift(Sample.SampleType), FD_BUFSIZE|FD_INT }
       });
 
@@ -373,8 +373,8 @@ static ERR audio_timer(extAudio *Self, int64_t Elapsed, int64_t CurrentTime)
    if (Self->Handle) {
       space_left = SAMPLE(snd_pcm_avail_update(Self->Handle)); // Returns available space measured in samples
    }
-   else if (Self->AudioBufferSize) { // Run in dummy mode - samples will be processed but not played
-      space_left = SAMPLE(Self->AudioBufferSize / Self->DriverBitSize);
+   else if (!Self->AudioBuffer.empty()) { // Run in dummy mode - samples will be processed but not played
+      space_left = SAMPLE(Self->AudioBuffer.size() / Self->DriverBitSize);
    }
    else {
       log.warning("ALSA not in an initialised state.");
@@ -402,14 +402,15 @@ static ERR audio_timer(extAudio *Self, int64_t Elapsed, int64_t CurrentTime)
       return ERR::Okay;
    }
 
-   if (space_left > SAMPLE(Self->AudioBufferSize / Self->DriverBitSize)) {
-      space_left = SAMPLE(Self->AudioBufferSize / Self->DriverBitSize);
+   auto buffer_size = SAMPLE(Self->AudioBuffer.size() / Self->DriverBitSize);
+   if (space_left > buffer_size) {
+      space_left = buffer_size;
    }
 
    // Fill our entire audio buffer with data to be sent to alsa
 
    auto space = space_left;
-   uint8_t *buffer = Self->AudioBuffer;
+   uint8_t *buffer = Self->AudioBuffer.data();
    while (space_left) {
       // Scan channels to check if an update rate is going to be met
 
@@ -434,7 +435,7 @@ static ERR audio_timer(extAudio *Self, int64_t Elapsed, int64_t CurrentTime)
 
    if (Self->Handle) {
       int err;
-      if ((err = snd_pcm_writei(Self->Handle, Self->AudioBuffer, space)) < 0) {
+      if ((err = snd_pcm_writei(Self->Handle, Self->AudioBuffer.data(), space)) < 0) {
          // If an EPIPE error is returned, a buffer underrun has probably occurred
 
          if (err IS -EPIPE) {
@@ -452,7 +453,7 @@ static ERR audio_timer(extAudio *Self, int64_t Elapsed, int64_t CurrentTime)
                if ((err = snd_pcm_prepare(Self->Handle)) >= 0) {
                   // Have another try at writing the audio data
                   if (snd_pcm_avail_update(Self->Handle) >= space) {
-                     snd_pcm_writei(Self->Handle, Self->AudioBuffer, space);
+                     snd_pcm_writei(Self->Handle, Self->AudioBuffer.data(), space);
                   }
                }
                else log.warning("snd_pcm_prepare() %s", snd_strerror(err));
@@ -688,7 +689,7 @@ static bool handle_sample_end(extAudio *Self, AudioChannel &Channel)
          BYTELEN bytes_read = fill_stream_buffer(Channel.SampleHandle, sample, -1);
          auto buffer_len = sample.SampleLength<<sample_shift(sample.SampleType);
          if (bytes_read < buffer_len) {
-            clearmem(sample.Data + bytes_read, buffer_len - bytes_read);
+            clearmem(sample.Data.data() + bytes_read, buffer_len - bytes_read);
          }
 
          if ((bytes_read <= 0) or (sample.PlayPos >= sample.StreamLength)) {
@@ -772,37 +773,37 @@ static bool handle_sample_end(extAudio *Self, AudioChannel &Channel)
       // Clear the mix buffer, then mix all channels to the buffer
 
       int window_size = sizeof(float) * (Self->Stereo ? (window<<1) : window);
-      clearmem(Self->MixBuffer, window_size);
+      clearmem(Self->MixBuffer.data(), window_size);
 
       for (auto n=1; n < (int)Self->Sets.size(); n++) {
          for (auto &c : Self->Sets[n].Channel) {
-            if (c.active()) mix_channel(Self, c, window, Self->MixBuffer);
+            if (c.active()) mix_channel(Self, c, window, Self->MixBuffer.data());
          }
 
          for (auto &c : Self->Sets[n].Shadow) {
-            if (c.active()) mix_channel(Self, c, window, Self->MixBuffer);
+            if (c.active()) mix_channel(Self, c, window, Self->MixBuffer.data());
          }
       }
 
       // Do optional post-processing
 
       if ((Self->Flags & (ADF::FILTER_LOW|ADF::FILTER_HIGH)) != ADF::NIL) {
-         if (Self->Stereo) filter_float_stereo(Self, (float *)Self->MixBuffer, window);
-         else filter_float_mono(Self, (float *)Self->MixBuffer, window);
+         if (Self->Stereo) filter_float_stereo(Self, Self->MixBuffer.data(), window);
+         else filter_float_mono(Self, Self->MixBuffer.data(), window);
       }
 
       // Convert the floating point data to the correct output format
 
       if (Self->BitDepth IS 32) { // Presumes a floating point target identical to our own
-         convert_float((float *)Self->MixBuffer, (Self->Stereo) ? window<<1 : window, (float *)Dest);
+         convert_float(Self->MixBuffer.data(), (Self->Stereo) ? window<<1 : window, (float *)Dest);
       }
       else if (Self->BitDepth IS 24) {
 
       }
       else if (Self->BitDepth IS 16) {
-         convert_float16((float *)Self->MixBuffer, (Self->Stereo) ? window<<1 : window, (int16_t *)Dest);
+         convert_float16(Self->MixBuffer.data(), (Self->Stereo) ? window<<1 : window, (int16_t *)Dest);
       }
-      else convert_float8((float *)Self->MixBuffer,  (Self->Stereo) ? window<<1 : window, (uint8_t *)Dest);
+      else convert_float8(Self->MixBuffer.data(),  (Self->Stereo) ? window<<1 : window, (uint8_t *)Dest);
 
       Dest = ((uint8_t *)Dest) + (window * Self->DriverBitSize);
       Elements -= window;
@@ -821,7 +822,7 @@ static void mix_channel(extAudio *Self, AudioChannel &Channel, int TotalSamples,
 
    // Check that we have something to mix
 
-   if ((!Channel.Frequency) or (!sample.Data) or (sample.SampleLength <= 0)) return;
+   if ((!Channel.Frequency) or (sample.Data.empty()) or (sample.SampleLength <= 0)) return;
 
    // Calculate resampling step (16.16 fixed point)
 
@@ -888,7 +889,7 @@ static void mix_channel(extAudio *Self, AudioChannel &Channel, int TotalSamples,
          }
 
          int mix_pos = Channel.PositionLow;
-         uint8_t *MixSample = sample.Data + (sample_size * Channel.Position); // source of sample data to mix into destination
+         uint8_t *MixSample = sample.Data.data() + (sample_size * Channel.Position); // source of sample data to mix into destination
 
          // Thread-safe: pass step direction as parameter instead of using global
          const int mix_step = ((Channel.Flags & CHF::BACKWARD) != CHF::NIL) ? -step : step;
@@ -966,7 +967,7 @@ static void mix_channel(extAudio *Self, AudioChannel &Channel, int TotalSamples,
 
          // Save state back to channel structure
          Channel.PositionLow = mix_pos & 0xffff;
-         Channel.Position = (mix_pos>>16) + ((MixSample - sample.Data) / sample_size);
+         Channel.Position = (mix_pos>>16) + ((MixSample - sample.Data.data()) / sample_size);
       }
       else if (mix_now < 0) {
          log.warning("Detected invalid mix values; TotalSamples: %d, MixNow: %d, SUE: %d, NextOffset: %d, Step: %d, ChannelPos: %d", TotalSamples, mix_now, sue, next_offset, step, Channel.Position);


### PR DESCRIPTION
* Replaced manual sample and mixer allocations with std::vector storage
* Updated ALSA output paths to size and write through vector buffers