### PR TITLE
[Display] Exposed bitmap data arrays for perceptual SVG hashes

### DIFF
--- a/docs/xml/modules/classes/bitmap.xml
+++ b/docs/xml/modules/classes/bitmap.xml
@@ -611,11 +611,12 @@ unpackAlpha(Colour)
 
     <field>
       <name>Data</name>
-      <comment>Pointer to a bitmap's data area.</comment>
-      <access read="R" write="S">Read/Set</access>
-      <type>UINT8 *</type>
+      <comment>Provides direct access to the bitmap's data area.</comment>
+      <access read="G" write="S">Get/Set</access>
+      <type>UINT8[]</type>
       <description>
 <p>Data points to the first byte of the bitmap's pixel buffer when CPU-visible memory is available.  Caller-supplied memory can be used for data-backed bitmaps, but most callers should let <action>Init</action> allocate the correctly sized buffer.</p>
+<p>Tiri exposes Data as a fixed-length byte array containing <fl>Size</fl> elements.  The array references the bitmap's existing storage directly and must not outlive the bitmap.</p>
 <p>For video or texture-backed bitmaps, <fl>Data</fl> may be unavailable until <action>Lock</action> succeeds.</p>
       </description>
     </field>

--- a/docs/xml/modules/display.xml
+++ b/docs/xml/modules/display.xml
@@ -10,7 +10,7 @@
     <prefix>gfx</prefix>
     <copyright>Paul Manias © 2003-2026</copyright>
     <source>
-      <file path="src/display/">display-driver.cpp</file>
+      <file path="src/display/">display.cpp</file>
       <file path="src/display/">lib_bitmap.cpp</file>
       <file path="src/display/">lib_display.cpp</file>
       <file path="src/display/">lib_cursor.cpp</file>

