### PR TITLE
[Tiri] Added compile-time constant folding and dead-branch elimination to the IR emitter

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -827,7 +827,7 @@ endif ()
 set (TIRI_TESTS
    defer debuglog io object regex struct async async_actions async_wait xml strings math array array_any array_manip
    array_functional array_typed_syntax bitshift bitwise has_operator approx if_empty if_empty_guard presence blank ternary table stress unit_tests
-   jitoptions fstring const import_scope unicode ellipsis safe_nav close type_annotations type_fixing
+   jitoptions fstring const const_optimisation import_scope unicode ellipsis safe_nav close type_annotations type_fixing
    type_inference jit pipe pipe_iteration arrow_functions result_filter thunks deferred_expr shadow_assert ranges
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus

--- a/src/tiri/jit/src/parser/constant_evaluator.cpp
+++ b/src/tiri/jit/src/parser/constant_evaluator.cpp
@@ -1,0 +1,291 @@
+// Side-effect-free evaluation of primitive constant AST expressions.
+// Copyright © 2026 Paul Manias
+
+#include "constant_evaluator.h"
+
+#include "lj_vm.h"
+#include "lj_str.h"
+
+#include <string>
+
+//********************************************************************************************************************
+
+CompileTimeValue CompileTimeValue::from_literal(const LiteralValue &Literal)
+{
+   CompileTimeValue result;
+   result.kind = Literal.kind;
+   result.bool_value = Literal.bool_value;
+   result.number_value = Literal.number_value;
+   result.string_value = Literal.string_value;
+   return result;
+}
+
+//********************************************************************************************************************
+
+LiteralValue CompileTimeValue::to_literal() const
+{
+   switch (this->kind) {
+      case LiteralKind::Nil:     return LiteralValue::nil();
+      case LiteralKind::Boolean: return LiteralValue::boolean(this->bool_value);
+      case LiteralKind::Number:  return LiteralValue::number(this->number_value);
+      case LiteralKind::String:  return LiteralValue::string(this->string_value);
+   }
+   return LiteralValue::nil();
+}
+
+//********************************************************************************************************************
+
+bool CompileTimeValue::is_truthy() const
+{
+   return this->kind != LiteralKind::Nil and
+      not (this->kind IS LiteralKind::Boolean and not this->bool_value);
+}
+
+//********************************************************************************************************************
+
+bool CompileTimeValue::is_extended_falsey() const
+{
+   switch (this->kind) {
+      case LiteralKind::Nil: return true;
+      case LiteralKind::Boolean: return not this->bool_value;
+      case LiteralKind::Number: return this->number_value IS 0.0;
+      case LiteralKind::String: return not this->string_value or this->string_value->len IS 0;
+   }
+   return false;
+}
+
+//********************************************************************************************************************
+
+ConstantEvaluator::ConstantEvaluator(LexState &State, CompileTimeResolver Resolver)
+   : lex_state(State), resolver(std::move(Resolver))
+{
+}
+
+//********************************************************************************************************************
+
+static std::optional<CompileTimeValue> checked_number(lua_Number Number)
+{
+   TValue value;
+   setnumV(&value, Number);
+   if (tvisnan(&value) or tvismzero(&value)) return std::nullopt;
+   return CompileTimeValue::from_literal(LiteralValue::number(Number));
+}
+
+//********************************************************************************************************************
+
+static std::optional<CompileTimeValue> evaluate_arithmetic(
+   AstBinaryOperator Operator, const CompileTimeValue &Left, const CompileTimeValue &Right)
+{
+   if (Left.kind != LiteralKind::Number or Right.kind != LiteralKind::Number) return std::nullopt;
+
+   int offset;
+   switch (Operator) {
+      case AstBinaryOperator::Add:      offset = 0; break;
+      case AstBinaryOperator::Subtract: offset = 1; break;
+      case AstBinaryOperator::Multiply: offset = 2; break;
+      case AstBinaryOperator::Divide:   offset = 3; break;
+      case AstBinaryOperator::Modulo:   offset = 4; break;
+      case AstBinaryOperator::Power:    offset = 5; break;
+      default: return std::nullopt;
+   }
+
+   return checked_number(lj_vm_foldarith(Left.number_value, Right.number_value, offset));
+}
+
+//********************************************************************************************************************
+
+static std::optional<CompileTimeValue> evaluate_bitwise(
+   AstBinaryOperator Operator, const CompileTimeValue &Left, const CompileTimeValue &Right)
+{
+   if (Left.kind != LiteralKind::Number or Right.kind != LiteralKind::Number) return std::nullopt;
+
+   int32_t lhs = lj_num2bit(Left.number_value);
+   int32_t rhs = lj_num2bit(Right.number_value);
+   int32_t result;
+
+   switch (Operator) {
+      case AstBinaryOperator::BitAnd: result = lhs & rhs; break;
+      case AstBinaryOperator::BitOr: result = lhs | rhs; break;
+      case AstBinaryOperator::BitXor: result = lhs ^ rhs; break;
+      case AstBinaryOperator::ShiftLeft:
+         result = int32_t(uint32_t(lhs) << (uint32_t(rhs) & 31));
+         break;
+      case AstBinaryOperator::ShiftRight:
+         result = int32_t(uint32_t(lhs) >> (uint32_t(rhs) & 31));
+         break;
+      default: return std::nullopt;
+   }
+
+   return CompileTimeValue::from_literal(LiteralValue::number(lua_Number(result)));
+}
+
+//********************************************************************************************************************
+
+static bool primitive_equal(const CompileTimeValue &Left, const CompileTimeValue &Right)
+{
+   if (Left.kind != Right.kind) return false;
+
+   switch (Left.kind) {
+      case LiteralKind::Nil: return true;
+      case LiteralKind::Boolean: return Left.bool_value IS Right.bool_value;
+      case LiteralKind::Number: return Left.number_value IS Right.number_value;
+      case LiteralKind::String: return Left.string_value IS Right.string_value;
+   }
+   return false;
+}
+
+//********************************************************************************************************************
+
+static std::optional<bool> primitive_order(
+   AstBinaryOperator Operator, const CompileTimeValue &Left, const CompileTimeValue &Right)
+{
+   if (Left.kind IS LiteralKind::Number and Right.kind IS LiteralKind::Number) {
+      switch (Operator) {
+         case AstBinaryOperator::LessThan: return Left.number_value < Right.number_value;
+         case AstBinaryOperator::LessEqual: return Left.number_value <= Right.number_value;
+         case AstBinaryOperator::GreaterThan: return Left.number_value > Right.number_value;
+         case AstBinaryOperator::GreaterEqual: return Left.number_value >= Right.number_value;
+         default: return std::nullopt;
+      }
+   }
+   else if (Left.kind IS LiteralKind::String and Right.kind IS LiteralKind::String) {
+      int comparison = lj_str_cmp(Left.string_value, Right.string_value);
+      switch (Operator) {
+         case AstBinaryOperator::LessThan: return comparison < 0;
+         case AstBinaryOperator::LessEqual: return comparison <= 0;
+         case AstBinaryOperator::GreaterThan: return comparison > 0;
+         case AstBinaryOperator::GreaterEqual: return comparison >= 0;
+         default: return std::nullopt;
+      }
+   }
+   return std::nullopt;
+}
+
+//********************************************************************************************************************
+
+std::optional<CompileTimeValue> ConstantEvaluator::evaluate(const ExprNode &Expression) const
+{
+   switch (Expression.kind) {
+      case AstNodeKind::LiteralExpr:
+         return CompileTimeValue::from_literal(std::get<LiteralValue>(Expression.data));
+      case AstNodeKind::IdentifierExpr:
+         if (this->resolver) return this->resolver(std::get<NameRef>(Expression.data));
+         return std::nullopt;
+      case AstNodeKind::UnaryExpr:
+         return this->evaluate_unary(std::get<UnaryExprPayload>(Expression.data));
+      case AstNodeKind::BinaryExpr:
+         return this->evaluate_binary(std::get<BinaryExprPayload>(Expression.data));
+      case AstNodeKind::TernaryExpr:
+         return this->evaluate_ternary(std::get<TernaryExprPayload>(Expression.data));
+      default:
+         return std::nullopt;
+   }
+}
+
+//********************************************************************************************************************
+
+std::optional<CompileTimeValue> ConstantEvaluator::evaluate_unary(const UnaryExprPayload &Payload) const
+{
+   if (not Payload.operand) return std::nullopt;
+   auto operand = this->evaluate(*Payload.operand);
+   if (not operand) return std::nullopt;
+
+   switch (Payload.op) {
+      case AstUnaryOperator::Negate:
+         if (operand->kind != LiteralKind::Number) return std::nullopt;
+         return checked_number(-operand->number_value);
+      case AstUnaryOperator::Not:
+         return CompileTimeValue::from_literal(LiteralValue::boolean(not operand->is_truthy()));
+      case AstUnaryOperator::BitNot:
+         if (operand->kind != LiteralKind::Number) return std::nullopt;
+         return CompileTimeValue::from_literal(
+            LiteralValue::number(lua_Number(int32_t(~uint32_t(lj_num2bit(operand->number_value))))));
+      case AstUnaryOperator::Length:
+         return std::nullopt;
+   }
+   return std::nullopt;
+}
+
+//********************************************************************************************************************
+
+std::optional<CompileTimeValue> ConstantEvaluator::evaluate_binary(const BinaryExprPayload &Payload) const
+{
+   if (not Payload.left or not Payload.right) return std::nullopt;
+
+   auto lhs = this->evaluate(*Payload.left);
+   if (not lhs) return std::nullopt;
+
+   if (Payload.op IS AstBinaryOperator::LogicalAnd) {
+      auto rhs = this->evaluate(*Payload.right);
+      if (not rhs) return std::nullopt;
+      return lhs->is_truthy() ? rhs : lhs;
+   }
+   if (Payload.op IS AstBinaryOperator::LogicalOr) {
+      auto rhs = this->evaluate(*Payload.right);
+      if (not rhs) return std::nullopt;
+      return lhs->is_truthy() ? lhs : rhs;
+   }
+   if (Payload.op IS AstBinaryOperator::IfEmpty) {
+      auto rhs = this->evaluate(*Payload.right);
+      if (not rhs) return std::nullopt;
+      return lhs->is_extended_falsey() ? rhs : lhs;
+   }
+
+   auto rhs = this->evaluate(*Payload.right);
+   if (not rhs) return std::nullopt;
+
+   if (auto arithmetic = evaluate_arithmetic(Payload.op, *lhs, *rhs)) return arithmetic;
+   if (auto bitwise = evaluate_bitwise(Payload.op, *lhs, *rhs)) return bitwise;
+
+   if (Payload.op IS AstBinaryOperator::Concat) {
+      if (lhs->kind != LiteralKind::String or rhs->kind != LiteralKind::String) return std::nullopt;
+      std::string text;
+      text.reserve(lhs->string_value->len + rhs->string_value->len);
+      text.append(strdata(lhs->string_value), lhs->string_value->len);
+      text.append(strdata(rhs->string_value), rhs->string_value->len);
+      return CompileTimeValue::from_literal(LiteralValue::string(this->lex_state.keepstr(text)));
+   }
+
+   if (Payload.op IS AstBinaryOperator::Equal or Payload.op IS AstBinaryOperator::NotEqual) {
+      bool result = primitive_equal(*lhs, *rhs);
+      if (Payload.op IS AstBinaryOperator::NotEqual) result = not result;
+      return CompileTimeValue::from_literal(LiteralValue::boolean(result));
+   }
+
+   if (auto ordered = primitive_order(Payload.op, *lhs, *rhs)) {
+      return CompileTimeValue::from_literal(LiteralValue::boolean(*ordered));
+   }
+
+   if (Payload.op IS AstBinaryOperator::Approx) {
+      if (lhs->kind != LiteralKind::Number or rhs->kind != LiteralKind::Number) return std::nullopt;
+      lua_Number delta = lhs->number_value - rhs->number_value;
+      bool result = delta <= TIRI_APPROX_TOLERANCE and delta >= -TIRI_APPROX_TOLERANCE;
+      return CompileTimeValue::from_literal(LiteralValue::boolean(result));
+   }
+
+   if (Payload.op IS AstBinaryOperator::HasFlag) {
+      if (lhs->kind != LiteralKind::Number or rhs->kind != LiteralKind::Number) return std::nullopt;
+      bool result = (lj_num2bit(lhs->number_value) & lj_num2bit(rhs->number_value)) != 0;
+      return CompileTimeValue::from_literal(LiteralValue::boolean(result));
+   }
+
+   return std::nullopt;
+}
+
+//********************************************************************************************************************
+
+std::optional<CompileTimeValue> ConstantEvaluator::evaluate_ternary(const TernaryExprPayload &Payload) const
+{
+   if (not Payload.condition or not Payload.if_true or not Payload.if_false) return std::nullopt;
+
+   auto condition = this->evaluate(*Payload.condition);
+   if (not condition) return std::nullopt;
+
+   auto if_true = this->evaluate(*Payload.if_true);
+   auto if_false = this->evaluate(*Payload.if_false);
+   if (not if_true or not if_false) return std::nullopt;
+
+   bool take_true = Payload.condition_mode IS TernaryConditionMode::Extended ?
+      not condition->is_extended_falsey() : condition->is_truthy();
+   return take_true ? if_true : if_false;
+}

--- a/src/tiri/jit/src/parser/constant_evaluator.h
+++ b/src/tiri/jit/src/parser/constant_evaluator.h
@@ -1,0 +1,49 @@
+// Side-effect-free evaluation of primitive constant AST expressions.
+// Copyright © 2026 Paul Manias
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <utility>
+
+#include "ast/nodes.h"
+
+//********************************************************************************************************************
+// Shared by compile-time folding and runtime emission of the approximate equality operator; the two paths must
+// always agree on this tolerance.
+
+inline constexpr lua_Number TIRI_APPROX_TOLERANCE = 1e-5;
+
+//********************************************************************************************************************
+
+struct CompileTimeValue {
+   LiteralKind kind = LiteralKind::Nil;
+   bool bool_value = false;
+   lua_Number number_value = 0.0;
+   GCstr *string_value = nullptr;
+
+   [[nodiscard]] static CompileTimeValue from_literal(const LiteralValue &Literal);
+   [[nodiscard]] LiteralValue to_literal() const;
+   [[nodiscard]] bool is_truthy() const;
+   [[nodiscard]] bool is_extended_falsey() const;
+};
+
+using CompileTimeResolver = std::function<std::optional<CompileTimeValue>(const NameRef &)>;
+
+//********************************************************************************************************************
+
+class ConstantEvaluator {
+public:
+   explicit ConstantEvaluator(LexState &State, CompileTimeResolver Resolver = {});
+
+   [[nodiscard]] std::optional<CompileTimeValue> evaluate(const ExprNode &Expression) const;
+
+private:
+   LexState &lex_state;
+   CompileTimeResolver resolver;
+
+   [[nodiscard]] std::optional<CompileTimeValue> evaluate_unary(const UnaryExprPayload &Payload) const;
+   [[nodiscard]] std::optional<CompileTimeValue> evaluate_binary(const BinaryExprPayload &Payload) const;
+   [[nodiscard]] std::optional<CompileTimeValue> evaluate_ternary(const TernaryExprPayload &Payload) const;
+};

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -34,6 +34,8 @@ inline const TiriConstant * lookup_constant(const GCstr *Name)
    return nullptr;
 }
 
