### PR TITLE
[Tiri] Eliminate redundant array bounds checks in canonical ranges

### DIFF
--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -2816,7 +2816,7 @@ static TRef rec_array_op(jit_State *J, RecordOps *ops)
    }
 
    TRef len_ref = ir.fload_int(array_ref, IRFL_ARRAY_LEN);
-   ir.guard_int(IR_ULT, idx_ref, len_ref);
+   rec_idx_abc(J, len_ref, idx_ref, arrayV(ops->rbv())->len);
 
    if (is_get) {
       GCarray *arr = arrayV(ops->rbv());

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -130,7 +130,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    auto base = BCReg(child_state.varmap.size() - param_count.raw());
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
-      if (param.type IS TiriType::Struct) {
+      if (param.type != TiriType::Unknown and param.type != TiriType::Any) {
          auto &param_info = child_state.var_get(base.raw() + i.raw());
          param_info.fixed_type = param.type;
          param_info.struct_def = param.struct_def;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -749,6 +749,64 @@ return sum
    return true;
 }
 
+//********************************************************************************************************************
+
+static bool test_array_length_range_for_ast(kt::Log &Log)
+{
+   constexpr const char *source = R"(
+local values = array<int> { 1, 2, 3 }
+for index in {0 to #values} do
+   values[index] += 1
+end
+)";
+
+   auto result = build_ast_from_source(source);
+   if (not result.chunk.ok()) {
+      Log.error("failed to parse array-length range loop");
+      log_diagnostics(result.diagnostics, Log);
+      return false;
+   }
+
+   StatementListView statements = result.chunk.value_ref()->view();
+   if (statements.size() != 2) {
+      Log.error("expected local declaration and range loop; got %" PRId64, int64_t(statements.size()));
+      return false;
+   }
+
+   const StmtNode &loop = statements[1];
+   if (loop.kind != AstNodeKind::GenericForStmt) {
+      Log.error("array-length range should remain generic until semantic type analysis");
+      return false;
+   }
+
+   const auto *payload = std::get_if<GenericForStmtPayload>(&loop.data);
+   if (not payload or payload->iterators.size() != 1) {
+      Log.error("generic array-length range should retain one iterator");
+      return false;
+   }
+
+   const ExprNode *iterator = payload->iterators[0].get();
+   if (not iterator or iterator->kind != AstNodeKind::CallExpr) {
+      Log.error("generic array-length range should retain its iterator call");
+      return false;
+   }
+
+   const auto *call = std::get_if<CallExprPayload>(&iterator->data);
+   const auto *direct = call ? std::get_if<DirectCallTarget>(&call->target) : nullptr;
+   if (not direct or not direct->callable or direct->callable->kind != AstNodeKind::RangeExpr) {
+      Log.error("generic iterator should retain the source range expression");
+      return false;
+   }
+
+   const auto *range = std::get_if<RangeExprPayload>(&direct->callable->data);
+   if (not range or not range->stop or range->stop->kind != AstNodeKind::UnaryExpr) {
+      Log.error("source range should retain its length stop expression");
+      return false;
+   }
+
+   return true;
+}
+
 static bool test_generic_for_ast(kt::Log &log)
 {
    constexpr const char* source = R"(
@@ -2011,7 +2069,7 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 24> tests = { {
+   constexpr std::array<TestCase, 25> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2023,6 +2081,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "local_function_table_ast", test_local_function_table_ast },
       { "ast_statement_matrix", test_ast_statement_matrix },
       { "numeric_for_ast", test_numeric_for_ast },
+      { "array_length_range_for_ast", test_array_length_range_for_ast },
       { "generic_for_ast", test_generic_for_ast },
       { "repeat_defer_ast", test_repeat_defer_ast },
       { "ternary_presence_expr_ast", test_ternary_presence_expr_ast },

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -93,7 +93,7 @@ public:
    explicit TypeAnalyser(ParserContext &Context) : ctx_(Context) {}
 
    // Entry point: analyse an entire module (top-level block)
-   void analyse_module(const BlockStmt &);
+   void analyse_module(BlockStmt &);
 
    // Access collected type diagnostics after analysis
    [[nodiscard]] const std::vector<TypeDiagnostic> & diagnostics() const { return this->diagnostics_; }
@@ -115,8 +115,13 @@ private:
    [[nodiscard]] const FunctionContext* current_function() const;
 
    // AST traversal methods - recursively analyse each node type
-   void analyse_block(const BlockStmt &);
-   void analyse_statement(const StmtNode &);
+   void analyse_block(BlockStmt &);
+   void analyse_statement(StmtNode &);
+   bool lower_array_length_range(StmtNode &);
+   void lower_unanalysed_block(BlockStmt &);
+   void lower_unanalysed_except_clause(ExceptClause &);
+   void lower_unanalysed_function(const FunctionExprPayload &);
+   void lower_unanalysed_statement(StmtNode &);
    void analyse_assignment(const AssignmentStmtPayload &);
    void analyse_local_decl(const LocalDeclStmtPayload &);
    void analyse_global_decl(const GlobalDeclStmtPayload &);
@@ -163,13 +168,15 @@ private:
 
    #ifdef INCLUDE_TIPS
    // Tip gating - tips carry no file attribution, so they are suppressed entirely while analysing
-   // imported statements to avoid misattributing library internals to the importing file
+   // imported statements to avoid misattributing library internals to the importing file.  They are also
+   // suppressed during reduced traversal, which declares variables without observing their uses and would
+   // otherwise report false unused-variable tips.
    [[nodiscard]] bool should_emit_tip(uint8_t Priority) const {
-      return this->import_depth_ IS 0 and this->ctx_.should_emit_tip(Priority);
+      return this->import_depth_ IS 0 and this->unanalysed_depth_ IS 0 and this->ctx_.should_emit_tip(Priority);
    }
 
    void emit_tip(uint8_t Priority, TipCategory Category, std::string Message, const Token &Location) {
-      if (this->import_depth_ != 0) return;
+      if (this->import_depth_ != 0 or this->unanalysed_depth_ != 0) return;
       this->ctx_.emit_tip(Priority, Category, std::move(Message), Location);
    }
    #endif
@@ -257,6 +264,7 @@ private:
    std::vector<TypeDiagnostic> diagnostics_{};      // Collected type errors and warnings
    uint32_t loop_depth_{0};                         // Current loop nesting depth for performance tip
    uint32_t import_depth_{0};                       // Import nesting depth; non-zero suppresses tips
+   uint32_t unanalysed_depth_{0};                   // Reduced-traversal nesting depth; non-zero suppresses tips
    uint8_t current_file_index_{0};                  // FileSource index of the file being analysed
    ankerl::unordered_dense::map<GCstr*, GlobalTypeInfo> global_types_{};  // Type info for global variables
    #ifdef INCLUDE_TIPS
@@ -538,7 +546,7 @@ const FunctionContext* TypeAnalyser::current_function() const
    return &this->function_stack_.back();
 }
 
-void TypeAnalyser::analyse_module(const BlockStmt &Module)
+void TypeAnalyser::analyse_module(BlockStmt &Module)
 {
    // For loadFile sources the whole chunk carries a single non-zero FileSource index
    this->current_file_index_ = this->ctx_.lex().current_file_index;
@@ -547,11 +555,254 @@ void TypeAnalyser::analyse_module(const BlockStmt &Module)
    this->pop_scope();
 }
 
-void TypeAnalyser::analyse_block(const BlockStmt &Block)
+void TypeAnalyser::analyse_block(BlockStmt &Block)
 {
-   for (const auto &statement : Block.view()) {
-      this->analyse_statement(statement);
+   for (auto &statement : Block.statements) {
+      if (statement) this->analyse_statement(*statement);
    }
+}
+
+//********************************************************************************************************************
+// Lowers `{0 to #array}` only after semantic analysis has proved that the length operand is a native array.  Keeping
+// unknown and non-array operands on the generic range path preserves custom __len direction and validation semantics.
+
+bool TypeAnalyser::lower_array_length_range(StmtNode &Statement)
+{
+   if (Statement.kind != AstNodeKind::GenericForStmt) return false;
+
+   auto *generic = std::get_if<GenericForStmtPayload>(&Statement.data);
+   if (not generic or generic->names.size() != 1 or generic->iterators.size() != 1 or not generic->body) return false;
+
+   ExprNode *iterator = generic->iterators[0].get();
+   if (not iterator or iterator->kind != AstNodeKind::CallExpr) return false;
+
+   auto *call = std::get_if<CallExprPayload>(&iterator->data);
+   if (not call or not call->arguments.empty()) return false;
+
+   auto *direct = std::get_if<DirectCallTarget>(&call->target);
+   if (not direct or not direct->callable or direct->callable->kind != AstNodeKind::RangeExpr) return false;
+
+   auto *range = std::get_if<RangeExprPayload>(&direct->callable->data);
+   if (not range or range->inclusive or range->step or not range->start or not range->stop) return false;
+
+   const auto *start = std::get_if<LiteralValue>(&range->start->data);
+   if (range->start->kind != AstNodeKind::LiteralExpr or not start or start->kind != LiteralKind::Number or
+       start->number_value != 0) {
+      return false;
+   }
+
+   auto *length = std::get_if<UnaryExprPayload>(&range->stop->data);
+   if (range->stop->kind != AstNodeKind::UnaryExpr or not length or
+       length->op != AstUnaryOperator::Length or not length->operand) {
+      return false;
+   }
+
+   InferredType operand_type = this->infer_expression_type(*length->operand);
+   if (operand_type.primary != TiriType::Array) return false;
+
+   SourceSpan span = direct->callable->span;
+   Identifier control = std::move(generic->names[0]);
+   ExprNodePtr start_expr = std::move(range->start);
+   ExprNodePtr stop_expr = std::move(range->stop);
+   ExprNodePtr one_expr = make_literal_expr(span, LiteralValue::number(1));
+   ExprNodePtr final_stop_expr = make_binary_expr(
+      span, AstBinaryOperator::Subtract, std::move(stop_expr), std::move(one_expr));
+   ExprNodePtr step_expr = make_literal_expr(span, LiteralValue::number(1));
+   std::unique_ptr<BlockStmt> body = std::move(generic->body);
+
+   Statement.kind = AstNodeKind::NumericForStmt;
+   Statement.data.emplace<NumericForStmtPayload>(std::move(control), std::move(start_expr),
+      std::move(final_stop_expr), std::move(step_expr), std::move(body));
+   return true;
+}
+
+//********************************************************************************************************************
+// Some statement forms deliberately bypass ordinary type diagnostics so runtime type failures inside them remain
+// catchable.  This reduced traversal tracks only the lexical types needed for safe array-range lowering.  Each
+// entry point raises unanalysed_depth_ so tip emission stays suppressed: the traversal declares variables but
+// never observes their uses, so unused-variable reporting on scope exit would be a false positive.
+
+void TypeAnalyser::lower_unanalysed_block(BlockStmt &Block)
+{
+   this->unanalysed_depth_++;
+   this->push_scope();
+   for (auto &statement : Block.statements) {
+      if (statement) this->lower_unanalysed_statement(*statement);
+   }
+   this->pop_scope();
+   this->unanalysed_depth_--;
+}
+
+//********************************************************************************************************************
+
+void TypeAnalyser::lower_unanalysed_except_clause(ExceptClause &Clause)
+{
+   if (not Clause.block) return;
+
+   this->unanalysed_depth_++;
+   this->push_scope();
+   if (Clause.exception_var and Clause.exception_var->symbol) {
+      this->current_scope().declare_local(
+         Clause.exception_var->symbol, InferredType(TiriType::Any), Clause.exception_var->span);
+   }
+   for (auto &statement : Clause.block->statements) {
+      if (statement) this->lower_unanalysed_statement(*statement);
+   }
+   this->pop_scope();
+   this->unanalysed_depth_--;
+}
+
+//********************************************************************************************************************
+
+void TypeAnalyser::lower_unanalysed_function(const FunctionExprPayload &Function)
+{
+   this->unanalysed_depth_++;
+   this->push_scope();
+   for (const FunctionParameter &param : Function.parameters) {
+      this->current_scope().declare_parameter(param.name.symbol, param.type, param.struct_def, param.name.span);
+   }
+   if (Function.body) {
+      for (auto &statement : Function.body->statements) {
+         if (statement) this->lower_unanalysed_statement(*statement);
+      }
+   }
+   this->pop_scope();
+   this->unanalysed_depth_--;
+}
+
+//********************************************************************************************************************
+
+void TypeAnalyser::lower_unanalysed_statement(StmtNode &Statement)
+{
+   this->unanalysed_depth_++;
+   this->lower_array_length_range(Statement);
+
+   switch (Statement.kind) {
+      case AstNodeKind::LocalDeclStmt: {
+         auto *payload = std::get_if<LocalDeclStmtPayload>(&Statement.data);
+         if (not payload) break;
+
+         std::vector<InferredType> inferred_types;
+         inferred_types.reserve(payload->names.size());
+         for (size_t i = 0; i < payload->names.size(); ++i) {
+            InferredType inferred;
+            if (payload->names[i].type != TiriType::Unknown) {
+               inferred.primary = payload->names[i].type;
+               inferred.struct_def = payload->names[i].struct_def;
+               inferred.is_fixed = inferred.primary != TiriType::Any;
+            }
+            else if (i < payload->values.size() and payload->values[i]) {
+               // Unlike analyse_local_decl this marks Unknown inferences as fixed, which is harmless here:
+               // these scopes only feed the Array check in lower_array_length_range, never diagnostics.
+               inferred = this->infer_expression_type(*payload->values[i]);
+               inferred.is_fixed = inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any;
+            }
+            inferred_types.push_back(inferred);
+         }
+
+         for (size_t i = 0; i < payload->names.size(); ++i) {
+            const Identifier &name = payload->names[i];
+            this->current_scope().declare_local(name.symbol, inferred_types[i], name.span, name.has_const);
+         }
+         break;
+      }
+      case AstNodeKind::LocalFunctionStmt: {
+         auto *payload = std::get_if<LocalFunctionStmtPayload>(&Statement.data);
+         if (payload and payload->function) {
+            this->current_scope().declare_function(
+               payload->name.symbol, payload->function.get(), payload->name.span);
+            this->lower_unanalysed_function(*payload->function);
+         }
+         break;
+      }
+      case AstNodeKind::FunctionStmt: {
+         auto *payload = std::get_if<FunctionStmtPayload>(&Statement.data);
+         if (payload and payload->function) this->lower_unanalysed_function(*payload->function);
+         break;
+      }
+      case AstNodeKind::IfStmt: {
+         auto *payload = std::get_if<IfStmtPayload>(&Statement.data);
+         if (payload) {
+            for (auto &clause : payload->clauses) {
+               if (clause.block) this->lower_unanalysed_block(*clause.block);
+            }
+         }
+         break;
+      }
+      case AstNodeKind::WhileStmt:
+      case AstNodeKind::RepeatStmt: {
+         auto *payload = std::get_if<LoopStmtPayload>(&Statement.data);
+         if (payload and payload->body) this->lower_unanalysed_block(*payload->body);
+         break;
+      }
+      case AstNodeKind::NumericForStmt: {
+         auto *payload = std::get_if<NumericForStmtPayload>(&Statement.data);
+         if (payload and payload->body) {
+            this->push_scope();
+            InferredType control_type(TiriType::Num);
+            this->current_scope().declare_local(
+               payload->control.symbol, control_type, payload->control.span);
+            for (auto &statement : payload->body->statements) {
+               if (statement) this->lower_unanalysed_statement(*statement);
+            }
+            this->pop_scope();
+         }
+         break;
+      }
+      case AstNodeKind::GenericForStmt: {
+         auto *payload = std::get_if<GenericForStmtPayload>(&Statement.data);
+         if (payload and payload->body) {
+            this->push_scope();
+            for (const Identifier &name : payload->names) {
+               this->current_scope().declare_local(name.symbol, InferredType(TiriType::Any), name.span);
+            }
+            for (auto &statement : payload->body->statements) {
+               if (statement) this->lower_unanalysed_statement(*statement);
+            }
+            this->pop_scope();
+         }
+         break;
+      }
+      case AstNodeKind::DoStmt: {
+         auto *payload = std::get_if<DoStmtPayload>(&Statement.data);
+         if (payload and payload->block) this->lower_unanalysed_block(*payload->block);
+         break;
+      }
+      case AstNodeKind::ConditionalShorthandStmt: {
+         auto *payload = std::get_if<ConditionalShorthandStmtPayload>(&Statement.data);
+         if (payload and payload->body) this->lower_unanalysed_statement(*payload->body);
+         break;
+      }
+      case AstNodeKind::TryExceptStmt: {
+         auto *payload = std::get_if<TryExceptPayload>(&Statement.data);
+         if (payload) {
+            if (payload->try_block) this->lower_unanalysed_block(*payload->try_block);
+            for (auto &clause : payload->except_clauses) {
+               this->lower_unanalysed_except_clause(clause);
+            }
+            if (payload->success_block) this->lower_unanalysed_block(*payload->success_block);
+         }
+         break;
+      }
+      case AstNodeKind::ImportStmt: {
+         auto *payload = std::get_if<ImportStmtPayload>(&Statement.data);
+         if (payload) {
+            for (auto &entry : payload->entries) {
+               if (entry.inlined_body) this->lower_unanalysed_block(*entry.inlined_body);
+            }
+         }
+         break;
+      }
+      case AstNodeKind::WithStmt: {
+         auto *payload = std::get_if<WithStmtPayload>(&Statement.data);
+         if (payload and payload->block) this->lower_unanalysed_block(*payload->block);
+         break;
+      }
+      default:
+         break;
+   }
+
+   this->unanalysed_depth_--;
 }
 
 //********************************************************************************************************************
@@ -560,8 +811,10 @@ void TypeAnalyser::analyse_block(const BlockStmt &Block)
 // Dispatches to the appropriate handler based on statement type.
 // Each handler may push/pop scopes, declare variables, or analyse nested expressions.
 
-void TypeAnalyser::analyse_statement(const StmtNode &Statement)
+void TypeAnalyser::analyse_statement(StmtNode &Statement)
 {
+   this->lower_array_length_range(Statement);
+
    switch (Statement.kind) {
       case AstNodeKind::AssignmentStmt: {
          auto *payload = std::get_if<AssignmentStmtPayload>(&Statement.data);
@@ -693,6 +946,22 @@ void TypeAnalyser::analyse_statement(const StmtNode &Statement)
          }
          break;
       }
+      case AstNodeKind::ConditionalShorthandStmt: {
+         auto *payload = std::get_if<ConditionalShorthandStmtPayload>(&Statement.data);
+         if (payload and payload->body) this->lower_unanalysed_statement(*payload->body);
+         break;
+      }
+      case AstNodeKind::TryExceptStmt: {
+         auto *payload = std::get_if<TryExceptPayload>(&Statement.data);
+         if (payload) {
+            if (payload->try_block) this->lower_unanalysed_block(*payload->try_block);
+            for (auto &clause : payload->except_clauses) {
+               this->lower_unanalysed_except_clause(clause);
+            }
+            if (payload->success_block) this->lower_unanalysed_block(*payload->success_block);
+         }
+         break;
+      }
       case AstNodeKind::ExpressionStmt: {
          auto *payload = std::get_if<ExpressionStmtPayload>(&Statement.data);
          if (payload and payload->expression) this->analyse_expression(*payload->expression);
@@ -715,6 +984,11 @@ void TypeAnalyser::analyse_statement(const StmtNode &Statement)
                this->pop_scope();
             }
          }
+         break;
+      }
+      case AstNodeKind::WithStmt: {
+         auto *payload = std::get_if<WithStmtPayload>(&Statement.data);
+         if (payload and payload->block) this->lower_unanalysed_block(*payload->block);
          break;
       }
       default:
@@ -1619,6 +1893,8 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
             this->mark_identifier_used(payload->identifier.symbol);
             auto resolved = this->resolve_identifier(payload->identifier.symbol);
             if (resolved) return *resolved;
+            resolved = this->lookup_global_type(payload->identifier.symbol);
+            if (resolved) return *resolved;
          }
          break;
       }
@@ -2496,7 +2772,7 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
 
 //********************************************************************************************************************
 
-void run_type_analysis(ParserContext& Context, const BlockStmt& Module)
+void run_type_analysis(ParserContext& Context, BlockStmt& Module)
 {
    TypeAnalyser analyser(Context);
    analyser.analyse_module(Module);

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -1,6 +1,9 @@
 -- Flute tests that need to exercise the JIT in specific ways.
 
 local glCfg
+local ir_ult <const> = 4  -- IRDEF order; unsigned less-than guard.
+local ir_abc <const> = 10  -- IRDEF order; array bounds check.
+local ir_loop <const> = 17  -- IRDEF order; loop body boundary.
 local ir_min <const> = 50  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_max <const> = 51  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_xload <const> = 70  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
@@ -91,6 +94,58 @@ end
    assert(disassembly:find('OBGETF') != nil, 'obj<Class> metadata should specialise chained object field access')
 end
 
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ArrayParameterAndLengthRangeBytecode()
+   local script = obj.new('tiri', { statement=[[
+global glBytecodeValues:array = array<int> { 1, 2, 3 }
+
+function increment(Array:array)
+   for index in {0 to #Array} do
+      Array[index] += 1
+   end
+end
+
+function incrementInTry(Array:array)
+   try
+      for index in {0 to #Array} do
+         Array[index] += 1
+      end
+   success
+   end
+end
+
+function localArrayInTry()
+   try
+      local values = array<int> { 1, 2, 3 }
+      for index in {0 to #values} do
+         values[index] += 1
+      end
+   success
+   end
+end
+
+function sumGlobal():num
+   local total = 0
+   for index in {0 to #glBytecodeValues} do
+      total += glBytecodeValues[index]
+   end
+   return total
+end
+]] })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+
+   assert(disassembly:find('FORI') != nil and disassembly:find('FORL') != nil,
+      'A canonical array-length range should emit numeric loop bytecode')
+   assert(disassembly:find('ITERC') is nil and disassembly:find('ITERA') is nil and
+      disassembly:find('ITERL') is nil,
+      'Canonical parameter, nested and global array-length ranges should not construct generic range iterators')
+   assert(disassembly:find('AGETV') != nil and disassembly:find('ASETV') != nil,
+      'An array-annotated parameter should emit specialised array bytecode')
+end
+
 @AfterAll
 function TeardownJitTests()
    jit.opt.start()
@@ -152,6 +207,14 @@ function count_trace_opcode(TraceNo, Info, Opcode)
    return count
 end
 
+function first_trace_opcode(TraceNo, Info, Opcode)
+   for idx = 1, Info.nins do
+      local _, ir_ot = jit.util.traceIR(TraceNo, idx)
+      if ir_ot != nil and ir_opcode(ir_ot) is Opcode then return idx end
+   end
+   return nil
+end
+
 function count_jit_traces(MaxTraceNo)
    local count = 0
    for trace_no = 1, MaxTraceNo do
@@ -163,6 +226,93 @@ end
 function count_trace_calls(TraceNo, Info)
    return count_trace_opcode(TraceNo, Info, ir_calln) + count_trace_opcode(TraceNo, Info, ir_calla) +
       count_trace_opcode(TraceNo, Info, ir_calll) + count_trace_opcode(TraceNo, Info, ir_calls)
+end
+
+function canonical_array_workload(Count)
+   local values = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
+
+   for pass = 1, Count do
+      for index in {0 to #values} do
+         values[index] += 1
+      end
+   end
+
+   return values:concat(',', '%d')
+end
+
+function canonical_array_try_workload(Count)
+   local values = array<int, 8>
+
+   try
+      for pass = 1, Count do
+         for index in {0 to #values} do
+            values[index] += 1
+         end
+      end
+   success
+   end
+
+   return values:concat(',', '%d')
+end
+
+global glCanonicalArrayRangeValues:array = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
+
+function canonical_global_array_workload(Count)
+   local total = 0
+   for pass = 1, Count do
+      for index in {0 to #glCanonicalArrayRangeValues} do
+         total += glCanonicalArrayRangeValues[index]
+      end
+   end
+   return total
+end
+
+function find_array_bounds_trace(MaxTraceNo)
+   for trace_no = 1, MaxTraceNo do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil then
+         local abc_count = count_trace_opcode(trace_no, info, ir_abc)
+         local load_count = count_trace_opcode(trace_no, info, ir_xload)
+         local store_count = count_trace_opcode(trace_no, info, ir_xstore)
+         if abc_count > 0 and load_count > 0 and store_count > 0 then
+            return trace_no, info, abc_count
+         end
+      end
+   end
+
+   return nil, nil, 0
+end
+
+function resize_during_array_loop(Array:array, Shrink:bool)
+   local alias = Array
+   for index in {0 to #Array} do
+      if Shrink and index is 16 then alias:resize(8) end
+      Array[index] += 1
+   end
+end
+
+function clear_during_array_loop(Array:array, Clear:bool)
+   local alias = Array
+   for index in {0 to #Array} do
+      if Clear and index is 16 then alias:clear() end
+      Array[index] += 1
+   end
+end
+
+function reassign_during_array_loop(Array:array, Reassign:bool)
+   for index in {0 to #Array} do
+      if Reassign and index is 16 then Array = array<int, 8> end
+      Array[index] += 1
+   end
+end
+
+function push_during_array_loop(Array:array)
+   local original_length = #Array
+   for index in {0 to #Array} do
+      if index is 0 then Array:push(99) end
+      Array[index] += 1
+   end
+   return original_length, #Array, Array[#Array - 1]
 end
 
 function run_array_method_trace(Workload, Count)
@@ -179,6 +329,166 @@ function run_array_method_trace(Workload, Count)
    end
 
    return expected, result, count_jit_traces(30)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function CanonicalArrayRangeMatchesInterpreter()
+   jit.flush()
+   jit.off()
+   local expected = canonical_array_workload(12)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local result = nil
+   for repeat_no = 1, 20 do
+      result = canonical_array_workload(12)
+   end
+
+   assert(result is expected, f"JIT array range result '{result}' should match interpreter result '{expected}'")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function CanonicalArrayRangeInsideTryMatchesInterpreter()
+   jit.flush()
+   jit.off()
+   local expected = canonical_array_try_workload(10)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local result = nil
+   for repeat_no = 1, 20 do
+      result = canonical_array_try_workload(10)
+   end
+
+   assert(result is expected,
+      f"JIT nested array range result '{result}' should match interpreter result '{expected}'")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function CanonicalGlobalArrayRangeMatchesInterpreter()
+   jit.flush()
+   jit.off()
+   local expected = canonical_global_array_workload(12)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local result = nil
+   for repeat_no = 1, 20 do
+      result = canonical_global_array_workload(12)
+   end
+
+   assert(result is expected,
+      f"JIT global array range result '{result}' should match interpreter result '{expected}'")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function CanonicalArrayRangeHoistsBoundsCheck()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   for repeat_no = 1, 20 do
+      canonical_array_workload(12)
+   end
+
+   local trace_no, info, abc_count = find_array_bounds_trace(40)
+   assert(trace_no != nil and info != nil, 'Expected a traced typed-array loop with direct element access')
+   assert(abc_count is 1, f'Expected one invariant array bounds check, found {abc_count}')
+
+   local abc_position = first_trace_opcode(trace_no, info, ir_abc)
+   local loop_position = first_trace_opcode(trace_no, info, ir_loop)
+   assert(abc_position != nil and loop_position != nil, 'Expected both ABC and LOOP instructions in the array trace')
+   assert(abc_position < loop_position,
+      f'Expected invariant ABC before LOOP, found ABC at {abc_position} and LOOP at {loop_position}')
+
+   local ult_count = count_trace_opcode(trace_no, info, ir_ult)
+   assert(ult_count is 0, f'Expected no loop-resident ULT array bounds guard, found {ult_count}')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ArrayResizeInvalidatesBoundsProof()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   for repeat_no = 1, 20 do
+      local values = array<int, 32>
+      resize_during_array_loop(values, false)
+   end
+
+   local values = array<int, 32>
+   try
+      resize_during_array_loop(values, true)
+   success
+      error('Shrinking an aliased array during traversal should invalidate the bounds proof')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ArrayClearInvalidatesBoundsProof()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   for repeat_no = 1, 20 do
+      local values = array<int, 32>
+      clear_during_array_loop(values, false)
+   end
+
+   local values = array<int, 32>
+   try
+      clear_during_array_loop(values, true)
+   success
+      error('Clearing an aliased array during traversal should invalidate the bounds proof')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ArrayReassignmentInvalidatesBoundsProof()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   for repeat_no = 1, 20 do
+      local values = array<int, 32>
+      reassign_during_array_loop(values, false)
+   end
+
+   local values = array<int, 32>
+   try
+      reassign_during_array_loop(values, true)
+   success
+      error('Reassigning the traversed array should invalidate the bounds proof')
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ArrayGrowthKeepsCapturedRangeBound()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   for repeat_no = 1, 20 do
+      local values = array<int, 32>
+      local original_length, final_length, appended = push_during_array_loop(values)
+      assert(original_length is 32, 'The original array length should be captured before traversal')
+      assert(final_length is 33, 'Pushing during traversal should grow the array once')
+      assert(appended is 99, 'The appended element should remain outside the captured traversal bound')
+   end
 end
 
 function traced_clamp_sum(Count)

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -936,6 +936,56 @@ end
    assert(value is 5, "single element should be 5")
 end
 
+@Test function ArrayLengthRangeIterationBoundaries()
+   local empty = array<int>
+   local empty_count = 0
+   for index in {0 to #empty} do
+      empty_count += 1
+   end
+   assert(empty_count is 0, 'An empty array length range should not iterate')
+
+   local single = array<int> { 41 }
+   for index in {0 to #single} do
+      single[index] += 1
+   end
+   assert(single[0] is 42, 'A single-element array length range should visit index zero exactly once')
+end
+
+@Test function NonArrayLengthRangePreservesDynamicDirection()
+   local value = setmetatable({}, { __len = function() return -2 end })
+
+   local direct = {}
+   for index in {0 to #value} do
+      direct[#direct] = index
+   end
+
+   local length = #value
+   local indirect = {}
+   for index in {0 to length} do
+      indirect[#indirect] = index
+   end
+
+   assert(#direct is 2 and direct[0] is 0 and direct[1] is -1,
+      'Direct custom __len range should infer descending direction')
+   assert(#indirect is 2 and indirect[0] is 0 and indirect[1] is -1,
+      'Direct and captured custom __len ranges should have identical semantics')
+end
+
+@Test function NonArrayLengthRangeInsideTryPreservesDynamicDirection()
+   local visited = {}
+
+   try
+      local value = setmetatable({}, { __len = function() return -2 end })
+      for index in {0 to #value} do
+         visited[#visited] = index
+      end
+   success
+   end
+
+   assert(#visited is 2 and visited[0] is 0 and visited[1] is -1,
+      'A custom __len range inside try should retain generic descending semantics')
+end
+
 @Test function RangeIterationWithVariable()
    -- Test iteration using range stored in variable
    r = {0 to 5}

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -75,3 +75,22 @@ end
       error("Expected unknown type name to prevent compilation")
    end
 end
+
+@Test function MistypedArrayArgumentRaisesCleanly()
+   -- Annotated parameters emit specialised bytecode, so passing a mismatched value must raise a
+   -- catchable error rather than crash or silently operate on the wrong type.
+   function increment(Values:array)
+      for index in {0 to #Values} do
+         Values[index] += 1
+      end
+   end
+
+   local plain_table = { 1, 2, 3 }
+   try
+      increment(plain_table)
+      error("Expected a table argument to an array-annotated parameter to raise")
+   except e
+      assert(e.message != nil, "The mistyped argument error should carry a message")
+   end
+   assert(plain_table[0] is 1, "A rejected table argument should remain unmodified")
+end

--- a/tools/idl/include/types.tiri
+++ b/tools/idl/include/types.tiri
@@ -621,8 +621,7 @@ global function cType(Value:table, Origin:str):table
             assert(not inner_fd:find('FD_UNIT'), f'Unit element spans are not supported for {Origin}.')
             assert(not inner_fd:find('FD_ARRAY'), f'Nested array spans are not supported for {Origin}.')
             assert(not inner_fd:find('FD_VECTOR'), f'Nested vector spans are not supported for {Origin}.')
-            assert(not (Value.struct and Value.isPointer),
-               f'Pointer-qualified structure spans are not supported for {Origin}.')
+            assert(not (Value.struct and Value.isPointer), f'Pointer-qualified structure spans are not supported for {Origin}.')
 
             local element_type = Value.type
             if not Value.mutable then


### PR DESCRIPTION
* Lower typed array length ranges to numeric loops while preserving dynamic range and catchable error semantics
* Propagate array parameter and global types into specialised bytecode and JIT bounds-check recording
* Add parser and Flute coverage for hoisting, mutations, nested blocks and mistyped arguments