--- a/include/kotuku/modules/display.h
+++ b/include/kotuku/modules/display.h
@@ -564,7 +564,7 @@ class objBitmap : public Object {
    void (*ReadUCRPixel)(objBitmap *, int, int, struct RGB8 *);     // Points to a C function that reads pixels from the bitmap in RGB format.
    void (*ReadUCRIndex)(objBitmap *, uint8_t *, struct RGB8 *);    // Points to a C function that reads pixels from the bitmap in RGB format.
    void (*DrawUCRIndex)(objBitmap *, uint8_t *, struct RGB8 *);    // Points to a C function that draws pixels to the bitmap in RGB format.
-   uint8_t * Data;                                                 // Pointer to a bitmap's data area.
+   uint8_t * Data;                                                 // Provides direct access to the bitmap's data area.
    int       Width;                                                // The width of the bitmap, in pixels.
    int       ByteWidth;                                            // The width of the bitmap, in bytes.
    int       Height;                                               // The height of the bitmap, in pixels.
@@ -773,9 +773,13 @@ class objBitmap : public Object {
       return ERR::Okay;
    }
 
-   inline ERR getData(uint8_t * &Value) noexcept {
-      Value = this->Data;
-      return ERR::Okay;
+   inline ERR getData(std::span<uint8_t> &Value) noexcept {
+      auto field = &this->Class->Dictionary[27];
+      SetObjectContext(this, field, AC::NIL);
+      auto get_field = (ERR (*)(APTR, std::span<uint8_t> &))field->GetValue;
+      auto error = get_field(this, Value);
+      RestoreObjectContext();
+      return error;
    }
 
    inline ERR getWidth(int &Value) noexcept {
@@ -916,9 +920,9 @@ class objBitmap : public Object {
       return field->WriteValue(this, field, 0x08000300, Value);
    }
 
-   inline ERR setData(uint8_t * Value) noexcept {
+   inline ERR setData(std::span<const uint8_t> Value) noexcept {
       auto field = &this->Class->Dictionary[27];
-      return field->WriteValue(this, field, 0x08000500, Value);
+      return field->WriteValue(this, field, 0x01001500, &Value);
    }
 
    inline ERR setWidth(const int Value) noexcept {

--- a/src/display/class_bitmap.cpp
+++ b/src/display/class_bitmap.cpp
@@ -144,12 +144,13 @@ static void DrawRGBPixelPlanar(objBitmap *, int X, int Y, RGB8 *);
 //********************************************************************************************************************
 
 static ERR GET_Handle(extBitmap *, APTR *);
+static ERR GET_Data(extBitmap *, std::span<uint8_t> &);
 
 static ERR SET_Bkgd(extBitmap *, RGB8 *);
 static ERR SET_BkgdIndex(extBitmap *, int);
 static ERR SET_Trans(extBitmap *, RGB8 *);
 static ERR SET_TransIndex(extBitmap *, int);
-static ERR SET_Data(extBitmap *, uint8_t *);
+static ERR SET_Data(extBitmap *, std::span<const uint8_t> &);
 static ERR SET_Handle(extBitmap *, APTR);
 static ERR SET_Palette(extBitmap *, RGBPalette *);
 
@@ -2190,22 +2191,33 @@ unpackAlpha(Colour)
 </pre>
 
 -FIELD-
-Data: Pointer to a bitmap's data area.
+Data: Provides direct access to the bitmap's data area.
 
 Data points to the first byte of the bitmap's pixel buffer when CPU-visible memory is available.  Caller-supplied
 memory can be used for data-backed bitmaps, but most callers should let #Init() allocate the correctly sized buffer.
+
+Tiri exposes Data as a fixed-length byte array containing #Size elements.  The array references the bitmap's existing
+storage directly and must not outlive the bitmap.
 
 For video or texture-backed bitmaps, #Data may be unavailable until #Lock() succeeds.
 
 *********************************************************************************************************************/
 
-ERR SET_Data(extBitmap *Self, uint8_t *Value)
+static ERR GET_Data(extBitmap *Self, std::span<uint8_t> &Value)
+{
+   if ((not Self->Data) or (Self->Size <= 0)) return ERR::FieldNotSet;
+
+   Value = std::span<uint8_t>(Self->Data, size_t(Self->Size));
+   return ERR::Okay;
+}
+
+static ERR SET_Data(extBitmap *Self, std::span<const uint8_t> &Value)
 {
 #ifdef __xwindows__
    if (Self->x11.XShmImage) return ERR::NotPossible;
 #endif
 
-   if (Self->Data != Value) Self->Data = Value;
+   Self->Data = const_cast<uint8_t *>(Value.data());
    return ERR::Okay;
 }
 
@@ -2738,7 +2750,7 @@ static const FieldArray clBitmapFields[] = {
    { "ReadUCRPixel",  FDF_POINTER|FDF_R },
    { "ReadUCRIndex",  FDF_POINTER|FDF_R },
    { "DrawUCRIndex",  FDF_POINTER|FDF_R },
-   { "Data",          FDF_POINTER|FDF_RI, nullptr, SET_Data },
+   { "Data",          FDF_ARRAY|FDF_BYTE|FDF_RI, GET_Data, SET_Data },
    { "Width",         FDF_INT|FDF_RI, nullptr, nullptr },
    { "ByteWidth",     FDF_INT|FDF_R, nullptr, nullptr },
    { "Height",        FDF_INT|FDF_RI, nullptr, nullptr },

--- a/src/display/display.tdl
+++ b/src/display/display.tdl
@@ -2,7 +2,7 @@
 
 module({
     name="Display", copyright="Paul Manias © 2003-2026", version=1.0, status="stable", prefix="gfx", timestamp=20240611,
-    src={ "display-driver.cpp", "lib_bitmap.cpp", "lib_display.cpp", "lib_cursor.cpp", "lib_input.cpp", "lib_surfaces.cpp" }
+    src={ "display.cpp", "lib_bitmap.cpp", "lib_display.cpp", "lib_cursor.cpp", "lib_input.cpp", "lib_surfaces.cpp" }
   }, function()
 
   restrict(function()
@@ -391,7 +391,7 @@ module({
     fptr(void obj(Bitmap) int int struct(*RGB8)) ReadUCRPixel
     fptr(void obj(Bitmap) ptr(uchar) struct(*RGB8)) ReadUCRIndex
     fptr(void obj(Bitmap) ptr(uchar) struct(*RGB8)) DrawUCRIndex
-    ptr(uchar) Data             # Pointer to bitmap data area
+    array(uchar) Data           # Bitmap data area
     int   Width                 # Width
     int   ByteWidth             # Byte width (not including padding - see `LineWidth`)
     int   Height                # Height

--- a/src/regex/srell/srell.hpp
+++ b/src/regex/srell/srell.hpp
@@ -4730,6 +4730,7 @@ private:
       cvars_type cvars;
       state_type flstate;
 
+      piecesize.reset();
       this->reset(flags);
       cvars.reset(flags, begin);
 

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -150,7 +150,7 @@ end
 
 function pHashString(Hash:array):str
    local result = ''
-   for i = 0, #Hash - 1 do result ..= string.format('%d', Hash[i]) end
+   for i = 0, #Hash - 1 do result ..= string.format('%d,', Hash[i]) end
    return result
 end
 
@@ -278,7 +278,7 @@ end
 @Test global function ContourGradient() pHashTestSVG('gradients/contour-gradient.svg', array<byte> { 0x76,0x97,0xa3,0x8d,0x18,0xb0,0x7c,0x43 }, 6, true) end
 @Test global function MeshGradient() hashTestSVG('gradients/meshgradient.svg', 0x647d054f) end
 @Test global function DiffusionGradient() hashTestSVG('gradients/diffusiongradient.svg', 0xafe6ee58) end
-@Test global function MeshGradientInkscape() hashTestSVG('gradients/meshgradient_inkscape.svg', 0xeefbdff2) end
+@Test global function MeshGradientInkscape() pHashTestSVG('gradients/meshgradient_inkscape.svg', array<byte> { 110,238,145,49,230,131,1,110 }, 6, true) end
 @Test global function W3Gradients01() hashTestSVG('gradients/w3-pservers-grad-01-b.svg', 0xd6ab0e01) end
 @Test global function W3Gradients02() hashTestSVG('gradients/w3-pservers-grad-02-b.svg', 0xe8e84124) end
 @Test global function W3Gradients04() hashTestSVG('gradients/w3-pservers-grad-04-b.svg', 0x11d0611e) end

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -63,6 +63,128 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+-- Generate a 64-bit perceptual hash from a bitmap.  The image is reduced to 32x32 luminance samples before applying
+-- an 8x8 discrete cosine transform.  Bitmap.data is an external byte-array view over the pixel buffer, so this avoids
+-- the overhead of calling a pixel reader for every source pixel.
+
+function pHash(Bitmap:obj):array
+   local sample_size <const> = 32
+   local dct_size <const> = 8
+   local pixels = Bitmap.data
+   local format = Bitmap.colourFormat
+   local bytes_per_pixel = Bitmap.bytesPerPixel
+   local red_offset = format.redPos / 8
+   local green_offset = format.greenPos / 8
+   local blue_offset = format.bluePos / 8
+   local samples = array<double>
+
+   for sample_y = 0, sample_size - 1 do
+      local y_start = math.floor((sample_y * Bitmap.height) / sample_size)
+      local y_end = math.floor(((sample_y + 1) * Bitmap.height) / sample_size)
+
+      for sample_x = 0, sample_size - 1 do
+         local x_start = math.floor((sample_x * Bitmap.width) / sample_size)
+         local x_end = math.floor(((sample_x + 1) * Bitmap.width) / sample_size)
+         local luminance = 0
+
+         for y = y_start, y_end - 1 do
+            local pixel = (y * Bitmap.lineWidth) + (x_start * bytes_per_pixel)
+            for x = x_start, x_end - 1 do
+               luminance += (77 * pixels[pixel + red_offset]) + (150 * pixels[pixel + green_offset]) +
+                  (29 * pixels[pixel + blue_offset])
+               pixel += bytes_per_pixel
+            end
+         end
+
+         samples:push(luminance / (256 * (x_end - x_start) * (y_end - y_start)))
+      end
+   end
+
+   local cosines = array<double>
+   for frequency = 0, dct_size - 1 do
+      for position = 0, sample_size - 1 do
+         cosines:push(math.cos(((2 * position + 1) * frequency * math.pi) / (2 * sample_size)))
+      end
+   end
+
+   local row_dct = array<double>
+   for y = 0, sample_size - 1 do
+      for frequency_x = 0, dct_size - 1 do
+         local coefficient = 0
+         for x = 0, sample_size - 1 do
+            coefficient += samples[(y * sample_size) + x] * cosines[(frequency_x * sample_size) + x]
+         end
+         row_dct:push(coefficient)
+      end
+   end
+
+   local coefficients = array<double>
+   for frequency_y = 0, dct_size - 1 do
+      for frequency_x = 0, dct_size - 1 do
+         local coefficient = 0
+         for y = 0, sample_size - 1 do
+            coefficient += row_dct[(y * dct_size) + frequency_x] * cosines[(frequency_y * sample_size) + y]
+         end
+         coefficients:push(coefficient)
+      end
+   end
+
+   local ac_coefficients = array<double>
+   for i = 1, #coefficients - 1 do ac_coefficients:push(coefficients[i]) end
+   ac_coefficients:sort()
+   local median = ac_coefficients[math.floor(#ac_coefficients / 2)]
+   local fingerprint = array<byte> { 0, 0, 0, 0, 0, 0, 0, 0 }
+
+   for i = 1, #coefficients - 1 do
+      if coefficients[i] > median then
+         local bit_index = i - 1
+         local byte_index = math.floor(bit_index / 8)
+         fingerprint[byte_index] = bit.bor(fingerprint[byte_index], bit.lshift(1, bit_index % 8))
+      end
+   end
+
+   return fingerprint
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+function pHashString(Hash:array):str
+   local result = ''
+   for i = 0, #Hash - 1 do result ..= string.format('%d', Hash[i]) end
+   return result
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+function pHashDistance(Left:array, Right:array):num
+   assert(#Left is #Right, 'Perceptual hashes must have the same length')
+   local set_bits <const> = array<byte> { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 }
+   local distance = 0
+
+   for i = 0, #Left - 1 do
+      local difference = bit.bxor(Left[i], Right[i])
+      distance += set_bits[bit.band(difference, 0x0f)] + set_bits[bit.rshift(difference, 4)]
+   end
+
+   return distance
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+function pHashTestSVG(Path:str, ExpectedHash:array, MaxDistance:num, Stable:bool)
+   local bmp = renderSVGToBitmap(glSVGFolder .. Path, Stable)
+   local hash = pHash(bmp)
+   local distance = pHashDistance(hash, ExpectedHash)
+
+   if distance > MaxDistance then
+      saveBitmap(bmp, Path)
+      error('Computed pHash for "' .. Path .. '" is ' .. pHashString(hash) .. ', expected ' ..
+         pHashString(ExpectedHash) .. ' (Hamming distance ' .. distance .. ', maximum ' .. MaxDistance .. ')')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test global function Basics01() hashTestSVG('basics/w3-render-elems-01-t.svg', 0x8ab4f1f1) end
 @Test global function Basics02() hashTestSVG('basics/w3-render-elems-02-t.svg', 0x16c115bb) end
 @Test global function Basics03() hashTestSVG('basics/w3-render-elems-03-t.svg', -1) end
@@ -153,8 +275,10 @@ end
 @Test global function W3Coords08() hashTestSVG('coords/w3-coords-viewattr-03-b.svg', 0xf59f3551) end
 
 @Test global function EasingGradients() hashTestSVG('gradients/easing.svg', 0xc45a0cf6) end
-@Test global function ContourGradient() hashTestSVG('gradients/contour-gradient.svg', 0x35a1899a, true) end
+@Test global function ContourGradient() pHashTestSVG('gradients/contour-gradient.svg', array<byte> { 0x76,0x97,0xa3,0x8d,0x18,0xb0,0x7c,0x43 }, 6, true) end
 @Test global function MeshGradient() hashTestSVG('gradients/meshgradient.svg', 0x647d054f) end
+@Test global function DiffusionGradient() hashTestSVG('gradients/diffusiongradient.svg', 0xafe6ee58) end
+@Test global function MeshGradientInkscape() hashTestSVG('gradients/meshgradient_inkscape.svg', 0xeefbdff2) end
 @Test global function W3Gradients01() hashTestSVG('gradients/w3-pservers-grad-01-b.svg', 0xd6ab0e01) end
 @Test global function W3Gradients02() hashTestSVG('gradients/w3-pservers-grad-02-b.svg', 0xe8e84124) end
 @Test global function W3Gradients04() hashTestSVG('gradients/w3-pservers-grad-04-b.svg', 0x11d0611e) end


### PR DESCRIPTION
* Added span-backed byte array access to Bitmap Data for direct Tiri processing
* [SVG] Added DCT perceptual hashing and Hamming-distance validation for ContourGradient
* [Regex] Reset piece sizing before compiling regular expressions