### PR TITLE
[Vector] Added seamless translucent Gouraud rendering

### DIFF
--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -278,7 +278,7 @@ end
 @Test global function ContourGradient() pHashTestSVG('gradients/contour-gradient.svg', array<byte> { 0x76,0x97,0xa3,0x8d,0x18,0xb0,0x7c,0x43 }, 6, true) end
 @Test global function MeshGradient() hashTestSVG('gradients/meshgradient.svg', 0x647d054f) end
 @Test global function DiffusionGradient() hashTestSVG('gradients/diffusiongradient.svg', 0xafe6ee58) end
-@Test global function MeshGradientInkscape() pHashTestSVG('gradients/meshgradient_inkscape.svg', array<byte> { 110,238,145,49,230,131,1,110 }, 6, true) end
+@Test global function MeshGradientInkscape() pHashTestSVG('gradients/meshgradient_inkscape.svg', array<byte> { 110,238,145,49,230,131,33,102 }, 6, true) end
 @Test global function W3Gradients01() hashTestSVG('gradients/w3-pservers-grad-01-b.svg', 0xd6ab0e01) end
 @Test global function W3Gradients02() hashTestSVG('gradients/w3-pservers-grad-02-b.svg', 0xe8e84124) end
 @Test global function W3Gradients04() hashTestSVG('gradients/w3-pservers-grad-04-b.svg', 0x11d0611e) end

