### PR TITLE
[Core] Replace compression scratch buffers with RAII storage

### DIFF
--- a/src/core/compression/class_compressed_stream.cpp
+++ b/src/core/compression/class_compressed_stream.cpp
@@ -31,7 +31,7 @@ class extCompressedStream : public objCompressedStream {
 
    // Note: As PublicSize is defined, these fields are specific to CompressedStream and will otherwise be
    // overwritten for derived classes.
-   uint8_t *OutputBuffer;
+   std::vector<uint8_t> OutputBuffer;
    ZStream Stream;
    gz_header Header;
 
@@ -46,7 +46,8 @@ class extCompressedStream : public objCompressedStream {
 
       Stream.reset();
 
-      if (OutputBuffer) { FreeResource(OutputBuffer); OutputBuffer = nullptr; }
+      OutputBuffer.clear();
+      OutputBuffer.shrink_to_fit();
    }
 };
 
@@ -117,10 +118,8 @@ static ERR COMPRESSEDSTREAM_Read(extCompressedStream *Self, struct acRead *Args)
    if (outputsize < MIN_OUTPUT_SIZE) {
       // An internal buffer will need to be allocated if the one supplied to Read() is not large enough.
       outputsize = MIN_OUTPUT_SIZE;
-      if (!(output = Self->OutputBuffer)) {
-         if (AllocMemory(MIN_OUTPUT_SIZE, MEM::DATA|MEM::NO_CLEAR, (APTR *)&Self->OutputBuffer) != ERR::Okay) return ERR::AllocMemory;
-         output = Self->OutputBuffer;
-      }
+      if (Self->OutputBuffer.empty()) Self->OutputBuffer.resize(MIN_OUTPUT_SIZE);
+      output = Self->OutputBuffer.data();
    }
 
    Self->Stream->next_in  = inputstream;
@@ -247,15 +246,13 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
       Self->TotalOutput = 0;
    }
 
