### PR TITLE
[Tiri] Namespaced module globals for static builds

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -131,6 +131,11 @@ set (JIT_KOTUKU_HEADER_DEPENDENCIES
    "${INCLUDE_OUTPUT}/system/registry.h"
 )
 
+set (JIT_TIRI_HEADER_DEPENDENCIES
+   "${CMAKE_CURRENT_SOURCE_DIR}/defs.h"
+   "${CMAKE_CURRENT_SOURCE_DIR}/struct_def.h"
+)
+
 option(KOTUKU_PARSER_TRACE "Emit parser token and expectation traces" OFF)
 option(INCLUDE_TIPS "Include the parser tips system for code analysis" ON)
 
@@ -614,7 +619,7 @@ else ()
             -Wno-trigraphs
             -c ${SOURCE_FILE} -o ${OBJECT_FILE}
          DEPENDS ${SOURCE_FILE} ${JIT_GENERATED_HEADERS} "${JIT_SRC}/lj_ircall.h"
-            ${JIT_KOTUKU_HEADER_DEPENDENCIES}
+            ${JIT_KOTUKU_HEADER_DEPENDENCIES} ${JIT_TIRI_HEADER_DEPENDENCIES}
          COMMENT "Compiling ${FILENAME}.cpp"
          VERBATIM
       )

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -34,9 +34,11 @@ class extTiri; // Internal extended Tiri class (full definition below); derives 
 template <class T> T ALIGN64(T a) { return (((a) + 7) & (~7)); }
 template <class T> T ALIGN32(T a) { return (((a) + 3) & (~3)); }
 
+namespace tiri {
 extern CSTRING const glBytecodeNames[];
 extern bool glPrintMsg;
 extern MSGID glDelayedCallMsgID;
+}
 
 //********************************************************************************************************************
 
@@ -71,6 +73,7 @@ struct CaseInsensitiveEqualView {
    }
 };
 
+namespace tiri {
 extern ankerl::unordered_dense::map<std::string_view, ACTIONID, CaseInsensitiveHashView, CaseInsensitiveEqualView> glActionLookup;
 extern struct ActionTable *glActions;
 extern OBJECTPTR modDisplay; // Required by tiri_input.c
@@ -82,6 +85,9 @@ extern JOF glJitOptions;
 extern ankerl::unordered_dense::map<uint32_t, StructInfo> *glStructSizes;
 extern std::unordered_map<struct_name, struct_record, struct_hash, struct_equal> glStructs;
 extern uint64_t glActionsWithResults;
+}
+
+using namespace tiri;
 
 //********************************************************************************************************************
 // Compile-time constant value (64-bit integer or double)
@@ -104,8 +110,10 @@ struct TiriConstant {
 
 // Global constant registry - case-sensitive, owns string keys
 // Protected by glConstantMutex for thread-safe access
+namespace tiri {
 extern ankerl::unordered_dense::map<uint32_t, TiriConstant> glConstantRegistry;
 extern std::shared_mutex glConstantMutex;
+}
 
 // Thread-safe shared pool for async.pool — see tiri_async.cpp
 // Owned by the main script's extTiri and shared with child scripts via std::shared_ptr.

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -49,6 +49,7 @@ JUMPTABLE_REGEX
 
 #include "defs.h"
 
+namespace tiri {
 OBJECTPTR modDisplay = nullptr; // Required by tiri_input.c
 OBJECTPTR modTiri = nullptr;
 OBJECTPTR modRegex = nullptr;
@@ -67,6 +68,7 @@ uint64_t glActionsWithResults = 0;
 static struct MsgHandler *glMsgThread = nullptr; // Message handler for thread callbacks
 static MsgHandler *glDelayedCallHandle = nullptr;
 MSGID glDelayedCallMsgID = MSGID::NIL;
+}
 
 constexpr auto HASH_TRACE_TOKENS         = kt::strhash("trace-tokens");
 constexpr auto HASH_TRACE_EXPECT         = kt::strhash("trace-expect");
@@ -377,11 +379,13 @@ static void MODTest(std::string_view Options, int *Passed, int *Total)
 //********************************************************************************************************************
 // Bytecode names for debugging purposes
 
+namespace tiri {
 CSTRING const glBytecodeNames[] = {
 #define BCNAME(name, ma, mb, mc, mt) #name,
    BCDEF(BCNAME)
 #undef BCNAME
 };
+}
 
 /*********************************************************************************************************************
 


### PR DESCRIPTION
* Isolated Tiri globals behind the tiri namespace to avoid static archive symbol collisions
* [Build] Added Tiri internal headers to JIT custom object dependencies