+static bool is_named_external_global(GCstr *Name);
+
 //********************************************************************************************************************
 // NilShortCircuitGuard - RAII helper for safe navigation nil-check pattern.
 //
@@ -292,13 +294,14 @@ void LocalBindingTable::pop_scope()
 
 // Add a new local variable binding to the table, associating a symbol with its register slot.
 
-void LocalBindingTable::add(GCstr* symbol, BCReg slot)
+void LocalBindingTable::add(GCstr* Symbol, BCReg Slot, std::optional<CompileTimeValue> Value)
 {
-   if (not symbol) return;
+   if (not Symbol) return;
    LocalBindingEntry entry;
-   entry.symbol = symbol;
-   entry.slot = slot;
+   entry.symbol = Symbol;
+   entry.slot = Slot;
    entry.depth = this->depth;
+   entry.compile_time_value = std::move(Value);
    this->bindings.push_back(entry);
 }
 
@@ -605,8 +608,23 @@ IrEmitter::IrEmitter(ParserContext& context)
      lex_state(context.lex()),
      register_allocator(&this->func_state),
      control_flow(&this->func_state),
-     operator_emitter(&this->func_state, &this->register_allocator, &this->control_flow)
+     operator_emitter(&this->func_state, &this->register_allocator, &this->control_flow),
+     constant_evaluator(this->lex_state, [this](const NameRef &Reference) {
+        return this->resolve_compile_time_value(Reference);
+     })
 {
+}
+
+std::optional<CompileTimeValue> IrEmitter::resolve_compile_time_value(const NameRef &Reference) const
+{
+   const LocalBindingEntry *entry = this->binding_table.resolve(Reference.identifier.symbol);
+   if (not entry or not entry->compile_time_value) return std::nullopt;
+
+   ExpDesc resolved;
+   this->lex_state.var_lookup_symbol(Reference.identifier.symbol, &resolved);
+   if (resolved.k != ExpKind::Local or resolved.u.s.info != entry->slot.raw()) return std::nullopt;
+
+   return entry->compile_time_value;
 }
 
 void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
