### PR TITLE
[Core] Tighten file buffering and watch ownership

### DIFF
--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -310,8 +310,9 @@ once buffering has been enabled.
 
 -ERRORS-
 Okay: The file content was successfully buffered.
-AllocMemory:
-Read: Failed to read the file content.
+Read:
+NothingDone: The file is already buffered.
+InvalidState: The targeted file is not open for read operations.
 
 -TAGS-
 blocking, mutates-object, creates-resource, updates-seek-index
@@ -322,6 +323,11 @@ static ERR FILE_BufferContent(extFile *Self)
 {
    kt::Log log;
    int len;
+
+   if (Self->Handle IS -1) {
+      if ((Self->Flags & FL::BUFFER) != FL::NIL) return ERR::NothingDone;
+      else return log.warning(ERR::InvalidState);
+   }
 
    Self->seekStart(0);
    Self->Buffer.clear();
@@ -425,7 +431,6 @@ Read: Data could not be read from the source path.
 Write: Data could not be written to the destination path.
 ResolvePath:
 Loop: Performing the copy would cause infinite recursion.
-AllocMemory:
 
 -TAGS-
 blocking, updates-seek-index, callback-inlines
@@ -611,7 +616,6 @@ FileNotFound:
 ResolvePath:
 Search: The file could not be found.
 NoPermission: Permission was denied when accessing or creating the file.
-AllocMemory
 InvalidPath
 ExpectedFile
 UseDerived
@@ -1536,6 +1540,8 @@ int(MFF) Flags: Filter events to those indicated in these flags.
 Okay
 Args
 NullArgs
+AllocMemory
+NoSupport
 
 -TAGS-
 non-blocking, mutates-object, callback-held
@@ -1572,8 +1578,7 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
       if (ignore_file) ignore_file(Self);
       else log.warning("Failed to find virtual volume ID $%.8x", id);
 
-      FreeResource(Self->prvWatch);
-      Self->prvWatch = nullptr;
+      Self->prvWatch.reset();
    }
 
    if ((not Args) or (not Args->Callback) or (Args->Flags IS MFF::NIL)) return ERR::Okay;
