### PR TITLE
[Core] Hardened timer subscriber lifetime management

### DIFF
--- a/include/kotuku/system/internals.h
+++ b/include/kotuku/system/internals.h
@@ -39,9 +39,8 @@ public:
    int64_t   LastCall;        // PreciseTime() recorded at the last call (us)
    int64_t   Interval;        // The amount of microseconds to wait at each interval
    int64_t   PendingInterval; // Switch to this interval after completing the next cycle
-   OBJECTPTR Subscriber;      // The object that is subscribed (pointer, if private)
-   OBJECTID  SubscriberID;    // The object that is subscribed
-   FUNCTION  Routine;         // Routine to call if not using AC::Timer - ERR Routine(OBJECTID, int, int);
+   OBJECTPTR Subscriber;      // Weak-pinned subscriber, or null for internal subscriptions with no subscriber
+   FUNCTION  Routine;         // Routine to call on trigger
    uint8_t   Cycle;
    bool      Locked;
 };
@@ -53,8 +52,9 @@ public:
 class ObjectRecord {
 public:
    OBJECTPTR Object;
-   OBJECTPTR Owner; // Null or a valid pointer whilst glmObjects is held; nulled by object_free() when the owner dies first
-   // Object children; entries are valid pointers whilst glmObjects is held.  Pinning of child objects is unnecessary,
+   // Can be null or a valid pointer whilst glmObjects is held.  Nulled by object_free() when the owner dies first.
+   OBJECTPTR Owner; 
+   // Object children entries are valid pointers whilst glmObjects is held.  Pinning of child objects is unnecessary,
    // the code has been designed for this and maintaining that behaviour is essential.
    ankerl::unordered_dense::set<OBJECTPTR> Children;
    ankerl::unordered_dense::set<RESOURCEID> Resources; // Non-object resources

--- a/src/core/lib_functions.cpp
+++ b/src/core/lib_functions.cpp
@@ -958,7 +958,6 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
       }
 
       auto it = glTimers.emplace(glTimers.end());
-      it->SubscriberID    = subscriber->UID;
       it->Interval        = usInterval;
       it->PendingInterval = 0;
       it->LastCall        = subscribed;
@@ -969,8 +968,13 @@ ERR SubscribeTimer(double Interval, FUNCTION *Callback, APTR *Subscription)
 
       it->Routine.pin();
 
-      if (subscriber->UID > 0) it->Subscriber = subscriber;
-      else it->Subscriber = nullptr;
+      if (subscriber->UID) {
+         // The weak pin keeps the subscriber's header readable so that the dispatcher can detect and remove
+         // orphaned subscriptions if the object_free() cleanup misses them due to a glmTimer lock timeout.
+         it->Subscriber = subscriber;
+         subscriber->pinWeak();
+      }
+      else it->Subscriber = nullptr; // Subscribed from the dummy context; internal subscriptions have no subscriber
 
       // This flag lets object_free() cheaply detect and remove abandoned timer subscriptions.
       subscriber->setFlag(NF::TIMER_SUB);