@@ -1047,11 +1065,21 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
 
    ExpDesc tail;
    auto nexps = BCReg(0);
+   std::vector<std::optional<CompileTimeValue>> compile_time_values(Payload.names.size());
    if (Payload.values.empty()) tail = ExpDesc(ExpKind::Void);
    else {
       auto list = this->emit_expression_list(Payload.values, nexps);
       if (not list.ok()) return ParserResult<IrEmitUnit>::failure(list.error_ref());
       tail = list.value_ref();
+
+      // This re-evaluates initialisers that emit_expression_list already folded; the duplication is accepted
+      // because evaluation is side-effect free and bails at the first non-constant operand.
+      for (size_t i = 0; i < Payload.names.size() and i < Payload.values.size(); ++i) {
+         const Identifier &identifier = Payload.names[i];
+         if (identifier.has_const and not identifier.has_close) {
+            compile_time_values[i] = this->constant_evaluator.evaluate(*Payload.values[i]);
+         }
+      }
    }
 
    this->lex_state.assign_adjust(nvars.raw(), nexps.raw(), &tail);
@@ -1110,7 +1138,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    for (auto i = BCReg(0); i < nvars; ++i) {
       const Identifier& identifier = Payload.names[i.raw()];
       if (is_blank_symbol(identifier)) continue;
-      this->update_local_binding(identifier.symbol, BCReg(base.raw() + i.raw()));
+      this->update_local_binding(
+         identifier.symbol, BCReg(base.raw() + i.raw()), std::move(compile_time_values[i.raw()]));
    }
    this->func_state.reset_freereg();
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
@@ -1136,17 +1165,240 @@ ParserResult<IrEmitUnit> IrEmitter::emit_extern_decl_stmt(const ExternDeclStmtPa
 }
 
 //********************************************************************************************************************
