### PR TITLE
[Tiri] Added dynamically sized native struct array fields

### DIFF
--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -398,7 +398,14 @@ int MAKESTRUCT(lua_State *);
 [[nodiscard]] struct_record * find_struct_reference(lua_State *Lua, const struct_record &Owner,
    std::string_view Name);
 [[nodiscard]] ERR register_declared_struct(lua_State *Lua, struct_record &&Record, bool *Inserted,
-   const struct_record **Existing = nullptr);
+   const struct_record **Existing = nullptr, std::string *Detail = nullptr);
+void construct_trivial_struct_vector(APTR Address);
+void destroy_trivial_struct_vector(APTR Address);
+void assign_trivial_struct_vector(APTR Address, CPTR Source, size_t Elements, size_t Stride);
+void copy_trivial_struct_vector(APTR Dest, CPTR Source, size_t Stride);
+[[nodiscard]] size_t trivial_struct_vector_size(CPTR Address);
+[[nodiscard]] APTR trivial_struct_vector_data(APTR Address);
+[[nodiscard]] CPTR trivial_struct_vector_data(CPTR Address);
 ERR named_struct_to_table(lua_State *, std::string_view, CPTR);
 void construct_struct_cpp_strings(lua_State *, const struct struct_record &, APTR);
 void destroy_struct_cpp_strings(lua_State *, const struct struct_record &, APTR);

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -84,7 +84,8 @@ template <typename T> static void copy_array_to_vector(APTR Address, GCarray *So
 
 static void write_array_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName)
 {
-   if ((Field.Type & FD_CUSTOM) and (Field.Type & FD_BYTE) and lua_isstring(L, StackIndex)) {
+   if ((Field.Type & FD_CUSTOM) and (Field.Type & FD_BYTE) and (not (Field.Type & FD_CPP)) and
+         lua_isstring(L, StackIndex)) {
       size_t length = 0;
       auto source = lua_tolstring(L, StackIndex, &length);
       size_t copied = std::min(length, size_t(Field.ArraySize - 1));
@@ -99,6 +100,45 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
 
    auto source = lua_toarray(L, StackIndex);
    auto expected_type = ff_to_aet(Field.Type);
+
+   if ((Field.Type & FD_CPP) and (Field.Type & FD_STRUCT) and (not (Field.Type & FD_PTR))) {
+      if (not Field.TrivialElements) {
+         luaL_error(L, ERR::NoSupport, "Array field '%s' has a non-trivial legacy struct element type.", FieldName);
+      }
+      auto field_def = Field.StructDefinition;
+      if (not field_def) {
+         luaL_error(L, ERR::Search, "Array field '%s' has an unresolved struct element type.", FieldName);
+      }
+      if (source->elemtype IS AET::STRUCT) {
+         if ((source->structdef != field_def) or (source->elemsize != Field.ElementStride)) {
+            luaL_error(L, ERR::InvalidType, "Array field '%s' requires '%s' struct elements.", FieldName,
+               field_def->Name.c_str());
+         }
+         assign_trivial_struct_vector(Address, source->arraydata(), source->len, Field.ElementStride);
+         return;
+      }
+      if (source->elemtype IS AET::TABLE) {
+         auto conversion = ERR::Okay;
+         { // Scoped so that the buffers are destroyed before luaL_error() unwinds the stack.
+            std::vector<uint8_t> serial(size_t(source->len) * Field.ElementStride);
+            for (MSize i = 0; i < source->len; i++) {
+               auto table = tabref(source->get<GCRef>()[i]);
+               settabV(L, L->top++, table);
+               std::unique_ptr<uint8_t[]> element;
+               conversion = table_to_struct(L, field_def->Name, element);
+               lua_pop(L, 1);
+               if (conversion != ERR::Okay) break;
+               std::memcpy(serial.data() + (size_t(i) * Field.ElementStride), element.get(), Field.ElementStride);
+            }
+            if (conversion IS ERR::Okay) {
+               assign_trivial_struct_vector(Address, serial.data(), source->len, Field.ElementStride);
+               return;
+            }
+         }
+         luaL_error(L, conversion, "Array field '%s' contains an invalid struct table.", FieldName);
+      }
+      luaL_error(L, ERR::InvalidType, "Array field '%s' requires struct elements.", FieldName);
+   }
 
    if ((Field.Type & FD_STRING) and (not (Field.Type & FD_CPP))) {
       luaL_error(L, ERR::NoSupport, "Raw C string array field '%s' does not support assignment.", FieldName);
@@ -206,7 +246,9 @@ static bool struct_has_unsupported_cpp_arrays(lua_State *L, const struct_record 
 {
    for (auto &field : Def.Fields) {
       if ((field.Type & FD_CPP) and (field.Type & FD_ARRAY) and
-            (not (field.Type & (FD_STRING|FD_FLOAT|FD_DOUBLE|FD_INT64|FD_INT|FD_WORD|FD_BYTE)))) return true;
+            (not (field.Type & (FD_STRUCT|FD_STRING|FD_FLOAT|FD_DOUBLE|FD_INT64|FD_INT|FD_WORD|FD_BYTE)))) return true;
+      if ((field.Type & FD_CPP) and (field.Type & FD_ARRAY) and (field.Type & FD_STRUCT) and
+            (not field.TrivialElements)) return true;
       if ((field.Type & FD_STRUCT) and (not (field.Type & FD_PTR)) and (not (field.Type & FD_CPP)) and
             (field.StructRef != 0)) {
          if (auto child = field.StructDefinition ? field.StructDefinition :
@@ -224,7 +266,10 @@ static void copy_cpp_fields(lua_State *L, const struct_record &Def, APTR Dest, C
       auto dest = (int8_t *)Dest + field.Offset;
       auto source = (const int8_t *)Source + field.Offset;
       if ((field.Type & FD_CPP) and (field.Type & FD_ARRAY)) {
-         if (field.Type & FD_STRING) {
+         if ((field.Type & FD_STRUCT) and (not (field.Type & FD_PTR))) {
+            copy_trivial_struct_vector(dest, source, field.ElementStride);
+         }
+         else if (field.Type & FD_STRING) {
             ((kt::vector<std::string> *)dest)[0] = ((const kt::vector<std::string> *)source)[0];
          }
          else if (field.Type & FD_FLOAT) ((kt::vector<float> *)dest)[0] = ((const kt::vector<float> *)source)[0];
@@ -445,8 +490,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
       if (not field_def) {
          luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
-      auto vector = (kt::vector<int> *)Address;
-      make_struct_serial_array(L, field_def->Name, vector->size(), vector->data(), field_def);
+      make_struct_array(L, field_def->Name, int(trivial_struct_vector_size(Address)),
+         trivial_struct_vector_data(Address), Field.ElementStride, field_def);
    }
    else if ((Field.Type & FD_STRUCT) and (Field.Type & FD_PTR) and (Field.StructRef != 0)) {
       if (((APTR *)Address)[0]) {
@@ -475,8 +520,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
          luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
       if (Field.Type & FD_CPP) {
-         auto vector = (kt::vector<int> *)Address;
-         make_any_array(L, Field.Type, field_def->Name, vector->size(), vector->data(), field_def);
+         make_struct_array(L, field_def->Name, int(trivial_struct_vector_size(Address)),
+            trivial_struct_vector_data(Address), Field.ElementStride, field_def);
       }
       else make_struct_array(L, field_def->Name, array_size, Address, 0, field_def);
    }

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -363,15 +363,86 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
 
       auto colon = this->ctx.consume(TokenKind::Colon, ParserErrorCode::ExpectedToken);
       if (not colon.ok()) return ParserResult<StmtNodePtr>::failure(colon.error_ref());
-      auto type_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
-      if (not type_token.ok()) return ParserResult<StmtNodePtr>::failure(type_token.error_ref());
-      GCstr *type_symbol = type_token.value_ref().identifier();
-      std::string_view type_name(strdata(type_symbol), type_symbol->len);
+      Token type_token = this->ctx.tokens().current();
+      bool array_type = type_token.kind() IS TokenKind::ArrayTyped;
+      int64_t array_dimension = array_type ? this->ctx.lex().array_typed_size : -1;
+      if (array_type) this->ctx.tokens().advance();
+      else {
+         auto type_result = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
+         if (not type_result.ok()) return ParserResult<StmtNodePtr>::failure(type_result.error_ref());
+         type_token = type_result.value_ref();
+      }
+      GCstr *type_symbol = array_type ? type_token.payload().as_string() : type_token.identifier();
+      std::string_view type_name = array_type ? std::string_view("array") :
+         std::string_view(strdata(type_symbol), type_symbol->len);
 
       struct_field field;
       field.Name = field_name;
       field.ArraySize = 0;
-      if (type_name IS "bool") { field.Type = FD_BYTE; field.NativeType = NativeStructType::Bool; }
+      bool dynamic_array = false;
+      if (type_name IS "array") {
+         dynamic_array = true;
+         if (array_dimension != -1) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, type_token,
+               "Dynamically sized struct array fields cannot declare a dimension");
+         }
+         std::string_view element_name(strdata(type_symbol), type_symbol->len);
+
+         if (element_name IS "bool") { field.Type = FD_BYTE; field.NativeType = NativeStructType::Bool; }
+         else if (element_name IS "char") { field.Type = FD_BYTE|FD_CUSTOM; field.NativeType = NativeStructType::Char; }
+         else if (element_name IS "byte" or element_name IS "uint8") {
+            field.Type = FD_BYTE; field.NativeType = NativeStructType::UInt8;
+         }
+         else if (element_name IS "int8") { field.Type = FD_BYTE; field.NativeType = NativeStructType::Int8; }
+         else if (element_name IS "int16") { field.Type = FD_WORD; field.NativeType = NativeStructType::Int16; }
+         else if (element_name IS "uint16") {
+            field.Type = FD_WORD|FD_UNSIGNED; field.NativeType = NativeStructType::UInt16;
+         }
+         else if (element_name IS "int" or element_name IS "int32") {
+            field.Type = FD_INT; field.NativeType = NativeStructType::Int32;
+         }
+         else if (element_name IS "uint" or element_name IS "uint32") {
+            field.Type = FD_INT|FD_UNSIGNED; field.NativeType = NativeStructType::UInt32;
+         }
+         else if (element_name IS "int64") { field.Type = FD_INT64; field.NativeType = NativeStructType::Int64; }
+         else if (element_name IS "uint64") {
+            field.Type = FD_INT64|FD_UNSIGNED; field.NativeType = NativeStructType::UInt64;
+         }
+         else if (element_name IS "float") { field.Type = FD_FLOAT; field.NativeType = NativeStructType::Float; }
+         else if (element_name IS "double") { field.Type = FD_DOUBLE; field.NativeType = NativeStructType::Double; }
+         else if (element_name IS "string") {
+            field.Type = FD_STRING; field.NativeType = NativeStructType::String;
+         }
+         else if (element_name.starts_with("struct<") and element_name.ends_with(">")) {
+            std::string_view reference_name = element_name.substr(7, element_name.size() - 8);
+            auto referenced = find_struct(&this->ctx.lua(), reference_name);
+            if (not referenced) {
+               return this->fail<StmtNodePtr>(ParserErrorCode::UnknownTypeName, type_token,
+                  std::format("Unknown struct name '{}'; declarations must precede use", reference_name));
+            }
+            field.Type = FD_STRUCT;
+            field.NativeType = NativeStructType::Struct;
+            field.StructRef = struct_key(reference_name);
+            field.StructDefinition = referenced;
+         }
+         else if (element_name IS "array") {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, type_token,
+               "Nested array fields are not supported");
+         }
+         else if (element_name IS "cstr" or element_name IS "ptr" or element_name IS "obj" or
+               element_name IS "func") {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, type_token,
+               std::format("array<{}> fields cannot own this element type", element_name));
+         }
+         else {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnknownTypeName, type_token,
+               std::format("Unknown array element type '{}'", element_name));
+         }
+
+         field.Type |= FD_CPP|FD_ARRAY;
+         field.ArraySize = 1;
+      }
+      else if (type_name IS "bool") { field.Type = FD_BYTE; field.NativeType = NativeStructType::Bool; }
       else if (type_name IS "char") { field.Type = FD_BYTE|FD_CUSTOM; field.NativeType = NativeStructType::Char; }
       else if (type_name IS "byte" or type_name IS "uint8") {
          field.Type = FD_BYTE; field.NativeType = NativeStructType::UInt8;
@@ -455,17 +526,21 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
             if (not close.ok()) return ParserResult<StmtNodePtr>::failure(close.error_ref());
          }
          else if (not is_pointer) {
-            return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, type_token.value_ref(),
+            return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, type_token,
                "struct fields require a referenced name, for example struct<User>");
          }
       }
       else {
-         return this->fail<StmtNodePtr>(ParserErrorCode::UnknownTypeName, type_token.value_ref(),
+         return this->fail<StmtNodePtr>(ParserErrorCode::UnknownTypeName, type_token,
             std::format("Unknown struct field type '{}'", type_name));
       }
 
       if (this->ctx.match(TokenKind::LeftBracket).ok()) {
          Token dimension = this->ctx.tokens().current();
+         if (dynamic_array) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, dimension,
+               "Dynamically sized array fields cannot have a fixed dimension");
+         }
          lua_Number dimension_value = dimension.payload().as_number();
          if (dimension.kind() != TokenKind::Number or dimension_value < 1 or
                dimension_value > lua_Number(std::numeric_limits<int>::max()) or
@@ -497,7 +572,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       Token last = this->ctx.tokens().current();
       if (this->ctx.match(TokenKind::Comma).ok()) continue;
       if (this->ctx.check(TokenKind::RightBrace)) continue;
-      if (last.span().line.lineNumber() <= type_token.value_ref().span().line.lineNumber()) {
+      if (last.span().line.lineNumber() <= type_token.span().line.lineNumber()) {
          return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, last,
             "Expected a newline, ',' or '}' after struct field");
       }
@@ -512,11 +587,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
 
    bool inserted = false;
    const struct_record *existing = nullptr;
-   ERR registration = register_declared_struct(&this->ctx.lua(), std::move(record), &inserted, &existing);
+   std::string registration_detail;
+   ERR registration = register_declared_struct(&this->ctx.lua(), std::move(record), &inserted, &existing,
+      &registration_detail);
    if (registration != ERR::Okay) {
       if (registration != ERR::Exists) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, name_token.value_ref(),
-            std::format("Failed to lay out struct '{}': {}", struct_name, GetErrorMsg(registration)));
+            registration_detail.empty() ? std::format("Failed to lay out struct '{}': {}", struct_name,
+               GetErrorMsg(registration)) : registration_detail);
       }
       std::string location = (existing and not existing->DeclarationSource.empty()) ?
          std::format(" at {}:{}", existing->DeclarationSource, existing->DeclarationLine) : " from native code";

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <cmath>
 #include <concepts>
+#include <format>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -1080,7 +1081,7 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
    } while (lj_char_isident(State->c));
 
    auto type_str = std::string_view(State->sb.b, sbuflen(&State->sb));
-   GCstr *type_name = State->keepstr(type_str);
+   std::string nested_type;
 
    lex_skip_inline_ws(State);
 
@@ -1102,6 +1103,24 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
          if (depth > 0) lex_next(State);
       }
       if (State->c IS '>') lex_next(State);  // Move past the inner closing '>'
+      lex_skip_inline_ws(State);
+   }
+   else if (type_str IS "struct" and State->c IS '<') {
+      lex_next(State);
+      lex_skip_inline_ws(State);
+      if (not (isalpha(State->c) or State->c IS '_')) {
+         lj_lex_error(State, lex_current_char_token(State), ErrMsg::XTOKEN, State->token2str(TK_name));
+      }
+      lj_buf_reset(&State->sb);
+      do {
+         lex_savenext(State);
+      } while (lj_char_isident(State->c));
+      nested_type = std::format("struct<{}>", std::string_view(State->sb.b, sbuflen(&State->sb)));
+      lex_skip_inline_ws(State);
+      if (State->c != '>') {
+         lj_lex_error(State, lex_current_char_token(State), ErrMsg::XTOKEN, State->token2str('>'));
+      }
+      lex_next(State);
       lex_skip_inline_ws(State);
    }
 
@@ -1142,7 +1161,7 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
    }
 
    // Store type name in token value
