### PR TITLE
[SVG] Improved mesh gradient parsing conformance

### DIFF
--- a/docs/xml/modules/classes/gradientmesh.xml
+++ b/docs/xml/modules/classes/gradientmesh.xml
@@ -39,6 +39,7 @@
       <description>
 <p>The Patches array defines one or more bilinear Coons patches.  Each <st>MeshPatchRecord</st> contains four cubic Bezier edges in clockwise order (<code>Top</code>, <code>Right</code>, <code>Bottom</code>, <code>Left</code>) plus the top-left, top-right, bottom-right and bottom-left corner colours.</p>
 <p>The coordinate system for patch positions is determined by <class name="Gradient" field="Units">Gradient.Units</class>.  Under <code>BOUNDING_BOX</code>, normalised patch coordinates in the range <code>0 - 1.0</code> are scaled into the target path's bounds.  Under <code>USERSPACE</code>, positions are taken directly in the viewport's coordinate system.</p>
+<p>Assigning an empty array clears the mesh entirely, including the <fl>Rows</fl> and <fl>Columns</fl> metadata.</p>
       </description>
     </field>
 

--- a/docs/xml/modules/classes/gradientmesh.xml
+++ b/docs/xml/modules/classes/gradientmesh.xml
@@ -14,7 +14,8 @@
     <copyright>Paul Manias © 2010-2026</copyright>
     <description>
 <p>GradientMesh interpolates colour across a grid of curved patches.  Each patch is bounded by four cubic Bezier edges and carries one colour at each corner.  Rendering tessellates the patches into Gouraud triangles, so colour follows the patch geometry rather than a one-dimensional colour ramp.</p>
-<p>The inherited colour-ramp fields <code>Stops</code>, <code>ColourMap</code>, <code>SpreadMethod</code> and <code>Colour</code> are not supported by this class. Patch geometry and corner colours are supplied through <fl>Patches</fl>.</p></description>
+<p>The inherited colour-ramp fields <code>Stops</code>, <code>ColourMap</code>, <code>SpreadMethod</code> and <code>Colour</code> are not supported by this class. Patch geometry and corner colours are supplied through <fl>Patches</fl>.</p>
+<p>When a mesh is exported to SVG, valid <fl>Rows</fl> and <fl>Columns</fl> metadata is preserved through the standard shared-edge <code>meshrow</code> syntax.  A mesh without valid row metadata (e.g. a non-rectangular grid) is flattened to a single row on export; every patch survives intact, with patches that do not share an edge with their predecessor written as independent patches, but the original row structure is not retained.</p></description>
     <source>
       <file path="painters/">gradient_mesh.cpp</file>
     </source>

--- a/src/svg/gradients.cpp
+++ b/src/svg/gradients.cpp
@@ -71,6 +71,50 @@ static void warn_unknown_gradient_attribute(kt::Log &Log, const XTag &Tag, const
 }
 
 //********************************************************************************************************************
+// Shared resolver for <stop> colour attributes, used by both the generic gradient stop parser and mesh gradient
+// stops.  Inline style declarations are converted to real attributes at load time (see convert_styles()), so only
+// presentation attributes require handling here.  Style-derived attributes are appended after the presentation
+// attributes, so processing in order gives them CSS precedence.  'inherit' resolves against the current state's
+// stop-color/stop-opacity and 'currentColor' against the current 'color' value.
+
+FRGB svgState::resolve_stop_colour(const XTag &Tag) noexcept
+{
+   FRGB colour(0,0,0,1);
+   double stop_opacity = 1.0;
+
+   for (int a=1; a < std::ssize(Tag.Attribs); a++) {
+      auto &name  = Tag.Attribs[a].Name;
+      auto &value = Tag.Attribs[a].Value;
+      if (value.empty()) continue;
+
+      if (iequals("stop-color", name)) {
+         VectorPainter painter;
+         if (iequals("inherit", value)) {
+            if (not m_stop_color.empty()) {
+               vec::ReadPainter(Self->Scene, m_stop_color, &painter, nullptr);
+               colour = painter.Colour;
+            }
+         }
+         else if (iequals("currentColor", value)) {
+            vec::ReadPainter(Self->Scene, m_color, &painter, nullptr);
+            colour = painter.Colour;
+         }
+         else {
+            vec::ReadPainter(Self->Scene, value, &painter, nullptr);
+            colour = painter.Colour;
+         }
+      }
+      else if (iequals("stop-opacity", name)) {
+         if (iequals("inherit", value)) stop_opacity = (m_stop_opacity >= 0) ? m_stop_opacity : 1.0;
+         else stop_opacity = svtonum<double>(value);
+      }
+   }
+
+   colour.Alpha = float(double(colour.Alpha) * stop_opacity);
+   return colour;
+}
+
+//********************************************************************************************************************
 // Note that all offsets are percentages.
 
 const kt::vector<GradientStop> svgState::process_gradient_stops(const XTag &Tag) noexcept
@@ -84,9 +128,8 @@ const kt::vector<GradientStop> svgState::process_gradient_stops(const XTag &Tag)
    for (auto &scan : Tag.Children) {
       if (svg_tag_hash(scan) IS kt::strhash("stop")) {
          GradientStop stop;
-         double stop_opacity = 1.0;
          stop.Offset = 0;
-         stop.RGB = FRGB(0,0,0,1);
+         stop.RGB = resolve_stop_colour(scan);
 
          for (int a=1; a < std::ssize(scan.Attribs); a++) {
             auto &name  = scan.Attribs[a].Name;
@@ -108,36 +151,13 @@ const kt::vector<GradientStop> svgState::process_gradient_stops(const XTag &Tag)
                if (stop.Offset < last_stop) stop.Offset = last_stop;
                else last_stop = stop.Offset;
             }
-            else if (iequals("stop-color", name)) {
-               if (iequals("inherit", value)) {
-                  VectorPainter painter;
-                  vec::ReadPainter(Self->Scene, m_stop_color, &painter, nullptr);
-                  stop.RGB = painter.Colour;
-               }
-               else if (iequals("currentColor", value)) {
-                  VectorPainter painter;
-                  vec::ReadPainter(Self->Scene, m_color, &painter, nullptr);
-                  stop.RGB = painter.Colour;
-               }
-               else {
-                  VectorPainter painter;
-                  vec::ReadPainter(Self->Scene, value, &painter, nullptr);
-                  stop.RGB = painter.Colour;
-               }
-            }
-            else if (iequals("stop-opacity", name)) {
-               if (iequals("inherit", value)) {
-                  stop_opacity = m_stop_opacity;
-               }
-               else stop_opacity = svtonum<double>(value);
-            }
+            else if (iequals("stop-color", name));   // Resolved by resolve_stop_colour()
+            else if (iequals("stop-opacity", name)); // Resolved by resolve_stop_colour()
             else if (iequals("id", name)) {
                log.trace("Use of id attribute in <stop/> ignored.");
             }
             else log.warning("Unable to process stop attribute '%s'", name.c_str());
          }
-
-         stop.RGB.Alpha = ((double)stop.RGB.Alpha) * stop_opacity;
 
          stops.emplace_back(stop);
       }
