### PR TITLE
[Network] Generate SSL certificate fixtures without mkcert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,12 +169,14 @@ if (SYSTEM_ENDIAN_STYLE EQUAL 0) # Little endian (Intel)
    set (LITTLE_ENDIAN TRUE)
 endif ()
 
+set (KOTUKU_OPENSSL_MINIMUM_VERSION 1.1.1)
+
 if (NOT DISABLE_SSL)
    if (WIN32)
       # Win32 SSL support is supported natively
    else ()
       set (OPENSSL_USE_STATIC_LIBS TRUE)
-      include (FindOpenSSL)
+      find_package (OpenSSL ${KOTUKU_OPENSSL_MINIMUM_VERSION} QUIET)
       if (NOT OpenSSL_FOUND)
          set (DISABLE_SSL TRUE)
       else ()
@@ -1223,16 +1225,7 @@ if (KOTUKU_INSTALL)
    endif ()
 
    if (NOT DISABLE_SSL)
-      if (WIN32)
-         install (DIRECTORY "${PROJECT_SOURCE_DIR}/data/ssl/" DESTINATION "${CONFIG_TARGET}/ssl"
-            FILES_MATCHING
-               PATTERN "ca-bundle.crt"
-               PATTERN "localhost.pem"
-               PATTERN "localhost.p12"
-               PATTERN "localhost-password.p12")
-      else ()
-         install (DIRECTORY "${PROJECT_SOURCE_DIR}/data/ssl/" DESTINATION "${CONFIG_TARGET}/ssl")
-      endif ()
+      install (FILES "${PROJECT_SOURCE_DIR}/data/ssl/ca-bundle.crt" DESTINATION "${CONFIG_TARGET}/ssl")
    endif ()
    if (NOT DISABLE_FONT)
       install (DIRECTORY "${PROJECT_SOURCE_DIR}/data/fonts/" DESTINATION "${CONFIG_TARGET}/fonts")

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -87,76 +87,75 @@ target_link_libraries (${MOD} PRIVATE ${NETWORK_LIBS})
 
 target_compile_definitions (${MOD} PRIVATE "MAX_ALIASES=64" "MAX_ADDRESSES=32" "HAVE_CONFIG_H=1")
 
-# SSL Certificate Generation
-find_program(MKCERT_EXECUTABLE mkcert PATHS ${CMAKE_SOURCE_DIR}/tools ENV PATH)
+# SSL test certificate generation
 find_program(OPENSSL_EXECUTABLE openssl)
 
