### PR TITLE
[Tiri] Replaced brace-delimited struct declarations with end blocks

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -623,8 +623,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_statement()
 
    if (current.kind() IS TokenKind::Identifier and current.identifier() and
          std::string_view(strdata(current.identifier()), current.identifier()->len) IS "struct" and
-         this->ctx.tokens().peek(1).kind() IS TokenKind::Identifier and
-         this->ctx.tokens().peek(2).kind() IS TokenKind::LeftBrace) {
+         this->ctx.tokens().peek(1).kind() IS TokenKind::Identifier) {
       return this->parse_struct_declaration();
    }
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -329,11 +329,13 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
    if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
    GCstr *name_symbol = name_token.value_ref().identifier();
    std::string struct_name(strdata(name_symbol), name_symbol->len);
-   auto open = this->ctx.consume(TokenKind::LeftBrace, ParserErrorCode::ExpectedToken);
-   if (not open.ok()) return ParserResult<StmtNodePtr>::failure(open.error_ref());
+   if (this->ctx.check(TokenKind::LeftBrace)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, this->ctx.tokens().current(),
+         "Struct declarations use 'end' termination; braces are reserved for struct<Name> { ... } construction");
+   }
 
-   // Capture comments for the body only.  The statement dispatcher peeks ahead as far as '{' to recognise the
-   // declaration, so nothing before this point could have been captured anyway.
+   // Capture comments for the body only.  The statement dispatcher peeks through the declaration name, so nothing
+   // before this point could have been captured anyway.
 
    CommentCaptureGuard comment_capture(this->ctx.lex());
 
@@ -354,7 +356,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       record.DeclarationSource.assign(strdata(source_symbol), source_symbol->len);
    }
 
-   while (not this->ctx.check(TokenKind::RightBrace)) {
+   while (not this->ctx.check(TokenKind::EndToken)) {
       if (this->ctx.check(TokenKind::EndOfFile)) {
          return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedEndOfFile, struct_token,
             "Unterminated struct declaration");
@@ -611,14 +613,14 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
 
       Token last = this->ctx.tokens().current();
       if (this->ctx.match(TokenKind::Comma).ok()) continue;
-      if (this->ctx.check(TokenKind::RightBrace)) continue;
+      if (this->ctx.check(TokenKind::EndToken)) continue;
       if (last.span().line.lineNumber() <= type_token.span().line.lineNumber()) {
          return this->fail<StmtNodePtr>(ParserErrorCode::ExpectedToken, last,
-            "Expected a newline, ',' or '}' after struct field");
+            "Expected a newline, ',' or 'end' after struct field");
       }
    }
 
-   auto close = this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   auto close = this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
    if (not close.ok()) return ParserResult<StmtNodePtr>::failure(close.error_ref());
    if (record.Fields.empty()) {
       return this->fail<StmtNodePtr>(ParserErrorCode::UnexpectedToken, struct_token,

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1116,7 +1116,7 @@ static bool parse_struct_source(lua_State *L, std::string_view Source, std::stri
    }
    if (context.diagnostics().has_errors()) {
       auto entries = context.diagnostics().entries();
-      Error = entries.empty() ? "unknown parser error" : entries.back().message;
+      Error = entries.empty() ? "unknown parser error" : entries.front().message;
       builder.rollback_registered_structs();
       return false;
    }
@@ -1187,7 +1187,7 @@ static bool test_struct_field_documentation(kt::Log &Log)
    // '--' in the source text would mistake the string literals for comment markers.
 
    if (not parse_struct_documentation(state,
-         "struct ParserDocumentedRecord {\n"
+         "struct ParserDocumentedRecord\n"
          "   Plain: int -- Trailing description.\n"
          "   -- Leading description.\n"
          "   -- Second leading line.\n"
@@ -1195,7 +1195,7 @@ static bool test_struct_field_documentation(kt::Log &Log)
          "   Marker: cstr -- Sets the \"--\" delimiter.\n"
          "   Divider: cstr\n"
          "   Undocumented: int\n"
-         "}", docs, error)) {
+         "end", docs, error)) {
       Log.error("failed to compile documented struct: %s", error.c_str());
       return false;
    }
@@ -1290,11 +1290,11 @@ static bool test_struct_declaration_metadata(kt::Log &Log)
    }
 
    if (not parse_struct_metadata(state,
-         "struct ParserMetadataPoint {\n"
+         "struct ParserMetadataPoint\n"
          "   X: double\n"
          "   Y: double\n"
-         "}\n"
-         "struct ParserMetadataRecord {\n"
+         "end\n"
+         "struct ParserMetadataRecord\n"
          "   Plain: byte -- Documented field.\n"
          "   Sock: obj<NetSocket>\n"
          "   Buffer: char[32]\n"
@@ -1302,7 +1302,7 @@ static bool test_struct_declaration_metadata(kt::Log &Log)
          "   Embedded: struct<ParserMetadataPoint>\n"
          "   Link: ptr<ParserMetadataPoint>\n"
          "   List: ptr<ParserMetadataPoint[]>\n"
-         "}", metadata, error)) {
+         "end", metadata, error)) {
       Log.error("failed to compile metadata struct source: %s", error.c_str());
       return false;
    }
@@ -1365,7 +1365,7 @@ static bool test_struct_declaration_metadata(kt::Log &Log)
       return false;
    }
 
-   constexpr std::string_view gated_source = "struct ParserMetadataGated { A: int }";
+   constexpr std::string_view gated_source = "struct ParserMetadataGated A: int end";
    StringReaderCtx reader = { gated_source.data(), gated_source.size() };
    LexState lex(plain_state, unit_reader, &reader, "parser-unit", std::nullopt);
    FuncState &func_state = lex.fs_init();