@@ -277,31 +297,6 @@ static SVGMeshPatchEdge reverse_mesh_edge(const SVGMeshPatchEdge &Edge) noexcept
    return SVGMeshPatchEdge { Edge.p1, Edge.c1, Edge.c0, Edge.p0 };
 }
 
-static bool read_mesh_stop_colour(extSVG *Self, const XTag &Tag, FRGB &Colour) noexcept
-{
-   Colour = FRGB(0,0,0,1);
-
-   double stop_opacity = 1.0;
-   bool found_colour = false;
-
-   for (int a=1; a < std::ssize(Tag.Attribs); a++) {
-      auto &name = Tag.Attribs[a].Name;
-      auto &value = Tag.Attribs[a].Value;
-      if (value.empty()) continue;
-
-      if (iequals("stop-color", name)) {
-         VectorPainter painter;
-         vec::ReadPainter(Self->Scene, value, &painter, nullptr);
-         Colour = painter.Colour;
-         found_colour = true;
-      }
-      else if (iequals("stop-opacity", name)) stop_opacity = svtonum<double>(value);
-   }
-
-   Colour.Alpha = ((double)Colour.Alpha) * stop_opacity;
-   return found_colour;
-}
-
 static bool read_mesh_stop_path(const XTag &Tag, std::string &Path) noexcept
 {
    for (int a=1; a < std::ssize(Tag.Attribs); a++) {
@@ -313,7 +308,14 @@ static bool read_mesh_stop_path(const XTag &Tag, std::string &Path) noexcept
    return false;
 }
 
-static bool parse_mesh_edge_path(const std::string &Path, const SVGMeshPoint &Start, SVGMeshPatchEdge &Edge) noexcept
+// Mesh stop path grammar (SVG 2 mesh gradient proposal, svgwg.org): each <stop> 'path' consists of exactly one
+// segment drawn with a single 'C', 'c', 'L' or 'l' command, starting from the previous stop's end point.  The
+// closing stop of a fully specified patch may instead use 'Z'/'z', which draws a straight line back to the patch
+// origin.  Multi-segment paths are not part of the grammar and are rejected.  Returns nullptr on success,
+// otherwise a description of the fault.
+
+static const char * parse_mesh_edge_path(const std::string &Path, const SVGMeshPoint &Start, SVGMeshPatchEdge &Edge,
+   const SVGMeshPoint *Close = nullptr) noexcept
 {
    Edge.p0 = Start;
    std::string_view scan(Path);
@@ -321,9 +323,8 @@ static bool parse_mesh_edge_path(const std::string &Path, const SVGMeshPoint &St
       while ((not Scan.empty()) and ((Scan.front() <= 0x20) or (Scan.front() IS ','))) Scan.remove_prefix(1);
    };
 
-   if (scan.empty()) return false;
    skip_separators(scan);
-   if (scan.empty()) return false;
+   if (scan.empty()) return "empty stop path";
 
    const char cmd = scan.front();
    scan.remove_prefix(1);
@@ -335,49 +336,54 @@ static bool parse_mesh_edge_path(const std::string &Path, const SVGMeshPoint &St
 
       char *end = nullptr;
       const double value = std::strtod(scan.data(), &end);
-      if (end IS scan.data()) return false;
-      if (not std::isfinite(value)) return false;
+      if (end IS scan.data()) return "unrecognised character in stop path";
+      if (not std::isfinite(value)) return "non-finite number in stop path";
       numbers.push_back(value);
       scan.remove_prefix(size_t(end - scan.data()));
    }
 
+   auto straight_line = [&Edge](const SVGMeshPoint &From, const SVGMeshPoint &To) noexcept {
+      const double dx = To.x - From.x;
+      const double dy = To.y - From.y;
+      Edge.c0 = SVGMeshPoint { From.x + (dx / 3.0), From.y + (dy / 3.0) };
+      Edge.c1 = SVGMeshPoint { From.x + (dx * 2.0 / 3.0), From.y + (dy * 2.0 / 3.0) };
+      Edge.p1 = To;
+   };
+
    switch (cmd) {
       case 'C':
-         if (numbers.size() != 6) return false;
-         Edge.c0 = SVGMeshPoint { numbers[0], numbers[1] };
-         Edge.c1 = SVGMeshPoint { numbers[2], numbers[3] };
-         Edge.p1 = SVGMeshPoint { numbers[4], numbers[5] };
-         return true;
-
       case 'c':
-         if (numbers.size() != 6) return false;
-         Edge.c0 = SVGMeshPoint { Start.x + numbers[0], Start.y + numbers[1] };
-         Edge.c1 = SVGMeshPoint { Start.x + numbers[2], Start.y + numbers[3] };
-         Edge.p1 = SVGMeshPoint { Start.x + numbers[4], Start.y + numbers[5] };
-         return true;
+         if (numbers.size() > 6) return "multi-segment stop paths are not supported";
+         if (numbers.size() != 6) return "curve commands require six numbers";
+         if (cmd IS 'C') {
+            Edge.c0 = SVGMeshPoint { numbers[0], numbers[1] };
+            Edge.c1 = SVGMeshPoint { numbers[2], numbers[3] };
+            Edge.p1 = SVGMeshPoint { numbers[4], numbers[5] };
+         }
+         else {
+            Edge.c0 = SVGMeshPoint { Start.x + numbers[0], Start.y + numbers[1] };
+            Edge.c1 = SVGMeshPoint { Start.x + numbers[2], Start.y + numbers[3] };
+            Edge.p1 = SVGMeshPoint { Start.x + numbers[4], Start.y + numbers[5] };
+         }
+         return nullptr;
 
-      case 'L': {
-         if (numbers.size() != 2) return false;
-         Edge.p1 = SVGMeshPoint { numbers[0], numbers[1] };
-         const double dx = Edge.p1.x - Start.x;
-         const double dy = Edge.p1.y - Start.y;
-         Edge.c0 = SVGMeshPoint { Start.x + (dx / 3.0), Start.y + (dy / 3.0) };
-         Edge.c1 = SVGMeshPoint { Start.x + (dx * 2.0 / 3.0), Start.y + (dy * 2.0 / 3.0) };
-         return true;
-      }
+      case 'L':
+      case 'l':
+         if (numbers.size() > 2) return "multi-segment stop paths are not supported";
+         if (numbers.size() != 2) return "line commands require two numbers";
+         if (cmd IS 'L') straight_line(Start, SVGMeshPoint { numbers[0], numbers[1] });
+         else straight_line(Start, SVGMeshPoint { Start.x + numbers[0], Start.y + numbers[1] });
+         return nullptr;
 
-      case 'l': {
-         if (numbers.size() != 2) return false;
-         Edge.p1 = SVGMeshPoint { Start.x + numbers[0], Start.y + numbers[1] };
-         const double dx = Edge.p1.x - Start.x;
-         const double dy = Edge.p1.y - Start.y;
-         Edge.c0 = SVGMeshPoint { Start.x + (dx / 3.0), Start.y + (dy / 3.0) };
-         Edge.c1 = SVGMeshPoint { Start.x + (dx * 2.0 / 3.0), Start.y + (dy * 2.0 / 3.0) };
-         return true;
-      }
+      case 'Z':
+      case 'z':
+         if (not Close) return "'Z' is only permitted on the closing stop of a fully specified patch";
+         if (not numbers.empty()) return "'Z' does not accept numbers";
+         straight_line(Start, *Close);
+         return nullptr;
 
       default:
-         return false;
+         return "unsupported stop path command";
    }
 }
 
@@ -409,14 +415,28 @@ static MeshPatchRecord mesh_patch_record_from_patch(const SVGMeshPatch &Patch) n
    return record;
 }
 
