### PR TITLE
[Core] Replace DataFeed buffer and size parameters with a byte span

### DIFF
--- a/docs/xml/modules/classes/clipboard.xml
+++ b/docs/xml/modules/classes/clipboard.xml
@@ -37,13 +37,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Sends data to the clipboard or handles drag-and-drop requests.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>For regular clipboard writes, DataFeed currently accepts <code>DATA::TEXT</code>.  Text received through this action replaces the current text clip and is cached as a generated file unless the host clipboard accepts it and no history buffer is active.</p>

--- a/docs/xml/modules/classes/config.xml
+++ b/docs/xml/modules/classes/config.xml
@@ -52,13 +52,12 @@ print('The Action class is located at ' .. str)
     <action>
       <name>DataFeed</name>
       <comment>Data can be added to a Config object through this action.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>This action will accept configuration data in <code>TEXT</code> format.  Any existing data that matches to the new group keys will be overwritten with new values.</p>

--- a/docs/xml/modules/classes/document.xml
+++ b/docs/xml/modules/classes/document.xml
@@ -57,13 +57,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Document data can be sent and consumed via feeds.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>Appending content to an active document can be achieved via the data feed feature.  The Document class currently supports the <code>DATA::TEXT</code> and <code>DATA::XML</code> types for this purpose.</p>

--- a/docs/xml/modules/classes/file.xml
+++ b/docs/xml/modules/classes/file.xml
@@ -31,13 +31,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Data can be streamed to any file as a method of writing content.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>Streaming data of any type to a file will result in the content being written to the file at the current seek <fl>Position</fl>.</p>

--- a/docs/xml/modules/classes/netsocket.xml
+++ b/docs/xml/modules/classes/netsocket.xml
@@ -35,16 +35,15 @@ initially fill the internal write buffer, thereafter it will be called whenever 
     <action>
       <name>DataFeed</name>
       <comment>Streams raw data to the socket for writing.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
-<p>Data sent to a NetSocket through this action is written using the same buffered behaviour as <action>Write</action>.  If the feed size is zero, the buffer is treated as null-terminated text.</p>
+<p>Data sent to a NetSocket through this action is written using the same buffered behaviour as <action>Write</action>.</p>
       </description>
     </action>
 

--- a/docs/xml/modules/classes/pointer.xml
+++ b/docs/xml/modules/classes/pointer.xml
@@ -25,13 +25,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Sends device input events to the pointer.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>Use DataFeed with the <code>DATA::DEVICE_INPUT</code> data type to submit one or more <code>dcDeviceInput</code> records to a pointer object. The supplied records are interpreted in the same way as input received from host or native hardware.</p>

--- a/docs/xml/modules/classes/svg.xml
+++ b/docs/xml/modules/classes/svg.xml
@@ -50,13 +50,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Processes SVG data streams for incremental document parsing.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>The DataFeed action enables real-time processing of SVG data streams, allowing documents to be parsed incrementally as data becomes available.  This is particularly useful for network-based loading scenarios or when processing large SVG documents that may arrive in segments.</p>

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -43,13 +43,12 @@
     <action>
       <name>DataFeed</name>
       <comment>Processes and integrates external XML data into the object's document structure.</comment>
-      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)</prototype>
+      <prototype>ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span&lt;const int8_t&gt; Buffer)</prototype>
       <tiriPrototype>err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)</tiriPrototype>
       <input>
         <param type="OBJECTID" name="Object">Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.</param>
         <param type="DATA" name="Datatype" lookup="DATA">The type of data being sent.</param>
-        <param type="APTR" name="Buffer">The data being sent to the target object.</param>
-        <param type="INT" name="Size">The size of the data in Buffer.</param>
+        <param type="std::span&lt;const int8_t&gt;" name="Buffer">The data being sent to the target object.</param>
       </input>
       <description>
 <p>DataFeed accepts XML or text data and parses it into the object's tag hierarchy.  If the object has no existing tags, the parsed data becomes the document structure.  If tags already exist, the new data is parsed into a temporary hierarchy and appended to the root-level tag list.</p>

