### PR TITLE
[Display] Use standard allocation for bitmap pixel data

### DIFF
--- a/src/display/class_bitmap.cpp
+++ b/src/display/class_bitmap.cpp
@@ -268,9 +268,8 @@ ERR lock_surface(extBitmap *Bitmap, int16_t Access)
       log.warning("Warning: Locking of OpenGL video surfaces for CPU access is bad practice (bitmap: #%d, mem: $%.8x)", Bitmap->UID, Bitmap->DataFlags);
 
       if (!Bitmap->Data) {
-         if (AllocMemory(Bitmap->Size, MEM::NO_CLEAR|Bitmap->DataFlags, &Bitmap->Data) != ERR::Okay) {
-            return log.warning(ERR::AllocMemory);
-         }
+         Bitmap->Data = (uint8_t *)malloc(Bitmap->Size);
+         if (!Bitmap->Data) return log.warning(ERR::AllocMemory);
          Bitmap->prvAFlags |= BF_DATA;
       }
 
@@ -296,7 +295,7 @@ ERR lock_surface(extBitmap *Bitmap, int16_t Access)
    }
 
    if (!Bitmap->Data) {
-      log.warning("[Bitmap:%d] Bitmap is missing the Data field.  Memory flags: $%.8x", Bitmap->UID, Bitmap->DataFlags);
+      log.warning("[Bitmap:%d] Bitmap is missing the Data field", Bitmap->UID);
       return ERR::FieldNotSet;
    }
 
@@ -979,7 +978,7 @@ static ERR BITMAP_Init(extBitmap *Self)
 
    if (acQuery(Self) != ERR::Okay) return log.warning(ERR::Query);
 
-   log.branch("Size: %dx%d @ %d bit, %d bytes, Mem: $%.8x, Flags: $%.8x", Self->Width, Self->Height, Self->BitsPerPixel, Self->BytesPerPixel, int(Self->DataFlags), int(Self->Flags));
+   log.branch("Size: %dx%d @ %d bit, %d bytes, Flags: $%.8x", Self->Width, Self->Height, Self->BitsPerPixel, Self->BytesPerPixel, int(Self->Flags));
 
    if (Self->Clip.Left < 0) Self->Clip.Left = 0;
    if (Self->Clip.Top < 0)  Self->Clip.Top  = 0;
@@ -1018,10 +1017,9 @@ static ERR BITMAP_Init(extBitmap *Self)
          if (!Self->Size) return log.warning(ERR::FieldNotSet);
 
          if (glHeadless) {
-            if (!AllocMemory(Self->Size, MEM::NO_CLEAR|Self->DataFlags, (APTR *)&Self->Data)) {
-               Self->prvAFlags |= BF_DATA;
-            }
-            else return log.warning(ERR::AllocMemory);
+            Self->Data = (uint8_t *)malloc(Self->Size);
+            if (!Self->Data) return log.warning(ERR::AllocMemory);
+            Self->prvAFlags |= BF_DATA;
          }
          else if (!Self->x11.XShmImage) {
             log.detail("Allocating a memory based XImage.");
@@ -1065,10 +1063,11 @@ static ERR BITMAP_Init(extBitmap *Self)
             Self->prvAFlags |= BF_WINVIDEO;
             if (!(Self->win.Drawable = winCreateCompatibleDC())) return log.warning(ERR::SystemCall);
          }
-         else if (!AllocMemory(Self->Size, MEM::NO_CLEAR|Self->DataFlags, (APTR *)&Self->Data)) {
+         else {
+            Self->Data = (uint8_t *)malloc(Self->Size);
+            if (!Self->Data) return log.warning(ERR::AllocMemory);
             Self->prvAFlags |= BF_DATA;
          }
-         else return log.warning(ERR::AllocMemory);
       }
       else if ((Self->DataFlags & MEM::VIDEO) != MEM::NIL) Self->prvAFlags |= BF_WINVIDEO;
    }
@@ -1093,10 +1092,11 @@ static ERR BITMAP_Init(extBitmap *Self)
             log.warning("Support for MEM::TEXTURE not included yet.");
             return ERR::NoSupport;
          }
-         else if (!AllocMemory(Self->Size, Self->DataFlags|MEM::NO_CLEAR, &Self->Data)) {
+         else {
+            Self->Data = (uint8_t *)malloc(Self->Size);
+            if (!Self->Data) return ERR::AllocMemory;
             Self->prvAFlags |= BF_DATA;
          }
-         else return ERR::AllocMemory;
       }
    }
 