-static bool read_mesh_patch_stop(extSVG *Self, const XTag &Stop, const SVGMeshPoint &Start, SVGMeshPatchEdge &Edge,
-   FRGB &Colour) noexcept
+// Snap the closing edge of a fully specified patch back to the patch origin so that numeric drift in authored
+// files cannot leave the patch unclosed.  Warn when the gap is large relative to the patch extent, as that
+// suggests an authoring error rather than rounding drift.
+
+static void close_mesh_patch(kt::Log &Log, SVGMeshPatch &Patch) noexcept
 {
-   std::string path;
-   if (!read_mesh_stop_path(Stop, path)) return false;
-   if (!parse_mesh_edge_path(path, Start, Edge)) return false;
-   read_mesh_stop_colour(Self, Stop, Colour);
-   return true;
+   auto &closing = Patch.edge[3];
+   const auto &origin = Patch.edge[0].p0;
+   const double dx = closing.p1.x - origin.x;
+   const double dy = closing.p1.y - origin.y;
+   const double gap = std::sqrt((dx * dx) + (dy * dy));
+
+   double extent = 0;
+   for (auto &edge : Patch.edge) {
+      extent = std::max({ extent, std::abs(edge.p1.x - edge.p0.x), std::abs(edge.p1.y - edge.p0.y) });
+   }
+
+   if (gap > std::max(extent, 1.0) * 0.001) {
+      Log.warning("Mesh patch closing edge misses the patch origin by %g units; snapping to close the patch.", gap);
+   }
+
+   closing.p1 = origin;
 }
 
 static bool read_mesh_patch_origin(const XTag &Tag, SVGMeshPoint &Origin) noexcept
