### PR TITLE
[Tiri] Added type analysis and attribution for imported files

### DIFF
--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -271,7 +271,7 @@ bmark.stats = function(Values:any):table
    stddev = math.sqrt(variance)
 
    -- Percentile calculation from sorted sample (inversed since the lower values are better)
-   function getPercentile(SortedValues:array, Percentile:num):num
+   function getPercentile(SortedValues:table, Percentile:num):num
       local sample_n = #SortedValues
       if sample_n is 0 then return 0 end
       local index = math.ceil(Percentile * sample_n / 100) - 1
@@ -391,7 +391,7 @@ bmark.removeOutliers = function(Values:array, Multiplier:num):table
    table.sort(sorted)
 
    -- Calculate Q1 (25th percentile) and Q3 (75th percentile)
-   local function getQuartile(SortedValues:array, Quartile:num):num
+   local function getQuartile(SortedValues:table, Quartile:num):num
       local n = #SortedValues
       local index = (Quartile / 4) * (n + 1) - 1 -- Convert to 0-based
       local lower_idx = math.floor(index)

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -494,7 +494,7 @@ function convert_builtin(TypeName:str, Value:any, Param:table):any
 
       raise ERR_WrongType, f"Parameter '{Param.name}' requires a boolean value."
    elseif TypeName is 'path' or TypeName is 'file' or TypeName is 'folder' then
-      if type(Value) is 'string' then return Value, nil end
+      if type(Value) is 'string' then return Value end
       return tostring(Value)
    elseif TypeName is 'csv' then
       return convert_csv(Value, Param)

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -1,5 +1,7 @@
 -- Visual FX interface.  Applies cosmetic effects to viewports.
 
