### PR TITLE
[Tiri] Require explicit syntax for declared struct construction

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -817,6 +817,45 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          break;
       }
 
+      case TokenKind::StructTyped: {
+         // Explicit struct construction: struct<Name> { fields }
+         // Desugar to: struct.new('Name', { fields })
+         // This is the only declaration-based construction form; declarations do not bind a constructor variable.
+
+         Token start = this->ctx.tokens().current();
+         GCstr *name_str = start.payload().as_string();
+         std::string_view struct_name(strdata(name_str), name_str->len);
+         if (not find_struct(&this->ctx.lua(), struct_name)) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::UnknownTypeName, start,
+               std::format("Unknown struct name '{}'; declarations must precede use", struct_name));
+         }
+         this->ctx.tokens().advance();
+
+         if (not this->ctx.check(TokenKind::LeftBrace)) {
+            return this->fail<ExprNodePtr>(ParserErrorCode::ExpectedToken, this->ctx.tokens().current(),
+               std::format("Expected '{{' to construct struct<{}>", struct_name));
+         }
+
+         auto table_result = this->parse_table_literal(false);
+         if (not table_result.ok()) return table_result;
+
+         SourceSpan span = start.span();
+
+         // Build struct.new('Name', { fields })
+         Identifier struct_id = Identifier::from_keepstr(this->ctx.lex().keepstr("struct"), span);
+         NameRef struct_ref;
+         struct_ref.identifier = struct_id;
+         ExprNodePtr struct_base = make_identifier_expr(span, struct_ref);
+         Identifier new_id = Identifier::from_keepstr(this->ctx.lex().keepstr("new"), span);
+         ExprNodePtr struct_new = make_member_expr(span, std::move(struct_base), new_id, false);
+
+         ExprNodeList args;
+         args.push_back(make_literal_expr(span, LiteralValue::string(name_str)));
+         args.push_back(std::move(table_result.value_ref()));
+         node = make_call_expr(span, std::move(struct_new), std::move(args), false);
+         break;
+      }
+
       case TokenKind::DeferredTyped: {
          // Typed deferred expression: <type{ expr }>
          // Desugar to: (thunk():explicit_type return expr end)()

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -105,6 +105,21 @@ ParserResult<Token> AstBuilder::parse_type_annotation(TiriType &Type, struct_rec
    auto kind = type_token.kind();
    std::string_view type_view;
 
+   if (kind IS TokenKind::StructTyped) {
+      // struct<Name> lexes as a single token carrying the referenced struct name
+      this->ctx.tokens().advance();
+      GCstr *name_symbol = type_token.payload().as_string();
+      std::string_view name(strdata(name_symbol), name_symbol->len);
+      auto found = find_struct(&this->ctx.lua(), name);
+      if (not found) {
+         return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
+            std::format("Unknown struct name '{}'; declarations must precede use", name));
+      }
+      Type = TiriType::Struct;
+      StructDef = found;
+      return ParserResult<Token>::success(type_token);
+   }
+
    if (kind IS TokenKind::Identifier) {
       this->ctx.tokens().advance();
       GCstr *type_symbol = type_token.identifier();

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -376,15 +376,17 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       if (not colon.ok()) return ParserResult<StmtNodePtr>::failure(colon.error_ref());
       Token type_token = this->ctx.tokens().current();
       bool array_type = type_token.kind() IS TokenKind::ArrayTyped;
+      bool struct_typed = type_token.kind() IS TokenKind::StructTyped;
       int64_t array_dimension = array_type ? this->ctx.lex().array_typed_size : -1;
-      if (array_type) this->ctx.tokens().advance();
+      if (array_type or struct_typed) this->ctx.tokens().advance();
       else {
          auto type_result = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
          if (not type_result.ok()) return ParserResult<StmtNodePtr>::failure(type_result.error_ref());
          type_token = type_result.value_ref();
       }
-      GCstr *type_symbol = array_type ? type_token.payload().as_string() : type_token.identifier();
+      GCstr *type_symbol = (array_type or struct_typed) ? type_token.payload().as_string() : type_token.identifier();
       std::string_view type_name = array_type ? std::string_view("array") :
+         struct_typed ? std::string_view("struct") :
          std::string_view(strdata(type_symbol), type_symbol->len);
 
       struct_field field;
@@ -454,6 +456,20 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
          field.Type |= FD_CPP|FD_ARRAY;
          field.ArraySize = 1;
          type_display = std::format("array<{}>", element_name);
+      }
+      else if (struct_typed) {
+         // Embedded struct reference in the single-token struct<Name> form
+         std::string_view reference_name(strdata(type_symbol), type_symbol->len);
+         auto referenced = find_struct(&this->ctx.lua(), reference_name);
+         if (not referenced) {
+            return this->fail<StmtNodePtr>(ParserErrorCode::UnknownTypeName, type_token,
+               std::format("Unknown struct name '{}'; declarations must precede use", reference_name));
+         }
+         field.Type = FD_STRUCT;
+         field.NativeType = NativeStructType::Struct;
+         field.StructRef = struct_key(reference_name);
+         field.StructDefinition = referenced;
+         type_display = std::format("struct<{}>", reference_name);
       }
       else if (type_name IS "bool") { field.Type = FD_BYTE; field.NativeType = NativeStructType::Bool; }
       else if (type_name IS "char") { field.Type = FD_BYTE|FD_CUSTOM; field.NativeType = NativeStructType::Char; }
@@ -626,28 +642,17 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
          std::format("Struct '{}' conflicts with its previous declaration{}", struct_name, location));
    }
    if (inserted) this->track_registered_struct(struct_key(struct_name));
