### PR TITLE
[Display] Simplified surface callback context handling

### DIFF
--- a/src/display/class_surface/class_surface.cpp
+++ b/src/display/class_surface/class_surface.cpp
@@ -58,9 +58,9 @@ static void deref_surface_callback(FUNCTION &Function)
    }
 }
 
-static void deref_surface_callbacks(std::vector<SurfaceCallback> &Callbacks)
+static void deref_surface_callbacks(std::vector<FUNCTION> &Callbacks)
 {
-   for (auto &callback : Callbacks) deref_surface_callback(callback.Function);
+   for (auto &callback : Callbacks) deref_surface_callback(callback);
 }
 
 //********************************************************************************************************************
@@ -454,8 +454,8 @@ static void notify_free_callback(OBJECTPTR Object, ACTIONID ActionID, ERR Result
    auto Self = (extSurface *)CurrentContext();
 
    for (auto callback = Self->Callback.begin(); callback != Self->Callback.end(); ) {
-      if (callback->Function.isScript() and (callback->Function.Context->UID IS Object->UID)) {
-         deref_surface_callback(callback->Function);
+      if (callback->isScript() and (callback->Context->UID IS Object->UID)) {
+         deref_surface_callback(*callback);
          callback = Self->Callback.erase(callback);
       }
       else callback++;
@@ -610,7 +610,7 @@ func Callback: Callback routine to insert or move in the draw callback list.
 -ERRORS-
 Okay
 NullArgs
-NoPermission: Public objects cannot draw directly to surfaces.
+
 -TAGS-
 mutates-object, callback-held
 -END-
@@ -629,43 +629,30 @@ static ERR SURFACE_AddCallback(extSurface *Self, struct drw::AddCallback *Args)
       if (not retained_callback) Args->Callback.consume();
    });
 
-   OBJECTPTR context = ParentContext();
-   OBJECTPTR call_context = nullptr;
-   if (Args->Callback.isC()) call_context = (OBJECTPTR)Args->Callback.Context;
-   else if (Args->Callback.isScript()) call_context = context; // Scripts use runtime ID resolution...
+   log.msg("Count: %d", int(Self->Callback.size()));
 
-   if (context->UID < 0) {
-      log.warning("Public objects may not draw directly to surfaces.");
-      return ERR::NoPermission;
-   }
-
-   log.msg("Context: %d, Callback Context: %d, Routine: %p (Count: %d)", context->UID,
-      call_context ? call_context->UID : 0, Args->Callback.Routine, int(Self->Callback.size()));
-
-   if (call_context) context = call_context;
-
-   // Check if the subscription is already on the list for our surface context.
+   // Check if the subscription is already registered
 
    auto callback = Self->Callback.begin();
    for (; callback != Self->Callback.end(); callback++) {
-      if (callback->Object IS context) {
-         if ((callback->Function.isC()) and (Args->Callback.isC())) {
-            if (callback->Function.Routine IS Args->Callback.Routine) break;
+      if (callback->Context IS Args->Callback.Context) {
+         if ((callback->isC()) and (Args->Callback.isC())) {
+            if (callback->Routine IS Args->Callback.Routine) break;
          }
-         else if ((callback->Function.isScript()) and (Args->Callback.isScript())) {
-            if (callback->Function.ProcedureID IS Args->Callback.ProcedureID) break;
+         else if ((callback->isScript()) and (Args->Callback.isScript())) {
+            if (callback->ProcedureID IS Args->Callback.ProcedureID) break;
          }
       }
    }
 
    if (callback != Self->Callback.end()) {
       log.trace("Moving existing subscription to foreground.");
-      deref_surface_callback(callback->Function);
+      deref_surface_callback(*callback);
       Self->Callback.erase(callback);
       new_callback = false;
    }
 
-   Self->Callback.push_back({ context, Args->Callback });
+   Self->Callback.push_back(Args->Callback);
 
    if (new_callback and (Args->Callback.Type IS CALL::SCRIPT)) {
       SubscribeAction(Args->Callback.Context, AC::Free, C_FUNCTION(notify_free_callback));
@@ -914,9 +901,7 @@ extSurface::~extSurface()
    if (ParentID) {
       if (kt::ScopedObjectLock<extSurface> parent(ParentID, 5000); parent.granted()) {
          UnsubscribeAction(*parent, AC::NIL);
-         if (transparent()) {
-            Action(drw::RemoveCallback::id, this, nullptr);
-         }
+         if (transparent()) Action(drw::RemoveCallback::id, this, nullptr);
       }
    }
 
@@ -1868,21 +1853,20 @@ static ERR SURFACE_RemoveCallback(extSurface *Self, struct drw::RemoveCallback *
    kt::Log log;
    OBJECTPTR context = nullptr;
 
-   auto consume_callback = kt::Defer([&]() {
-      if (Args) Args->Callback.consume();
-   });
-
    if (Args) {
+      context = Args->Callback.Context;
       if (Args->Callback.isC()) {
-         context = (OBJECTPTR)Args->Callback.Context;
          log.trace("Context: %d, Routine %p, Current Total: %d", context->UID, Args->Callback.Routine,
             int(Self->Callback.size()));
       }
-      else log.trace("Current Total: %d", int(Self->Callback.size()));
+      else {
+         log.trace("Current Total: %d", int(Self->Callback.size()));
+         Args->Callback.consume();
+      }
    }
    else log.trace("Current Total: %d [Remove All]", int(Self->Callback.size()));
 
-   if (!context) context = ParentContext();
+   if (not context) context = ParentContext();
 
    if (Self->Callback.empty()) return ERR::Okay;
 
@@ -1890,8 +1874,8 @@ static ERR SURFACE_RemoveCallback(extSurface *Self, struct drw::RemoveCallback *
       // Remove everything relating to this context if no callback was specified.
 
       for (auto callback = Self->Callback.begin(); callback != Self->Callback.end(); ) {
-         if (callback->Object IS context) {
-            deref_surface_callback(callback->Function);
+         if (callback->Context IS context) {
+            deref_surface_callback(*callback);
             callback = Self->Callback.erase(callback);
          }
          else callback++;
@@ -1899,25 +1883,22 @@ static ERR SURFACE_RemoveCallback(extSurface *Self, struct drw::RemoveCallback *
       return ERR::Okay;
    }
 
-   if (Args->Callback.isScript()) {
-      UnsubscribeAction(Args->Callback.Context, AC::Free);
-   }
+   if (Args->Callback.isScript()) UnsubscribeAction(Args->Callback.Context, AC::Free);
 
    // Find the callback entry, then shrink the list.
 
    auto callback = Self->Callback.begin();
    for (; callback != Self->Callback.end(); callback++) {
-      if ((callback->Function.isC()) and
-          (callback->Function.Context IS context) and
-          (callback->Function.Routine IS Args->Callback.Routine)) break;
+      if (callback->Context != context) continue;
 
-      if ((callback->Function.isScript()) and
-          (callback->Function.Context IS context) and
-          (callback->Function.ProcedureID IS Args->Callback.ProcedureID)) break;
+      if ((callback->isC()) and (callback->Routine IS Args->Callback.Routine)) break;
+
+      if ((callback->isScript()) and
+          (callback->ProcedureID IS Args->Callback.ProcedureID)) break;
    }
 
    if (callback != Self->Callback.end()) {
-      deref_surface_callback(callback->Function);
+      deref_surface_callback(*callback);
       Self->Callback.erase(callback);
       return ERR::Okay;
    }

--- a/src/display/defs.h
+++ b/src/display/defs.h
@@ -364,7 +364,7 @@ class extSurface : public objSurface {
 
    int64_t    LastRedimension;      // Timestamp of the last redimension call
    objBitmap *Bitmap;
-   std::vector<SurfaceCallback> Callback;
+   std::vector<FUNCTION> Callback;
    APTR     Data;
    double   Opacity;
    WINHANDLE DisplayWindow;       // Reference to the platform dependent window representing the Surface object

--- a/src/display/lib_surfaces.cpp
+++ b/src/display/lib_surfaces.cpp
@@ -837,7 +837,7 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
 
    for (int i=0; i < std::ssize(Self->Callback); ) {
       Bitmap->Opacity = 255;
-      auto &cb = Self->Callback[i].Function;
+      auto &cb = Self->Callback[i];
       if (cb.stale()) {
          deref_surface_callback(cb);
          Self->Callback.erase(Self->Callback.begin() + i);
@@ -848,15 +848,11 @@ void process_surface_callbacks(extSurface *Self, extBitmap *Bitmap)
 
          #ifdef DBG_DRAW_ROUTINES
             kt::Log log(__FUNCTION__);
-            log.branch("%d/%d: Routine: %p, Object: %p, Context: %p", i, int(Self->Callback.size()), routine,
-               Self->Callback[i].Object, cb.Context);
+            log.branch("%d/%d: Routine: %p, Context: %p", i, int(Self->Callback.size()), routine, cb.Context);
          #endif
 
-         if (cb.Context) {
-            kt::SwitchContext context(cb.Context);
-            routine(cb.Context, Self, Bitmap, cb.Meta);
-         }
-         else routine(Self->Callback[i].Object, Self, Bitmap, cb.Meta);
+         kt::SwitchContext context(cb.Context);
+         routine(cb.Context, Self, Bitmap, cb.Meta);
       }
       else if (cb.isScript()) {
          sc::Call(cb, std::to_array<ScriptArg>({


### PR DESCRIPTION
* Stored callbacks directly as FUNCTION entries
* Used callback-owned contexts for registration, removal and execution