+   include 'vector'
+
    mVec ?= mod.load('vector')
 
    global vfx ?= {

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -787,7 +787,7 @@ set (TIRI_TESTS
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
-   object_pinning
+   object_pinning import_type_analysis
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -43,6 +44,17 @@ private:
    AstBuilder *parent_builder = nullptr;
    std::vector<GCstr *> function_name_stack;
    std::vector<uint32_t> registered_enum_constants;
+   std::vector<uint32_t> chunk_import_hashes;  // Path hashes inlined during this compilation (root builder only)
+
+   // FileSource entries persist across compilations, so diagnose-mode re-parsing of cached imports needs a
+   // dedup scope limited to the current chunk.  Records Hash on the root builder; returns true if already seen.
+   [[nodiscard]] bool import_seen_this_chunk(uint32_t Hash) {
+      AstBuilder *root = this;
+      while (root->parent_builder) root = root->parent_builder;
+      if (std::find(root->chunk_import_hashes.begin(), root->chunk_import_hashes.end(), Hash) != root->chunk_import_hashes.end()) return true;
+      root->chunk_import_hashes.push_back(Hash);
+      return false;
+   }
 
    class FunctionNameScope {
    public:

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1298,11 +1298,19 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_imported_file(std::st
 
    auto libhash = kt::strihash(Path);
 
-   // Check if this file is already registered in FileSource
+   // Check if this file is already registered in FileSource.  FileSource entries persist for the lifetime of the
+   // lua_State, so this hit can come from an earlier, unrelated compilation.  In diagnose mode the type analyser
+   // needs the real body regardless - validation never emits or executes code, so re-parsing cannot double-execute
+   // library code, and skipping here would silently drop imported-file diagnostics on every validation after the
+   // first.  The existing FileSource index is reused below instead of registering a duplicate.
    auto existing_index = find_file_source(L, libhash);
+   bool seen_this_chunk = this->import_seen_this_chunk(libhash);
    if (existing_index.has_value()) {
-      log.detail("Library %.*s already imported (file index %d)", int(Library.size()), Library.data(), existing_index.value());
-      return ParserResult<std::unique_ptr<BlockStmt>>::success(make_block(ImportToken.span(), {}));
+      if (seen_this_chunk or not this->ctx.lex().diagnose_mode) {
+         log.detail("Library %.*s already imported (file index %d)", int(Library.size()), Library.data(), existing_index.value());
+         return ParserResult<std::unique_ptr<BlockStmt>>::success(make_block(ImportToken.span(), {}));
+      }
+      log.branch("Re-parsing '%.*s' for diagnostics (file index %d)", int(Library.size()), Library.data(), existing_index.value());
    }
    else log.branch("Importing '%.*s' from %s", int(Library.size()), Library.data(), Path.c_str());
 
@@ -1353,9 +1361,11 @@ ParserResult<std::unique_ptr<BlockStmt>> AstBuilder::parse_imported_file(std::st
    uint8_t parent_index = this->ctx.lex().current_file_index;
    BCLine import_line = ImportToken.span().line.lineNumber();  // Decode line from parent's encoded BCLine
 
-   // Register this imported file with FileSource tracking
+   // Register this imported file with FileSource tracking, or reuse the existing entry when re-parsing a cached
+   // import in diagnose mode.
 
-   uint8_t new_file_index = register_file_source(L, Path, filename, 1, source_lines, parent_index, import_line);
+   uint8_t new_file_index = existing_index.has_value() ? existing_index.value()
+      : register_file_source(L, Path, filename, 1, source_lines, parent_index, import_line);
 
    // RAII guard handles cleanup on normal path; lua_load handles SEH error path
    ImportLexerGuard import_guard(L, source, std::string("@") + Path);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -150,6 +150,47 @@ private:
    // Usage tracking - marks variables as used for unused variable detection
    void mark_identifier_used(GCstr *);
 
+   // Diagnostic recording - stamps the active file index so diagnostics raised inside imported
+   // statements are attributed to the imported file rather than the importing one
+   void record_diagnostic(TypeDiagnostic Diag) {
+      Diag.file_index = this->current_file_index_;
+      this->diagnostics_.push_back(std::move(Diag));
+   }
+
+   #ifdef INCLUDE_TIPS
+   // Tip gating - tips carry no file attribution, so they are suppressed entirely while analysing
+   // imported statements to avoid misattributing library internals to the importing file
+   [[nodiscard]] bool should_emit_tip(uint8_t Priority) const {
+      return this->import_depth_ IS 0 and this->ctx_.should_emit_tip(Priority);
+   }
+
+   void emit_tip(uint8_t Priority, TipCategory Category, std::string Message, const Token &Location) {
+      if (this->import_depth_ != 0) return;
+      this->ctx_.emit_tip(Priority, Category, std::move(Message), Location);
+   }
+   #endif
+
+   // RAII guard for descending into an imported file's inlined body: swaps the active file index
+   // and tracks import depth so early returns in analysis helpers cannot leave stale state
+   struct ImportGuard {
+      TypeAnalyser &analyser;
+      uint8_t saved_file_index;
+
+      ImportGuard(TypeAnalyser &Analyser, uint8_t FileIndex)
+         : analyser(Analyser), saved_file_index(Analyser.current_file_index_) {
+         Analyser.current_file_index_ = FileIndex;
+         Analyser.import_depth_++;
+      }
+
+      ~ImportGuard() {
+         this->analyser.current_file_index_ = this->saved_file_index;
+         this->analyser.import_depth_--;
+      }
+
+      ImportGuard(const ImportGuard &) = delete;
+      ImportGuard & operator=(const ImportGuard &) = delete;
+   };
+
    // Return type validation - ensures consistency within functions
    void validate_return_types(const ReturnStmtPayload &, SourceSpan);
 
@@ -206,6 +247,8 @@ private:
    std::vector<FunctionContext> function_stack_{};  // Stack of function contexts for return type tracking
    std::vector<TypeDiagnostic> diagnostics_{};      // Collected type errors and warnings
    uint32_t loop_depth_{0};                         // Current loop nesting depth for performance tip
+   uint32_t import_depth_{0};                       // Import nesting depth; non-zero suppresses tips
+   uint8_t current_file_index_{0};                  // FileSource index of the file being analysed
    ankerl::unordered_dense::map<GCstr*, GlobalTypeInfo> global_types_{};  // Type info for global variables
    #ifdef INCLUDE_TIPS
    std::vector<GCstr*> declared_globals_{};         // Globals explicitly declared with 'global' keyword
@@ -256,7 +299,7 @@ void TypeAnalyser::trace_decl(BCLine Line, GCstr* Name, TiriType Type, bool IsFi
 #ifdef INCLUDE_TIPS
 void TypeAnalyser::check_shadowing(GCstr *Name, SourceSpan Location)
 {
-   if (not this->ctx_.should_emit_tip(2)) return;
+   if (not this->should_emit_tip(2)) return;
    if (not Name) return;
    if (Name->len IS 1 and strdata(Name)[0] IS '_') return;
 
@@ -269,7 +312,7 @@ void TypeAnalyser::check_shadowing(GCstr *Name, SourceSpan Location)
       auto existing = scope.lookup_local_type(Name);
       if (existing) {
          std::string_view name_view(strdata(Name), Name->len);
-         this->ctx_.emit_tip(2, TipCategory::CodeQuality,
+         this->emit_tip(2, TipCategory::CodeQuality,
             std::format("Variable '{}' shadows a variable in an outer scope", name_view),
             Token::from_span(Location, TokenKind::Identifier));
          return;  // Only report once per variable
@@ -279,7 +322,7 @@ void TypeAnalyser::check_shadowing(GCstr *Name, SourceSpan Location)
       auto param = scope.lookup_parameter_type(Name);
       if (param) {
          std::string_view name_view(strdata(Name), Name->len);
-         this->ctx_.emit_tip(2, TipCategory::CodeQuality,
+         this->emit_tip(2, TipCategory::CodeQuality,
             std::format("Variable '{}' shadows a parameter in an outer scope", name_view),
             Token::from_span(Location, TokenKind::Identifier));
          return;
@@ -305,7 +348,7 @@ void TypeAnalyser::track_global(GCstr *Name)
 
 void TypeAnalyser::check_global_in_loop(GCstr *Name, SourceSpan Location)
 {
-   if (not this->ctx_.should_emit_tip(2)) return;
+   if (not this->should_emit_tip(2)) return;
    if (this->loop_depth_ IS 0) return;
    if (not Name) return;
    if (Name->len IS 1 and strdata(Name)[0] IS '_') return;
@@ -328,7 +371,7 @@ void TypeAnalyser::check_global_in_loop(GCstr *Name, SourceSpan Location)
 
    // It's a declared global variable being accessed inside a loop
    std::string_view name_view(strdata(Name), Name->len);
-   this->ctx_.emit_tip(2, TipCategory::Performance,
+   this->emit_tip(2, TipCategory::Performance,
       std::format("Global '{}' accessed in loop; consider caching in a local variable for better JIT performance",
          name_view),
       Token::from_span(Location, TokenKind::Identifier));
@@ -339,10 +382,10 @@ void TypeAnalyser::check_global_in_loop(GCstr *Name, SourceSpan Location)
 
 void TypeAnalyser::check_function_in_loop(SourceSpan Location)
 {
-   if (not this->ctx_.should_emit_tip(2)) return;
+   if (not this->should_emit_tip(2)) return;
    if (this->loop_depth_ IS 0) return;
 
-   this->ctx_.emit_tip(2, TipCategory::Performance,
+   this->emit_tip(2, TipCategory::Performance,
       "Function defined inside loop; consider moving it outside the loop for better performance",
       Token::from_span(Location, TokenKind::Function));
 }
@@ -354,10 +397,10 @@ void TypeAnalyser::check_function_in_loop(SourceSpan Location)
 
 void TypeAnalyser::check_concat_in_loop(SourceSpan Location)
 {
-   if (not this->ctx_.should_emit_tip(2)) return;
+   if (not this->should_emit_tip(2)) return;
    if (this->loop_depth_ IS 0) return;
 
-   this->ctx_.emit_tip(2, TipCategory::Performance,
+   this->emit_tip(2, TipCategory::Performance,
       "String concatenation in loop; consider using array.concat() for better performance",
       Token::from_span(Location, TokenKind::Cat));
 }
@@ -368,13 +411,13 @@ void TypeAnalyser::check_concat_in_loop(SourceSpan Location)
 
 void TypeAnalyser::check_choose_missing_fallback(const ChooseExprPayload &Payload, SourceSpan Location)
 {
-   if (not this->ctx_.should_emit_tip(1)) return;
+   if (not this->should_emit_tip(1)) return;
 
    for (const ChooseCase &case_item : Payload.cases) {
       if (case_item.is_else or (case_item.is_wildcard and not case_item.guard)) return;
    }
 
-   this->ctx_.emit_tip(1, TipCategory::TypeSafety,
+   this->emit_tip(1, TipCategory::TypeSafety,
       "Choose expression has no else branch; unmatched values evaluate to nil",
       Token::from_span(Location, TokenKind::Choose));
 }
@@ -401,22 +444,22 @@ void TypeAnalyser::pop_scope() {
 
    #ifdef INCLUDE_TIPS
    // Report unused variables before popping the scope (skip if tip wouldn't be emitted)
-   if (this->ctx_.should_emit_tip(2)) {
+   if (this->should_emit_tip(2)) {
       auto unused = this->scope_stack_.back().get_unused_variables();
       for (const auto& var : unused) {
          std::string_view name_view(strdata(var.name), var.name->len);
          if (var.is_parameter) {
-            this->ctx_.emit_tip(2, TipCategory::CodeQuality,
+            this->emit_tip(2, TipCategory::CodeQuality,
                std::format("Unused function parameter '{}'", name_view),
                Token::from_span(var.location, TokenKind::Identifier));
          }
          else if (var.is_function) {
-            this->ctx_.emit_tip(2, TipCategory::CodeQuality,
+            this->emit_tip(2, TipCategory::CodeQuality,
                std::format("Unused local function '{}'", name_view),
                Token::from_span(var.location, TokenKind::Identifier));
          }
          else {
-            this->ctx_.emit_tip(2, TipCategory::CodeQuality,
+            this->emit_tip(2, TipCategory::CodeQuality,
                std::format("Unused local variable '{}'", name_view),
                Token::from_span(var.location, TokenKind::Identifier));
          }
@@ -488,6 +531,8 @@ const FunctionContext* TypeAnalyser::current_function() const
 
 void TypeAnalyser::analyse_module(const BlockStmt &Module)
 {
+   // For loadFile sources the whole chunk carries a single non-zero FileSource index
+   this->current_file_index_ = this->ctx_.lex().current_file_index;
    this->push_scope();
    this->analyse_block(Module);
    this->pop_scope();
@@ -644,6 +689,25 @@ void TypeAnalyser::analyse_statement(const StmtNode &Statement)
          if (payload and payload->expression) this->analyse_expression(*payload->expression);
          break;
       }
+      case AstNodeKind::ImportStmt: {
+         // Imports are inlined at compile time and never independently compiled, so their bodies
+         // must be analysed here or their type errors can never surface.  Repeated imports of the
+         // same library are deduplicated at parse time (subsequent entries get an empty block), so
+         // descent cannot double-analyse a library.  The scope pair mirrors emit_import_entry(),
+         // which wraps the inlined body in its own lexical scope - imported top-level locals must
+         // not leak into the importer's scope tables.  Globals intentionally remain shared.
+         auto *payload = std::get_if<ImportStmtPayload>(&Statement.data);
+         if (payload) {
+            for (const auto &entry : payload->entries) {
+               if (not entry.inlined_body) continue;
+               ImportGuard guard(*this, entry.file_source_idx);
+               this->push_scope();
+               this->analyse_block(*entry.inlined_body);
+               this->pop_scope();
+            }
+         }
+         break;
+      }
       default:
          break;
    }
@@ -728,7 +792,7 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             diag.location = target.span;
             diag.code = ParserErrorCode::AssignToConstant;
             diag.message = std::format("cannot assign to const {} '{}'", is_global ? "global" : "local", name_view);
-            this->diagnostics_.push_back(std::move(diag));
+            this->record_diagnostic(std::move(diag));
             continue;  // Skip further checking for this target
          }
 
@@ -757,7 +821,7 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                diag.code = ParserErrorCode::TypeMismatchAssignment;
                diag.message = std::format("cannot assign '{}' to {} of type '{}'",
                   type_name(value_type.primary), is_global ? "global" : "variable", type_name(existing->primary));
-               this->diagnostics_.push_back(std::move(diag));
+               this->record_diagnostic(std::move(diag));
             }
             // Check for object class ID mismatch (both types are Object but different classes)
             else if (existing->primary IS TiriType::Object and value_type.primary IS TiriType::Object and
@@ -770,7 +834,7 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                   diag.code = ParserErrorCode::ObjectClassMismatch;
                   diag.message = std::format("object class mismatch: cannot assign object of different class to {} ({} vs {})",
                      is_global ? "global" : "variable", ResolveClassID(value_type.object_class_id), ResolveClassID(existing->object_class_id));
-                  this->diagnostics_.push_back(std::move(diag));
+                  this->record_diagnostic(std::move(diag));
                }
             }
          }
@@ -865,7 +929,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
                diag.code = ParserErrorCode::TypeMismatchAssignment;
                diag.message = std::format("cannot assign '{}' to variable of type '{}'",
                   type_name(value_type.primary), type_name(name.type));
-               this->diagnostics_.push_back(std::move(diag));
+               this->record_diagnostic(std::move(diag));
             }
          }
       }
@@ -964,7 +1028,7 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
          diag.location = name.span;
          diag.code = ParserErrorCode::AssignToConstant;
          diag.message = std::format("cannot assign to constant '{}'", name_view);
-         this->diagnostics_.push_back(std::move(diag));
+         this->record_diagnostic(std::move(diag));
          continue;
       }
 
@@ -998,12 +1062,12 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
    }
 
    // Check global naming conventions
-   if (this->ctx_.should_emit_tip(3)) {
+   if (this->should_emit_tip(3)) {
       for (const auto &name : Payload.names) {
          if (not name.symbol) continue;
          std::string_view name_view(strdata(name.symbol), name.symbol->len);
          if (not is_valid_global_name(name_view)) {
-            this->ctx_.emit_tip(3, TipCategory::Style,
+            this->emit_tip(3, TipCategory::Style,
                std::format("Global variable '{}' should follow naming convention: 'gl[A-Z]...' or 'ALL_CAPS'",
                   name_view),
                Token::from_span(name.span, TokenKind::Identifier));
@@ -1072,7 +1136,7 @@ void TypeAnalyser::analyse_function_stmt(const FunctionStmtPayload &Payload)
             diag.location = function_location;
             diag.code = ParserErrorCode::AssignToConstant;
             diag.message = std::format("cannot assign to constant '{}'", name_view);
-            this->diagnostics_.push_back(std::move(diag));
+            this->record_diagnostic(std::move(diag));
          }
          else this->declare_global_function(function_name, function, function_location);
       }
@@ -1134,7 +1198,7 @@ void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Loca
    diag.location = Location;
    diag.code = ParserErrorCode::OverrideProtectedGlobal;
    diag.message = std::format("cannot override built-in '{}'", std::string_view(strdata(Name), Name->len));
-   this->diagnostics_.push_back(std::move(diag));
+   this->record_diagnostic(std::move(diag));
 }
 
 void TypeAnalyser::report_computed_global_environment_store(SourceSpan Location)
@@ -1143,7 +1207,7 @@ void TypeAnalyser::report_computed_global_environment_store(SourceSpan Location)
    diag.location = Location;
    diag.code = ParserErrorCode::OverrideProtectedGlobal;
    diag.message = "cannot override built-in through computed _G key";
-   this->diagnostics_.push_back(std::move(diag));
+   this->record_diagnostic(std::move(diag));
 }
 
 //********************************************************************************************************************
@@ -1171,16 +1235,16 @@ void TypeAnalyser::analyse_function_payload(const FunctionExprPayload &Function,
       diag.code = ParserErrorCode::RecursiveFunctionNeedsType;
       diag.message = std::format("recursive function '{}' must have explicit return type declaration",
          Name ? std::string_view(strdata(Name), Name->len) : "<anonymous>");
-      this->diagnostics_.push_back(std::move(diag));
+      this->record_diagnostic(std::move(diag));
    }
 
    // Advise on missing return type annotation for functions that return values
 
    #ifdef INCLUDE_TIPS
-   if (this->ctx_.should_emit_tip(1) and
+   if (this->should_emit_tip(1) and
        (not Function.return_types.is_explicit) and this->function_has_return_values(Function)) {
       SourceSpan span = Function.body ? Function.body->span : SourceSpan{};
-      this->ctx_.emit_tip(1, TipCategory::TypeSafety,
+      this->emit_tip(1, TipCategory::TypeSafety,
          "Function lacks return type annotation; consider adding ': type' after the parameter list",
          Token::from_span(span, TokenKind::Function));
    }
@@ -1235,7 +1299,7 @@ void TypeAnalyser::analyse_expression(const ExprNode &Expression)
                      const char *op_name = payload->op IS AstBinaryOperator::HasFlag ? "has" : "≈";
                      diag.message = std::format("'{}' operator expects numeric {}, got {}", op_name, Side,
                         type_name(inferred.primary));
-                     this->diagnostics_.push_back(std::move(diag));
+                     this->record_diagnostic(std::move(diag));
                   }
                };
                check_operand(payload->left, "operand");
@@ -1418,7 +1482,7 @@ void TypeAnalyser::check_argument_type(const ExprNode& Argument, TiriType Expect
       diag.code = ParserErrorCode::TypeMismatchArgument;
       diag.message = std::format("type mismatch: argument {} expects '{}', got '{}'",
          Index + 1, type_name(Expected), type_name(actual.primary));
-      this->diagnostics_.push_back(std::move(diag));
+      this->record_diagnostic(std::move(diag));
    }
 }
 
@@ -1545,13 +1609,31 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                case AstBinaryOperator::Concat:
                   result.primary = TiriType::Str;
                   return result;
-               // Arithmetic operators return number
+               // Arithmetic operators return number, unless an operand may be a table or object
+               // whose metamethods (__add, __sub, ...) can overload the operation to return any
+               // type.  Operands of type Any or Unknown may hold such values, so the result is
+               // only known to be numeric when neither operand can carry a metatable.
                case AstBinaryOperator::Add:
                case AstBinaryOperator::Subtract:
                case AstBinaryOperator::Multiply:
                case AstBinaryOperator::Divide:
                case AstBinaryOperator::Modulo:
-               case AstBinaryOperator::Power:
+               case AstBinaryOperator::Power: {
+                  auto may_overload = [](TiriType Type) {
+                     return Type IS TiriType::Table or Type IS TiriType::Object or
+                            Type IS TiriType::Any or Type IS TiriType::Unknown;
+                  };
+                  InferredType left_type, right_type;
+                  if (payload->left) left_type = this->infer_expression_type(*payload->left);
+                  if (payload->right) right_type = this->infer_expression_type(*payload->right);
+                  if (may_overload(left_type.primary) or may_overload(right_type.primary)) {
+                     result.primary = TiriType::Any;
+                     return result;
+                  }
+                  result.primary = TiriType::Num;
+                  return result;
+               }
+               // Bitwise operators are implemented via the bit library and always return number
                case AstBinaryOperator::BitAnd:
                case AstBinaryOperator::BitOr:
                case AstBinaryOperator::BitXor:
@@ -1584,7 +1666,19 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                case AstUnaryOperator::Not:
                   result.primary = TiriType::Bool;
                   return result;
-               case AstUnaryOperator::Negate:
+               case AstUnaryOperator::Negate: {
+                  // Negation may be overloaded via the __unm metamethod on tables and objects;
+                  // Any/Unknown operands may hold such values
+                  InferredType operand_type;
+                  if (payload->operand) operand_type = this->infer_expression_type(*payload->operand);
+                  if (operand_type.primary IS TiriType::Table or operand_type.primary IS TiriType::Object or
+                      operand_type.primary IS TiriType::Any or operand_type.primary IS TiriType::Unknown) {
+                     result.primary = TiriType::Any;
+                     return result;
+                  }
+                  result.primary = TiriType::Num;
+                  return result;
+               }
                case AstUnaryOperator::BitNot:
                   result.primary = TiriType::Num;
                   return result;
@@ -1830,7 +1924,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
          diag.code     = ParserErrorCode::ReturnCountMismatch;
          diag.message  = std::format("too many return values: function declares {} but {} returned",
             ctx->expected_returns.count, return_count);
-         this->diagnostics_.push_back(std::move(diag));
+         this->record_diagnostic(std::move(diag));
       }
 
       // Validate type of each returned value
@@ -1853,7 +1947,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             diag.code = ParserErrorCode::ReturnTypeMismatch;
             diag.message = std::format("return type mismatch at position {}: expected '{}', got '{}'",
                i + 1, type_name(expected), type_name(actual.primary));
-            this->diagnostics_.push_back(std::move(diag));
+            this->record_diagnostic(std::move(diag));
          }
       }
    }
@@ -1907,7 +2001,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
                diag.code = ParserErrorCode::ReturnTypeMismatch;
                diag.message = std::format("inconsistent return type at position {}: first return established '{}', but this returns '{}'",
                   i + 1, type_name(expected), type_name(actual.primary));
-               this->diagnostics_.push_back(std::move(diag));
+               this->record_diagnostic(std::move(diag));
             }
          }
       }
@@ -2190,7 +2284,7 @@ static void publish_type_diagnostics(ParserContext& Context, const std::vector<T
             : ParserDiagnosticSeverity::Warning;
       }
       diagnostic.code = diag.code;
-      diagnostic.file_index = Context.lex().current_file_index;
+      diagnostic.file_index = diag.file_index;
       diagnostic.message = diag.message;
       diagnostic.token = Token::from_span(diag.location);
       Context.diagnostics().report(diagnostic);

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -35,6 +35,7 @@ struct TypeDiagnostic {
    TiriType expected = TiriType::Any;
    TiriType actual = TiriType::Any;
    ParserErrorCode code = ParserErrorCode::TypeMismatchArgument;
+   uint8_t file_index = 0;  // FileSource index of the file the diagnostic belongs to
 
    TypeDiagnostic() = default;
    TypeDiagnostic(SourceSpan Location, std::string Message, TiriType Expected, TiriType Actual,

--- a/src/tiri/tests/import_type_attr_helper.tiri
+++ b/src/tiri/tests/import_type_attr_helper.tiri
@@ -1,0 +1,9 @@
+-- Type-clean helper library for test_import_type_analysis.tiri (main-buffer attribution case).
+-- Each test in that file imports its own helper: import deduplication parses a library body only
+-- once per state and test order is randomised, so helpers cannot be shared between tests.
+
+namespace 'type_probe_attr'
+
+global function attr_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/import_type_clean_helper.tiri
+++ b/src/tiri/tests/import_type_clean_helper.tiri
@@ -1,0 +1,10 @@
+-- Type-clean helper library for test_import_type_analysis.tiri.  The unused local is deliberate:
+-- it verifies that tips raised inside imported statements are suppressed.
+
+namespace 'type_probe_clean'
+
+local unused_helper_var = 5
+
+global function clean_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/import_type_diamond_a.tiri
+++ b/src/tiri/tests/import_type_diamond_a.tiri
@@ -1,0 +1,8 @@
+-- Helper library for test_import_type_analysis.tiri.  Forms one side of a diamond import of
+-- import_type_diamond_inner.tiri.
+
+import './import_type_diamond_inner'
+
+global function diamond_a_fn(Value:num):num
+   return diamond_add(Value, 1)
+end

--- a/src/tiri/tests/import_type_diamond_b.tiri
+++ b/src/tiri/tests/import_type_diamond_b.tiri
@@ -1,0 +1,8 @@
+-- Helper library for test_import_type_analysis.tiri.  Forms one side of a diamond import of
+-- import_type_diamond_inner.tiri.
+
+import './import_type_diamond_inner'
+
+global function diamond_b_fn(Value:num):num
+   return diamond_add(Value, 2)
+end

--- a/src/tiri/tests/import_type_diamond_inner.tiri
+++ b/src/tiri/tests/import_type_diamond_inner.tiri
@@ -1,0 +1,11 @@
+-- Helper library for test_import_type_analysis.tiri containing a deliberate type error.  Imported by
+-- both import_type_diamond_a.tiri and import_type_diamond_b.tiri to form a diamond import.
+-- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
+
+namespace 'type_probe_diamond'
+
+local mismatch:num = 'str'
+
+global function diamond_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/import_type_error_helper.tiri
+++ b/src/tiri/tests/import_type_error_helper.tiri
@@ -1,0 +1,10 @@
+-- Helper library for test_import_type_analysis.tiri containing a deliberate type error.
+-- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
+
+namespace 'type_probe_err'
+
+local mismatch:num = 'str'
+
+global function probe_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/import_type_revalidate_helper.tiri
+++ b/src/tiri/tests/import_type_revalidate_helper.tiri
@@ -1,0 +1,10 @@
+-- Helper library for test_import_type_analysis.tiri containing a deliberate type error.
+-- Do not import this file from a compiled test; it is only referenced through debug.validate() buffers.
+
+namespace 'type_probe_reval'
+
+local mismatch:num = 'str'
+
+global function reval_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/import_type_tips_helper.tiri
+++ b/src/tiri/tests/import_type_tips_helper.tiri
@@ -1,0 +1,12 @@
+-- Tip-bait helper library for test_import_type_analysis.tiri.  The unused local is deliberate:
+-- it verifies that tips raised inside imported statements are suppressed.  This helper must not
+-- be shared with other tests: import deduplication means a library body is only parsed once per
+-- state, so a second validate of the same import cannot resolve its globals.
+
+namespace 'type_probe_tips'
+
+local unused_helper_var = 5
+
+global function tips_add(A:num, B:num):num
+   return A + B
+end

--- a/src/tiri/tests/test_import_type_analysis.tiri
+++ b/src/tiri/tests/test_import_type_analysis.tiri
@@ -1,0 +1,93 @@
+-- Flute regression tests for static type analysis descent into imports.
+--
+-- Type analysis descends into inline-imported libraries, so type errors inside an imported file
+-- are reported by debug.validate() with the imported file's name and line via FileSource indices.
+-- Tips carry no file attribution, so they are suppressed entirely while analysing imported
+-- statements to avoid spamming importers about library internals.
+
+local glFolder
+
+@BeforeAll
+function setup(State)
+   glFolder = State.folder
+end
+
+-- Validate a source buffer as if it were a document sitting in the tests folder, so that
+-- relative imports resolve against the helper libraries alongside this test.
+
+function validate_here(Source:str):table
+   return debug.validate(Source, { path = glFolder .. 'validate_buffer.tiri' })
+end
+
+@Test function ImportedTypeErrorAttributed()
+   local result = validate_here([[
+import './import_type_error_helper'
+local y:num = probe_add(1, 2)
+]])
+
+   assert(result.success is false, 'A type error inside an imported file should fail validation')
+   assert(#result.diagnostics is 1, f"Expected 1 diagnostic, got {#result.diagnostics}")
+
+   local diag = result.diagnostics[0]
+   assert(diag.file is 'import_type_error_helper.tiri',
+      f"Diagnostic should be attributed to the imported file, got '{tostring(diag.file)}'")
+   assert(diag.line is 5, f"Expected 0-based line 5 for the helper's type error, got {diag.line}")
+   assert(diag.code is 'TypeMismatchAssignment', f"Unexpected diagnostic code '{diag.code}'")
+   assert(string.find(diag.message, 'cannot assign', 0, true) != nil,
+      f"Unexpected diagnostic message: {diag.message}")
+end
+
+@Test function CleanImportNoDiagnostics()
+   local result = validate_here([[
+import './import_type_clean_helper'
+local total:num = clean_add(1, 2)
+print(total)
+]])
+
+   assert(result.success is true, 'A type-clean import should validate successfully')
+   assert(#result.diagnostics is 0, f"Expected no diagnostics, got {#result.diagnostics}")
+end
+
+@Test function MainErrorAttributedToBuffer()
+   -- Uses its own helper: test order is randomised and import deduplication parses a library
+   -- body only once per state, so helpers cannot be shared between tests.
+   local result = validate_here([[
+import './import_type_attr_helper'
+local bad:num = 'oops'
+]])
+
+   assert(result.success is false, 'A type error in the main source should fail validation')
+   assert(#result.diagnostics is 1, f"Expected 1 diagnostic, got {#result.diagnostics}")
+
+   local diag = result.diagnostics[0]
+   assert(diag.file is nil,
+      f"Main buffer diagnostics should carry no file attribution, got '{tostring(diag.file)}'")
+   assert(diag.line is 1, f"Expected 0-based line 1 for the main source error, got {diag.line}")
+   assert(diag.code is 'TypeMismatchAssignment', f"Unexpected diagnostic code '{diag.code}'")
+end
+
+@Test function ImportedTipsSuppressed()
+   -- The tips helper contains an unused local, which would normally raise a tip.  The main
+   -- buffer's own unused local proves the tip system is active while the helper's stays silent.
+   -- A dedicated helper is required: import deduplication parses a library body only once per
+   -- state, so re-importing the clean helper here could not resolve its global function.
+   local result = validate_here([[
+import './import_type_tips_helper'
+local main_unused = tips_add(1, 2)
+print('done')
+]])
+
+   assert(result.success is true, 'Validation should succeed for tip-only findings')
+
+   local main_tip_found = false
+   local i = 0
+   while result.tips[i] do
+      local tip = result.tips[i]
+      assert(string.find(tip.message, 'unused_helper_var', 0, true) is nil,
+         f"Tips from the imported library should be suppressed, got: {tip.message}")
+      if string.find(tip.message, 'main_unused', 0, true) != nil then main_tip_found = true end
+      i++
+   end
+
+   assert(main_tip_found, 'The main buffer unused-variable tip should still be emitted')
+end

--- a/src/tiri/tests/test_import_type_analysis.tiri
+++ b/src/tiri/tests/test_import_type_analysis.tiri
@@ -66,6 +66,52 @@ local bad:num = 'oops'
    assert(diag.code is 'TypeMismatchAssignment', f"Unexpected diagnostic code '{diag.code}'")
 end
 
+@Test function ImportedErrorSurvivesRevalidation()
+   -- FileSource entries persist for the lifetime of the state, but diagnose mode must re-parse
+   -- cached imports so that imported type errors surface on every validation, not just the first.
+   local source = [[
+import './import_type_revalidate_helper'
+local y:num = reval_add(1, 2)
+]]
+
+   for pass = 1, 2 do
+      local result = validate_here(source)
+      assert(result.success is false,
+         f"Pass {pass}: a type error inside an imported file should fail validation")
+      assert(#result.diagnostics is 1,
+         f"Pass {pass}: expected 1 diagnostic, got {#result.diagnostics}")
+
+      local diag = result.diagnostics[0]
+      assert(diag.file is 'import_type_revalidate_helper.tiri',
+         f"Pass {pass}: diagnostic should be attributed to the imported file, got '{tostring(diag.file)}'")
+      assert(diag.code is 'TypeMismatchAssignment', f"Pass {pass}: unexpected diagnostic code '{diag.code}'")
+   end
+end
+
+@Test function DiamondImportAnalysedOnce()
+   -- Two libraries importing the same inner helper within a single validation must analyse the
+   -- inner body exactly once - re-parsing of cached imports is deduplicated per compilation.
+   local source = [[
+import './import_type_diamond_a'
+import './import_type_diamond_b'
+local total:num = diamond_a_fn(1) + diamond_b_fn(2)
+print(total)
+]]
+
+   for pass = 1, 2 do
+      local result = validate_here(source)
+      assert(result.success is false,
+         f"Pass {pass}: the inner helper's type error should fail validation")
+      assert(#result.diagnostics is 1,
+         f"Pass {pass}: expected exactly 1 diagnostic from the shared inner helper, got {#result.diagnostics}")
+
+      local diag = result.diagnostics[0]
+      assert(diag.file is 'import_type_diamond_inner.tiri',
+         f"Pass {pass}: diagnostic should be attributed to the inner helper, got '{tostring(diag.file)}'")
+      assert(diag.code is 'TypeMismatchAssignment', f"Pass {pass}: unexpected diagnostic code '{diag.code}'")
+   end
+end
+
 @Test function ImportedTipsSuppressed()
    -- The tips helper contains an unused local, which would normally raise a tip.  The main
    -- buffer's own unused local proves the tip system is active while the helper's stays silent.

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -213,7 +213,7 @@ function hoverGetDocumentSymbols(Doc:table):array
 end
 
 function hoverTextHasContent(Text:str):bool
-   return Text and Text != ''
+   return Text != nil and Text != ''
 end
 
 function hoverSymbolMatches(Symbol:table, TokenInfo:table):bool


### PR DESCRIPTION
* Analysed inlined import bodies with isolated local scopes and imported-file diagnostics
* Suppressed unattributed tips from imports and corrected metamethod-aware arithmetic inference
* [Test] Added Flute coverage for imported diagnostics, clean imports, main-buffer attribution and tip suppression
* [Script] Fixed latent type-analysis errors exposed in standard libraries and LSP hover handling