-   auto registered = find_struct(&this->ctx.lua(), struct_name);
 
    if (collect_meta) {
       meta.end_span = close.value_ref().span();
       this->ctx.lex().struct_declaration_metadata.push_back(std::move(meta));
    }
 
-   Identifier variable = make_identifier(name_token.value_ref());
-   variable.type = TiriType::Func;
-   variable.struct_def = registered;
-   Identifier struct_identifier(&this->ctx.lua(), "struct", struct_token.span());
-   Identifier def_identifier(&this->ctx.lua(), "def", struct_token.span());
-   NameRef struct_reference;
-   struct_reference.identifier = struct_identifier;
-   auto base = make_identifier_expr(struct_token.span(), struct_reference);
-   auto callee = make_member_expr(struct_token.span(), std::move(base), def_identifier, false);
-   ExprNodeList arguments;
-   arguments.push_back(make_literal_expr(name_token.value_ref().span(),
-      LiteralValue::string(this->ctx.lex().keepstr(struct_name))));
-   ExprNodeList values;
-   values.push_back(make_call_expr(struct_token.span(), std::move(callee), std::move(arguments), false));
-   return ParserResult<StmtNodePtr>::success(make_local_decl_stmt(struct_token.span(), { variable }, std::move(values)));
+   // Declarations only register the layout.  Construction is explicit via struct<Name> { ... }, so no
+   // constructor variable is bound and the declaration itself emits no bytecode.
+   auto stmt = std::make_unique<StmtNode>(AstNodeKind::DoStmt, struct_token.span());
+   stmt->data = DoStmtPayload(make_block(struct_token.span(), {}));
+   return ParserResult<StmtNodePtr>::success(std::move(stmt));
 }
 
 static bool is_prefixed_attribute_token(TokenStreamAdapter &Tokens)

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -575,6 +575,7 @@ static LexToken lex_scan(LexState *, TValue *);
       case TK_string:
       case TK_regex_string:
       case TK_array_typed:
+      case TK_struct_typed:
       case TK_defer_typed:
       case TK_pipe:
          return true;
@@ -1166,6 +1167,37 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
 }
 
 //********************************************************************************************************************
+// Scan a struct type reference: struct<Name>
+// Caller has already scanned "struct" and confirmed c is '<'
+// Returns TK_struct_typed with the referenced struct name in tv
+
+static LexToken lex_struct_typed(LexState *State, TValue *tv)
+{
+   lex_next(State);  // Consume '<'
+   lex_skip_inline_ws(State);
+
+   if (not (isalpha(State->c) or State->c IS '_')) {
+      lj_lex_error(State, lex_current_char_token(State), ErrMsg::XTOKEN, State->token2str(TK_name));
+   }
+
+   lj_buf_reset(&State->sb);
+   do {
+      lex_savenext(State);
+   } while (lj_char_isident(State->c));
+
+   auto name_str = std::string_view(State->sb.b, sbuflen(&State->sb));
+
+   lex_skip_inline_ws(State);
+   if (State->c != '>') {
+      lj_lex_error(State, lex_current_char_token(State), ErrMsg::XTOKEN, State->token2str('>'));
+   }
+   lex_next(State);  // Consume '>'
+
+   setstrV(State->L, tv, State->keepstr(name_str));
+   return TK_struct_typed;
+}
+
+//********************************************************************************************************************
 // Token scanner, main entry point
 
 static LexToken lex_scan(LexState *State, TValue *tv)