@@ -1598,11 +1603,14 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
       auto vd = get_fs(resolve);
 
       if (vd.WatchPath) {
-         #ifdef _WIN32
-         if (!AllocMemory(sizeof(rkWatchPath) + winGetWatchBufferSize(), MEM::DATA, (APTR *)&Self->prvWatch)) {
-         #else
-         if (!AllocMemory(sizeof(rkWatchPath), MEM::DATA, (APTR *)&Self->prvWatch)) {
-         #endif
+         auto watch = std::unique_ptr<rkWatchPath>(new (std::nothrow) rkWatchPath);
+         if (watch) {
+            #ifdef _WIN32
+               watch->Buffer.reset(new (std::nothrow) uint8_t[winGetWatchBufferSize()]);
+               if (!watch->Buffer) return ERR::AllocMemory;
+            #endif
+
+            Self->prvWatch = std::move(watch);
             Self->prvWatch->VirtualID = vd.VirtualID;
             Self->prvWatch->Routine   = *Args->Callback;
             Self->prvWatch->Flags     = Args->Flags;
@@ -1614,8 +1622,7 @@ static ERR FILE_Watch(extFile *Self, struct fl::Watch *Args)
                auto &func = Self->prvWatch->Routine;
                if ((func.isScript()) and (not func.stale())) ((objScript *)func.Context)->derefProcedure(func);
                func.unpin();
-               FreeResource(Self->prvWatch);
-               Self->prvWatch = nullptr;
+               Self->prvWatch.reset();
             }
          }
          else error = ERR::AllocMemory;

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -17,6 +17,8 @@
 #include <thread>
 #include <algorithm>
 #include <optional>
+#include <memory>
+#include <new>
 #include <string_view>
 #include <ankerl/unordered_dense.h>
 #include <unordered_set>
@@ -171,13 +173,14 @@ struct THREADID : strong_typedef<THREADID, int> { // Internal thread ID, unrelat
 };
 
 struct rkWatchPath {
-   HOSTHANDLE Handle;    // The handle for the file being monitored, can be a special reference for virtual paths
+   HOSTHANDLE Handle = { }; // The handle for the file being monitored, can be a special reference for virtual paths
    FUNCTION   Routine;   // Routine to call on event trigger
-   MFF        Flags;     // Event mask (original flags supplied to Watch)
-   uint32_t   VirtualID; // If monitored path is virtual, this refers to an ID in the glVirtual table
+   MFF        Flags = MFF(); // Event mask (original flags supplied to Watch)
+   uint32_t   VirtualID = 0; // If monitored path is virtual, this refers to an ID in the glVirtual table
 
 #ifdef _WIN32
-   int WinFlags;
+   int WinFlags = 0;
+   std::unique_ptr<uint8_t[]> Buffer;
 #endif
 };
 
@@ -489,7 +492,7 @@ class extFile : public objFile {
       APTR  Stream;
    #endif
 
-   struct rkWatchPath *prvWatch;
+   std::unique_ptr<rkWatchPath> prvWatch;
    struct DirInfo *prvList;
    bool   isFolder;
    int    Handle;         // Native system file handle

--- a/src/core/fs_watch_path.cpp
+++ b/src/core/fs_watch_path.cpp
@@ -83,7 +83,8 @@ ERR fs_watch_path(extFile *File)
 
    // The path_monitor() function will be called whenever the Path or its content is modified.
 
-   if (!(error = winWatchFile(int(File->prvWatch->Flags), File->prvResolvedPath.c_str(), (File->prvWatch + 1), &handle, &winflags))) {
+   if (!(error = winWatchFile(int(File->prvWatch->Flags), File->prvResolvedPath.c_str(),
+         File->prvWatch->Buffer.get(), &handle, &winflags))) {
       if (!(error = RegisterFD(handle, RFD::READ, (void (*)(HOSTHANDLE, APTR))&path_monitor, File))) {
          File->prvWatch->Handle   = handle;
          File->prvWatch->WinFlags = winflags;
@@ -253,7 +254,8 @@ static void path_monitor(HOSTHANDLE Handle, extFile *File)
       // Validate resources before each iteration to prevent crashes
 
       while ((File->prvWatch) and (File->prvWatch->Handle IS Handle)) {
-         ERR read_result = winReadChanges(File->prvWatch->Handle, (APTR)(File->prvWatch + 1), File->prvWatch->WinFlags, path.data(), int(path.size()), &status);
+         ERR read_result = winReadChanges(File->prvWatch->Handle, File->prvWatch->Buffer.get(),
+            File->prvWatch->WinFlags, path.data(), int(path.size()), &status);
          if (read_result != ERR::Okay) {
             // If we get an error other than NothingDone, stop monitoring
             if (read_result != ERR::NothingDone) {

--- a/src/core/tests/test_filesystem.tiri
+++ b/src/core/tests/test_filesystem.tiri
@@ -219,7 +219,7 @@ end
    assert(fl.buffer:getString() is expected, 'Buffered physical file content was not preserved.')
 
    err = fl.mtBufferContent()
-   assert(err is ERR_Okay, 'Repeated BufferContent() should be a no-op: ' .. mSys.GetErrorMsg(err))
+   assert(err is ERR_NothingDone, 'Repeated BufferContent() should be a no-op: ' .. mSys.GetErrorMsg(err))
    assert(fl.buffer:getString() is expected, 'Repeated BufferContent() should not clear the existing buffer.')
 
    err = fl.acSeek(SEEK_START, 0)


### PR DESCRIPTION
* Return NothingDone when file content is already buffered without an open handle
* Replace file watch tail allocation with explicit unique_ptr-owned watch state and Windows buffer storage