### PR TITLE
[Core] Fixed queued action argument serialisation

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -29,7 +29,7 @@
 #include "ankerl/unordered_dense.h"
 #endif
 
-#define CORE_BUILD_DATE 202607102241
+#define CORE_BUILD_DATE 202607102320
 class objMetaClass;
 
 // Predefined cursor styles
@@ -1572,6 +1572,7 @@ struct CoreBase {
    ERR (*_AsyncWait)(kt::vector<OBJECTID> &Objects, int TimeOut);
    ERR (*_ClassDatabase)(kt::vector<ClassRecord *> *Classes);
    int (*_GetThreadID)(void);
+   void (*_UnitTests)(CSTRING Options, int *Passed, int *Total);
 #endif // KOTUKU_STATIC
 };
 
@@ -1670,6 +1671,7 @@ inline int AsyncPending(OBJECTID Object) { return CoreBase->_AsyncPending(Object
 inline ERR AsyncWait(kt::vector<OBJECTID> &Objects, int TimeOut) { return CoreBase->_AsyncWait(Objects,TimeOut); }
 inline ERR ClassDatabase(kt::vector<ClassRecord *> *Classes) { return CoreBase->_ClassDatabase(Classes); }
 inline int GetThreadID(void) { return CoreBase->_GetThreadID(); }
+inline void UnitTests(CSTRING Options, int *Passed, int *Total) { return CoreBase->_UnitTests(Options,Passed,Total); }
 #else
 extern "C" ERR Action(AC Action, OBJECTPTR Object, APTR Parameters);
 extern "C" void ActionList(struct ActionTable **Actions, int *Size);
@@ -1762,6 +1764,7 @@ extern "C" int AsyncPending(OBJECTID Object);
 extern "C" ERR AsyncWait(kt::vector<OBJECTID> &Objects, int TimeOut);
 extern "C" ERR ClassDatabase(kt::vector<ClassRecord *> *Classes);
 extern "C" int GetThreadID(void);
+extern "C" void UnitTests(CSTRING Options, int *Passed, int *Total);
 #endif // KOTUKU_STATIC
 
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -210,6 +210,11 @@ target_sources (core PRIVATE
    "classes/class_time.cpp"
    "compression/class_compression.cpp")
 
+if (UNIT_TESTS)
+   target_sources (core PRIVATE "tests/unit_tests_queue_action.cpp")
+   target_compile_definitions (core PRIVATE UNIT_TESTS)
+endif ()
+
 target_include_directories (core PRIVATE
    ${ZLIB_HEADERS})
 
@@ -239,6 +244,9 @@ flute_test (core_config "tests/test_config.tiri")
 flute_test (core_messages "tests/test_messages.tiri")
 flute_test (core_time "tests/test_time.tiri")
 flute_test (core_subscriber_lifetimes "tests/test_subscriber_lifetimes.tiri")
+if (UNIT_TESTS)
+flute_test (core_unit_tests "tests/test_unit_tests.tiri")
+endif ()
 
 if (INSTALL_TESTS)
    # Windows-compatible tests

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -478,6 +478,8 @@ static ERR msg_action(APTR Custom, int MsgID, int MsgType, APTR Message, int Msg
             }
 
             if (fields) {
+               // Argument pointers were serialised as offsets by QueueAction(); rebase them against this copy.
+               make_args_absolute(fields, action->ArgsSize, (int8_t *)(action + 1));
                glCurrentActionMsg = action;
                Action(action->ActionID, obj, action+1);
                executed = true;

--- a/src/core/data_functions.c
+++ b/src/core/data_functions.c
@@ -87,6 +87,7 @@ FDEF argsSubscribeAction[] = { { "Error", FD_INT|FD_ERROR }, { "Object", FD_OBJE
 FDEF argsSubscribeEvent[] = { { "Error", FD_INT|FD_ERROR }, { "Event", FD_INT64 }, { "Callback", FD_FUNCTIONPTR }, { "Handle", FD_RESULT|FD_PTR }, { 0, 0 } };
 FDEF argsSubscribeTimer[] = { { "Error", FD_INT|FD_ERROR }, { "Interval", FD_DOUBLE }, { "Callback", FD_FUNCTIONPTR }, { "Subscription", FD_RESULT|FD_PTR }, { 0, 0 } };
 FDEF argsTrackResource[] = { { "Error", FD_INT|FD_ERROR }, { "ResourceID", FD_INT }, { "Address", FD_PTR }, { "OwnerID", FD_INT }, { "ResourceManager:Manager", FD_PTR|FD_STRUCT }, { 0, 0 } };
+FDEF argsUnitTests[] = { { "Void", FD_VOID }, { "Options", FD_STR }, { "Passed", FD_RESULT|FD_INT }, { "Total", FD_RESULT|FD_INT }, { 0, 0 } };
 FDEF argsUnloadFile[] = { { "Void", FD_VOID }, { "CacheFile:Cache", FD_PTR|FD_STRUCT|FD_RESOURCE }, { 0, 0 } };
 FDEF argsUnsubscribeAction[] = { { "Error", FD_INT|FD_ERROR }, { "Object", FD_OBJECTPTR }, { "Action", FD_INT }, { "Callback", FD_FUNCTIONPTR }, { 0, 0 } };
 FDEF argsUnsubscribeEvent[] = { { "Void", FD_VOID }, { "Handle", FD_PTR }, { 0, 0 } };
@@ -192,6 +193,7 @@ const struct Function glFunctions[] = {
    { (APTR)AsyncWait, "AsyncWait", argsAsyncWait },
    { (APTR)ClassDatabase, "ClassDatabase", argsClassDatabase },
    { (APTR)GetThreadID, "GetThreadID", argsGetThreadID },
+   { (APTR)UnitTests, "UnitTests", argsUnitTests },
    { nullptr, nullptr, nullptr }
 };
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1176,6 +1176,8 @@ APTR   build_jump_table(const Function *);
 void   stop_async_actions(void);
 ERR    copy_args(const FunctionField *, int, int8_t *, std::vector<int8_t> &);
 void   release_copied_args(const FunctionField *, int, int8_t *, bool, FUNCTION * = nullptr);
+void   make_args_relative(const FunctionField *, int, int8_t *);
+void   make_args_absolute(const FunctionField *, int, int8_t *);
 ERR    create_archive_volume(void);
 void   dispatch_queued_action(OBJECTID);
 ERR    delete_tree(std::string &, FUNCTION *, FileFeedback *);

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -813,7 +813,8 @@ class objTask;
     "AsyncPending",
     "AsyncWait",
     "ClassDatabase",
-    "GetThreadID")
+    "GetThreadID",
+    "UnitTests")
 
   c_insert([==[
 

--- a/src/core/internal.cpp
+++ b/src/core/internal.cpp
@@ -454,6 +454,71 @@ ERR copy_args(const FunctionField *Args, int ArgsSize, int8_t *Parameters, std::
    return ERR::Okay;
 }
 
+/*********************************************************************************************************************
+A buffer produced by copy_args() embeds absolute pointers into its own storage for string and sized buffer arguments.
+Those pointers survive moves of the owning std::vector, but not byte-for-byte duplication (e.g. serialisation into
+the message queue).  make_args_relative() converts the self-referential pointers to offsets from the start of the
+argument block so that make_args_absolute() can rebase them against the receiving copy.  Object, array and function
+references are position independent and are left untouched, as are null pointers (offsets always exceed zero because
+extension data follows the argument block).
+*********************************************************************************************************************/
+
+void make_args_relative(const FunctionField *Args, int ArgsSize, int8_t *Buffer)
+{
+   if ((not Args) or (not Buffer)) return;
+
+   int pos = 0;
+   for (int i=0; Args[i].Name and (pos < ArgsSize); i++) {
+      int type = Args[i].Type;
+      if (type & FD_ARRAY); // Owned heap copy; position independent
+      else if (type & FD_STR) {
+         pos = align_arg_offset(pos);
+         if ((type & FD_CPP) and (not (type & FD_MUTABLE))) {
+            auto view = (std::string_view *)(Buffer + pos);
+            if (view->data()) *view = std::string_view((CSTRING)(view->data() - (CSTRING)Buffer), view->length());
+         }
+         else if (auto str = (int8_t **)(Buffer + pos); *str) {
+            *str = (int8_t *)(*str - Buffer);
+         }
+      }
+      else if (type & (FD_PTR|FD_BUFFER)) {
+         pos = align_arg_offset(pos);
+         if ((not (type & (FD_OBJECT|FD_RESULT))) and (Args[i+1].Type & FD_PTRSIZE)) {
+            if (auto ptr = (int8_t **)(Buffer + pos); *ptr) *ptr = (int8_t *)(*ptr - Buffer);
+         }
+      }
+      pos = argument_end_offset(type, pos);
+   }
+}
+
+void make_args_absolute(const FunctionField *Args, int ArgsSize, int8_t *Buffer)
+{
+   if ((not Args) or (not Buffer)) return;
+
+   int pos = 0;
+   for (int i=0; Args[i].Name and (pos < ArgsSize); i++) {
+      int type = Args[i].Type;
+      if (type & FD_ARRAY); // Owned heap copy; position independent
+      else if (type & FD_STR) {
+         pos = align_arg_offset(pos);
+         if ((type & FD_CPP) and (not (type & FD_MUTABLE))) {
+            auto view = (std::string_view *)(Buffer + pos);
+            if (view->data()) *view = std::string_view((CSTRING)Buffer + (MAXINT)view->data(), view->length());
+         }
+         else if (auto str = (int8_t **)(Buffer + pos); *str) {
+            *str = Buffer + (MAXINT)*str;
+         }
+      }
+      else if (type & (FD_PTR|FD_BUFFER)) {
+         pos = align_arg_offset(pos);
+         if ((not (type & (FD_OBJECT|FD_RESULT))) and (Args[i+1].Type & FD_PTRSIZE)) {
+            if (auto ptr = (int8_t **)(Buffer + pos); *ptr) *ptr = Buffer + (MAXINT)*ptr;
+         }
+      }
+      pos = argument_end_offset(type, pos);
+   }
+}
+
 //********************************************************************************************************************
 
 void release_copied_args(const FunctionField *Args, int ArgsSize, int8_t *Parameters, bool DereferenceAll,

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -1202,3 +1202,44 @@ ERR WakeThread(int Thread, int Stop)
    }
    return ERR::Okay;
 }
+
+/*********************************************************************************************************************
+
+-FUNCTION-
+UnitTests: Private.  Run the unit tests that are compiled into the Core.
+
+If the Core has been built with the `UNIT_TESTS` option enabled, calling this function runs the embedded unit tests
+and returns the resulting totals.  If unit tests are not present in the build then no tests are run and both
+counters are returned as zero.
+
+A test run is considered successful when `Passed` matches `Total`.  Details of individual test failures are printed
+to the application log.
+
+-INPUT-
+cstr Options: Reserved for future use; `NULL` is acceptable.
+&int Passed: Returns the number of tests that passed.
+&int Total: Returns the total number of tests that were executed.
+
+-END-
+
+*********************************************************************************************************************/
+
+#ifdef UNIT_TESTS
+extern void queue_action_unit_tests(int &, int &);
+#endif
+
+void UnitTests(CSTRING Options, int *Passed, int *Total)
+{
+   int passed = 0, total = 0;
+
+#ifdef UNIT_TESTS
+   {
+      kt::Log log("CoreTests");
+      log.branch("Running QueueAction unit tests...");
+      queue_action_unit_tests(passed, total);
+   }
+#endif
+
+   if (Passed) *Passed = passed;
+   if (Total) *Total = total;
+}

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -2471,6 +2471,11 @@ ERR QueueAction(ACTIONID ActionID, OBJECTID ObjectID, APTR Args)
    action.Fields = fields;
    action.ArgsSize = args_size;
 
+   // The buffer is duplicated byte-for-byte into the message queue, so self-referential argument pointers must be
+   // converted to offsets.  The receiver (msg_action) rebases them against its copy with make_args_absolute().
+
+   if (action.SendArgs) make_args_relative(fields, args_size, buffer.data());
+
    buffer.insert(buffer.begin(), (int8_t *)&action, (int8_t *)&action + sizeof(ActionMessage));
 
    if (auto error = SendMessage(MSGID::ACTION, MSF::NIL, buffer.data(), buffer.size()); error != ERR::Okay) {

--- a/src/core/prototypes.h
+++ b/src/core/prototypes.h
@@ -93,3 +93,4 @@ extern "C" int AsyncPending(OBJECTID Object);
 extern "C" ERR AsyncWait(kt::vector<OBJECTID> & Objects, int TimeOut);
 extern "C" ERR ClassDatabase(kt::vector<ClassRecord *> * Classes);
 extern "C" int GetThreadID();
+extern "C" void UnitTests(CSTRING Options, int * Passed, int * Total);

--- a/src/core/tests/test_unit_tests.tiri
+++ b/src/core/tests/test_unit_tests.tiri
@@ -1,0 +1,12 @@
+-- Call the unit tests that are compiled into the Core.  If the Core was built without the UNIT_TESTS option
+-- then UnitTests() reports zero totals and this test passes trivially.
+
+@Test function UnitTests()
+   local passed, total = mSys.UnitTests(nil)
+   assert(passed is total, 'Passed ' .. passed .. ' of ' .. total .. ' Core unit tests.  Use --log-api for details.')
+   if total is 0 then
+      print('The Core was built without embedded unit tests.')
+   else
+      print('Passed all ' .. total .. ' embedded unit tests.')
+   end
+end

--- a/src/core/tests/unit_tests_queue_action.cpp
+++ b/src/core/tests/unit_tests_queue_action.cpp
@@ -1,0 +1,93 @@
+/*********************************************************************************************************************
+
+The source code of the Kotuku project is made publicly available under the terms described in the LICENSE.TXT file
+that is distributed with this package.  Please refer to it for further information on licensing.
+
+**********************************************************************************************************************
+
+Unit tests for QueueAction() argument serialisation, compiled into the Core when UNIT_TESTS is enabled and invoked
+via the public UnitTests() function.  The primary concern is the relocation of self-referential string pointers
+when the argument buffer is duplicated into the message queue.
+
+*********************************************************************************************************************/
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../defs.h"
+
+//********************************************************************************************************************
+// Queue several SetKey actions with string arguments held in temporary storage, then destroy that storage before
+// the messages are processed.  Each QueueAction() call serialises into a temporary buffer that is released on
+// return, so successive calls reuse the same heap blocks.  If the serialised messages retain pointers into those
+// buffers (or into the caller's storage, which is scribbled after queueing), earlier messages are corrupted.
+
+static bool queued_setkey_relocation_check(kt::Log &Log)
+{
+   auto task = (OBJECTPTR)CurrentTask();
+   if (not task) {
+      Log.warning("No current task available.");
+      return false;
+   }
+
+   static const struct { CSTRING Key; CSTRING Value; } test_keys[] = {
+      { "relocation_key_1", "relocation_value_1" },
+      { "relocation_key_2", "relocation_value_2" },
+      { "relocation_key_3", "relocation_value_3" }
+   };
+
+   for (auto &entry : test_keys) {
+      auto key   = std::make_unique<char[]>(64);
+      auto value = std::make_unique<char[]>(64);
+      strcpy(key.get(), entry.Key);
+      strcpy(value.get(), entry.Value);
+
+      struct acSetKey args = { std::string_view(key.get()), std::string_view(value.get()) };
+      if (QueueAction(AC::SetKey, task->UID, &args) != ERR::Okay) {
+         Log.warning("QueueAction() rejected SetKey.");
+         return false;
+      }
+
+      memset(key.get(), 0xee, 64);
+      memset(value.get(), 0xee, 64);
+   }
+
+   // Additional heap churn so that the released serialisation buffers are reused before dispatch.
+
+   std::vector<std::unique_ptr<char[]>> churn;
+   for (int size=16; size <= 512; size += 8) {
+      auto block = std::make_unique<char[]>(size);
+      memset(block.get(), 0x55, size);
+      churn.push_back(std::move(block));
+   }
+
+   ProcessMessages(PMF::NIL, 0);
+
+   for (auto &entry : test_keys) {
+      std::string result;
+      struct acGetKey get = { entry.Key, &result };
+      if (Action(AC::GetKey, task, &get) != ERR::Okay) {
+         Log.warning("Queued SetKey for '%s' was not applied to the task.", entry.Key);
+         return false;
+      }
+
+      if (result != entry.Value) {
+         Log.warning("Queued SetKey for '%s' delivered a corrupted value '%s'.", entry.Key, result.c_str());
+         return false;
+      }
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+void queue_action_unit_tests(int &Passed, int &Total)
+{
+   kt::Log log("QueueAction");
+
+   Total++;
+   if (queued_setkey_relocation_check(log)) Passed++;
+}


### PR DESCRIPTION
* Rebased self-referential string and buffer arguments after message queue copies
* Added embedded QueueAction relocation coverage and a Flute entry point