### PR TITLE
[Core] Fixed path-only file ownership fields

### DIFF
--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -167,22 +167,22 @@ end
 
 function file_to_info(Path:str):table
    try
-      file = obj.new('file', { path=Path })
+      local fl = obj.new('file', { path=Path })
 
-      local folder_name, file_name = io.splitPath(file.path)
+      local folder_name, file_name = io.splitPath(fl.path)
 
       info = {
          name        = file_name,
-         size        = file.size,
-         timestamp   = file.timestamp,
-         modified    = file.date,
-         permissions = file.permissions,
-         userID      = file.user,
-         groupID     = file.group,
+         size        = fl.size,
+         timestamp   = fl.timestamp,
+         modified    = fl.date,
+         permissions = fl.permissions,
+         userID      = fl.user,
+         groupID     = fl.group,
          flags       = 0
       }
 
-      file_flags = file.flags
+      file_flags = fl.flags
       if file_flags has FL_FILE    then info.flags = info.flags | RDF_FILE end
       if file_flags has FL_FOLDER  then info.flags = info.flags | RDF_FOLDER end
       if file_flags has FL_LINK    then info.flags = info.flags | RDF_LINK end
@@ -192,6 +192,8 @@ function file_to_info(Path:str):table
       if Path:endsWith(':') then info.flags = info.flags | RDF_VOLUME end
 
       return info
+   except ex
+      msg('file_to_info() failed for ' .. Path .. ' with exception: ' .. ex.message)
    end
 end
 
@@ -777,7 +779,7 @@ gui.fileview = function(Options)
       if sort then self.view.sort() end
    end
 
-   function pathWatch(MonitoredFile, Path, Flags)
+   function pathWatch(MonitoredFile, Path:str, Flags:num)
       if self.inRefresh then return end
 
       if Flags is 0 then -- No flags means a change has occurred but the host is unable to tell us what happened.
@@ -842,7 +844,7 @@ gui.fileview = function(Options)
             end
             self.view.sort()
          else
-            msg('Attrib change misreported - file does not exist.')
+            msg(f'Attrib change for "{Path}" misreported, error {mSys.GetErrorMsg(info_err)}')
             deleteItem(Path)
          end
       end

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -2000,7 +2000,16 @@ static ERR GET_Group(extFile *Self, int *Value)
 {
 #ifdef __unix__
    struct stat64 info;
-   if (fstat64(Self->Handle, &info) IS -1) return ERR::FileNotFound;
+
+   if (Self->Handle != -1) {
+      if (fstat64(Self->Handle, &info) IS -1) return convert_errno(errno, ERR::SystemCall);
+   }
+   else {
+      std::string_view path;
+      if (auto error = GET_ResolvedPath(Self, path); error != ERR::Okay) return error;
+      if (stat64(path.data(), &info) IS -1) return convert_errno(errno, ERR::SystemCall);
+   }
+
    *Value = info.st_gid;
    return ERR::Okay;
 #else
@@ -2705,7 +2714,14 @@ static ERR GET_User(extFile *Self, int *Value)
 #ifdef __unix__
    struct stat64 info;
 
-   if (fstat64(Self->Handle, &info) IS -1) return ERR::FileNotFound;
+   if (Self->Handle != -1) {
+      if (fstat64(Self->Handle, &info) IS -1) return convert_errno(errno, ERR::SystemCall);
+   }
+   else {
+      std::string_view path;
+      if (auto error = GET_ResolvedPath(Self, path); error != ERR::Okay) return error;
+      if (stat64(path.data(), &info) IS -1) return convert_errno(errno, ERR::SystemCall);
+   }
 
    *Value = info.st_uid;
    return ERR::Okay;

--- a/src/core/tests/test_filesystem.tiri
+++ b/src/core/tests/test_filesystem.tiri
@@ -2,6 +2,8 @@
 Tests for file functions
 --]]
 
+extern logOutput
+
 glPath = 'kotuku:'
 glTempRoot = 'temp:filesystem_tests/'
 
@@ -14,17 +16,17 @@ function ensureFolder(Path)
    end
 end
 
-function resetPath(Path)
+function resetPath(Path:str)
    mSys.DeleteFile(Path)
 end
 
-function writeFile(Path, Content)
+function writeFile(Path:str, Content:str)
    file = obj.new('file', { path=Path, flags=FL_NEW|FL_WRITE })
    file.acWrite(Content, #Content)
    file.free()
 end
 
-function readFile(Path)
+function readFile(Path:str):str
    file = obj.new('file', { path=Path })
    buffer = array<byte, file.size>
    err = mSys.ReadFileToBuffer(Path, buffer)
@@ -134,6 +136,34 @@ end
 
    fl.acSeek(SEEK_START, 0)
    fl.acWrite(buf:reverse())
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test; @Requires(linux_platform=true)
+function PathOnlyFileOwnership()
+   ownership_path = glTempRoot .. 'ownership.txt'
+   writeFile(ownership_path, 'ownership')
+
+   path_file = obj.new('file', { path=ownership_path })
+   open_file = obj.new('file', { path=ownership_path, flags=FL_READ })
+
+   assert(path_file.user is open_file.user, 'A path-only File should report the same user ID as an open File.')
+   assert(path_file.group is open_file.group, 'A path-only File should report the same group ID as an open File.')
+
+   missing_path = glTempRoot .. 'missing-ownership.txt'
+   writeFile(missing_path, 'ownership')
+   missing_file = obj.new('file', { path=missing_path })
+   err = mSys.DeleteFile(missing_path)
+   assert(err is ERR_Okay, 'Failed to remove ownership test file: ' .. mSys.GetErrorMsg(err))
+   try
+      print(missing_file.user)
+   except ex
+      assert(ex.message:startsWith('Read failure: File.user:'),
+         'A failed field read should identify File.user, got: ' .. ex.message)
+   success
+      error('Reading User for a missing file should fail.')
+   end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -550,7 +580,7 @@ end
    out.free()
 
    -- Pump the message queue so inotify / ReadDirectoryChangesW events are delivered.
-   for i=0,20 do
+   for {0 to 20} do
       processing.sleep(0.05)
       if #events > 0 then break end
    end

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -245,7 +245,8 @@ extern "C" void bc_object_getfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
    if (func->Call(L, *func, Obj) > 0) copyTV(L, Dest, L->top - 1);
    else { // An error occurred and is stored in L->CaughtError
       if (L->CaughtError > ERR::ExceptionThreshold) {
-         luaL_error(L, L->CaughtError, "Read failure: %s.%s: %s", cl->ClassName.c_str(), luaL_checkstring(L, 2), GetErrorMsg(L->CaughtError));
+         luaL_error(L, L->CaughtError, "Read failure: %s.%s: %s", cl->ClassName.c_str(), strdata(Key),
+            GetErrorMsg(L->CaughtError));
       }
 
       setnilV(Dest);


### PR DESCRIPTION
* Read user and group IDs from resolved paths when file handles are unavailable
* [Tiri] Report failing object field names without reading invalid stack values
* [Script] Hardened file view metadata conversion and diagnostics
* [Test] Covered path-only ownership and field read failures