### PR TITLE
[Core] Deferred cross-thread WaitForObjects signals to the main thread

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -213,7 +213,8 @@ target_sources (core PRIVATE
 if (UNIT_TESTS)
    target_sources (core PRIVATE
       "tests/unit_tests_object_layout.cpp"
-      "tests/unit_tests_queue_action.cpp")
+      "tests/unit_tests_queue_action.cpp"
+      "tests/unit_tests_wait_for_objects.cpp")
    target_compile_definitions (core PRIVATE UNIT_TESTS)
 endif ()
 

--- a/src/core/classes/class_task.cpp
+++ b/src/core/classes/class_task.cpp
@@ -420,13 +420,6 @@ extern "C" void task_deregister_incoming(WINHANDLE Handle)
 
 //********************************************************************************************************************
 
-static ERR msg_waitforobjects(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSize)
-{
-   return ERR::Terminate;
-}
-
-//********************************************************************************************************************
-
 static CSTRING action_id_name(ACTIONID ActionID)
 {
    static char idname[20];
@@ -1575,7 +1568,7 @@ static ERR TASK_Init(extTask *Self)
       AddMsgHandler(MSGID::QUIT, &call, &handler);
       Self->MsgQuit.reset(handler);
 
-      call.Routine = (APTR)msg_waitforobjects;
+      call.Routine = (APTR)msg_waitforobjects; // lib_messages.cpp
       AddMsgHandler(MSGID::WAIT_FOR_OBJECTS, &call, &handler);
       Self->MsgWaitForObjects.reset(handler);
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1192,6 +1192,7 @@ Field * lookup_id(OBJECTPTR, uint32_t, OBJECTPTR *);
 ERR    msg_event(APTR, int, int, APTR, int);
 ERR    msg_threadcallback(APTR, int, int, APTR, int);
 ERR    msg_threadaction(APTR, int, int, APTR, int);
+ERR    msg_waitforobjects(APTR, int, int, APTR, int);
 ERR    msg_free(APTR, int, int, APTR, int);
 void   optimise_write_field(Field &);
 void   PrepareSleep(void);

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -1227,6 +1227,7 @@ cstr Options: Reserved for future use; `NULL` is acceptable.
 #ifdef UNIT_TESTS
 extern void object_layout_unit_tests(int &, int &);
 extern void queue_action_unit_tests(int &, int &);
+extern void wait_for_objects_unit_tests(int &, int &);
 #endif
 
 void UnitTests(CSTRING Options, int *Passed, int *Total)
@@ -1240,6 +1241,8 @@ void UnitTests(CSTRING Options, int *Passed, int *Total)
       object_layout_unit_tests(passed, total);
       log.branch("Running QueueAction unit tests...");
       queue_action_unit_tests(passed, total);
+      log.branch("Running WaitForObjects unit tests...");
+      wait_for_objects_unit_tests(passed, total);
    }
 #endif
 

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -78,6 +78,14 @@ static ResourceManager glResourceMsgHandler = { "Message", &msghandler_free, nul
 
 static void notify_signal_wfo(OBJECTPTR Object, ACTIONID ActionID, ERR Result, APTR Args)
 {
+   if (!tlMainThread) {
+      // Signals and frees can be initiated from any thread, but glWFOList is owned by the main thread.  Defer
+      // processing by posting the object ID back to the main queue; see msg_waitforobjects() for the follow-up.
+      OBJECTID object_id = Object->UID;
+      SendMessage(MSGID::WAIT_FOR_OBJECTS, MSF::NIL, &object_id, sizeof(object_id));
+      return;
+   }
+
    if (auto lref = glWFOList.find(Object->UID); lref != glWFOList.end()) {
       kt::Log log;
       auto &ref = lref->second;
@@ -96,6 +104,44 @@ static void notify_signal_wfo(OBJECTPTR Object, ACTIONID ActionID, ERR Result, A
          SendMessage(MSGID::WAIT_FOR_OBJECTS, MSF::NIL, nullptr, 0); // Will result in ProcessMessages() terminating
       }
    }
+}
+
+//********************************************************************************************************************
+// Handler for MSGID::WAIT_FOR_OBJECTS messages, called from ProcessMessages() on the main thread.  A message with
+// no payload indicates that the monitored object list is exhausted and the WaitForObjects() message loop can
+// terminate.  A message carrying an object ID is a signal or free that occurred on a child thread, deferred by
+// notify_signal_wfo() so that glWFOList is only ever modified by the main thread.
+
+ERR msg_waitforobjects(APTR Custom, int MsgID, int MsgType, APTR Message, int MsgSize)
+{
+   if ((Message) and (MsgSize >= int(sizeof(OBJECTID)))) {
+      auto object_id = ((OBJECTID *)Message)[0];
+      if (auto lref = glWFOList.find(object_id); lref != glWFOList.end()) {
+         kt::Log log;
+         kt::ScopedObjectLock lock(object_id); // Locking by ID fails safely if the object has been freed
+         if (lock.granted()) {
+            if (lock.obj->defined(NF::SIGNALLED)) {
+               log.trace("Object #%d was signalled from a child thread.", object_id);
+               UnsubscribeAction(lock.obj, AC::Free, nullptr);
+               UnsubscribeAction(lock.obj, AC::Signal, nullptr);
+               lock.obj->clearFlag(NF::SIGNALLED);
+               glWFOList.erase(lref);
+            }
+            // An unsignalled object indicates a stale message from an earlier wait; leave it monitored.
+         }
+         else if (!GetObjectPtr(object_id)) {
+            // The object was freed by the child thread; its subscriptions died with it.
+            log.trace("Object #%d was freed from a child thread.", object_id);
+            glWFOList.erase(lref);
+         }
+         // Other lock failures are transient; the object remains monitored.
+
+         if (glWFOList.empty()) return ERR::Terminate;
+      }
+      return ERR::Okay; // Never terminate the message loop on a stale deferral
+   }
+
+   return ERR::Terminate;
 }
 
 /*********************************************************************************************************************
@@ -696,9 +742,14 @@ ERR WaitForObjects(PMF Flags, int TimeOut, ObjectSignal *ObjectSignals)
                // NB: An object being freed is treated as equivalent to it receiving a signal.
                // Refer to notify_signal_wfo() for notification handling and clearing of signals.
                log.detail("Monitoring object #%d", ObjectSignals[i].Object->UID);
-               if (!(SubscribeAction(ObjectSignals[i].Object, AC::Free, C_FUNCTION(notify_signal_wfo))) and
-                   (!SubscribeAction(ObjectSignals[i].Object, AC::Signal, C_FUNCTION(notify_signal_wfo)))) {
-                  glWFOList.insert(std::make_pair(ObjectSignals[i].Object->UID, ObjectSignals[i]));
+               if (!SubscribeAction(ObjectSignals[i].Object, AC::Free, C_FUNCTION(notify_signal_wfo))) {
+                  if (!SubscribeAction(ObjectSignals[i].Object, AC::Signal, C_FUNCTION(notify_signal_wfo))) {
+                     glWFOList.insert(std::make_pair(ObjectSignals[i].Object->UID, ObjectSignals[i]));
+                  }
+                  else {
+                     UnsubscribeAction(ObjectSignals[i].Object, AC::Free, nullptr);
+                     error = ERR::MessageOperation;
+                  }
                }
                else error = ERR::MessageOperation;
             }
@@ -732,10 +783,12 @@ ERR WaitForObjects(PMF Flags, int TimeOut, ObjectSignal *ObjectSignals)
 
    if (not glWFOList.empty()) { // Clean up if there are dangling subscriptions
       for (auto &ref : glWFOList) {
-         kt::ScopedObjectLock lock(ref.second.Object); // For thread safety
+         // Lock by ID rather than pointer; a child thread may have freed the object with its
+         // deferred notification still unprocessed (see msg_waitforobjects()).
+         kt::ScopedObjectLock lock(ref.first);
          if (lock.granted()) {
-            UnsubscribeAction(ref.second.Object, AC::Free, nullptr);
-            UnsubscribeAction(ref.second.Object, AC::Signal, nullptr);
+            UnsubscribeAction(lock.obj, AC::Free, nullptr);
+            UnsubscribeAction(lock.obj, AC::Signal, nullptr);
          }
       }
       glWFOList.clear();

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -129,12 +129,19 @@ ERR msg_waitforobjects(APTR Custom, int MsgID, int MsgType, APTR Message, int Ms
             }
             // An unsignalled object indicates a stale message from an earlier wait; leave it monitored.
          }
-         else if (!GetObjectPtr(object_id)) {
-            // The object was freed by the child thread; its subscriptions died with it.
+         else if ((lock.error IS ERR::MarkedForDeletion) or (lock.error IS ERR::DoesNotExist) or
+                  (lock.error IS ERR::NoMatchingObject)) {
+            // The object was freed - or its destruction is already guaranteed - on the child thread.  Freeing is
+            // equivalent to a signal, so the entry is removed; any remaining subscriptions die with the object.
             log.trace("Object #%d was freed from a child thread.", object_id);
             glWFOList.erase(lref);
          }
-         // Other lock failures are transient; the object remains monitored.
+         else {
+            // A transient lock failure (e.g. time-out).  Requeue the deferral so that the wake-up is not lost;
+            // an indefinite WaitForObjects() would otherwise sleep forever on an already-signalled object.
+            log.trace("Deferred signal for object #%d requeued (%s).", object_id, GetErrorMsg(lock.error));
+            SendMessage(MSGID::WAIT_FOR_OBJECTS, MSF::NIL, &object_id, sizeof(object_id));
+         }
 
          if (glWFOList.empty()) return ERR::Terminate;
       }

--- a/src/core/tests/unit_tests_wait_for_objects.cpp
+++ b/src/core/tests/unit_tests_wait_for_objects.cpp
@@ -90,6 +90,50 @@ static bool cross_thread_free_check(kt::Log &Log)
 }
 
 //********************************************************************************************************************
+// A deferred notification can be drained while the child thread is still inside object_free(): NF::FREE is set but
+// the object has not yet left the registry.  The handler must treat a terminating object as completed rather than
+// leaving the entry monitored, because the consumed message was the only wake-up an indefinite wait would receive.
+
+static bool mid_free_window_check(kt::Log &Log)
+{
+   OBJECTPTR object;
+   if (NewObject(CLASSID::TIME, NF::NIL, &object) != ERR::Okay) {
+      Log.warning("Failed to create the test object.");
+      return false;
+   }
+
+   if (InitObject(object) != ERR::Okay) {
+      Log.warning("Failed to initialise the test object.");
+      FreeResource(object->UID);
+      return false;
+   }
+
+   // Simulate the mid-free window as msg_waitforobjects() would encounter it.
+
+   glWFOList.insert(std::make_pair(object->UID, ObjectSignal { object }));
+   object->setFlag(NF::FREE);
+
+   OBJECTID object_id = object->UID;
+   auto result = msg_waitforobjects(nullptr, 0, 0, &object_id, sizeof(object_id));
+
+   object->clearFlag(NF::FREE);
+
+   bool okay = true;
+   if (glWFOList.contains(object->UID)) {
+      Log.warning("A terminating object was left in the monitored list.");
+      glWFOList.erase(object->UID);
+      okay = false;
+   }
+   else if (result != ERR::Terminate) {
+      Log.warning("Expected ERR::Terminate for an emptied list, got '%s'.", GetErrorMsg(result));
+      okay = false;
+   }
+
+   FreeResource(object->UID);
+   return okay;
+}
+
+//********************************************************************************************************************
 
 void wait_for_objects_unit_tests(int &Passed, int &Total)
 {
@@ -100,4 +144,7 @@ void wait_for_objects_unit_tests(int &Passed, int &Total)
 
    Total++;
    if (cross_thread_free_check(log)) Passed++;
+
+   Total++;
+   if (mid_free_window_check(log)) Passed++;
 }

--- a/src/core/tests/unit_tests_wait_for_objects.cpp
+++ b/src/core/tests/unit_tests_wait_for_objects.cpp
@@ -1,0 +1,103 @@
+/*********************************************************************************************************************
+
+The source code of the Kotuku project is made publicly available under the terms described in the LICENSE.TXT file
+that is distributed with this package.  Please refer to it for further information on licensing.
+
+**********************************************************************************************************************
+
+Unit tests for WaitForObjects(), compiled into the Core when UNIT_TESTS is enabled and invoked via the public
+UnitTests() function.  The primary concern is signals and frees that are initiated from a child thread, which must
+be deferred to the main thread through the message queue (refer to notify_signal_wfo() and msg_waitforobjects()).
+
+*********************************************************************************************************************/
+
+#include <chrono>
+#include <thread>
+
+#include "../defs.h"
+
+//********************************************************************************************************************
+// Signal a monitored object from a child thread.  The notification fires on the child thread and must be deferred
+// so that glWFOList is only modified by the main thread; WaitForObjects() is expected to wake before its timeout.
+
+static bool cross_thread_signal_check(kt::Log &Log)
+{
+   OBJECTPTR object;
+   if (NewObject(CLASSID::TIME, NF::NIL, &object) != ERR::Okay) {
+      Log.warning("Failed to create the test object.");
+      return false;
+   }
+
+   if (InitObject(object) != ERR::Okay) {
+      Log.warning("Failed to initialise the test object.");
+      FreeResource(object->UID);
+      return false;
+   }
+
+   std::thread worker([object]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      Action(AC::Signal, object, nullptr);
+   });
+
+   ObjectSignal signals[2] = { { object }, { nullptr } };
+   auto error = WaitForObjects(PMF::NIL, 4000, signals);
+
+   worker.join();
+   FreeResource(object->UID);
+
+   if (error != ERR::Okay) {
+      Log.warning("WaitForObjects() returned '%s' for a child-thread signal.", GetErrorMsg(error));
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+// Free a monitored object from a child thread.  Freeing is treated as equivalent to a signal; the deferred handler
+// must detect that the object no longer exists and still wake WaitForObjects() before its timeout.
+
+static bool cross_thread_free_check(kt::Log &Log)
+{
+   OBJECTPTR object;
+   if (NewObject(CLASSID::TIME, NF::NIL, &object) != ERR::Okay) {
+      Log.warning("Failed to create the test object.");
+      return false;
+   }
+
+   if (InitObject(object) != ERR::Okay) {
+      Log.warning("Failed to initialise the test object.");
+      FreeResource(object->UID);
+      return false;
+   }
+
+   std::thread worker([object]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      FreeResource(object->UID);
+   });
+
+   ObjectSignal signals[2] = { { object }, { nullptr } };
+   auto error = WaitForObjects(PMF::NIL, 4000, signals);
+
+   worker.join();
+
+   if (error != ERR::Okay) {
+      Log.warning("WaitForObjects() returned '%s' for a child-thread free.", GetErrorMsg(error));
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+void wait_for_objects_unit_tests(int &Passed, int &Total)
+{
+   kt::Log log("WaitForObjects");
+
+   Total++;
+   if (cross_thread_signal_check(log)) Passed++;
+
+   Total++;
+   if (cross_thread_free_check(log)) Passed++;
+}

--- a/src/tiri/tests/test_try_except.tiri
+++ b/src/tiri/tests/test_try_except.tiri
@@ -369,7 +369,7 @@ end
 @Test(priority=19) function MultipleErrorsSequence()
    count = 0
 
-   for i in {0 to 30} do  -- Range is exclusive, so 0..3 gives 0, 1, 2
+   for i in {0 to 30} do  -- Range is exclusive, so 0..30 gives 0, 1, 2, ..., 29
       try
          error("Error " .. i)
       except e
@@ -695,7 +695,7 @@ end
    except e
       error(f"Expected ERR_Args code, got {e.code}")
    success
-      error("Error should have been raised by faulty sytem call.")
+      error("Error should have been raised by faulty system call.")
    end
 
    -- Try can only check ERR codes in its immediate scope, so the AllocMemory() result would not be tested in this case

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -196,8 +196,7 @@ static int processing_sleep(lua_State *Lua)
          signal_list_c[i].Object = nullptr;
 
          std::scoped_lock lock(recursion);
-         auto timeout = int(seconds * 1000.0);
-         error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c.get());
+         error = WaitForObjects(seconds IS -1 ? PMF::EVENT_LOOP : PMF::NIL, int(seconds * 1000.0), signal_list_c.get());
       }
       else { // Default behaviour: Sleeping can be broken with a signal to the Tiri object.
          if (Lua->script->defined(NF::SIGNALLED)) {
@@ -208,8 +207,7 @@ static int processing_sleep(lua_State *Lua)
          else {
             ObjectSignal signal_list_c[2] = { { .Object = Lua->script }, { .Object = nullptr } };
             std::scoped_lock lock(recursion);
-            auto timeout = int(seconds * 1000.0);
-            error = WaitForObjects(timeout IS -1 ? PMF::EVENT_LOOP : PMF::NIL, timeout, signal_list_c);
+            error = WaitForObjects(seconds IS -1 ? PMF::EVENT_LOOP : PMF::NIL, int(seconds * 1000.0), signal_list_c);
          }
       }
    }


### PR DESCRIPTION
* Signals and frees raised on child threads are now posted to the message queue by notify_signal_wfo() so that glWFOList is only ever modified by the main thread
* msg_waitforobjects() processes deferred signals by locking objects by ID, safely discarding entries for objects freed by other threads
* Fixed a leaked AC::Free subscription in WaitForObjects() when the AC::Signal subscription fails
* The WaitForObjects() cleanup path locks monitored objects by ID to avoid dereferencing pointers freed by child threads
* Added embedded unit tests covering child-thread signal and free wake-ups
* [Tiri] processing.sleep() now tests the seconds value rather than the millisecond conversion when selecting PMF::EVENT_LOOP