@@ -1420,9 +1420,9 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
       }
 
       if (not parse_struct_source(first_state,
-            "struct ParserStateLocalRecord { Value: int }\n"
-            "struct ParserStateShadowRecord { Local: double }\n"
-            "struct ParserGlobalChildRecord { LocalValue: double }", error)) {
+            "struct ParserStateLocalRecord Value: int end\n"
+            "struct ParserStateShadowRecord Local: double end\n"
+            "struct ParserGlobalChildRecord LocalValue: double end", error)) {
          Log.error("failed to compile local struct declarations: %s", error.c_str());
          return false;
       }
@@ -1462,8 +1462,8 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
       }
 
       if (compile_snapshot(first_state,
-            "struct ParserLocalExpectedRecord { Value: int }\n"
-            "struct ParserLocalActualRecord { Value: double }\n"
+            "struct ParserLocalExpectedRecord Value: int end\n"
+            "struct ParserLocalActualRecord Value: double end\n"
             "local value:struct<ParserLocalExpectedRecord> = struct<ParserLocalActualRecord> { }", true, error).has_value()) {
          Log.error("local declaration accepted an initialiser with a different struct layout");
          return false;
@@ -1474,8 +1474,8 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
       }
 
       if (parse_struct_source(first_state,
-            "struct ParserRolledBackRecord { Value: int }\n"
-            "struct ParserInvalidRecord { Value: mystery }", error)) {
+            "struct ParserRolledBackRecord Value: int end\n"
+            "struct ParserInvalidRecord Value: mystery end", error)) {
          Log.error("invalid declaration fixture compiled successfully");
          return false;
       }