-set(OPENSSL_RSA_TRADITIONAL_FLAG)
-if(OPENSSL_EXECUTABLE)
-   execute_process(
-      COMMAND "${OPENSSL_EXECUTABLE}" rsa -help
-      OUTPUT_VARIABLE OPENSSL_RSA_HELP
-      ERROR_VARIABLE OPENSSL_RSA_HELP
-      RESULT_VARIABLE OPENSSL_RSA_HELP_RESULT)
-   if(OPENSSL_RSA_HELP MATCHES "(^|[ \\r\\n])-traditional([ \\r\\n]|$)")
-      set(OPENSSL_RSA_TRADITIONAL_FLAG -traditional)
-   endif()
-endif()
+if (OPENSSL_EXECUTABLE)
+   execute_process (
+      COMMAND "${OPENSSL_EXECUTABLE}" version
+      RESULT_VARIABLE OPENSSL_EXECUTABLE_VERSION_RESULT
+      OUTPUT_VARIABLE OPENSSL_EXECUTABLE_VERSION_OUTPUT
+      ERROR_VARIABLE OPENSSL_EXECUTABLE_VERSION_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(SSL_DATA_DIR "${CMAKE_SOURCE_DIR}/data/ssl")
-set(LOCALHOST_PEM "${SSL_DATA_DIR}/localhost.pem")
-set(LOCALHOST_KEY_PEM "${SSL_DATA_DIR}/localhost-key.pem")
-set(LOCALHOST_RSA_KEY_PEM "${SSL_DATA_DIR}/localhost-rsa-key.pem")
-set(LOCALHOST_EC_PEM "${SSL_DATA_DIR}/localhost-ec.pem")
-set(LOCALHOST_EC_KEY_PEM "${SSL_DATA_DIR}/localhost-ec-key.pem")
-set(LOCALHOST_P12 "${SSL_DATA_DIR}/localhost.p12")
-set(LOCALHOST_PASSWORD_P12 "${SSL_DATA_DIR}/localhost-password.p12")
-set(MKCERT_PEM "${SSL_DATA_DIR}/localhost+2.pem")
-set(MKCERT_KEY_PEM "${SSL_DATA_DIR}/localhost+2-key.pem")
+   if ((NOT OPENSSL_EXECUTABLE_VERSION_RESULT EQUAL 0) OR
+      (NOT OPENSSL_EXECUTABLE_VERSION_OUTPUT MATCHES "^OpenSSL[ \t]+([0-9]+\\.[0-9]+\\.[0-9]+)"))
+      message (STATUS "The openssl executable is unavailable or did not report a supported version")
+      set (OPENSSL_EXECUTABLE "")
+   elseif (CMAKE_MATCH_1 VERSION_LESS KOTUKU_OPENSSL_MINIMUM_VERSION)
+      message (STATUS
+         "The openssl executable is version ${CMAKE_MATCH_1}; "
+         "version ${KOTUKU_OPENSSL_MINIMUM_VERSION} or later is required")
+      set (OPENSSL_EXECUTABLE "")
+   endif ()
+endif ()
 
-if(MKCERT_EXECUTABLE AND OPENSSL_EXECUTABLE)
-   # Custom command to generate SSL certificates only when they don't exist
-   add_custom_command(
-      OUTPUT "${LOCALHOST_PEM}" "${LOCALHOST_KEY_PEM}" "${LOCALHOST_RSA_KEY_PEM}" "${LOCALHOST_P12}"
-             "${LOCALHOST_PASSWORD_P12}" "${LOCALHOST_EC_PEM}" "${LOCALHOST_EC_KEY_PEM}"
-      COMMAND ${CMAKE_COMMAND} -E make_directory "${SSL_DATA_DIR}"
-      COMMAND ${CMAKE_COMMAND} -E remove -f "${LOCALHOST_PEM}" "${LOCALHOST_KEY_PEM}" "${LOCALHOST_P12}"
-              "${LOCALHOST_PASSWORD_P12}" "${LOCALHOST_RSA_KEY_PEM}" "${LOCALHOST_EC_PEM}"
-              "${LOCALHOST_EC_KEY_PEM}" "${MKCERT_PEM}" "${MKCERT_KEY_PEM}"
-      COMMAND ${CMAKE_COMMAND} -E chdir "${SSL_DATA_DIR}" "${MKCERT_EXECUTABLE}" localhost 127.0.0.1 ::1
-      COMMAND ${CMAKE_COMMAND} -E rename "${MKCERT_PEM}" "${LOCALHOST_PEM}"
-      COMMAND ${CMAKE_COMMAND} -E rename "${MKCERT_KEY_PEM}" "${LOCALHOST_KEY_PEM}"
-      COMMAND "${OPENSSL_EXECUTABLE}" rsa -in "${LOCALHOST_KEY_PEM}" ${OPENSSL_RSA_TRADITIONAL_FLAG} -out "${LOCALHOST_RSA_KEY_PEM}"
-      COMMAND "${OPENSSL_EXECUTABLE}" ecparam -name prime256v1 -genkey -noout -out "${LOCALHOST_EC_KEY_PEM}"
-      COMMAND "${OPENSSL_EXECUTABLE}" req -new -x509 -key "${LOCALHOST_EC_KEY_PEM}" -out "${LOCALHOST_EC_PEM}"
-              -days 3650 -subj "/CN=localhost"
-      COMMAND "${OPENSSL_EXECUTABLE}" pkcs12 -export -out "${LOCALHOST_P12}"
-              -inkey "${LOCALHOST_KEY_PEM}" -in "${LOCALHOST_PEM}" -passout pass:
-      COMMAND "${OPENSSL_EXECUTABLE}" pkcs12 -export -out "${LOCALHOST_PASSWORD_P12}"
-              -inkey "${LOCALHOST_KEY_PEM}" -in "${LOCALHOST_PEM}" -passout pass:kotuku-test
-      COMMENT "Generating SSL certificates for localhost testing"
-      VERBATIM
-   )
+set (SSL_FIXTURE_DIR "${CMAKE_CURRENT_BINARY_DIR}/ssl")
+set (SSL_FIXTURE_GENERATOR "${CMAKE_CURRENT_SOURCE_DIR}/generate_ssl_certificates.cmake")
+set (LOCALHOST_PEM "${SSL_FIXTURE_DIR}/localhost.pem")
+set (LOCALHOST_KEY_PEM "${SSL_FIXTURE_DIR}/localhost-key.pem")
+set (LOCALHOST_RSA_KEY_PEM "${SSL_FIXTURE_DIR}/localhost-rsa-key.pem")
+set (LOCALHOST_EC_PEM "${SSL_FIXTURE_DIR}/localhost-ec.pem")
+set (LOCALHOST_EC_KEY_PEM "${SSL_FIXTURE_DIR}/localhost-ec-key.pem")
+set (LOCALHOST_P12 "${SSL_FIXTURE_DIR}/localhost.p12")
+set (LOCALHOST_PASSWORD_P12 "${SSL_FIXTURE_DIR}/localhost-password.p12")
+set (SSL_FIXTURES
+   "${LOCALHOST_PEM}"
+   "${LOCALHOST_KEY_PEM}"
+   "${LOCALHOST_RSA_KEY_PEM}"
+   "${LOCALHOST_EC_PEM}"
+   "${LOCALHOST_EC_KEY_PEM}"
+   "${LOCALHOST_P12}"
+   "${LOCALHOST_PASSWORD_P12}")
 
-   # Custom target that depends on the certificate files
-   add_custom_target(generate_ssl_certificates DEPENDS "${LOCALHOST_PEM}" "${LOCALHOST_KEY_PEM}"
-      "${LOCALHOST_RSA_KEY_PEM}" "${LOCALHOST_EC_PEM}" "${LOCALHOST_EC_KEY_PEM}" "${LOCALHOST_P12}"
-      "${LOCALHOST_PASSWORD_P12}")
+if (NOT DISABLE_SSL AND (WIN32 OR OPENSSL_FOUND) AND OPENSSL_EXECUTABLE)
+   add_custom_target (generate_ssl_certificates ALL
+      COMMAND ${CMAKE_COMMAND}
+         "-DOPENSSL_EXECUTABLE=${OPENSSL_EXECUTABLE}"
+         "-DOUTPUT_DIR=${SSL_FIXTURE_DIR}"
+         -P "${SSL_FIXTURE_GENERATOR}"
+      BYPRODUCTS ${SSL_FIXTURES} "${SSL_FIXTURE_DIR}/fixture-version.txt"
+      DEPENDS "${SSL_FIXTURE_GENERATOR}"
+      COMMENT "Checking Network SSL test certificates"
+      VERBATIM)
 
-   # Make the network module depend on certificate generation
-   add_dependencies(${MOD} generate_ssl_certificates)
+   add_dependencies (${MOD} generate_ssl_certificates)
 
-   message(STATUS "SSL certificate generation enabled (mkcert and openssl found)")
-else()
-   if(NOT MKCERT_EXECUTABLE)
-      message(STATUS "mkcert not found - SSL certificates will not be auto-generated")
-      message(STATUS "Install mkcert from: https://github.com/FiloSottile/mkcert")
-   endif()
+   if (KOTUKU_INSTALL)
+      if (WIN32)
+         install (FILES "${LOCALHOST_PEM}" "${LOCALHOST_P12}" "${LOCALHOST_PASSWORD_P12}"
+            DESTINATION "${CONFIG_TARGET}/ssl")
+      else ()
+         install (FILES ${SSL_FIXTURES} DESTINATION "${CONFIG_TARGET}/ssl")
+      endif ()
+   endif ()
 
-   if(NOT OPENSSL_EXECUTABLE)
-      message(STATUS "openssl not found - SSL certificates will not be auto-generated")
-   endif()
-endif()
+   message (STATUS "Network SSL test certificate generation enabled")
+elseif (NOT DISABLE_SSL AND (WIN32 OR OPENSSL_FOUND) AND BUILD_TESTS)
+   message (FATAL_ERROR "The Network SSL tests require the openssl executable to generate certificate fixtures")
+elseif (NOT DISABLE_SSL AND (WIN32 OR OPENSSL_FOUND))
+   message (STATUS "openssl not found - Network SSL test certificates will not be generated")
+endif ()
 
 set (NETWORK_TESTS
    bind_address dns_parallel server_io client_server error_handling ipv6 concurrency ssl iocp_pipeline

--- a/src/network/generate_ssl_certificates.cmake
+++ b/src/network/generate_ssl_certificates.cmake
@@ -1,0 +1,118 @@
+if (NOT DEFINED OPENSSL_EXECUTABLE)
+   message (FATAL_ERROR "OPENSSL_EXECUTABLE is not defined")
+endif ()
+
+if (NOT DEFINED OUTPUT_DIR)
+   message (FATAL_ERROR "OUTPUT_DIR is not defined")
+endif ()
+
+set (FIXTURE_FORMAT_VERSION 2)
+set (STAMP_FILE "${OUTPUT_DIR}/fixture-version.txt")
+set (LOCALHOST_PEM "${OUTPUT_DIR}/localhost.pem")
+set (LOCALHOST_KEY_PEM "${OUTPUT_DIR}/localhost-key.pem")
+set (LOCALHOST_RSA_KEY_PEM "${OUTPUT_DIR}/localhost-rsa-key.pem")
+set (LOCALHOST_EC_PEM "${OUTPUT_DIR}/localhost-ec.pem")
+set (LOCALHOST_EC_KEY_PEM "${OUTPUT_DIR}/localhost-ec-key.pem")
+set (LOCALHOST_P12 "${OUTPUT_DIR}/localhost.p12")
+set (LOCALHOST_PASSWORD_P12 "${OUTPUT_DIR}/localhost-password.p12")
+
+file (SHA256 "${CMAKE_CURRENT_LIST_FILE}" GENERATOR_HASH)
+
+function (run_openssl)
+   execute_process (
+      COMMAND "${OPENSSL_EXECUTABLE}" ${ARGN}
+      RESULT_VARIABLE OPENSSL_RESULT
+      OUTPUT_VARIABLE OPENSSL_OUTPUT
+      ERROR_VARIABLE OPENSSL_ERROR)
+
+   if (NOT OPENSSL_RESULT EQUAL 0)
+      message (FATAL_ERROR
+         "OpenSSL command failed (${OPENSSL_RESULT}): ${OPENSSL_EXECUTABLE} ${ARGN}\n"
+         "${OPENSSL_OUTPUT}${OPENSSL_ERROR}")
+   endif ()
+endfunction ()
+
+execute_process (
+   COMMAND "${OPENSSL_EXECUTABLE}" version
+   RESULT_VARIABLE OPENSSL_VERSION_RESULT
+   OUTPUT_VARIABLE OPENSSL_VERSION
+   ERROR_VARIABLE OPENSSL_VERSION_ERROR
+   OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if (NOT OPENSSL_VERSION_RESULT EQUAL 0)
+   message (FATAL_ERROR "Failed to query OpenSSL version: ${OPENSSL_VERSION_ERROR}")
+endif ()
+
+set (EXPECTED_STAMP "${FIXTURE_FORMAT_VERSION}\n${GENERATOR_HASH}\n${OPENSSL_VERSION}\n")
+set (FIXTURES_CURRENT TRUE)
+
+foreach (FIXTURE IN ITEMS
+      "${LOCALHOST_PEM}"
+      "${LOCALHOST_KEY_PEM}"
+      "${LOCALHOST_RSA_KEY_PEM}"
+      "${LOCALHOST_EC_PEM}"
+      "${LOCALHOST_EC_KEY_PEM}"
+      "${LOCALHOST_P12}"
+      "${LOCALHOST_PASSWORD_P12}")
+   if (NOT EXISTS "${FIXTURE}")
+      set (FIXTURES_CURRENT FALSE)
+   endif ()
+endforeach ()
+
+if (FIXTURES_CURRENT AND EXISTS "${STAMP_FILE}")
+   file (READ "${STAMP_FILE}" EXISTING_STAMP)
+   if (EXISTING_STAMP STREQUAL EXPECTED_STAMP)
+      return ()
+   endif ()
+endif ()
+
+message (STATUS "Generating Network SSL test certificates with ${OPENSSL_VERSION}")
+file (REMOVE_RECURSE "${OUTPUT_DIR}")
+file (MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+run_openssl (req -new -x509 -newkey rsa:2048 -sha256 -nodes
+   -keyout "${LOCALHOST_KEY_PEM}"
+   -out "${LOCALHOST_PEM}"
+   -days 3650
+   -subj "/CN=localhost"
+   -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1")
+
+execute_process (
+   COMMAND "${OPENSSL_EXECUTABLE}" rsa -help
+   OUTPUT_VARIABLE OPENSSL_RSA_HELP
+   ERROR_VARIABLE OPENSSL_RSA_HELP)
+
+set (OPENSSL_RSA_ARGS rsa -in "${LOCALHOST_KEY_PEM}")
+if (OPENSSL_RSA_HELP MATCHES "(^|[ \\r\\n])-traditional([ \\r\\n]|$)")
+   list (APPEND OPENSSL_RSA_ARGS -traditional)
+endif ()
+list (APPEND OPENSSL_RSA_ARGS -out "${LOCALHOST_RSA_KEY_PEM}")
+run_openssl (${OPENSSL_RSA_ARGS})
+
+run_openssl (ecparam -name prime256v1 -genkey -noout -out "${LOCALHOST_EC_KEY_PEM}")
+run_openssl (req -new -x509 -sha256
+   -key "${LOCALHOST_EC_KEY_PEM}"
+   -out "${LOCALHOST_EC_PEM}"
+   -days 3650
+   -subj "/CN=localhost"
+   -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1")
+
+run_openssl (pkcs12 -export
+   -out "${LOCALHOST_P12}"
+   -inkey "${LOCALHOST_KEY_PEM}"
+   -in "${LOCALHOST_PEM}"
+   -keypbe AES-256-CBC
+   -certpbe AES-256-CBC
+   -macalg sha256
+   -passout pass:)
+
+run_openssl (pkcs12 -export
+   -out "${LOCALHOST_PASSWORD_P12}"
+   -inkey "${LOCALHOST_KEY_PEM}"
+   -in "${LOCALHOST_PEM}"
+   -keypbe AES-256-CBC
+   -certpbe AES-256-CBC
+   -macalg sha256
+   -passout pass:kotuku-test)
+
+file (WRITE "${STAMP_FILE}" "${EXPECTED_STAMP}")

--- a/src/network/tests/test_ssl.tiri
+++ b/src/network/tests/test_ssl.tiri
@@ -541,6 +541,11 @@ function customCertificateFilesAvailable(CertPath, KeyPath)
    return true
 end
 
+function requireCustomCertificateFile(CertPath)
+   assert(mSys.AnalysePath(CertPath) is ERR_Okay,
+      'Required PKCS#12 test certificate is not installed: ' .. CertPath)
+end
+
 function runCustomCertificateHandshake(TestName, CertPath, KeyPath, KeyPassword)
    custom_cert_test_complete = false
    handshake_successful = false
@@ -607,7 +612,7 @@ end
 @Test(priority=40); @Requires(ssl=true)
 function CustomCertificate()
    cert_path = 'config:ssl/localhost.p12'
-   if not customCertificateFilesAvailable(cert_path, nil) then return end
+   requireCustomCertificateFile(cert_path)
 
    runCustomCertificateHandshake('CustomCert', cert_path, nil, nil)
 end
@@ -615,7 +620,7 @@ end
 @Test(priority=41); @Requires(ssl=true)
 function PasswordProtectedCustomCertificate()
    cert_path = 'config:ssl/localhost-password.p12'
-   if not customCertificateFilesAvailable(cert_path, nil) then return end
+   requireCustomCertificateFile(cert_path)
 
    runCustomCertificateHandshake('PasswordCert', cert_path, nil, 'kotuku-test')
 end
@@ -623,7 +628,7 @@ end
 @Test(priority=42); @Requires(ssl=true)
 function PasswordProtectedCustomCertificateRejectsWrongPassword()
    cert_path = 'config:ssl/localhost-password.p12'
-   if not customCertificateFilesAvailable(cert_path, nil) then return end
+   requireCustomCertificateFile(cert_path)
 
    glPort++
 


### PR DESCRIPTION
* Generate reproducible localhost certificates in the build tree with OpenSSL 1.1.1 or later
* Install platform-appropriate certificate fixtures and require PKCS#12 coverage in SSL tests