-   if (!Self->OutputBuffer) {
-      if (AllocMemory(MIN_OUTPUT_SIZE, MEM::DATA|MEM::NO_CLEAR, (APTR *)&Self->OutputBuffer) != ERR::Okay) return ERR::AllocMemory;
-   }
+   if (Self->OutputBuffer.empty()) Self->OutputBuffer.resize(MIN_OUTPUT_SIZE);
 
    Args->Result = 0;
    int mode;
    if (Args->Length IS -1) { // A length of -1 is a signal to complete the compression process.
       mode = Z_FINISH;
-      Self->Stream->next_in  = Self->OutputBuffer;
+      Self->Stream->next_in  = Self->OutputBuffer.data();
       Self->Stream->avail_in = 0;
    }
    else {
@@ -269,7 +266,7 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
 
    Self->Stream->avail_out = 0;
    while (Self->Stream->avail_out IS 0) {
-      Self->Stream->next_out  = Self->OutputBuffer;
+      Self->Stream->next_out  = Self->OutputBuffer.data();
       Self->Stream->avail_out = MIN_OUTPUT_SIZE;
 
       if ((deflate(Self->Stream.get(), mode))) {
@@ -282,7 +279,7 @@ static ERR COMPRESSEDSTREAM_Write(extCompressedStream *Self, struct acWrite *Arg
       if (len > 0) {
          Self->TotalOutput += len;
          log.trace("%d bytes (total %" PF64 ") were compressed.", len, Self->TotalOutput);
-         acWrite(Self->Output, Self->OutputBuffer, len, nullptr);
+         acWrite(Self->Output, Self->OutputBuffer.data(), len, nullptr);
       }
       else {
          // deflate() may not output anything if it needs more data to fill up a compression frame.  Return ERR::Okay

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -458,6 +458,8 @@ static ERR remove_file(extCompression *Self, std::list<ZipFile>::iterator &File)
 // if the zip file is damaged or partially downloaded, it will fail.  In the event that the directory is unavailable,
 // the function will fallback to scan_zip().
 
+static const uint32_t MAX_FAST_SCAN_LIST_SIZE = 64 * 1024 * 1024;
+
 static ERR fast_scan_zip(extCompression *Self)
 {
    kt::Log log(__FUNCTION__);
@@ -479,23 +481,41 @@ static ERR fast_scan_zip(extCompression *Self)
    tail.listoffset = le32_cpu(tail.listoffset);
 #endif
 
+   int64_t file_size;
+   if (Self->FileIO->getSize(file_size) != ERR::Okay) return scan_zip(Self);
+   if ((file_size < 0) or (uint64_t(tail.listoffset) > uint64_t(file_size))) return scan_zip(Self);
+   if (uint64_t(tail.listsize) > uint64_t(file_size) - uint64_t(tail.listoffset)) return scan_zip(Self);
+   if (tail.listsize > MAX_FAST_SCAN_LIST_SIZE) return scan_zip(Self);
+
    if (acSeek(Self->FileIO, tail.listoffset, SEEK::START) != ERR::Okay) return ERR::Seek;
 
    int total_files = 0;
+   if (tail.filecount IS 0) return ERR::Okay;
    if ((tail.filecount > 0) and (tail.listsize < uint32_t(tail.filecount) * LIST_LENGTH)) return scan_zip(Self);
 
    std::vector<uint8_t> list(tail.listsize);
 
    log.trace("Reading end-of-central directory from index %d, %d bytes.", tail.listoffset, tail.listsize);
-   if (acRead(Self->FileIO, list.data(), tail.listsize, nullptr) != ERR::Okay) {
+   int read_result;
+   if ((acRead(Self->FileIO, list.data(), tail.listsize, &read_result) != ERR::Okay) or
+      (read_result != int(tail.listsize))) {
       return scan_zip(Self);
    }
 
-   #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
-   auto head = (uint32_t *)list.data();
-   #pragma GCC diagnostic warning "-Waddress-of-packed-member"
+   auto list_pos = list.data();
+   auto list_end = list.data() + list.size();
 
    for (int i=0; i < tail.filecount; i++) {
+      if (uint64_t(list_end - list_pos) < LIST_LENGTH) {
+         log.warning("Zip file has corrupt end-of-file signature.");
+         Self->Files.clear();
+         return scan_zip(Self);
+      }
+
+      #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+      auto head = (uint32_t *)list_pos;
+      #pragma GCC diagnostic warning "-Waddress-of-packed-member"
+
       if (0x02014b50 != head[0]) {
          log.warning("Zip file has corrupt end-of-file signature.");
          Self->Files.clear();
@@ -519,6 +539,13 @@ static ERR fast_scan_zip(extCompression *Self)
       scan->offset         = le32_cpu(scan->offset);
 #endif
 
+      auto entry_size = uint64_t(LIST_LENGTH) + scan->commentlen + scan->namelen + scan->extralen;
+      if (entry_size > uint64_t(list_end - list_pos)) {
+         log.warning("Zip file has corrupt end-of-file signature.");
+         Self->Files.clear();
+         return scan_zip(Self);
+      }
+
       total_files++;
 
       ZipFile zf;
@@ -537,8 +564,9 @@ static ERR fast_scan_zip(extCompression *Self)
 
       // Read string information
 
-      STRING str = STRING(head) + LIST_LENGTH;
-      if ((str[0] IS '.') and (str[1] IS '/')) { // Get rid of any useless './' prefix that sometimes make their way into zip files
+      STRING str = STRING(list_pos) + LIST_LENGTH;
+      // Get rid of any useless './' prefix that sometimes make their way into zip files.
+      if ((scan->namelen >= 2) and (str[0] IS '.') and (str[1] IS '/')) {
          zf.Name.assign(str+2, scan->namelen-2);
       }
       else zf.Name.assign(str, scan->namelen);
@@ -546,11 +574,11 @@ static ERR fast_scan_zip(extCompression *Self)
       zf.Comment.assign(str + scan->namelen + scan->extralen, scan->commentlen);
 
       if (zf.Flags & ZIP_LINK);
-      else if ((!zf.OriginalSize) and (zf.Name.back() IS '/')) zf.IsFolder = true;
+      else if ((!zf.OriginalSize) and (not zf.Name.empty()) and (zf.Name.back() IS '/')) zf.IsFolder = true;
 
       Self->Files.push_back(zf);
 
-      head = (uint32_t *)(((uint8_t *)head) + LIST_LENGTH + scan->commentlen + scan->namelen + scan->extralen);
+      list_pos += entry_size;
    }
 
    return ERR::Okay;

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -481,80 +481,78 @@ static ERR fast_scan_zip(extCompression *Self)
 
    if (acSeek(Self->FileIO, tail.listoffset, SEEK::START) != ERR::Okay) return ERR::Seek;
 
-   zipentry *list, *scan;
    int total_files = 0;
-   if (!AllocMemory(tail.listsize, MEM::DATA|MEM::NO_CLEAR, (APTR *)&list)) {
-      log.trace("Reading end-of-central directory from index %d, %d bytes.", tail.listoffset, tail.listsize);
-      if (acRead(Self->FileIO, list, tail.listsize, nullptr) != ERR::Okay) {
-         FreeResource(list);
+   if ((tail.filecount > 0) and (tail.listsize < uint32_t(tail.filecount) * LIST_LENGTH)) return scan_zip(Self);
+
+   std::vector<uint8_t> list(tail.listsize);
+
+   log.trace("Reading end-of-central directory from index %d, %d bytes.", tail.listoffset, tail.listsize);
+   if (acRead(Self->FileIO, list.data(), tail.listsize, nullptr) != ERR::Okay) {
+      return scan_zip(Self);
+   }
+
+   #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+   auto head = (uint32_t *)list.data();
+   #pragma GCC diagnostic warning "-Waddress-of-packed-member"
+
+   for (int i=0; i < tail.filecount; i++) {
+      if (0x02014b50 != head[0]) {
+         log.warning("Zip file has corrupt end-of-file signature.");
+         Self->Files.clear();
          return scan_zip(Self);
       }
 
-      #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
-      auto head = (uint32_t *)list;
-      #pragma GCC diagnostic warning "-Waddress-of-packed-member"
-
-      for (int i=0; i < tail.filecount; i++) {
-         if (0x02014b50 != head[0]) {
-            log.warning("Zip file has corrupt end-of-file signature.");
-            Self->Files.clear();
-            FreeResource(list);
-            return scan_zip(Self);
-         }
-
-         scan = (zipentry *)(head + 1);
+      auto scan = (zipentry *)(head + 1);
 
 #ifndef REVERSE_BYTEORDER
-         scan->deflatemethod  = le16_cpu(scan->deflatemethod);
-         scan->timestamp      = le32_cpu(scan->timestamp);
-         scan->crc32          = le32_cpu(scan->crc32);
-         scan->compressedsize = le32_cpu(scan->compressedsize);
-         scan->originalsize   = le32_cpu(scan->originalsize);
-         scan->namelen        = le16_cpu(scan->namelen);
-         scan->extralen       = le16_cpu(scan->extralen);
-         scan->commentlen     = le16_cpu(scan->commentlen);
-         scan->diskno         = le16_cpu(scan->diskno);
-         scan->ifile          = le16_cpu(scan->ifile);
-         scan->attrib         = le32_cpu(scan->attrib);
-         scan->offset         = le32_cpu(scan->offset);
+      scan->deflatemethod  = le16_cpu(scan->deflatemethod);
+      scan->timestamp      = le32_cpu(scan->timestamp);
+      scan->crc32          = le32_cpu(scan->crc32);
+      scan->compressedsize = le32_cpu(scan->compressedsize);
+      scan->originalsize   = le32_cpu(scan->originalsize);
+      scan->namelen        = le16_cpu(scan->namelen);
+      scan->extralen       = le16_cpu(scan->extralen);
+      scan->commentlen     = le16_cpu(scan->commentlen);
+      scan->diskno         = le16_cpu(scan->diskno);
+      scan->ifile          = le16_cpu(scan->ifile);
+      scan->attrib         = le32_cpu(scan->attrib);
+      scan->offset         = le32_cpu(scan->offset);
 #endif
 
-         total_files++;
+      total_files++;
 
-         ZipFile zf;
+      ZipFile zf;
 
-         zf.NameLen        = scan->namelen;
-         zf.CommentLen     = scan->commentlen;
-         zf.CompressedSize = scan->compressedsize;
-         zf.OriginalSize   = scan->originalsize;
-         zf.DeflateMethod  = scan->deflatemethod;
-         zf.Timestamp      = scan->timestamp;
-         zf.CRC            = scan->crc32;
-         zf.Offset         = scan->offset;
+      zf.NameLen        = scan->namelen;
+      zf.CommentLen     = scan->commentlen;
+      zf.CompressedSize = scan->compressedsize;
+      zf.OriginalSize   = scan->originalsize;
+      zf.DeflateMethod  = scan->deflatemethod;
+      zf.Timestamp      = scan->timestamp;
+      zf.CRC            = scan->crc32;
+      zf.Offset         = scan->offset;
 
-         if (scan->ostype IS ZIP_KOTUKU) zf.Flags = scan->attrib;
-         else zf.Flags = 0;
+      if (scan->ostype IS ZIP_KOTUKU) zf.Flags = scan->attrib;
+      else zf.Flags = 0;
 
-         // Read string information
+      // Read string information
 
-         STRING str = STRING(head) + LIST_LENGTH;
-         if ((str[0] IS '.') and (str[1] IS '/')) { // Get rid of any useless './' prefix that sometimes make their way into zip files
-            zf.Name.assign(str+2, scan->namelen-2);
-         }
-         else zf.Name.assign(str, scan->namelen);
-
-         zf.Comment.assign(str + scan->namelen + scan->extralen, scan->commentlen);
-
-         if (zf.Flags & ZIP_LINK);
-         else if ((!zf.OriginalSize) and (zf.Name.back() IS '/')) zf.IsFolder = true;
-
-         Self->Files.push_back(zf);
-
-         head = (uint32_t *)(((uint8_t *)head) + LIST_LENGTH + scan->commentlen + scan->namelen + scan->extralen);
+      STRING str = STRING(head) + LIST_LENGTH;
+      if ((str[0] IS '.') and (str[1] IS '/')) { // Get rid of any useless './' prefix that sometimes make their way into zip files
+         zf.Name.assign(str+2, scan->namelen-2);
       }
+      else zf.Name.assign(str, scan->namelen);
+
+      zf.Comment.assign(str + scan->namelen + scan->extralen, scan->commentlen);
+
+      if (zf.Flags & ZIP_LINK);
+      else if ((!zf.OriginalSize) and (zf.Name.back() IS '/')) zf.IsFolder = true;
+
+      Self->Files.push_back(zf);
+
+      head = (uint32_t *)(((uint8_t *)head) + LIST_LENGTH + scan->commentlen + scan->namelen + scan->extralen);
    }
 
-   FreeResource(list);
    return ERR::Okay;
 }
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1397,7 +1397,7 @@ typename Container::const_iterator binary_search(const Container& container, con
 
 //********************************************************************************************************************
 
-static void clear_callback(FUNCTION &Function)
+[[maybe_unused]] static void clear_callback(FUNCTION &Function)
 {
    if (Function.defined()) {
       if (Function.isScript() and (not Function.stale())) ((objScript *)Function.Context)->derefProcedure(Function);


### PR DESCRIPTION
* Use std::vector for CompressedStream output buffering
* Use a local vector for fast zip central-directory scans