@@ -459,8 +479,10 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
 
       auto attrib = strhash(Tag.Attribs[a].Name);
       switch(attrib) {
-         case SVF_x: start_x = svtonum<double>(val); break;
-         case SVF_y: start_y = svtonum<double>(val); break;
+         // Percentages scale to 0 - 1.0, matching bounding-box semantics (cf. parse_units()).  Under userspace
+         // units the viewport size is not known at parse time, so a percentage resolves to the same fraction.
+         case SVF_x: { auto v = std::string_view(val); start_x = read_unit(v); break; }
+         case SVF_y: { auto v = std::string_view(val); start_y = read_unit(v); break; }
          case SVF_type:
             if ((not iequals("bilinear", val)) and (not iequals("Coons", val))) {
                log.warning("Mesh gradient type '%s' is not supported; using bilinear Coons patches.", val.c_str());
@@ -480,102 +502,123 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
    int columns = 0;
    bool rectangular = true;
 
+   // Read one stop: parse its edge path and resolve its colour.  Returns nullptr on success or a fault description.
+
+   auto read_stop = [&](const XTag &Stop, const SVGMeshPoint &Start, SVGMeshPatchEdge &Edge, FRGB &Colour,
+         const SVGMeshPoint *Close) noexcept -> const char * {
+      std::string path;
+      if (not read_mesh_stop_path(Stop, path)) return "missing or empty stop path";
+      if (auto fault = parse_mesh_edge_path(path, Start, Edge, Close)) return fault;
+      Colour = resolve_stop_colour(Stop);
+      return nullptr;
+   };
+
+   // Parse one <meshpatch>, appending it to current_row and records.  Returns nullptr on success or a fault
+   // description.  Any fault aborts the entire gradient - a silently dropped patch would shift the remaining
+   // patches left by one column and sew the wrong shared edges together.
+
+   auto parse_patch = [&](const XTag &PatchTag) noexcept -> const char * {
+      SVGMeshPatch patch = {};
+      std::vector<const XTag *> stops;
+      for (auto &stop_tag : PatchTag.Children) {
+         if (svg_tag_hash(stop_tag) IS kt::strhash("stop")) stops.push_back(&stop_tag);
+      }
+
+      const int col = int(current_row.size());
+
+      SVGMeshPoint independent_origin;
+      if (read_mesh_patch_origin(PatchTag, independent_origin)) {
+         if (stops.size() != 4) return "independent patches require exactly four stops";
+
+         patch.edge[0].p0 = independent_origin;
+         if (auto fault = read_stop(*stops[0], patch.edge[0].p0, patch.edge[0], patch.corner[1], nullptr)) return fault;
+         patch.edge[1].p0 = patch.edge[0].p1;
+         if (auto fault = read_stop(*stops[1], patch.edge[1].p0, patch.edge[1], patch.corner[2], nullptr)) return fault;
+         patch.edge[2].p0 = patch.edge[1].p1;
+         if (auto fault = read_stop(*stops[2], patch.edge[2].p0, patch.edge[2], patch.corner[3], nullptr)) return fault;
+         patch.edge[3].p0 = patch.edge[2].p1;
+         if (auto fault = read_stop(*stops[3], patch.edge[3].p0, patch.edge[3], patch.corner[0], &patch.edge[0].p0)) return fault;
+         close_mesh_patch(log, patch);
+
+         current_row.push_back(patch);
+         records.push_back(mesh_patch_record_from_patch(patch));
+         return nullptr;
+      }
+
+      // Expected stop counts under the shared-edge grammar: 4 for the first patch of the first row, 3 for
+      // subsequent first-row patches and for the first patch of later rows, 2 otherwise.
+
+      const size_t expected = (rows IS 0) ? ((col IS 0) ? 4 : 3) : ((col IS 0) ? 3 : 2);
+      if (stops.size() != expected) return "unexpected number of stops for the patch's grid position";
+
+      int stop_index = 0;
+      if (rows IS 0) {
+         if (col IS 0) patch.edge[0].p0 = SVGMeshPoint { start_x, start_y };
+         else {
+            auto &prev = current_row[size_t(col - 1)];
+            patch.edge[3] = reverse_mesh_edge(prev.edge[1]);
+            patch.edge[0].p0 = patch.edge[3].p1;
+            patch.corner[0] = prev.corner[1];
+            patch.corner[3] = prev.corner[2];
+         }
+
+         if (auto fault = read_stop(*stops[size_t(stop_index++)], patch.edge[0].p0,
+            patch.edge[0], patch.corner[1], nullptr)) return fault;
+      }
+      else {
+         if (col >= int(previous_row.size())) return "row contains more patches than the row above";
+         auto &above = previous_row[size_t(col)];
+         patch.edge[0] = reverse_mesh_edge(above.edge[2]);
+         patch.corner[0] = above.corner[3];
+         patch.corner[1] = above.corner[2];
+      }
+
+      patch.edge[1].p0 = patch.edge[0].p1;
+      if (auto fault = read_stop(*stops[size_t(stop_index++)], patch.edge[1].p0,
+         patch.edge[1], patch.corner[2], nullptr)) return fault;
+
+      patch.edge[2].p0 = patch.edge[1].p1;
+      if (auto fault = read_stop(*stops[size_t(stop_index++)], patch.edge[2].p0,
+         patch.edge[2], patch.corner[3], nullptr)) return fault;
+
+      if (col IS 0) {
+         patch.edge[3].p0 = patch.edge[2].p1;
+         if (auto fault = read_stop(*stops[size_t(stop_index++)], patch.edge[3].p0,
+            patch.edge[3], patch.corner[0], &patch.edge[0].p0)) return fault;
+         if (rows IS 0) close_mesh_patch(log, patch);
+         else {
+            patch.edge[3].p1 = patch.edge[0].p0;
+            patch.corner[0] = previous_row[0].corner[3];
+         }
+      }
+      else {
+         auto &prev = current_row[size_t(col - 1)];
+         if (rows != 0) patch.edge[3] = reverse_mesh_edge(prev.edge[1]);
+         patch.edge[2].p1 = patch.edge[3].p0;
+         patch.corner[3] = prev.corner[2];
+         patch.corner[0] = prev.corner[1];
+      }
+
+      current_row.push_back(patch);
+      records.push_back(mesh_patch_record_from_patch(patch));
+      return nullptr;
+   };
+
+   const char *fault = nullptr;
    for (auto &row_tag : Tag.Children) {
       if (svg_tag_hash(row_tag) != SVF_meshrow) continue;
 
       current_row.clear();
-      int col = 0;
       for (auto &patch_tag : row_tag.Children) {
          if (svg_tag_hash(patch_tag) != SVF_meshpatch) continue;
 
-         SVGMeshPatch patch = {};
-         std::vector<const XTag *> stops;
-         for (auto &stop_tag : patch_tag.Children) {
-            if (svg_tag_hash(stop_tag) IS kt::strhash("stop")) stops.push_back(&stop_tag);
+         if ((fault = parse_patch(patch_tag))) {
+            log.warning("Discarding <meshgradient> @ line %d; row %d, patch %d: %s",
+               patch_tag.LineNo, rows + 1, int(current_row.size()) + 1, fault);
+            break;
          }
-
-         SVGMeshPoint independent_origin;
-         if (read_mesh_patch_origin(patch_tag, independent_origin)) {
-            if (stops.size() < 4) continue;
-
-            patch.edge[0].p0 = independent_origin;
-            int stop_index = 0;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[0].p0,
-               patch.edge[0], patch.corner[1])) continue;
-
-            patch.edge[1].p0 = patch.edge[0].p1;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[1].p0,
-               patch.edge[1], patch.corner[2])) continue;
-
-            patch.edge[2].p0 = patch.edge[1].p1;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[2].p0,
-               patch.edge[2], patch.corner[3])) continue;
-
-            patch.edge[3].p0 = patch.edge[2].p1;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[3].p0,
-               patch.edge[3], patch.corner[0])) continue;
-
-            current_row.push_back(patch);
-            records.push_back(mesh_patch_record_from_patch(patch));
-            col++;
-            continue;
-         }
-
-         int stop_index = 0;
-         if (rows IS 0) {
-            if (col IS 0) patch.edge[0].p0 = SVGMeshPoint { start_x, start_y };
-            else {
-               auto &prev = current_row[size_t(col - 1)];
-               patch.edge[3] = reverse_mesh_edge(prev.edge[1]);
-               patch.edge[0].p0 = patch.edge[3].p1;
-               patch.corner[0] = prev.corner[1];
-               patch.corner[3] = prev.corner[2];
-            }
-
-            if (stop_index >= int(stops.size())) continue;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[0].p0,
-               patch.edge[0], patch.corner[1])) continue;
-         }
-         else {
-            if (col >= int(previous_row.size())) continue;
-            auto &above = previous_row[size_t(col)];
-            patch.edge[0] = reverse_mesh_edge(above.edge[2]);
-            patch.corner[0] = above.corner[3];
-            patch.corner[1] = above.corner[2];
-         }
-
-         patch.edge[1].p0 = patch.edge[0].p1;
-         if (stop_index >= int(stops.size())) continue;
-         if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[1].p0,
-            patch.edge[1], patch.corner[2])) continue;
-
-         patch.edge[2].p0 = patch.edge[1].p1;
-         if (stop_index >= int(stops.size())) continue;
-         if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[2].p0,
-            patch.edge[2], patch.corner[3])) continue;
-
-         if (col IS 0) {
-            patch.edge[3].p0 = patch.edge[2].p1;
-            if (stop_index >= int(stops.size())) continue;
-            if (!read_mesh_patch_stop(Self, *stops[size_t(stop_index++)], patch.edge[3].p0,
-               patch.edge[3], patch.corner[0])) continue;
-            if (rows != 0) {
-               patch.edge[3].p1 = patch.edge[0].p0;
-               patch.corner[0] = previous_row[0].corner[3];
-            }
-         }
-         else {
-            auto &prev = current_row[size_t(col - 1)];
-            if (rows != 0) patch.edge[3] = reverse_mesh_edge(prev.edge[1]);
-            patch.edge[2].p1 = patch.edge[3].p0;
-            patch.corner[3] = prev.corner[2];
-            patch.corner[0] = prev.corner[1];
-         }
-
-         current_row.push_back(patch);
-         records.push_back(mesh_patch_record_from_patch(patch));
-         col++;
       }
