### PR TITLE
[Tiri] Added source locations and tracebacks to check failures

### DIFF
--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -165,7 +165,9 @@ extern "C" LJ_NORET void lj_check_raise(lua_State *L, int32_t ErrorCode, uint32_
    }
 
    if (not L->sent_traceback) {
-      luaL_traceback(L, L, strdata(message), 0);
+      // luaL_traceback() can collect while formatting its first string.  Root the message before exposing its data.
+      setstrV(L, L->top++, message);
+      luaL_traceback(L, L, strVdata(L->top - 1), 0);
       message = strV(L->top - 1);
       L->sent_traceback = true;
    }

--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -12,6 +12,7 @@
 #include "lua.h"
 #include "lj_gc.h"
 #include "lj_array.h"
+#include "lj_buf.h"
 #include "lj_obj.h"
 #include "lj_debug.h"
 #include "lj_err.h"
@@ -135,6 +136,40 @@ extern "C" LJ_NORET void lj_raise(lua_State *L, int32_t ErrorCode)
 {
    ERR error = ERR(ErrorCode);
    GCstr *message = lj_str_newz(L, GetErrorMsg(error));
+   lj_raise_recorded(L, error, message);
+}
+
+extern "C" LJ_NORET void lj_check_raise(lua_State *L, int32_t ErrorCode, uint32_t SourceColumn)
+{
+   ERR error = ERR(ErrorCode);
+   GCstr *message = lj_str_newz(L, GetErrorMsg(error));
+
+   // VM helpers enter with top synchronised to base.  Keep traceback temporaries above the current function's register
+   // frame so caught checks cannot overwrite live locals before the try handler restores execution.
+   GCfunc *func = frame_func(L->base - 1);
+   if (isluafunc(func)) L->top = L->base + funcproto(func)->framesize;
+
+   DebugLocation location;
+   int32_t line = 0;
+   if (lj_debug_getloc(L, L->base - 1, nullptr, &location)) line = location.line;
+
+   if (line > 0) {
+      SBuf *sb = lj_buf_tmp_(L);
+      lj_buf_putchar(sb, '[');
+      lj_strfmt_putint(sb, line);
+      lj_buf_putchar(sb, ':');
+      lj_strfmt_putint(sb, SourceColumn);
+      lj_buf_putmem(sb, "] ", 2);
+      lj_buf_putmem(sb, strdata(message), message->len);
+      message = lj_buf_str(L, sb);
+   }
+
+   if (not L->sent_traceback) {
+      luaL_traceback(L, L, strdata(message), 0);
+      message = strV(L->top - 1);
+      L->sent_traceback = true;
+   }
+
    lj_raise_recorded(L, error, message);
 }
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4471,7 +4471,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_CHECK:
-    // BC_CHECK A, D: Check error code in RA, raise if >= ExceptionThreshold (9)
+    // BC_CHECK A, D: Check error code in RA, raise with source column D if >= ExceptionThreshold (9)
     // Fast path: If error code < 9, return
     // Slow path: Throw exception
     |  ins_AD                         // A = error code register
@@ -4484,15 +4484,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |2:
     |  cmp RAw, #9                    // Compare with ExceptionThreshold (ERR::Terminate = 9)
     |  b.lo >1                        // Below threshold? Skip to fast path exit