@@ -1108,10 +1108,9 @@ static ERR BITMAP_Init(extBitmap *Self)
    if (!Self->Data) {
       if ((Self->Flags & BMF::NO_DATA) IS BMF::NIL) {
          if (!Self->Size) return log.warning(ERR::FieldNotSet);
-         if (!AllocMemory(Self->Size, MEM::NO_CLEAR|Self->DataFlags, &Self->Data)) {
-            Self->prvAFlags |= BF_DATA;
-         }
-         else return log.warning(ERR::AllocMemory);
+         Self->Data = (uint8_t *)malloc(Self->Size);
+         if (!Self->Data) return log.warning(ERR::AllocMemory);
+         Self->prvAFlags |= BF_DATA;
       }
    }
 #endif
@@ -1651,8 +1650,8 @@ static ERR BITMAP_Resize(extBitmap *Self, struct acResize *Args)
       if ((size <= Self->Size) and (size / Self->Size > 0.5)) { // Do nothing when shrinking unless able to save considerable resources
          size = Self->Size;
       }
-      else if (!AllocMemory(size, Self->DataFlags|MEM::NO_CLEAR, (APTR *)&data)) {
-         if (Self->Data) FreeResource(Self->Data);
+      else if ((data = (uint8_t *)malloc(size))) {
+         if (Self->Data) free(Self->Data);
          Self->Data = data;
       }
       else return log.warning(ERR::AllocMemory);
@@ -2217,10 +2216,7 @@ ERR SET_Data(extBitmap *Self, uint8_t *Value)
 
    if (Self->Data != Value) {
       Self->Data = Value;
-
-      if (Self->DataFlags IS MEM::NIL) {
-         Self->DataFlags = MEM::DATA;
-      }
+      if (Self->DataFlags IS MEM::NIL) Self->DataFlags = MEM::DATA;
    }
 
    return ERR::Okay;
@@ -2728,7 +2724,7 @@ extBitmap::~extBitmap()
    if (x11.gc) XFreeGC(XDisplay, x11.gc);
 #endif
 
-   if ((Data) and (prvAFlags & BF_DATA)) FreeResource(Data);
+   if ((Data) and (prvAFlags & BF_DATA)) free(Data);
    if (ResolutionChangeHandle) UnsubscribeEvent(ResolutionChangeHandle);
 
 #ifdef __xwindows__

--- a/src/origo/gui/origo.cpp
+++ b/src/origo/gui/origo.cpp
@@ -395,7 +395,7 @@ static ERROR decompress_archive(CSTRING Location)
 
    objCompression::create compress = { fl::Path(Location) };
    if (compress.ok()) {
-      if (!(error = AllocMemory(sizeof(STR_UNPACK) + len + sizeof(STR_MAIN) + 2, MEM::STRING, &glDirectory))) {
+      if (!(error = malloc(sizeof(STR_UNPACK) + len + sizeof(STR_MAIN) + 2, MEM::STRING, &glDirectory))) {
          for (i=0; STR_UNPACK[i]; i++) glDirectory[i] = STR_UNPACK[i];
          for (j=len; (j > 1) and (Location[j-1] != '/') and (Location[j-1] != '\\') and (Location[j-1] != ':'); j--);
          while (Location[j]) {

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -43,7 +43,7 @@ GCstruct * lj_struct_new(lua_State *L, struct_record &Def)
 
 //********************************************************************************************************************
 // Create a GCstruct header that references externally managed memory.  Pass STRUCT_DEALLOCATE in Flags if the
-// memory was allocated with AllocMemory() and ownership transfers to the GC.
+// memory ownership transfers to the GC and can be removed with FreeResource().
 //
 // If the payload's validity depends on a Kotuku object staying alive (e.g. live views of object struct fields),
 // pass that object as Lifecycle.  The view takes a weak pin so that the object's header remains testable after

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -241,6 +241,7 @@ static int processing_signal(lua_State *Lua)
 static int processing_flush(lua_State *Lua)
 {
    Lua->script->clearFlag(NF::SIGNALLED);
+
    if (auto fp = (fprocessing *)get_meta(Lua, lua_upvalueindex(1), "Tiri.processing")) {
       if ((fp->SignalRefs) and (not fp->SignalRefs->empty())) {
          for (auto ref : *fp->SignalRefs) {
@@ -254,9 +255,6 @@ static int processing_flush(lua_State *Lua)
             }
             lua_pop(Lua, 1);
          }
-      }
-      else if ((fp->Signals) and (not fp->Signals->empty())) {
-         Lua->script->clearFlag(NF::SIGNALLED);
       }
    }
    return 0;


### PR DESCRIPTION
* Allocate and release owned bitmap buffers with the standard memory functions
* [Tiri] Ensure processing flush clears the signalled state consistently