--- a/include/kotuku/modules/config.h
+++ b/include/kotuku/modules/config.h
@@ -120,8 +120,8 @@ class objConfig : public Object {
    // Action stubs
 
    inline ERR clear() noexcept { return Action(AC::Clear, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR flush() noexcept { return Action(AC::Flush, this, nullptr); }

--- a/include/kotuku/modules/display.h
+++ b/include/kotuku/modules/display.h
@@ -1091,8 +1091,8 @@ class objDisplay : public Object {
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
    inline ERR clear() noexcept { return Action(AC::Clear, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR disable() noexcept { return Action(AC::Disable, this, nullptr); }
@@ -1475,8 +1475,8 @@ class objClipboard : public Object {
    // Action stubs
 
    inline ERR clear() noexcept { return Action(AC::Clear, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR init() noexcept { return InitObject(this); }
@@ -1659,8 +1659,8 @@ class objPointer : public Object {
 
    // Action stubs
 
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR hide() noexcept { return Action(AC::Hide, this, nullptr); }

--- a/include/kotuku/modules/document.h
+++ b/include/kotuku/modules/document.h
@@ -144,8 +144,8 @@ class objDocument : public Object {
       struct acClipboard args = { Mode };
       return Action(AC::Clipboard, this, &args);
    }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR disable() noexcept { return Action(AC::Disable, this, nullptr); }

--- a/include/kotuku/modules/filesystem.h
+++ b/include/kotuku/modules/filesystem.h
@@ -151,8 +151,8 @@ class objFile : public Object {
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR flush() noexcept { return Action(AC::Flush, this, nullptr); }

--- a/include/kotuku/modules/network.h
+++ b/include/kotuku/modules/network.h
@@ -569,8 +569,8 @@ class objNetSocket : public Object {
 
    // Action stubs
 
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR disable() noexcept { return Action(AC::Disable, this, nullptr); }

--- a/include/kotuku/modules/scintilla.h
+++ b/include/kotuku/modules/scintilla.h
@@ -42,6 +42,7 @@ enum class SCLEX : int {
    PROPERTIES = 9,
 };
 
+
 // Optional flags.
 
 enum class SCIF : uint32_t {
@@ -137,8 +138,8 @@ class objScintilla : public Object {
       struct acClipboard args = { Mode };
       return Action(AC::Clipboard, this, &args);
    }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR disable() noexcept { return Action(AC::Disable, this, nullptr); }
@@ -624,4 +625,3 @@ class objScintillaSearch : public Object {
    }
 
 };
-

--- a/include/kotuku/modules/script.h
+++ b/include/kotuku/modules/script.h
@@ -89,8 +89,8 @@ class objScript : public Object {
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR getKey(std::string_view Key, std::string &Value) noexcept {

--- a/include/kotuku/modules/svg.h
+++ b/include/kotuku/modules/svg.h
@@ -59,8 +59,8 @@ class objSVG : public Object {
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR deactivate() noexcept { return Action(AC::Deactivate, this, nullptr); }

--- a/include/kotuku/modules/tiri.h
+++ b/include/kotuku/modules/tiri.h
@@ -52,8 +52,8 @@ class objTiri : public objScript {
    // Action stubs
 
    inline ERR activate() noexcept { return Action(AC::Activate, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR init() noexcept { return InitObject(this); }

--- a/include/kotuku/modules/xml.h
+++ b/include/kotuku/modules/xml.h
@@ -263,8 +263,8 @@ class objXML : public Object {
    // Action stubs
 
    inline ERR clear() noexcept { return Action(AC::Clear, this, nullptr); }
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }
    inline ERR init() noexcept { return InitObject(this); }

--- a/include/kotuku/objects.h
+++ b/include/kotuku/objects.h
@@ -1001,7 +1001,7 @@ inline void SharedObjectAccess::release() {
 
 struct acClipboard     { static const AC id = AC::Clipboard; CLIPMODE Mode; };
 struct acCopyData      { static const AC id = AC::CopyData; OBJECTPTR Dest; };
-struct acDataFeed      { static const AC id = AC::DataFeed; OBJECTPTR Object; DATA Datatype; const void *Buffer; int Size; };
+struct acDataFeed      { static const AC id = AC::DataFeed; OBJECTPTR Object; DATA Datatype; std::span<const int8_t> Buffer; };
 struct acDragDrop      { static const AC id = AC::DragDrop; OBJECTPTR Source; int Item; std::string_view Datatype; };
 struct acDraw          { static const AC id = AC::Draw; int X; int Y; int Width; int Height; };
 struct acGetKey        { static const AC id = AC::GetKey; std::string_view Key; std::string *Value; };
@@ -1061,8 +1061,8 @@ inline ERR acDrawArea(OBJECTPTR Object, int X, int Y, int Width, int Height) {
    return Action(AC::Draw, Object, &args);
 }
 
-inline ERR acDataFeed(OBJECTPTR Object, OBJECTPTR Sender, DATA Datatype, const void *Buffer, int Size) {
-   struct acDataFeed args = { Sender, Datatype, Buffer, Size };
+inline ERR acDataFeed(OBJECTPTR Object, OBJECTPTR Sender, DATA Datatype, std::span<const int8_t> Buffer) {
+   struct acDataFeed args = { Sender, Datatype, Buffer };
    return Action(AC::DataFeed, Object, &args);
 }
 

--- a/src/core/classes/class_config.cpp
+++ b/src/core/classes/class_config.cpp
@@ -236,12 +236,10 @@ be overwritten with new values.
 
 static ERR CONFIG_DataFeed(extConfig *Self, struct acDataFeed *Args)
 {
-   kt::Log log;
-
-   if (not Args) return log.warning(ERR::NullArgs);
+   if (not Args) return ERR::NullArgs;
 
    if (Args->Datatype IS DATA::TEXT) {
-      auto buf = (Args->Size > 0) ? std::string_view((CSTRING)Args->Buffer, Args->Size) : std::string_view((CSTRING)Args->Buffer);
+      auto buf = std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size());
       if (auto error = parse_config(Self, buf); !error) {
          apply_filters(Self);
       }
@@ -361,23 +359,19 @@ pure-query, object-owns-result, null-terminated-result
 
 static ERR CONFIG_GetGroupFromIndex(extConfig *Self, struct cfg::GetGroupFromIndex *Args)
 {
-   kt::Log log;
-
-   if ((not Args) or (Args->Index < 0)) return log.warning(ERR::Args);
+   if (not Args) return ERR::Args;
 
    if ((Args->Index >= 0) and (Args->Index < (int)Self->Groups.size())) {
       Args->Group = std::string_view(Self->Groups[Args->Index].first);
       return ERR::Okay;
    }
-   else return log.warning(ERR::OutOfRange);
+   else return kt::Log().warning(ERR::OutOfRange);
 }
 
 //********************************************************************************************************************
 
 static ERR CONFIG_Init(extConfig *Self)
 {
-   kt::Log log;
-
    if ((Self->Flags & CNF::NEW) != CNF::NIL) return ERR::Okay; // Do not load any data even if the path is defined.
 
    ERR error = ERR::Okay;
@@ -498,9 +492,7 @@ pure-query, object-owns-result, null-terminated-result
 
 static ERR CONFIG_ReadValue(extConfig *Self, struct cfg::ReadValue *Args)
 {
-   kt::Log log;
-
-   if (not Args) return log.warning(ERR::NullArgs);
+   if (not Args) return ERR::NullArgs;
 
    for (auto & [group, keys] : Self->Groups) {
       if ((not Args->Group.empty()) and (group != Args->Group)) continue;
@@ -516,7 +508,6 @@ static ERR CONFIG_ReadValue(extConfig *Self, struct cfg::ReadValue *Args)
       }
    }
 
-   log.trace("Could not find key %.*s : %.*s.", int(Args->Group.size()), Args->Group.data(), int(Args->Key.size()), Args->Key.data());
    Args->Data = std::string_view{};
    return ERR::Search;
 }

--- a/src/core/classes/class_file.cpp
+++ b/src/core/classes/class_file.cpp
@@ -392,13 +392,10 @@ static ERR FILE_DataFeed(extFile *Self, struct acDataFeed *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Buffer)) return log.warning(ERR::NullArgs);
+   if (not Args) return log.warning(ERR::NullArgs);
+   if ((not Args->Buffer.data()) and (not Args->Buffer.empty())) return log.warning(ERR::NullArgs);
 
-   if (Args->Size) return acWrite(Self, std::span<const int8_t>((const int8_t *)Args->Buffer, Args->Size));
-   else {
-      auto input = std::string_view((const char *)Args->Buffer);
-      return acWrite(Self, std::span<const int8_t>((const int8_t *)Args->Buffer, input.size()));
-   }
+   return acWrite(Self, Args->Buffer);
 }
 
 /*********************************************************************************************************************

--- a/src/core/classes/class_script.cpp
+++ b/src/core/classes/class_script.cpp
@@ -61,11 +61,8 @@ static ERR SCRIPT_DataFeed(objScript *Self, struct acDataFeed *Args)
 {
    if (not Args) return ERR::NullArgs;
 
-   if (Args->Datatype IS DATA::XML) {
-      Self->setStatement((STRING)Args->Buffer);
-   }
-   else if (Args->Datatype IS DATA::TEXT) {
-      Self->setStatement((STRING)Args->Buffer);
+   if ((Args->Datatype IS DATA::XML) or (Args->Datatype IS DATA::TEXT)) {
+      Self->setStatement(std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size()));
    }
 
    return ERR::Okay;

--- a/src/core/compression/compression_func.cpp
+++ b/src/core/compression/compression_func.cpp
@@ -17,7 +17,8 @@ static void print(extCompression *Self, CSTRING Buffer)
 
    if (Self->OutputID) {
       kt::ScopedObjectLock output(Self->OutputID);
-      if (output.granted()) acDataFeed(*output, Self, DATA::TEXT, Buffer, strlen(Buffer) + 1);
+      if (output.granted()) acDataFeed(*output, Self, DATA::TEXT,
+         std::span<const int8_t>((const int8_t *)Buffer, strlen(Buffer)));
    }
    else log.msg("%s", Buffer);
 }
@@ -28,7 +29,8 @@ static void print(extCompression *Self, std::string Buffer)
 
    if (Self->OutputID) {
       kt::ScopedObjectLock output(Self->OutputID);
-      if (output.granted()) acDataFeed(*output, Self, DATA::TEXT, Buffer.c_str(), Buffer.length() + 1);
+      if (output.granted()) acDataFeed(*output, Self, DATA::TEXT,
+         std::span<const int8_t>((const int8_t *)Buffer.data(), Buffer.size()));
    }
    else log.msg("%s", Buffer.c_str());
 }

--- a/src/core/data_actionlist.cpp
+++ b/src/core/data_actionlist.cpp
@@ -6,7 +6,7 @@
 
 FDEF argsClipboard[]     = { { "Mode", FD_INT }, { 0, 0 } };
 FDEF argsCopyData[]      = { { "Dest", FD_OBJECTPTR  }, { 0, 0 } };
-FDEF argsDataFeed[]      = { { "Object", FD_OBJECTPTR }, { "Datatype", FD_INT }, { "Buffer", FD_PTR }, { "Size", FD_INT|FD_PTRSIZE }, { 0, 0 } };
+FDEF argsDataFeed[]      = { { "Object", FD_OBJECTPTR }, { "Datatype", FD_INT }, { "Buffer", FDF_SPAN|FD_PTR }, { 0, 0 } };
 FDEF argsDragDrop[]      = { { "Source", FD_OBJECTPTR }, { "Item", FD_INT }, { "Datatype", FDF_CPPSTRING }, { 0, 0 } };
 FDEF argsDraw[]          = { { "X", FD_INT }, { "Y", FD_INT }, { "Width", FD_INT }, { "Height", FD_INT }, { 0, 0 } };
 FDEF argsGetKey[]        = { { "Field", FDF_CPPSTRING }, { "Value", FDF_CPPSTRING|FD_RESULT|FD_MUTABLE }, { 0, 0 } };

--- a/src/core/tests/test_config.tiri
+++ b/src/core/tests/test_config.tiri
@@ -37,7 +37,7 @@ end
 
 function new_config()
    cfg = obj.new('config', { })
-   err = cfg.acDataFeed(nil, DATA_TEXT, glLegalData, 0)
+   err = cfg.acDataFeed(nil, DATA_TEXT, glLegalData)
    assert(err is ERR_Okay, 'DataFeed() returned ' .. mSys.GetErrorMsg(err))
    return cfg
 end
@@ -130,7 +130,7 @@ end
    cfg = new_config()
 
    cfgMerge = obj.new('config', { })
-   err = cfgMerge.acDataFeed(nil, DATA_TEXT, glMerge, 0)
+   err = cfgMerge.acDataFeed(nil, DATA_TEXT, glMerge)
    assert(err is ERR_Okay, 'DataFeed() returned ' .. mSys.GetErrorMsg(err))
 
    err = cfg.mtMerge(cfgMerge);

--- a/src/display/class_clipboard.cpp
+++ b/src/display/class_clipboard.cpp
@@ -442,8 +442,9 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::TEXT) {
       log.msg("Copying text to the clipboard.");
 
-      if (not Args->Buffer) return log.warning(ERR::NullArgs);
-      if (auto error = add_text_to_host(Self, std::string_view((CSTRING)Args->Buffer, size_t(Args->Size)));
+      if ((not Args->Buffer.data()) and (not Args->Buffer.empty())) return log.warning(ERR::NullArgs);
+      if (auto error = add_text_to_host(Self,
+            std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size()));
             (error != ERR::Okay) and (error != ERR::NoSupport)) {
          return log.warning(error);
       }
@@ -452,7 +453,7 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
       if (auto error = add_clip(CLIPTYPE::TEXT, items); !error) {
          auto file = objFile::create { fl::Path(items[0].Path), fl::Flags(FL::NEW|FL::WRITE), fl::Permissions(PERMIT::READ|PERMIT::WRITE) };
          if (file.ok()) {
-            if (file->write(std::span<const int8_t>((const int8_t *)Args->Buffer, Args->Size)) != ERR::Okay) {
+            if (file->write(Args->Buffer) != ERR::Okay) {
                return log.warning(ERR::Write);
             }
             return ERR::Okay;
@@ -462,10 +463,13 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
       else return log.warning(error);
    }
    else if ((Args->Datatype IS DATA::REQUEST) and ((Self->Flags & CPF::DRAG_DROP) != CPF::NIL))  {
-      if ((not Args->Buffer) or (not Args->Object)) return log.warning(ERR::NullArgs);
+      if ((not Args->Buffer.data()) or (not Args->Object)) return log.warning(ERR::NullArgs);
+      if (Args->Buffer.size() < sizeof(struct dcRequest)) return log.warning(ERR::Args);
 
-      auto request = (struct dcRequest *)Args->Buffer;
-      log.branch("Data request from #%d received for item %d, datatype %d", Args->Object->UID, request->Item, request->Preference[0]);
+      struct dcRequest request;
+      copymem(Args->Buffer.data(), &request, sizeof(request));
+      log.branch("Data request from #%d received for item %d, datatype %d", Args->Object->UID, request.Item,
+         request.Preference[0]);
 
       ERR error = ERR::Okay;
       if (Self->RequestHandler.stale()) {
@@ -476,15 +480,15 @@ static ERR CLIPBOARD_DataFeed(objClipboard *Self, struct acDataFeed *Args)
       if (Self->RequestHandler.isC()) {
          auto routine = (ERR (*)(objClipboard *, OBJECTPTR, int, char *, APTR))Self->RequestHandler.Routine;
          kt::SwitchContext ctx(Self->RequestHandler.Context);
-         error = routine(Self, Args->Object, request->Item, request->Preference, Self->RequestHandler.Meta);
+         error = routine(Self, Args->Object, request.Item, request.Preference, Self->RequestHandler.Meta);
       }
       else if (Self->RequestHandler.isScript()) {
          if (sc::Call(Self->RequestHandler, std::to_array<ScriptArg>({
             { "Clipboard", Self, FD_OBJECTPTR },
             { "Requester", Args->Object, FD_OBJECTPTR },
-            { "Item",      request->Item },
-            { "Datatypes", request->Preference, FD_ARRAY|FD_BYTE },
-            { "Size",      int(std::ssize(request->Preference)), FD_INT|FD_ARRAYSIZE }
+            { "Item",      request.Item },
+            { "Datatypes", request.Preference, FD_ARRAY|FD_BYTE },
+            { "Size",      int(std::ssize(request.Preference)), FD_INT|FD_ARRAYSIZE }
          }), error) != ERR::Okay) error = ERR::Terminate;
       }
       else error = log.warning(ERR::FieldNotSet);

--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -234,17 +234,20 @@ static ERR DISPLAY_DataFeed(extDisplay *Self, struct acDataFeed *Args)
    if (Args->Datatype IS DATA::REQUEST) {
       // Supported for handling the windows clipboard
 
-      if ((not Args->Buffer) or (not Args->Object)) return log.warning(ERR::NullArgs);
-      auto request = (struct dcRequest *)Args->Buffer;
+      if ((not Args->Buffer.data()) or (not Args->Object)) return log.warning(ERR::NullArgs);
+      if (Args->Buffer.size() < sizeof(struct dcRequest)) return log.warning(ERR::Args);
+      struct dcRequest request;
+      copymem(Args->Buffer.data(), &request, sizeof(request));
 
-      log.traceBranch("Received data request from object %d, item %d", Args->Object ? Args->Object->UID : 0, request->Item);
+      log.traceBranch("Received data request from object %d, item %d", Args->Object ? Args->Object->UID : 0,
+         request.Item);
 
       #ifdef WIN_DRAGDROP
       struct WinDT *data;
       int total_items;
-      if (not winGetData(request->Preference, &data, &total_items)) {
+      if (not winGetData(request.Preference, &data, &total_items)) {
          std::ostringstream xml;
-         xml << "<receipt totalitems=\"" << total_items << "\" id=\"" << request->Item << "\">";
+         xml << "<receipt totalitems=\"" << total_items << "\" id=\"" << request.Item << "\">";
          for (int i=0; i < total_items; i++) {
             if (DATA(data[i].Datatype) IS DATA::FILE) {
                xml << "<file path=\"" << (CSTRING)data[i].Data << "\"/>";
@@ -256,14 +259,9 @@ static ERR DISPLAY_DataFeed(extDisplay *Self, struct acDataFeed *Args)
          }
          xml << "</receipt>";
 
-         struct acDataFeed dc;
          auto result = xml.str();
-         dc.Object   = Self;
-         dc.Datatype = DATA::RECEIPT;
-         dc.Buffer   = result.c_str();
-         dc.Size     = result.size() + 1;
-         auto error = Action(AC::DataFeed, Args->Object, &dc);
-         return error;
+         return acDataFeed(Args->Object, Self, DATA::RECEIPT,
+            std::span<const int8_t>((const int8_t *)result.data(), result.size()));
       }
       else return log.warning(ERR::NoSupport);
       #endif

--- a/src/display/class_pointer.cpp
+++ b/src/display/class_pointer.cpp
@@ -133,7 +133,8 @@ static ERR POINTER_DataFeed(extPointer *Self, struct acDataFeed *Args)
    if (!Args) return log.warning(ERR::NullArgs);
 
    if (Args->Datatype IS DATA::DEVICE_INPUT) {
-      if (auto input = (struct dcDeviceInput *)Args->Buffer) {
+      if (Args->Buffer.size() % sizeof(struct dcDeviceInput)) return log.warning(ERR::Args);
+      if (Args->Buffer.data()) {
          // Remove any stale objects
          for (int i=0; i < std::ssize(Self->ButtonClicks); i++) {
             if (Self->ButtonClicks[i].LastClicked) {
@@ -141,16 +142,18 @@ static ERR POINTER_DataFeed(extPointer *Self, struct acDataFeed *Args)
             }
          }
 
-         for (auto i=sizeof(struct dcDeviceInput); i <= (size_t)Args->Size; i+=sizeof(struct dcDeviceInput), input++) {
-            if ((int(input->Type) < 1) or (int(input->Type) >= int(JET::END))) continue;
+         for (size_t offset=0; offset < Args->Buffer.size(); offset+=sizeof(struct dcDeviceInput)) {
+            struct dcDeviceInput input;
+            copymem(Args->Buffer.data() + offset, &input, sizeof(input));
+            if ((int(input.Type) < 1) or (int(input.Type) >= int(JET::END))) continue;
 
-            input->Flags |= glInputType[int(input->Type)].Flags;
+            input.Flags |= glInputType[int(input.Type)].Flags;
 
             //log.traceBranch("Incoming Input: %s, Value: %.2f, Flags: $%.8x, Time: %" PF64, (input->Type < JET::END) ? glInputNames[input->Type] : (STRING)"", input->Value, input->Flags, input->Timestamp);
 
-            if (input->Type IS JET::WHEEL) process_ptr_wheel(Self, input);
-            else if ((input->Flags & JTYPE::BUTTON) != JTYPE::NIL) process_ptr_button(Self, input);
-            else process_ptr_movement(Self, input);
+            if (input.Type IS JET::WHEEL) process_ptr_wheel(Self, &input);
+            else if ((input.Flags & JTYPE::BUTTON) != JTYPE::NIL) process_ptr_button(Self, &input);
+            else process_ptr_movement(Self, &input);
          }
       }
    }

--- a/src/display/win32/handlers.cpp
+++ b/src/display/win32/handlers.cpp
@@ -59,7 +59,8 @@ void MsgMovement(OBJECTID SurfaceID, double AbsX, double AbsY, int WinX, int Win
          .Flags = NonClient ? JTYPE::SECONDARY : JTYPE::NIL,
          .Type  = JET::ABS_XY
       };
-      acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &joy, sizeof(joy));
+      acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+         std::span<const int8_t>((const int8_t *)&joy, sizeof(joy)));
       ReleaseObject(pointer);
    }
 }
@@ -80,7 +81,8 @@ void MsgWheelMovement(OBJECTID SurfaceID, float Wheel)
          .Type      = JET::WHEEL
       };
 
-      acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &joy, sizeof(joy));
+      acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+         std::span<const int8_t>((const int8_t *)&joy, sizeof(joy)));
       ReleaseObject(pointer);
    }
 }
@@ -153,7 +155,8 @@ void MsgButtonPress(int button, int State)
          i++;
       }
 
-      if (i) acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &joy, sizeof(struct dcDeviceInput) * i);
+      if (i) acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+         std::span<const int8_t>((const int8_t *)&joy, sizeof(struct dcDeviceInput) * i));
 
       ReleaseObject(pointer);
    }

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -218,7 +218,8 @@ void handle_button_press(XEvent *xevent)
             .Type      = JET::WHEEL
          };
 
-         acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &input, sizeof(input));
+         acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+            std::span<const int8_t>((const int8_t *)&input, sizeof(input)));
       }
       else {
          struct dcDeviceInput input;
@@ -241,7 +242,8 @@ void handle_button_press(XEvent *xevent)
             input.Flags = glInputType[int(input.Type)].Flags;
             input.Timestamp = PreciseTime();
 
-            acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &input, sizeof(input));
+            acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+               std::span<const int8_t>((const int8_t *)&input, sizeof(input)));
          }
       }
 
@@ -267,7 +269,10 @@ void handle_button_release(XEvent *xevent)
       else if (xevent->xbutton.button IS 2) input.Type  = JET::BUTTON_3;
       else if (xevent->xbutton.button IS 3) input.Type  = JET::BUTTON_2;
 
-      if (input.Type != JET::NIL) acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT, &input, sizeof(input));
+      if (input.Type != JET::NIL) {
+         acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+            std::span<const int8_t>((const int8_t *)&input, sizeof(input)));
+      }
       ReleaseObject(pointer);
    }
 
@@ -712,18 +717,14 @@ void process_movement(Window Window, int X, int Y)
 
       // Refer to the handler code in the Display class to see how the HostX and HostY fields are updated from afar.
 
-      struct acDataFeed feed;
       struct dcDeviceInput input;
-      feed.Object   = nullptr;
-      feed.Datatype = DATA::DEVICE_INPUT;
-      feed.Buffer   = &input;
-      feed.Size     = sizeof(input);
       input.Type      = JET::ABS_XY;
       input.Flags     = JTYPE::NIL;
       input.Values[0] = X;
       input.Values[1] = Y;
       input.Timestamp = PreciseTime();
-      Action(AC::DataFeed, pointer, &feed);
+      acDataFeed(pointer, nullptr, DATA::DEVICE_INPUT,
+         std::span<const int8_t>((const int8_t *)&input, sizeof(input)));
 
       ReleaseObject(pointer);
    }

--- a/src/document/class/document_class.cpp
+++ b/src/document/class/document_class.cpp
@@ -383,7 +383,8 @@ static ERR DOCUMENT_Clipboard(extDocument *Self, struct acClipboard *Args)
                      int result;
                      if (!(error = file->read(std::span<int8_t>((int8_t *)buffer, size_t(size)), &result))) {
                         buffer[result] = 0;
-                        error = Self->dataFeed(Self, DATA::TEXT, buffer, result);
+                        error = Self->dataFeed(Self, DATA::TEXT,
+                           std::span<const int8_t>((const int8_t *)buffer, size_t(result)));
                      }
                      else error_dialog("Clipboard Paste Error", ERR::Read);
                      delete[] buffer;
@@ -435,7 +436,8 @@ static ERR DOCUMENT_DataFeed(extDocument *Self, struct acDataFeed *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Buffer)) return log.warning(ERR::NullArgs);
+   if (not Args) return log.warning(ERR::NullArgs);
+   if ((not Args->Buffer.data()) and (not Args->Buffer.empty())) return log.warning(ERR::NullArgs);
 
    if ((Args->Datatype IS DATA::TEXT) or (Args->Datatype IS DATA::XML)) {
       // Incoming data is translated on the fly and added to the end of the current document page.  The original XML
@@ -448,7 +450,7 @@ static ERR DOCUMENT_DataFeed(extDocument *Self, struct acDataFeed *Args)
 
       objXML::create xml = {
          fl::Flags(XMF::INCLUDE_WHITESPACE|XMF::PARSE_HTML|XMF::STRIP_HEADERS|XMF::WELL_FORMED|XMF::READ_ONLY),
-         fl::Statement(CSTRING(Args->Buffer))
+         fl::Statement(std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size()))
       };
 
       if (xml.ok()) {

--- a/src/document/menu.cpp
+++ b/src/document/menu.cpp
@@ -150,7 +150,8 @@ void doc_menu::refresh()
 
    acClear(m_doc);
    auto bufstr = buf.str();
-   m_doc->dataFeed(m_doc, DATA::XML, bufstr.c_str(), bufstr.size());
+   m_doc->dataFeed(m_doc, DATA::XML,
+      std::span<const int8_t>((const int8_t *)bufstr.data(), bufstr.size()));
 
    // Resize the menu to match the new content.  If the height of the menu is excessive (relative to the height
    // of the display), we reduce it and utilise a scrollbar to see all menu items.

--- a/src/http/http_incoming.cpp
+++ b/src/http/http_incoming.cpp
@@ -892,7 +892,8 @@ static ERR output_incoming_data(extHTTP *Self, APTR Buffer, int Length)
       if (Self->ObjectMode IS HOM::DATA_FEED) {
          kt::ScopedObjectLock output(Self->OutputObjectID);
          if (output.granted()) {
-            if (auto error = acDataFeed(*output, Self, Self->Datatype, Buffer, Length); error != ERR::Okay) {
+            if (auto error = acDataFeed(*output, Self, Self->Datatype,
+                  std::span<const int8_t>((const int8_t *)Buffer, size_t(Length))); error != ERR::Okay) {
                Self->Error = error;
                return Self->Error;
             }

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -369,8 +369,7 @@ static ERR connect_timeout_handler(OBJECTPTR Subscriber, int64_t TimeElapsed, in
 -ACTION-
 DataFeed: Streams raw data to the socket for writing.
 
-Data sent to a NetSocket through this action is written using the same buffered behaviour as #Write().  If the feed
-size is zero, the buffer is treated as null-terminated text.
+Data sent to a NetSocket through this action is written using the same buffered behaviour as #Write().
 
 *********************************************************************************************************************/
 
@@ -378,10 +377,9 @@ static ERR NETSOCKET_DataFeed(extNetSocket *Self, struct acDataFeed *Args)
 {
    kt::Log log;
 
-   if ((not Args) or (not Args->Buffer)) return log.warning(ERR::NullArgs);
-
-   if (not Args->Size) return ERR::Okay;
-   if (Args->Size < 0) return log.warning(ERR::Args);
+   if (not Args) return log.warning(ERR::NullArgs);
+   if ((not Args->Buffer.data()) and (not Args->Buffer.empty())) return log.warning(ERR::NullArgs);
+   if (Args->Buffer.empty()) return ERR::Okay;
 
    switch(Args->Datatype) {
       case DATA::TEXT:
@@ -389,10 +387,11 @@ static ERR NETSOCKET_DataFeed(extNetSocket *Self, struct acDataFeed *Args)
       case DATA::XML:
       case DATA::AUDIO:
       case DATA::IMAGE:
-         return acWrite(Self, std::span<const int8_t>((const int8_t *)Args->Buffer, Args->Size));
+         return acWrite(Self, Args->Buffer);
 
       case DATA::FILE: { // File path
-         auto file = objFile::create({ fl::Path(CSTRING(Args->Buffer)), fl::Flags(FL::READ) });
+         auto path = std::string((const char *)Args->Buffer.data(), Args->Buffer.size());
+         auto file = objFile::create({ fl::Path(path), fl::Flags(FL::READ) });
          if (file.ok()) {
             int64_t size;
             file->getSize(size);

--- a/src/network/tests/test_client_server.tiri
+++ b/src/network/tests/test_client_server.tiri
@@ -144,7 +144,7 @@ end
       name = 'DataFeedClient',
       feedback = function(Socket:obj, State:num)
          if State is NTC_CONNECTED then
-            err = Socket.acDataFeed(nil, DATA_TEXT, expected_msg, #expected_msg)
+            err = Socket.acDataFeed(nil, DATA_TEXT, expected_msg)
             assert(err is ERR_Okay, '[Client] Failed to feed socket data: ' .. mSys.GetErrorMsg(err))
          end
       end,

--- a/src/scintilla/class_scintilla.cxx
+++ b/src/scintilla/class_scintilla.cxx
@@ -287,12 +287,8 @@ static void notify_dragdrop(OBJECTPTR Object, ACTIONID ActionID, ERR Result, str
    request.Preference[1] = int8_t(DATA::TEXT);
    request.Preference[2] = 0;
 
-   struct acDataFeed dc;
-   dc.Object   = Self;
-   dc.Datatype = DATA::REQUEST;
-   dc.Buffer   = &request;
-   dc.Size     = sizeof(request);
-   if (!Action(AC::DataFeed, Args->Source, &dc)) {
+   if (!acDataFeed(Args->Source, Self, DATA::REQUEST,
+         std::span<const int8_t>((const int8_t *)&request, sizeof(request)))) {
       // The source will return a DATA::RECEIPT for the items that we've asked for (see the DataFeed action).
    }
 }
@@ -385,7 +381,8 @@ static void notify_write(OBJECTPTR Object, ACTIONID ActionID, ERR Result, struct
    SCICALL(SCI_SETUNDOCOLLECTION, 0UL); // Turn off undo
 
    if (Args->Buffer) {
-      acDataFeed(Self, Self, DATA::TEXT, Args->Buffer, Args->Result);
+      acDataFeed(Self, Self, DATA::TEXT,
+         std::span<const int8_t>((const int8_t *)Args->Buffer, size_t(Args->Result)));
    }
    else { // We have to read the data from the file stream
    }
@@ -449,19 +446,14 @@ static ERR SCINTILLA_DataFeed(extScintilla *Self, struct acDataFeed *Args)
    if (!Args) return log.warning(ERR::NullArgs);
 
    if (Args->Datatype IS DATA::TEXT) {
-      CSTRING str;
-
       // Incoming text is appended to the end of the document
-
-      if (!Args->Buffer) str = "";
-      else str = (CSTRING)Args->Buffer;
-
-      SCICALL(SCI_APPENDTEXT, strlen(str), str);
+      SCICALL(SCI_APPENDTEXT, Args->Buffer.size(), (const char *)Args->Buffer.data());
    }
    else if (Args->Datatype IS DATA::RECEIPT) {
       log.msg("Received item receipt from object %d.", Args->Object ? Args->Object->UID : 0);
 
-      objXML::create xml = { fl::Statement((CSTRING)Args->Buffer) };
+      objXML::create xml = { fl::Statement(
+         std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size())) };
       if (xml.ok()) {
          for (auto &tag : xml->Tags) {
             if (iequals("file", tag.name())) {

--- a/src/scintilla/class_scintilla_ext.cxx
+++ b/src/scintilla/class_scintilla_ext.cxx
@@ -145,7 +145,8 @@ void ScintillaKTK::AddToPopUp(const char *label, int cmD, bool enabled)
 
    if (auto menu = OBJECTPTR(popup.GetID()); menu) {
       auto buffer = std::format("<item text=\"{}\"></item>", label);
-      acDataFeed(menu, nullptr, DATA::XML, buffer.c_str(), buffer.size());
+      acDataFeed(menu, nullptr, DATA::XML,
+         std::span<const int8_t>((const int8_t *)buffer.data(), buffer.size()));
    }
 }
 

--- a/src/svg/class_svg.cpp
+++ b/src/svg/class_svg.cpp
@@ -118,7 +118,8 @@ static ERR SVG_DataFeed(extSVG *Self, struct acDataFeed *Args)
    if (!Args) return ERR::NullArgs;
 
    if (Args->Datatype IS DATA::XML) {
-      return parse_svg(Self, std::string_view{}, std::string_view((const char *)Args->Buffer, Args->Size));
+      return parse_svg(Self, std::string_view{},
+         std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size()));
    }
 
    return ERR::Okay;

--- a/src/tiri/tests/test_config_library.tiri
+++ b/src/tiri/tests/test_config_library.tiri
@@ -114,7 +114,7 @@ end
 @Test function InteroperatesWithConfigClass()
    local encoded = config.encode({ Font={ Name='Clean', Points=8, Scalable=true } })
    local cfg = obj.new('config')
-   check(cfg.acDataFeed(nil, DATA_TEXT, encoded, 0))
+   check(cfg.acDataFeed(nil, DATA_TEXT, encoded))
 
    local name = [_*]cfg.mtReadValue('Font', 'Name')
    local points = [_*]cfg.mtReadValue('Font', 'Points')

--- a/src/tiri/tiri_class.cpp
+++ b/src/tiri/tiri_class.cpp
@@ -361,11 +361,8 @@ static ERR TIRI_DataFeed(extTiri *Self, struct acDataFeed *Args)
 
    if (not Args) return ERR::NullArgs;
 
-   if (Args->Datatype IS DATA::TEXT) {
-      Self->setStatement((CSTRING)Args->Buffer);
-   }
-   else if (Args->Datatype IS DATA::XML) {
-      Self->setStatement((CSTRING)Args->Buffer);
+   if ((Args->Datatype IS DATA::TEXT) or (Args->Datatype IS DATA::XML)) {
+      Self->setStatement(std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size()));
    }
    else if (Args->Datatype IS DATA::RECEIPT) {
       log.branch("Incoming data receipt from #%d", Args->Object ? Args->Object->UID : 0);
@@ -379,7 +376,8 @@ static ERR TIRI_DataFeed(extTiri *Self, struct acDataFeed *Args)
                lua_rawgeti(Self->Lua, LUA_REGISTRYINDEX, it->Callback); // +1 Reference to callback
                lua_newtable(Self->Lua); // +1 Item table
 
-               if (auto xml = objXML::create::local(fl::Statement((CSTRING)Args->Buffer))) {
+               if (auto xml = objXML::create::local(fl::Statement(
+                     std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size())))) {
                   // <file path="blah.exe"/> becomes { item='file', path='blah.exe' }
 
                   if (not xml->Tags.empty()) {

--- a/src/tiri/tiri_input.cpp
+++ b/src/tiri/tiri_input.cpp
@@ -276,7 +276,8 @@ static void release_input_subscription(lua_State *Lua, struct finput *Input)
             .Preference = { char(datatype), 0 }
          };
 
-         auto error = acDataFeed(*src, Lua->script, DATA::REQUEST, &dcr, sizeof(dcr));
+         auto error = acDataFeed(*src, Lua->script, DATA::REQUEST,
+            std::span<const int8_t>((const int8_t *)&dcr, sizeof(dcr)));
          if (error != ERR::Okay) {
             if (callback_ref) {
                bool request_found = false;

--- a/src/xml/xml_class.cpp
+++ b/src/xml/xml_class.cpp
@@ -147,13 +147,15 @@ static ERR XML_DataFeed(extXML *Self, struct acDataFeed *Args)
       if ((Self->Flags & XMF::READ_ONLY) != XMF::NIL) return log.warning(ERR::ReadOnly);
 
       if (Self->Tags.empty()) {
-         if (auto error = txt_to_xml(Self, Self->Tags, std::string_view((char *)Args->Buffer, Args->Size)); error != ERR::Okay) {
+         if (auto error = txt_to_xml(Self, Self->Tags,
+               std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size())); error != ERR::Okay) {
             return log.warning(error);
          }
       }
       else {
          TAGS tags;
-         if (auto error = txt_to_xml(Self, tags, std::string_view((char *)Args->Buffer, Args->Size)); error != ERR::Okay) {
+         if (auto error = txt_to_xml(Self, tags,
+               std::string_view((const char *)Args->Buffer.data(), Args->Buffer.size())); error != ERR::Okay) {
             return log.warning(error);
          }
 

--- a/tools/idl/include/actions.tiri
+++ b/tools/idl/include/actions.tiri
@@ -52,8 +52,8 @@ global glActionStubs = {
       return Action(AC::Draw, this, &args);
    }]],
    DataFeed = [[
-   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, const void *Buffer, int Size) noexcept {
-      struct acDataFeed args = { Object, Datatype, Buffer, Size };
+   inline ERR dataFeed(OBJECTPTR Object, DATA Datatype, std::span<const int8_t> Buffer) noexcept {
+      struct acDataFeed args = { Object, Datatype, Buffer };
       return Action(AC::DataFeed, this, &args);
    }]],
    Move = [[

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -102,13 +102,12 @@ setAction('CopyData', {
 
 setAction('DataFeed', {
    comment   = 'Provides a mechanism for feeding data to objects.',
-   prototype = 'ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, APTR Buffer, INT Size)',
+   prototype = 'ERR acDataFeed(*Object, OBJECTID Object, DATA Datatype, std::span<const int8_t> Buffer)',
    tiriPrototype = 'err = Object.acDataFeed(Object:obj, Datatype:DATA, Buffer:str)',
    params    = {
       { name='Object', type='OBJECTID', comment='Must refer to the unique ID of the object that you represent. If you do not represent an object, set this parameter to the current task ID.' },
       { name='Datatype', type='DATA', lookup='DATA', comment='The type of data being sent.' },
-      { name='Buffer', type='APTR', comment='The data being sent to the target object.' },
-      { name='Size', type='INT', comment='The size of the data in Buffer.' }
+      { name='Buffer', type='std::span<const int8_t>', comment='The data being sent to the target object.' }
    }
 })
 


### PR DESCRIPTION
* Updated DataFeed implementations and call sites to use length-aware spans
* [Tiri] Updated action bindings and tests for the three-parameter interface
* [Doc] Regenerated action documentation and module headers