+// Return true when an expression can be skipped without suppressing emitter diagnostics.
+
+bool IrEmitter::can_elide_expression(const ExprNode &Expression) const
+{
+   switch (Expression.kind) {
+      case AstNodeKind::LiteralExpr:
+         return true;
+
+      case AstNodeKind::IdentifierExpr: {
+         const NameRef &reference = std::get<NameRef>(Expression.data);
+         if (reference.identifier.is_blank or not reference.identifier.symbol) return false;
+
+         ExpDesc resolved;
+         this->lex_state.var_lookup_symbol(reference.identifier.symbol, &resolved);
+         if (resolved.k != ExpKind::Unscoped) return true;
+         if (lookup_constant(reference.identifier.symbol)) return true;
+         if (this->func_state.declared_globals.contains(reference.identifier.symbol)) return true;
+         if (this->func_state.external_symbols.contains(reference.identifier.symbol)) return true;
+         if (this->func_state.allow_external_symbol_reads) return true;
+
+         cTValue *global = lj_tab_getstr(tabref(this->lex_state.L->env), reference.identifier.symbol);
+         return (global and not tvisnil(global)) or is_named_external_global(reference.identifier.symbol);
+      }
+
+      case AstNodeKind::UnaryExpr: {
+         const auto &payload = std::get<UnaryExprPayload>(Expression.data);
+         return payload.operand and this->can_elide_expression(*payload.operand);
+      }
+
+      case AstNodeKind::BinaryExpr: {
+         const auto &payload = std::get<BinaryExprPayload>(Expression.data);
+         return payload.left and payload.right and
+            this->can_elide_expression(*payload.left) and this->can_elide_expression(*payload.right);
+      }
+
+      case AstNodeKind::ComparisonChainExpr: {
+         const auto &payload = std::get<ComparisonChainExprPayload>(Expression.data);
+         for (const ExprNodePtr &operand : payload.operands) {
+            if (not operand or not this->can_elide_expression(*operand)) return false;
+         }
+         return true;
+      }
+
+      case AstNodeKind::TernaryExpr: {
+         const auto &payload = std::get<TernaryExprPayload>(Expression.data);
+         return payload.condition and payload.if_true and payload.if_false and
+            this->can_elide_expression(*payload.condition) and
+            this->can_elide_expression(*payload.if_true) and
+            this->can_elide_expression(*payload.if_false);
+      }
+
+      case AstNodeKind::PresenceExpr: {
+         const auto &payload = std::get<PresenceExprPayload>(Expression.data);
+         return payload.value and this->can_elide_expression(*payload.value);
+      }
+
+      case AstNodeKind::MemberExpr: {
+         const auto &payload = std::get<MemberExprPayload>(Expression.data);
+         return payload.table and this->can_elide_expression(*payload.table);
+      }
+
+      case AstNodeKind::SafeMemberExpr: {
+         const auto &payload = std::get<SafeMemberExprPayload>(Expression.data);
+         return payload.table and this->can_elide_expression(*payload.table);
+      }
+
+      case AstNodeKind::IndexExpr: {
+         const auto &payload = std::get<IndexExprPayload>(Expression.data);
+         return payload.table and payload.index and
+            this->can_elide_expression(*payload.table) and this->can_elide_expression(*payload.index);
+      }
+
+      case AstNodeKind::SafeIndexExpr: {
+         const auto &payload = std::get<SafeIndexExprPayload>(Expression.data);
+         return payload.table and payload.index and
+            this->can_elide_expression(*payload.table) and this->can_elide_expression(*payload.index);
+      }
+
+      case AstNodeKind::CallExpr:
+      case AstNodeKind::SafeCallExpr: {
+         const auto &payload = std::get<CallExprPayload>(Expression.data);
+         bool target_valid = false;
+         if (const auto *direct = std::get_if<DirectCallTarget>(&payload.target)) {
+            target_valid = direct->callable and this->can_elide_expression(*direct->callable);
+         }
+         else if (const auto *method = std::get_if<MethodCallTarget>(&payload.target)) {
+            target_valid = method->receiver and this->can_elide_expression(*method->receiver);
+         }
+         else if (const auto *safe_method = std::get_if<SafeMethodCallTarget>(&payload.target)) {
+            target_valid = safe_method->receiver and this->can_elide_expression(*safe_method->receiver);
+         }
+         if (not target_valid) return false;
+
+         for (const ExprNodePtr &argument : payload.arguments) {
+            if (not argument or not this->can_elide_expression(*argument)) return false;
+         }
+         return true;
+      }
+
+      default:
+         return false;
+   }
+}
+
+//********************************************************************************************************************
+// Return true when a statement can be skipped without suppressing emitter diagnostics.
+
+bool IrEmitter::can_elide_statement(const StmtNode &Statement, bool InLoop) const
+{
+   switch (Statement.kind) {
+      case AstNodeKind::ExpressionStmt: {
+         const auto &payload = std::get<ExpressionStmtPayload>(Statement.data);
+         return payload.expression and this->can_elide_expression(*payload.expression);
+      }
+
+      case AstNodeKind::ReturnStmt: {
+         const auto &payload = std::get<ReturnStmtPayload>(Statement.data);
+         for (const ExprNodePtr &value : payload.values) {
+            if (not value or not this->can_elide_expression(*value)) return false;
+         }
+         return true;
+      }
+
+      case AstNodeKind::DoStmt: {
+         const auto &payload = std::get<DoStmtPayload>(Statement.data);
+         return payload.block and this->can_elide_block(*payload.block, InLoop);
+      }
+
+      case AstNodeKind::IfStmt: {
+         const auto &payload = std::get<IfStmtPayload>(Statement.data);
+         for (const IfClause &clause : payload.clauses) {
+            if (clause.condition and not this->can_elide_expression(*clause.condition)) return false;
+            if (clause.block and not this->can_elide_block(*clause.block, InLoop)) return false;
+         }
+         return true;
+      }
+
+      case AstNodeKind::WhileStmt:
+      case AstNodeKind::RepeatStmt: {
+         const auto &payload = std::get<LoopStmtPayload>(Statement.data);
+         return payload.condition and payload.body and
+            this->can_elide_expression(*payload.condition) and this->can_elide_block(*payload.body, true);
+      }
+
+      case AstNodeKind::BreakStmt:
+      case AstNodeKind::ContinueStmt:
+         return InLoop;
+
+      default:
+         return false;
+   }
+}
+
+//********************************************************************************************************************
+
+bool IrEmitter::can_elide_block(const BlockStmt &Block, bool InLoop) const
+{
+   for (const StmtNode &statement : Block.view()) {
+      if (not this->can_elide_statement(statement, InLoop)) return false;
+   }
+   return true;
+}
+
+//********************************************************************************************************************
 // Emit bytecode for an if statement with one or more conditional clauses and an optional else clause.
 
 ParserResult<IrEmitUnit> IrEmitter::emit_if_stmt(const IfStmtPayload &Payload)
 {
    if (Payload.clauses.empty()) return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
 
+   struct PlannedClause {
+      const IfClause *clause = nullptr;
+      bool unconditional = false;
+   };
+
+   std::vector<PlannedClause> plan;
+   std::vector<const IfClause *> omitted;
+   bool terminated = false;
+
+   for (const IfClause &clause : Payload.clauses) {
+      if (terminated) {
+         omitted.push_back(&clause);
+         continue;
+      }
+
+      if (not clause.condition) {
+         plan.push_back(PlannedClause{ &clause, true });
+         terminated = true;
+         continue;
+      }
+
+      auto condition = this->constant_evaluator.evaluate(*clause.condition);
+      if (not condition) {
+         plan.push_back(PlannedClause{ &clause, false });
+         continue;
+      }
+
+      if (condition->is_truthy()) {
+         plan.push_back(PlannedClause{ &clause, true });
+         terminated = true;
+      }
+      else omitted.push_back(&clause);
+   }
+
+   bool can_use_plan = true;
+   for (const PlannedClause &planned : plan) {
+      if (planned.unconditional and planned.clause->condition and
+          not this->can_elide_expression(*planned.clause->condition)) {
+         can_use_plan = false;
+         break;
+      }
+   }
+
+   for (const IfClause *clause : omitted) {
+      if ((clause->condition and not this->can_elide_expression(*clause->condition)) or
+          (clause->block and not this->can_elide_block(*clause->block))) {
+         can_use_plan = false;
+         break;
+      }
+   }
+
+   if (not can_use_plan) {
+      plan.clear();
+      for (const IfClause &clause : Payload.clauses) {
+         plan.push_back(PlannedClause{ &clause, not clause.condition });
+      }
+   }
+
    ControlFlowEdge escapelist = this->control_flow.make_unconditional();
-   for (size_t i = 0; i < Payload.clauses.size(); ++i) {
-      const IfClause& clause = Payload.clauses[i];
-      bool has_next = (i + 1) < Payload.clauses.size();
-      if (clause.condition) {
+   for (size_t i = 0; i < plan.size(); ++i) {
+      const PlannedClause &planned = plan[i];
+      const IfClause &clause = *planned.clause;
+      bool has_next = (i + 1) < plan.size();
+      if (clause.condition and not planned.unconditional) {
          auto condexit_result = this->emit_condition_jump(*clause.condition);
          if (not condexit_result.ok()) return ParserResult<IrEmitUnit>::failure(condexit_result.error_ref());
 
@@ -1180,6 +1432,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_while_stmt(const LoopStmtPayload &Paylo
 {
    if (Payload.style != LoopStyle::WhileLoop or not Payload.condition or not Payload.body) {
       return this->unsupported_stmt(AstNodeKind::WhileStmt, SourceSpan{});
+   }
+
+   if (auto condition = this->constant_evaluator.evaluate(*Payload.condition);
+       condition and not condition->is_truthy() and this->can_elide_expression(*Payload.condition) and
+       this->can_elide_block(*Payload.body, true)) {
+      return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
    }
 
    FuncState* fs = &this->func_state;
@@ -1227,6 +1485,27 @@ ParserResult<IrEmitUnit> IrEmitter::emit_repeat_stmt(const LoopStmtPayload &Payl
    }
 
    FuncState* fs = &this->func_state;
+   auto constant_condition = this->constant_evaluator.evaluate(*Payload.condition);
+   if (constant_condition and constant_condition->is_truthy() and
+       this->can_elide_expression(*Payload.condition)) {
+      auto loop_stack_guard = this->push_loop_context(fs->current_pc());
+
+      FuncScope outer_scope;
+      ScopeGuard loop_guard(fs, &outer_scope, FuncScopeFlag::Loop);
+      {
+         FuncScope inner_scope;
+         ScopeGuard inner_guard(fs, &inner_scope, FuncScopeFlag::None);
+         auto block_result = this->emit_block(*Payload.body, FuncScopeFlag::None);
+         if (not block_result.ok()) return block_result;
+      }
+
+      BCPos iter = fs->current_pc();
+      this->loop_stack.back().continue_target = iter;
+      this->loop_stack.back().continue_edge.patch_to(iter);
+      this->loop_stack.back().break_edge.patch_here();
+      return ParserResult<IrEmitUnit>::success(IrEmitUnit{});
+   }
+
    BCPos loop = BCPos(fs->lasttarget = fs->pc);
    BCPos iter = BCPos(NO_JMP);
    ControlFlowEdge condexit;
@@ -1745,6 +2024,13 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
    // final instruction gets the correct line.
 
    this->lex_state.lastline = expr.span.line;
+
+   // Attempting the fold at every node means a non-constant subtree can be re-walked once per ancestor,
+   // giving O(depth^2) behaviour on deep chains; evaluation bails at the first non-constant operand, which
+   // keeps the cost negligible for hand-written code.  Memoise per-node if generated code makes this hot.
+   if (auto constant = this->constant_evaluator.evaluate(expr)) {
+      return this->emit_literal_expr(constant->to_literal());
+   }
 
    switch (expr.kind) {
       case AstNodeKind::LiteralExpr:      return this->emit_literal_expr(std::get<LiteralValue>(expr.data));
@@ -2311,20 +2597,6 @@ ParserResult<ExpDesc> IrEmitter::emit_bitwise_expr(BinOpr opr, ExpDesc lhs, cons
 ParserResult<ExpDesc> IrEmitter::emit_has_flag_expr(ExpDesc lhs, const ExprNode& rhs_ast)
 {
    FuncState* fs = &this->func_state;
-
-   // Constant folding: if both operands are numeric constants, compute at compile time.
-   // Read RHS directly from AST so we do not emit/evaluate RHS before resolving bit.band.
-   if (lhs.is_num_constant_nojump() and rhs_ast.kind IS AstNodeKind::LiteralExpr) {
-      auto *rhs_literal = std::get_if<LiteralValue>(&rhs_ast.data);
-      if (rhs_literal and rhs_literal->kind IS LiteralKind::Number) {
-         auto k1 = lj_num2bit(lhs.number_value());
-         auto k2 = lj_num2bit(rhs_literal->number_value);
-         bool result = (k1 & k2) != 0;
-         lhs.k = result ? ExpKind::True : ExpKind::False;
-         lhs.result_type = TiriType::Bool;
-         return ParserResult<ExpDesc>::success(lhs);
-      }
-   }
 
    // Runtime path: emit bit.band(lhs, rhs) call, then compare result against 0.
    // Keep LHS stable before RHS emission so RHS side effects cannot alter which LHS value we test.

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../ast/nodes.h"
+#include "../constant_evaluator.h"
 #include "operator_emitter.h"
 #include "../parser_context.h"
 #include "../parse_control_flow.h"
@@ -23,6 +24,7 @@ struct LocalBindingEntry {
    GCstr *symbol = nullptr;
    BCReg slot = BCReg(0);
    uint32_t depth = 0;
+   std::optional<CompileTimeValue> compile_time_value;
 };
 
 //********************************************************************************************************************
@@ -44,14 +46,14 @@ public:
    }
 
    void pop_scope();
-   void add(GCstr *, BCReg);
+   void add(GCstr *, BCReg, std::optional<CompileTimeValue> = std::nullopt);
 
-   [[nodiscard]] inline std::optional<BCReg> resolve(GCstr *symbol) const {
-      if (not symbol) return std::nullopt;
+   [[nodiscard]] inline const LocalBindingEntry * resolve(GCstr *Symbol) const {
+      if (not Symbol) return nullptr;
       for (auto it = this->bindings.rbegin(); it != this->bindings.rend(); ++it) {
-         if (it->symbol IS symbol) return it->slot;
+         if (it->symbol IS Symbol) return &*it;
       }
-      return std::nullopt;
+      return nullptr;
    }
 
 private:
@@ -154,6 +156,7 @@ private:
    ControlFlowGraph  control_flow;
    OperatorEmitter   operator_emitter;
    LocalBindingTable binding_table;
+   ConstantEvaluator constant_evaluator;
 
    ParserResult<IrEmitUnit> emit_block(const BlockStmt& block, FuncScopeFlag flags = FuncScopeFlag::None);
    ParserResult<IrEmitUnit> emit_block_with_bindings(const BlockStmt& block, FuncScopeFlag flags, std::span<const BlockBinding> bindings);
@@ -227,12 +230,22 @@ private:
    void optimise_assert(ExprNodeList &Args);
    void apply_inferred_local_type(BCReg Slot, const ExprNode& Value);
    BCReg finalise_pending_local_assignment(PreparedAssignment& Target);
+   [[nodiscard]] bool can_elide_expression(const ExprNode &Expression) const;
+   [[nodiscard]] bool can_elide_statement(const StmtNode &Statement, bool InLoop) const;
+   [[nodiscard]] bool can_elide_block(const BlockStmt &Block, bool InLoop = false) const;
 
    ParserResult<IrEmitUnit> unsupported_stmt(AstNodeKind kind, const SourceSpan& span);
    ParserResult<ExpDesc> unsupported_expr(AstNodeKind kind, const SourceSpan& span);
 
-   inline std::optional<BCReg> resolve_local(GCstr *symbol) const { return this->binding_table.resolve(symbol); }
-   inline void update_local_binding(GCstr *symbol, BCReg slot) { this->binding_table.add(symbol, slot); }
+   [[nodiscard]] std::optional<CompileTimeValue> resolve_compile_time_value(const NameRef &Reference) const;
+   inline std::optional<BCReg> resolve_local(GCstr *Symbol) const {
+      const LocalBindingEntry *entry = this->binding_table.resolve(Symbol);
+      return entry ? std::optional<BCReg>(entry->slot) : std::nullopt;
+   }
+   inline void update_local_binding(
+      GCstr *Symbol, BCReg Slot, std::optional<CompileTimeValue> Value = std::nullopt) {
+      this->binding_table.add(Symbol, Slot, std::move(Value));
+   }
    inline void release_expression(ExpDesc &expression, std::string_view usage) { expr_free(&this->func_state, &expression); this->ensure_register_floor(usage); }
 
    struct LoopContext {

--- a/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
@@ -87,82 +87,6 @@ static CSTRING get_expkind_name(ExpKind k)
 }
 
 //********************************************************************************************************************
-// Bytecode emitter for operators - constant folding
-
-// Try constant-folding of arithmetic operators.
-
-[[nodiscard]] static int foldarith(BinOpr opr, ExpDesc* e1, ExpDesc* e2)
-{
-   TValue o;
-   lua_Number n;
-   if (!e1->is_num_constant_nojump() or !e2->is_num_constant_nojump()) [[likely]] return 0;
-   n = lj_vm_foldarith(e1->number_value(), e2->number_value(), to_arith_offset(opr));
-   setnumV(&o, n);
-   if (tvisnan(&o) or tvismzero(&o)) [[unlikely]] return 0;  // Avoid NaN and -0 as consts.
-   if (LJ_DUALNUM) {
-      int32_t k = lj_num2int(n);
-      if (lua_Number(k) IS n) {
-         setintV(&e1->u.nval, k);
-         return 1;
-      }
-   }
-   setnumV(&e1->u.nval, n);
-   return 1;
-}
-
-//********************************************************************************************************************
-// Try constant-folding of bitwise operators.
-// Bitwise operations in Lua/LuaJIT operate on 32-bit integers.
-
-[[nodiscard]] static int foldbitwise(BinOpr opr, ExpDesc* e1, ExpDesc* e2)
-{
-   if (!e1->is_num_constant_nojump() or !e2->is_num_constant_nojump()) [[likely]] return 0;
-
-   // Convert to 32-bit integers using lj_num2bit() to match bit library semantics
-   auto k1 = lj_num2bit(e1->number_value());
-   auto k2 = lj_num2bit(e2->number_value());
-   int32_t result;
-
-   switch (opr) {
-      case BinOpr::BitAnd: result = k1 & k2; break;
-      case BinOpr::BitOr:  result = k1 | k2; break;
-      case BinOpr::BitXor: result = k1 ^ k2; break;
-      case BinOpr::ShiftLeft:  result = k1 << (k2 & 31); break;  // Mask shift count to 0-31
-      case BinOpr::ShiftRight:  result = int32_t(uint32_t(k1) >> (k2 & 31)); break;  // Unsigned right shift
-      default: return 0;
-   }
-
-   // Store result as integer if possible, otherwise as number
-
-   if (LJ_DUALNUM) setintV(&e1->u.nval, result);
-   else setnumV(&e1->u.nval, lua_Number(result));
-
-   e1->k = ExpKind::Num;
-   return 1;
-}
-
-//********************************************************************************************************************
-// Try constant-folding of unary bitwise NOT.
-
-[[nodiscard]] static int foldbitnot(ExpDesc* e)
-{
-   if (!e->is_num_constant_nojump()) [[likely]] return 0;
-
-   // Convert to 32-bit integer using lj_num2bit() and apply bitwise NOT
-
-   auto k = lj_num2bit(e->number_value());
-   int32_t result = ~k;
-
-   // Store result as integer if possible, otherwise as number
-
-   if (LJ_DUALNUM) setintV(&e->u.nval, result);
-   else setnumV(&e->u.nval, lua_Number(result));
-
-   e->k = ExpKind::Num;
-   return 1;
-}
-
-//********************************************************************************************************************
 // Emit arithmetic operator.
 
 static void bcemit_arith(FuncState* fs, BinOpr opr, ExpDesc* e1, ExpDesc* e2)
@@ -170,8 +94,6 @@ static void bcemit_arith(FuncState* fs, BinOpr opr, ExpDesc* e1, ExpDesc* e2)
    RegisterAllocator allocator(fs);
    BCREG rb, rc, t;
    uint32_t op;
-
-   if (foldarith(opr, e1, e2)) return;
 
    if (opr IS BinOpr::Pow) {
       op = BC_POW;
@@ -225,29 +147,11 @@ static void bcemit_arith(FuncState* fs, BinOpr opr, ExpDesc* e1, ExpDesc* e2)
 //********************************************************************************************************************
 // Emit comparison operator.
 
-static constexpr lua_Number TIRI_APPROX_TOLERANCE = 1e-5;
-
-//********************************************************************************************************************
-// Try constant-folding of approximate equality.
-
-[[nodiscard]] static int foldapprox(ExpDesc* e1, ExpDesc* e2)
-{
-   if (!e1->is_num_constant_nojump() or !e2->is_num_constant_nojump()) [[likely]] return 0;
-
-   lua_Number delta = e1->number_value() - e2->number_value();
-   bool result = delta <= TIRI_APPROX_TOLERANCE and delta >= -TIRI_APPROX_TOLERANCE;
-   *e1 = ExpDesc(result);
-   e1->result_type = TiriType::Bool;
-   return 1;
-}
-
 //********************************************************************************************************************
 // Emit approximate equality: `(lhs - rhs) <= tolerance and (lhs - rhs) >= -tolerance`.
 
 static void bcemit_approx(FuncState* fs, ExpDesc* e1, ExpDesc* e2)
 {
-   if (foldapprox(e1, e2)) return;
-
    RegisterAllocator allocator(fs);
 
    bcemit_arith(fs, BinOpr::Sub, e1, e2);
@@ -687,21 +591,11 @@ void OperatorEmitter::emit_unary(int op, ExprValue operand)
 }
 
 //********************************************************************************************************************
-// Emit bitwise NOT operator (~)
-// Performs constant folding when possible, otherwise calls bit.bnot library function
+// Emit bitwise NOT operator (~).
 
 void OperatorEmitter::emit_bitnot(ExprValue operand)
 {
    ExpDesc* e = operand.raw();
-
-   // Try constant folding first
-   if (foldbitnot(e)) {
-      if (should_trace_operators(this->func_state)) {
-         kt::Log("Parser").msg("[%d] operator ~: constant-folded to %d", this->func_state->ls->linenumber.lineNumber(),
-            int32_t(e->number_value()));
-      }
-      return;
-   }
 
    if (should_trace_operators(this->func_state)) {
       kt::Log("Parser").msg("[%d] operator ~: calling bit.bnot, operand kind=%s", this->func_state->ls->linenumber.lineNumber(),
@@ -770,21 +664,11 @@ void OperatorEmitter::emit_comparison(BinOpr opr, ExprValue left, ExpDesc right)
 }
 
 //********************************************************************************************************************
-// Emit bitwise binary operator
-// Performs constant folding when possible, otherwise emits function calls to bit.* library
+// Emit bitwise binary operator via the bit library.
 
 void OperatorEmitter::emit_binary_bitwise(BinOpr opr, ExprValue left, ExpDesc right)
 {
    ExpDesc* lhs = left.raw();
-
-   // Try constant folding first
-   if (foldbitwise(opr, lhs, &right)) {
-      if (should_trace_operators(this->func_state)) {
-         kt::Log("Parser").msg("[%d] operator %s: constant-folded to %d", this->func_state->ls->linenumber.lineNumber(),
-            get_binop_name(opr), int32_t(lhs->number_value()));
-      }
-      return;
-   }
 
    CSTRING op_name = priority[int(opr)].name;
    size_t op_name_len = priority[int(opr)].name_len;
@@ -859,15 +743,6 @@ void OperatorEmitter::complete_bitwise(BinOpr opr, ExprValue left, ExpDesc right
 {
    ExpDesc* lhs = left.raw();
    FuncState* fs = this->func_state;
-
-   // Try constant folding first - if both operands are constants, we can fold
-   if (foldbitwise(opr, lhs, &right)) {
-      if (should_trace_operators(fs)) {
-         kt::Log("Parser").msg("[%d] complete_bitwise %s: constant-folded to %d",
-            fs->ls->linenumber.lineNumber(), get_binop_name(opr), int32_t(lhs->number_value()));
-      }
-      return;
-   }
 
    // Get the base register from aux field (set by prepare_bitwise)
 

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -61,6 +61,7 @@ static const struct {
 #include "ast/builder.cpp"
 #include "parser_symbols.cpp"
 #include "parse_control_flow.cpp"
+#include "constant_evaluator.cpp"
 #include "ir_emitter/ir_emitter.cpp"
 #include "parse_constants.cpp"
 #include "parse_scope.cpp"

--- a/src/tiri/tests/test_const_optimisation.tiri
+++ b/src/tiri/tests/test_const_optimisation.tiri
@@ -1,0 +1,579 @@
+-- Regression tests for local <const> code generation and primitive literal folding.
+
+local ir_add <const> = 41
+local ir_mul <const> = 43
+local ir_sload <const> = 71
+
+@BeforeEach(hotpath=true)
+function EnableHotPath()
+end
+
+@AfterEach
+function ResetJit()
+   jit.on()
+   jit.opt.start()
+end
+
+function disassemble(Statement:str):str
+   local script = obj.new('tiri', { statement = Statement })
+   check script.acQuery()
+   check script.acActivate()
+   local _, result = script.mtDebugLog('disasm')
+   script.free()
+   return result
+end
+
+function disassembly_has_line(Disassembly:str, Opcode:str, Operand:str):bool
+   for line in values(Disassembly:split('\n')) do
+      if line:find(Opcode) != nil and line:find(Operand) != nil then return true end
+   end
+   return false
+end
+
+function expect_undeclared_diagnostic(Source:str)
+   try
+      exec(Source)
+   except ex
+      assert(ex.message:find('Undeclared variable') != nil,
+         f'Elided control flow should retain source diagnostics: {ex.message}')
+      return
+   end
+   error('An undeclared name in elided control flow should still fail compilation')
+end
+
+function count_trace_opcode(TraceNo:num, Info:table, Opcode:num):num
+   local count = 0
+   for index = 1, Info.nins do
+      local _, ir_ot = jit.util.traceIR(TraceNo, index)
+      if ir_ot != nil and (ir_ot >> 8) is Opcode then count++ end
+   end
+   return count
+end
+
+function first_trace_metrics():table
+   for trace_no = 1, 20 do
+      local info = jit.util.traceInfo(trace_no)
+      if info then
+         return {
+            instructions = info.nins,
+            loads = count_trace_opcode(trace_no, info, ir_sload),
+            adds = count_trace_opcode(trace_no, info, ir_add),
+            multiplies = count_trace_opcode(trace_no, info, ir_mul)
+         }
+      end
+   end
+   error('Failed to record a JIT trace for const optimisation baseline')
+end
+
+function local_workload(Count:num):num
+   local factor = 7
+   local offset = 3
+   local total = 0
+   for index = 1, Count do
+      total += (index * factor) + offset
+   end
+   return total
+end
+
+function const_workload(Count:num):num
+   local factor <const> = 7
+   local offset <const> = 3
+   local total = 0
+   for index = 1, Count do
+      total += (index * factor) + offset
+   end
+   return total
+end
+
+function record_local_metrics():table
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1')
+   for run = 1, 80 do local_workload(40) end
+   return first_trace_metrics()
+end
+
+function record_const_metrics():table
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1')
+   for run = 1, 80 do const_workload(40) end
+   return first_trace_metrics()
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstLocalPropagationBytecode()
+   local mutable = disassemble([[
+function sample()
+   local value = 10
+   return value * 2 + value
+end
+]])
+   local immutable = disassemble([[
+function sample()
+   local value <const> = 10
+   return value * 2 + value
+end
+]])
+
+   assert(mutable:find('MULVN') != nil and mutable:find('ADDVV') != nil,
+      'Mutable primitive locals should retain their runtime arithmetic')
+   assert(immutable:find('MULVN') is nil and immutable:find('ADDVV') is nil,
+      'A primitive const expression should fold after local substitution')
+   assert(immutable:find('D=#10') != nil, 'The const local slot should remain materialised in Phase 2')
+   assert(immutable:find('D=#30') != nil, 'The propagated expression should emit its final constant')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function PrimitiveLiteralFoldingBytecode()
+   local result = disassemble([[
+global glBaselineValue <const> = 10 + 20
+
+function numericInitialiser()
+   local value <const> = (10 + 20) * 2 - 5
+   return value
+end
+
+function constReuse()
+   local value <const> = 10
+   return value * 2 + value
+end
+
+function stringLiterals()
+   return ('a' .. 'b') .. 'c'
+end
+
+function literalComparison()
+   return 10 < 20
+end
+
+function literalBitwise()
+   return (15 & 7) << 2
+end
+
+function constBranch()
+   local enabled <const> = false
+   if enabled then return 1 else return 2 end
+end
+
+function globalReuse()
+   return glBaselineValue * 2
+end
+]])
+
+   assert(result:find('D=#55') != nil, 'Numeric literal arithmetic should fold to 55')
+   assert(result:find('K"abc"') != nil, 'Literal string concatenation should fold to one string constant')
+   assert(result:find('CAT') is nil, 'Literal string concatenation should not retain CAT bytecode')
+   assert(result:find('ISLT') is nil, 'Literal comparison should not retain comparison bytecode')
+   assert(result:find('K"bit"') is nil, 'Literal bitwise operations should not retain a bit-library lookup')
+   assert(result:find('D=#2') != nil,
+      'The selected const-controlled branch should remain in bytecode')
+   assert(disassembly_has_line(result, 'GGET', 'K"glBaselineValue"'),
+      'Global const reuse should retain a lookup of glBaselineValue')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function PrimitiveConstPropagationCoverage()
+   local result = disassemble([[
+function sample()
+   local number <const> = 10
+   local text <const> = 'a'
+   local enabled <const> = true
+   local missing <const> = nil
+   return number * 3, text .. 'b', enabled and 7, missing ?? 9
+end
+]])
+
+   assert(result:find('D=#30') != nil, 'A propagated numeric const should fold later arithmetic')
+   assert(result:find('K"ab"') != nil, 'A propagated string const should fold later concatenation')
+   assert(result:find('MUL') is nil and result:find('CAT') is nil,
+      'Primitive const reads should not retain arithmetic or concatenation bytecode')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function MultipleConstDeclarationsPropagate()
+   local result = disassemble([[
+function sample()
+   local first <const>, second <const> = 10, 20
+   return first + second
+end
+]])
+
+   assert(result:find('D=#30') != nil, 'One-to-one multiple const initialisers should propagate')
+   assert(result:find('ADD') is nil, 'Propagated multiple const declarations should fold later arithmetic')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function MultiResultTailIsNotPropagated()
+   local result = disassemble([[
+function pair()
+   return 20, 30
+end
+
+function sample()
+   local first <const>, second <const> = 10, pair()
+   return first + second
+end
+]])
+
+   assert(result:find('CALL') != nil, 'A multi-result tail initialiser should still execute at runtime')
+   assert(result:find('ADD') != nil, 'A const value sourced from a call should retain its local read')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function MutableShadowBlocksPropagation()
+   local result = disassemble([[
+function sample()
+   local value <const> = 10
+   do
+      local value = 20
+      return value * 2
+   end
+end
+]])
+
+   assert(result:find('MULVN') != nil, 'A mutable inner binding should block substitution of an outer const')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function CapturedAndNonPrimitiveConstsRetainReads()
+   local captured = disassemble([[
+function sample()
+   local value <const> = 37
+   return function()
+      return value
+   end
+end
+]])
+   local non_primitive = disassemble([[
+function sample()
+   local value <const> = { count = 1 }
+   value.count++
+   return value.count
+end
+]])
+
+   assert(captured:find('UGET') != nil, 'A nested function should continue reading a captured const as an upvalue')
+   assert(non_primitive:find('TGETS') != nil,
+      'A const table binding should retain runtime reads because its contents remain mutable')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function PrimitiveLiteralFoldingCoverage()
+   local result = disassemble([[
+function foldedValues()
+   return 2 + 3 * 4, 20 / 4, 20 % 6, 2 ** 5, -7, ~0,
+      (15 & 7) << 2, 8 | 3 ^ 1, 'a' .. 'b' .. 'c',
+      10 < 20, 'a' <= 'b', 4 is 4, 4 != 5, 1.0 ≈ 1.000001, 7 has 3,
+      false and 41, true or 42, 0 ?? 9,
+      true ? 11 :> 12, '' ?? 14 :> 13
+end
+]])
+
+   assert(result:find('K"abc"') != nil, 'An adjacent literal concatenation run should become one constant')
+   assert(result:find('K"bit"') is nil, 'Folded bitwise expressions should not load the bit library')
+   assert(result:find('CAT') is nil, 'Folded concatenation should not emit CAT')
+   assert(result:find('CALL') is nil, 'Folded primitive expressions should not emit calls')
+   assert(result:find('ISLT') is nil and result:find('ISLE') is nil,
+      'Folded relational expressions should not emit comparisons')
+   assert(result:find('ADD') is nil and result:find('MUL') is nil and result:find('DIV') is nil,
+      'Folded numeric expressions should not emit arithmetic instructions')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstantControlFlowBytecode()
+   local branch = disassemble([[
+function sample(flag)
+   if flag then
+      return 'phase3_unknown'
+   elseif false then
+      print('phase3_false')
+   elseif true then
+      return 'phase3_selected'
+   else
+      print('phase3_after_true')
+   end
+end
+]])
+   local while_loop = disassemble([[
+function sample()
+   while false do
+      print('phase3_while')
+   end
+   return 7
+end
+]])
+   local repeat_loop = disassemble([[
+function sample()
+   local count = 0
+   repeat
+      count++
+   until true
+   return count
+end
+]])
+
+   assert(branch:find('K"phase3_unknown"') != nil,
+      'A dynamic leading branch should remain in bytecode')
+   assert(branch:find('K"phase3_selected"') != nil,
+      'The first constant-true branch should become the final branch')
+   assert(branch:find('phase3_false') is nil and branch:find('phase3_after_true') is nil,
+      'False branches and clauses after a constant-true branch should be omitted')
+   assert(while_loop:find('phase3_while') is nil,
+      'A while false body should be omitted from bytecode')
+   assert(while_loop:find('LOOP') is nil,
+      'A while false loop should not retain loop bytecode')
+   assert(repeat_loop:find('LOOP') is nil,
+      'A repeat until true loop should not retain a back-edge')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstantControlFlowRuntimeSemantics()
+   local function select(Value:bool):str
+      if Value then
+         return 'dynamic'
+      elseif false then
+         return 'false'
+      elseif true then
+         return 'selected'
+      else
+         return 'after'
+      end
+   end
+
+   assert(select(true) is 'dynamic' and select(false) is 'selected',
+      'Mixed dynamic and constant if clauses should retain source order')
+
+   local while_count = 0
+   while false do while_count++ end
+   assert(while_count is 0, 'A while false body should never execute')
+
+   local repeat_count = 0
+   repeat repeat_count++ until true
+   assert(repeat_count is 1, 'A repeat until true body should execute exactly once')
+
+   local continue_count = 0
+   repeat
+      continue_count++
+      continue
+      continue_count += 100
+   until true
+   assert(continue_count is 1, 'Continue should exit a one-pass repeat after running scope cleanup')
+
+   local break_count = 0
+   repeat
+      break_count++
+      break
+      break_count += 100
+   until true
+   assert(break_count is 1, 'Break should exit a one-pass repeat immediately')
+
+   local deferred_count = 0
+   repeat
+      defer
+         deferred_count++
+      end
+   until true
+   assert(deferred_count is 1, 'A one-pass repeat should run deferred work exactly once')
+
+   local deferred_continue_count = 0
+   repeat
+      defer
+         deferred_continue_count += 10
+      end
+      deferred_continue_count++
+      continue
+   until true
+   assert(deferred_continue_count is 11,
+      'Continue should run deferred work once before leaving a one-pass repeat')
+
+   local deferred_break_count = 0
+   repeat
+      defer
+         deferred_break_count += 10
+      end
+      deferred_break_count++
+      break
+   until true
+   assert(deferred_break_count is 11,
+      'Break should run deferred work once before leaving a one-pass repeat')
+
+   local try_count = 0
+   repeat
+      try
+         try_count++
+      except ex
+         error(ex)
+      end
+   until true
+   assert(try_count is 1, 'A one-pass repeat should preserve try block execution')
+
+   local try_continue_count = 0
+   repeat
+      try
+         try_continue_count++
+         continue
+      except ex
+         error(ex)
+      end
+   until true
+   assert(try_continue_count is 1, 'Continue from try should leave a one-pass repeat cleanly')
+
+   local function return_from_branch():num
+      if true then return 4 else return 5 end
+   end
+   assert(return_from_branch() is 4, 'A return in a selected constant branch should retain its value')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstantControlFlowPreservesDiagnostics()
+   expect_undeclared_diagnostic([[if false then missing_phase3_branch() end]])
+   expect_undeclared_diagnostic([[if true or missing_phase3_condition() then print('selected') end]])
+   expect_undeclared_diagnostic([[while false do missing_phase3_while() end]])
+   expect_undeclared_diagnostic([[repeat print('body') until true or missing_phase3_repeat()]])
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function PrimitiveLiteralFoldingRuntimeSemantics()
+   assert(2 + 3 * 4 is 14, 'Arithmetic folding should preserve precedence')
+   assert(20 / 4 is 5 and 20 % 6 is 2 and 2 ** 5 is 32, 'Arithmetic folding should preserve VM results')
+   assert(-7 is 0 - 7 and ~0 is bit.bnot(0), 'Unary folding should preserve numeric and bitwise results')
+   assert(1 / -0.0 is -math.huge, 'Unary folding should preserve the sign of negative zero')
+   assert((15 & 7) << 2 is bit.lshift(bit.band(15, 7), 2),
+      'Bitwise folding should preserve 32-bit conversion and shift behaviour')
+   assert('a' .. 'b' .. 'c' is 'abc', 'String-only concatenation should preserve content')
+   assert(10 < 20 and 'a' <= 'b' and 4 is 4 and 4 != 5, 'Comparison folding should preserve results')
+   assert(1.0 ≈ 1.000001 and 7 has 3, 'Approximate equality and has should preserve results')
+   assert((false and 41) is false, 'Logical and should return its known left value')
+   assert((true or 42) is true, 'Logical or should return its known left value')
+   assert((0 ?? 9) is 9 and ('' ?? 8) is 8, 'If-empty folding should use extended falseyness')
+   assert((true ? 11 :> 12) is 11, 'Standard ternary folding should select the reachable value')
+   assert(('' ?? 14 :> 13) is 13, 'Extended ternary folding should use extended falseyness')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function FoldingPreservesUnreachableExpressionDiagnostics()
+   try
+      exec([[local value = false and missing_const_fold_name()]])
+   except ex
+      assert(ex.message:find('Undeclared variable') != nil,
+         f'An unreachable expression should retain its source diagnostics: {ex.message}')
+      return
+   end
+   error('An undeclared name in an unreachable expression should still fail compilation')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstRuntimeSemanticsBaseline()
+   local initialiser_calls = 0
+
+   local function initialise(Value:num):num
+      initialiser_calls++
+      return Value
+   end
+
+   local first <const>, second <const> = initialise(11), initialise(22)
+   assert(first is 11 and second is 22, 'Multiple const declaration should preserve initialiser values')
+   assert(initialiser_calls is 2, 'Each side-effecting const initialiser should execute exactly once')
+
+   local explicit_nil <const> = nil
+   assert(explicit_nil is nil, 'An explicit nil const initialiser should remain distinct from a missing initialiser')
+
+   local outer <const> = 7
+   do
+      local outer = 9
+      outer++
+      assert(outer is 10, 'A mutable inner binding should shadow an outer const')
+   end
+   assert(outer is 7, 'Leaving a shadowing scope should restore the outer const binding')
+
+   local capture
+   do
+      local captured <const> = 37
+      capture = function():num
+         return captured
+      end
+   end
+   assert(capture() is 37, 'A nested function should capture a const local as an upvalue')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function PrimitiveConstPropagationRuntimeSemantics()
+   local first <const>, second <const> = 10, 20
+   assert(first + second is 30, 'Multiple primitive const declarations should retain their values')
+
+   local value <const> = 7
+   do
+      local value <const>, sibling <const> = 11, value + 1
+      assert(value is 11 and sibling is 8,
+         'Sibling initialisers should resolve against the environment before declaration activation')
+   end
+
+   do
+      local value = 9
+      value++
+      assert(value is 10, 'A mutable shadow should retain its own storage')
+   end
+   assert(value * 3 is 21, 'Leaving a mutable shadow should restore outer const propagation')
+
+   do
+      local value <const> = 11
+      assert(value * 2 is 22, 'An inner const should propagate independently of an outer const')
+   end
+   assert(value is 7, 'Leaving an inner const scope should restore the outer const value')
+
+   local record_value <const> = { count = 1 }
+   record_value.count++
+   assert(record_value.count is 2, 'Const propagation must not freeze or substitute mutable table contents')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstJitAndInterpreterResultsMatch()
+   jit.off()
+   local interpreted = const_workload(100)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1')
+   local compiled = 0
+   for run = 1, 80 do
+      compiled = const_workload(100)
+   end
+
+   assert(compiled is interpreted, 'Const workload should return the same result with JIT enabled and disabled')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstPropagationImprovesJitIr()
+   local mutable = record_local_metrics()
+   local immutable = record_const_metrics()
+
+   assert(mutable.loads > 0 and mutable.adds > 0 and mutable.multiplies > 0,
+      'The baseline trace should contain the measured local loads and arithmetic operations')
+   assert(immutable.instructions < mutable.instructions,
+      f'Const propagation should reduce trace instructions: {immutable.instructions} >= {mutable.instructions}')
+   assert(immutable.loads < mutable.loads,
+      f'Const propagation should reduce stack loads: {immutable.loads} >= {mutable.loads}')
+   assert(immutable.adds is mutable.adds,
+      f'Const propagation should preserve required loop additions: {immutable.adds} != {mutable.adds}')
+   assert(immutable.multiplies is mutable.multiplies,
+      f'Const propagation should preserve required loop multiplications: ' ..
+      f'{immutable.multiplies} != {mutable.multiplies}')
+end

--- a/tools/benchmark/benchmark.tiri
+++ b/tools/benchmark/benchmark.tiri
@@ -96,6 +96,7 @@ Examples:
    import './benchmark_control'
    import './benchmark_object'
    import './benchmark_struct'
+   import './benchmark_const_optimisation'
 
 function logMessage(message)
    print(message)

--- a/tools/benchmark/benchmark_const_optimisation.tiri
+++ b/tools/benchmark/benchmark_const_optimisation.tiri
@@ -1,0 +1,101 @@
+----------------------------------------------------------------------------------------------------------------------
+-- CONST LOCAL COMPARISONS
+----------------------------------------------------------------------------------------------------------------------
+-- Matched benchmarks for primitive local <const> propagation.  Each pair performs identical work and differs only in
+-- the declaration attributes applied to its constants.
+
+@Test function ConstBindingLocal()
+   local offset = 3
+   local factor_a = 7
+   local factor_b = 2
+   local factor_c = 4.3
+   local factor_d = 7
+   local factor_e = 2
+   local factor_f = 4.3
+   local total = 0
+
+   for index in {0 to 10000000} do
+      total += (factor_a * factor_b * factor_c * factor_d * factor_e * factor_f) + offset
+   end
+
+   return total
+end
+
+@Test function ConstBindingAnnotated()
+   local offset <const> = 3
+   local factor_a <const> = 7
+   local factor_b <const> = 2
+   local factor_c <const> = 4.3
+   local factor_d <const> = 7
+   local factor_e <const> = 2
+   local factor_f <const> = 4.3
+   local total = 0
+
+   for index in {0 to 10000000} do
+      total += (factor_a * factor_b * factor_c * factor_d * factor_e * factor_f) + offset
+   end
+
+   return total
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstNumericLocal()
+   local factor = 7
+   local offset = 3
+   local total = 0
+
+   for index in {0 to 10000000} do
+      total += (index * factor) + offset
+   end
+
+   return total
+end
+
+@Test function ConstNumericAnnotated()
+   local factor <const> = 7
+   local offset <const> = 3
+   local total = 0
+
+   for index in {0 to 10000000} do
+      total += (index * factor) + offset
+   end
+
+   return total
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function ConstSizingLocal()
+   local base_width = 320
+   local base_height = 180
+   local padding = 12
+   local border = 2
+   local total = 0
+
+   for index in {0 to 100000} do
+      local scale = 1 + ((index % 4) * 0.25)
+      local width = (base_width * scale) + (padding * 2) + (border * 2)
+      local height = (base_height * scale) + (padding * 2) + (border * 2)
+      total += width + height
+   end
+
+   return total
+end
+
+@Test function ConstSizingAnnotated()
+   local base_width <const> = 320
+   local base_height <const> = 180
+   local padding <const> = 12
+   local border <const> = 2
+   local total = 0
+
+   for index in {0 to 100000} do
+      local scale = 1 + ((index % 4) * 0.25)
+      local width = (base_width * scale) + (padding * 2) + (border * 2)
+      local height = (base_height * scale) + (padding * 2) + (border * 2)
+      total += width + height
+   end
+
+   return total
+end


### PR DESCRIPTION
* Introduced ConstantEvaluator for side-effect-free evaluation of primitive constant AST expressions, shared by folding and runtime emission
* Tracked compile-time values on const local bindings so constant initialisers fold when the local is later referenced
* Folded constant if-clause conditions to select or eliminate branches, with elidable-code checks that preserve emitter diagnostics
* Centralised operator constant-folding into the shared evaluator, removing the duplicated foldarith and foldbitwise helpers
* Added const_optimisation Flute test and benchmark coverage