+      if (fault) break;
 
       if (not current_row.empty()) {
          if (columns IS 0) columns = int(current_row.size());
@@ -584,6 +627,13 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
          previous_row = current_row;
          rows++;
       }
+   }
+
+   if (fault) {
+      // A malformed patch invalidates the entire mesh, matching SVG's in-error paint server behaviour.  Clearing
+      // the patches also discards any records inherited via href.
+      Gradient->setPatches(std::span<const MeshPatchRecord>());
+      return;
    }
 
    if (not records.empty()) {

--- a/src/svg/gradients.cpp
+++ b/src/svg/gradients.cpp
@@ -94,6 +94,9 @@ FRGB svgState::resolve_stop_colour(const XTag &Tag) noexcept
                vec::ReadPainter(Self->Scene, m_stop_color, &painter, nullptr);
                colour = painter.Colour;
             }
+            // With no inherited value, 'inherit' resolves to the initial stop-color.  It must still
+            // overwrite any colour set by an earlier attribute (style declarations arrive last and win).
+            else colour = FRGB(0,0,0,1);
          }
          else if (iequals("currentColor", value)) {
             vec::ReadPainter(Self->Scene, m_color, &painter, nullptr);
@@ -472,6 +475,7 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
 
    double start_x = 0;
    double start_y = 0;
+   bool origin_set = false;
 
    for (int a=1; a < std::ssize(Tag.Attribs); a++) {
       auto &val = Tag.Attribs[a].Value;
@@ -481,8 +485,8 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
       switch(attrib) {
          // Percentages scale to 0 - 1.0, matching bounding-box semantics (cf. parse_units()).  Under userspace
          // units the viewport size is not known at parse time, so a percentage resolves to the same fraction.
-         case SVF_x: { auto v = std::string_view(val); start_x = read_unit(v); break; }
-         case SVF_y: { auto v = std::string_view(val); start_y = read_unit(v); break; }
+         case SVF_x: { auto v = std::string_view(val); start_x = read_unit(v); origin_set = true; break; }
+         case SVF_y: { auto v = std::string_view(val); start_y = read_unit(v); origin_set = true; break; }
          case SVF_type:
             if ((not iequals("bilinear", val)) and (not iequals("Coons", val))) {
                log.warning("Mesh gradient type '%s' is not supported; using bilinear Coons patches.", val.c_str());
@@ -493,6 +497,18 @@ void svgState::parse_meshgradient(const XTag &Tag, objGradientMesh *Gradient, st
             parse_gradient_defaults(log, Tag, Gradient, attrib, Tag.Attribs[a].Name, val, ID);
             break;
       }
+   }
+
+   // The x/y origin only anchors locally defined rows.  A referencing tag without rows of its own cannot
+   // re-anchor patches inherited via href because their geometry was baked when the href target was parsed,
+   // so x/y is documented as ignored in that case.
+
+   if (origin_set) {
+      bool has_rows = false;
+      for (auto &row_tag : Tag.Children) {
+         if (svg_tag_hash(row_tag) IS SVF_meshrow) { has_rows = true; break; }
+      }
+      if (not has_rows) log.warning("x/y on a <meshgradient> without its own rows is ignored @ line %d.", Tag.LineNo);
    }
 
    std::vector<MeshPatchRecord> records;

--- a/src/svg/svg.cpp
+++ b/src/svg/svg.cpp
@@ -171,6 +171,7 @@ private:
    void applyTag(const XTag &) noexcept;
    void applyStateToVector(objVector *) const noexcept;
    const kt::vector<GradientStop> process_gradient_stops(const XTag &) noexcept;
+   FRGB resolve_stop_colour(const XTag &) noexcept;
    ERR  set_property(objVector *, uint32_t, XTag &, const std::string) noexcept;
    ERR  process_tag(XTag &, XTag &, OBJECTPTR, objVector * &) noexcept;
 

--- a/src/svg/tests/test_meshgradient_roundtrip.tiri
+++ b/src/svg/tests/test_meshgradient_roundtrip.tiri
@@ -160,6 +160,30 @@ function inheritedColourMesh():str
 ]]
 end
 
+-- No ancestor supplies stop-color, so the style-derived 'inherit' must resolve to the initial value (black)
+-- and overwrite the earlier presentation attribute rather than preserving it.
+
+function inheritFallbackMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="#ff0000" style="stop-color:inherit"/>
+          <stop path="L 100 100" stop-color="#ffff00"/>
+          <stop path="L 0 100" stop-color="#0000ff"/>
+          <stop path="Z" stop-color="#00ff00"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
 function percentageOriginMesh():str
    return [[
 <?xml version="1.0" standalone="no"?>
@@ -172,6 +196,95 @@ function percentageOriginMesh():str
           <stop path="L 1 1" stop-color="#ffff00"/>
           <stop path="L 0.5 1" stop-color="#0000ff"/>
           <stop path="Z" stop-color="#ff0000"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+-- A referencing mesh with no rows of its own must retain the patches inherited via href; its x/y is ignored
+-- because inherited patch geometry was baked when the href target was parsed.
+
+function hrefOnlyMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="base2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 50 0" stop-color="#00ff00"/>
+          <stop path="L 50 50" stop-color="#ffff00"/>
+          <stop path="L 0 50" stop-color="#0000ff"/>
+          <stop path="L 0 0" stop-color="#ff0000"/>
+        </meshpatch>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="#00ffff"/>
+          <stop path="L 100 50" stop-color="#ff00ff"/>
+          <stop path="L 50 50" stop-color="#ffff00"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+    <meshgradient id="mesh2x2" href="#base2x2" x="30" y="40"/>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+-- currentColor in a paint server defined outside <defs> must resolve against the definition context (the
+-- enclosing <g>), not the colour of the element that references the gradient.  Exercises process_inherit_refs().
+
+function definitionContextMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <g color="#008000">
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="currentColor"/>
+          <stop path="L 100 100" stop-color="#ffff00"/>
+          <stop path="L 0 100" stop-color="#0000ff"/>
+          <stop path="Z" stop-color="#ff0000"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </g>
+  <rect x="0" y="0" width="100" height="100" color="#112233" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+-- Two patches in the first row, one in the second: a valid but non-rectangular grid.
+
+function nonRectangularMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 50 0" stop-color="#00ff00"/>
+          <stop path="L 50 50" stop-color="#ffff00"/>
+          <stop path="L 0 50" stop-color="#0000ff"/>
+          <stop path="L 0 0" stop-color="#ff0000"/>
+        </meshpatch>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="#00ffff"/>
+          <stop path="L 100 50" stop-color="#ff00ff"/>
+          <stop path="L 50 50" stop-color="#ffff00"/>
+        </meshpatch>
+      </meshrow>
+      <meshrow>
+        <meshpatch>
+          <stop path="L 50 100" stop-color="#ff8800"/>
+          <stop path="L 0 100" stop-color="#8800ff"/>
+          <stop path="L 0 50" stop-color="#0000ff"/>
         </meshpatch>
       </meshrow>
     </meshgradient>
@@ -482,6 +595,76 @@ end
    assertChannel(patch.bottomLeft.alpha, 0.25, 'inherited stop-opacity')
    assertChannel(patch.topLeft.red, 0, 'literal stop-color is unaffected')
    assertChannel(patch.topLeft.alpha, 1.0, 'literal stop keeps full opacity')
+end
+
+@Test function HrefOnlyMeshRetainsInheritedPatches()
+   local path = 'temp:meshgradient_href_only.svg'
+   io.writeAll(path, hrefOnlyMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 2, 'A rowless referencing mesh should retain the inherited patches')
+   assert(gradient.rows is 1, 'Inherited row metadata should be retained')
+   assert(gradient.columns is 2, 'Inherited column metadata should be retained')
+   assert(gradient.units is VUNIT_USERSPACE, 'Inherited units should be retained')
+
+   -- x="30" y="40" on the referencing tag cannot re-anchor baked patch geometry and is ignored.
+   local patch = gradient.patches[0]
+   assertNear(patch.top.startX, 0, 'x on a rowless referencing mesh is ignored')
+   assertNear(patch.top.startY, 0, 'y on a rowless referencing mesh is ignored')
+   assertNear(gradient.patches[1].right.startX, 100, 'inherited second patch geometry')
+end
+
+@Test function CurrentColorResolvesInDefinitionContext()
+   local path = 'temp:meshgradient_definition_context.svg'
+   io.writeAll(path, definitionContextMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Definition-context mesh should parse')
+
+   -- currentColor must be baked from the enclosing <g color="#008000">, not the referencing rect's colour.
+   local patch = gradient.patches[0]
+   assertChannel(patch.topRight.red, 0, 'definition-context currentColor red')
+   assertChannel(patch.topRight.green, 128 / 255, 'definition-context currentColor green')
+   assertChannel(patch.topRight.blue, 0, 'definition-context currentColor blue')
+end
+
+@Test function NonRectangularMeshFlattensToSingleRowOnSave()
+   local path = 'temp:meshgradient_non_rectangular.svg'
+   io.writeAll(path, nonRectangularMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 3, 'Non-rectangular mesh should parse all patches')
+   assert(gradient.rows is 1, 'Non-rectangular mesh defaults to single-row metadata')
+   assert(gradient.columns is 3, 'Non-rectangular mesh defaults to flat column metadata')
+
+   local saved = saveScene(scene, 'temp:meshgradient_non_rectangular_saved.svg')
+   assert(countMeshRowsInGradient(saved, 'mesh2x2') is 1, 'Non-rectangular mesh should flatten to one meshrow')
+   assert(string.find(saved, 'kotuku:x', 0, true) != nil, 'Flattened non-adjacent patch should save as independent')
+   assert(string.find(saved, 'xmlns:kotuku="http://www.kotuku.dev/xmlns/svg"', 0, true) != nil,
+      'Saved document must declare the kotuku namespace for independent-patch attributes')
+
+   local reparsed_scene, reparsed_gradient = loadMesh('temp:meshgradient_non_rectangular_saved.svg')
+   assert(#reparsed_gradient.patches is 3, 'Flattened mesh should reparse all patches')
+   assertPatchesMatch(reparsed_gradient, gradient, 'non-rectangular flatten round-trip')
+end
+
+@Test function InheritWithoutParentResolvesToInitialColour()
+   local path = 'temp:meshgradient_inherit_fallback.svg'
+   io.writeAll(path, inheritFallbackMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Inherit-fallback mesh should parse')
+
+   -- style="stop-color:inherit" wins over stop-color="#ff0000"; with no parent value it resolves to black.
+   local patch = gradient.patches[0]
+   assertChannel(patch.topRight.red, 0, 'inherit without parent value red')
+   assertChannel(patch.topRight.green, 0, 'inherit without parent value green')
+   assertChannel(patch.topRight.blue, 0, 'inherit without parent value blue')
+   assertChannel(patch.topRight.alpha, 1.0, 'inherit without parent value alpha')
 end
 
 @Test function PercentageOriginParses()

--- a/src/svg/tests/test_meshgradient_roundtrip.tiri
+++ b/src/svg/tests/test_meshgradient_roundtrip.tiri
@@ -27,6 +27,12 @@ function assertNear(Actual, Expected, Message)
    assert(Actual ≈ Expected, Message .. ' expected ' .. Expected .. ', got ' .. Actual)
 end
 
+-- Compare a colour channel against an expected value, tolerating 8-bit quantisation and float storage.
+
+function assertChannel(Actual:num, Expected:num, Message:str)
+   assert(absValue(Actual - Expected) < 0.01, Message .. ' expected ' .. Expected .. ', got ' .. Actual)
+end
+
 function countMatches(Text:str, Needle:str)
    local count = 0
    local offset = 0
@@ -61,6 +67,9 @@ function countMeshRowsInGradient(Text:str, ID:str)
    return count
 end
 
+-- A two-patch mesh where the second patch's top edge is injectable.  A malformed second patch must discard the
+-- whole mesh rather than leaving the valid first patch behind.
+
 function malformedMesh(PathValue:str):str
    return [[
 <?xml version="1.0" standalone="no"?>
@@ -69,10 +78,127 @@ function malformedMesh(PathValue:str):str
     <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
       <meshrow>
         <meshpatch>
-          <stop path="]] .. PathValue .. [[" stop-color="#00ff00"/>
+          <stop path="L 50 0" stop-color="#00ff00"/>
           <stop path="L 50 50" stop-color="#ffff00"/>
           <stop path="L 0 50" stop-color="#0000ff"/>
           <stop path="L 0 0" stop-color="#ff0000"/>
+        </meshpatch>
+        <meshpatch>
+          <stop path="]] .. PathValue .. [[" stop-color="#00ffff"/>
+          <stop path="L 100 50" stop-color="#ff00ff"/>
+          <stop path="L 50 50" stop-color="#888888"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+function zClosedMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="C 25 -10 75 10 100 0" stop-color="#00ff00"/>
+          <stop path="L 100 100" stop-color="#ffff00"/>
+          <stop path="L 0 100" stop-color="#0000ff"/>
+          <stop path="Z" stop-color="#ff0000"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+function styledStopMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 100 0" style="stop-color:#8f97ff;stop-opacity:0.5"/>
+          <stop path="L 100 100" style="stop-color:#ff0000"/>
+          <stop path="L 0 100" stop-color="#00ff00" style="stop-color:#0000ff"/>
+          <stop path="Z" stop-color="#ffffff"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+function inheritedColourMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse" color="#008000"
+        stop-color="#102030" stop-opacity="0.25">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="currentColor"/>
+          <stop path="L 100 100" stop-color="inherit"/>
+          <stop path="L 0 100" stop-color="#ffffff" stop-opacity="inherit"/>
+          <stop path="Z" stop-color="#000000"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+function percentageOriginMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="50%" y="25%">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 1 0.25" stop-color="#00ff00"/>
+          <stop path="L 1 1" stop-color="#ffff00"/>
+          <stop path="L 0.5 1" stop-color="#0000ff"/>
+          <stop path="Z" stop-color="#ff0000"/>
+        </meshpatch>
+      </meshrow>
+    </meshgradient>
+  </defs>
+  <rect x="0" y="0" width="100" height="100" fill="url(#mesh2x2)"/>
+</svg>
+]]
+end
+
+function wrongStopCountMesh():str
+   return [[
+<?xml version="1.0" standalone="no"?>
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <meshgradient id="mesh2x2" x="0" y="0" gradientUnits="userSpaceOnUse">
+      <meshrow>
+        <meshpatch>
+          <stop path="L 50 0" stop-color="#00ff00"/>
+          <stop path="L 50 50" stop-color="#ffff00"/>
+          <stop path="L 0 50" stop-color="#0000ff"/>
+          <stop path="L 0 0" stop-color="#ff0000"/>
+        </meshpatch>
+        <meshpatch>
+          <stop path="L 100 0" stop-color="#00ffff"/>
+          <stop path="L 100 50" stop-color="#ff00ff"/>
+          <stop path="L 50 50" stop-color="#888888"/>
+          <stop path="L 50 0" stop-color="#444444"/>
         </meshpatch>
       </meshrow>
     </meshgradient>
@@ -273,4 +399,101 @@ end
    assertMalformedPathRejected('L 50 0 60 0', 'extra_line_values')
    assertMalformedPathRejected('C 10 0 20 0 50 0 60 0', 'extra_cubic_values')
    assertMalformedPathRejected('L nan 0', 'non_finite_value')
+   assertMalformedPathRejected('Z', 'z_on_non_closing_stop')
+   assertMalformedPathRejected('', 'empty_path')
+end
+
+@Test function MalformedMeshFixtureIsOtherwiseValid()
+   -- Control for the rejection tests: with a valid injected path the two-patch fixture parses fully.
+   local path = 'temp:meshgradient_malformed_control.svg'
+   io.writeAll(path, malformedMesh('L 100 0'))
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(gradient.rows is 1, 'Control mesh should produce one row')
+   assert(gradient.columns is 2, 'Control mesh should produce two columns')
+   assert(#gradient.patches is 2, 'Control mesh should produce two patch records')
+end
+
+@Test function WrongStopCountDiscardsMesh()
+   local path = 'temp:meshgradient_wrong_stop_count.svg'
+   io.writeAll(path, wrongStopCountMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 0, 'A patch with a surplus stop should discard the whole mesh')
+end
+
+@Test function ZClosedPatchSnapsToOrigin()
+   local path = 'temp:meshgradient_z_close.svg'
+   io.writeAll(path, zClosedMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Z-closed patch should parse')
+
+   local patch = gradient.patches[0]
+   assertNear(patch.left.endX, 0, 'Z-closed left edge endX')
+   assertNear(patch.left.endY, 0, 'Z-closed left edge endY')
+
+   -- The closing edge must round-trip as a canonical straight 'C' path.
+
+   local output_path = 'temp:meshgradient_z_close_roundtrip.svg'
+   saveScene(scene, output_path)
+   local reparsed_scene, reparsed_gradient = loadMesh(output_path)
+   assert(#reparsed_gradient.patches is 1, 'Z-closed patch should round-trip')
+   assertPatchesMatch(reparsed_gradient, gradient, 'z-close round-trip')
+end
+
+@Test function StyleAttributeStopsResolve()
+   local path = 'temp:meshgradient_styled_stops.svg'
+   io.writeAll(path, styledStopMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Styled mesh should parse')
+
+   -- Stops apply clockwise: 1st = topRight, 2nd = bottomRight, 3rd = bottomLeft, 4th = topLeft.
+   local patch = gradient.patches[0]
+   assertChannel(patch.topRight.red, 143 / 255, 'style stop-color red')
+   assertChannel(patch.topRight.green, 151 / 255, 'style stop-color green')
+   assertChannel(patch.topRight.blue, 1.0, 'style stop-color blue')
+   assertChannel(patch.topRight.alpha, 0.5, 'style stop-opacity')
+   assertChannel(patch.bottomRight.red, 1.0, 'style-only stop-color red')
+   assertChannel(patch.bottomLeft.blue, 1.0, 'style should override the presentation attribute')
+   assertChannel(patch.bottomLeft.green, 0, 'style should override the presentation attribute')
+   assertChannel(patch.topLeft.red, 1.0, 'presentation attribute stop-color')
+end
+
+@Test function CurrentColorAndInheritStopsResolve()
+   local path = 'temp:meshgradient_inherited_stops.svg'
+   io.writeAll(path, inheritedColourMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Inherited-colour mesh should parse')
+
+   local patch = gradient.patches[0]
+   assertChannel(patch.topRight.red, 0, 'currentColor red')
+   assertChannel(patch.topRight.green, 128 / 255, 'currentColor green')
+   assertChannel(patch.bottomRight.red, 16 / 255, 'inherited stop-color red')
+   assertChannel(patch.bottomRight.green, 32 / 255, 'inherited stop-color green')
+   assertChannel(patch.bottomRight.blue, 48 / 255, 'inherited stop-color blue')
+   assertChannel(patch.bottomLeft.alpha, 0.25, 'inherited stop-opacity')
+   assertChannel(patch.topLeft.red, 0, 'literal stop-color is unaffected')
+   assertChannel(patch.topLeft.alpha, 1.0, 'literal stop keeps full opacity')
+end
+
+@Test function PercentageOriginParses()
+   local path = 'temp:meshgradient_percent_origin.svg'
+   io.writeAll(path, percentageOriginMesh())
+   glFiles:push(path)
+
+   local scene, gradient = loadMesh(path)
+   assert(#gradient.patches is 1, 'Percentage-origin mesh should parse')
+   assert(gradient.units is VUNIT_BOUNDING_BOX, 'Mesh should default to bounding-box units')
+
+   local patch = gradient.patches[0]
+   assertNear(patch.top.startX, 0.5, 'x="50%" should scale to 0.5 under bounding-box units')
+   assertNear(patch.top.startY, 0.25, 'y="25%" should scale to 0.25 under bounding-box units')
 end

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -118,6 +118,7 @@ OBJECTPTR access_object(GCobject *Object)
       Object->accesscount++;
       return Object->ptr;
    }
+
    if (not Object->uid) return nullptr;
 
    if (Object->is_pinned()) {

--- a/src/vector/painters/gradient_mesh.cpp
+++ b/src/vector/painters/gradient_mesh.cpp
@@ -10,6 +10,11 @@ the patch geometry rather than a one-dimensional colour ramp.
 The inherited colour-ramp fields `Stops`, `ColourMap`, `SpreadMethod` and `Colour` are not supported by this class.
 Patch geometry and corner colours are supplied through #Patches.
 
+When a mesh is exported to SVG, valid #Rows and #Columns metadata is preserved through the standard shared-edge
+`meshrow` syntax.  A mesh without valid row metadata (e.g. a non-rectangular grid) is flattened to a single row on
+export; every patch survives intact, with patches that do not share an edge with their predecessor written as
+independent patches, but the original row structure is not retained.
+
 -END-
 
 TODO:
@@ -231,7 +236,7 @@ static ERR GRADIENTMESH_SET_Columns(extGradientMesh *Self, int Value)
 
 static ERR GRADIENTMESH_SET_Patches(extGradientMesh *Self, std::span<const MeshPatchRecord> &Array)
 {
-   if (Array.empty()) { // An empty array clears the mesh entirely.
+   if ((not Array.data()) or Array.empty()) { // An empty array clears the mesh entirely.
       if (Self->Mesh) {
          Self->Mesh->patches.clear();
          Self->Mesh->rows = 0;

--- a/src/vector/painters/gradient_mesh.cpp
+++ b/src/vector/painters/gradient_mesh.cpp
@@ -135,6 +135,8 @@ The coordinate system for patch positions is determined by @Gradient.Units.  Und
 coordinates in the range `0 - 1.0` are scaled into the target path's bounds.  Under `USERSPACE`, positions are taken
 directly in the viewport's coordinate system.
 
+Assigning an empty array clears the mesh entirely, including the #Rows and #Columns metadata.
+
 -END-
 *********************************************************************************************************************/
 
@@ -229,7 +231,15 @@ static ERR GRADIENTMESH_SET_Columns(extGradientMesh *Self, int Value)
 
 static ERR GRADIENTMESH_SET_Patches(extGradientMesh *Self, std::span<const MeshPatchRecord> &Array)
 {
-   if ((not Array.data()) or (Array.empty())) return kt::Log().warning(ERR::InvalidValue);
+   if (Array.empty()) { // An empty array clears the mesh entirely.
+      if (Self->Mesh) {
+         Self->Mesh->patches.clear();
+         Self->Mesh->rows = 0;
+         Self->Mesh->cols = 0;
+         invalidate_mesh(Self);
+      }
+      return ERR::Okay;
+   }
 
    if (not Self->Mesh) Self->Mesh = std::make_unique<MeshGradient>();
 


### PR DESCRIPTION
* Enforced the shared-edge stop grammar, complete-mesh rejection, patch closure and percentage origins
* Resolved styled, inherited and current-colour mesh stops consistently with standard gradients
* [Vector] Allowed empty patch arrays to clear mesh data and dimensions
* Added Flute coverage for valid, malformed and round-tripped mesh gradients