@@ -1240,6 +1272,11 @@ static LexToken lex_scan(LexState *State, TValue *tv)
          // Check for array<type> syntax before interning the string
          if (str_view IS "array" and State->c IS '<') {
             return lex_array_typed(State, tv);
+         }
+
+         // Check for struct<Name> syntax (type references and explicit construction)
+         if (str_view IS "struct" and State->c IS '<') {
+            return lex_struct_typed(State, tv);
          }
 
          // Check for f-string prefix: f"..." or f'...'

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -123,6 +123,7 @@ struct TokenDefinition {
    TOKEN_DEF(defer_typed,  "<type{",   TKF_NONE) \
    TOKEN_DEF(defer_close,  "}>",       TKF_CAN_END_RANGE_EXPRESSION) \
    TOKEN_DEF(array_typed,  "array<type>", TKF_NONE) \
+   TOKEN_DEF(struct_typed, "struct<name>", TKF_NONE) \
    TOKEN_DEF(annotate,     "@",        TKF_STATEMENT_START) \
    TOKEN_DEF(compif,       "@if",      TKF_STATEMENT_START) \
    TOKEN_DEF(compend,      "@end",     TKF_NONE) \

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1456,7 +1456,7 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
       }
 
       if (not parse_struct_source(first_state,
-            "local value:struct<ParserStateLocalRecord> = ParserStateLocalRecord()", error)) {
+            "local value:struct<ParserStateLocalRecord> = struct<ParserStateLocalRecord> { }", error)) {
          Log.error("later compilation in the same state could not resolve its declaration: %s", error.c_str());
          return false;
       }
@@ -1464,7 +1464,7 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
       if (compile_snapshot(first_state,
             "struct ParserLocalExpectedRecord { Value: int }\n"
             "struct ParserLocalActualRecord { Value: double }\n"
-            "local value:struct<ParserLocalExpectedRecord> = ParserLocalActualRecord()", true, error).has_value()) {
+            "local value:struct<ParserLocalExpectedRecord> = struct<ParserLocalActualRecord> { }", true, error).has_value()) {
          Log.error("local declaration accepted an initialiser with a different struct layout");
          return false;
       }

