### PR TITLE
[Display] Store surface callbacks in a vector

### DIFF
--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -58,13 +58,9 @@ static void deref_surface_callback(FUNCTION &Function)
    }
 }
 
-static void deref_surface_callback_range(SurfaceCallback *Callbacks, int Total)
+static void deref_surface_callbacks(std::vector<SurfaceCallback> &Callbacks)
 {
-   if (not Callbacks) return;
-
-   for (int i=0; i < Total; i++) {
-      deref_surface_callback(Callbacks[i].Function);
-   }
+   for (auto &callback : Callbacks) deref_surface_callback(callback.Function);
 }
 
 //********************************************************************************************************************
@@ -457,19 +453,12 @@ static void notify_free_callback(OBJECTPTR Object, ACTIONID ActionID, ERR Result
    kt::Log log(__FUNCTION__);
    auto Self = (extSurface *)CurrentContext();
 
-   for (int i=0; i < Self->CallbackCount; i++) {
-      if (Self->Callback[i].Function.isScript()) {
-         if (Self->Callback[i].Function.Context->UID IS Object->UID) {
-            deref_surface_callback(Self->Callback[i].Function);
-
-            int j;
-            for (j=i; j < Self->CallbackCount-1; j++) { // Shorten the array
-               Self->Callback[j] = Self->Callback[j+1];
-            }
-            i--;
-            Self->CallbackCount--;
-         }
+   for (auto callback = Self->Callback.begin(); callback != Self->Callback.end(); ) {
+      if (callback->Function.isScript() and (callback->Function.Context->UID IS Object->UID)) {
+         deref_surface_callback(callback->Function);
+         callback = Self->Callback.erase(callback);
       }
+      else callback++;
    }
 }
 
@@ -622,9 +611,6 @@ func Callback: Callback routine to insert or move in the draw callback list.
 Okay
 NullArgs
 NoPermission: Public objects cannot draw directly to surfaces.
-AllocMemory: The callback list could not be expanded.
-ArrayFull: The callback list has reached its maximum size.
-
 -TAGS-
 mutates-object, callback-held
 -END-
@@ -634,6 +620,7 @@ mutates-object, callback-held
 static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
 {
    kt::Log log;
+   bool new_callback = true;
    bool retained_callback = false;
 
    if ((not Args) or (not Args->Callback.defined())) return log.warning(ERR::NullArgs);
@@ -653,76 +640,34 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
    }
 
    log.msg("Context: %d, Callback Context: %d, Routine: %p (Count: %d)", context->UID,
-      call_context ? call_context->UID : 0, Args->Callback.Routine, Self->CallbackCount);
+      call_context ? call_context->UID : 0, Args->Callback.Routine, int(Self->Callback.size()));
 
    if (call_context) context = call_context;
 
-   if (Self->Callback) {
-      // Check if the subscription is already on the list for our surface context.
+   // Check if the subscription is already on the list for our surface context.
 
-      int i;
-      for (i=0; i < Self->CallbackCount; i++) {
-         if (Self->Callback[i].Object IS context) {
-            if ((Self->Callback[i].Function.isC()) and (Args->Callback.isC())) {
-               if (Self->Callback[i].Function.Routine IS Args->Callback.Routine) break;
-            }
-            else if ((Self->Callback[i].Function.isScript()) and (Args->Callback.isScript())) {
-               if (Self->Callback[i].Function.ProcedureID IS Args->Callback.ProcedureID) break;
-            }
+   auto callback = Self->Callback.begin();
+   for (; callback != Self->Callback.end(); callback++) {
+      if (callback->Object IS context) {
+         if ((callback->Function.isC()) and (Args->Callback.isC())) {
+            if (callback->Function.Routine IS Args->Callback.Routine) break;
+         }
+         else if ((callback->Function.isScript()) and (Args->Callback.isScript())) {
+            if (callback->Function.ProcedureID IS Args->Callback.ProcedureID) break;
          }
       }
-
-      if (i < Self->CallbackCount) {
-         log.trace("Moving existing subscription to foreground.");
-
-         deref_surface_callback(Self->Callback[i].Function);
-         while (i < Self->CallbackCount-1) {
-            Self->Callback[i] = Self->Callback[i+1];
-            i++;
-         }
-         Self->Callback[i].Object   = context;
-         Self->Callback[i].Function = Args->Callback;
-         Args->Callback.pin();
-         retained_callback = true;
-         return ERR::Okay;
-      }
-      else if (Self->CallbackCount < Self->CallbackSize) {
-         // Add the callback routine to the cache
-
-         Self->Callback[Self->CallbackCount].Object   = context;
-         Self->Callback[Self->CallbackCount].Function = Args->Callback;
-         Self->CallbackCount++;
-      }
-      else if (Self->CallbackCount < 255) {
-         log.detail("Expanding draw subscription array.");
-
-         int new_size = Self->CallbackSize + 10;
-         if (new_size > 255) new_size = 255;
-         SurfaceCallback *scb;
-         if (!AllocMemory(sizeof(SurfaceCallback) * new_size, MEM::DATA|MEM::NO_CLEAR, (APTR *)&scb)) {
-            copymem(Self->Callback, scb, sizeof(SurfaceCallback) * Self->CallbackCount);
-
-            scb[Self->CallbackCount].Object   = context;
-            scb[Self->CallbackCount].Function = Args->Callback;
-            Self->CallbackCount++;
-            Self->CallbackSize = new_size;
-
-            if (Self->Callback != Self->CallbackCache) FreeResource(Self->Callback);
-            Self->Callback = scb;
-         }
-         else return ERR::AllocMemory;
-      }
-      else return ERR::ArrayFull;
-   }
-   else {
-      Self->Callback = Self->CallbackCache;
-      Self->CallbackCount = 1;
-      Self->CallbackSize = std::ssize(Self->CallbackCache);
-      Self->Callback[0].Object = context;
-      Self->Callback[0].Function = Args->Callback;
    }
 
-   if (Args->Callback.Type IS CALL::SCRIPT) {
+   if (callback != Self->Callback.end()) {
+      log.trace("Moving existing subscription to foreground.");
+      deref_surface_callback(callback->Function);
+      Self->Callback.erase(callback);
+      new_callback = false;
+   }
+
+   Self->Callback.push_back({ context, Args->Callback });
+
+   if (new_callback and (Args->Callback.Type IS CALL::SCRIPT)) {
       SubscribeAction(Args->Callback.Context, AC::Free, C_FUNCTION(notify_free_callback));
    }
 
@@ -963,17 +908,8 @@ extSurface::~extSurface()
 {
    if (RedrawTimer) UpdateTimer(RedrawTimer, 0);
 
-   if ((Callback) and (Callback != CallbackCache)) {
-      deref_surface_callback_range(Callback, CallbackCount);
-      FreeResource(Callback);
-      Callback = nullptr;
-      CallbackCount = 0;
-      CallbackSize = 0;
-   }
-   else if (Callback IS CallbackCache) {
-      deref_surface_callback_range(Callback, CallbackCount);
-      CallbackCount = 0;
-   }
+   deref_surface_callbacks(Callback);
+   Callback.clear();
 
    if (ParentID) {
       if (kt::ScopedObjectLock<extSurface> parent(ParentID, 5000); parent.granted()) {
@@ -1940,30 +1876,26 @@ static ERR SURFACE_RemoveCallback(extSurface *Self, struct drw::RemoveCallback *
       if (Args->Callback.isC()) {
          context = (OBJECTPTR)Args->Callback.Context;
          log.trace("Context: %d, Routine %p, Current Total: %d", context->UID, Args->Callback.Routine,
-            Self->CallbackCount);
+            int(Self->Callback.size()));
       }
-      else log.trace("Current Total: %d", Self->CallbackCount);
+      else log.trace("Current Total: %d", int(Self->Callback.size()));
    }
-   else log.trace("Current Total: %d [Remove All]", Self->CallbackCount);
+   else log.trace("Current Total: %d [Remove All]", int(Self->Callback.size()));
 
    if (!context) context = ParentContext();
 
-   if (!Self->Callback) return ERR::Okay;
+   if (Self->Callback.empty()) return ERR::Okay;
 
    if ((not Args) or (not Args->Callback.defined())) {
       // Remove everything relating to this context if no callback was specified.
 
-      int i;
-      int shrink = 0;
-      for (i=0; i < Self->CallbackCount; i++) {
-         if (Self->Callback[i].Object IS context) {
-            deref_surface_callback(Self->Callback[i].Function);
-            shrink--;
-            continue;
+      for (auto callback = Self->Callback.begin(); callback != Self->Callback.end(); ) {
+         if (callback->Object IS context) {
+            deref_surface_callback(callback->Function);
+            callback = Self->Callback.erase(callback);
          }
-         if (shrink) Self->Callback[i+shrink] = Self->Callback[i];
+         else callback++;
       }
-      Self->CallbackCount += shrink;
       return ERR::Okay;
    }
 
@@ -1973,26 +1905,20 @@ static ERR SURFACE_RemoveCallback(extSurface *Self, struct drw::RemoveCallback *
 
    // Find the callback entry, then shrink the list.
 
-   int i;
-   for (i=0; i < Self->CallbackCount; i++) {
-      //log.msg("  %d: #%d, Routine %p", i, Self->Callback[i].Object->UID, Self->Callback[i].Function.Routine);
+   auto callback = Self->Callback.begin();
+   for (; callback != Self->Callback.end(); callback++) {
+      if ((callback->Function.isC()) and
+          (callback->Function.Context IS context) and
+          (callback->Function.Routine IS Args->Callback.Routine)) break;
 
-      if ((Self->Callback[i].Function.isC()) and
-          (Self->Callback[i].Function.Context IS context) and
-          (Self->Callback[i].Function.Routine IS Args->Callback.Routine)) break;
-
-      if ((Self->Callback[i].Function.isScript()) and
-          (Self->Callback[i].Function.Context IS context) and
-          (Self->Callback[i].Function.ProcedureID IS Args->Callback.ProcedureID)) break;
+      if ((callback->Function.isScript()) and
+          (callback->Function.Context IS context) and
+          (callback->Function.ProcedureID IS Args->Callback.ProcedureID)) break;
    }
 
-   if (i < Self->CallbackCount) {
-      deref_surface_callback(Self->Callback[i].Function);
-      while (i < Self->CallbackCount-1) {
-         Self->Callback[i] = Self->Callback[i+1];
-         i++;
-      }
-      Self->CallbackCount--;
+   if (callback != Self->Callback.end()) {
+      deref_surface_callback(callback->Function);
+      Self->Callback.erase(callback);
       return ERR::Okay;
    }
    else {

--- a/src/display/class_surface/surface_drawing.cpp
+++ b/src/display/class_surface/surface_drawing.cpp
@@ -604,7 +604,7 @@ void move_layer(extSurface *Self, int X, int Y)
 
    bool redraw;
    if (Self->transparent()) { // Transparent surfaces are treated as volatile if they contain graphics
-      if (Self->CallbackCount > 0) redraw = true;
+      if (not Self->Callback.empty()) redraw = true;
       else redraw = false;
    }
    else if ((volatilegfx) and ((Self->Flags & RNF::COMPOSITE) IS RNF::NIL)) redraw = true;

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -27,6 +27,7 @@
 #include <queue>
 #include <sstream>
 #include <array>
+#include <vector>
 #include <math.h>
 
 #ifdef __linux__
@@ -363,7 +364,7 @@ class extSurface : public objSurface {
 
    int64_t    LastRedimension;      // Timestamp of the last redimension call
    objBitmap *Bitmap;
-   SurfaceCallback *Callback;
+   std::vector<SurfaceCallback> Callback;
    APTR     Data;
    double   Opacity;
    WINHANDLE DisplayWindow;       // Reference to the platform dependent window representing the Surface object
@@ -375,7 +376,6 @@ class extSurface : public objSurface {
    int      InputHandle;          // Input handler for dragging of surfaces
    SWIN     WindowType;           // See SWIN constants
    TIMER    RedrawTimer;          // For ScheduleRedraw()
-   SurfaceCallback CallbackCache[3]; // For AddCallback()
    int16_t FixedWidth, FixedHeight, FixedX, FixedY, FixedXO, FixedYO;
    uint16_t InheritedRoot:1;      // TRUE if the user set the RootLayer manually
    uint16_t ParentDefined:1;      // TRUE if the parent field was set manually
@@ -385,8 +385,6 @@ class extSurface : public objSurface {
    uint8_t  RedrawRate;           // Last refresh rate used for scheduled redrawing
    int8_t   BitsPerPixel;         // Bitmap bits per pixel
    int8_t   BytesPerPixel;        // Bitmap bytes per pixel
-   uint8_t  CallbackCount;
-   uint8_t  CallbackSize;         // Current size of the callback array.
 
    extSurface(objMetaClass *ClassPtr, OBJECTID ObjectID) : objSurface(ClassPtr, ObjectID) {
       Opacity    = 1.0;

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -832,16 +832,15 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
    kt::Log log(__FUNCTION__);
 
    #ifdef DBG_DRAW_ROUTINES
-      log.traceBranch("Bitmap: %d, Count: %d", Bitmap->UID, Self->CallbackCount);
+      log.traceBranch("Bitmap: %d, Count: %d", Bitmap->UID, int(Self->Callback.size()));
    #endif
 
-   for (int i=0; i < Self->CallbackCount; ) {
+   for (int i=0; i < std::ssize(Self->Callback); ) {
       Bitmap->Opacity = 255;
       auto &cb = Self->Callback[i].Function;
       if (cb.stale()) {
          deref_surface_callback(cb);
-         for (int j=i; j < Self->CallbackCount-1; j++) Self->Callback[j] = Self->Callback[j+1];
-         Self->CallbackCount--;
+         Self->Callback.erase(Self->Callback.begin() + i);
          continue;
       }
       else if (cb.isC()) {
@@ -849,7 +848,8 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
 
          #ifdef DBG_DRAW_ROUTINES
             kt::Log log(__FUNCTION__);
-            log.branch("%d/%d: Routine: %p, Object: %p, Context: %p", i, Self->CallbackCount, routine, Self->Callback[i].Object, cb.Context);
+            log.branch("%d/%d: Routine: %p, Object: %p, Context: %p", i, int(Self->Callback.size()), routine,
+               Self->Callback[i].Object, cb.Context);
          #endif
 
          if (cb.Context) {


### PR DESCRIPTION
* Replaced manual callback storage, capacity tracking and cache management with std::vector
* Simplified callback insertion, removal, stale cleanup and destruction while preserving callback ownership