--- a/src/vector/agg/include/agg_renderer_scanline.h
+++ b/src/vector/agg/include/agg_renderer_scanline.h
@@ -324,7 +324,6 @@ namespace agg
             unsigned style;
             bool     solid;
             while ((num_styles = ras.sweep_styles()) > 0) {
-                typename ScanlineAA::const_iterator span_aa;
                 if (num_styles == 1) { // Optimization for a single style. Happens often
                     if (ras.sweep_scanline(sl_aa, 0)) {
                         style = ras.style(0);
@@ -332,7 +331,7 @@ namespace agg
                             render_scanline_aa_solid(sl_aa, ren, sh.color(style));
                         }
                         else { // Arbitrary span generator
-                            span_aa   = sl_aa.begin();
+                            auto span_aa = sl_aa.begin();
                             num_spans = sl_aa.num_spans();
                             for (;;) {
                                 len = span_aa->len;
@@ -347,12 +346,14 @@ namespace agg
                 else {
                     if (ras.sweep_scanline(sl_bin, -1)) {
                         // Clear the spans of the mix_buffer
-                        typename ScanlineBin::const_iterator span_bin = sl_bin.begin();
-                        num_spans = sl_bin.num_spans();
-                        for(;;) {
-                            memset(mix_buffer + span_bin->x - min_x, 0, span_bin->len * sizeof(color_type));
-                            if (--num_spans == 0) break;
-                            ++span_bin;
+                        {
+                            auto span_bin = sl_bin.begin();
+                            num_spans = sl_bin.num_spans();
+                            for(;;) {
+                                memset(mix_buffer + span_bin->x - min_x, 0, span_bin->len * sizeof(color_type));
+                                if (--num_spans == 0) break;
+                                ++span_bin;
+                            }
                         }
 
                         unsigned i;
@@ -364,7 +365,7 @@ namespace agg
                                 color_type* colors;
                                 color_type* cspan;
                                 typename ScanlineAA::cover_type* covers;
-                                span_aa   = sl_aa.begin();
+                                auto span_aa = sl_aa.begin();
                                 num_spans = sl_aa.num_spans();
                                 if (solid) {
                                     for(;;) {
@@ -407,7 +408,7 @@ namespace agg
 
                         // Emit the blended result as a color hspan
 
-                        span_bin = sl_bin.begin();
+                        auto span_bin = sl_bin.begin();
                         num_spans = sl_bin.num_spans();
                         for(;;) {
                             ren.blend_color_hspan(span_bin->x, sl_bin.y(), span_bin->len, mix_buffer + span_bin->x - min_x, 0, cover_full);
@@ -438,7 +439,6 @@ namespace agg
          unsigned style;
          bool     solid;
          while ((num_styles = ras.sweep_styles()) > 0) {
-             typename ScanlineAA::const_iterator span_aa;
              if (num_styles == 1) { // Optimization for a single style. Happens often
                  if (ras.sweep_scanline(sl_aa, 0)) {
                      style = ras.style(0);
@@ -446,7 +446,7 @@ namespace agg
                         render_scanline_aa_solid(sl_aa, ren, sh.color(style));
                      }
                      else { // Arbitrary span generator
-                         span_aa   = sl_aa.begin();
+                         auto span_aa = sl_aa.begin();
                          num_spans = sl_aa.num_spans();
                          for(;;) {
                              len = span_aa->len;
@@ -479,7 +479,7 @@ namespace agg
                              color_type* cspan;
                              cover_type* src_covers;
                              cover_type* dst_covers;
-                             span_aa   = sl_aa.begin();
+                             auto span_aa = sl_aa.begin();
                              num_spans = sl_aa.num_spans();
                              sl_y      = sl_aa.y();
                              if (solid) {

--- a/src/vector/scene/scene.cpp
+++ b/src/vector/scene/scene.cpp
@@ -36,6 +36,8 @@ Vector definitions can be saved and loaded from permanent storage by using the @
 #include "agg_span_gouraud_rgba.h"
 #include "agg_span_gouraud_rgba_linear.h"
 #include "agg_span_gouraud_rgba_quantise.h"
+#include "agg_rasterizer_compound_aa.h"
+#include "agg_pixfmt_amask_adaptor.h"
 #include "agg_conv_contour.h"
 
 //#include "../vector.h"

--- a/src/vector/scene/scene_fill.cpp
+++ b/src/vector/scene/scene_fill.cpp
@@ -298,6 +298,99 @@ static bool build_gouraud_path_mask(agg::rasterizer_scanline_aa<> &Raster,
 //   * VCS::LINEAR_RGB -> colours are decoded to linear here, so span_gouraud_rgba_linear interpolates in linear
 //     space and re-encodes each output pixel back to sRGB for storage.
 
+// Positive-area overlap requires ordered source-over compositing, while triangles that only share edges or vertices
+// can use the seamless compound path.  Sweep along the mesh's widest axis to discard most pairs cheaply, then use a
+// strict separating-axis test for candidates whose bounding boxes overlap.
+
+static bool gouraud_triangles_overlap(const std::vector<GouraudTriangle> &Triangles)
+{
+   if (Triangles.size() < 2) return false;
+
+   constexpr double overlap_epsilon = 1e-7;
+
+   struct TriangleBounds {
+      size_t triangle;
+      double min_x, max_x, min_y, max_y;
+   };
+
+   std::vector<TriangleBounds> bounds;
+   bounds.reserve(Triangles.size());
+   for (size_t i=0; i < Triangles.size(); i++) {
+      const auto &tri = Triangles[i];
+      bounds.push_back({ i,
+         std::min({ tri.x[0], tri.x[1], tri.x[2] }), std::max({ tri.x[0], tri.x[1], tri.x[2] }),
+         std::min({ tri.y[0], tri.y[1], tri.y[2] }), std::max({ tri.y[0], tri.y[1], tri.y[2] }) });
+   }
+
+   double mesh_min_x = bounds[0].min_x, mesh_max_x = bounds[0].max_x;
+   double mesh_min_y = bounds[0].min_y, mesh_max_y = bounds[0].max_y;
+   for (auto &item : bounds) {
+      mesh_min_x = std::min(mesh_min_x, item.min_x);
+      mesh_max_x = std::max(mesh_max_x, item.max_x);
+      mesh_min_y = std::min(mesh_min_y, item.min_y);
+      mesh_max_y = std::max(mesh_max_y, item.max_y);
+   }
+   const bool sweep_x = (mesh_max_x - mesh_min_x) >= (mesh_max_y - mesh_min_y);
+
+   std::sort(bounds.begin(), bounds.end(), [&](const TriangleBounds &A, const TriangleBounds &B) {
+      return sweep_x ? (A.min_x < B.min_x) : (A.min_y < B.min_y);
+   });
+
+   auto interiors_overlap = [&](const GouraudTriangle &A, const GouraudTriangle &B) {
+      auto separated_by_edge = [&](const GouraudTriangle &AxisTriangle, int Edge) {
+         const int next = (Edge + 1) % 3;
+         double axis_x = -(AxisTriangle.y[next] - AxisTriangle.y[Edge]);
+         double axis_y = AxisTriangle.x[next] - AxisTriangle.x[Edge];
+         const double axis_length = std::hypot(axis_x, axis_y);
+         if (axis_length <= overlap_epsilon) return false;
+         axis_x /= axis_length;
+         axis_y /= axis_length;
+
+         auto project = [&](const GouraudTriangle &Triangle) {
+            double minimum = (Triangle.x[0] * axis_x) + (Triangle.y[0] * axis_y);
+            double maximum = minimum;
+            for (int i=1; i < 3; i++) {
+               const double value = (Triangle.x[i] * axis_x) + (Triangle.y[i] * axis_y);
+               minimum = std::min(minimum, value);
+               maximum = std::max(maximum, value);
+            }
+            return std::pair(minimum, maximum);
+         };
+
+         const auto [a_min, a_max] = project(A);
+         const auto [b_min, b_max] = project(B);
+         return (a_max <= b_min + overlap_epsilon) or (b_max <= a_min + overlap_epsilon);
+      };
+
+      for (int edge=0; edge < 3; edge++) if (separated_by_edge(A, edge)) return false;
+      for (int edge=0; edge < 3; edge++) if (separated_by_edge(B, edge)) return false;
+      return true;
+   };
+
+   std::vector<size_t> active;
+   for (size_t i=0; i < bounds.size(); i++) {
+      const auto &current = bounds[i];
+      std::erase_if(active, [&](size_t Active) {
+         return sweep_x ? (bounds[Active].max_x <= current.min_x + overlap_epsilon) :
+            (bounds[Active].max_y <= current.min_y + overlap_epsilon);
+      });
+
+      for (auto active_index : active) {
+         const auto &candidate = bounds[active_index];
+         if (sweep_x) {
+            if ((candidate.max_y <= current.min_y + overlap_epsilon) or
+                (current.max_y <= candidate.min_y + overlap_epsilon)) continue;
+         }
+         else if ((candidate.max_x <= current.min_x + overlap_epsilon) or
+                  (current.max_x <= candidate.min_x + overlap_epsilon)) continue;
+         if (interiors_overlap(Triangles[candidate.triangle], Triangles[current.triangle])) return true;
+      }
+      active.push_back(i);
+   }
+
+   return false;
+}
+
 static void rebuild_gouraud_cache(GouraudCache &Cache, const GouraudMesh &Mesh, const agg::trans_affine &Transform,
    double Opacity, VCS ColourSpace, uint64_t MeshHash)
 {
@@ -325,6 +418,7 @@ static void rebuild_gouraud_cache(GouraudCache &Cache, const GouraudMesh &Mesh, 
 
    Cache.Triangles.clear();
    Cache.Triangles.reserve(tri_count);
+   Cache.Translucent = false;
 
    auto fetch = [&](size_t Tri, int Corner) -> const PreparedVertex & {
       const int idx = Mesh.Indices.empty() ? int(Tri * 3 + Corner) : Mesh.Indices[Tri * 3 + Corner];
@@ -346,7 +440,11 @@ static void rebuild_gouraud_cache(GouraudCache &Cache, const GouraudMesh &Mesh, 
       tri.x[1] = b.x; tri.y[1] = b.y; tri.colour[1] = b.colour;
       tri.x[2] = c.x; tri.y[2] = c.y; tri.colour[2] = c.colour;
       Cache.Triangles.push_back(tri);
+
+      if ((a.colour.a < 0xff) or (b.colour.a < 0xff) or (c.colour.a < 0xff)) Cache.Translucent = true;
    }
+
+   Cache.Overlapping = Cache.Translucent and gouraud_triangles_overlap(Cache.Triangles);
 
    Cache.Transform   = Transform;
    Cache.MeshHash    = MeshHash;
@@ -354,6 +452,50 @@ static void rebuild_gouraud_cache(GouraudCache &Cache, const GouraudMesh &Mesh, 
    Cache.ColourSpace = ColourSpace;
    Cache.Valid       = true;
 }
+
+// The compound rasteriser stores style ids in int16 cells, so a single pass supports at most ~32k styles (one per
+// triangle).  fill_mesh() reduces its tessellation density to stay under this cap when the translucent path will be
+// taken; render_gouraud_triangles() additionally guards against oversized caches by falling back to the dilated path.
+
+constexpr size_t GOURAUD_COMPOUND_STYLE_LIMIT = 32000;
+
+//********************************************************************************************************************
+// Style handler for the compound (translucent) Gouraud render path.  One span generator is pre-built and prepared
+// per triangle, indexed by the triangle's compound style id, so generate_span() performs no per-span setup.
+// Generators are constructed with zero dilation: the compound rasteriser partitions coverage exactly along shared
+// edges, so no overlap is needed to seal seams.
+
+template<class SpanGen> class GouraudStyleHandler {
+public:
+   GouraudStyleHandler(const std::vector<GouraudTriangle> &Triangles, int Levels) {
+      generators.reserve(Triangles.size());
+      for (auto &tri : Triangles) {
+         // The quantising wrapper takes a trailing 'levels' argument that the plain/linear generators do not.
+         if constexpr (requires { SpanGen(tri.colour[0], tri.colour[1], tri.colour[2],
+            tri.x[0], tri.y[0], tri.x[1], tri.y[1], tri.x[2], tri.y[2], 0.0, Levels); }) {
+            generators.emplace_back(tri.colour[0], tri.colour[1], tri.colour[2],
+               tri.x[0], tri.y[0], tri.x[1], tri.y[1], tri.x[2], tri.y[2], 0.0, Levels);
+         }
+         else {
+            generators.emplace_back(tri.colour[0], tri.colour[1], tri.colour[2],
+               tri.x[0], tri.y[0], tri.x[1], tri.y[1], tri.x[2], tri.y[2], 0.0);
+         }
+         generators.back().prepare();
+      }
+   }
+
+   bool is_solid(unsigned) const { return false; }
+   agg::rgba8 color(unsigned) const { return agg::rgba8(0, 0, 0, 0); }
+
+   void generate_span(agg::rgba8 *Span, int X, int Y, unsigned Len, unsigned Style) {
+      generators[Style].generate(Span, X, Y, Len);
+   }
+
+private:
+   std::vector<SpanGen> generators;
+};
+
+//********************************************************************************************************************
 
 static void render_gouraud_triangles(const GouraudCache &Cache, double Resolution, VCS ColourSpace,
    agg::renderer_base<agg::pixfmt_psl> &RenderBase, agg::rendering_buffer &PathMaskBuffer)
@@ -374,15 +516,13 @@ static void render_gouraud_triangles(const GouraudCache &Cache, double Resolutio
    const int levels = int(std::clamp(level_count, 2.0, 256.0));
    const bool quantise = (levels < 256);
 
-   // Render every cached triangle through the chosen Gouraud span generator.  The cache stores colours in the
-   // encoding the generator expects (sRGB-encoded for the plain generator, linear-decoded for the linear one).
-   //
-   // Each triangle is rendered as a separate anti-aliased scanline pass, so the partial edge coverage of adjacent
-   // triangles does not sum to full opacity along a shared edge.  That leaves a faint translucent seam where the
-   // background bleeds through.  span_gouraud dilates the triangle outward by 'd' into a 6-vertex polygon (colours
-   // are still interpolated from the original vertices via miter joins), so feeding the rasteriser that dilated
-   // outline makes adjacent triangles overlap by ~'d' pixels.  Because shared edges carry identical colours on both
-   // sides, the overlap blends invisibly and seals the seam.
+   // Fast (opaque) path: every cached triangle is rendered as a separate anti-aliased scanline pass, so the partial
+   // edge coverage of adjacent triangles does not sum to full opacity along a shared edge.  That leaves a faint
+   // translucent seam where the background bleeds through.  span_gouraud dilates the triangle outward by 'd' into a
+   // 6-vertex polygon (colours are still interpolated from the original vertices via miter joins), so feeding the
+   // rasteriser that dilated outline makes adjacent triangles overlap by ~'d' pixels.  Because shared edges carry
+   // identical colours on both sides, the overlap blends invisibly and seals the seam.  The cache stores colours in
+   // the encoding the generator expects (sRGB-encoded for the plain generator, linear-decoded for the linear one).
 
    auto render_triangles = [&]<typename SpanGen>() {
       constexpr double DILATION = 0.5; // px; ~half a pixel of overlap is enough to cover the AA gap
@@ -407,13 +547,55 @@ static void render_gouraud_triangles(const GouraudCache &Cache, double Resolutio
       }
    };
 
+   // Slow (translucent) path: the dilation trick fails when vertex alpha < 255 because the ~1px overlap band is
+   // source-over blended twice, roughly doubling its opacity and exposing the tessellation grid as dark seams.
+   // For a non-overlapping mesh, all triangles are fed into a single compound rasterisation pass as per-triangle
+   // styles: coverage at shared edges is partitioned exactly between neighbours and each destination pixel is blended
+   // exactly once, so no dilation is required and any alpha renders correctly.  Overlapping triangles retain the
+   // ordered path above because their translucent layers must source-over composite.  The compound pass writes
+   // directly to the destination through an alpha-mask adaptor over the existing path mask.
+
+   const auto &clip = RenderBase.clip_box();
+
+   auto render_compound = [&]<typename SpanGen>() {
+      GouraudStyleHandler<SpanGen> handler(Cache.Triangles, levels);
+
+      agg::rasterizer_compound_aa<> compound_raster;
+      compound_raster.clip_box(clip.x1, clip.y1, clip.x2 + 1, clip.y2 + 1);
+      compound_raster.layer_order(agg::layer_direct);
+
+      for (size_t i=0; i < Cache.Triangles.size(); i++) {
+         auto &tri = Cache.Triangles[i];
+         compound_raster.styles(int(i), -1);
+         compound_raster.move_to_d(tri.x[0], tri.y[0]);
+         compound_raster.line_to_d(tri.x[1], tri.y[1]);
+         compound_raster.line_to_d(tri.x[2], tri.y[2]);
+         compound_raster.line_to_d(tri.x[0], tri.y[0]);
+      }
+
+      agg::pixfmt_amask_adaptor<agg::pixfmt_psl, agg::alpha_mask_gray8> masked_pixels(RenderBase.ren(), alpha_mask);
+      agg::renderer_base<agg::pixfmt_amask_adaptor<agg::pixfmt_psl, agg::alpha_mask_gray8>> masked_base(masked_pixels);
+      masked_base.clip_box_naked(clip);
+
+      agg::scanline_u8 scanline;
+      agg::render_scanlines_compound_layered(compound_raster, scanline, masked_base, span_allocator, handler);
+   };
+
+   const bool compound = Cache.Translucent and (not Cache.Overlapping) and
+      (Cache.Triangles.size() <= GOURAUD_COMPOUND_STYLE_LIMIT);
+
+   auto dispatch = [&]<typename SpanGen>() {
+      if (compound) render_compound.template operator()<SpanGen>();
+      else render_triangles.template operator()<SpanGen>();
+   };
+
    if (ColourSpace IS VCS::LINEAR_RGB) {
-      if (quantise) render_triangles.template operator()<agg::span_gouraud_rgba_quantise<agg::span_gouraud_rgba_linear<agg::rgba8>>>();
-      else render_triangles.template operator()<agg::span_gouraud_rgba_linear<agg::rgba8>>();
+      if (quantise) dispatch.template operator()<agg::span_gouraud_rgba_quantise<agg::span_gouraud_rgba_linear<agg::rgba8>>>();
+      else dispatch.template operator()<agg::span_gouraud_rgba_linear<agg::rgba8>>();
    }
    else {
-      if (quantise) render_triangles.template operator()<agg::span_gouraud_rgba_quantise<agg::span_gouraud_rgba<agg::rgba8>>>();
-      else render_triangles.template operator()<agg::span_gouraud_rgba<agg::rgba8>>();
+      if (quantise) dispatch.template operator()<agg::span_gouraud_rgba_quantise<agg::span_gouraud_rgba<agg::rgba8>>>();
+      else dispatch.template operator()<agg::span_gouraud_rgba<agg::rgba8>>();
    }
 }
 
@@ -664,6 +846,8 @@ static void mesh_push_triangle(GouraudCache &Cache, const MeshPreparedVertex &A,
    tri.x[1] = B.x; tri.y[1] = B.y; tri.colour[1] = B.colour;
    tri.x[2] = C.x; tri.y[2] = C.y; tri.colour[2] = C.colour;
    Cache.Triangles.push_back(tri);
+
+   if ((A.colour.a < 0xff) or (B.colour.a < 0xff) or (C.colour.a < 0xff)) Cache.Translucent = true;
 }
 
 static void rebuild_mesh_cache(GouraudCache &Cache, const MeshGradient &Mesh, const agg::trans_affine &Transform,
@@ -681,6 +865,7 @@ static void rebuild_mesh_cache(GouraudCache &Cache, const MeshGradient &Mesh, co
 
    Cache.Triangles.clear();
    Cache.Triangles.reserve(Mesh.patches.size() * size_t(Segments) * size_t(Segments) * 2);
+   Cache.Translucent = false;
 
    for (size_t p=0; p < Mesh.patches.size(); p++) {
       const auto &patch = Mesh.patches[p];
@@ -715,6 +900,8 @@ static void rebuild_mesh_cache(GouraudCache &Cache, const MeshGradient &Mesh, co
       }
    }
 
+   Cache.Overlapping = Cache.Translucent and gouraud_triangles_overlap(Cache.Triangles);
+
    Cache.Transform   = Transform;
    Cache.MeshHash    = MeshHash;
    Cache.Opacity     = Opacity;
@@ -746,7 +933,28 @@ static void fill_mesh(VectorState &State, const TClipRectangle<double> &Bounds, 
    transform *= Transform;
 
    const double resolution = std::clamp(Gradient.Resolution, 0.0, 1.0);
-   const int segments = int(std::clamp(std::round(4.0 + (resolution * 28.0)), 1.0, 64.0));
+   int segments = int(std::clamp(std::round(4.0 + (resolution * 28.0)), 1.0, 64.0));
+
+   // A translucent mesh renders through the compound rasteriser, which stores per-triangle style ids as int16 and
+   // caps a single pass at GOURAUD_COMPOUND_STYLE_LIMIT triangles.  Reduce the per-patch tessellation density until
+   // the projected triangle count fits; the quality impact is negligible and seam correctness is preserved because
+   // everything still renders in one pass.
+
+   auto translucent = [&]() {
+      if (Opacity < 1.0) return true;
+      for (auto &patch : Gradient.Mesh->patches) {
+         for (auto &corner : patch.corner) if (corner.Alpha < 1.0) return true;
+      }
+      return false;
+   };
+
+   if (translucent()) {
+      const size_t patches = Gradient.Mesh->patches.size();
+      while ((segments > 1) and ((patches * size_t(segments) * size_t(segments) * 2) > GOURAUD_COMPOUND_STYLE_LIMIT)) {
+         segments--;
+      }
+   }
+
    const VCS colour_space = Gradient.ColourSpace;
    const uint64_t mesh_hash = mesh_gradient_fingerprint(*Gradient.Mesh, segments);
    if (!Gradient.MeshTriangles.matches(mesh_hash, transform, Opacity, colour_space)) {

--- a/src/vector/scene/scene_fill.cpp
+++ b/src/vector/scene/scene_fill.cpp
@@ -566,7 +566,10 @@ static void render_gouraud_triangles(const GouraudCache &Cache, double Resolutio
 
       for (size_t i=0; i < Cache.Triangles.size(); i++) {
          auto &tri = Cache.Triangles[i];
-         compound_raster.styles(int(i), -1);
+         const double area = ((tri.x[1] - tri.x[0]) * (tri.y[2] - tri.y[0])) -
+            ((tri.x[2] - tri.x[0]) * (tri.y[1] - tri.y[0]));
+         if (area > 0) compound_raster.styles(int(i), -1);
+         else compound_raster.styles(-1, int(i));
          compound_raster.move_to_d(tri.x[0], tri.y[0]);
          compound_raster.line_to_d(tri.x[1], tri.y[1]);
          compound_raster.line_to_d(tri.x[2], tri.y[2]);

--- a/src/vector/tests/test_gouraud_gradient.tiri
+++ b/src/vector/tests/test_gouraud_gradient.tiri
@@ -458,3 +458,120 @@ end
    assert(res4_greys is 4, 'Resolution 0.75 should yield 4 distinct levels (got ' .. res4_greys .. ')')
    assert(res2_greys is 2, 'Resolution 0.5 should yield 2 distinct levels (got ' .. res2_greys .. ')')
 end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Translucent Gouraud rendering.  Vertices with alpha < 1 select the compound (single-pass) render path, where
+-- coverage along shared triangle edges is partitioned exactly instead of being sealed by overlap.  The dilated
+-- fast path would source-over blend the ~1px overlap band twice, exposing the shared edge as a seam.
+
+function translucentVertex(X, Y, R, G, B, A)
+   local v = struct.new('GouraudVertex')
+   v.x = X
+   v.y = Y
+   v.colour.red   = R
+   v.colour.green = G
+   v.colour.blue  = B
+   v.colour.alpha = A
+   return v
+end
+
+-- A uniform red quad at 50% alpha, split into two triangles sharing the top-right / bottom-left diagonal.
+
+function newTranslucentQuadScene()
+   local scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   local viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+
+   local vertices = { }
+   table.insert(vertices, translucentVertex(0,   0,   1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(100, 0,   1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(0,   100, 1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(100, 100, 1.0, 0.0, 0.0, 0.5))
+
+   local gradient = scene.new('GradientGouraud', {
+      units    = VUNIT_USERSPACE,
+      vertices = vertices
+   })
+   gradient.indices = array<int> { 0, 1, 2,   -- triangle A: TL, TR, BL
+                                   1, 3, 2 }  -- triangle B: TR, BR, BL
+   check scene.mtAddDef('gouraud_translucent', gradient)
+
+   viewport.new('VectorRectangle', { x=0, y=0, width='100%', height='100%', fill='url(#gouraud_translucent)' })
+   return scene, gradient
+end
+
+-- Two translucent triangles with positive-area overlap.  They must retain ordered source-over compositing rather
+-- than being flattened as neighbouring cells of one compound mesh.
+
+function newOverlappingTranslucentScene()
+   local scene = obj.new('VectorScene', { pageWidth=100, pageHeight=100 })
+   local viewport = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
+
+   local vertices = { }
+   table.insert(vertices, translucentVertex(10, 10, 1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(90, 10, 1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(50, 90, 1.0, 0.0, 0.0, 0.5))
+   table.insert(vertices, translucentVertex(10, 90, 0.0, 0.0, 1.0, 0.5))
+   table.insert(vertices, translucentVertex(50, 10, 0.0, 0.0, 1.0, 0.5))
+   table.insert(vertices, translucentVertex(90, 90, 0.0, 0.0, 1.0, 0.5))
+
+   local gradient = scene.new('GradientGouraud', {
+      units    = VUNIT_USERSPACE,
+      vertices = vertices
+   })
+   check scene.mtAddDef('gouraud_translucent_overlap', gradient)
+
+   viewport.new('VectorRectangle', {
+      x=0, y=0, width='100%', height='100%', fill='url(#gouraud_translucent_overlap)'
+   })
+   return scene
+end
+
+@Test function TranslucentQuadHasNoSeam()
+   -- Composite the translucent quad over white.  The framework blends in linear-light space, so red at 50% alpha
+   -- yields green/blue ~186 (sRGB encoding of linear 0.5) everywhere - the same value a plain 'rgba(255,0,0,.5)'
+   -- fill produces.  A seam along the shared diagonal would source-over blend twice (linear 0.25 -> ~137), so
+   -- every sample across the diagonal must stay near the single-blend value.
+
+   local scene = newTranslucentQuadScene()
+   local bmp = obj.new('bitmap', { width=100, height=100, bitsPerPixel=32, bkgd='255,255,255,255' })
+   drawScene(scene, bmp)
+
+   for x = 40, 60 do
+      local c = mGfx.ReadRGBPixel(bmp, x, 100 - x)  -- track the diagonal x+y=100
+      assert((c.green > 165) and (c.green < 205),
+         'Translucent shared edge must blend exactly once (green ' .. c.green .. ' at ' .. x .. ',' .. (100 - x) .. ')')
+      assert(c.red > 250, 'Red channel should remain saturated over a white background (got ' .. c.red .. ')')
+   end
+end
+
+@Test function TranslucentFillCompositesCorrectly()
+   -- Away from any edge, 50% red over white must match the plain-fill source-over result on all channels
+   -- (green/blue ~186 under linear-light blending).
+
+   local scene = newTranslucentQuadScene()
+   local bmp = obj.new('bitmap', { width=100, height=100, bitsPerPixel=32, bkgd='255,255,255,255' })
+   drawScene(scene, bmp)
+
+   local p = mGfx.ReadRGBPixel(bmp, 25, 25)
+   assert(p.red > 250, '50% red over white should keep red saturated (got ' .. p.red .. ')')
+   assert((p.green > 175) and (p.green < 200),
+      '50% red over white should blend green to ~186 (got ' .. p.green .. ')')
+   assert((p.blue > 175) and (p.blue < 200),
+      '50% red over white should blend blue to ~186 (got ' .. p.blue .. ')')
+end
+
+@Test function OverlappingTranslucentTrianglesCompositeInOrder()
+   -- At the centre, 50% blue is composited over 50% red over white.  In linear light that produces approximately
+   -- (186, 137, 224); flattening the triangles as compound styles would discard the red layer and produce
+   -- approximately (186, 186, 255).
+
+   local scene = newOverlappingTranslucentScene()
+   local bmp = obj.new('bitmap', { width=100, height=100, bitsPerPixel=32, bkgd='255,255,255,255' })
+   drawScene(scene, bmp)
+
+   local p = mGfx.ReadRGBPixel(bmp, 50, 50)
+   assert((p.red > 170) and (p.red < 205), 'Overlapping red contribution should remain visible (got ' .. p.red .. ')')
+   assert((p.green > 120) and (p.green < 155),
+      'Two translucent layers should source-over composite in order (green ' .. p.green .. ')')
+   assert(p.blue > 215, 'Top blue layer should remain dominant (got ' .. p.blue .. ')')
+end

--- a/src/vector/tests/test_gouraud_gradient.tiri
+++ b/src/vector/tests/test_gouraud_gradient.tiri
@@ -560,6 +560,22 @@ end
       '50% red over white should blend blue to ~186 (got ' .. p.blue .. ')')
 end
 
+@Test function ReflectedTranslucentMeshRenders()
+   -- Reflection reverses the transformed triangle winding.  The compound rasteriser must assign each triangle's
+   -- style to its new interior side rather than silently treating the reflected interior as unstyled.
+
+   local scene, gradient = newTranslucentQuadScene()
+   gradient.transform = 'matrix(-1 0 0 1 100 0)'
+
+   local bmp = obj.new('bitmap', { width=100, height=100, bitsPerPixel=32, bkgd='255,255,255,255' })
+   drawScene(scene, bmp)
+
+   local p = mGfx.ReadRGBPixel(bmp, 50, 50)
+   assert(p.red > 250, 'Reflected translucent mesh should retain its red fill (got ' .. p.red .. ')')
+   assert((p.green > 175) and (p.green < 200),
+      'Reflected translucent mesh should composite at 50% alpha (green ' .. p.green .. ')')
+end
+
 @Test function OverlappingTranslucentTrianglesCompositeInOrder()
    -- At the centre, 50% blue is composited over 50% red over white.  In linear light that produces approximately
    -- (186, 137, 224); flattening the triangles as compound styles would discard the red layer and produce

--- a/src/vector/vector.h
+++ b/src/vector/vector.h
@@ -417,6 +417,8 @@ struct GouraudCache {
    uint64_t MeshHash = 0;       // Fingerprint of the source mesh (positions, colours, indices)
    double Opacity = -1.0;       // Fill opacity the colours were built with (-1 => never built)
    VCS ColourSpace = VCS::INHERIT; // Colour space the vertex colours were encoded for
+   bool Translucent = false;    // Any vertex alpha < 255; may select the seamless compound render path
+   bool Overlapping = false;    // Triangle interiors overlap; requires ordered source-over compositing
    bool Valid = false;
 
    bool matches(uint64_t pMeshHash, const agg::trans_affine &pTransform, double pOpacity, VCS pColourSpace) const {


### PR DESCRIPTION
* Rendered non-overlapping translucent meshes through compound rasterisation to eliminate shared-edge overdraw
* Preserved ordered source-over compositing when transformed triangle interiors overlap
* Added Gouraud regression coverage and updated the affected SVG render expectation