@@ -1488,6 +1488,33 @@ static bool test_state_local_struct_declarations(kt::Log &Log)
    LuaStateHolder replacement;
    if (find_struct(replacement.get(), local_name)) {
       Log.error("declarative struct survived closure of its owning state");
+      return false;
+   }
+
+   return true;
+}
+
+static bool test_struct_declaration_syntax(kt::Log &Log)
+{
+   std::string error;
+   LuaStateHolder holder;
+   lua_State *state = holder.get();
+   if (not state) {
+      Log.error("failed to allocate state for struct declaration syntax test");
+      return false;
+   }
+
+   if (not parse_struct_source(state, "struct ParserSingleLine X: int, Y: int end", error)) {
+      Log.error("single-line end-terminated declaration failed: %s", error.c_str());
+      return false;
+   }
+
+   if (parse_struct_source(state, "struct ParserBraceDeclaration { X: int }", error)) {
+      Log.error("brace-delimited struct declaration compiled successfully");
+      return false;
+   }
+   if (error.find("Struct declarations use 'end' termination") IS std::string::npos) {
+      Log.error("brace-delimited declaration produced an unexpected diagnostic: %s", error.c_str());
       return false;
    }
 
@@ -1984,7 +2011,7 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 23> tests = { {
+   constexpr std::array<TestCase, 24> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2003,6 +2030,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "state_local_struct_declarations", test_state_local_struct_declarations },
+      { "struct_declaration_syntax", test_struct_declaration_syntax },
       { "struct_field_documentation", test_struct_field_documentation },
       { "struct_declaration_metadata", test_struct_declaration_metadata },
       { "expdesc_is_falsey", test_expdesc_is_falsey },

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -683,13 +683,13 @@ end
 
 @Test function ValidateStructSymbols()
    code = [=[
-struct ValidatePoint {
+struct ValidatePoint
    X: double
    Y: double
-}
+end
 
 -- Leading description.
-struct ValidateUser {
+struct ValidateUser
    Name: string -- The user name.
    Age: int
    Sock: obj<NetSocket>
@@ -698,7 +698,7 @@ struct ValidateUser {
    Home: struct<ValidatePoint>
    Next: ptr<ValidatePoint>
    List: ptr<ValidatePoint[]>
-}
+end
 
 function validateGreet(U)
    return U.Name
@@ -722,7 +722,7 @@ end
    assert(point.signature is 'struct ValidatePoint', "Unexpected struct signature: " .. tostring(point.signature))
    assert(#point.fields is 2, "Expected two ValidatePoint fields, got " .. #point.fields)
    assert(point.line is 0, "Struct symbol line should be 0-based, got " .. point.line)
-   assert(point.endLine is 3, "Struct endLine should sit on the closing brace, got " .. point.endLine)
+   assert(point.endLine is 3, "Struct endLine should sit on the end keyword, got " .. point.endLine)
 
    assert(user and user.kind is 'struct', "Expected a struct symbol for ValidateUser")
    assert(#user.fields is 8, "Expected eight ValidateUser fields, got " .. #user.fields)
@@ -749,10 +749,10 @@ end
    -- Validation must not permanently register declared structs: an edited declaration would otherwise conflict
    -- with the version registered by an earlier validation of the same document.
 
-   first = debug.validate('struct RevalidateRecord { Value: int }', { symbols = true })
+   first = debug.validate('struct RevalidateRecord Value: int end', { symbols = true })
    assert(first.success is true, "Initial struct declaration should validate")
 
-   second = debug.validate('struct RevalidateRecord { Value: float }', { symbols = true })
+   second = debug.validate('struct RevalidateRecord Value: float end', { symbols = true })
    assert(second.success is true,
       "Revalidating an edited struct must not conflict with the previous validation")
    assert(#second.diagnostics is 0, "No diagnostics expected for the edited declaration")

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -29,7 +29,7 @@ end
 
 @Test function LayoutAwareStructBytecodeDisassembly()
    local script = obj.new('tiri', { statement=[[
-struct PhaseTwoLayout { First: int, Second: int }
+struct PhaseTwoLayout First: int, Second: int end
 global glPhaseTwo:struct<PhaseTwoLayout> = struct<PhaseTwoLayout> { }
 
 function annotatedLocal():num
@@ -79,7 +79,7 @@ end
 
 @Test function ConstrainedObjectFieldTypePropagation()
    local script = obj.new('tiri', { statement=[[
-struct PhaseTwoObjectHolder { Clock: obj<Time> }
+struct PhaseTwoObjectHolder Clock: obj<Time> end
 function readYear(Holder:struct<PhaseTwoObjectHolder>):num
    return Holder.Clock.year
 end

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -1,9 +1,9 @@
 
-struct DeclaredChild {
+struct DeclaredChild
    Value: int
-}
+end
 
-struct DeclaredUser {
+struct DeclaredUser
    -- User-facing name retained as parser tooling metadata.
    Name: string -- Owned string storage.
    Borrowed: cstr
@@ -16,34 +16,34 @@ struct DeclaredUser {
    Object: obj
    Clock: obj<Time>
    Markup: obj<XML>
-}
+end
 
-struct DeclaredLayout {
+struct DeclaredLayout
    Bool: bool, Char: char, Byte: byte, Int8: int8, UInt8: uint8,
    Int16: int16, UInt16: uint16, Int: int, UInt: uint,
    Int32: int32, UInt32: uint32, Int64: int64, UInt64: uint64,
    Float: float, Double: double, String: string, CStr: cstr,
    Pointer: ptr, IntPointer: ptr<int>, IntList: ptr<int[]>, Object: obj, Callback: func, Buffer: char[7],
    Fixed: int[3], Child: struct<DeclaredChild>, ChildPointer: ptr<DeclaredChild>
-}
+end
 
-struct DeclaredVectorElement {
+struct DeclaredVectorElement
    Red: byte
    Green: byte
    Blue: byte
-}
+end
 
-struct DeclaredVectorFields {
+struct DeclaredVectorFields
    Bool: array<bool>, Char: array<char>, Byte: array<byte>, Int8: array<int8>, UInt8: array<uint8>,
    Int16: array<int16>, UInt16: array<uint16>, Int: array<int>, UInt: array<uint>,
    Int32: array<int32>, UInt32: array<uint32>, Int64: array<int64>, UInt64: array<uint64>,
    Float: array<float>, Double: array<double>, String: array<string>,
    Points: array<struct<DeclaredVectorElement>>
-}
+end
 
-struct DeclaredNonTrivialVectorElement {
+struct DeclaredNonTrivialVectorElement
    Name: string
-}
+end
 
 function declared_user_age(Value: struct<DeclaredUser>):num
    return Value.Age
@@ -87,7 +87,7 @@ end
 @Test function ExplicitConstructionRequired()
    try
       exec([[
-struct RetiredTableSyntax { Value: int }
+struct RetiredTableSyntax Value: int end
 local value = RetiredTableSyntax { Value=1 }
 ]])
    success
@@ -96,7 +96,7 @@ local value = RetiredTableSyntax { Value=1 }
 
    try
       exec([[
-struct RetiredCallSyntax { Value: int }
+struct RetiredCallSyntax Value: int end
 local value = RetiredCallSyntax()
 ]])
    success
@@ -111,7 +111,7 @@ local value = RetiredCallSyntax()
 
    try
       exec([[
-struct MissingInitialiser { Value: int }
+struct MissingInitialiser Value: int end
 local value = struct<MissingInitialiser>
 ]])
    success
@@ -266,15 +266,15 @@ end
 
 @Test function NativeStructVectorDeclarationErrors()
    for statement in values(array<string> {
-      'struct BadCStrVector { Values: array<cstr> }',
-      'struct BadObjectVector { Values: array<obj> }',
-      'struct BadPointerVector { Values: array<ptr> }',
-      'struct BadFunctionVector { Values: array<func> }',
-      'struct BadNestedVector { Values: array<array<int>> }',
-      'struct BadGenericSizedVector { Values: array<int, 4> }',
-      'struct BadSizedVector { Values: array<int>[4] }',
-      'struct BadUnknownVector { Values: array<mystery> }',
-      'struct BadOwnedElementVector { Values: array<struct<DeclaredNonTrivialVectorElement>> }'
+      'struct BadCStrVector Values: array<cstr> end',
+      'struct BadObjectVector Values: array<obj> end',
+      'struct BadPointerVector Values: array<ptr> end',
+      'struct BadFunctionVector Values: array<func> end',
+      'struct BadNestedVector Values: array<array<int>> end',
+      'struct BadGenericSizedVector Values: array<int, 4> end',
+      'struct BadSizedVector Values: array<int>[4] end',
+      'struct BadUnknownVector Values: array<mystery> end',
+      'struct BadOwnedElementVector Values: array<struct<DeclaredNonTrivialVectorElement>> end'
    }) do
       try
          exec(statement)
@@ -296,64 +296,70 @@ end
 
 @Test function NativeStructDeclarationErrors()
    try
+      exec([[struct RetiredBraceDeclaration { Value: int }]])
+   success
+      error("Brace-delimited struct declarations should fail to compile")
+   end
+
+   try
       MAKESTRUCT('Bad_Name', 'lValue')
    success
       error('MAKESTRUCT should reject names containing non-alphanumeric characters')
    end
 
    try
-      exec([[struct Bad_Name { Value: int }]])
+      exec([[struct Bad_Name Value: int end]])
    success
       error('Struct declarations should reject names containing non-alphanumeric characters')
    end
 
    exec([[
-struct IdenticalLayout { Value: int }
-struct IdenticalLayout { Value: int }
+struct IdenticalLayout Value: int end
+struct IdenticalLayout Value: int end
 local value = struct<IdenticalLayout> { Value=12 }
 assert(value.Value is 12)
 ]])
 
    try
-      exec([[struct BadUnknownType { Value: mystery }]])
+      exec([[struct BadUnknownType Value: mystery end]])
    success
       error('Unknown declaration field types should fail')
    end
 
    try
-      exec([[struct BadForwardReference { Value: struct<NotDeclaredYet> }]])
+      exec([[struct BadForwardReference Value: struct<NotDeclaredYet> end]])
    success
       error('Forward struct references should fail')
    end
 
    try
-      exec([[struct BadCaseCollision { Value: int, value: int }]])
+      exec([[struct BadCaseCollision Value: int, value: int end]])
    success
       error('Case-insensitive field-name collisions should fail')
    end
 
    try
-      exec([[struct BadArrayDimensionRange { Values: int[4294967296] }]])
+      exec([[struct BadArrayDimensionRange Values: int[4294967296] end]])
    success
       error('Array dimensions that exceed the parser integer range should fail')
    end
 
    try
-      exec([[struct BadArrayStorageRange { Values: int[20000] }]])
+      exec([[struct BadArrayStorageRange Values: int[20000] end]])
    success
       error('Array layouts that exceed the native struct offset range should fail')
    end
 
    try
       exec([[
-struct ConflictingLayout { Value: int }
-struct ConflictingLayout { Value: double }
+struct ConflictingLayout Value: int end
+struct ConflictingLayout Value: double end
 ]])
    success
       error('Conflicting declarations should fail')
    end
    exec([[
-struct ConflictingLayout { Value: double }
+struct ConflictingLayout Value: double end
 local value = struct<ConflictingLayout> { Value=2.5 }
 assert(value.Value is 2.5)
 ]])
@@ -379,20 +385,20 @@ end
       local statement
       if (i & 1) is 0 then
          statement = [[
-struct ConcurrentDeclaredStruct { Value: int }
+struct ConcurrentDeclaredStruct Value: int end
 local value = struct<ConcurrentDeclaredStruct> { Value=42 }
 assert(value.Value is 42)
 ]]
       else
          statement = [[
-struct ConcurrentDeclaredStruct { Value: double }
+struct ConcurrentDeclaredStruct Value: double end
 local value = struct<ConcurrentDeclaredStruct> { Value=42.5 }
 assert(value.Value is 42.5)
 ]]
       end
       if (i & 2) is 0 then
          statement ..= [[
-struct ConcurrentInvalidStruct { Value: mystery }]]
+struct ConcurrentInvalidStruct Value: mystery end]]
       end
       scripts:push(obj.new('tiri', { statement=statement }))
    end
@@ -409,7 +415,7 @@ struct ConcurrentInvalidStruct { Value: mystery }]]
    check proc.sleep()
    assert(succeeded is total / 2 and failed is total / 2,
       f'Expected equal successful and failed concurrent declarations, got {succeeded}/{failed}')
-   exec([[struct ConcurrentDeclaredStruct { Value: int }
+   exec([[struct ConcurrentDeclaredStruct Value: int end
 assert(struct<ConcurrentDeclaredStruct> { Value=17 }.Value is 17)]])
 end
 

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -10,6 +10,7 @@ rx_def_assign         <const> = <{ regex.new([[^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=]
 rx_def_param          <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)]]) }>
 rx_def_struct         <const> = <{ regex.new([[^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
 rx_def_struct_field   <const> = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)\s*:]]) }>
+rx_def_end            <const> = <{ regex.new([[\bend\b]]) }>
 rx_def_struct_new     <const> = <{ regex.new([=[([A-Za-z_]\w*)\s*=\s*struct\.new\s*\(\s*['"]([A-Za-z_]\w*)['"]]=]) }>
 rx_def_struct_anno    <const> = <{ regex.new([[([A-Za-z_]\w*)\s*:\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
 rx_def_struct_ctor    <const> = <{ regex.new([[([A-Za-z_]\w*)\s*=\s*struct<\s*([A-Za-z_]\w*)\s*>]]) }>
@@ -340,34 +341,17 @@ global function extractDefinitionSymbols(Doc:table):array
    total_lines = getTotalLines(Doc)
    in_block_comment = false
    table_depth = 0
-   local struct_frame  -- { name, depth } while inside a struct declaration body
-   local pending_struct -- Struct declaration waiting for its opening brace
+   local struct_frame  -- Struct name while inside an end-terminated declaration body
 
    for line_num = 0, total_lines - 1 do
       line_text = getLine(Doc, line_num)
       line_code, in_block_comment = maskNonCode(line_text, in_block_comment)
       in_table_literal = table_depth > 0
 
-      if pending_struct then
-         brace_pos = line_code:find('{', 0, true)
-         if brace_pos then
-            remainder = line_code:sub(brace_pos + 1)
-            addStructFieldSymbols(symbols, pending_struct.name, remainder, line_text, line_num, brace_pos)
-            open_depth = updateTableDepth(line_code, 0)
-            if open_depth > 0 then
-               struct_frame = { name = pending_struct.name, depth = open_depth }
-            end
-            pending_struct = nil
-         end
-         table_depth = updateTableDepth(line_code, table_depth)
-         continue
-      end
-
       -- Struct declaration bodies contain only field declarations; register them and skip the other extractors.
       if struct_frame then
-         addStructFieldSymbols(symbols, struct_frame.name, line_code, line_text, line_num, 0)
-         struct_frame.depth = updateTableDepth(line_code, struct_frame.depth)
-         if struct_frame.depth is 0 then struct_frame = nil end
+         addStructFieldSymbols(symbols, struct_frame, line_code, line_text, line_num, 0)
+         if rx_def_end.test(line_code) then struct_frame = nil end
          table_depth = updateTableDepth(line_code, table_depth)
          continue
       end
@@ -378,17 +362,9 @@ global function extractDefinitionSymbols(Doc:table):array
          name_start = line_text:find(struct_name, struct_start, true) or struct_start
          addSymbol(symbols, struct_name, 'struct', line_num, name_start, name_start + #struct_name)
 
-         brace_pos = line_code:find('{', 0, true)
-         if brace_pos then
-            remainder = line_code:sub(brace_pos + 1)
-            addStructFieldSymbols(symbols, struct_name, remainder, line_text, line_num, brace_pos)
-            open_depth = updateTableDepth(line_code, 0)
-            if open_depth > 0 then
-               struct_frame = { name = struct_name, depth = open_depth }
-            end
-         else
-            pending_struct = { name = struct_name }
-         end
+         remainder = line_code:sub(struct_stop)
+         addStructFieldSymbols(symbols, struct_name, remainder, line_text, line_num, struct_stop)
+         if not rx_def_end.test(remainder) then struct_frame = struct_name end
          table_depth = updateTableDepth(line_code, table_depth)
          continue
       end

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -454,9 +454,8 @@ global function tokenizeTiri(Source:str):array
             addToken(line, ident_start, ident_len, 1, 0)  -- range separator operator
          elseif ident is 'struct' then
             -- 'struct' is a soft keyword.  Followed immediately by '<' it forms a struct<Name> type reference or
-            -- explicit construction; followed by an identifier and '{' it begins a declaration (newlines permitted,
-            -- matching the parser's token-based lookahead).  Anything else is the runtime library namespace,
-            -- e.g. struct.new().
+            -- explicit construction; followed by an identifier it begins an end-terminated declaration.  Anything
+            -- else is the runtime library namespace, e.g. struct.new().
             if pos < len and Source:sub(pos, pos + 1) is '<' then
                sk_pos = pos
                sk_col = col
@@ -508,16 +507,12 @@ global function tokenizeTiri(Source:str):array
                after_pos = pos
                after_col = col
                after_line = line
-               skipWhitespace()
-               if pos < len and Source:sub(pos, pos + 1) is '{' then
-                  addToken(sk_line, ident_start, ident_len, 0, 0)  -- 'struct' keyword
-                  addToken(name_line, name_col, name_len, 11, 1)   -- struct name: class + declaration
-                  -- Resume immediately after the struct name; the '{' is tokenised normally
-                  pos = after_pos
-                  col = after_col
-                  line = after_line
-                  sk_matched = true
-               end
+               addToken(sk_line, ident_start, ident_len, 0, 0)  -- 'struct' keyword
+               addToken(name_line, name_col, name_len, 11, 1)   -- struct name: class + declaration
+               pos = after_pos
+               col = after_col
+               line = after_line
+               sk_matched = true
             end
             if not sk_matched then
                pos = sk_pos
@@ -856,7 +851,6 @@ global function extractFoldingRanges(Doc:table):array
    block_stack = array<table>  -- Stack of { line, kind } for nested blocks
    in_block_comment = false
    block_comment_start = 0
-   local pending_struct_line
 
    for line_num = 0, total_lines - 1 do
       line_text = getLine(Doc, line_num)
@@ -901,49 +895,6 @@ global function extractFoldingRanges(Doc:table):array
       -- Find comment position to avoid matching keywords in comments
       comment_pos = line_text:find('--')
 
-      -- Net brace balance for the code portion of the line (struct bodies are brace-delimited)
-      function countLineBraces()
-         limit = comment_pos or #line_text
-         net = 0
-         for i = 0, limit - 1 do
-            c = line_text:sub(i, i + 1)
-            if c is '{' then
-               net++
-            elseif c is '}' then
-               net -= 1
-            end
-         end
-         return net
-      end
-
-      if pending_struct_line != nil then
-         net_braces = countLineBraces()
-         if net_braces > 0 then
-            block_stack:push({ line = pending_struct_line, kind = 'struct', depth = net_braces })
-            pending_struct_line = nil
-         elseif line_text:find('{', 0, true) then
-            pending_struct_line = nil
-         end
-         continue
-      end
-
-      -- While inside a struct declaration body, track brace balance instead of keyword blocks.  Struct bodies
-      -- cannot contain keyword blocks, so this cannot interleave with the frames below.
-      if #block_stack > 0 and block_stack[#block_stack - 1].kind is 'struct' then
-         frame = block_stack[#block_stack - 1]
-         frame.depth += countLineBraces()
-         if frame.depth <= 0 then
-            block_stack:pop()
-            if line_num > frame.line then
-               ranges:push({
-                  startLine = frame.line,
-                  endLine = line_num
-               })
-            end
-         end
-         continue
-      end
-
       -- Check for block openers (only if not in a comment)
       function checkKeyword(RxPattern)
          start_pos, stop_pos = RxPattern.findFirst(line_text)
@@ -983,20 +934,13 @@ global function extractFoldingRanges(Doc:table):array
          block_stack:push({ line = line_num, kind = 'defer' })
       end
 
-      -- struct Name { ... } (brace-delimited declaration block)
+      -- struct Name ... end (declaration block)
       if checkKeyword(rx_kw_struct) then
-         net_braces = countLineBraces()
-         if net_braces > 0 then
-            block_stack:push({ line = line_num, kind = 'struct', depth = net_braces })
-            continue
-         elseif line_text:find('{', 0, true) is nil then
-            pending_struct_line = line_num
-            continue
-         end
+         block_stack:push({ line = line_num, kind = 'struct' })
       end
 
       -- Check for block closers
-      -- 'end' closes function, if, for, while, defer
+      -- 'end' closes function, if, for, while, defer and struct declarations
       if checkKeyword(rx_kw_end) then
          if #block_stack > 0 then
             block_start = block_stack:pop()

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -10,6 +10,7 @@ rx_symbol_decl            = <{ regex.new([[\s*(local|global)\s+([A-Za-z_][A-Za-z
 rx_symbol_assign          = <{ regex.new([[\s*([A-Za-z_][A-Za-z0-9_]*(?:[.:][A-Za-z_][A-Za-z0-9_]*)*)\s*(<const>)?\s*=]]) }>
 rx_symbol_struct          = <{ regex.new([[^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\b]]) }>
 rx_symbol_struct_field    = <{ regex.new([[([A-Za-z_][A-Za-z0-9_]*)\s*:]]) }>
+rx_symbol_struct_end      = <{ regex.new([[\s+end\s*$]]) }>
 
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -330,7 +331,7 @@ function symbolAddStructFields(Symbol:table, LineCode:str, LineText:str, LineNo:
       if s then
          field_name = cap[0]
          field_type = segment:sub(e)
-         close_pos = field_type:find(' end', 0, true)
+         close_pos = rx_symbol_struct_end.findFirst(field_type)
          if close_pos then field_type = field_type:sub(0, close_pos) end
          field_type = field_type:trim()
          name_start = LineText:find(field_name, search_pos, true) or search_pos

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -309,7 +309,7 @@ function symbolDetectModuleValue(LineCode:str, LineText:str, LineNo:num):table
    return nil
 end
 
--- Detect a top-level struct declaration; the opening brace may appear on a later line.
+-- Detect a top-level end-terminated struct declaration.
 
 function symbolDetectStruct(LineCode:str, LineText:str, LineNo:num):table
    start_pos, stop_pos, cap = rx_symbol_struct.findFirst(LineCode)
@@ -330,7 +330,7 @@ function symbolAddStructFields(Symbol:table, LineCode:str, LineText:str, LineNo:
       if s then
          field_name = cap[0]
          field_type = segment:sub(e)
-         close_pos = field_type:find('}', 0, true)
+         close_pos = field_type:find(' end', 0, true)
          if close_pos then field_type = field_type:sub(0, close_pos) end
          field_type = field_type:trim()
          name_start = LineText:find(field_name, search_pos, true) or search_pos
@@ -390,7 +390,7 @@ function symbolCloseBlockFrames(Stack:array, LineCode:str, LineNo:num, LineText:
 end
 
 function symbolIsBraceFrame(Frame:table):bool
-   return Frame.kind is 'table' or Frame.kind is 'struct'
+   return Frame.kind is 'table'
 end
 
 function symbolFindTopTableFrame(Stack:array):table
@@ -479,20 +479,11 @@ global function extractDocumentSymbols(Doc:table):array
          struct_symbol = symbolDetectStruct(symbol_code, line_text, line_num)
          if struct_symbol then
             symbolAddChild(symbols, stack, struct_symbol)
-            open_count = symbolCountChar(symbol_code, '{')
-            close_count = symbolCountChar(symbol_code, '}')
-            brace_pos = symbol_code:find('{', 0, true)
-            remainder = brace_pos and symbol_code:sub(brace_pos + 1) or ''
-            if not brace_pos or open_count > close_count then
-               stack:push({
-                  kind = 'struct',
-                  symbol = struct_symbol,
-                  brace_depth = 0,
-                  awaiting_brace = not brace_pos
-               })
-            end
-            -- Fields declared on the opening line, e.g. struct P { X: int }
-            symbolAddStructFields(struct_symbol, remainder, line_text, line_num, brace_pos or 0)
+            name_start = line_text:find(struct_symbol.name, 0, true) or 0
+            remainder_start = name_start + #struct_symbol.name
+            symbolAddStructFields(struct_symbol, symbol_code:sub(remainder_start), line_text, line_num,
+               remainder_start)
+            stack:push({ kind = 'struct', symbol = struct_symbol })
          else
             module_symbol = symbolDetectModuleValue(symbol_code, line_text, line_num)
             if module_symbol then

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -173,13 +173,13 @@ end
 end
 
 @Test function StructAnnotationResolvesToDeclaration()
-   doc = makeDoc('struct User {\n   Name: string\n}\n\nfunction describe(Person: struct<User>)\nend\n')
+   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction describe(Person: struct<User>)\nend\n')
    locations = resolveDefinition(doc, { line = 4, character = 34 })
    assertLocationLine(locations, 0, 'struct<User> annotation should resolve to the struct declaration')
 end
 
 @Test function StructFieldAccessResolvesToFieldLine()
-   doc = makeDoc('struct User {\n   Name: string\n   Age: int\n}\n\nu = struct.new(\'User\')\nprint(u.Age)\n')
+   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n\nu = struct.new(\'User\')\nprint(u.Age)\n')
    locations = resolveDefinition(doc, { line = 6, character = 9 })
    assertLocationLine(locations, 2, 'Field access should resolve to the field declaration line')
 end
@@ -191,19 +191,19 @@ end
 end
 
 @Test function StructFieldDefinitionUsesInstanceType()
-   doc = makeDoc('struct A { Value: int }\nstruct B { Value: float }\na = struct.new(\'A\')\nprint(a.Value)\n')
+   doc = makeDoc('struct A Value: int end\nstruct B Value: float end\na = struct.new(\'A\')\nprint(a.Value)\n')
    locations = resolveDefinition(doc, { line = 3, character = 10 })
    assertLocationLine(locations, 0, 'Field access should resolve through the instance struct type')
 end
 
-@Test function StructDeclarationWithDeferredBraceResolves()
-   doc = makeDoc('struct User\n{\n   Name: string\n}\n\nfunction describe(Person: struct<User>)\nend\n')
-   locations = resolveDefinition(doc, { line = 5, character = 34 })
-   assertLocationLine(locations, 0, 'A struct declaration with a deferred brace should resolve')
+@Test function EndTerminatedStructDeclarationResolves()
+   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction describe(Person: struct<User>)\nend\n')
+   locations = resolveDefinition(doc, { line = 4, character = 34 })
+   assertLocationLine(locations, 0, 'An end-terminated struct declaration should resolve')
 end
 
 @Test function LaterStructAssignmentDoesNotAffectEarlierDefinition()
-   doc = makeDoc('struct A { Value: int }\nstruct B { Value: float }\na = struct<A> { }\nprint(a.Value)\na = struct<B> { }\n')
+   doc = makeDoc('struct A Value: int end\nstruct B Value: float end\na = struct<A> { }\nprint(a.Value)\na = struct<B> { }\n')
    locations = resolveDefinition(doc, { line = 3, character = 10 })
    assertLocationLine(locations, 0, 'A later assignment must not change the type at an earlier field access')
 end

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -203,13 +203,13 @@ end
 
 @Test function StructDeclarationWithFieldChildren()
    doc = makeDoc([[
-struct User {
+struct User
    Name: string -- The user name
    Age: int
    Sock: obj<NetSocket>
    Buf: char[32]
    Tags: array<float>
-}
+end
 
 function greet()
 end
@@ -222,7 +222,7 @@ end
    assert(user.kind is SYMBOL_KIND.STRUCT, 'Struct declaration should use the struct kind.')
    assert(user.detail is 'struct', 'Struct detail should identify structs.')
    assert(user.range.start.line is 0, 'Struct range should start on the declaration line.')
-   assert(user.range['end'].line is 6, 'Struct range should end at the closing brace.')
+   assert(user.range['end'].line is 6, 'Struct range should end at the end keyword.')
    assert(#user.children is 5, 'Struct should list one child per field.')
 
    name_field = findChild(user, 'Name')
@@ -244,11 +244,11 @@ end
 
 @Test function StructSingleLineAndCommaFields()
    doc = makeDoc([[
-struct Point { X: double, Y: double }
+struct Point X: double, Y: double end
 
-struct Pair {
+struct Pair
    First: int, Second: int
-}
+end
 ]])
    symbols = extractDocumentSymbols(doc)
    point = findSymbol(symbols, 'Point')
@@ -275,19 +275,18 @@ size = struct.size('User')
    assert(user and user.kind is SYMBOL_KIND.VARIABLE, 'struct.new() assignment should remain a variable symbol.')
 end
 
-@Test function StructDeferredBraceAndNestedFieldType()
+@Test function StructBlockAndNestedFieldType()
    doc = makeDoc([[
-struct Child { Value: int }
+struct Child Value: int end
 struct Parent
-{
    Children: array<struct<Child>>
-}
+end
 ]])
    symbols = extractDocumentSymbols(doc)
    parent = findSymbol(symbols, 'Parent')
 
-   assert(parent and parent.kind is SYMBOL_KIND.STRUCT, 'A deferred brace should retain the struct symbol.')
-   assert(parent.range['end'].line is 4, 'The deferred struct frame should close at its brace.')
+   assert(parent and parent.kind is SYMBOL_KIND.STRUCT, 'An end-terminated block should retain the struct symbol.')
+   assert(parent.range['end'].line is 3, 'The struct frame should close at its end keyword.')
    children = findChild(parent, 'Children')
    assert(children, 'The nested generic field should be listed.')
    assert(children.detail is 'array<struct<Child>>', 'Nested generic field types should remain complete.')

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -263,6 +263,16 @@ end
    assert(findChild(pair, 'Second').detail is 'int', 'Second comma-separated field should carry its type.')
 end
 
+@Test function StructSingleLineTabBeforeEnd()
+   doc = makeDoc('struct Point X: double, Y: double\tend\n')
+   symbols = extractDocumentSymbols(doc)
+   point = findSymbol(symbols, 'Point')
+   y_field = findChild(point, 'Y')
+
+   assert(y_field and y_field.detail is 'double',
+      'Whitespace before end should not be included in the final field type.')
+end
+
 @Test function StructLibraryUsageIsNotADeclaration()
    doc = makeDoc([[
 user = struct.new('User')

--- a/tools/tiri_lsp/tests/test_folding.tiri
+++ b/tools/tiri_lsp/tests/test_folding.tiri
@@ -34,20 +34,20 @@ end
 end
 
 @Test function StructBlockFolds()
-   doc = makeDoc('struct User {\n   Name: string\n   Age: int\n}\n')
+   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n')
    ranges = extractFoldingRanges(doc)
-   assert(findRange(ranges, 0, 3), 'Struct declaration blocks should fold to the closing brace.')
+   assert(findRange(ranges, 0, 3), 'Struct declaration blocks should fold to the end keyword.')
 end
 
 @Test function StructFollowedByFunctionFoldsBoth()
-   doc = makeDoc('struct User {\n   Name: string\n}\n\nfunction greet()\n   print(2)\nend\n')
+   doc = makeDoc('struct User\n   Name: string\nend\n\nfunction greet()\n   print(2)\nend\n')
    ranges = extractFoldingRanges(doc)
    assert(findRange(ranges, 0, 2), 'The struct block should fold.')
    assert(findRange(ranges, 4, 6), 'A function after the struct should fold normally.')
 end
 
 @Test function SingleLineStructDoesNotFold()
-   doc = makeDoc('struct Point { X: double, Y: double }\nprint(1)\n')
+   doc = makeDoc('struct Point X: double, Y: double end\nprint(1)\n')
    ranges = extractFoldingRanges(doc)
    assert(#ranges is 0, 'A single-line struct declaration should not create a folding range.')
 end
@@ -58,15 +58,15 @@ end
    assert(#ranges is 0, 'struct.new() usage should not create a folding range.')
 end
 
-@Test function StructDeferredBraceFolds()
-   doc = makeDoc('struct User\n{\n   Name: string\n}\n')
+@Test function StructNameOnOpeningLineFolds()
+   doc = makeDoc('struct User\n   Name: string\n   Age: int\nend\n')
    ranges = extractFoldingRanges(doc)
-   assert(findRange(ranges, 0, 3), 'A deferred opening brace should fold from the struct declaration.')
+   assert(findRange(ranges, 0, 3), 'An end-terminated struct should fold from its declaration.')
 end
 
-@Test function SingleLineBodyAfterDeferredBraceDoesNotFold()
-   doc = makeDoc('struct Empty\n{}\nfunction greet()\nend\n')
+@Test function FoldingResumesAfterStructEnd()
+   doc = makeDoc('struct Item\n   Value: int\nend\nfunction greet()\nend\n')
    ranges = extractFoldingRanges(doc)
-   assert(not findRange(ranges, 0, 1), 'A single-line body should not create a struct folding range.')
-   assert(findRange(ranges, 2, 3), 'Folding should resume after the deferred single-line body.')
+   assert(findRange(ranges, 0, 2), 'The struct should close at its end keyword.')
+   assert(findRange(ranges, 3, 4), 'Folding should resume after the struct block.')
 end

--- a/tools/tiri_lsp/tests/test_hover.tiri
+++ b/tools/tiri_lsp/tests/test_hover.tiri
@@ -180,10 +180,10 @@ end
 
 @Test function StructDeclarationHoverShowsFields()
    hover, token = hoverAt([[
-struct Us|er {
+struct Us|er
    Name: string -- The user name
    Age: int
-}
+end
 ]])
 
    assert(token and token.text is 'User', 'Hover token extraction should identify the struct name.')
@@ -195,10 +195,10 @@ end
 
 @Test function StructFieldHoverViaStructNew()
    hover, token = hoverAt([[
-struct User {
+struct User
    Name: string -- The user name
    Age: int
-}
+end
 u = struct.new('User')
 print(u.Na|me)
 ]])
@@ -211,10 +211,10 @@ end
 
 @Test function StructFieldHoverViaAnnotatedParameter()
    hover, token = hoverAt([[
-struct User {
+struct User
    Name: string
    Age: int -- Age in years
-}
+end
 function describe(Person: struct<User>)
    return Person.Ag|e
 end
@@ -227,9 +227,9 @@ end
 
 @Test function StructFieldHoverViaConstruction()
    hover, token = hoverAt([[
-struct User {
+struct User
    Name: string -- The user name
-}
+end
 user = struct<User> { Name = 'Paul' }
 print(user.Na|me)
 ]])
@@ -240,9 +240,9 @@ end
 
 @Test function StructUnknownFieldHasNoHover()
    hover, token = hoverAt([[
-struct User {
+struct User
    Name: string
-}
+end
 u = struct.new('User')
 print(u.Mis|sing)
 ]])
@@ -253,12 +253,12 @@ end
 
 @Test function LaterStructAssignmentDoesNotAffectEarlierHover()
    hover, token = hoverAt([[
-struct A {
+struct A
    Value: int -- Value from A
-}
-struct B {
+end
+struct B
    Value: float -- Value from B
-}
+end
 u = struct.new('A')
 print(u.Val|ue)
 u = struct.new('B')

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -305,9 +305,9 @@ end
 end
 
 @Test function StructDeclarationReceivesKeywordToken()
-   source = 'struct User {\n' ..
+   source = 'struct User\n' ..
       '   Name: string\n' ..
-      '}\n'
+      'end\n'
 
    tokens = tokenizeTiri(source)
 
@@ -339,19 +339,19 @@ end
    assert(anno_name and anno_name.type is 11, 'The annotated struct name should be a class token.')
 end
 
-@Test function StructDeclarationBraceOnNextLine()
-   source = 'struct User\n' ..
-      '{\n' ..
+@Test function StructDeclarationNameOnNextLine()
+   source = 'struct\n' ..
+      'User\n' ..
       '   Name: string\n' ..
-      '}\n'
+      'end\n'
 
    tokens = tokenizeTiri(source)
 
    struct_keyword = findToken(tokens, 0, 0, 'struct')
-   struct_name = findToken(tokens, 0, 7, 'User')
+   struct_name = findToken(tokens, 1, 0, 'User')
 
-   assert(struct_keyword and struct_keyword.type is 0, 'A brace on the following line is still a declaration.')
-   assert(struct_name and struct_name.type is 11, 'The struct name should be a class token with the brace deferred.')
+   assert(struct_keyword and struct_keyword.type is 0, 'struct should remain a declaration keyword before a newline.')
+   assert(struct_name and struct_name.type is 11, 'A declaration name on the following line should be a class token.')
 end
 
 @Test function StructLibraryRemainsNamespace()

--- a/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
+++ b/tools/tiri_lsp/vscode_plugin/syntaxes/tiri.tmLanguage.json
@@ -309,7 +309,7 @@
             },
             {
                "name": "meta.struct.declaration.tiri",
-               "match": "\\b(struct)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(?=\\{)",
+               "match": "\\b(struct)\\s+([A-Za-z_][A-Za-z0-9_]*)\\b",
                "captures": {
                   "1": {
                      "name": "storage.type.struct.tiri"


### PR DESCRIPTION
* Updated parser dispatch and diagnostics while retaining explicit struct<Name> constructors
* Migrated parser and Flute coverage to end-terminated declarations
* [LSP] Simplified semantic tokens, folding, symbols and definitions for struct blocks