### PR TITLE
[Tiri] Improved typed array object field handling and errors

### DIFF
--- a/data/styles/default/scrollbar.tiri
+++ b/data/styles/default/scrollbar.tiri
@@ -36,7 +36,7 @@ return {
       end
 
       decA = dec.new('VectorPolygon', {
-         strokeWidth = 3, stroke = stroke, dashArray = '3,3'
+         strokeWidth = 3, stroke = stroke, dashArray = array<double> { 3, 3 }
       })
 
       if State.direction is 'V' then

--- a/scripts/gui/toolbar.tiri
+++ b/scripts/gui/toolbar.tiri
@@ -178,7 +178,7 @@ gui.toolbar = function(Options)
 
             seq = string.format('M%f,%f l0,%f', x+(item.width-1) * 0.5, y+1, item.height)
             self.vg.new('VectorPath', {
-               name = 'break', stroke = self._groupBorder, sequence = seq, dashArray = '1, 1'
+               name = 'break', stroke = self._groupBorder, sequence = seq, dashArray = array<double> { 1, 1 }
             })
 
             if self._horizontal then

--- a/src/font/tests/font_metrics.tiri
+++ b/src/font/tests/font_metrics.tiri
@@ -40,7 +40,7 @@ function setFont(Face, Size)
       -- METRICS ASCENT: BLUE DOTTED
       -- The ascent is the distance from the baseline to the top of the font, NOT including accents.  Generally very
       -- reliable, the margin of error is reasonably tight for our fonts.
-      global glAscent = glViewport.new('vectorpolygon', { x1 = 0, y1 = 0, x2 = '100%', y2 = 0, stroke='rgb(0,0,255,128)', dashArray="4,4" })
+      global glAscent = glViewport.new('vectorpolygon', { x1 = 0, y1 = 0, x2 = '100%', y2 = 0, stroke='rgb(0,0,255,128)', dashArray=array<double> { 4,4 } })
    end
 
    baseline = glTextY + Size

--- a/src/tiri/jit/src/lib/lib_object.cpp
+++ b/src/tiri/jit/src/lib/lib_object.cpp
@@ -68,7 +68,7 @@ static constexpr uint32_t OJH_unsubscribe = simple_hash("unsubscribe");
 [[nodiscard]] static int object_action_call(lua_State *);
 [[nodiscard]] static int object_method_call(lua_State *);
 [[nodiscard]] static int get_results(lua_State *, const FunctionField *, const int8_t *);
-[[nodiscard]] static ERR set_object_field(lua_State *, OBJECTPTR, uint32_t, int);
+[[nodiscard]] static ERR set_object_field(lua_State *, OBJECTPTR, uint32_t, int, const Field ** = nullptr);
 
 [[nodiscard]] static int object_children(lua_State *);
 [[nodiscard]] static int object_detach(lua_State *);
@@ -445,9 +445,11 @@ extern int object_newindex(lua_State *Lua)
          OBJECTPTR obj;
          if (auto error = access_object(def, obj); error IS ERR::Okay) {
             auto jt = get_write_table(def->classptr);
+            const Field *write_field = nullptr;
 
             auto func = std::lower_bound(jt->begin(), jt->end(), obj_write(hash), write_hash);
             if ((func != jt->end()) and (func->Hash IS hash)) {
+               write_field = func->Field;
                // All fields in the table are writable, but init checks are still required.
                if ((func->Field->Flags & FD_INIT) and obj->initialised()) error = ERR::NoFieldAccess;
                else error = func->Call(Lua, obj, func->Field, 3);
@@ -456,7 +458,9 @@ extern int object_newindex(lua_State *Lua)
             release_object(def);
 
             if (error >= ERR::ExceptionThreshold) {
-               luaL_error(Lua, error, "Write failure: %s.%s: %s", def->classptr->ClassName.c_str(), luaL_checkstring(Lua, 2), GetErrorMsg(error));
+               auto field_type = write_field ? field_typename(*write_field) : "unknown";
+               luaL_error(Lua, error, "Failed to set %s %s.%s field: %s", field_type.c_str(),
+                  def->classptr->ClassName.c_str(), luaL_checkstring(Lua, 2), GetErrorMsg(error));
             }
          }
          else { // Report why the object could not be accessed rather than dropping the write silently.
@@ -574,12 +578,14 @@ LJLIB_CF(object_new)
       if (lua_istable(L, 2)) {
          ERR field_error    = ERR::Okay;
          CSTRING field_name = nullptr;
+         const Field *failed_field = nullptr;
          int failed_type    = LUA_TNONE;
          lua_pushnil(L);
          while (lua_next(L, 2) != 0) {
+            failed_field = nullptr;
             if ((field_name = luaL_checkstring(L, -2))) {
                if (iequals("owner", field_name)) field_error = ERR::UnsupportedOwner;
-               else field_error = set_object_field(L, obj, fieldhash(field_name), -1);
+               else field_error = set_object_field(L, obj, fieldhash(field_name), -1, &failed_field);
             }
             else field_error = ERR::UnsupportedField;
 
@@ -592,11 +598,13 @@ LJLIB_CF(object_new)
          }
 
          if ((field_error != ERR::Okay) or ((error = InitObject(obj)) != ERR::Okay)) {
-            class_name = obj->className();
+            auto class_name = obj->className();
             FreeResource(obj);
 
             if (field_error != ERR::Okay) {
-               luaL_error(L, field_error, "obj.new() failed to set field '%s.%s' with %s, error: %s", class_name, field_name, lua_typename(L, failed_type), GetErrorMsg(field_error));
+               auto field_type = failed_field ? field_typename(*failed_field) : "unknown";
+               luaL_error(L, field_error, "Failed to set %s %s.%s field with %s: %s",
+                  field_type.c_str(), class_name, field_name, lua_typename(L, failed_type), GetErrorMsg(field_error));
             }
             else luaL_error(L, error, "obj.new() failed to Init() %s: %s", class_name, GetErrorMsg(error));
 
@@ -772,15 +780,19 @@ static int object_newchild(lua_State *Lua)
       if (lua_istable(Lua, 2)) {
          ERR field_error = ERR::Okay;
          std::string_view field_name;
+         const Field *failed_field = nullptr;
+         auto failed_type = LUA_TNONE;
          lua_pushnil(Lua);
          while (lua_next(Lua, 2) != 0) {
+            failed_field = nullptr;
             if (field_name = luaL_checkstring(Lua, -2); not field_name.empty()) {
                if (iequals("owner", field_name)) field_error = ERR::UnsupportedOwner; // Setting the owner field in this situation is illegal
-               else field_error = set_object_field(Lua, obj, fieldhash(field_name), -1);
+               else field_error = set_object_field(Lua, obj, fieldhash(field_name), -1, &failed_field);
             }
             else field_error = ERR::UnsupportedField;
 
             if (field_error != ERR::Okay) {
+               failed_type = lua_type(Lua, -1);
                lua_pop(Lua, 2);
                break;
             }
@@ -788,10 +800,14 @@ static int object_newchild(lua_State *Lua)
          }
 
          if ((field_error != ERR::Okay) or ((error = InitObject(obj)) != ERR::Okay)) {
+            auto class_name = obj->className();
             FreeResource(obj);
 
             if (field_error != ERR::Okay) {
-               luaL_error(Lua, field_error, "Failed to set field '%.*s', error: %s", int(field_name.size()), field_name.data(), GetErrorMsg(field_error));
+               auto field_type = failed_field ? field_typename(*failed_field) : "unknown";
+               luaL_error(Lua, field_error, "Failed to set %s %s.%.*s with %s: %s",
+                  field_type.c_str(), class_name, int(field_name.size()), field_name.data(),
+                  lua_typename(Lua, failed_type), GetErrorMsg(field_error));
             }
             else luaL_error(Lua, ERR::Init, "Failed to Init() object '%s', error: %s", class_name, GetErrorMsg(error));
          }

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -29,14 +29,12 @@ const std::string field_typename(const Field &Field)
    else if (Field.Flags & FD_OBJECT)   result = "object";
    else if (Field.Flags & FD_UNIT)     result = "unit";
    else if (Field.Flags & FD_FUNCTION) result = "function";
-   esle if (Field.Flags & FD_POINTER)  return = "pointer";
+   else if (Field.Flags & FD_POINTER)  result = "pointer";
    else return "unknown";
 
    if (Field.Flags & FD_UNSIGNED) result = "u" + result;
    if (Field.Flags & FD_ARRAY)    result = "array<" + result + ">";
-   if (Field.Flags & FD_POINTER) {
-      result += "*";
-   }
+   if (Field.Flags & FD_POINTER)  result += "*";
    return result;
 }
 

--- a/src/tiri/jit/src/runtime/lj_object.cpp
+++ b/src/tiri/jit/src/runtime/lj_object.cpp
@@ -13,6 +13,34 @@
 #include "../../defs.h"
 
 //********************************************************************************************************************
+
+const std::string field_typename(const Field &Field)
+{
+   std::string result;
+
+   if (Field.Flags & FD_STRING)        result = "string";
+   else if (Field.Flags & FD_DOUBLE)   result = "double";
+   else if (Field.Flags & FD_FLOAT)    result = "float";
+   else if (Field.Flags & FD_INT64)    result = "int64";
+   else if (Field.Flags & FD_INT)      result = "int";
+   else if (Field.Flags & FD_WORD)     result = "int16";
+   else if (Field.Flags & FD_BYTE)     result = "byte";
+   else if (Field.Flags & FD_STRUCT)   result = "struct";
+   else if (Field.Flags & FD_OBJECT)   result = "object";
+   else if (Field.Flags & FD_UNIT)     result = "unit";
+   else if (Field.Flags & FD_FUNCTION) result = "function";
+   esle if (Field.Flags & FD_POINTER)  return = "pointer";
+   else return "unknown";
+
+   if (Field.Flags & FD_UNSIGNED) result = "u" + result;
+   if (Field.Flags & FD_ARRAY)    result = "array<" + result + ">";
+   if (Field.Flags & FD_POINTER) {
+      result += "*";
+   }
+   return result;
+}
+
+//********************************************************************************************************************
 // Create a new GCobject for a Kotuku object reference.  The object is allocated via the GC.
 
 GCobject * lj_object_new(lua_State *L, OBJECTID UID, OBJECTPTR Ptr, objMetaClass *ClassPtr, uint8_t Flags)

--- a/src/tiri/jit/src/runtime/lj_object.h
+++ b/src/tiri/jit/src/runtime/lj_object.h
@@ -25,6 +25,8 @@ extern void lj_object_free(global_State *, GCobject *);
 extern int lj_object_pairs(lua_State *);
 extern int lj_object_ipairs(lua_State *);
 
+extern const std::string field_typename(const Field &);
+
 // Fast path bytecode handlers for BC_OBGETF and BC_OBSETF.
 // Ins points to the current instruction for inline caching (nullptr disables caching in JIT traces).
 

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -164,7 +164,7 @@ static ERR object_set_array(lua_State *Lua, OBJECTPTR Object, const Field *Field
       else return ERR::BufferOverflow;
    }
    else if (type IS LUA_TARRAY) {
-      GCarray *arr = arrayV(Lua, ValueIndex);
+      GCarray *arr = lua_toarray(Lua, ValueIndex);
       std::span<int> span((int *)arr->arraydata(), arr->len);
       return Object->set(Field, span, arr->type_flags());
    }
@@ -607,10 +607,12 @@ static int object_setkey(lua_State *Lua)
 //********************************************************************************************************************
 // Used by obj.new() exclusively.
 
-static ERR set_object_field(lua_State *Lua, OBJECTPTR Object, uint32_t FieldHash, int ValueIndex)
+static ERR set_object_field(lua_State *Lua, OBJECTPTR Object, uint32_t FieldHash, int ValueIndex,
+   const Field **ResolvedField)
 {
    OBJECTPTR target;
    if (auto field = FindField(Object, FieldHash, &target)) {
+      if (ResolvedField) *ResolvedField = field;
       if (not field->writeable()) return ERR::NoFieldAccess;
       else if ((field->Flags & FD_INIT) and target->initialised()) return ERR::NoFieldAccess;
 
@@ -653,7 +655,10 @@ static ERR set_object_field(lua_State *Lua, OBJECTPTR Object, uint32_t FieldHash
       }
       else return ERR::UnsupportedField;
    }
-   else return ERR::UnsupportedField;
+   else {
+      if (ResolvedField) *ResolvedField = nullptr;
+      return ERR::UnsupportedField;
+   }
 }
 
 //********************************************************************************************************************

--- a/src/vector/CMakeLists.txt
+++ b/src/vector/CMakeLists.txt
@@ -82,3 +82,4 @@ flute_test(vector_isolated_bitmap_pool "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_i
 flute_test(vector_shared_invalidation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shared_invalidation.tiri")
 flute_test(vector_callback_lifetimes "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_callback_lifetimes.tiri")
 flute_test(vector_path_command_spans "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_path_command_spans.tiri")
+flute_test(vector_dash_array "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dash_array.tiri")

--- a/src/vector/tests/test_dash_array.tiri
+++ b/src/vector/tests/test_dash_array.tiri
@@ -1,0 +1,80 @@
+   include 'vector'
+
+function newViewport()
+   scene = obj.new('VectorScene')
+   viewport = scene.new('VectorViewport')
+   check scene.init()
+   check viewport.init()
+   return scene, viewport
+end
+
+function assertDashArray(Vector, Expected)
+   actual = Vector.dashArray
+   assert(#actual is #Expected, 'DashArray should preserve the number of values.')
+   for i in {0 to #Expected} do
+      assert(actual[i] ≈ Expected[i], f'DashArray value {i} should match the typed array input.')
+   end
+end
+
+@Test function TypedDashArrayInObjectInitialiser()
+   scene, viewport = newViewport()
+   expected = array<double> { 4, 6 }
+   polygon = viewport.new('VectorPolygon', {
+      x1 = 0, y1 = 0, x2 = 10, y2 = 0,
+      stroke = 'blue',
+      dashArray = expected
+   })
+
+   assertDashArray(polygon, expected)
+end
+
+@Test function TypedDashArrayInFieldAssignment()
+   scene, viewport = newViewport()
+   polygon = viewport.new('VectorPolygon', {
+      x1 = 0, y1 = 0, x2 = 10, y2 = 0,
+      stroke = 'blue'
+   })
+   expected = array<double> { 2.5, 3.5 }
+
+   polygon.dashArray = expected
+
+   assertDashArray(polygon, expected)
+end
+
+@Test function InitialiserTypeMismatchNamesExpectedArrayType()
+   scene, viewport = newViewport()
+   local caught = false
+
+   try
+      viewport.new('VectorPolygon', {
+         x1 = 0, y1 = 0, x2 = 10, y2 = 0,
+         stroke = 'blue',
+         dashArray = array<int> { 2, 3 }
+      })
+   except e when ERR_SetValueNotArray
+      caught = true
+      assert(e.message:contains('array<double>'),
+         'The DashArray type mismatch should identify array<double> as the expected field type.')
+   end
+
+   assert(caught, 'An array<int> should not be accepted by the DashArray field.')
+end
+
+@Test function AssignmentTypeMismatchNamesExpectedArrayType()
+   scene, viewport = newViewport()
+   polygon = viewport.new('VectorPolygon', {
+      x1 = 0, y1 = 0, x2 = 10, y2 = 0,
+      stroke = 'blue'
+   })
+   local caught = false
+
+   try
+      polygon.dashArray = array<int> { 2, 3 }
+   except e when ERR_SetValueNotArray
+      caught = true
+      assert(e.message:contains('array<double>'),
+         'The DashArray type mismatch should identify array<double> as the expected field type.')
+   end
+
+   assert(caught, 'An array<int> should not be accepted by the DashArray field.')
+end


### PR DESCRIPTION
* Report expected field types when object initialisation or assignment fails
* Accept Tiri arrays through the checked array conversion when writing object fields
* [Vector] Added dash array coverage and migrated script callers to typed double arrays