### PR TITLE
[Core] Hash class field structure references

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -25,6 +25,10 @@
 #include <sstream>
 #include <cmath>
 #include <type_traits>
+#ifndef STRINGS_HPP
+#include <kotuku/strings.hpp>
+#endif
+
 #include "ankerl/unordered_dense.h"
 #endif
 
@@ -1157,6 +1161,7 @@ typedef AC ACTIONID;
 struct StructInfo {
    uint16_t Size;       // Byte size of the structure (sizeof)
    uint16_t Alignment;  // Alignment requirement of the structure (alignof)
+   std::string Name;     // Readable structure name
 };
 
 using LOG_CALLBACK = void(*)(CSTRING Header, CSTRING Message, int Depth, int MsgLevel, int LogLevel);
@@ -1237,9 +1242,18 @@ struct FieldArray {
    APTR     SetField; // ERR SetField(*Object, APTR Value);
    int64_t  Arg;    // Can be a pointer or an integer value
    uint32_t Flags;  // Special flags that describe the field
-  template <class G = APTR, class S = APTR, class T = MAXINT> FieldArray(CSTRING pName, uint32_t pFlags, G pGetField = nullptr, S pSetField = nullptr, T pArg = 0) :
-     Name(pName), GetField((APTR)pGetField), SetField((APTR)pSetField), Arg((MAXINT)pArg), Flags(pFlags)
-     { }
+   template <class T> static int64_t encode_arg(uint32_t Flags, T Arg) {
+      if constexpr (std::is_convertible_v<T, CSTRING>) {
+         if ((Flags & FD_STRUCT) and CSTRING(Arg)) return int64_t(uint32_t(kt::strhash(CSTRING(Arg))));
+      }
+      return int64_t((MAXINT)Arg);
+   }
+
+   template <class G = APTR, class S = APTR, class T = MAXINT>
+   FieldArray(CSTRING FieldName, uint32_t FieldFlags, G GetFieldFn = nullptr, S SetFieldFn = nullptr,
+      T FieldArg = 0) :
+      Name(FieldName), GetField((APTR)GetFieldFn), SetField((APTR)SetFieldFn),
+      Arg(encode_arg(FieldFlags, FieldArg)), Flags(FieldFlags) { }
 };
 
 struct FieldDef {

--- a/src/core/classes/class_metaclass.cpp
+++ b/src/core/classes/class_metaclass.cpp
@@ -113,8 +113,11 @@ static const FieldDef CategoryTable[] = {
 static const std::vector<Field> glMetaFieldsPreset = {
    // If you adjust this table, remember to adjust the index numbers and the byte offsets into the structure.
    { 0, nullptr, nullptr, writeval_default, "ClassVersion",    strhash("classVersion"), glMetaClassVersionOffset, 0, FDF_DOUBLE|FDF_RI },
-   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_Fields, (ERR (*)(APTR, APTR))SET_Fields, writeval_default, "Fields", strhash("fields"), glMetaFieldsOffset, 1, FDF_ARRAY|FD_STRUCT|FDF_RI },
-   { MAXINT("Field"),      (ERR (*)(APTR, APTR))GET_Dictionary, nullptr, writeval_default, "Dictionary", strhash("dictionary"), glMetaDictionaryOffset, 2, FDF_ARRAY|FD_STRUCT|FDF_R },
+   { int64_t(uint32_t(strhash("FieldArray"))), (ERR (*)(APTR, APTR))GET_Fields,
+      (ERR (*)(APTR, APTR))SET_Fields, writeval_default, "Fields", strhash("fields"), glMetaFieldsOffset, 1,
+      FDF_ARRAY|FD_STRUCT|FDF_RI },
+   { int64_t(uint32_t(strhash("Field"))), (ERR (*)(APTR, APTR))GET_Dictionary, nullptr, writeval_default,
+      "Dictionary", strhash("dictionary"), glMetaDictionaryOffset, 2, FDF_ARRAY|FD_STRUCT|FDF_R },
    { 0, nullptr, nullptr, writeval_default, "ClassName",       strhash("className"),       glMetaClassNameOffset,        3,  FDF_CPPSTRING|FDF_RI|FDF_PURE },
    { 0, nullptr, nullptr, writeval_default, "FileExtension",   strhash("fileExtension"),   glMetaFileExtensionOffset,    4,  FDF_CPPSTRING|FDF_RI|FDF_PURE },
    { 0, nullptr, nullptr, writeval_default, "FileDescription", strhash("fileDescription"), glMetaFileDescriptionOffset,  5,  FDF_CPPSTRING|FDF_RI|FDF_PURE },
@@ -129,14 +132,17 @@ static const std::vector<Field> glMetaFieldsPreset = {
    { MAXINT(&CategoryTable), nullptr, nullptr, writeval_default, "Category",  strhash("category"), glMetaCategoryOffset, 14, FDF_INT|FDF_LOOKUP|FDF_RI },
    { 0, nullptr, nullptr, writeval_default, "PublicSize",      strhash("publicSize"),      glMetaPublicSizeOffset,       15, FDF_INT|FDF_RI },
    // Virtual fields
-   { MAXINT("MethodEntry"), (ERR (*)(APTR, APTR))GET_Methods, (ERR (*)(APTR, APTR))SET_Methods, writeval_default, "Methods", strhash("methods"), sizeof(Object), 16, FDF_ARRAY|FD_STRUCT|FDF_RI },
+   { int64_t(uint32_t(strhash("MethodEntry"))), (ERR (*)(APTR, APTR))GET_Methods,
+      (ERR (*)(APTR, APTR))SET_Methods, writeval_default, "Methods", strhash("methods"), sizeof(Object), 16,
+      FDF_ARRAY|FD_STRUCT|FDF_RI },
    { 0, nullptr, (ERR (*)(APTR, APTR))SET_Actions, writeval_default,  "Actions",           strhash("actions"),         sizeof(Object), 17, FDF_POINTER|FDF_I },
    { 0, (ERR (*)(APTR, APTR))GET_ActionTable, 0,  writeval_default,   "ActionTable",       strhash("actionTable"),     sizeof(Object), 18, FDF_ARRAY|FDF_POINTER|FDF_R },
    { 0, (ERR (*)(APTR, APTR))GET_Location, 0,     writeval_default,   "Location",          strhash("location"),        sizeof(Object), 19, FDF_CPPSTRING|FDF_R|FDF_PURE },
    { 0, (ERR (*)(APTR, APTR))GET_ClassName, (ERR (*)(APTR, APTR))SET_ClassName, writeval_default, "Name", strhash("name"), sizeof(Object), 20, FDF_CPPSTRING|FDF_SYSTEM|FDF_RI|FDF_PURE },
    { 0, (ERR (*)(APTR, APTR))GET_Module, 0,       writeval_default,   "Module",            strhash("module"),          sizeof(Object), 21, FDF_CPPSTRING|FDF_R },
    { MAXINT(CLASSID::METACLASS), (ERR (*)(APTR, APTR))GET_SubClasses, nullptr, writeval_default, "SubClasses", strhash("subClasses"), sizeof(Object), 22, FDF_ARRAY|FD_OBJECT|FDF_R },
-   { MAXINT("FieldArray"), (ERR (*)(APTR, APTR))GET_SubFields, 0, writeval_default, "SubFields", strhash("subFields"), sizeof(Object), 23, FDF_ARRAY|FD_STRUCT|FDF_SYSTEM|FDF_R },
+   { int64_t(uint32_t(strhash("FieldArray"))), (ERR (*)(APTR, APTR))GET_SubFields, 0, writeval_default,
+      "SubFields", strhash("subFields"), sizeof(Object), 23, FDF_ARRAY|FD_STRUCT|FDF_SYSTEM|FDF_R },
    { MAXINT(CLASSID::ROOTMODULE), (ERR (*)(APTR, APTR))GET_RootModule, 0, writeval_default, "RootModule", strhash("rootModule"), sizeof(Object), 24, FDF_OBJECT|FDF_R },
    { 0, (ERR (*)(APTR, APTR))OBJECT_GetID, 0,     writeval_default,   "ID",                strhash("id"),              sizeof(Object), 25, FDF_INT|FDF_SYSTEM|FDF_R },
    { 0, 0, 0, nullptr, "", 0, 0, 0,  0 }
@@ -1230,17 +1236,16 @@ static void add_field(extMetaClass *Class, std::vector<Field> &Fields, const Fie
    }
    else if (field.Flags & FD_STRUCT) {
       if (field.Arg) {
-         CSTRING struct_name = CSTRING(field.Arg);
-         if (struct_name) {
-            auto struct_hash = kt::strhash(struct_name);
-            if (auto it = glStructSizes.find(struct_hash); it != glStructSizes.end()) {
-               field_size      = it->second.Size;
-               field_alignment = it->second.Alignment;
-               field_type      = struct_name;
-            }
-            else log.warning("%s.%s field refers to unknown struct name '%s'.", Class->ClassName.c_str(), field.Name, CSTRING(field.Arg));
+         auto struct_hash = uint32_t(field.Arg);
+         if (auto it = glStructSizes.find(struct_hash); it != glStructSizes.end()) {
+            field_size      = it->second.Size;
+            field_alignment = it->second.Alignment;
+            field_type      = it->second.Name.c_str();
          }
-         else log.warning("%s.%s field requires a struct name reference.", Class->ClassName.c_str(), field.Name);
+         else {
+            log.warning("%s.%s field refers to unknown struct hash $%.8x.", Class->ClassName.c_str(), field.Name,
+               struct_hash);
+         }
       }
       else log.warning("%s.%s field requires a struct name.", Class->ClassName.c_str(), field.Name);
    }

--- a/src/core/classes/class_module.cpp
+++ b/src/core/classes/class_module.cpp
@@ -318,7 +318,9 @@ static ERR MODULE_Init(extModule *Self)
          root->Flags   = table->Flags;
 
          if (auto structs = table->StructDefs) {
-            for (auto &s : structs[0]) glStructSizes[kt::strhash(s.first)] = s.second;
+            for (auto &s : structs[0]) {
+               glStructSizes[kt::strhash(s.first)] = { s.second.Size, s.second.Alignment, s.first };
+            }
          }
       }
 

--- a/src/core/data.cpp
+++ b/src/core/data.cpp
@@ -92,7 +92,8 @@ std::unordered_map<OBJECTID, int> glAsyncObjectThreads;
 // metaclass can position FD_STRUCT fields at the offsets the compiler actually uses (alignment cannot be
 // derived from size alone).
 
-#define REG_STRUCT(name) { kt::strhash(#name), { uint16_t(sizeof(name)), uint16_t(alignof(name)) } }
+#define REG_STRUCT(name) \
+   { kt::strhash(#name), { uint16_t(sizeof(name)), uint16_t(alignof(name)), #name } }
 
 ankerl::unordered_dense::map<uint32_t, StructInfo> glStructSizes = {
    REG_STRUCT(ActionArray),
@@ -118,7 +119,8 @@ ankerl::unordered_dense::map<uint32_t, StructInfo> glStructSizes = {
    REG_STRUCT(InputEvent),
    REG_STRUCT(Message),
    REG_STRUCT(MethodEntry),
-   { kt::strhash("ModHeader"), { uint16_t(sizeof(struct ModHeader)), uint16_t(alignof(struct ModHeader)) } },
+   { kt::strhash("ModHeader"),
+      { uint16_t(sizeof(struct ModHeader)), uint16_t(alignof(struct ModHeader)), "ModHeader" } },
    REG_STRUCT(MsgHandler),
    REG_STRUCT(ObjectSignal),
    REG_STRUCT(RGB16),

--- a/src/core/defs/core.tdl
+++ b/src/core/defs/core.tdl
@@ -7,7 +7,8 @@ module({ name="Core", copyright="Paul Manias 1996-2026", timestamp=20241015,
   } }, function()
   c_include("<stdarg.h>", "<inttypes.h>", "<string.h>", "<stdlib.h>")
   cpp_include("<list>", "<map>", "<string>", "<set>", "<vector>", "<unordered_map>", "<bit>", "<atomic>",
-     "<array>", "<charconv>", "<sstream>", "<cmath>", "<type_traits>", "ankerl/unordered_dense.h")
+     "<array>", "<charconv>", "<sstream>", "<cmath>", "<type_traits>", "<kotuku/strings.hpp>",
+     "ankerl/unordered_dense.h")
 
   privateNames({ "CoreBase", "DateTime", "ResourceManager" })
 
@@ -398,6 +399,7 @@ typedef AC ACTIONID;
 struct StructInfo {
    uint16_t Size;       // Byte size of the structure (sizeof)
    uint16_t Alignment;  // Alignment requirement of the structure (alignof)
+   std::string Name;     // Readable structure name
 };
 
 using LOG_CALLBACK = void(*)(CSTRING Header, CSTRING Message, int Depth, int MsgLevel, int LogLevel);
@@ -485,9 +487,18 @@ class objTask;
     uint  Flags     # Special flags that describe the field
   ]],
   [[
-  template <class G = APTR, class S = APTR, class T = MAXINT> FieldArray(CSTRING pName, uint32_t pFlags, G pGetField = nullptr, S pSetField = nullptr, T pArg = 0) :
-     Name(pName), GetField((APTR)pGetField), SetField((APTR)pSetField), Arg((MAXINT)pArg), Flags(pFlags)
-     { }
+   template <class T> static int64_t encode_arg(uint32_t Flags, T Arg) {
+      if constexpr (std::is_convertible_v<T, CSTRING>) {
+         if ((Flags & FD_STRUCT) and CSTRING(Arg)) return int64_t(uint32_t(kt::strhash(CSTRING(Arg))));
+      }
+      return int64_t((MAXINT)Arg);
+   }
+
+   template <class G = APTR, class S = APTR, class T = MAXINT>
+   FieldArray(CSTRING FieldName, uint32_t FieldFlags, G GetFieldFn = nullptr, S SetFieldFn = nullptr,
+      T FieldArg = 0) :
+      Name(FieldName), GetField((APTR)GetFieldFn), SetField((APTR)SetFieldFn),
+      Arg(encode_arg(FieldFlags, FieldArg)), Flags(FieldFlags) { }
   ]])
 
   structdef("FieldDef", { comment="Used to define constants for field references." }, [[

--- a/src/core/lib_fields_write.cpp
+++ b/src/core/lib_fields_write.cpp
@@ -352,7 +352,7 @@ static ERR writeval_struct(OBJECTPTR Object, const Field *Field, int Flags, CPTR
 {
    if (Flags & FD_STRUCT) {
       // Possibly dangerous if the struct happens to contain C++ classes, but otherwise works.
-      if (auto it = glStructSizes.find(kt::strhash(CSTRING(Field->Arg))); it != glStructSizes.end()) {
+      if (auto it = glStructSizes.find(uint32_t(Field->Arg)); it != glStructSizes.end()) {
          auto struct_size = it->second.Size;
          auto offset = ((int8_t *)Object + Field->Offset);
          copymem(Data, offset, struct_size);

--- a/src/tiri/defs.h
+++ b/src/tiri/defs.h
@@ -420,6 +420,7 @@ extern ERR delayed_msg_handler(APTR Meta, int MsgID, int MsgType, APTR Message, 
 extern int object_index(lua_State *);
 extern int object_newindex(lua_State *);
 GCstruct * push_struct(extTiri *, APTR, std::string_view, bool, bool, OBJECTPTR Lifecycle = nullptr);
+GCstruct * push_struct(extTiri *, APTR, uint32_t, bool, bool, OBJECTPTR Lifecycle = nullptr);
 extern void register_io_class(lua_State *);
 extern void register_input_class(lua_State *);
 extern void register_module_class(lua_State *);

--- a/src/tiri/tiri_objects_indexes.cpp
+++ b/src/tiri/tiri_objects_indexes.cpp
@@ -50,7 +50,7 @@ static ERR set_array_from_table(lua_State *Lua, OBJECTPTR Object, const Field *F
    else if (Field->Flags & FD_STRUCT) {
       // Array structs can be set if the Lua table consists of Tiri.struct types.
 
-      if (auto def = find_struct(Lua, (CSTRING)Field->Arg)) {
+      if (auto def = find_struct(Lua, uint32_t(Field->Arg))) {
          int aligned_size = ALIGN64(def->Size);
          auto structbuf = std::make_unique<uint8_t[]>(total * aligned_size);
 
@@ -364,7 +364,7 @@ static struct_record * lookup_struct_field_def(lua_State *Lua, const Field *Fiel
 {
    if (not Field->Arg) return nullptr;
 
-   return find_struct(Lua, (CSTRING)Field->Arg);
+   return find_struct(Lua, uint32_t(Field->Arg));
 }
 
 static ERR object_set_struct(lua_State *Lua, OBJECTPTR Object, const Field *Field, int ValueIndex)
@@ -679,10 +679,23 @@ template <class Callback> static int object_get_field(lua_State *Lua, const obj_
    return error != ERR::Okay ? 0 : 1;
 }
 
-static std::string_view object_field_struct_name(const Field *Field)
+static ERR make_object_field_array(lua_State *Lua, const Field *Field, size_t Elements, CPTR Values)
 {
-   if (Field->Flags & FD_STRUCT) return std::string_view((CSTRING)Field->Arg);
-   else return std::string_view {};
+   struct_record *struct_def = nullptr;
+   std::string_view struct_name;
+
+   if (Field->Flags & FD_STRUCT) {
+      struct_def = find_struct(Lua, uint32_t(Field->Arg));
+      if (not struct_def) {
+         kt::Log("make_object_field_array").warning("Struct hash $%.8x not found for field '%s'.",
+            uint32_t(Field->Arg), Field->Name);
+         return ERR::Search;
+      }
+      struct_name = struct_def->Name;
+   }
+
+   make_any_array(Lua, Field->Flags, struct_name, int(Elements), Values, struct_def);
+   return ERR::Okay;
 }
 
 static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *Def)
@@ -705,8 +718,7 @@ static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *De
             // For kt::vector primitives we can just convert to a raw data array.
             std::span<int> values; // The type doesn't matter.
             if (!(error = Object->get(Field->FieldID, values, false))) {
-               std::string_view struct_name = object_field_struct_name(Field);
-               make_any_array(Lua, Field->Flags, struct_name, values.size(), values.data());
+               error = make_object_field_array(Lua, Field, values.size(), values.data());
             }
          }
       }
@@ -718,8 +730,7 @@ static int object_get_array(lua_State *Lua, const obj_read &Handle, GCobject *De
             make_array(Lua, AET::OBJECT, span.size(), span.data());
          }
          else if (Field->Flags & (FD_INT|FD_INT64|FD_FLOAT|FD_DOUBLE|FD_POINTER|FD_BYTE|FD_WORD|FD_STRUCT)) {
-            std::string_view struct_name = object_field_struct_name(Field);
-            make_any_array(Lua, Field->Flags, struct_name, span.size(), span.data());
+            error = make_object_field_array(Lua, Field, span.size(), span.data());
          }
          else {
             kt::Log("object_get_array").warning("Invalid array type for '%s', flags: $%.8x", Field->Name,
@@ -749,7 +760,7 @@ static int object_get_struct(lua_State *Lua, const obj_read &Handle, GCobject *D
                // no dependency and skip it, and a JIT-compiled access would compile the guard out in that case.
                bool is_resource = Field->Flags & FD_RESOURCE;
                bool owns_copy = is_resource and (Field->Flags & FD_STORE);
-               if (not push_struct(Lua->script, result, (CSTRING)Field->Arg, owns_copy, is_resource,
+               if (not push_struct(Lua->script, result, uint32_t(Field->Arg), owns_copy, is_resource,
                      owns_copy ? nullptr : Object)) {
                   error = ERR::Search;
                }

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -611,6 +611,32 @@ GCstruct * push_struct(extTiri *Self, APTR Address, std::string_view StructName,
 }
 
 //********************************************************************************************************************
+// Use this for creating a struct on the Lua stack from a pre-hashed structure name.
+
+GCstruct * push_struct(extTiri *Self, APTR Address, uint32_t StructKey, bool Deallocate, bool AllowEmpty,
+   OBJECTPTR Lifecycle)
+{
+   kt::Log log(__FUNCTION__);
+
+   log.traceBranch("Struct: $%.8x, Address: %p, Deallocate: %d", StructKey, Address, Deallocate);
+
+   if (auto def = find_struct(Self->Lua, StructKey)) {
+      return push_struct_def(Self->Lua, Address, *def, Deallocate, Lifecycle);
+   }
+   else if (AllowEmpty) {
+      // Preserve the name-based overload's fallback for resource structs that Tiri does not know about.
+
+      static struct_record empty("");
+      return push_struct_def(Self->Lua, Address, empty, false, Lifecycle);
+   }
+   else {
+      if (Deallocate) FreeResource(Address);
+      log.warning("Unrecognised struct hash $%.8x", StructKey);
+      return nullptr;
+   }
+}
+
+//********************************************************************************************************************
 // structdef = MAKESTRUCT(Name, Sequence)
 //
 // This function makes a structure definition which can be passed to struct.new()


### PR DESCRIPTION
* Store owned structure names alongside size and alignment metadata

* Encode FD_STRUCT field arguments as hashes and update direct consumers

* [Tiri] Resolve class field structures through pre-hashed dictionary keys