-    |  // Error >= threshold: raise exception
+    |  // Error >= threshold: raise exception with assert-style location and traceback details
     |  ldr L, SAVE_L
     |  str BASE, L->base              // Sync L->base for error handling
     |  str BASE, L->top               // Sync L->top for error handling
     |  str PC, SAVE_PC                // Ensure cframe has a valid PC for trace capture
     |  str RAw, [L, #L_CAUGHTERROR_OFS]  // Set L->CaughtError
+    |  mov CARG3w, RCw                // 3rd arg: source column (RC == RD after ins_AD)
     |  mov CARG2w, RAw                // 2nd arg: error code
     |  mov CARG1, L                   // 1st arg: lua_State *L
-    |  bl extern lj_raise             // Never returns
+    |  bl extern lj_check_raise       // Never returns
     |1:
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6453,10 +6453,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_CHECK:
-    // BC_CHECK A, D: Check error code in RA, raise if >= ExceptionThreshold (9)
+    // BC_CHECK A, D: Check error code in RA, raise with source column D if >= ExceptionThreshold (9)
     // Fast path: if error code < 9, just continue (no exception)
     // Slow path: call lj_check_raise to throw exception
-    |  ins_AD                         // A = error code register
+    |  ins_AD                         // A = error code register, D = source column
+    |  mr SAVE0, RD                   // Preserve the source column across numeric conversion helpers
     |  lwzx TMP0, BASE, RA            // Load type tag/high word
     |  checknum TMP0
     |  bgt >1                         // Not a number - skip
@@ -6492,9 +6493,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  stp BASE, L->top               // Sync L->top for error handling
     |  stw PC, SAVE_PC                // Ensure cframe has a valid PC for trace capture
     |  stw TMP1, L_CAUGHTERROR_OFS(L) // Set L->CaughtError
+    |  mr CARG3, SAVE0                // 3rd arg: source column
     |  mr CARG2, TMP1                 // 2nd arg: error code
     |  mr CARG1, L                    // 1st arg: lua_State *L
-    |  bl extern lj_raise             // Never returns
+    |  bl extern lj_check_raise       // Never returns
     |1:
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5401,7 +5401,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_CHECK:
-    // BC_CHECK A, D: Check error code in RA, raise if >= ExceptionThreshold (9)
+    // BC_CHECK A, D: Check error code in RA, raise with source column D if >= ExceptionThreshold (9)
     // Fast path: If error code < 9, return
     // Slow path: Throw exception
     |  ins_AD                         // A = error code register
@@ -5419,19 +5419,15 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endif
     |  cmp RAd, 9                     // Compare with ExceptionThreshold (ERR::Terminate = 9)
     |  jb >1                          // Below threshold? Skip to fast path exit
-    |  // Error >= threshold: raise exception
+    |  // Error >= threshold: raise exception with assert-style location and traceback details
     |  mov L:RB, SAVE_L
     |  mov L:RB->base, BASE           // Sync L->base for error handling
     |  mov L:RB->top, BASE            // Sync L->top for error handling
     |  mov SAVE_PC, PC                // Ensure cframe has a valid PC for trace capture
-    |.if X64WIN
+    |  mov CARG3d, RDd                // 3rd arg: source column
     |  mov CARG2d, RAd                // 2nd arg: error code
     |  mov CARG1, L:RB                // 1st arg: lua_State *L
-    |.else
-    |  mov CARG2d, RAd                // 2nd arg: error code (esi)
-    |  mov CARG1, L:RB                // 1st arg: lua_State *L (rdi)
-    |.endif
-    |  call extern lj_raise     // Never returns
+    |  call extern lj_check_raise      // Never returns
     |1:
     |  ins_next
     break;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_try.cpp
@@ -306,7 +306,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_raise_stmt(const RaiseStmtPayload &Payl
 // Emit bytecode for check statement: check expression
 //
 // Bytecode structure:
-//   BC_CHECK  A=error_reg, D=0
+//   BC_CHECK  A=error_reg, D=source_column
 
 ParserResult<IrEmitUnit> IrEmitter::emit_check_stmt(const CheckStmtPayload &Payload, const SourceSpan &Span)
 {
@@ -324,8 +324,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_check_stmt(const CheckStmtPayload &Payl
    ExpDesc code_expr = code_result.value_ref();
    expr_toanyreg(fs, &code_expr);
 
-   // Emit BC_CHECK: A=error_reg, D=0
-   bcemit_AD(fs, BC_CHECK, BCReg(code_expr.u.s.info), BCReg(0));
+   // Preserve the expression column for assert-style error formatting.  BC_CHECK's D operand is otherwise unused.
+   int32_t raw_column = Payload.error_code->span.column.lineNumber();
+   BCReg source_column = BCReg(raw_column > int32_t(BCMAX_D) ? BCMAX_D : raw_column);
+   bcemit_AD(fs, BC_CHECK, BCReg(code_expr.u.s.info), source_column);
    expr_free(fs, &code_expr);
 
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -1453,6 +1453,24 @@ end
    error("check with expression should have thrown")
 end
 
+@Test(priority=0.5,hotpath=false) function CheckIncludesLocationAndTraceback()
+   expected_line = @SourceLine + 3
+
+   try
+      check ERR_Failed
+   except e
+      assert(e.line is expected_line,
+         f"check should retain source line {expected_line}, got {e.line}; message: {e.message}")
+      assert(e.message:startsWith(f'[{expected_line}:'), "check should prefix its line and column, got " .. e.message)
+      assert(e.message:find(mSys.GetErrorMsg(ERR_Failed)), "check should include the error description")
+      assert(e.message:find("stack traceback:"), "check should include a stack traceback")
+      assert(e.message:find("in function 'func'"), "check traceback should identify the Flute test function")
+      return
+   end
+
+   error("check should have raised an exception with a traceback")
+end
+
 @Test(priority=67) function RaiseWithVariable()
    -- Test that raise works with variables, not just constants
    err_code = ERR_Failed


### PR DESCRIPTION
* Carry source columns through BC_CHECK on supported VM architectures
* Format check errors with assert-style locations and stack tracebacks
* Preserve live frame locals while constructing caught check diagnostics
* Add Flute coverage for verbose check failures