### PR TITLE
[Tiri] Protected new arrays from premature garbage collection

### DIFF
--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -530,9 +530,10 @@ void make_array(lua_State *Lua, AET Type, int Elements, CPTR Data, std::string_v
 
    GCarray *array = lj_array_new(Lua, Elements, Type, (void *)Data, ARRAY_CACHED, StructName);
 
-   // Push to the stack
-   lj_gc_check(Lua);
+   // Anchor the array on the stack before running a GC check; the new object is otherwise unreferenced and a GC
+   // step that flips the current white can sweep it immediately.
    setarrayV(Lua, Lua->top++, array);
+   lj_gc_check(Lua);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -688,8 +688,9 @@ static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *De
             if (!(error = Object->get(Field->FieldID, values))) {
                kt::vector<std::string> strings(values.data(), values.data() + values.size());
                GCarray *array = lj_array_new(Lua, values.size(), AET::STR_CPP, (void *)&strings, ARRAY_CACHED, "");
-               lj_gc_check(Lua);
+               // Anchor before the GC check so the unreferenced array cannot be swept by a white flip.
                setarrayV(Lua, Lua->top++, array);
+               lj_gc_check(Lua);
             }
          }
          else {

--- a/tools/flute.tiri
+++ b/tools/flute.tiri
@@ -349,7 +349,7 @@ function runTests()
          processing.collect()
 
          if not succeeded then
-            not error_msg ?? print(error_msg)
+            if error_msg then print(error_msg) end
             if success_count is 0 then
                print(string.format('FAIL: %.6f sec', totalTime))
             else


### PR DESCRIPTION
* Anchored newly created arrays on the Tiri stack before garbage collection checks
* [Test] Corrected Flute failure-message output when an error is present