### PR TITLE
[Core] Store File buffers in kt::vector

### DIFF
--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -426,7 +426,7 @@
       <name>Buffer</name>
       <comment>Points to the internal data buffer if the file content is held in memory.</comment>
       <access read="G">Get</access>
-      <type>INT8[]</type>
+      <type>kt::vector&lt;int8_t&gt;</type>
       <description>
 <p>If a file has been created with an internal buffer (by setting the <code>BUFFER</code> flag on creation), this field will point to the address of that buffer.  The size of the buffer will match the <fl>Size</fl> field.</p>
       </description>

--- a/include/kotuku/modules/filesystem.h
+++ b/include/kotuku/modules/filesystem.h
@@ -134,12 +134,12 @@ class objFile : public Object {
    using create = kt::Create<objFile>;
    objFile(objMetaClass *pClass, OBJECTID pUID) noexcept : Object(pClass, pUID) {}
 
-   int64_t  Position;   // The current read/write byte position in a file.
-   std::string Path;    // Specifies the location of a file or folder.
-   FL       Flags;      // File flags and options.
-   PERMIT   Permissions; // Manages the permissions of a file.
-   int8_t * Buffer;     // Points to the internal data buffer if the file content is held in memory.
-   int64_t  Size;       // The byte size of a file.
+   int64_t Position;             // The current read/write byte position in a file.
+   std::string Path;             // Specifies the location of a file or folder.
+   FL      Flags;                // File flags and options.
+   PERMIT  Permissions;          // Manages the permissions of a file.
+   kt::vector<int8_t> Buffer;    // Points to the internal data buffer if the file content is held in memory.
+   int64_t Size;                 // The byte size of a file.
    public:
    inline std::string readLine() {
       std::string str;

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -323,8 +323,6 @@ static ERR FILE_BufferContent(extFile *Self)
    kt::Log log;
    int len;
 
-   if ((Self->Flags & FL::BUFFER) != FL::NIL) return ERR::Okay;
-
    Self->seekStart(0);
    Self->Buffer.clear();
 

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -323,9 +323,10 @@ static ERR FILE_BufferContent(extFile *Self)
    kt::Log log;
    int len;
 
-   if (Self->Buffer) return ERR::Okay;
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) return ERR::Okay;
 
    Self->seekStart(0);
+   Self->Buffer.clear();
 
    if (not Self->Size) {
       // If the file has no size, it could be a stream (or simply empty).  This routine handles this situation.
@@ -335,17 +336,15 @@ static ERR FILE_BufferContent(extFile *Self)
          Self->Flags |= FL::STREAM;
          // Allocate a 1 MB memory block, read the stream into it, then reallocate the block to the correct size.
 
-         uint8_t *buffer;
-         if (!AllocMemory(1024 * 1024, MEM::NO_CLEAR, (APTR *)&buffer)) {
-            Self->seekStart(0);
-            acRead(Self, buffer, 1024 * 1024, &len);
-            if (len > 0) {
-               if (!AllocMemory(len, MEM::NO_CLEAR, (APTR *)&Self->Buffer)) {
-                  copymem(buffer, Self->Buffer, len);
-                  Self->Size = len;
-               }
-            }
-            FreeResource(buffer);
+         kt::vector<int8_t> buffer;
+         buffer.resize((1024 * 1024) + 1);
+         Self->seekStart(0);
+         acRead(Self, buffer.data(), 1024 * 1024, &len);
+         if (len > 0) {
+            buffer.resize(len + 1);
+            buffer[len] = 0;
+            Self->Buffer.swap(buffer);
+            Self->Size = len;
          }
       }
    }
@@ -353,26 +352,18 @@ static ERR FILE_BufferContent(extFile *Self)
       // Allocate buffer and load file content.  A NULL byte is added so that there is some safety in the event that
       // the file content is treated as a string.
 
-      int8_t *buffer;
-      if (!AllocMemory(Self->Size+1, MEM::NO_CLEAR, (APTR *)&buffer)) {
-         buffer[Self->Size] = 0;
-         if (!acRead(Self, buffer, Self->Size, &len)) {
-            Self->Buffer = buffer;
-         }
-         else {
-            FreeResource(buffer);
-            return log.warning(ERR::Read);
-         }
+      kt::vector<int8_t> buffer;
+      buffer.resize(Self->Size + 1);
+      buffer[Self->Size] = 0;
+      if (!acRead(Self, buffer.data(), Self->Size, &len)) {
+         Self->Buffer.swap(buffer);
       }
-      else return log.warning(ERR::AllocMemory);
+      else return log.warning(ERR::Read);
    }
 
-   // If the file was empty, allocate a 1-byte memory block for the Buffer field, in order to satisfy condition tests.
-
-   if (not Self->Buffer) {
-      if (AllocMemory(1, MEM::DATA, (APTR *)&Self->Buffer) != ERR::Okay) {
-         return log.warning(ERR::AllocMemory);
-      }
+   if (Self->Buffer.empty()) {
+      Self->Buffer.resize(1);
+      Self->Buffer[0] = 0;
    }
 
    log.msg("File content now buffered in a %" PF64 " byte memory block.", (long long)Self->Size);
@@ -570,7 +561,7 @@ static ERR FILE_Flush(extFile *Self)
    kt::Log log;
 
    if ((Self->Flags & FL::WRITE) IS FL::NIL) return ERR::Okay;
-   if (Self->Buffer) return ERR::Okay;
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) return ERR::Okay;
    if ((Self->isFolder) or ((Self->Flags & FL::FOLDER) != FL::NIL)) return log.warning(ERR::ExpectedFile);
    if (Self->Handle IS -1) return log.warning(ERR::ObjectCorrupt);
 
@@ -643,14 +634,10 @@ static ERR FILE_Init(extFile *Self)
    if (((Self->Flags & FL::BUFFER) != FL::NIL) and (Self->Path.empty())) {
       if (Self->Size < 0) Self->Size = 0;
       Self->Flags |= FL::READ|FL::WRITE|FL::VIRTUAL;
-      if (not Self->Buffer) {
-         // Allocate buffer if none specified.  An extra byte is allocated for a NULL byte on the end, in case the file
-         // content is treated as a string.
-
-         if (AllocMemory((Self->Size < 1) ? 1 : Self->Size+1, MEM::NO_CLEAR, (APTR *)&Self->Buffer) != ERR::Okay) {
-            return log.warning(ERR::AllocMemory);
-         }
-         ((int8_t *)Self->Buffer)[Self->Size] = 0;
+      if (Self->Buffer.empty()) {
+         // An extra byte is allocated for a NULL character, in case the file content is treated as a string.
+         Self->Buffer.resize(Self->Size + 1);
+         Self->Buffer[Self->Size] = 0;
       }
       Self->Permissions |= PERMIT::HIDDEN;
       return ERR::Okay;
@@ -667,13 +654,12 @@ static ERR FILE_Init(extFile *Self)
       Self->Size = Self->Path.size() - 7;
 
       if (Self->Size > 0) {
-         if (!AllocMemory(Self->Size, MEM::DATA, (APTR *)&Self->Buffer)) {
-            Self->Flags |= FL::READ|FL::WRITE|FL::VIRTUAL|FL::BUFFER;
-            Self->Permissions |= PERMIT::HIDDEN;
-            copymem(Self->Path.c_str() + 7, Self->Buffer, Self->Size);
-            return ERR::Okay;
-         }
-         else return log.warning(ERR::AllocMemory);
+         Self->Buffer.resize(Self->Size + 1);
+         Self->Buffer[Self->Size] = 0;
+         Self->Flags |= FL::READ|FL::WRITE|FL::VIRTUAL|FL::BUFFER;
+         Self->Permissions |= PERMIT::HIDDEN;
+         copymem(Self->Path.c_str() + 7, Self->Buffer.data(), Self->Size);
+         return ERR::Okay;
       }
       else return log.warning(ERR::InvalidPath);
    }
@@ -1082,7 +1068,7 @@ static ERR FILE_Read(extFile *Self, struct acRead *Args)
 
    if ((Self->Flags & FL::READ) IS FL::NIL) return log.warning(ERR::FileReadFlag);
 
-   if (Self->Buffer) {
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       if ((Self->Flags & FL::LOOP) != FL::NIL) {
          // In loop mode, we must make the file buffer appear to be of infinite length in terms of the read/write
          // position marker.
@@ -1094,25 +1080,17 @@ static ERR FILE_Read(extFile *Self, struct acRead *Args)
             else len = 0; // Avoid division by zero if the file size is zero.
             if (len > readlen) len = readlen; // Restrict the length of the read operation to the length of the destination.
 
-            copymem(Self->Buffer + (Self->Position % Self->Size), dest, len);
+            copymem(Self->Buffer.data() + (Self->Position % Self->Size), dest, len);
             dest += len;
             Self->Position += len;
          }
-/*
-         readlen = Self->Position % Self->Size;
-         for (len=0; len < Args->Length; len++) {
-            ((BYTE *)Args->Buffer)[len] = Self->Buffer[readlen++];
-            if (readlen >= Self->Size) readlen = 0;
-         }
-         Self->Position += Args->Length;
-*/
          Args->Result = Args->Length;
          return ERR::Okay;
       }
       else {
          if (Self->Position + Args->Length > Self->Size) Args->Result = Self->Size - Self->Position;
          else Args->Result = Args->Length;
-         copymem(Self->Buffer + Self->Position, Args->Buffer, Args->Result);
+         copymem(Self->Buffer.data() + Self->Position, Args->Buffer, Args->Result);
          Self->Position += Args->Result;
          return ERR::Okay;
       }
@@ -1183,17 +1161,17 @@ static ERR FILE_ReadLine(extFile *Self, struct fl::ReadLine *Args)
    std::string &output = *Args->Result;
    output.clear();
 
-   if (Self->Buffer) {
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       if (Self->Position >= Self->Size) return ERR::NoData;
       const std::size_t start = std::size_t(Self->Position);
-      auto content = std::string_view((char *)Self->Buffer, std::size_t(Self->Size));
+      auto content = std::string_view((char *)Self->Buffer.data(), std::size_t(Self->Size));
       auto line_feed = content.find('\n', start);
       if (line_feed IS std::string_view::npos) {
-         output.assign((char *)Self->Buffer + start, std::size_t(Self->Size) - start);
+         output.assign((char *)Self->Buffer.data() + start, std::size_t(Self->Size) - start);
          Self->Position = Self->Size;
       }
       else {
-         output.assign((char *)Self->Buffer + start, line_feed - start);
+         output.assign((char *)Self->Buffer.data() + start, line_feed - start);
          Self->Position = line_feed + 1;
       }
       return ERR::Okay;
@@ -1337,7 +1315,7 @@ static ERR FILE_Seek(extFile *Self, struct acSeek *Args)
 
    if (Self->Position < 0) Self->Position = 0;
 
-   if (Self->Buffer) {
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       if ((Self->Flags & FL::LOOP) != FL::NIL) return ERR::Okay; // In loop mode, the position marker can legally be above the buffer size
       else if (Self->Position > Self->Size) Self->Position = Self->Size;
       return ERR::Okay;
@@ -1680,7 +1658,7 @@ static ERR FILE_Write(extFile *Self, struct acWrite *Args)
    if (Args->Length <= 0) return ERR::Args;
    if ((Self->Flags & FL::WRITE) IS FL::NIL) return log.warning(ERR::FileWriteFlag);
 
-   if (Self->Buffer) {
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       if ((Self->Flags & FL::LOOP) != FL::NIL) {
          // In loop mode, we must make the file buffer appear to be of infinite length in terms of the read/write
          // position marker.
@@ -1691,7 +1669,7 @@ static ERR FILE_Write(extFile *Self, struct acWrite *Args)
             len = Self->Size - (Self->Position % Self->Size); // Calculate amount of space ahead of us.
             if (len > writelen) len = writelen; // Restrict the length to the requested amount to write.
 
-            copymem(src, Self->Buffer + (Self->Position % Self->Size), len);
+            copymem(src, Self->Buffer.data() + (Self->Position % Self->Size), len);
             src += len;
             Self->Position += len;
          }
@@ -1703,16 +1681,14 @@ static ERR FILE_Write(extFile *Self, struct acWrite *Args)
          if (Self->Position + Args->Length > Self->Size) {
             // Increase the size of the buffer to cater for the write.  A null byte (not included in the official size)
             // is always placed at the end.
-            if (!ReallocMemory(Self->Buffer, Self->Position + Args->Length + 1, (APTR *)&Self->Buffer)) {
-               Self->Size = Self->Position + Args->Length;
-               Self->Buffer[Self->Size] = 0;
-            }
-            else return log.warning(ERR::ReallocMemory);
+            Self->Buffer.resize(Self->Position + Args->Length + 1);
+            Self->Size = Self->Position + Args->Length;
+            Self->Buffer[Self->Size] = 0;
          }
 
          Args->Result = Args->Length;
 
-         copymem(Args->Buffer, Self->Buffer + Self->Position, Args->Result);
+         copymem(Args->Buffer, Self->Buffer.data() + Self->Position, Args->Result);
 
          Self->Position += Args->Result;
          return ERR::Okay;
@@ -1769,7 +1745,7 @@ the address of that buffer.  The size of the buffer will match the #Size field.
 
 static ERR GET_Buffer(extFile *Self, std::span<int8_t> &Array)
 {
-   Array = std::span<int8_t>(Self->Buffer, Self->Size);
+   Array = std::span<int8_t>(Self->Buffer.data(), std::size_t(Self->Size));
    return ERR::Okay;
 }
 
@@ -2528,7 +2504,7 @@ static ERR GET_Size(extFile *Self, int64_t *Size)
       }
       else return convert_errno(errno, ERR::SystemCall);
    }
-   else if (Self->Buffer) {
+   else if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       *Size = Self->Size;
       return ERR::Okay;
    }
@@ -2553,10 +2529,11 @@ static ERR SET_Size(extFile *Self, int64_t Size)
    if (Size IS Self->Size) return ERR::Okay;
    if (Size < 0) return log.warning(ERR::OutOfRange);
 
-   if (Self->Buffer) {
+   if ((Self->Flags & FL::BUFFER) != FL::NIL) {
       if (Self->initialised()) return ERR::NoSupport;
-      else Self->Size = Size;
-
+      Self->Size = Size;
+      Self->Buffer.resize(Size + 1);
+      Self->Buffer[Size] = 0;
       if (Self->Position > Self->Size) Self->seekStart(Size);
       return ERR::Okay;
    }
@@ -2766,7 +2743,6 @@ extFile::~extFile() {
 #endif
 
    if (prvList) FreeResource(prvList);
-   if (Buffer)  FreeResource(Buffer);
 
    if (Handle != -1) {
       if (close(Handle) IS -1) {
@@ -2798,7 +2774,7 @@ static const FieldArray FileFields[] = {
    { "Src",          FDF_SYNONYM },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, SET_Flags, &clFileFlags },
    { "Permissions",  FDF_INTFLAGS|FDF_RW, GET_Permissions, SET_Permissions, &clFilePERMIT },
-   { "Buffer",       FDF_ARRAY|FDF_BYTE|FDF_R|FDF_PURE, GET_Buffer },
+   { "Buffer",       FDF_VECTOR|FDF_BYTE|FDF_R|FDF_PURE, GET_Buffer },
    { "Size",         FDF_INT64|FDF_RW, GET_Size, SET_Size },
    // Virtual fields
    { "Date",         FDF_VIRTUAL|FDF_STRUCT|FDF_RW,        GET_Date, SET_Date, "DateTime" },

--- a/src/core/defs/filesystem.tdl
+++ b/src/core/defs/filesystem.tdl
@@ -61,7 +61,7 @@ header({ module="Core", copyright="Paul Manias © 1996-2026", timestamp=20240611
     string    Path      # The file path.
     int(FL)   Flags     # File flags and options.
     int(PERMIT) Permissions
-    array(char) Buffer  # Points to the internal data buffer if the file content is held in memory.
+    vector(char) Buffer # Points to the internal data buffer if the file content is held in memory.
     large     Size      # The size of the file's content.
     ~struct(DateTime) Date
     ~struct(DateTime) Created

--- a/src/core/tests/test_filesystem.tiri
+++ b/src/core/tests/test_filesystem.tiri
@@ -177,6 +177,118 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function BufferedVirtualFileGrow()
+   expected = 'abcdef'
+   fl = obj.new('file', { flags=FL_BUFFER, size=2 })
+
+   assert(fl.size is 2, 'Buffered file should honour the initial Size field.')
+   assert(#fl.buffer is 2, 'Public Buffer length should match the initial Size field.')
+
+   err, result = fl.acWrite(expected, #expected)
+   assert(err is ERR_Okay, 'Buffered acWrite() failed: ' .. mSys.GetErrorMsg(err))
+   assert(result is #expected, 'Buffered acWrite() returned an unexpected byte count.')
+   assert(fl.size is #expected, 'Buffered file Size should grow to match the write length.')
+   assert(#fl.buffer is #expected, 'Public Buffer length should track the grown Size field.')
+
+   err = fl.acSeek(SEEK_START, 0)
+   assert(err is ERR_Okay, 'Buffered acSeek() failed: ' .. mSys.GetErrorMsg(err))
+
+   buffer = string.alloc(#expected)
+   err, result = fl.acRead(buffer, #expected)
+   assert(err is ERR_Okay, 'Buffered acRead() failed: ' .. mSys.GetErrorMsg(err))
+   assert(result is #expected, 'Buffered acRead() returned an unexpected byte count.')
+   assert(string.substr(buffer, 0, result) is expected, 'Buffered acRead() returned unexpected content.')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function BufferContentVirtualisesPhysicalFile()
+   read_path = glTempRoot .. 'buffer_content_source.txt'
+   expected = 'Alpha\nBeta\nGamma'
+
+   resetPath(read_path)
+   writeFile(read_path, expected)
+
+   fl = obj.new('file', { src=read_path, flags=FL_READ|FL_WRITE })
+
+   err = fl.mtBufferContent()
+   assert(err is ERR_Okay, 'BufferContent() failed: ' .. mSys.GetErrorMsg(err))
+   assert((fl.flags & FL_BUFFER) != 0, 'BufferContent() should enable the BUFFER flag.')
+   assert(fl.size is #expected, 'Buffered physical file Size should match the source content length.')
+   assert(#fl.buffer is #expected, 'Public Buffer length should match the buffered file Size.')
+   assert(fl.buffer:getString() is expected, 'Buffered physical file content was not preserved.')
+
+   err = fl.mtBufferContent()
+   assert(err is ERR_Okay, 'Repeated BufferContent() should be a no-op: ' .. mSys.GetErrorMsg(err))
+   assert(fl.buffer:getString() is expected, 'Repeated BufferContent() should not clear the existing buffer.')
+
+   err = fl.acSeek(SEEK_START, 0)
+   assert(err is ERR_Okay, 'Buffered physical acSeek() failed: ' .. mSys.GetErrorMsg(err))
+
+   err, result = fl.acWrite('RAM', 3)
+   assert(err is ERR_Okay, 'Buffered physical acWrite() failed: ' .. mSys.GetErrorMsg(err))
+   assert(result is 3, 'Buffered physical acWrite() returned an unexpected byte count.')
+
+   fl = nil
+   processing.collect()
+
+   assert(readFile(read_path) is expected, 'Writes after BufferContent() should not modify the physical file.')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function BufferedStringPathReadLine()
+   expected = 'first\nsecond\nthird'
+   fl = obj.new('file', { path='string:' .. expected })
+
+   assert((fl.flags & FL_BUFFER) != 0, 'string: paths should create buffered files.')
+   assert(fl.size is #expected, 'string: buffered file Size should match the string content length.')
+   assert(#fl.buffer is #expected, 'string: public Buffer length should match the Size field.')
+   assert(fl.buffer:getString() is expected, 'string: buffer content was not preserved.')
+
+   err, line = fl.mtReadLine()
+   assert(err is ERR_Okay, 'First buffered ReadLine() failed: ' .. mSys.GetErrorMsg(err))
+   assert(line is 'first', 'First buffered line was unexpected: ' .. tostring(line))
+
+   err, line = fl.mtReadLine()
+   assert(err is ERR_Okay, 'Second buffered ReadLine() failed: ' .. mSys.GetErrorMsg(err))
+   assert(line is 'second', 'Second buffered line was unexpected: ' .. tostring(line))
+
+   err, line = fl.mtReadLine()
+   assert(err is ERR_Okay, 'Final buffered ReadLine() failed: ' .. mSys.GetErrorMsg(err))
+   assert(line is 'third', 'Final buffered line was unexpected: ' .. tostring(line))
+
+   err, line = fl.mtReadLine()
+   assert(err is ERR_NoData, 'ReadLine() should report NoData after the final buffered line, got: ' ..
+      mSys.GetErrorMsg(err))
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function BufferContentEmptyFile()
+   read_path = glTempRoot .. 'buffer_content_empty.txt'
+
+   resetPath(read_path)
+
+   fl = obj.new('file', { src=read_path, flags=FL_NEW|FL_WRITE })
+   fl = nil
+   processing.collect()
+
+   fl = obj.new('file', { src=read_path, flags=FL_READ|FL_WRITE })
+   err = fl.mtBufferContent()
+   assert(err is ERR_Okay, 'BufferContent() failed for an empty file: ' .. mSys.GetErrorMsg(err))
+   assert((fl.flags & FL_BUFFER) != 0, 'Empty BufferContent() should enable the BUFFER flag.')
+   assert(fl.size is 0, 'Empty buffered file Size should remain zero.')
+   assert(#fl.buffer is 0, 'Public Buffer length for an empty buffered file should be zero.')
+
+   buffer = string.alloc(1)
+   err, result = fl.acRead(buffer, 1)
+   assert(err is ERR_Okay, 'Reading an empty buffered file should succeed: ' .. mSys.GetErrorMsg(err))
+   assert(result is 0, 'Reading an empty buffered file should return zero bytes.')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function FileIcons()
    if mSys.AnalysePath('icons:') != ERR_Okay then
       -- Icons not available, skip test


### PR DESCRIPTION
* Converted File.Buffer from a raw allocation to a kt::vector-backed field
* Preserved buffered read/write, string path, and BufferContent semantics across the File API
* [Test] Added core filesystem coverage for buffered virtual files, string buffers, and empty buffers