--- a/src/tiri/jit/src/parser/token_types.h
+++ b/src/tiri/jit/src/parser/token_types.h
@@ -82,6 +82,7 @@ enum class TokenKind : uint16_t {
    DeferredTyped = TK_defer_typed,
    DeferredClose = TK_defer_close,
    ArrayTyped = TK_array_typed,
+   StructTyped = TK_struct_typed,
    ThunkToken = TK_thunk,
    Choose = TK_choose,
    From = TK_from,
@@ -222,6 +223,7 @@ enum class TokenKind : uint16_t {
       case TokenKind::DeferredTyped: return "<type{";
       case TokenKind::DeferredClose: return "}>";
       case TokenKind::ArrayTyped: return "array<type>";
+      case TokenKind::StructTyped: return "struct<name>";
       case TokenKind::Choose: return "choose";
       case TokenKind::From: return "from";
       case TokenKind::When: return "when";

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1507,6 +1507,21 @@ void TypeAnalyser::analyse_call_expr(const CallExprPayload &Call)
             Call.result_type = TiriType::Struct;
             Call.struct_def = callable->struct_def;
          }
+         else if (not callable and not this->lookup_global_type(name_ref.identifier.symbol)) {
+            // Declared structs no longer bind constructor variables.  A call on an unresolved name that matches a
+            // registered struct is almost certainly the retired 'Name { ... }' / 'Name()' construction syntax.
+            std::string_view name(strdata(name_ref.identifier.symbol), name_ref.identifier.symbol->len);
+            if (find_struct(&this->ctx_.lua(), name)) {
+               TypeDiagnostic diag;
+               diag.location = direct->callable->span;
+               diag.expected = TiriType::Struct;
+               diag.actual = TiriType::Nil;
+               diag.code = ParserErrorCode::UnexpectedToken;
+               diag.message = std::format("'{}' is a struct declaration; construct instances with struct<{}> {{ ... }}",
+                  name, name);
+               this->record_diagnostic(std::move(diag));
+            }
+         }
       }
    }
 

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1546,7 +1546,8 @@ void TypeAnalyser::analyse_call_expr(const CallExprPayload &Call)
 
    const FunctionExprPayload* target = this->resolve_call_target(Call.target);
    if (target) {
-      if (target->return_types.is_explicit and target->return_types.count > 0) {
+      if (Call.result_type IS TiriType::Unknown and target->return_types.is_explicit and
+          target->return_types.count > 0) {
          Call.result_type = target->return_types.types[0];
          Call.struct_def = target->return_types.struct_defs[0];
       }

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -30,10 +30,10 @@ end
 @Test function LayoutAwareStructBytecodeDisassembly()
    local script = obj.new('tiri', { statement=[[
 struct PhaseTwoLayout { First: int, Second: int }
-global glPhaseTwo:struct<PhaseTwoLayout> = PhaseTwoLayout()
+global glPhaseTwo:struct<PhaseTwoLayout> = struct<PhaseTwoLayout> { }
 
 function annotatedLocal():num
-   local value:struct<PhaseTwoLayout> = PhaseTwoLayout()
+   local value:struct<PhaseTwoLayout> = struct<PhaseTwoLayout> { }
    return value.Second
 end
 
@@ -42,13 +42,13 @@ function annotatedParameter(Value:struct<PhaseTwoLayout>):num
 end
 
 function inferredLocal():num
-   local value = PhaseTwoLayout()
+   local value = struct<PhaseTwoLayout> { }
    value.Second = 9
    return value.Second
 end
 
 function createValue():struct<PhaseTwoLayout>
-   return PhaseTwoLayout()
+   return struct<PhaseTwoLayout> { }
 end
 
 function returnedValue():num

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -66,6 +66,10 @@ end
    assert(create_declared_user().Age is 0, 'struct<Name> return annotations should parse and retain the layout')
    local typed_user:struct<DeclaredUser> = user
    assert(typed_user.Name is 'Paul', 'struct<Name> local annotations should resolve declared layouts')
+   local constructed_user:struct<DeclaredUser> = struct<DeclaredUser> { Age=42 }
+   assert(constructed_user.Age is 42, 'Explicit construction should retain its type in annotated assignments')
+   assert(declared_user_age(struct<DeclaredUser> { Age=31 }) is 31,
+      'Explicit construction should retain its type when passed to annotated parameters')
 
    user.Child.Value = 91
    assert(user.Child.Value is 91, 'Embedded declared structs should expose their fields')

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -50,14 +50,14 @@ function declared_user_age(Value: struct<DeclaredUser>):num
 end
 
 function create_declared_user():struct<DeclaredUser>
-   return DeclaredUser()
+   return struct<DeclaredUser> { }
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Retrieve a known struct from a function and test the field values.
 
 @Test function NativeStructDeclarationConstruction()
-   local user = DeclaredUser { Name='Paul', Age=37, Enabled=true, Initial=65, Buffer='hello' }
+   local user = struct<DeclaredUser> { Name='Paul', Age=37, Enabled=true, Initial=65, Buffer='hello' }
    assert(type(user) is 'struct', 'A declared definition should construct a native struct')
    assert(user.Name is 'Paul' and user.Age is 37, 'Definition calls should apply initialiser fields verbatim')
    assert(user.Enabled is true, 'Boolean fields should be exposed as Tiri booleans')
@@ -72,15 +72,53 @@ end
    assert(user.ChildPointer is nil, 'Typed struct pointers should initialise to nil')
    assert(user.Object is nil, 'Object fields should initialise to nil')
 
-   local empty_user = DeclaredUser()
-   assert(empty_user.Age is 0 and empty_user.Name is '', 'Empty definition calls should zero-initialise fields')
+   local empty_user = struct<DeclaredUser> { }
+   assert(empty_user.Age is 0 and empty_user.Name is '', 'Empty initialisers should zero-initialise fields')
    assert(struct.new('DeclaredUser').Age is 0, 'struct.new() should interoperate with declarations')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Declarations no longer bind a constructor variable; construction must use the explicit struct<Name> form.
+
+@Test function ExplicitConstructionRequired()
+   try
+      exec([[
+struct RetiredTableSyntax { Value: int }
+local value = RetiredTableSyntax { Value=1 }
+]])
+   success
+      error('The retired Name { fields } construction syntax should fail to compile')
+   end
+
+   try
+      exec([[
+struct RetiredCallSyntax { Value: int }
+local value = RetiredCallSyntax()
+]])
+   success
+      error('The retired Name() construction syntax should fail to compile')
+   end
+
+   try
+      exec([[local value = struct<NotARegisteredStruct> { }]])
+   success
+      error('Constructing an unknown struct name should fail to compile')
+   end
+
+   try
+      exec([[
+struct MissingInitialiser { Value: int }
+local value = struct<MissingInitialiser>
+]])
+   success
+      error('struct<Name> without an initialiser table should fail to compile')
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function ConstrainedObjectField()
-   local holder = DeclaredUser()
+   local holder = struct<DeclaredUser> { }
    local clock = obj.new('time', { })
    holder.Clock = clock
    assert(holder.Clock.year is clock.year, 'obj<Class> fields should retain typed object references')
@@ -99,7 +137,7 @@ end
 -- accept it.  An exact ClassID comparison would incorrectly reject this.
 
 @Test function ConstrainedObjectFieldAcceptsSubClass()
-   local holder = DeclaredUser()
+   local holder = struct<DeclaredUser> { }
    local markup = obj.new('xml', { statement='<a/>' })
    holder.Markup = markup
    assert(holder.Markup is not nil, 'obj<Class> fields should accept an exact class match')
@@ -143,7 +181,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function NativeStructVectorRoundTrips()
-   local value = DeclaredVectorFields {
+   local value = struct<DeclaredVectorFields> {
       Int=array<int> { 1, 2, 3 },
       String=array<string> { 'alpha', 'beta' }
    }
@@ -179,7 +217,7 @@ end
    assert(#value.Int is 5, 'Whole-field assignment should resize dynamic vector fields')
 
    local clone = struct.clone(value)
-   local copy = DeclaredVectorFields()
+   local copy = struct<DeclaredVectorFields> { }
    struct.copy(copy, value)
    value.Int = array<int> { 99 }
    value.String = array<string> { 'changed' }
@@ -195,7 +233,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Test function NativeStructElementVectorRoundTrips()
-   local value = DeclaredVectorFields()
+   local value = struct<DeclaredVectorFields> { }
    value.Points = array<table> {
       { red=1, green=2, blue=3 },
       { red=4, green=5, blue=6 },
@@ -207,7 +245,7 @@ end
       'Struct vectors should use the exact three-byte C++ element stride')
 
    local clone = struct.clone(value)
-   local copy = DeclaredVectorFields()
+   local copy = struct<DeclaredVectorFields> { }
    struct.copy(copy, value)
    value.Points = array<table> { { red=20, green=21, blue=22 } }
    assert(#clone.Points is 3 and clone.Points[2].Blue is 9,
@@ -268,7 +306,7 @@ end
    exec([[
 struct IdenticalLayout { Value: int }
 struct IdenticalLayout { Value: int }
-local value = IdenticalLayout { Value=12 }
+local value = struct<IdenticalLayout> { Value=12 }
 assert(value.Value is 12)
 ]])
 
@@ -312,7 +350,7 @@ struct ConflictingLayout { Value: double }
    end
    exec([[
 struct ConflictingLayout { Value: double }
-local value = ConflictingLayout { Value=2.5 }
+local value = struct<ConflictingLayout> { Value=2.5 }
 assert(value.Value is 2.5)
 ]])
 
@@ -338,13 +376,13 @@ end
       if (i & 1) is 0 then
          statement = [[
 struct ConcurrentDeclaredStruct { Value: int }
-local value = ConcurrentDeclaredStruct { Value=42 }
+local value = struct<ConcurrentDeclaredStruct> { Value=42 }
 assert(value.Value is 42)
 ]]
       else
          statement = [[
 struct ConcurrentDeclaredStruct { Value: double }
-local value = ConcurrentDeclaredStruct { Value=42.5 }
+local value = struct<ConcurrentDeclaredStruct> { Value=42.5 }
 assert(value.Value is 42.5)
 ]]
       end
@@ -368,7 +406,7 @@ struct ConcurrentInvalidStruct { Value: mystery }]]
    assert(succeeded is total / 2 and failed is total / 2,
       f'Expected equal successful and failed concurrent declarations, got {succeeded}/{failed}')
    exec([[struct ConcurrentDeclaredStruct { Value: int }
-assert(ConcurrentDeclaredStruct { Value=17 }.Value is 17)]])
+assert(struct<ConcurrentDeclaredStruct> { Value=17 }.Value is 17)]])
 end
 
 @Test(hotpath=true)

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -12,7 +12,7 @@ rx_def_struct         <const> = <{ regex.new([[^\s*struct\s+([A-Za-z_][A-Za-z0-9
 rx_def_struct_field   <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)\s*:]]) }>
 rx_def_struct_new     <const> = <{ regex.new([=[([A-Za-z_]\w*)\s*=\s*struct\.new\s*\(\s*['"]([A-Za-z_]\w*)['"]]=]) }>
 rx_def_struct_anno    <const> = <{ regex.new([[([A-Za-z_]\w*)\s*:\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
-rx_def_struct_ctor    <const> = <{ regex.new([=[([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*[\(\{]]=]) }>
+rx_def_struct_ctor    <const> = <{ regex.new([[([A-Za-z_]\w*)\s*=\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
 rx_def_loader_before  <const> = <{ regex.new(
    [[\b(import|require|include)\s*(?:\(\s*)?]] ..
    [[(?:(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*,\s*)*$]]

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -5,7 +5,7 @@ rx_action_prefix = <{ regex.new("^ac[A-Z]") }>
 rx_method_prefix = <{ regex.new("^mt[A-Z]") }>
 rx_struct_new  = <{ regex.new("([\\w]+)\\s*=\\s*struct\\.new\\s*\\(\\s*['\"]([\\w]+)['\"]", regex.DOT_ALL) }>
 rx_struct_anno = <{ regex.new([[([A-Za-z_]\w*)\s*:\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
-rx_struct_ctor = <{ regex.new("([A-Za-z_]\\w*)\\s*=\\s*([A-Za-z_]\\w*)\\s*[\\(\\{]") }>
+rx_struct_ctor = <{ regex.new([[([A-Za-z_]\w*)\s*=\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
 
 extern lspUriToPath, maskNonCode
 
@@ -117,8 +117,8 @@ function buildTypeMap(Doc)
    return typeMap
 end
 
--- Build a mapping of variable names to declared-struct names.  Sources, in increasing precedence: definition-value
--- construction (user = User {...} / User()), struct.new('Name') assignments, and struct<Name> type annotations.
+-- Build a mapping of variable names to declared-struct names.  Sources, in increasing precedence: explicit
+-- construction (user = struct<User> {...}), struct.new('Name') assignments, and struct<Name> type annotations.
 -- Constructor matches are speculative; lookups only succeed when the mapped name resolves to a struct symbol.
 
 function buildStructTypeMap(Doc:table, Position:table):table

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -453,9 +453,44 @@ global function tokenizeTiri(Source:str):array
          if isRangeOperator(start_pos, pos, ident) then
             addToken(line, ident_start, ident_len, 1, 0)  -- range separator operator
          elseif ident is 'struct' then
-            -- 'struct' is a soft keyword: it begins a declaration only when followed by an identifier and '{'
-            -- (newlines permitted, matching the parser's token-based lookahead).  Anything else is the runtime
-            -- library namespace, e.g. struct.new().
+            -- 'struct' is a soft keyword.  Followed immediately by '<' it forms a struct<Name> type reference or
+            -- explicit construction; followed by an identifier and '{' it begins a declaration (newlines permitted,
+            -- matching the parser's token-based lookahead).  Anything else is the runtime library namespace,
+            -- e.g. struct.new().
+            if pos < len and Source:sub(pos, pos + 1) is '<' then
+               sk_pos = pos
+               sk_col = col
+               pos++
+               col++
+               while pos < len and (Source:sub(pos, pos + 1) is ' ' or Source:sub(pos, pos + 1) is '\t') do
+                  pos++
+                  col++
+               end
+               if pos < len and isIdentStart(Source:sub(pos, pos + 1)) then
+                  name_col = col
+                  while pos < len and isIdentChar(Source:sub(pos, pos + 1)) do
+                     pos++
+                     col++
+                  end
+                  name_len = col - name_col
+                  while pos < len and (Source:sub(pos, pos + 1) is ' ' or Source:sub(pos, pos + 1) is '\t') do
+                     pos++
+                     col++
+                  end
+                  if pos < len and Source:sub(pos, pos + 1) is '>' then
+                     pos++
+                     col++
+                     addToken(line, ident_start, ident_len, 0, 0)  -- 'struct' keyword
+                     addToken(line, name_col, name_len, 11, 0)     -- referenced struct name: class
+                     continue
+                  end
+               end
+               -- Not a well-formed struct<Name>; rewind and fall through to the namespace token
+               pos = sk_pos
+               col = sk_col
+               addToken(line, ident_start, ident_len, 10, 0)  -- namespace ('struct' library)
+               continue
+            end
             sk_pos = pos
             sk_col = col
             sk_line = line

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -203,7 +203,7 @@ end
 end
 
 @Test function LaterStructAssignmentDoesNotAffectEarlierDefinition()
-   doc = makeDoc('struct A { Value: int }\nstruct B { Value: float }\na = A()\nprint(a.Value)\na = B()\n')
+   doc = makeDoc('struct A { Value: int }\nstruct B { Value: float }\na = struct<A> { }\nprint(a.Value)\na = struct<B> { }\n')
    locations = resolveDefinition(doc, { line = 3, character = 10 })
    assertLocationLine(locations, 0, 'A later assignment must not change the type at an earlier field access')
 end

--- a/tools/tiri_lsp/tests/test_hover.tiri
+++ b/tools/tiri_lsp/tests/test_hover.tiri
@@ -230,11 +230,11 @@ end
 struct User {
    Name: string -- The user name
 }
-user = User { Name = 'Paul' }
+user = struct<User> { Name = 'Paul' }
 print(user.Na|me)
 ]])
 
-   assertContains(hover, 'User.Name', 'Definition-value construction should map the variable to its struct.')
+   assertContains(hover, 'User.Name', 'Explicit struct construction should map the variable to its struct.')
    assertContains(hover, 'The user name', 'Constructed instance hover should include the doc comment.')
 end
 

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -319,6 +319,26 @@ end
    assert((struct_name.modifiers & 1) != 0, 'The declared struct name should carry the declaration modifier.')
 end
 
+@Test function StructTypedReferenceReceivesClassToken()
+   source = 'user = struct<User> { Name="Paul" }\n' ..
+      'function age(Value: struct<User>):num\n' ..
+      '   return Value.Age\n' ..
+      'end\n'
+
+   tokens = tokenizeTiri(source)
+
+   construct_keyword = findToken(tokens, 0, 7, 'struct')
+   construct_name = findToken(tokens, 0, 14, 'User')
+   anno_keyword = findToken(tokens, 1, 20, 'struct')
+   anno_name = findToken(tokens, 1, 27, 'User')
+
+   assert(construct_keyword and construct_keyword.type is 0, 'struct<Name> construction should highlight struct as a keyword.')
+   assert(construct_name and construct_name.type is 11, 'The constructed struct name should be a class token.')
+   assert(construct_name.modifiers is 0, 'A struct<Name> reference should not carry the declaration modifier.')
+   assert(anno_keyword and anno_keyword.type is 0, 'struct<Name> annotations should highlight struct as a keyword.')
+   assert(anno_name and anno_name.type is 11, 'The annotated struct name should be a class token.')
+end
+
 @Test function StructDeclarationBraceOnNextLine()
    source = 'struct User\n' ..
       '{\n' ..


### PR DESCRIPTION
* Added struct<Name> parsing for typed references and initialised values without binding declaration constructors
* Updated struct type analysis and regression coverage for explicit construction
* [LSP] Added definition, hover and semantic token support for struct<Name> references