@@ -1051,6 +1055,7 @@ ERR UpdateTimer(APTR Subscription, double Interval)
 
          for (auto it=glTimers.begin(); it != glTimers.end(); it++) {
             if (timer IS &(*it)) {
+               if (it->Subscriber) it->Subscriber->unpinWeak();
                glTimers.erase(it);
                break;
             }

--- a/src/core/lib_messages.cpp
+++ b/src/core/lib_messages.cpp
@@ -338,6 +338,7 @@ timer_cycle:
             if (current_time < timer->NextCall) { timer++; continue; }
             if (timer->Cycle IS glTimerCycle) { timer++; continue; }
             if (timer->Routine.releaseIfStale()) {
+               if (timer->Subscriber) timer->Subscriber->unpinWeak();
                timer = glTimers.erase(timer);
                continue;
             }
@@ -354,38 +355,43 @@ timer_cycle:
             timer->LastCall = current_time;
             timer->Cycle = glTimerCycle;
 
-            //log.trace("Subscriber: %d, Interval: %d, Time: %" PRId64, timer->SubscriberID, timer->Interval, current_time);
-
             timer->Locked = true; // Prevents termination of the structure irrespective of having a TL_TIMER lock.
 
             bool relock = false;
-            if (timer->Routine.isC()) {
-               OBJECTPTR subscriber;
-               if (!timer->SubscriberID) { // Internal subscriptions like process_janitor() don't have a subscriber
+            if ((timer->Subscriber) and (timer->Subscriber->terminating())) {
+               // Orphaned entry: the subscriber terminated but object_free() could not acquire glmTimer to remove
+               // the subscription.  The weak pin keeps the subscriber's header readable for this detection.
+               error = ERR::Terminate;
+            }
+            else if (timer->Routine.isC()) {
+               if (auto subscriber = timer->Subscriber) {
+                  if (!LockObject(subscriber, 50)) {
+                     kt::SwitchContext context(subscriber);
+
+                     auto routine = (ERR (*)(OBJECTPTR, int64_t, int64_t, APTR))timer->Routine.Routine;
+                     glmTimer.unlock();
+                     relock = true;
+
+                     error = routine(subscriber, elapsed, current_time, timer->Routine.Meta);
+
+                     ReleaseObject(subscriber);
+                  }
+                  else error = ERR::AccessObject;
+               }
+               else { // Internal subscriptions like process_janitor() don't have a subscriber
                   auto routine = (ERR (*)(OBJECTPTR, int64_t, int64_t, APTR))timer->Routine.Routine;
                   glmTimer.unlock();
                   relock = true;
                   error = routine(nullptr, elapsed, current_time, timer->Routine.Meta);
                }
-               else if (!AccessObject(timer->SubscriberID, 50, &subscriber)) {
-                  kt::SwitchContext context(subscriber);
-
-                  auto routine = (ERR (*)(OBJECTPTR, int64_t, int64_t, APTR))timer->Routine.Routine;
-                  glmTimer.unlock();
-                  relock = true;
-
-                  error = routine(subscriber, elapsed, current_time, timer->Routine.Meta);
-
-                  ReleaseObject(subscriber);
-               }
-               else error = ERR::AccessObject;
             }
             else if (timer->Routine.isScript()) {
+               OBJECTID subscriber_id = timer->Subscriber ? timer->Subscriber->UID : 0;
                glmTimer.unlock();
                relock = true;
 
                if (sc::Call(timer->Routine, std::to_array<ScriptArg>({
-                     { "Subscriber",  timer->SubscriberID, FDF_OBJECTID },
+                     { "Subscriber",  subscriber_id, FDF_OBJECTID },
                      { "Elapsed",     elapsed },
                      { "CurrentTime", current_time }
                   }), error) != ERR::Okay) error = ERR::Terminate;
@@ -399,6 +405,7 @@ timer_cycle:
                   ((objScript *)timer->Routine.Context)->derefProcedure(timer->Routine);
                }
                if (timer->Routine.defined()) timer->Routine.unpin();
+               if (timer->Subscriber) timer->Subscriber->unpinWeak();
 
                timer = glTimers.erase(timer);
             }

--- a/src/core/lib_objects.cpp
+++ b/src/core/lib_objects.cpp
@@ -459,13 +459,14 @@ ERR object_free(ResourceRecord &Resource, Object *Object)
 
          if (auto lock = std::unique_lock{glmTimer, 1000ms}) {
             for (auto it=glTimers.begin(); it != glTimers.end(); ) {
-               if (it->SubscriberID IS Object->UID) {
+               if (it->Subscriber IS Object) {
                   log.warning("%s object #%d has an unfreed timer subscription, routine %p, interval %" PF64,
                      mc->ClassName.c_str(), Object->UID, &it->Routine, (long long)it->Interval);
                   if (it->Routine.isScript() and (not it->Routine.stale()) and (it->Routine.Context != Object)) {
                      script_routines.emplace_back(it->Routine);
                   }
                   if (it->Routine.defined()) it->Routine.unpin();
+                  it->Subscriber->unpinWeak();
                   it = glTimers.erase(it);
                }
                else it++;


### PR DESCRIPTION
* Weak-pinned timer subscribers so orphaned subscriptions remain safely detectable during object teardown
* Released subscriber pins across cancellation, stale callback and termination cleanup paths
* Replaced subscriber ID lookups with direct locked access to the retained object header