-   setstrV(State->L, tv, type_name);
+   setstrV(State->L, tv, State->keepstr(nested_type.empty() ? type_str : std::string_view(nested_type)));
    return TK_array_typed;
 }
 

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -187,6 +187,60 @@ static bool test_struct_pointer_array_sentinel(kt::Log &Log)
    return true;
 }
 
+//********************************************************************************************************************
+// struct_to_table() receives the address of a native structure rather than using the struct field getter.  C++ string
+// arrays require the vector object itself because the array cache reads std::string elements through its vector header.
+
+static bool test_struct_to_table_cpp_string_array(kt::Log &Log)
+{
+   LuaStateHolder holder;
+   lua_State *lua = holder.get();
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   kt::vector<std::string> names;
+   names.push_back("alpha");
+   names.push_back("beta");
+
+   struct_record def("StringArrayResult");
+   def.Size = int(sizeof(names));
+   struct_field field;
+   field.Name = "Names";
+   field.Type = FD_CPP|FD_ARRAY|FD_STRING;
+   field.ArraySize = 1;
+   def.Fields.push_back(field);
+
+   std::vector<lua_ref> references;
+   if (struct_to_table(lua, references, def, &names) != ERR::Okay) {
+      Log.error("failed to convert native structure containing a C++ string array");
+      unref_struct_references(lua, references);
+      return false;
+   }
+   unref_struct_references(lua, references);
+
+   lua_getfield(lua, -1, "Names");
+   if (not lua_isarray(lua, -1)) {
+      Log.error("C++ string array field did not produce an array");
+      return false;
+   }
+
+   auto array = lua_toarray(lua, -1);
+   if ((array->len != 2) or (array->elemtype != AET::CSTR)) {
+      Log.error("C++ string array field produced length %d and type %d", array->len, int(array->elemtype));
+      return false;
+   }
+
+   auto result = array->get<CSTRING>();
+   if ((std::string_view(result[0]) != "alpha") or (std::string_view(result[1]) != "beta")) {
+      Log.error("C++ string array field did not preserve its values");
+      return false;
+   }
+
+   return true;
+}
+
 static bool test_array_creation_double(kt::Log &Log)
 {
    LuaStateHolder Holder;
@@ -1099,11 +1153,12 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
 void array_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 30> Tests = { {
+   constexpr std::array<TestCase, 31> Tests = { {
       // Core Data Structures
       { "array_creation_byte", test_array_creation_byte },
       { "array_creation_int32", test_array_creation_int32 },
       { "struct_pointer_array_sentinel", test_struct_pointer_array_sentinel },
+      { "struct_to_table_cpp_string_array", test_struct_to_table_cpp_string_array },
       { "array_creation_double", test_array_creation_double },
       { "array_index_access", test_array_index_access },
       { "array_elemsize", test_array_elemsize },

--- a/src/tiri/struct_def.h
+++ b/src/tiri/struct_def.h
@@ -39,6 +39,8 @@ struct struct_field {
    uint16_t Offset = 0;   // Offset to the field value.
    int  Type      = 0;    // FD flags
    int  ArraySize = 0;    // Set if the field is an array
+   uint16_t ElementStride = 0; // Byte stride for dynamically sized struct elements
+   bool TrivialElements = false; // Struct vectors may use type-erased ownership only when validated as trivial
    NativeStructType NativeType = NativeStructType::Legacy;
 
    void precomputeNameHash() { NameHash = kt::strihash(Name); }
@@ -52,6 +54,7 @@ struct struct_record {
    std::string Name;
    std::vector<struct_field> Fields;
    int Size = 0; // Total byte size of the structure
+   int Alignment = 1; // Strictest native member alignment, including tail padding
    std::string DeclarationSource;
    uint32_t DeclarationLine = 0;
    struct_record(std::string_view pName) : Name(pName) { }

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -27,6 +27,24 @@ struct DeclaredLayout {
    Fixed: int[3], Child: struct<DeclaredChild>, ChildPointer: ptr<DeclaredChild>
 }
 
+struct DeclaredVectorElement {
+   Red: byte
+   Green: byte
+   Blue: byte
+}
+
+struct DeclaredVectorFields {
+   Bool: array<bool>, Char: array<char>, Byte: array<byte>, Int8: array<int8>, UInt8: array<uint8>,
+   Int16: array<int16>, UInt16: array<uint16>, Int: array<int>, UInt: array<uint>,
+   Int32: array<int32>, UInt32: array<uint32>, Int64: array<int64>, UInt64: array<uint64>,
+   Float: array<float>, Double: array<double>, String: array<string>,
+   Points: array<struct<DeclaredVectorElement>>
+}
+
+struct DeclaredNonTrivialVectorElement {
+   Name: string
+}
+
 function declared_user_age(Value: struct<DeclaredUser>):num
    return Value.Age
 end
@@ -108,6 +126,128 @@ end
       'eChild:LegacyDeclaredChild,pChildPointer:LegacyDeclaredChild')
    assert(struct.size('DeclaredLayout') is struct.size('LegacyDeclaredLayout'),
       'Declarative and MAKESTRUCT layouts should have identical byte sizes')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function NativeStructVectorLayoutParity()
+   MAKESTRUCT('LegacyDeclaredVectorElement', 'ubRed,ubGreen,ubBlue')
+   MAKESTRUCT('LegacyDeclaredVectorFields',
+      'zbBool[1],zcChar[1],zubByte[1],zbInt8[1],zubUInt8[1],zwInt16[1],zuwUInt16[1],zlInt[1],zulUInt[1],' ..
+      'zlInt32[1],zulUInt32[1],zxInt64[1],zuxUInt64[1],zfFloat[1],zdDouble[1],zsString[1],' ..
+      'zePoints:LegacyDeclaredVectorElement[1]')
+   assert(struct.size('DeclaredVectorFields') is struct.size('LegacyDeclaredVectorFields'),
+      'Declarative vector fields should match the MAKESTRUCT vector layout')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function NativeStructVectorRoundTrips()
+   local value = DeclaredVectorFields {
+      Int=array<int> { 1, 2, 3 },
+      String=array<string> { 'alpha', 'beta' }
+   }
+
+   value.Bool = array<byte> { 0, 1 }
+   value.Char = array<byte> { 65, 66 }
+   value.Byte = array<byte> { 250, 251 }
+   value.Int8 = array<byte> { 1, 2 }
+   value.UInt8 = array<byte> { 3, 4 }
+   value.Int16 = array<int16> { -12, 34 }
+   value.UInt16 = array<int16> { 123, 456 }
+   value.UInt = array<int> { 4000000000 }
+   value.Int32 = array<int> { -123456, 654321 }
+   value.UInt32 = array<int> { 123456, 654321 }
+   value.Int64 = array<int64> { -9007199, 9007199 }
+   value.UInt64 = array<int64> { 9007199, 18014398 }
+   value.Float = array<float> { 1.25, 2.5 }
+   value.Double = array<double> { 3.5, 7.25 }
+
+   assert(value.Int is array<int> { 1, 2, 3 }, 'Initialiser assignment should populate an int vector')
+   local initial_strings = value.String
+   assert(#initial_strings is 2 and initial_strings[0] is 'alpha' and initial_strings[1] is 'beta',
+      'Initialiser assignment should populate a string vector')
+   assert(value.Bool is array<byte> { 0, 1 } and value.Char is array<byte> { 65, 66 },
+      'Byte-sized vector categories should round-trip')
+   assert(value.Int16 is array<int16> { -12, 34 } and value.UInt16 is array<int16> { 123, 456 },
+      'Word-sized vector categories should round-trip')
+   assert(value.Int64 is array<int64> { -9007199, 9007199 }, 'Int64 vectors should round-trip')
+   assert(value.Float is array<float> { 1.25, 2.5 } and value.Double is array<double> { 3.5, 7.25 },
+      'Floating-point vectors should round-trip')
+
+   value.Int = array<int> { 8, 9, 10, 11, 12 }
+   assert(#value.Int is 5, 'Whole-field assignment should resize dynamic vector fields')
+
+   local clone = struct.clone(value)
+   local copy = DeclaredVectorFields()
+   struct.copy(copy, value)
+   value.Int = array<int> { 99 }
+   value.String = array<string> { 'changed' }
+   assert(clone.Int is array<int> { 8, 9, 10, 11, 12 } and copy.Int is array<int> { 8, 9, 10, 11, 12 },
+      'copy() and clone() should deep-copy scalar vectors')
+   local clone_strings = clone.String
+   local copy_strings = copy.String
+   assert(#clone_strings is 2 and clone_strings[0] is 'alpha' and clone_strings[1] is 'beta' and
+      #copy_strings is 2 and copy_strings[0] is 'alpha' and copy_strings[1] is 'beta',
+      'copy() and clone() should deep-copy string vectors')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function NativeStructElementVectorRoundTrips()
+   local value = DeclaredVectorFields()
+   value.Points = array<table> {
+      { red=1, green=2, blue=3 },
+      { red=4, green=5, blue=6 },
+      { red=7, green=8, blue=9 }
+   }
+
+   local points = value.Points
+   assert(#points is 3 and points[0].Red is 1 and points[1].Green is 5 and points[2].Blue is 9,
+      'Struct vectors should use the exact three-byte C++ element stride')
+
+   local clone = struct.clone(value)
+   local copy = DeclaredVectorFields()
+   struct.copy(copy, value)
+   value.Points = array<table> { { red=20, green=21, blue=22 } }
+   assert(#clone.Points is 3 and clone.Points[2].Blue is 9,
+      'clone() should deep-copy trivially owned struct vectors')
+   assert(#copy.Points is 3 and copy.Points[1].Green is 5,
+      'copy() should deep-copy trivially owned struct vectors')
+
+   points[0].Red = 99
+   assert(value.Points[0].Red is 20,
+      'A previously read vector snapshot should remain independent after whole-field reassignment')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function NativeStructVectorDeclarationErrors()
+   for statement in values(array<string> {
+      'struct BadCStrVector { Values: array<cstr> }',
+      'struct BadObjectVector { Values: array<obj> }',
+      'struct BadPointerVector { Values: array<ptr> }',
+      'struct BadFunctionVector { Values: array<func> }',
+      'struct BadNestedVector { Values: array<array<int>> }',
+      'struct BadGenericSizedVector { Values: array<int, 4> }',
+      'struct BadSizedVector { Values: array<int>[4] }',
+      'struct BadUnknownVector { Values: array<mystery> }',
+      'struct BadOwnedElementVector { Values: array<struct<DeclaredNonTrivialVectorElement>> }'
+   }) do
+      try
+         exec(statement)
+      success
+         error('Invalid vector field declaration should fail: ' .. statement)
+      end
+   end
+
+   MAKESTRUCT('LegacyNonTrivialVectorElement', 'zsName')
+   MAKESTRUCT('LegacyBadOwnedElementVector', 'zeValues:LegacyNonTrivialVectorElement[1]')
+   try
+      struct.new('LegacyBadOwnedElementVector').values = array<table> { { name='unsafe' } }
+   success
+      error('Legacy non-trivial struct vectors should reject type-erased assignment')
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -1,13 +1,12 @@
 /*********************************************************************************************************************
 
-To create a struct definition:                    MAKESTRUCT('XTag', 'Definition')
 To create a struct from a registered definition:  xmltag = struct.new('XTag')
 To create a struct with pre-configured values:    xmltag = struct.new('XTag', { name='Hello' })
 To get the byte size of any structure definition: size = struct.size('XTag')
 To get the total number of fields in a structure: #xmltag
 To get the byte size of a created structure:      xmltag.structSize()
 
-Acceptable field definitions:
+Acceptable short-hand field definitions, for MAKESTRUCT() and IDL usage only:
 
   l = Long
   d = Double
@@ -29,8 +28,6 @@ Prefixes for variants, in order of acceptable usage:
 
 Embedded arrays are permitted if you follow the field name with [n] where 'n' is the array size.  For pointers to
 null terminated arrays, use [0].
-
-TODO: Support for kt::vector
 
 *********************************************************************************************************************/
 
@@ -512,6 +509,10 @@ static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Ad
                      trivial_struct_vector_data(address), field.ElementStride, field_def);
                }
                else lua_pushnil(Lua);
+            }
+            else if (type & FD_STRING) {
+               auto vector = (kt::vector<std::string> *)(address);
+               make_array(Lua, AET::STR_CPP, int(vector->size()), vector);
             }
             else {
                auto vector = (kt::vector<int> *)(address); // Uses int as a type-stable layout placeholder

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -55,6 +55,62 @@ TODO: Support for kt::vector
 
 static constexpr int MAX_STRUCT_DEF = 2048; // Struct definitions are typically 100 - 400 bytes.
 
+struct trivial_struct_vector {
+   size_t Capacity;
+   size_t Length;
+   APTR Elements;
+};
+
+static_assert(sizeof(trivial_struct_vector) IS sizeof(kt::vector<int>));
+
+void construct_trivial_struct_vector(APTR Address)
+{
+   new (Address) trivial_struct_vector { 0, 0, nullptr };
+}
+
+void destroy_trivial_struct_vector(APTR Address)
+{
+   auto vector = (trivial_struct_vector *)Address;
+   ::operator delete(vector->Elements);
+   vector->Elements = nullptr;
+   vector->Length = 0;
+   vector->Capacity = 0;
+}
+
+void assign_trivial_struct_vector(APTR Address, CPTR Source, size_t Elements, size_t Stride)
+{
+   auto vector = (trivial_struct_vector *)Address;
+   if (Elements > vector->Capacity) {
+      APTR replacement = Elements ? ::operator new(Elements * Stride) : nullptr;
+      ::operator delete(vector->Elements);
+      vector->Elements = replacement;
+      vector->Capacity = Elements;
+   }
+   if (Elements) std::memcpy(vector->Elements, Source, Elements * Stride);
+   vector->Length = Elements;
+}
+
+void copy_trivial_struct_vector(APTR Dest, CPTR Source, size_t Stride)
+{
+   auto source = (const trivial_struct_vector *)Source;
+   assign_trivial_struct_vector(Dest, source->Elements, source->Length, Stride);
+}
+
+size_t trivial_struct_vector_size(CPTR Address)
+{
+   return ((const trivial_struct_vector *)Address)->Length;
+}
+
+APTR trivial_struct_vector_data(APTR Address)
+{
+   return ((trivial_struct_vector *)Address)->Elements;
+}
+
+CPTR trivial_struct_vector_data(CPTR Address)
+{
+   return ((const trivial_struct_vector *)Address)->Elements;
+}
+
 inline GCstruct * push_struct_def(lua_State *Lua, APTR Address, struct_record &StructDef, bool Deallocate,
    OBJECTPTR Lifecycle = nullptr)
 {
@@ -96,7 +152,11 @@ static void process_struct_cpp_strings(lua_State *Lua, const struct_record &Stru
       }
 
       if ((type & FD_CPP) and (type & FD_ARRAY)) {
-         if (type & FD_STRING) {
+         if ((type & FD_STRUCT) and (not (type & FD_PTR))) {
+            if (Construct) construct_trivial_struct_vector(field_address);
+            else destroy_trivial_struct_vector(field_address);
+         }
+         else if (type & FD_STRING) {
             if (Construct) new (field_address) kt::vector<std::string>();
             else ((kt::vector<std::string> *)field_address)->~vector();
          }
@@ -223,6 +283,87 @@ static bool write_primitive_field(lua_State *Lua, APTR Address, int Type, int St
    return true;
 }
 
+template <typename T> static ERR table_values_to_vector(lua_State *Lua, int StackIndex, int Type, APTR Address)
+{
+   auto &dest = ((kt::vector<T> *)Address)[0];
+   size_t elements = lua_objlen(Lua, StackIndex);
+   dest.resize(elements);
+   for (size_t i = 0; i < elements; i++) {
+      lua_rawgeti(Lua, StackIndex, i);
+      if (not lua_isnumber(Lua, -1)) {
+         lua_pop(Lua, 1);
+         return ERR::InvalidType;
+      }
+      (void)write_primitive_field(Lua, dest.data(), Type, -1, int(i));
+      lua_pop(Lua, 1);
+   }
+   return ERR::Okay;
+}
+
+template <typename T> static ERR array_values_to_vector(GCarray *Source, APTR Address)
+{
+   auto &dest = ((kt::vector<T> *)Address)[0];
+   dest.resize(Source->len);
+   if (Source->len) std::memcpy(dest.data(), Source->arraydata(), size_t(Source->len) * sizeof(T));
+   return ERR::Okay;
+}
+
+static ERR value_to_cpp_vector(lua_State *Lua, int StackIndex, int Type, APTR Address)
+{
+   if (lua_isarray(Lua, StackIndex)) {
+      auto source = lua_toarray(Lua, StackIndex);
+      if (Type & FD_STRING) {
+         if ((source->elemtype != AET::STR_GC) and (source->elemtype != AET::CSTR) and
+               (source->elemtype != AET::STR_CPP)) return ERR::InvalidType;
+         auto &dest = ((kt::vector<std::string> *)Address)[0];
+         dest.resize(source->len);
+         for (MSize i = 0; i < source->len; i++) {
+            if (source->elemtype IS AET::STR_GC) {
+               auto value = strref(source->get<GCRef>()[i]);
+               dest[i].assign(strdata(value), value->len);
+            }
+            else if (source->elemtype IS AET::CSTR) dest[i] = source->get<CSTRING>()[i];
+            else dest[i] = source->get<std::string>()[i];
+         }
+         return ERR::Okay;
+      }
+      if (source->elemtype != ff_to_aet(Type)) return ERR::InvalidType;
+      if (Type & FD_FLOAT) return array_values_to_vector<float>(source, Address);
+      if (Type & FD_DOUBLE) return array_values_to_vector<double>(source, Address);
+      if (Type & FD_INT64) return array_values_to_vector<int64_t>(source, Address);
+      if (Type & FD_INT) return array_values_to_vector<int>(source, Address);
+      if (Type & FD_WORD) return array_values_to_vector<int16_t>(source, Address);
+      if (Type & FD_BYTE) return array_values_to_vector<uint8_t>(source, Address);
+      return ERR::NoSupport;
+   }
+
+   if (not lua_istable(Lua, StackIndex)) return ERR::InvalidType;
+   if (Type & FD_STRING) {
+      auto &dest = ((kt::vector<std::string> *)Address)[0];
+      size_t elements = lua_objlen(Lua, StackIndex);
+      dest.resize(elements);
+      for (size_t i = 0; i < elements; i++) {
+         lua_rawgeti(Lua, StackIndex, i);
+         size_t length = 0;
+         auto value = lua_tolstring(Lua, -1, &length);
+         if (not value) {
+            lua_pop(Lua, 1);
+            return ERR::InvalidType;
+         }
+         dest[i].assign(value, length);
+         lua_pop(Lua, 1);
+      }
+      return ERR::Okay;
+   }
+   if (Type & FD_FLOAT) return table_values_to_vector<float>(Lua, StackIndex, Type, Address);
+   if (Type & FD_DOUBLE) return table_values_to_vector<double>(Lua, StackIndex, Type, Address);
+   if (Type & FD_INT64) return table_values_to_vector<int64_t>(Lua, StackIndex, Type, Address);
+   if (Type & FD_INT) return table_values_to_vector<int>(Lua, StackIndex, Type, Address);
+   if (Type & FD_WORD) return table_values_to_vector<int16_t>(Lua, StackIndex, Type, Address);
+   if (Type & FD_BYTE) return table_values_to_vector<uint8_t>(Lua, StackIndex, Type, Address);
+   return ERR::NoSupport;
+}
+
 //********************************************************************************************************************
 
 // Convert a Lua table to a C structure.  The returned structure is owned by a unique pointer.
@@ -258,7 +399,44 @@ static bool write_primitive_field(lua_State *Lua, APTR Address, int Type, int St
                auto type = field.Type;
 
                if (type & FD_ARRAY) {
-                  if (type & FD_CPP);
+                  if ((type & FD_CPP) and (type & FD_STRUCT)) {
+                     if (not field.TrivialElements) {
+                        destroy_struct_cpp_strings(Lua, struct_def, memory.get());
+                        return ERR::NoSupport;
+                     }
+                     auto field_def = field.StructDefinition ? field.StructDefinition :
+                        find_struct_reference(Lua, struct_def, field.StructRef);
+                     if ((not field_def) or (not lua_isarray(Lua, -1))) {
+                        destroy_struct_cpp_strings(Lua, struct_def, memory.get());
+                        return ERR::InvalidType;
+                     }
+                     auto source = lua_toarray(Lua, -1);
+                     if (source->elemtype != AET::TABLE) {
+                        destroy_struct_cpp_strings(Lua, struct_def, memory.get());
+                        return ERR::InvalidType;
+                     }
+                     std::vector<uint8_t> serial(size_t(source->len) * field.ElementStride);
+                     for (MSize i = 0; i < source->len; i++) {
+                        auto table = tabref(source->get<GCRef>()[i]);
+                        settabV(Lua, Lua->top++, table);
+                        std::unique_ptr<uint8_t[]> element;
+                        auto error = table_to_struct(Lua, field_def->Name, element);
+                        lua_pop(Lua, 1);
+                        if (error != ERR::Okay) {
+                           destroy_struct_cpp_strings(Lua, struct_def, memory.get());
+                           return error;
+                        }
+                        std::memcpy(serial.data() + (size_t(i) * field.ElementStride), element.get(),
+                           field.ElementStride);
+                     }
+                     assign_trivial_struct_vector(address, serial.data(), source->len, field.ElementStride);
+                  }
+                  else if (type & FD_CPP) {
+                     if (auto error = value_to_cpp_vector(Lua, -1, type, address); error != ERR::Okay) {
+                        destroy_struct_cpp_strings(Lua, struct_def, memory.get());
+                        return error;
+                     }
+                  }
                   else if (field.ArraySize IS - 1); // Pointer to a null-terminated array
                   else if (lua_istable(Lua, -1) and is_primitive_field(type)) { // Embedded, fixed size array
                      for (int i = 0; i < field.ArraySize; i++) {
@@ -328,14 +506,17 @@ static bool write_primitive_field(lua_State *Lua, APTR Address, int Type, int St
 
       if (type & FD_ARRAY) {
          if (type & FD_CPP) { // kt::vector<ANY>
-            auto vector = (kt::vector<int> *)(address); // Uses int as a placeholder
             if (type & FD_STRUCT) {
                if (field_def) {
-                  make_any_array(Lua, type, field_def->Name, vector->size(), vector->data(), field_def);
+                  make_struct_array(Lua, field_def->Name, int(trivial_struct_vector_size(address)),
+                     trivial_struct_vector_data(address), field.ElementStride, field_def);
                }
                else lua_pushnil(Lua);
             }
-            else make_array(Lua, ff_to_aet(type), vector->size(), vector->data());
+            else {
+               auto vector = (kt::vector<int> *)(address); // Uses int as a type-stable layout placeholder
+               make_array(Lua, ff_to_aet(type), vector->size(), vector->data());
+            }
          }
          else if (field.ArraySize IS -1) { // Pointer to a null-terminated array.
             if (type & FD_STRUCT) {
@@ -496,11 +677,23 @@ static void make_camel_case(std::string &String)
 //
 // NB: A scalar field is recorded as 1, never -1.  Only an explicit [0]/ptr<T[]> yields -1.
 
+static int struct_field_alignment(const struct_field &Field, int Type, int FieldSize)
+{
+   if ((Type & FD_CPP) and (Type & FD_ARRAY)) return alignof(kt::vector<int>);
+   if (Type & (FD_POINTER|FD_OBJECT|FD_FUNCTION)) return alignof(APTR);
+   if ((Type & FD_STRUCT) and (not (Type & FD_PTR)) and Field.StructDefinition) {
+      return Field.StructDefinition->Alignment;
+   }
+   if (FieldSize >= 8) return 8;
+   if (FieldSize >= 4) return 4;
+   if (FieldSize >= 2) return 2;
+   return 1;
+}
+
 static ERR layout_struct_field(struct_field &Field, int Type, int FieldSize, int ArraySize, int &Offset)
 {
-   if ((FieldSize >= 8) and (Type != FD_STRUCT)) Offset = ALIGN64(Offset);
-   else if (FieldSize IS 4) Offset = ALIGN32(Offset);
-   else if ((FieldSize IS 2) and (Offset & 1)) Offset++;
+   int alignment = struct_field_alignment(Field, Type, FieldSize);
+   Offset = (Offset + alignment - 1) & ~(alignment - 1);
 
    // Offset is a uint16_t in struct_field, so oversized fixed arrays must be rejected rather than silently wrapped.
 
@@ -518,6 +711,8 @@ static ERR layout_struct_field(struct_field &Field, int Type, int FieldSize, int
    Offset += int(storage_size);
    return ERR::Okay;
 }
+
+static bool struct_is_trivial(lua_State *Lua, const struct_record &Record, std::string &Offending);
 
 //********************************************************************************************************************
 // The TypeName is optional and usually refers to the name of a struct.  The list is sorted by name for fast lookups.
@@ -649,6 +844,8 @@ static ERR layout_struct_field(struct_field &Field, int Type, int FieldSize, int
          return error;
       }
 
+      Record.Alignment = std::max(Record.Alignment, struct_field_alignment(field, type, field_size));
+
       log.trace("Added field %s @ offset %d", field.Name.c_str(), field.Offset);
 
       Record.Fields.push_back(field);
@@ -656,7 +853,16 @@ static ERR layout_struct_field(struct_field &Field, int Type, int FieldSize, int
       while ((pos < Sequence.size()) and ((Sequence[pos] <= 0x20) or (Sequence[pos] IS ','))) pos++;
    }
 
-   *StructSize = offset;
+   for (auto &field : Record.Fields) {
+      if ((field.Type & FD_CPP) and (field.Type & FD_ARRAY) and (field.Type & FD_STRUCT) and
+            (not (field.Type & FD_PTR)) and field.StructDefinition) {
+         field.ElementStride = field.StructDefinition->Size;
+         std::string offending;
+         field.TrivialElements = struct_is_trivial(Self->Lua, *field.StructDefinition, offending);
+      }
+   }
+
+   *StructSize = (offset + Record.Alignment - 1) & ~(Record.Alignment - 1);
    return ERR::Okay;
 }
 
@@ -751,6 +957,7 @@ static ERR layout_struct_field(struct_field &Field, int Type, int FieldSize, int
 
 static int declared_field_size(lua_State *Lua, const struct_field &Field)
 {
+   if ((Field.Type & FD_CPP) and (Field.Type & FD_ARRAY)) return sizeof(kt::vector<int>);
    // FD_PTR is an alias of FD_POINTER, so this only matches a struct embedded inline rather than by reference.
 
    if ((Field.Type & FD_STRUCT) and (not (Field.Type & FD_PTR))) {
@@ -773,7 +980,8 @@ static int declared_field_size(lua_State *Lua, const struct_field &Field)
 
 static bool identical_struct_layout(const struct_record &Left, const struct_record &Right)
 {
-   if ((Left.Size != Right.Size) or (Left.Fields.size() != Right.Fields.size())) return false;
+   if ((Left.Size != Right.Size) or (Left.Alignment != Right.Alignment) or
+         (Left.Fields.size() != Right.Fields.size())) return false;
    for (size_t i = 0; i < Left.Fields.size(); i++) {
       const auto &left = Left.Fields[i];
       const auto &right = Right.Fields[i];
@@ -781,6 +989,8 @@ static bool identical_struct_layout(const struct_record &Left, const struct_reco
          (left.ObjectClassID != right.ObjectClassID) or (left.Offset != right.Offset) or
             (left.Type != right.Type)) return false;
       if ((left.Type & FD_ARRAY) and (left.ArraySize != right.ArraySize)) return false;
+      if (left.ElementStride != right.ElementStride) return false;
+      if (left.TrivialElements != right.TrivialElements) return false;
       if ((left.NativeType != NativeStructType::Legacy) and (right.NativeType != NativeStructType::Legacy) and
             (left.NativeType != right.NativeType)) return false;
    }
@@ -790,8 +1000,27 @@ static bool identical_struct_layout(const struct_record &Left, const struct_reco
 // Register a parser-built declaration.  Keeping layout calculation here ensures declarative definitions use the
 // same alignment and embedded-structure rules as MAKESTRUCT.
 
+static bool struct_is_trivial(lua_State *Lua, const struct_record &Record, std::string &Offending)
+{
+   for (auto &field : Record.Fields) {
+      if ((field.Type & FD_CPP) and ((field.Type & FD_STRING) or (field.Type & FD_ARRAY))) {
+         Offending = field.Name;
+         return false;
+      }
+      if ((field.Type & FD_STRUCT) and (not (field.Type & FD_PTR))) {
+         auto child = field.StructDefinition ? field.StructDefinition :
+            find_struct_reference(Lua, Record, field.StructRef);
+         if (child and not struct_is_trivial(Lua, *child, Offending)) {
+            Offending = field.Name + "." + Offending;
+            return false;
+         }
+      }
+   }
+   return true;
+}
+
 [[nodiscard]] ERR register_declared_struct(lua_State *Lua, struct_record &&Record, bool *Inserted,
-   const struct_record **Existing)
+   const struct_record **Existing, std::string *Detail)
 {
    if (Inserted) *Inserted = false;
    if (Existing) *Existing = nullptr;
@@ -805,6 +1034,22 @@ static bool identical_struct_layout(const struct_record &Left, const struct_reco
       int field_size = declared_field_size(Lua, field);
       if (field_size <= 0) return ERR::NotFound;
 
+      if ((field.Type & FD_CPP) and (field.Type & FD_ARRAY) and (field.Type & FD_STRUCT) and
+            (not (field.Type & FD_PTR))) {
+         auto child = field.StructDefinition ? field.StructDefinition : find_struct(Lua, field.StructRef);
+         std::string offending;
+         if ((not child) or (not struct_is_trivial(Lua, *child, offending))) {
+            if (Detail) {
+               auto field_path = field.Name + (offending.empty() ? std::string() : "." + offending);
+               *Detail = std::format("Struct array field '{}.{}' requires a trivially owned element layout",
+                  Record.Name, field_path);
+            }
+            return ERR::NoSupport;
+         }
+         field.ElementStride = child->Size;
+         field.TrivialElements = true;
+      }
+
       // Mirror the sequence parser's convention: scalars carry a count of 1, and the parser's ArraySize of -1 for
       // ptr<T[]> passes straight through as the null-terminated-pointer marker.
 
@@ -812,9 +1057,10 @@ static bool identical_struct_layout(const struct_record &Left, const struct_reco
       if (auto error = layout_struct_field(field, field.Type, field_size, array_size, offset); error != ERR::Okay) {
          return error;
       }
+      Record.Alignment = std::max(Record.Alignment, struct_field_alignment(field, field.Type, field_size));
       field.precomputeNameHash();
    }
-   Record.Size = offset;
+   Record.Size = (offset + Record.Alignment - 1) & ~(Record.Alignment - 1);
 
    if (auto found = Lua->struct_declarations.find(key);
          found != Lua->struct_declarations.end()) {


### PR DESCRIPTION
* Added array<T> field parsing, layout, lifecycle and value conversion for native structs
* Added safe support for trivial struct element vectors with deep copying
* [Test] Added coverage for primitive, string and struct vectors and invalid declarations