### PR TITLE
[Tiri] Report object access failures from wrappers

### DIFF
--- a/src/document/tests/test_benchmark.tiri
+++ b/src/document/tests/test_benchmark.tiri
@@ -28,7 +28,8 @@ function renderDocToBitmap(Path:str, Width:num)
    scene.bitmap = bmp
    scene.acDraw()
 
-   return { doc = doc, bmp = bmp }
+   -- The scene owns the viewport and document; it must be returned to keep the document alive for the caller.
+   return { scene = scene, doc = doc, bmp = bmp }
 end
 
 function benchmarkDoc(Name:str, Path:str, Widths, MinHeight:num)
@@ -49,7 +50,8 @@ function benchmarkDoc(Name:str, Path:str, Widths, MinHeight:num)
          f'{Name} bitmap height mismatch at {width}px, got {result.bmp.height}, pageHeight {result.doc.pageHeight}')
       assert(result.bmp.size > 0, f'{Name} bitmap must contain pixel data at {width}px')
 
-      crc = mSys.GenCRC32(0, result.bmp.data, result.bmp.size)
+      bmpdata = result.bmp.data
+      crc = mSys.GenCRC32(0, bmpdata, #bmpdata)
       assert(crc >= 0, f'{Name} CRC generation failed at {width}px')
 
       print(f'pageHeight={result.doc.pageHeight}, render={elapsed}s')
@@ -63,22 +65,22 @@ end
    benchmarkDoc('PlainTextFlow', 'benchmark/plain_text_flow.rpl', array<int> { 1024, 720, 480 }, 250)
 end
 
-@Test(priority=1) function ManyParagraphs()
+@Test(priority=2) function ManyParagraphs()
    benchmarkDoc('ManyParagraphs', 'benchmark/many_paragraphs.rpl', array<int> { 1024, 720, 480 }, 700)
 end
 
-@Test(priority=2) function LongWords()
+@Test(priority=3) function LongWords()
    benchmarkDoc('LongWords', 'benchmark/long_words.rpl', array<int> { 1024, 640, 420 }, 180)
 end
 
-@Test(priority=2) function FloatingWidgets()
+@Test(priority=4) function FloatingWidgets()
    benchmarkDoc('FloatingWidgets', 'benchmark/floating_widgets.rpl', array<int> { 1024, 700, 520 }, 260)
 end
 
-@Test(priority=3) function NestedTables()
+@Test(priority=5) function NestedTables()
    benchmarkDoc('NestedTables', 'benchmark/nested_tables.rpl', array<int> { 1024, 760, 560 }, 260)
 end
 
---@Test(priority=3) function EditCells()
+--@Test(priority=6) function EditCells()
 --   benchmarkDoc('EditCells', 'benchmark/edit_cells.rpl', array<int> { 1024, 720, 520 }, 220)
 --end

--- a/src/document/tests/test_layout.tiri
+++ b/src/document/tests/test_layout.tiri
@@ -47,7 +47,8 @@ function crcTest(Name:str, Path:str, ExpectedCRC:any, TimeLimit:num)
          bmp = renderDocToBitmap(glDocFolder .. Path, res)
          timeTaken = (mSys.PreciseTime() - startTime) / 1000000
 
-         bmp_crc = mSys.GenCRC32(0, bmp.data, bmp.size)
+         bmpdata = bmp.data
+         bmp_crc = mSys.GenCRC32(0, bmpdata, #bmpdata)
          if crc is 0 then
             saveBitmap(bmp, f'{Name}_{res}')
             error(f'File "{Path}" @ page width {res} is yet to be assigned a checksum, current CRC is {string.format("0x%.8x", bmp_crc)}')
@@ -67,7 +68,8 @@ function crcTest(Name:str, Path:str, ExpectedCRC:any, TimeLimit:num)
    bmp = renderDocToBitmap(glDocFolder .. Path, 1024)
    timeTaken = (mSys.PreciseTime() - startTime) / 1000000
 
-   crc = mSys.GenCRC32(0, bmp.data, bmp.size)
+   bmpdata = bmp.data
+   crc = mSys.GenCRC32(0, bmpdata, #bmpdata)
    if ExpectedCRC is 0 then
       saveBitmap(bmp, Name)
       error(f'The {Name} test is yet to be assigned a checksum, current CRC is {string.format("0x%.8x", crc)}')

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -347,7 +347,7 @@ struct lua_ref {
    int Ref;
 };
 
-OBJECTPTR access_object(GCobject *);
+ERR access_object(GCobject *, OBJECTPTR &);
 inline bool object_is_dead(GCobject *Object)
 {
    return (not Object->uid) or (Object->is_pinned() and Object->ptr->collecting());

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -139,7 +139,7 @@ static int action_activate(lua_State *Lua)
 
    OBJECTPTR obj;
    if (auto direct = direct_object_ptr(obj_ref)) error = Action(AC::Activate, direct, nullptr);
-   else if (auto error = access_object(obj_ref, obj); error IS ERR::Okay) {
+   else if (error = access_object(obj_ref, obj); error IS ERR::Okay) {
       error = Action(AC::Activate, obj, nullptr);
       release = true;
    }

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -137,12 +137,12 @@ static int action_activate(lua_State *Lua)
    ERR error = ERR::Okay;
    bool release = false;
 
+   OBJECTPTR obj;
    if (auto direct = direct_object_ptr(obj_ref)) error = Action(AC::Activate, direct, nullptr);
-   else if (auto obj = access_object(obj_ref)) {
+   else if (auto error = access_object(obj_ref, obj); error IS ERR::Okay) {
       error = Action(AC::Activate, obj, nullptr);
       release = true;
    }
-   else error = ERR::AccessObject;
 
    lua_pushinteger(Lua, int(error));
    if (release) release_object(obj_ref);
@@ -170,12 +170,12 @@ static int action_draw(lua_State *Lua)
    }
 
    bool release = false;
+   OBJECTPTR obj;
    if (auto direct = direct_object_ptr(obj_ref)) error = Action(AC::Draw, direct, argbuffer);
-   else if (auto obj = access_object(obj_ref)) {
+   else if (error = access_object(obj_ref, obj); error IS ERR::Okay) {
       error = Action(AC::Draw, obj, argbuffer);
       release = true;
    }
-   else error = ERR::AccessObject;
 
    lua_pushinteger(Lua, int(error));
    if (release) release_object(obj_ref);
@@ -442,10 +442,10 @@ extern int object_newindex(lua_State *Lua)
 {
    if (auto def = lj_get_object_fast(Lua, 1)) {
       if (auto hash = luaL_checkstringhash(Lua, 2)) {
-         if (auto obj = access_object(def)) {
+         OBJECTPTR obj;
+         if (auto error = access_object(def, obj); error IS ERR::Okay) {
             auto jt = get_write_table(def->classptr);
 
-            ERR error;
             auto func = std::lower_bound(jt->begin(), jt->end(), obj_write(hash), write_hash);
             if ((func != jt->end()) and (func->Hash IS hash)) {
                // All fields in the table are writable, but init checks are still required.
@@ -458,6 +458,10 @@ extern int object_newindex(lua_State *Lua)
             if (error >= ERR::ExceptionThreshold) {
                luaL_error(Lua, error, "Write failure: %s.%s: %s", def->classptr->ClassName.c_str(), luaL_checkstring(Lua, 2), GetErrorMsg(error));
             }
+         }
+         else { // Report why the object could not be accessed rather than dropping the write silently.
+            luaL_error(Lua, error, "Write failure: %s.%s: %s", def->classptr->ClassName.c_str(),
+               luaL_checkstring(Lua, 2), GetErrorMsg(error));
          }
       }
    }
@@ -852,7 +856,8 @@ static int object_exists(lua_State *Lua)
    auto def = object_context(Lua);
 
    if (object_is_dead(def)) {
-      access_object(def); // Clears the stale UID and releases the wrapper's weak pin.
+      OBJECTPTR obj;
+      access_object(def, obj); // Clears the stale UID and releases the wrapper's weak pin.
       lua_pushboolean(Lua, false);
       return 1;
    }
@@ -863,7 +868,8 @@ static int object_exists(lua_State *Lua)
       return 1;
    }
 
-   if (access_object(def)) {
+   OBJECTPTR obj;
+   if (!access_object(def, obj)) {
       release_object(def);
       lua_pushboolean(Lua, true);
       return 1;
@@ -887,7 +893,7 @@ static int object_subscribe(lua_State *Lua)
    if (action_id IS AC::NIL) luaL_argerror(Lua, 1, "Action/Method name is invalid.");
 
    OBJECTPTR obj;
-   if (not (obj = access_object(def))) luaL_error(Lua, ERR::AccessObject);
+   if (auto error = access_object(def, obj); error != ERR::Okay) luaL_error(Lua, error);
 
    kt::Log log("obj.subscribe");
    log.trace("Object: %d, Action: %s (ID %d)", def->uid, action, action_id);
@@ -982,13 +988,14 @@ static int object_init(lua_State *Lua)
 {
    auto def = object_context(Lua);
 
-   if (auto obj = access_object(def)) {
+   OBJECTPTR obj;
+   if (auto error = access_object(def, obj); error IS ERR::Okay) {
       auto error = InitObject(obj);
       report_action_error(Lua, def, "Init", error);
       lua_pushinteger(Lua, int(error));
       release_object(def);
    }
-   else luaL_error(Lua, ERR::AccessObject);
+   else luaL_error(Lua, error);
    return 1;
 }
 
@@ -1013,7 +1020,10 @@ static int object_close_handler(lua_State *Lua)
 static int object_with_lock(lua_State *Lua)
 {
    if (auto *def = lj_get_object_fast(Lua, 1)) {
-      if (not access_object(def)) luaL_error(Lua, ERR::AccessObject, "Failed to lock object for 'with' statement.");
+      OBJECTPTR obj;
+      if (auto error = access_object(def, obj); error != ERR::Okay) {
+         luaL_error(Lua, error, "Failed to access object for 'with' statement.");
+      }
       lua_pushvalue(Lua, 1); // Return the object
    }
    else luaL_argerror(Lua, 1, "Object expected for 'with' statement.");

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -990,7 +990,7 @@ static int object_init(lua_State *Lua)
 
    OBJECTPTR obj;
    if (auto error = access_object(def, obj); error IS ERR::Okay) {
-      auto error = InitObject(obj);
+      error = InitObject(obj);
       report_action_error(Lua, def, "Init", error);
       lua_pushinteger(Lua, int(error));
       release_object(def);

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -322,16 +322,17 @@ extern "C" void bc_object_setfield(lua_State *L, GCobject *Obj, GCstr *Key, TVal
       func = found;
    }
 
-   if (auto pobj = access_object(Obj)) {
+   OBJECTPTR pobj;
+   if (auto error = access_object(Obj, pobj); !error) {
       auto stack_idx = int(val_ptr - L->base) + 1;
-      ERR error = func->Call(L, pobj, func->Field, stack_idx);
+      error = func->Call(L, pobj, func->Field, stack_idx);
       L->base = saved_base;
       L->top = saved_top;
       release_object(Obj);
 
       if (error >= ERR::ExceptionThreshold) luaL_error(L, error);
    }
-   else luaL_error(L, ERR::AccessObject);
+   else luaL_error(L, error);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -112,33 +112,46 @@ APTR get_meta(lua_State *Lua, int Arg, CSTRING MetaTable)
 //********************************************************************************************************************
 // Returns a locked pointer to an object if it still exists.  Weak-pinned wrappers retain a safe header pointer between
 // accesses, avoiding repeated global resource-table lookups without delaying object termination.
+//
+// The optional Error parameter reports why access failed so that callers can distinguish a genuine locking problem
+// (ERR::AccessObject) from an object that has been terminated (ERR::DoesNotExist) or is scheduled for collection
+// (ERR::MarkedForDeletion).
 
-OBJECTPTR access_object(GCobject *Object)
+ERR access_object(GCobject *Object, OBJECTPTR &ObjectPtr)
 {
+   ObjectPtr = nullptr;
+   ERR error = ERR::AccessObject; // Default reason if access fails
+
    if (Object->accesscount) {
       Object->accesscount++;
-      return Object->ptr;
+      ObjectPtr = Object->ptr;
+      return ERR::Okay;
    }
 
-   if (not Object->uid) return nullptr;
+   if (not Object->uid) {
+      // The wrapper has already observed object termination in a previous access attempt.
+      return ERR::DoesNotExist;
+   }
 
    if (Object->is_pinned()) {
       if (Object->ptr->collecting()) {
+         // NF::FREE means destruction is in progress; FREE_ON_UNLOCK alone means collection is scheduled.
+         error = Object->ptr->terminating() ? ERR::DoesNotExist : ERR::MarkedForDeletion;
          Object->ptr->unpinWeak();
          Object->set_pinned(false);
          Object->ptr = nullptr;
          Object->uid = 0;
-         return nullptr;
+         return error;
       }
-      if (auto error = Object->ptr->lock(); error != ERR::Okay) {
+      if ((error = Object->ptr->lock()) != ERR::Okay) {
          kt::Log(__FUNCTION__).warning("#%d lock() failed: %s, Queue: %d", Object->uid, GetErrorMsg(error),
             Object->ptr->Queue.load());
-         return nullptr;
+         return error;
       }
    }
    else {
       OBJECTPTR obj_ptr;
-      if (auto error = AccessObject(Object->uid, 5000, &obj_ptr); !error) {
+      if (!(error = AccessObject(Object->uid, 5000, &obj_ptr))) {
          Object->ptr = obj_ptr;
          Object->set_locked(true);
          Object->ptr->pinWeak();
@@ -151,9 +164,13 @@ OBJECTPTR access_object(GCobject *Object)
       }
    }
 
-   if (Object->ptr) Object->accesscount++;
+   if (Object->ptr) {
+      Object->accesscount++;
+      ObjectPtr = Object->ptr;
+      return ERR::Okay;
+   }
 
-   return Object->ptr;
+   return error;
 }
 
 void release_object(GCobject *Object)

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -878,7 +878,8 @@ static ERR run_script(extTiri *Self)
 
                      if (args->Address) {
                         GCobject *obj = push_object(Self->Lua, (OBJECTPTR)args->Address);
-                        if ((r < release_list.size()) and (access_object(obj))) {
+                        OBJECTPTR ptr_obj;
+                        if ((r < release_list.size()) and (access_object(obj, ptr_obj) IS ERR::Okay)) {
                            release_list[r++] = obj;
                         }
                      }

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -1109,13 +1109,17 @@ static ERR module_call_inner(lua_State *Lua, std::string &ErrorMsg, int &Results
             if (auto direct = direct_object_ptr(obj)) {
                ((OBJECTPTR *)(buffer + j))[0] = direct;
             }
-            else if (auto ptr_obj = (OBJECTPTR)access_object(obj)) {
-               ((OBJECTPTR *)(buffer + j))[0] = ptr_obj;
-               release_object(obj);
-            }
             else {
-               log.warning("Unable to resolve object pointer for #%d.", obj->uid);
-               ((OBJECTPTR *)(buffer + j))[0] = nullptr;
+               OBJECTPTR ptr_obj;
+               if (auto error = access_object(obj, ptr_obj); error IS ERR::Okay) {
+                  ((OBJECTPTR *)(buffer + j))[0] = ptr_obj;
+                  release_object(obj);
+               }
+               else {
+                  // Referenced object probably does not exist
+                  ErrorMsg = std::format("Unable to resolve object #{}: {}", obj->uid, GetErrorMsg(error));
+                  return error;
+               }
             }
 
             arg_values[in] = buffer + j;

--- a/src/tiri/tiri_objects_calls.cpp
+++ b/src/tiri/tiri_objects_calls.cpp
@@ -16,11 +16,14 @@ struct pending_function_arg {
    Release = false;
 
    if (auto direct = direct_object_ptr(Def)) return Action(ActionID, direct, Args);
-   else if (auto obj = access_object(Def)) {
+
+   OBJECTPTR obj;
+   auto error = access_object(Def, obj);
+   if (error IS ERR::Okay) {
       Release = true;
       return Action(ActionID, obj, Args);
    }
-   else return ERR::AccessObject;
+   else return error;
 }
 
 //********************************************************************************************************************
@@ -269,11 +272,14 @@ static ERR copy_object_cpp_array_arg(GCarray *Array, kt::vector<OBJECTPTR> *Vect
 
       auto obj_ref = gco_to_object(gcref(refs[i]));
       if (auto direct = direct_object_ptr(obj_ref)) Vector->push_back(direct);
-      else if (auto ptr_obj = access_object(obj_ref)) {
-         Vector->push_back(ptr_obj);
-         release_object(obj_ref);
+      else {
+         OBJECTPTR ptr_obj;
+         if (!access_object(obj_ref, ptr_obj)) {
+            Vector->push_back(ptr_obj);
+            release_object(obj_ref);
+         }
+         else Vector->push_back(nullptr);
       }
-      else Vector->push_back(nullptr);
    }
 
    return ERR::Okay;
@@ -685,7 +691,7 @@ ERR build_args(lua_State *Lua, CSTRING Name, const FunctionField *Args, int Args
                if (auto direct = direct_object_ptr(obj_ref)) {
                   ((OBJECTPTR *)(ArgBuffer + j))[0] = direct;
                }
-               else if ((ptr_obj = access_object(obj_ref))) {
+               else if (!access_object(obj_ref, ptr_obj)) {
                   ((OBJECTPTR *)(ArgBuffer + j))[0] = ptr_obj;
                   release_object(obj_ref);
                }

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -195,12 +195,13 @@ static ERR object_set_function(lua_State *Lua, OBJECTPTR Object, const Field *Fi
 static ERR object_set_object(lua_State *Lua, OBJECTPTR Object, const Field *Field, int ValueIndex)
 {
    if (auto def = lua_toobject(Lua, ValueIndex)) {
-      if (auto ptr_obj = access_object(def)) {
-         ERR error = Object->set(Field, ptr_obj);
+      OBJECTPTR ptr_obj;
+      if (auto error = access_object(def, ptr_obj); error IS ERR::Okay) {
+         error = Object->set(Field, ptr_obj);
          release_object(def);
          return error;
       }
-      else return ERR::AccessObject;
+      else return error;
    }
    else return Object->set(Field, (APTR)nullptr);
 }
@@ -446,9 +447,9 @@ static int object_get(lua_State *Lua)
    if (luaL_checkstring(Lua, 1, fieldname)) {
       auto def = object_context(Lua);
 
-      auto obj = access_object(def);
-      if (not obj) {
-         Lua->CaughtError = ERR::AccessObject;
+      OBJECTPTR obj;
+      if (auto error = access_object(def, obj); error != ERR::Okay) {
+         Lua->CaughtError = error;
          lua_pushvalue(Lua, 2); // Push the client's default value
          return 1;
       }
@@ -524,15 +525,15 @@ static int object_getkey(lua_State *Lua)
    std::string_view fieldname;
    if (luaL_checkstring(Lua, 1, fieldname)) {
       auto def = object_context(Lua);
-      ERR error;
-      if (auto obj = access_object(def)) {
+      OBJECTPTR obj;
+      ERR error = access_object(def, obj);
+      if (error IS ERR::Okay) {
          std::string buffer;
          if (!(error = acGetKey(obj, fieldname, buffer))) {
             lua_pushstring(Lua, buffer);
          }
          release_object(def);
       }
-      else error = ERR::AccessObject;
 
       if (error != ERR::Okay) {
          if (lua_gettop(Lua) >= 2) lua_pushvalue(Lua, 2);
@@ -554,7 +555,8 @@ static int object_set(lua_State *Lua)
    std::string_view fieldname;
    if (not luaL_checkstring(Lua, 1, fieldname)) return 0;
 
-   if (auto obj = access_object(def)) {
+   OBJECTPTR obj;
+   if (access_object(def, obj) IS ERR::Okay) {
       int type = lua_type(Lua, 2);
 
       OBJECTPTR target;
@@ -589,7 +591,8 @@ static int object_setkey(lua_State *Lua)
    std::string_view fieldname;
    if (luaL_checkstring(Lua, 1, fieldname)) {
       auto value = luaL_optstring(Lua, 2, nullptr);
-      if (auto obj = access_object(def)) {
+      OBJECTPTR obj;
+      if (access_object(def, obj) IS ERR::Okay) {
          ERR error = acSetKey(obj, fieldname, value);
          release_object(def);
          lua_pushinteger(Lua, int(error));
@@ -659,13 +662,13 @@ static ERR set_object_field(lua_State *Lua, OBJECTPTR Object, uint32_t FieldHash
 template <class Callback> static int object_get_field(lua_State *Lua, const obj_read &Handle, GCobject *Def,
    Callback GetValue)
 {
-   ERR error;
-   if (auto obj = access_object(Def)) {
+   OBJECTPTR obj;
+   ERR error = access_object(Def, obj);
+   if (error IS ERR::Okay) {
       auto field = (Field *)(Handle.Data);
       error = GetValue(obj, field);
       release_object(Def);
    }
-   else error = ERR::AccessObject;
 
    Lua->CaughtError = error;
    return error != ERR::Okay ? 0 : 1;

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -268,7 +268,8 @@ static int processing_flush(lua_State *Lua)
             lua_rawgeti(Lua, LUA_REGISTRYINDEX, ref);
             if (lua_type(Lua, -1) IS LUA_TOBJECT) {
                auto object = lua_toobject(Lua, -1);
-               if (auto obj = access_object(object)) {
+               OBJECTPTR obj;
+               if (access_object(object, obj) IS ERR::Okay) {
                   obj->clearFlag(NF::SIGNALLED);
                   release_object(object);
                }


### PR DESCRIPTION
* Return precise access errors when object wrappers reference deleted or collecting objects
* [Test] Preserve document benchmark scene lifetimes during render checks