### PR TITLE
[Tiri] Added type-guided runtime contracts and JIT specialisation

### DIFF
--- a/include/kotuku/modules/core.h
+++ b/include/kotuku/modules/core.h
@@ -32,7 +32,7 @@
 #include "ankerl/unordered_dense.h"
 #endif
 
-#define CORE_BUILD_DATE 20260723
+#define CORE_BUILD_DATE 20260725
 class objMetaClass;
 
 // Predefined cursor styles

--- a/scripts/gui/window.tiri
+++ b/scripts/gui/window.tiri
@@ -20,7 +20,7 @@ lStyle = (function()
    end
 end)()
 
-function hosted(self:table):bool
+function hosted(self:userdata):bool
    self.hosted ?= self.surface and self.surface.parent ? false :> true
    return self.hosted
 end
@@ -46,7 +46,7 @@ gui.window = function(Options:table)
       viewport     = nil -- The window's top-level viewport
    }
 
-   self.clientViewport = function(self:table, Options:table)
+   self.clientViewport = function(self:userdata, Options:table)
       if self._clientViewport then return self._clientViewport end
       Options ?= { }
 
@@ -69,7 +69,7 @@ gui.window = function(Options:table)
       return self._clientViewport
    end
 
-   self.getSize = function(self:table)
+   self.getSize = function(self:userdata)
       if hosted(self) then
          return {
             x      = self.surface.x - self.client.left,
@@ -84,7 +84,7 @@ gui.window = function(Options:table)
       end
    end
 
-   self.getClientSize = function(self:table)
+   self.getClientSize = function(self:userdata)
       if hosted(self) then
          return {
             x = self.surface.x, y = self.surface.y, width = self.surface.width, height = self.surface.height
@@ -100,7 +100,7 @@ gui.window = function(Options:table)
 
    -- Resize the window via the client area
 
-   self.resizeClientArea = function(self:table, ClientWidth:num, ClientHeight:num)
+   self.resizeClientArea = function(self:userdata, ClientWidth:num, ClientHeight:num)
       if not ClientWidth then
          ClientWidth = self.surface.width
          if not hosted(self) then ClientWidth -= self.client.left + self.client.right end
@@ -121,7 +121,7 @@ gui.window = function(Options:table)
    -- Changes the size of the position of the window in relation to its parent.  All dimensions refer to the
    -- border of the window.
 
-   self.resize = function(self:table, X:num, Y:num, Width:num, Height:num)
+   self.resize = function(self:userdata, X:num, Y:num, Width:num, Height:num)
       Width ?= self.surface.width
       Height ?= self.surface.height
 
@@ -144,7 +144,7 @@ gui.window = function(Options:table)
 
    -- Define window sizing limits.
 
-   self.sizeHints = function(self:table, MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect)
+   self.sizeHints = function(self:userdata, MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect)
       if self.surface.display.mtSizeHints(MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect) != ERR_Okay then
          self.surface.maxWidth  = MaxWidth
          self.surface.minWidth  = MinWidth
@@ -155,7 +155,7 @@ gui.window = function(Options:table)
 
    -- Smart limits are used to prevent the window from moving completely outside of the visible display area.
 
-   self.applySmartLimits = function(self:table)
+   self.applySmartLimits = function(self:userdata)
       self.smartLimitsEnabled = true
       if not hosted(self) then
          err, info = mGfx.GetSurfaceInfo(self.surface.parent)
@@ -170,7 +170,7 @@ gui.window = function(Options:table)
 
    -- Run the minimise procedure for the window (environment dependent).
 
-   self.minimise = function(self:table)
+   self.minimise = function(self:userdata)
       if self.MinimiseEnabled then
          self?.events?.minimise(self)
       end
@@ -182,7 +182,7 @@ gui.window = function(Options:table)
    --
    -- If Toggle is true, the window is restored to its original position if the window is already maximised.
 
-   self.maximise = function(self:table, Toggle)
+   self.maximise = function(self:userdata, Toggle)
       if not self.maximiseEnabled then
          msg('Maximisation for this window is turned off.')
          return
@@ -199,15 +199,15 @@ gui.window = function(Options:table)
       end
    end
 
-   self.moveToBack = function(self:table)
+   self.moveToBack = function(self:userdata)
       self.surface.acMoveToBack()
    end
 
-   self.moveToFront = function(self:table)
+   self.moveToFront = function(self:userdata)
       self.surface.acMoveToFront()
    end
 
-   self.parentSize = function(self:table)
+   self.parentSize = function(self:userdata)
       if hosted(self) then
          err, info = mGfx.getDisplayInfo(self.surface.display)
          return info.monitorWidth, info.monitorHeight
@@ -217,7 +217,7 @@ gui.window = function(Options:table)
       end
    end
 
-   self.show = function(self:table, Centre:bool)
+   self.show = function(self:userdata, Centre:bool)
       if Centre then
          x, y = (function()
             if self.surface.popOver then
@@ -269,13 +269,13 @@ gui.window = function(Options:table)
       self.events?.show(self)
    end
 
-   self.hide = function(self:table)
+   self.hide = function(self:userdata)
       self.visible = false
       self.surface.acHide()
       self.events?.hide(self)
    end
 
-   self.setTitle = function(self:table, Title:str)
+   self.setTitle = function(self:userdata, Title:str)
       if hosted(self) then
          self.surface.display.title = Title
       end

--- a/scripts/gui/window.tiri
+++ b/scripts/gui/window.tiri
@@ -20,11 +20,6 @@ lStyle = (function()
    end
 end)()
 
-function hosted(self:userdata):bool
-   self.hosted ?= self.surface and self.surface.parent ? false :> true
-   return self.hosted
-end
-
 gui.window = function(Options:table)
    self = { -- Public variables
       events       = Options.events ?? { },
@@ -52,17 +47,10 @@ gui.window = function(Options:table)
 
       Options.aspectRatio ?= 'XMin|YMin|Meet'
 
-      if hosted(self) then
-         Options.x = 0
-         Options.y = 0
-         Options.xOffset = 0
-         Options.yOffset = 0
-      else
-         Options.x = self.margins.left
-         Options.y = self.margins.top
-         Options.xOffset = self.margins.right
-         Options.yOffset = self.margins.bottom
-      end
+      Options.x = 0
+      Options.y = 0
+      Options.xOffset = 0
+      Options.yOffset = 0
 
       self._clientViewport = self.viewport.new('VectorViewport', Options)
 
@@ -70,52 +58,26 @@ gui.window = function(Options:table)
    end
 
    self.getSize = function(self:userdata)
-      if hosted(self) then
-         return {
-            x      = self.surface.x - self.client.left,
-            y      = self.surface.y - self.client.top,
-            width  = self.surface.width + self.client.left + self.client.right,
-            height =  self.surface.height + self.client.top + self.client.bottom
-         }
-      else
-         return {
-            x = self.surface.x, y = self.surface.y, width = self.surface.width, height = self.surface.height
-         }
-      end
+      return {
+         x      = self.surface.x - self.client.left,
+         y      = self.surface.y - self.client.top,
+         width  = self.surface.width + self.client.left + self.client.right,
+         height =  self.surface.height + self.client.top + self.client.bottom
+      }
    end
 
    self.getClientSize = function(self:userdata)
-      if hosted(self) then
-         return {
-            x = self.surface.x, y = self.surface.y, width = self.surface.width, height = self.surface.height
-         }
-      else
-         return {
-            x = self.surface.x + self.client.left, y = self.surface.y + self.client.top,
-            width = self.surface.width - self.client.left - self.client.right,
-            height = self.surface.height - self.client.top - self.client.bottom
-         }
-      end
+      return {
+         x = self.surface.x, y = self.surface.y, width = self.surface.width, height = self.surface.height
+      }
    end
 
    -- Resize the window via the client area
 
    self.resizeClientArea = function(self:userdata, ClientWidth:num, ClientHeight:num)
-      if not ClientWidth then
-         ClientWidth = self.surface.width
-         if not hosted(self) then ClientWidth -= self.client.left + self.client.right end
-      end
-
-      if not ClientHeight then
-         ClientHeight = self.surface.height
-         if not hosted(self) then ClientHeight -= self.client.top + self.client.bottom end
-      end
-
-      if hosted(self) then
-         self.surface.acResize(ClientWidth, ClientHeight, 0)
-      else
-         self.surface.acResize(ClientWidth + self.client.left + self.client.right, ClientHeight + self.client.top + self.client.bottom, 0)
-      end
+      ClientWidth ?= self.surface.width
+      ClientHeight ?= self.surface.height
+      self.surface.acResize(ClientWidth, ClientHeight, 0)
    end
 
    -- Changes the size of the position of the window in relation to its parent.  All dimensions refer to the
@@ -125,21 +87,11 @@ gui.window = function(Options:table)
       Width ?= self.surface.width
       Height ?= self.surface.height
 
-      if hosted(self) then
-         X ?= self.surface.x
-         Y ?= self.surface.y
-         self.surface.acRedimension(X + self.client.left, Y + self.client.top, 0,
-            Width - self.client.left - self.client.right,
-            Height - self.client.top - self.client.bottom, 0)
-      else
-         if X or Y then
-            X ?= self.surface.x
-            Y ?= self.surface.y
-            self.surface.acRedimension(X, Y, 0, Width, Height, 0)
-         else
-            self.surface.acResize(Width, Height, 0)
-         end
-      end
+      X ?= self.surface.x
+      Y ?= self.surface.y
+      self.surface.acRedimension(X + self.client.left, Y + self.client.top, 0,
+         Width - self.client.left - self.client.right,
+         Height - self.client.top - self.client.bottom, 0)
    end
 
    -- Define window sizing limits.
@@ -157,15 +109,6 @@ gui.window = function(Options:table)
 
    self.applySmartLimits = function(self:userdata)
       self.smartLimitsEnabled = true
-      if not hosted(self) then
-         err, info = mGfx.GetSurfaceInfo(self.surface.parent)
-         if err is ERR_Okay then
-            self.surface.topLimit    = 0
-            self.surface.bottomLimit = -self.surface.height + self.surface.topMargin
-            self.surface.leftLimit   = -(self.surface.width * 0.75)
-            self.surface.rightLimit  = -(self.surface.width * 0.75)
-         end
-      end
    end
 
    -- Run the minimise procedure for the window (environment dependent).
@@ -192,11 +135,9 @@ gui.window = function(Options:table)
          self.events.maximise(self)
       end
 
-      if hosted(self) then -- Send the maximisation request to the display
-         display = obj.find(self.surface.display)
-         display.flags = display.flags | SCR_MAXIMISE
-         return
-      end
+      -- Send the maximisation request to the display
+      display = obj.find(self.surface.display)
+      display.flags = display.flags | SCR_MAXIMISE
    end
 
    self.moveToBack = function(self:userdata)
@@ -207,14 +148,9 @@ gui.window = function(Options:table)
       self.surface.acMoveToFront()
    end
 
-   self.parentSize = function(self:userdata)
-      if hosted(self) then
-         err, info = mGfx.getDisplayInfo(self.surface.display)
-         return info.monitorWidth, info.monitorHeight
-      else
-         x, y, width, height = mGfx.getSurfaceCoords(self.surface.parent)
-         return width, height
-      end
+   self.parentSize = function(self:any)
+      err, info = mGfx.getDisplayInfo(self.surface.display)
+      return info.monitorWidth, info.monitorHeight
    end
 
    self.show = function(self:userdata, Centre:bool)
@@ -276,9 +212,7 @@ gui.window = function(Options:table)
    end
 
    self.setTitle = function(self:userdata, Title:str)
-      if hosted(self) then
-         self.surface.display.title = Title
-      end
+      self.surface.display.title = Title
       self.title = Title
    end
 
@@ -296,19 +230,9 @@ gui.window = function(Options:table)
       popOver   = Options.popOver,
       flags = (function()
          local flags = 0
-
-         if not hosted(self) then
-            if Options.enableVideo then -- Allow video surface buffers when in full screen mode
-               flags = flags | RNF_VIDEO
-            end
-
-            flags = flags | RNF_PERVASIVE_COPY
-         end
-
          if Options.aspectRatio then
             flags = flags | RNF_ASPECT_RATIO
          end
-
          return flags
       end)()
    }
@@ -338,7 +262,8 @@ gui.window = function(Options:table)
 
    if Options.noMargins or Options.borderless then
       self.margins = { left = 0, top = 0, right = 0, bottom = 0 }
-   elseif hosted(self) then -- Windows, X11 etc
+      self.client = { left = 0, top = 0, right = 0, bottom = 0 }
+   else
       self.margins = { left = 6, top = 6, right = 6, bottom = 6 }
       self.client = { -- Retrieve the available client area from the host
          left   = self.surface.display.leftMargin,
@@ -346,8 +271,6 @@ gui.window = function(Options:table)
          right  = self.surface.display.rightMargin,
          bottom = self.surface.display.bottomMargin
       }
-   else
-      self.margins = { left = 6, top = 6, right = 6, bottom = 6 }
    end
 
    self.scene = self.surface.new('VectorScene', { flags=VPF_RESIZE, surface=self.surface })
@@ -360,26 +283,18 @@ gui.window = function(Options:table)
       x = 0, y = 0, width = '100%', height = '100%', aspectRatio = 'XMin|YMin|Meet'
    })
 
-   if hosted(self) then
-      self.bkgd = self.viewport.new('VectorRectangle', {
-         fill = self.theme.window.bkgd, x = 0, y = 0, width = '100%', height = '100%'
-      })
-   elseif mGfx.GetDisplayType() is DT_NATIVE then
-      -- Full-screen mode (for video playback or gaming), do nothing.
-   else
-      lStyle.initialise(self)
-      lStyle.frame(self)
-      lStyle.titlebar(self)
-   end
+   self.bkgd = self.viewport.new('VectorRectangle', {
+      fill = self.theme.window.bkgd, x = 0, y = 0, width = '100%', height = '100%'
+   })
 
-   self:setTitle(self.title)
+   self.surface.display.title = self.title
 
    if Options.insideWidth then
-      self.surface.width = hosted(self) ? Options.insideWidth :> Options.insideWidth + self.client.left + self.client.right
+      self.surface.width = Options.insideWidth
    end
 
    if Options.insideHeight then
-      self.surface.height = hosted(self) ? Options.insideHeight :> Options.insideHeight + self.client.top + self.client.bottom
+      self.surface.height = Options.insideHeight
    end
 
    if self.surface.popOver != 0 then

--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -485,7 +485,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse JSON body
 
-function parseJsonBody(Body:str):table
+function parseJsonBody(Body:str):any
    Body ?! return {}
 
    try

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -833,7 +833,7 @@ set (TIRI_TESTS
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
    object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
-   type_guided_emission
+   type_guided_emission type_guided_jit_signatures
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -832,7 +832,7 @@ set (TIRI_TESTS
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
-   object_pinning import_type_analysis global_types
+   object_pinning import_type_analysis global_types type_contracts
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -832,7 +832,7 @@ set (TIRI_TESTS
    annotations locality anonymous_for key_values debug_filesources compound choose_from enum flow table_slice options
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
-   object_pinning import_type_analysis global_types type_contracts
+   object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -833,6 +833,7 @@ set (TIRI_TESTS
    try_except import include_list processing metatables with thunk_table_index debug malformed_syntax numeric_limits return_types url tips tempus
    comparison_chaining reserved_keywords compile_if_import overflow protected_globals constant_shadowing config_library
    object_pinning import_type_analysis global_types type_contracts thunk_contract_argument type_signature_dumps
+   type_guided_emission
 )
 
 foreach (TEST_NAME ${TIRI_TESTS})

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -646,3 +646,14 @@ Enables type inference for untyped functions, allowing the VM to optimize subseq
 - `PROTO_TYPEFIX`: flag indicating runtime type inference is enabled for function return types.
 - `TryBlockDesc`: metadata for try blocks stored in `GCproto.try_blocks[]`.
 - `TryHandlerDesc`: metadata for exception handlers stored in `GCproto.try_handlers[]`.
+
+### Runtime Type Contracts
+- `CONTRACT A, D`: validates values starting at register `A` using the portable descriptor string at constant `D`.
+  Descriptors encode the boundary, exact Tiri types, nullable/required flags, labels, named-structure identity and
+  fixed or dynamic result shape.
+- `MRSAVE A` / `MRRESTORE A`: preserve the VM multi-result count in register `A` while return-path `<close>` and
+  `defer` handlers execute. Return values are allocated above the cleanup scratch area.
+- Basic tag contracts use trace slot specialisation. Prototypes needing structure identity, range metatable,
+  callable-value or dynamic-result predicates remain interpreter-only until those predicates have dedicated trace IR
+  guards.
+- The private bytecode dump version is `0x80`; older dumps are intentionally rejected and must be regenerated.

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -552,18 +552,46 @@ Each `TryHandlerDesc` contains:
 
 **Opcode semantics:**
 - `BC_TYPEFIX A, D`: Fixes return types at runtime. `A` is the base register, `D` is the count of return values to process.
-- Fast path: checks if `PROTO_TYPEFIX` flag is set in the function prototype. If not set, this is a no-op.
-- Slow path: calls `lj_meta_typefix(L, base, count)` to infer and record types based on actual runtime values.
+- The VM calls `lj_meta_typefix(L, base, count)`. The helper returns immediately unless the prototype signature has
+  `DynamicResults` set.
+- Each non-`nil` observation can replace an unknown result entry's type. Its inferred provenance and advisory strength
+  remain unchanged.
 
 **When emitted:**
-The parser sets the `PROTO_TYPEFIX` flag (defined in [lj_obj.h:623](src/tiri/jit/src/runtime/lj_obj.h#L623)) on function prototypes when:
+The parser sets the canonical signature's `DynamicResults` flag on function prototypes when:
 1. The function has NO explicit return type annotations, AND
 2. At least one return statement exists
 
 **Purpose:**
-Enables type inference for untyped functions, allowing the VM to optimize subsequent calls based on observed return types. The inferred types are stored in `GCproto.result_types[]` (up to `PROTO_MAX_RETURN_TYPES` positions).
+Enables type inference for untyped functions, allowing the VM to optimise subsequent calls based on observed return
+types. The inferred types are stored in the canonical signature's result entries (up to
+`PROTO_MAX_RETURN_TYPES` positions).
 
 **Implementation:** See [vm_x64.dasc:4901-4922](src/tiri/jit/src/jit/vm_x64.dasc#L4901-L4922), [lj_meta.cpp:664-685](src/tiri/jit/src/runtime/lj_meta.cpp#L664-L685), [parse_scope.cpp:1012-1024](src/tiri/jit/src/parser/parse_scope.cpp#L1012-L1024).
+
+The update is state-owned: a prototype belongs to its Tiri state and is not published for concurrent mutation by
+another state. Asynchronous workers use their own state and prototype graph.
+
+### 10.3 Prototype Signatures
+
+Every typed function prototype carries one versioned signature containing:
+
+- complete fixed parameter and semantic result counts;
+- stored positional parameter and result entries;
+- parameter/result variadic, explicit-result and dynamic-result flags;
+- each entry's nominal type, portable structure or class constraint, nullability, required state, provenance and
+  strength.
+
+Constraints use stable 32-bit structure keys or class identifiers, never process-local pointers. Declared non-`any`
+contracts have checked strength, while omitted, explicit `any` and runtime-inferred positions remain advisory.
+`BC_TYPEFIX` changes only the type of a reserved inferred result entry.
+
+The signature is stored in the prototype allocation between upvalue descriptors and debug metadata. Its fields are
+written explicitly because bytecode-loaded prototypes are allocated as raw GC memory. Both stripped and unstripped
+bytecode dumps retain signatures, and nested prototypes are handled recursively.
+
+Debug bytecode output prints a deterministic signature header and one line for every stored parameter and result
+entry. It resolves known constraint names when possible and otherwise prints the stable identifier.
 
 ## 11. Testing, Debugging, and Tooling
 ### 11.1 Using Flute and Tiri Tests
@@ -643,7 +671,6 @@ Enables type inference for untyped functions, allowing the VM to optimize subseq
 - `STGETF`/`STSETF`: named field access with a P32 field-index cache and generic metamethod fallback.
 
 ### Exception Handling
-- `PROTO_TYPEFIX`: flag indicating runtime type inference is enabled for function return types.
 - `TryBlockDesc`: metadata for try blocks stored in `GCproto.try_blocks[]`.
 - `TryHandlerDesc`: metadata for exception handlers stored in `GCproto.try_handlers[]`.
 
@@ -656,4 +683,6 @@ Enables type inference for untyped functions, allowing the VM to optimize subseq
 - Basic tag contracts use trace slot specialisation. Prototypes needing structure identity, range metatable,
   callable-value or dynamic-result predicates remain interpreter-only until those predicates have dedicated trace IR
   guards.
-- The private bytecode dump version is `0x81`; older dumps are intentionally rejected and must be regenerated.
+- The private bytecode dump version is `0x82`. It includes a length-delimited, schema-versioned signature before each
+  prototype's bytecode. Version `0x81` dumps remain loadable and receive conservative advisory defaults; older versions
+  are rejected and must be regenerated.

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -656,4 +656,4 @@ Enables type inference for untyped functions, allowing the VM to optimize subseq
 - Basic tag contracts use trace slot specialisation. Prototypes needing structure identity, range metatable,
   callable-value or dynamic-result predicates remain interpreter-only until those predicates have dedicated trace IR
   guards.
-- The private bytecode dump version is `0x80`; older dumps are intentionally rejected and must be regenerated.
+- The private bytecode dump version is `0x81`; older dumps are intentionally rejected and must be regenerated.

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -259,7 +259,12 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(TRYENTER, base,  ___, lit, ___) \
   _(TRYLEAVE, base,  ___, ___, ___) \
   _(CHECK,    var,   ___, lit, ___) \
-  _(RAISE,    var,   ___, var, ___)
+  _(RAISE,    var,   ___, var, ___) \
+  \
+  /* Portable runtime type contracts. */ \
+  _(CONTRACT, rbase, ___, str, ___) \
+  _(MRSAVE,   rbase, ___, ___, ___) \
+  _(MRRESTORE,rbase, ___, ___, ___)
 
 // Bytecode opcode numbers.
 // Explicitly enumerated for debugger visibility and easy value lookup.
@@ -412,7 +417,12 @@ typedef enum {
    BC_CHECK  = 114,  // Check error code, raise if >= threshold
    BC_RAISE  = 115,  // Raise exception with error code and optional message
 
-   BC__MAX   = 116
+   // Runtime contracts (appended to preserve every existing opcode number)
+   BC_CONTRACT = 116,
+   BC_MRSAVE = 117,
+   BC_MRRESTORE = 118,
+
+   BC__MAX   = 119
 } BCOp;
 
 [[nodiscard]] inline constexpr bool bc_is_func_header(BCOp Op) noexcept

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -35,7 +35,7 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // If you perform *any* kind of private modifications to the bytecode itself
 // or to the dump format, you *must* set BCDUMP_VERSION to 0x80 or higher.
 
-constexpr int BCDUMP_VERSION = 3;
+constexpr int BCDUMP_VERSION = 0x80;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -14,9 +14,11 @@
 ** dump   = header proto+ 0U
 ** header = ESC 'L' 'J' versionB flagsU [namelenU nameB*]
 ** proto  = lengthU pdata
-** pdata  = phead bcinsW* uvdataH* kgc* knum* [debugB*]
-** phead  = flagsB numparamsB framesizeB numuvB numkgcU numknU numbcU
+** pdata  = phead signatureB* bcinsW* uvdataH* kgc* knum* [debugB*]
+** phead  = flagsB numparamsB framesizeB numuvB numkgcU numknU numbcU siglenU
 **          [debuglenU [firstlineU numlineU]]
+** signature = sigversionB sigflagsB paramcountU resultcountU resultentriesU typeentry*
+** typeentry = typeB metaflagsB constraintU
 ** kgc    = kgctypeU { ktab | (loU hiU) | (rloU rhiU iloU ihiU) | strB* }
 ** knum   = intU0 | (loU1 hiU)
 ** ktab   = narrayU nhashU karray* khash*
@@ -35,7 +37,8 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // If you perform *any* kind of private modifications to the bytecode itself
 // or to the dump format, you *must* set BCDUMP_VERSION to 0x80 or higher.
 
-constexpr int BCDUMP_VERSION = 0x81;
+constexpr uint8_t BCDUMP_VERSION_LEGACY = 0x81;
+constexpr uint8_t BCDUMP_VERSION = 0x82;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -35,7 +35,7 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // If you perform *any* kind of private modifications to the bytecode itself
 // or to the dump format, you *must* set BCDUMP_VERSION to 0x80 or higher.
 
-constexpr int BCDUMP_VERSION = 0x80;
+constexpr int BCDUMP_VERSION = 0x81;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -287,9 +287,10 @@ static void bcread_knum(LexState *State, GCproto *pt, MSize sizekn)
 //********************************************************************************************************************
 // Read bytecode instructions.
 
-static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
+static bool bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
 {
    BCIns* bc = proto_bc(pt);
+   bool has_typefix = false;
    bc[0] = BCINS_AD((pt->flags & PROTO_VARARG) ? BC_FUNCV : BC_FUNCF,
       pt->framesize, 0);
    bcread_block(State, bc + 1, (sizebc - 1) * (MSize)sizeof(BCIns));
@@ -300,11 +301,12 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
    }
    for (MSize i = 1; i < sizebc; ++i) {
       BCOp op = bc_op(bc[i]);
+      if (op IS BC_TYPEFIX) has_typefix = true;
       if (op IS BC_MRSAVE or op IS BC_MRRESTORE) {
          pt->flags |= PROTO_NOJIT;
-         break;
       }
    }
+   return has_typefix;
 }
 
 //********************************************************************************************************************
@@ -325,15 +327,175 @@ static void bcread_uv(LexState *State, GCproto *pt, MSize sizeuv)
 }
 
 //********************************************************************************************************************
+// Read and validate a portable prototype signature.
+
+struct BCReadSignature {
+   bool present = false;
+   uint8_t flags = 0;
+   uint8_t parameter_count = 0;
+   uint8_t result_count = 0;
+   uint8_t result_entry_count = 0;
+   std::array<ProtoTypeEntry, 256> parameters{};
+   std::array<ProtoTypeEntry, PROTO_MAX_RETURN_TYPES> results{};
+};
+
+static bool bcread_signature_uleb(const uint8_t *&Cursor, const uint8_t *End, uint32_t &Value)
+{
+   Value = 0;
+   uint32_t shift = 0;
+   for (uint32_t count = 0; count < 5 and Cursor < End; ++count) {
+      uint8_t byte = *Cursor++;
+      if (count IS 4 and (byte & 0xf0)) return false;
+      Value |= uint32_t(byte & 0x7f) << shift;
+      if (not (byte & 0x80)) return true;
+      shift += 7;
+   }
+   return false;
+}
+
+static void bcread_signature_entry(LexState *State, const uint8_t *&Cursor, const uint8_t *End,
+   ProtoTypeEntry &Entry)
+{
+   if (End - Cursor < 2) bcread_error(State, ErrMsg::BCBAD);
+   uint8_t type = *Cursor++;
+   uint8_t flags = *Cursor++;
+   uint32_t constraint = 0;
+   if (not bcread_signature_uleb(Cursor, End, constraint)) bcread_error(State, ErrMsg::BCBAD);
+
+   constexpr uint8_t known_flags = PROTO_TYPE_NULLABLE | PROTO_TYPE_REQUIRED | PROTO_TYPE_ORIGIN_MASK |
+      PROTO_TYPE_STRENGTH_MASK;
+   if (type > uint8_t(TiriType::Unknown) or (flags & ~known_flags) or
+       uint8_t((flags & PROTO_TYPE_ORIGIN_MASK) >> PROTO_TYPE_ORIGIN_SHIFT) >
+          uint8_t(ProtoTypeOrigin::Inferred) or
+       uint8_t((flags & PROTO_TYPE_STRENGTH_MASK) >> PROTO_TYPE_STRENGTH_SHIFT) >
+          uint8_t(ProtoTypeStrength::Trusted) or
+       ((flags & PROTO_TYPE_NULLABLE) and (flags & PROTO_TYPE_REQUIRED))) {
+      bcread_error(State, ErrMsg::BCBAD);
+   }
+
+   TiriType entry_type = TiriType(type);
+   if (constraint and entry_type != TiriType::Struct and entry_type != TiriType::Object) {
+      bcread_error(State, ErrMsg::BCBAD);
+   }
+
+   Entry = ProtoTypeEntry{
+      .constraint = constraint,
+      .type = entry_type,
+      .flags = flags
+   };
+}
+
+static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCReadSignature &Result)
+{
+   if (Size IS 0) {
+      if (NumParams != 0) bcread_error(State, ErrMsg::BCBAD);
+      return;
+   }
+
+   bcread_need(State, Size);
+   const uint8_t *cursor = bcread_mem(State, Size);
+   const uint8_t *end = cursor + Size;
+   if (end - cursor < 2 or *cursor++ != PROTO_SIGNATURE_VERSION) bcread_error(State, ErrMsg::BCBAD);
+
+   uint8_t flags = *cursor++;
+   constexpr uint8_t known_flags = proto_signature_flag(ProtoSignatureFlag::ParameterVariadic) |
+      proto_signature_flag(ProtoSignatureFlag::ResultVariadic) |
+      proto_signature_flag(ProtoSignatureFlag::ExplicitResults) |
+      proto_signature_flag(ProtoSignatureFlag::DynamicResults);
+   if (flags & ~known_flags) bcread_error(State, ErrMsg::BCBAD);
+
+   uint32_t parameter_count = 0;
+   uint32_t result_count = 0;
+   uint32_t result_entry_count = 0;
+   if (not bcread_signature_uleb(cursor, end, parameter_count) or
+       not bcread_signature_uleb(cursor, end, result_count) or
+       not bcread_signature_uleb(cursor, end, result_entry_count) or
+       parameter_count != NumParams or parameter_count > 255 or result_count > 255 or
+       result_entry_count > PROTO_MAX_RETURN_TYPES) {
+      bcread_error(State, ErrMsg::BCBAD);
+   }
+
+   const bool explicit_results = flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults);
+   const bool dynamic_results = flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults);
+   const bool variadic_results = flags & proto_signature_flag(ProtoSignatureFlag::ResultVariadic);
+   if ((explicit_results and dynamic_results) or (variadic_results and (not explicit_results or result_count IS 0)) or
+       (dynamic_results and (result_count != 0 or result_entry_count != PROTO_MAX_RETURN_TYPES)) or
+       (explicit_results and result_entry_count != std::min<uint32_t>(result_count, PROTO_MAX_RETURN_TYPES)) or
+       (not explicit_results and not dynamic_results and (result_count != 0 or result_entry_count != 0))) {
+      bcread_error(State, ErrMsg::BCBAD);
+   }
+
+   Result.present = true;
+   Result.flags = flags;
+   Result.parameter_count = uint8_t(parameter_count);
+   Result.result_count = uint8_t(result_count);
+   Result.result_entry_count = uint8_t(result_entry_count);
+   for (uint32_t i = 0; i < parameter_count; ++i) {
+      bcread_signature_entry(State, cursor, end, Result.parameters[i]);
+   }
+   for (uint32_t i = 0; i < result_entry_count; ++i) {
+      bcread_signature_entry(State, cursor, end, Result.results[i]);
+   }
+   if (cursor != end) bcread_error(State, ErrMsg::BCBAD);
+}
+
+static void bcread_legacy_signature(MSize NumParams, BCReadSignature &Result)
+{
+   Result.present = true;
+   Result.parameter_count = uint8_t(NumParams);
+   Result.result_entry_count = PROTO_MAX_RETURN_TYPES;
+   for (MSize i = 0; i < NumParams; ++i) {
+      Result.parameters[i] = ProtoTypeEntry{
+         .constraint = 0,
+         .type = TiriType::Any,
+         .flags = proto_type_flags(true, false, ProtoTypeOrigin::Unspecified, ProtoTypeStrength::Advisory)
+      };
+   }
+   for (auto &entry : Result.results) {
+      entry = ProtoTypeEntry{
+         .constraint = 0,
+         .type = TiriType::Unknown,
+         .flags = proto_type_flags(true, false, ProtoTypeOrigin::Inferred, ProtoTypeStrength::Advisory)
+      };
+   }
+}
+
+static void bcread_install_signature(GCproto *Proto, void *Buffer, const BCReadSignature &Source)
+{
+   if (not Source.present) return;
+
+   auto signature = (ProtoSignature *)Buffer;
+   signature->version = PROTO_SIGNATURE_VERSION;
+   signature->flags = Source.flags;
+   signature->parameter_count = Source.parameter_count;
+   signature->result_count = Source.result_count;
+   signature->result_entry_count = Source.result_entry_count;
+   memset(signature->reserved, 0, sizeof(signature->reserved));
+
+   auto parameters = (ProtoTypeEntry *)(signature + 1);
+   if (Source.parameter_count > 0) {
+      memcpy(parameters, Source.parameters.data(), Source.parameter_count * sizeof(ProtoTypeEntry));
+   }
+   if (Source.result_entry_count > 0) {
+      memcpy(parameters + Source.parameter_count, Source.results.data(),
+         Source.result_entry_count * sizeof(ProtoTypeEntry));
+   }
+   setmref(Proto->signature, signature);
+   Proto->signature_size = uint16_t(proto_signature_size(Source.parameter_count, Source.result_entry_count));
+}
+
+//********************************************************************************************************************
 // Read a prototype.
 
 GCproto *lj_bcread_proto(LexState *State)
 {
    GCproto *pt;
    MSize framesize, numparams, flags, sizeuv, sizekgc, sizekn, sizebc, sizept;
-   MSize ofsk, ofsuv, ofsdbg;
+   MSize ofsk, ofsuv, ofssig, ofsdbg;
    MSize sizedbg = 0;
+   MSize sizesig = 0;
    BCLine firstline = 0, numline = 0;
+   BCReadSignature signature;
 
    // Read prototype header.
    flags     = bcread_byte(State);
@@ -343,6 +505,7 @@ GCproto *lj_bcread_proto(LexState *State)
    sizekgc   = bcread_uleb128(State);
    sizekn    = bcread_uleb128(State);
    sizebc    = bcread_uleb128(State) + 1;
+   if (State->bytecode_version >= BCDUMP_VERSION) sizesig = bcread_uleb128(State);
    if (!(bcread_flags(State) & BCDUMP_F_STRIP)) {
       sizedbg = bcread_uleb128(State);
       if (sizedbg) {
@@ -350,18 +513,24 @@ GCproto *lj_bcread_proto(LexState *State)
          numline = bcread_uleb128(State);
       }
    }
+   if (State->bytecode_version >= BCDUMP_VERSION) bcread_signature(State, sizesig, numparams, signature);
+   else bcread_legacy_signature(numparams, signature);
 
    // Calculate total size of prototype including all colocated arrays.
 
+   MSize signature_memory_size = signature.present ?
+      MSize(proto_signature_size(signature.parameter_count, signature.result_entry_count)) : 0;
    sizept = (MSize)sizeof(GCproto) + sizebc * (MSize)sizeof(BCIns) + sizekgc * (MSize)sizeof(GCRef);
    sizept = (sizept + (MSize)sizeof(TValue) - 1) & ~((MSize)sizeof(TValue) - 1);
    ofsk   = sizept; sizept += sizekn * (MSize)sizeof(TValue);
    ofsuv  = sizept; sizept += ((sizeuv + 1) & ~1) * 2;
+   ofssig = sizept; sizept += signature_memory_size;
    ofsdbg = sizept; sizept += sizedbg;
 
    // Allocate prototype object and initialize its fields.
 
    pt = (GCproto*)lj_mem_newgco(State->L, (MSize)sizept);
+   proto_metadata_init(pt);
    pt->gct = ~LJ_TPROTO;
    pt->numparams = (uint8_t)numparams;
    pt->framesize = (uint8_t)framesize;
@@ -375,6 +544,7 @@ GCproto *lj_bcread_proto(LexState *State)
    pt->flags = (uint8_t)flags;
    pt->trace = 0;
    setgcref(pt->chunk_name, obj2gco(State->chunk_name));
+   bcread_install_signature(pt, (char *)pt + ofssig, signature);
 
    // Close potentially uninitialized gap between bc and kgc.
 
@@ -382,7 +552,21 @@ GCproto *lj_bcread_proto(LexState *State)
 
    // Read bytecode instructions and upvalue refs.
 
-   bcread_bytecode(State, pt, sizebc);
+   bool has_typefix = bcread_bytecode(State, pt, sizebc);
+   auto installed_signature = proto_signature(pt);
+   if (State->bytecode_version IS BCDUMP_VERSION_LEGACY) {
+      if (has_typefix) {
+         installed_signature->flags |= proto_signature_flag(ProtoSignatureFlag::DynamicResults);
+      }
+      else installed_signature->result_entry_count = 0;
+      pt->signature_size = uint16_t(proto_signature_size(installed_signature->parameter_count,
+         installed_signature->result_entry_count));
+   }
+   else {
+      bool dynamic_results = installed_signature and
+         (installed_signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults));
+      if (has_typefix and not dynamic_results) bcread_error(State, ErrMsg::BCBAD);
+   }
    bcread_uv(State, pt, sizeuv);
 
    // Read constants.
@@ -418,7 +602,10 @@ static int bcread_header(LexState *State)
 {
    uint32_t flags;
    bcread_want(State, 3 + 5 + 5);
-   if (bcread_byte(State) != BCDUMP_HEAD2 or bcread_byte(State) != BCDUMP_HEAD3 or bcread_byte(State) != BCDUMP_VERSION) return 0;
+   if (bcread_byte(State) != BCDUMP_HEAD2 or bcread_byte(State) != BCDUMP_HEAD3) return 0;
+   uint8_t version = uint8_t(bcread_byte(State));
+   if (version != BCDUMP_VERSION and version != BCDUMP_VERSION_LEGACY) return 0;
+   State->bytecode_version = version;
    bcread_flags(State) = flags = bcread_uleb128(State);
    if ((flags & ~(BCDUMP_F_KNOWN)) != 0) return 0;
    if ((flags & BCDUMP_F_FR2) != LJ_FR2 * BCDUMP_F_FR2) return 0;

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -298,6 +298,13 @@ static void bcread_bytecode(LexState *State, GCproto *pt, MSize sizebc)
       MSize i;
       for (i = 1; i < sizebc; i++) bc[i] = lj_bswap64(bc[i]);
    }
+   for (MSize i = 1; i < sizebc; ++i) {
+      BCOp op = bc_op(bc[i]);
+      if (op IS BC_MRSAVE or op IS BC_MRRESTORE) {
+         pt->flags |= PROTO_NOJIT;
+         break;
+      }
+   }
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/bytecode/lj_bcwrite.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcwrite.cpp
@@ -230,11 +230,61 @@ static char * bcwrite_bytecode(BCWriteCtx *ctx, char *p, GCproto *pt)
 }
 
 //********************************************************************************************************************
+// Calculate and write the portable prototype signature.
+
+static MSize bcwrite_uleb128_size(uint32_t Value)
+{
+   MSize size = 1;
+   while (Value >= 0x80) {
+      Value >>= 7;
+      size++;
+   }
+   return size;
+}
+
+static MSize bcwrite_signature_size(const GCproto *Proto)
+{
+   const auto signature = proto_signature(Proto);
+   if (not signature) return 0;
+
+   MSize size = 2 + bcwrite_uleb128_size(signature->parameter_count) +
+      bcwrite_uleb128_size(signature->result_count) + bcwrite_uleb128_size(signature->result_entry_count);
+   auto entries = proto_parameter_types(Proto);
+   MSize entry_count = MSize(signature->parameter_count) + signature->result_entry_count;
+   for (MSize i = 0; i < entry_count; ++i) {
+      size += 2 + bcwrite_uleb128_size(entries[i].constraint);
+   }
+   return size;
+}
+
+static char * bcwrite_signature(char *Buffer, const GCproto *Proto)
+{
+   const auto signature = proto_signature(Proto);
+   if (not signature) return Buffer;
+
+   *Buffer++ = signature->version;
+   *Buffer++ = signature->flags;
+   Buffer = lj_strfmt_wuleb128(Buffer, signature->parameter_count);
+   Buffer = lj_strfmt_wuleb128(Buffer, signature->result_count);
+   Buffer = lj_strfmt_wuleb128(Buffer, signature->result_entry_count);
+
+   auto entries = proto_parameter_types(Proto);
+   MSize entry_count = MSize(signature->parameter_count) + signature->result_entry_count;
+   for (MSize i = 0; i < entry_count; ++i) {
+      *Buffer++ = uint8_t(entries[i].type);
+      *Buffer++ = entries[i].flags;
+      Buffer = lj_strfmt_wuleb128(Buffer, entries[i].constraint);
+   }
+   return Buffer;
+}
+
+//********************************************************************************************************************
 // Write prototype.
 
 static void bcwrite_proto(BCWriteCtx *ctx, GCproto *pt)
 {
    MSize sizedbg = 0;
+   MSize sizesig = bcwrite_signature_size(pt);
    char *p;
 
    // Recursively write children of prototype.
@@ -248,7 +298,8 @@ static void bcwrite_proto(BCWriteCtx *ctx, GCproto *pt)
    }
 
    // Start writing the prototype info to a buffer.
-   p = lj_buf_need(&ctx->sb, 5 + 4 + 6 * 5 + (pt->sizebc - 1) * (MSize)sizeof(BCIns) + pt->sizeuv * 2);
+   p = lj_buf_need(&ctx->sb, 5 + 4 + 7 * 5 + sizesig +
+      (pt->sizebc - 1) * (MSize)sizeof(BCIns) + pt->sizeuv * 2);
    p += 5;  //  Leave room for final size.
 
    // Write prototype header.
@@ -259,6 +310,7 @@ static void bcwrite_proto(BCWriteCtx *ctx, GCproto *pt)
    p = lj_strfmt_wuleb128(p, pt->sizekgc);
    p = lj_strfmt_wuleb128(p, pt->sizekn);
    p = lj_strfmt_wuleb128(p, pt->sizebc - 1);
+   p = lj_strfmt_wuleb128(p, sizesig);
    if (!ctx->strip) {
       if (proto_lineinfo(pt)) sizedbg = pt->sizept - (MSize)((char*)proto_lineinfo(pt) - (char*)pt);
       p = lj_strfmt_wuleb128(p, sizedbg);
@@ -267,6 +319,8 @@ static void bcwrite_proto(BCWriteCtx *ctx, GCproto *pt)
          p = lj_strfmt_wuleb128(p, pt->numline);
       }
    }
+
+   p = bcwrite_signature(p, pt);
 
    // Write bytecode instructions and upvalue refs.
    p = bcwrite_bytecode(ctx, p, pt);

--- a/src/tiri/jit/src/debug/dump_bytecode.cpp
+++ b/src/tiri/jit/src/debug/dump_bytecode.cpp
@@ -23,6 +23,7 @@
 #include "filesource.h"
 #include "token_types.h"
 #include "parse_types.h"
+#include "../parser/ast/nodes.h"
 #include "dump_bytecode.h"
 #include "../../../defs.h"
 
@@ -291,6 +292,75 @@ static BytecodeInfo extract_instruction_info(BCIns Ins)
 
 //********************************************************************************************************************
 
+static std::string_view signature_origin_name(ProtoTypeOrigin Origin)
+{
+   switch (Origin) {
+      case ProtoTypeOrigin::Declared: return "declared";
+      case ProtoTypeOrigin::Inferred: return "inferred";
+      default: return "unspecified";
+   }
+}
+
+static std::string_view signature_strength_name(ProtoTypeStrength Strength)
+{
+   switch (Strength) {
+      case ProtoTypeStrength::Checked: return "checked";
+      case ProtoTypeStrength::Trusted: return "trusted";
+      default: return "advisory";
+   }
+}
+
+static std::string signature_type_name(lua_State *L, const ProtoTypeEntry &Entry)
+{
+   std::string name(type_name(Entry.type));
+   if (not Entry.constraint) return name;
+
+   if (Entry.type IS TiriType::Struct) {
+      if (auto definition = find_struct(L, Entry.constraint)) return std::format("struct<{}>", definition->Name);
+      return std::format("struct<#{:08x}>", Entry.constraint);
+   }
+   if (Entry.type IS TiriType::Object) {
+      if (auto class_name = ResolveClassID(CLASSID(Entry.constraint))) return std::format("obj<{}>", class_name);
+      return std::format("obj<#{:08x}>", Entry.constraint);
+   }
+   return name;
+}
+
+static void trace_proto_signature(lua_State *L, const GCproto *Proto, BytecodeLogger Logger, void *Meta,
+   std::string_view Indent)
+{
+   const auto signature = proto_signature(Proto);
+   if (not signature) {
+      Logger(std::format("{}Signature: <none>", Indent), Meta);
+      return;
+   }
+
+   std::string flags;
+   if (signature->flags & proto_signature_flag(ProtoSignatureFlag::ParameterVariadic)) flags += " param-variadic";
+   if (signature->flags & proto_signature_flag(ProtoSignatureFlag::ResultVariadic)) flags += " result-variadic";
+   if (signature->flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults)) flags += " explicit-results";
+   if (signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults)) flags += " dynamic-results";
+   if (flags.empty()) flags = " none";
+
+   Logger(std::format("{}Signature: params={}, results={}, stored-results={}, flags:{}",
+      Indent, signature->parameter_count, signature->result_count, signature->result_entry_count, flags), Meta);
+
+   auto log_entries = [&](std::string_view Prefix, const ProtoTypeEntry *Entries, size_t Count) {
+      for (size_t i = 0; i < Count; ++i) {
+         const auto &entry = Entries[i];
+         Logger(std::format("{}  {}{}:{} [{},{},{},{}]", Indent, Prefix, i + 1,
+            signature_type_name(L, entry), proto_type_nullable(entry) ? "nullable" : "non-null",
+            proto_type_required(entry) ? "required" : "optional", signature_origin_name(proto_type_origin(entry)),
+            signature_strength_name(proto_type_strength(entry))), Meta);
+      }
+   };
+
+   log_entries("P", proto_parameter_types(Proto), signature->parameter_count);
+   log_entries("R", proto_result_types(Proto), signature->result_entry_count);
+}
+
+//********************************************************************************************************************
+
 void format_bc_line(lua_State *L, BCLine Line, int FileWidth, BytecodeLogger Logger, std::string_view Indent, BCPOS pc,
    const std::string &Operands, void *Meta, BytecodeInfo &Info, bool JumpTarget, bool Verbose)
 {
@@ -368,6 +438,8 @@ void trace_proto_bytecode(lua_State *L, GCproto *Proto, BytecodeLogger Logger, v
       Logger(std::format("{}--- Nested function: lines {}-{}, {} bytecodes ---",
          indent_str, first_line, last_line, int(Proto->sizebc)), Meta);
    }
+
+   trace_proto_signature(L, Proto, Logger, Meta, indent_str);
 
    auto file_width = widest_file_source(L, false);
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4525,6 +4525,32 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  b <2
     break;
 
+  case BC_CONTRACT:
+    |  str BASE, L->base
+    |  mov CARG2, PC
+    |  ldr CARG3w, SAVE_MULTRES
+    |  lsr CARG3w, CARG3w, #3
+    |  sub CARG3w, CARG3w, #1
+    |  mov CARG1, L
+    |  str PC, SAVE_PC
+    |  bl extern lj_meta_contract_pc
+    |  ldr BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_MRSAVE:
+    |  ldr TMP0w, SAVE_MULTRES
+    |  add TMP0, TMP0, TISNUM
+    |  str TMP0, [BASE, RA, lsl #3]
+    |  ins_next
+    break;
+
+  case BC_MRRESTORE:
+    |  ldr TMP0w, [BASE, RA, lsl #3]
+    |  str TMP0w, SAVE_MULTRES
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -4134,14 +4134,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // BC_TYPEFIX: Fix function return types at runtime
     |  // RA = base register index (rbase), RD = count of values to fix
     |  ins_AD
-    |  // Fast path: check if prototype has PROTO_TYPEFIX flag set
-    |  ldr LFUNC:CARG1, [BASE, FRAME_FUNC]  // Get current function from frame
-    |  and CARG1, CARG1, #LJ_GCVMASK        // Clear type bits
-    |  ldr CARG1, LFUNC:CARG1->pc           // Get prototype pointer
-    |  ldrb CARG1w, [CARG1, #PC2PROTO(flags)]
-    |  tst CARG1w, #PROTO_TYPEFIX
-    |  beq >1                               // Skip if no type inference needed
-    |  // Slow path: call C helper to fix types
+    |  // Call the helper; the canonical signature decides whether inference is active.
     |   str BASE, L->base                   // Save BASE
     |  add CARG2, BASE, RA, lsl #3          // Compute pointer to first return value
     |  mov CARG3w, RCw                      // count (RC == RD after ins_AD)
@@ -4149,7 +4142,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |   str PC, SAVE_PC
     |  bl extern lj_meta_typefix            // (lua_State *L, TValue *base, uint32_t count)
     |  ldr BASE, L->base                    // Restore BASE
-    |1:
     |  ins_next
     break;
 

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -5997,13 +5997,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // BC_TYPEFIX: Fix function return types at runtime
     |  // RA = base register index (rbase*8), RD = count of values to fix
     |  ins_AD
-    |  // Fast path: check if prototype has PROTO_TYPEFIX flag set
-    |  lwz LFUNC:TMP1, FRAME_FUNC(BASE)     // Get current function from frame
-    |  lwz TMP1, LFUNC:TMP1->pc             // Get prototype pointer
-    |  lbz TMP2, PC2PROTO(flags)(TMP1)
-    |  andi. TMP2, TMP2, PROTO_TYPEFIX
-    |  beq >1                               // Skip if no type inference needed
-    |  // Slow path: call C helper to fix types
+    |  // Call the helper; the canonical signature decides whether inference is active.
     |  mr CARG1, L
     |   stp BASE, L->base                   // Save BASE
     |  add CARG2, BASE, RA                  // Compute pointer to first return value (RA already *8)
@@ -6011,7 +6005,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |   stw PC, SAVE_PC
     |  bl extern lj_meta_typefix            // (lua_State *L, TValue *base, uint32_t count)
     |  lp BASE, L->base                     // Restore BASE
-    |1:
     |  ins_next
     break;
 

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -6550,6 +6550,31 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  b <2
     break;
 
+  case BC_CONTRACT:
+    |  stp BASE, L->base
+    |  mr CARG2, PC
+    |  mr CARG3, MULTRES
+    |  srwi CARG3, CARG3, 3
+    |  subi CARG3, CARG3, 1
+    |  mr CARG1, L
+    |  stw PC, SAVE_PC
+    |  bl extern lj_meta_contract_pc
+    |  lp BASE, L->base
+    |  ins_next
+    break;
+
+  case BC_MRSAVE:
+    |  stwux TISNUM, RA, BASE
+    |  stw MULTRES, 4(RA)
+    |  ins_next
+    break;
+
+  case BC_MRRESTORE:
+    |  lwzux TMP0, RA, BASE
+    |  lwz MULTRES, 4(RA)
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -4968,13 +4968,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // BC_TYPEFIX: Fix function return types at runtime
     |  // RA = base register index (rbase), RD = count of values to fix
     |  ins_AD
-    |  // Fast path: check if prototype has PROTO_TYPEFIX flag set
-    |  mov LFUNC:RB, [BASE-16]       // Get current function from frame
-    |  cleartp LFUNC:RB
-    |  mov TMPR, LFUNC:RB->pc        // Get prototype pointer
-    |  test byte [TMPR+PC2PROTO(flags)], PROTO_TYPEFIX
-    |  jz >1                         // Skip if no type inference needed
-    |  // Slow path: call C helper to fix types
+    |  // Call the helper; the canonical signature decides whether inference is active.
     |  mov L:RB, SAVE_L
     |  mov L:RB->base, BASE          // Save BASE before potential clobber
     |  lea CARG2, [BASE+RA*8]        // Compute pointer to first return value
@@ -4983,7 +4977,6 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov SAVE_PC, PC
     |  call extern lj_meta_typefix   // (lua_State *L, TValue *base, uint32_t count)
     |  mov BASE, L:RB->base          // Restore BASE
-    |1:
     |  ins_next
     break;
 

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -5469,6 +5469,32 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jmp <2
     break;
 
+  case BC_CONTRACT:
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG2, PC
+    |  mov CARG3d, MULTRES
+    |  sub CARG3d, 1
+    |  mov L:CARG1, L:RB
+    |  mov SAVE_PC, PC
+    |  call extern lj_meta_contract_pc
+    |  mov BASE, L:RB->base
+    |  ins_next
+    break;
+
+  case BC_MRSAVE:
+    |  mov RCd, MULTRES
+    |  setint RC
+    |  mov [BASE+RA*8], RC
+    |  ins_next
+    break;
+
+  case BC_MRRESTORE:
+    |  mov RCd, [BASE+RA*8]
+    |  mov MULTRES, RCd
+    |  ins_next
+    break;
+
   //  ----------------------------------------------------------------------
 
   default:

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -2240,7 +2240,7 @@ LJLIB_CF(array_each)
       lua_pushvalue(L, 2);            // Push the callback function
       array_push_element(L, arr, i);  // Push value
       lua_pushinteger(L, i);          // Push index
-      lua_call(L, 2, 0);              // Call callback(value, index)
+      if (lua_pcall(L, 2, 0, 0) != 0) lua_error(L);
    }
 
    // Return the array for chaining

--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -26,6 +26,7 @@
 #include "lj_struct.h"
 #include "lib.h"
 #include "lib_range.h"
+#include "../parser/static_type_descriptor.h"
 
 #include <cstdio>
 #include <cstring>
@@ -98,28 +99,8 @@ static OBJECTID object_uid_from_value(lua_State *L, int ArgIndex)
 static AET parse_elemtype(lua_State *L, int NArg)
 {
    GCstr *type_str = lj_lib_checkstr(L, NArg);
-
    std::string_view type_name(strdata(type_str), type_str->len);
-   if (type_name.starts_with("struct<") and type_name.ends_with('>') and (type_name.size() > 8)) {
-      return AET::STRUCT;
-   }
-
-   switch (type_str->hash) {
-      case HASH_INT:     return AET::INT32;
-      case HASH_BYTE:    return AET::BYTE;
-      case HASH_CHAR:    return AET::BYTE;
-      case HASH_INT16:   return AET::INT16;
-      case HASH_INT64:   return AET::INT64;
-      case HASH_FLOAT:   return AET::FLOAT;
-      case HASH_DOUBLE:  return AET::DOUBLE;
-      case HASH_STRING:  return AET::STR_GC;
-      case HASH_STRUCT:  return AET::STRUCT;
-      case HASH_POINTER: return AET::PTR;
-      case HASH_OBJECT:  return AET::OBJECT;
-      case HASH_TABLE:   return AET::TABLE;
-      case HASH_ARRAY:   return AET::ARRAY;
-      case HASH_ANY:     return AET::ANY;
-   }
+   if (auto descriptor = describe_array_element(type_name, L)) return descriptor->storage;
 
    lj_err_argv(L, NArg, ErrMsg::BADTYPE, "valid array type", strdata(type_str));
    return AET(0);  // unreachable

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -130,7 +130,26 @@ LJLIB_ASM(assert)      LJLIB_REC(.)
 
 constexpr uint32_t TYPE_NAME_USERDATA = 3;
 constexpr uint32_t TYPE_NAME_RANGE = 15;
-constexpr uint8_t TIRI_TYPE_RANGE_TAG = uint8_t(~LJ_TUDATA);
+
+static uint32_t tiri_type_name_index(TiriType Type)
+{
+   switch (Type) {
+      case TiriType::Nil:      return 0;
+      case TiriType::Bool:     return 2;
+      case TiriType::Str:      return 4;
+      case TiriType::Struct:   return 6;
+      case TiriType::Func:     return 8;
+      case TiriType::Object:   return 10;
+      case TiriType::Table:    return 11;
+      case TiriType::Array:    return 13;
+      case TiriType::Num:      return 14;
+      case TiriType::Range:    return TYPE_NAME_RANGE;
+      case TiriType::Userdata: return TYPE_NAME_USERDATA;
+      case TiriType::Any:
+      case TiriType::Unknown:  return TYPE_NAME_USERDATA;
+   }
+   return TYPE_NAME_USERDATA;
+}
 
 static bool is_range_userdata(lua_State *L, GCudata *Userdata)
 {
@@ -171,9 +190,8 @@ LJLIB_ASM(type)      LJLIB_REC(.)
       else if (ud->udtype IS UDTYPE_THUNK) {
          ThunkPayload *payload = thunk_payload(ud);
          if (payload->expected_type != 0xFF) {
-            // Use the declared type string from the upvalue array
-            uint32_t type_index = payload->expected_type;
-            if (type_index IS TIRI_TYPE_RANGE_TAG) type_index = TYPE_NAME_RANGE;
+            // Use the declared logical type rather than the thunk container's userdata tag.
+            uint32_t type_index = tiri_type_name_index(TiriType(payload->expected_type));
             GCstr *type_str = strV(&fn->c.upvalue[type_index]);
             setstrV(L, L->base - 1 - LJ_FR2, type_str);
             return FFH_RES(1);
@@ -805,8 +823,12 @@ LJLIB_CF(resolve)
 LJLIB_CF(__create_thunk)
 {
    GCfunc *fn = lj_lib_checkfunc(L, 1);
-   int expected_type = (int)lj_lib_checkint(L, 2);
-   lj_thunk_new(L, fn, expected_type);
+   int expected_type = int(lj_lib_checkint(L, 2));
+   if (expected_type != 0xff and
+       (expected_type < int(TiriType::Nil) or expected_type > int(TiriType::Userdata))) {
+      lj_err_argv(L, 2, ErrMsg::BADTYPE, "valid logical type code", "number");
+   }
+   lj_thunk_new(L, fn, uint8_t(expected_type));
    return 1;
 }
 
@@ -1019,7 +1041,7 @@ extern int luaopen_base(lua_State* L)
    reg_func_prototype("setmetatable", { TiriType::Table }, { TiriType::Table, TiriType::Table });
    reg_func_prototype("select", { TiriType::Any }, { TiriType::Any }, FProtoFlags::Variadic);
    reg_func_prototype("next", { TiriType::Any, TiriType::Any }, { TiriType::Table, TiriType::Any });
-   reg_func_prototype("newproxy", { TiriType::Any }, { TiriType::Any });
+   reg_func_prototype("newproxy", { TiriType::Userdata }, { TiriType::Any });
    reg_func_prototype("__create_thunk", { TiriType::Any }, { TiriType::Func, TiriType::Num });
    reg_func_prototype("ltr", { TiriType::Str }, { TiriType::Str });
 

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1614,7 +1614,7 @@ extern int luaopen_debug(lua_State *L)
    reg_iface_prototype("debug", "setLocal", { TiriType::Str }, { TiriType::Num, TiriType::Num, TiriType::Any });
    reg_iface_prototype("debug", "getUpvalue", { TiriType::Str, TiriType::Any }, { TiriType::Func, TiriType::Num });
    reg_iface_prototype("debug", "setUpvalue", { TiriType::Str }, { TiriType::Func, TiriType::Num, TiriType::Any });
-   reg_iface_prototype("debug", "upvalueID", { TiriType::Any }, { TiriType::Func, TiriType::Num });
+   reg_iface_prototype("debug", "upvalueID", { TiriType::Userdata }, { TiriType::Func, TiriType::Num });
    reg_iface_prototype("debug", "upvalueJoin", {}, { TiriType::Func, TiriType::Num, TiriType::Func, TiriType::Num });
    reg_iface_prototype("debug", "getUserValue", { TiriType::Table }, { TiriType::Any });
    reg_iface_prototype("debug", "setUserValue", { TiriType::Any }, { TiriType::Any, TiriType::Table });

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -233,7 +233,26 @@ static void recff_assert(jit_State* J, RecordFFData* rd)
 
 constexpr uint32_t TYPE_NAME_USERDATA = 3;
 constexpr uint32_t TYPE_NAME_RANGE = 15;
-constexpr uint8_t TIRI_TYPE_RANGE_TAG = uint8_t(~LJ_TUDATA);
+
+static uint32_t recff_type_name_index(TiriType Type)
+{
+   switch (Type) {
+      case TiriType::Nil:      return 0;
+      case TiriType::Bool:     return 2;
+      case TiriType::Str:      return 4;
+      case TiriType::Struct:   return 6;
+      case TiriType::Func:     return 8;
+      case TiriType::Object:   return 10;
+      case TiriType::Table:    return 11;
+      case TiriType::Array:    return 13;
+      case TiriType::Num:      return 14;
+      case TiriType::Range:    return TYPE_NAME_RANGE;
+      case TiriType::Userdata: return TYPE_NAME_USERDATA;
+      case TiriType::Any:
+      case TiriType::Unknown:  return TYPE_NAME_USERDATA;
+   }
+   return TYPE_NAME_USERDATA;
+}
 
 static bool recff_is_range_userdata(jit_State *J, GCudata *Userdata)
 {
@@ -261,9 +280,8 @@ static void recff_type(jit_State* J, RecordFFData* rd)
       else if (ud->udtype IS UDTYPE_THUNK) {
          ThunkPayload *payload = thunk_payload(ud);
          if (payload->expected_type != 0xFF) {
-            // Use the declared type instead of userdata
-            t = payload->expected_type;
-            if (t IS TIRI_TYPE_RANGE_TAG) t = TYPE_NAME_RANGE;
+            // Use the declared logical type instead of the thunk container's userdata tag.
+            t = recff_type_name_index(TiriType(payload->expected_type));
          }
       }
       else {

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3662,7 +3662,7 @@ void lj_record_ins(jit_State *J)
       // - If types not fixed, skip during recording (mutation is safe for interpreter)
 
       GCproto *pt = funcproto(curr_func(J->L));
-      if (pt->result_types[0] IS TiriType::Unknown) {
+      if (proto_result_type(pt, 0).type IS TiriType::Unknown) {
          // Types not yet fixed.  We can leave it for the interpreter and keep recording
          // TODO: Need to consider if it is viable to mutate the function prototype (set the result types) here during recording.
          // It could also be considered a red-flag if the interpreter hasn't mutated the function by this point, even if only

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -33,6 +33,9 @@
 #include "runtime/lj_struct.h"
 #include "runtime/lj_state.h"
 #include "runtime/lj_contract.h"
+#include "runtime/lj_thunk.h"
+#include "lib/lib_range.h"
+#include "../../defs.h"
 
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)         (&J->cur.ir[(ref)])
@@ -199,96 +202,6 @@ enum class RecordedContract : uint8_t {
    Invalid
 };
 
-static RecordedContract rec_contract_classify(cTValue *Base, GCstr *Descriptor, uint8_t &ValueCount)
-{
-   const uint8_t *cursor = (const uint8_t *)strdata(Descriptor);
-   const uint8_t *end = cursor + Descriptor->len;
-   auto read_byte = [&cursor, end](uint8_t &Value) {
-      if (cursor >= end) return false;
-      Value = *cursor++;
-      return true;
-   };
-   auto skip_text = [&cursor, end](uint8_t &Length) {
-      if (cursor >= end) return false;
-      Length = *cursor++;
-      if (size_t(end - cursor) < Length) return false;
-      cursor += Length;
-      return true;
-   };
-
-   uint8_t version;
-   uint8_t boundary;
-   uint8_t descriptor_flags;
-   uint8_t static_count;
-   uint8_t contract_count;
-   if (not read_byte(version) or version != TIRI_CONTRACT_VERSION or not read_byte(boundary) or
-       boundary < uint8_t(ContractBoundary::Parameter) or boundary > uint8_t(ContractBoundary::Global) or
-       not read_byte(descriptor_flags) or not read_byte(static_count) or not read_byte(contract_count) or
-       contract_count > MAX_RETURN_TYPES) {
-      return RecordedContract::Invalid;
-   }
-   if (descriptor_flags & contract_flag(ContractDescriptorFlag::DynamicCount)) return RecordedContract::Complex;
-
-   struct Entry {
-      TiriType type;
-      uint8_t flags;
-      uint8_t struct_name_length;
-   };
-   std::array<Entry, MAX_RETURN_TYPES> entries;
-   for (uint8_t i = 0; i < contract_count; ++i) {
-      uint8_t type;
-      uint8_t position;
-      uint8_t label_length;
-      if (not read_byte(type) or type > uint8_t(TiriType::Unknown) or not read_byte(entries[i].flags) or
-          not read_byte(position) or not skip_text(entries[i].struct_name_length) or not skip_text(label_length)) {
-         return RecordedContract::Invalid;
-      }
-      entries[i].type = TiriType(type);
-   }
-
-   bool variadic = (descriptor_flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
-   ValueCount = static_count;
-   for (uint8_t i = 0; i < static_count; ++i) {
-      uint8_t contract_index;
-      if (i < contract_count) contract_index = i;
-      else if (variadic and contract_count > 0) contract_index = contract_count - 1;
-      else continue;
-
-      const Entry &entry = entries[contract_index];
-      cTValue *value = Base + i;
-      bool nullable = (entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
-      bool required = (entry.flags & contract_flag(ContractEntryFlag::Required)) != 0;
-      if (tvisnil(value)) {
-         if (not nullable or required) return RecordedContract::Mismatch;
-         continue;
-      }
-
-      bool matches = true;
-      switch (entry.type) {
-         case TiriType::Any:
-         case TiriType::Unknown: break;
-         case TiriType::Nil:     matches = false; break;
-         case TiriType::Bool:    matches = tvisbool(value); break;
-         case TiriType::Num:     matches = tvisnumber(value); break;
-         case TiriType::Str:     matches = tvisstr(value); break;
-         case TiriType::Table:   matches = tvistab(value); break;
-         case TiriType::Array:   matches = tvisarray(value); break;
-         case TiriType::Object:  matches = tvisobject(value); break;
-         case TiriType::Func:
-            if (not tvisfunc(value)) return RecordedContract::Complex;
-            break;
-         case TiriType::Struct:
-            if (entry.struct_name_length > 0) return RecordedContract::Complex;
-            matches = tvisstruct(value);
-            break;
-         case TiriType::Range: return RecordedContract::Complex;
-         case TiriType::Userdata: return RecordedContract::Complex;
-      }
-      if (not matches) return RecordedContract::Mismatch;
-   }
-   return RecordedContract::Basic;
-}
-
 //********************************************************************************************************************
 // Sanity checks
 
@@ -450,6 +363,152 @@ static TRef sload(jit_State *J, int32_t slot)
 #define getslot(J, s)   (J->base[(s)] ? J->base[(s)] : sload(J, (int32_t)(s)))
 // Note: getslot macro retained for compatibility; SlotView can be used for new code:
 //   SlotView slots(J); TRef tr = slots.is_loaded(s) ? slots[s] : sload(J, s);
+
+//********************************************************************************************************************
+// Record exact runtime contracts.  Stack specialisation handles simple TValue tags.  Predicates that refine a tag
+// emit their own guards so a failed guard resumes at BC_CONTRACT and preserves the interpreter's diagnostic.
+
+static TRef rec_contract_range_metatable(jit_State *J)
+{
+   IRBuilder ir(J);
+   GCtab *registry_table = tabV(registry(J->L));
+   GCstr *range_name = lj_str_newz(J->L, RANGE_METATABLE);
+
+   RecordIndex lookup{};
+   settabV(J->L, &lookup.tabv, registry_table);
+   setstrV(J->L, &lookup.keyv, range_name);
+   lookup.tab = ir.ktab(registry_table);
+   lookup.key = ir.kstr(range_name);
+   return lj_record_idx(J, &lookup);
+}
+
+static bool rec_contract_is_range(jit_State *J, cTValue *Value)
+{
+   if (not tvisudata(Value)) return false;
+   GCtab *metatable = tabref(udataV(Value)->metatable);
+   if (not metatable) return false;
+
+   cTValue *registered = lj_tab_getstr(tabV(registry(J->L)), lj_str_newz(J->L, RANGE_METATABLE));
+   return registered and tvistab(registered) and tabV(registered) IS metatable;
+}
+
+static RecordedContract rec_contract_guard_range(jit_State *J, TRef ValueRef, cTValue *Value, bool Expected)
+{
+   bool is_range = rec_contract_is_range(J, Value);
+   if (is_range != Expected) return RecordedContract::Mismatch;
+
+   TRef registered_ref = rec_contract_range_metatable(J);
+   if (not tref_istab(registered_ref)) return RecordedContract::Mismatch;
+
+   IRBuilder ir(J);
+   TRef metatable_ref = ir.fload_tab(ValueRef, IRFL_UDATA_META);
+   if (Expected) ir.guard_eq(metatable_ref, registered_ref, IRT_TAB);
+   else ir.guard_ne(metatable_ref, registered_ref, IRT_TAB);
+   return RecordedContract::Basic;
+}
+
+static RecordedContract rec_contract_guard_callable(jit_State *J, TRef ValueRef, cTValue *Value)
+{
+   if (tvisfunc(Value)) return RecordedContract::Basic;
+
+   RecordIndex lookup{};
+   lookup.tab = ValueRef;
+   copyTV(J->L, &lookup.tabv, Value);
+   if (not lj_record_mm_lookup(J, &lookup, MM_call) or not tref_isfunc(lookup.mobj)) {
+      return RecordedContract::Mismatch;
+   }
+   return RecordedContract::Basic;
+}
+
+static RecordedContract rec_contract_guard_struct(
+   jit_State *J, TRef ValueRef, cTValue *Value, std::string_view Name)
+{
+   if (not tvisstruct(Value)) return RecordedContract::Mismatch;
+   if (Name.empty()) return RecordedContract::Basic;
+
+   struct_record *definition = find_struct(J->L, Name);
+   if (not definition or structV(Value)->def != definition) return RecordedContract::Mismatch;
+
+   IRBuilder ir(J);
+   TRef definition_ref = ir.fload(ValueRef, IRFL_STRUCT_DEF, IRT_PTR);
+   ir.guard_eq(definition_ref, ir.kkptr(definition), IRT_PTR);
+   return RecordedContract::Basic;
+}
+
+static RecordedContract rec_contract_guard_userdata(jit_State *J, TRef ValueRef, cTValue *Value)
+{
+   if (tvislightud(Value)) return RecordedContract::Basic;
+   if (not tvisudata(Value) or lj_is_thunk(Value)) return RecordedContract::Mismatch;
+
+   IRBuilder ir(J);
+   TRef userdata_type = ir.fload(ValueRef, IRFL_UDATA_UDTYPE, IRT_U8);
+   ir.guard_ne_int(userdata_type, ir.kint(UDTYPE_THUNK));
+   return rec_contract_guard_range(J, ValueRef, Value, false);
+}
+
+static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Encoded)
+{
+   RuntimeContractDescriptor descriptor;
+   if (not decode_runtime_contract(Encoded, descriptor)) return RecordedContract::Invalid;
+   if (descriptor.dynamic_count()) return RecordedContract::Complex;
+
+   for (uint8_t i = 0; i < descriptor.static_value_count; ++i) {
+      const RuntimeContractEntry *entry = descriptor.entry_for(i);
+      if (not entry) continue;
+
+      cTValue *value = J->L->base + Base + i;
+      bool nullable = (entry->flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
+      bool required = (entry->flags & contract_flag(ContractEntryFlag::Required)) != 0;
+      if (tvisnil(value)) {
+         if (not nullable or required) return RecordedContract::Mismatch;
+         (void)getslot(J, Base + i);
+         continue;
+      }
+
+      if (lj_is_thunk(value)) return RecordedContract::Complex;
+
+      TRef value_ref = getslot(J, Base + i);
+      RecordedContract result = RecordedContract::Basic;
+      switch (entry->type) {
+         case TiriType::Any:
+         case TiriType::Unknown: break;
+         case TiriType::Nil:     result = RecordedContract::Mismatch; break;
+         case TiriType::Bool:
+            if (not tvisbool(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Num:
+            if (not tvisnumber(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Str:
+            if (not tvisstr(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Table:
+            if (not tvistab(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Array:
+            if (not tvisarray(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Object:
+            if (not tvisobject(value)) result = RecordedContract::Mismatch;
+            break;
+         case TiriType::Func:
+            result = rec_contract_guard_callable(J, value_ref, value);
+            break;
+         case TiriType::Struct:
+            result = rec_contract_guard_struct(J, value_ref, value, entry->struct_name);
+            break;
+         case TiriType::Range:
+            if (not tvisudata(value)) result = RecordedContract::Mismatch;
+            else result = rec_contract_guard_range(J, value_ref, value, true);
+            break;
+         case TiriType::Userdata:
+            result = rec_contract_guard_userdata(J, value_ref, value);
+            break;
+      }
+      if (result != RecordedContract::Basic) return result;
+   }
+   return RecordedContract::Basic;
+}
 
 //********************************************************************************************************************
 // Get TRef for current function.
@@ -3766,10 +3825,8 @@ void lj_record_ins(jit_State *J)
 
    case BC_CONTRACT:
    {
-      uint8_t value_count = 0;
-      RecordedContract contract = rec_contract_classify(lbase + bc_a(ins), strV(rcv), value_count);
+      RecordedContract contract = rec_contract_record(J, bc_a(ins), strV(rcv));
       if (contract IS RecordedContract::Basic) {
-         for (uint8_t i = 0; i < value_count; ++i) (void)getslot(J, bc_a(ins) + i);
          J->needsnap = 1;
          break;
       }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -282,6 +282,7 @@ static RecordedContract rec_contract_classify(cTValue *Base, GCstr *Descriptor, 
             matches = tvisstruct(value);
             break;
          case TiriType::Range: return RecordedContract::Complex;
+         case TiriType::Userdata: return RecordedContract::Complex;
       }
       if (not matches) return RecordedContract::Mismatch;
    }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -32,6 +32,7 @@
 #include "runtime/lj_object.h"
 #include "runtime/lj_struct.h"
 #include "runtime/lj_state.h"
+#include "runtime/lj_contract.h"
 
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)         (&J->cur.ir[(ref)])
@@ -185,6 +186,107 @@ struct RecordOps {
    TValue *rbv() { return &ix.tabv; }
    TValue *rcv() { return &ix.keyv; }
 };
+
+//********************************************************************************************************************
+// Classify a runtime contract while recording.  Exact TValue tag checks are already represented by trace slot
+// specialisation.  Identity and metatable predicates require dedicated IR guards, so prototypes containing those
+// predicates remain interpreter-only for now.
+
+enum class RecordedContract : uint8_t {
+   Basic,
+   Complex,
+   Mismatch,
+   Invalid
+};
+
+static RecordedContract rec_contract_classify(cTValue *Base, GCstr *Descriptor, uint8_t &ValueCount)
+{
+   const uint8_t *cursor = (const uint8_t *)strdata(Descriptor);
+   const uint8_t *end = cursor + Descriptor->len;
+   auto read_byte = [&cursor, end](uint8_t &Value) {
+      if (cursor >= end) return false;
+      Value = *cursor++;
+      return true;
+   };
+   auto skip_text = [&cursor, end](uint8_t &Length) {
+      if (cursor >= end) return false;
+      Length = *cursor++;
+      if (size_t(end - cursor) < Length) return false;
+      cursor += Length;
+      return true;
+   };
+
+   uint8_t version;
+   uint8_t boundary;
+   uint8_t descriptor_flags;
+   uint8_t static_count;
+   uint8_t contract_count;
+   if (not read_byte(version) or version != TIRI_CONTRACT_VERSION or not read_byte(boundary) or
+       boundary < uint8_t(ContractBoundary::Parameter) or boundary > uint8_t(ContractBoundary::Global) or
+       not read_byte(descriptor_flags) or not read_byte(static_count) or not read_byte(contract_count) or
+       contract_count > MAX_RETURN_TYPES) {
+      return RecordedContract::Invalid;
+   }
+   if (descriptor_flags & contract_flag(ContractDescriptorFlag::DynamicCount)) return RecordedContract::Complex;
+
+   struct Entry {
+      TiriType type;
+      uint8_t flags;
+      uint8_t struct_name_length;
+   };
+   std::array<Entry, MAX_RETURN_TYPES> entries;
+   for (uint8_t i = 0; i < contract_count; ++i) {
+      uint8_t type;
+      uint8_t position;
+      uint8_t label_length;
+      if (not read_byte(type) or type > uint8_t(TiriType::Unknown) or not read_byte(entries[i].flags) or
+          not read_byte(position) or not skip_text(entries[i].struct_name_length) or not skip_text(label_length)) {
+         return RecordedContract::Invalid;
+      }
+      entries[i].type = TiriType(type);
+   }
+
+   bool variadic = (descriptor_flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
+   ValueCount = static_count;
+   for (uint8_t i = 0; i < static_count; ++i) {
+      uint8_t contract_index;
+      if (i < contract_count) contract_index = i;
+      else if (variadic and contract_count > 0) contract_index = contract_count - 1;
+      else continue;
+
+      const Entry &entry = entries[contract_index];
+      cTValue *value = Base + i;
+      bool nullable = (entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
+      bool required = (entry.flags & contract_flag(ContractEntryFlag::Required)) != 0;
+      if (tvisnil(value)) {
+         if (not nullable or required) return RecordedContract::Mismatch;
+         continue;
+      }
+
+      bool matches = true;
+      switch (entry.type) {
+         case TiriType::Any:
+         case TiriType::Unknown: break;
+         case TiriType::Nil:     matches = false; break;
+         case TiriType::Bool:    matches = tvisbool(value); break;
+         case TiriType::Num:     matches = tvisnumber(value); break;
+         case TiriType::Str:     matches = tvisstr(value); break;
+         case TiriType::Table:   matches = tvistab(value); break;
+         case TiriType::Array:   matches = tvisarray(value); break;
+         case TiriType::Object:  matches = tvisobject(value); break;
+         case TiriType::Func:
+            if (not tvisfunc(value)) return RecordedContract::Complex;
+            break;
+         case TiriType::Struct:
+            if (entry.struct_name_length > 0) return RecordedContract::Complex;
+            matches = tvisstruct(value);
+            break;
+         case TiriType::Range: return RecordedContract::Complex;
+      }
+      if (not matches) return RecordedContract::Mismatch;
+   }
+   return RecordedContract::Basic;
+}
 
 //********************************************************************************************************************
 // Sanity checks
@@ -3662,6 +3764,30 @@ void lj_record_ins(jit_State *J)
       // clean handoff without corrupting interpreter state.
       lj_snap_add(J);
       lj_record_stop(J, TraceLink::INTERP, 0);
+      break;
+
+   case BC_CONTRACT:
+   {
+      uint8_t value_count = 0;
+      RecordedContract contract = rec_contract_classify(lbase + bc_a(ins), strV(rcv), value_count);
+      if (contract IS RecordedContract::Basic) {
+         for (uint8_t i = 0; i < value_count; ++i) (void)getslot(J, bc_a(ins) + i);
+         J->needsnap = 1;
+         break;
+      }
+      if (contract IS RecordedContract::Complex) {
+         J->pt->flags |= PROTO_NOJIT;
+         lj_trace_err(J, LJ_TRERR_CJITOFF);
+      }
+      setintV(&J->errinfo, int32_t(op));
+      lj_trace_err_info(J, LJ_TRERR_NYIBC);
+      break;
+   }
+
+   case BC_MRSAVE:
+   case BC_MRRESTORE:
+      J->pt->flags |= PROTO_NOJIT;
+      lj_trace_err(J, LJ_TRERR_CJITOFF);
       break;
 
    default:

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1079,6 +1079,15 @@ static void rec_isarr(jit_State *J, BCREG ra)
 //********************************************************************************************************************
 // Record calls and returns
 
+// Preserve the prototype specialisation previously implied by PROTO_TYPEFIX sharing the closure-count flag range.
+
+static bool rec_proto_specialise_by_prototype(const GCproto *Proto)
+{
+   if (Proto->flags >= PROTO_CLC_POLY) return true;
+   const auto signature = proto_signature(Proto);
+   return signature and (signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults));
+}
+
 // Specialise to the runtime value of the called function or its prototype.
 
 static TRef rec_call_specialise(jit_State *J, GCfunc* fn, TRef tr)
@@ -1088,7 +1097,7 @@ static TRef rec_call_specialise(jit_State *J, GCfunc* fn, TRef tr)
    if (isluafunc(fn)) {
       GCproto* pt = funcproto(fn);
       // Too many closures created? Probably not a monomorphic function.
-      if (pt->flags >= PROTO_CLC_POLY) {  // Specialise to prototype instead.
+      if (rec_proto_specialise_by_prototype(pt)) {  // Specialise to prototype instead.
          TRef trpt = ir.fload_ptr(tr, IRFL_FUNC_PC);
          ir.guard_eq(trpt, ir.kptr(proto_bc(pt)), IRT_PGC);
          (void)lj_ir_kgc(J, obj2gco(pt), IRT_PROTO);  //  Prevent GC of proto.
@@ -2055,7 +2064,7 @@ static TRef rec_upvalue(jit_State *J, uint32_t uv, TRef val)
       TRef tr, kfunc;
       lj_assertJ(val IS 0, "bad usage");
       if (not tref_isk(fn)) {  // Late specialisation of current function.
-         if (J->pt->flags >= PROTO_CLC_POLY) goto noconstify;
+         if (rec_proto_specialise_by_prototype(J->pt)) goto noconstify;
          kfunc = ir.kfunc(J->fn);
          ir.guard_eq(fn, kfunc, IRT_FUNC);
          J->base[-2] = kfunc;
@@ -3655,22 +3664,10 @@ void lj_record_ins(jit_State *J)
 
       // Type fixing
 
-   case BC_TYPEFIX: {
-      // BC_TYPEFIX is a one-time operation that mutates the prototype.
-      // After first execution, it becomes a no-op. For JIT recording:
-      // - If types are already fixed (common case), treat as no-op
-      // - If types not fixed, skip during recording (mutation is safe for interpreter)
-
-      GCproto *pt = funcproto(curr_func(J->L));
-      if (proto_result_type(pt, 0).type IS TiriType::Unknown) {
-         // Types not yet fixed.  We can leave it for the interpreter and keep recording
-         // TODO: Need to consider if it is viable to mutate the function prototype (set the result types) here during recording.
-         // It could also be considered a red-flag if the interpreter hasn't mutated the function by this point, even if only
-         // setting the result type to TiriType::Any.
-         break;
-      }
-      else break; // Types already fixed - no-op, continue recording
-   }
+   case BC_TYPEFIX:
+      // Result inference changes prototype metadata rather than trace values.  Dynamic-result calls are guarded by the
+      // prototype-specialisation policy above, independently of whether each result entry has already been inferred.
+      break;
 
       // Loops and branches
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -278,6 +278,7 @@ ParserResult<AstBuilder::ParameterListResult> AstBuilder::parse_parameter_list(b
             this->ctx.tokens().advance();
             auto parsed = this->parse_type_annotation(param.type, param.struct_def);
             if (not parsed.ok()) return ParserResult<ParameterListResult>::failure(parsed.error_ref());
+            param.type_is_explicit = true;
          }
          else { // No type annotation provided - emit tips for untyped parameter
             if (param.name.symbol) {
@@ -546,12 +547,22 @@ ParserResult<FunctionReturnTypes> AstBuilder::parse_return_type_annotation()
    if (current.raw() IS '<') {
       this->ctx.tokens().advance();  // consume '<'
 
+      // An empty list is an explicit void declaration.
+      if (this->ctx.tokens().current().raw() IS '>') {
+         this->ctx.tokens().advance();
+         return ParserResult<FunctionReturnTypes>::success(result);
+      }
+
       // Parse comma-separated type list
       do {
          current = this->ctx.tokens().current();
 
          // Check for variadic marker ...
          if (current.kind() IS TokenKind::Dots) {
+            if (result.count IS 0) {
+               return this->fail<FunctionReturnTypes>(ParserErrorCode::ExpectedToken, current,
+                  "variadic result marker requires a preceding result type");
+            }
             this->ctx.tokens().advance();
             result.is_variadic = true;
             break;  // ... must be last

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -23,7 +23,8 @@ TiriType parse_type_name(std::string_view Name)
       { "struct",    TiriType::Struct },
       { "obj",       TiriType::Object },
       { "object",    TiriType::Object },
-      { "range",     TiriType::Range }
+      { "range",     TiriType::Range },
+      { "userdata",  TiriType::Userdata }
    };
 
    auto it = type_map.find(Name);
@@ -33,16 +34,17 @@ TiriType parse_type_name(std::string_view Name)
 std::string_view type_name(TiriType Type)
 {
    switch (Type) {
-      case TiriType::Nil:    return "nil";
-      case TiriType::Bool:   return "bool";
-      case TiriType::Num:    return "num";
-      case TiriType::Str:    return "str";
-      case TiriType::Table:  return "table";
-      case TiriType::Array:  return "array";
-      case TiriType::Func:   return "func";
-      case TiriType::Struct: return "struct";
-      case TiriType::Object: return "obj";
-      case TiriType::Range:  return "range";
+      case TiriType::Nil:      return "nil";
+      case TiriType::Bool:     return "bool";
+      case TiriType::Num:      return "num";
+      case TiriType::Str:      return "str";
+      case TiriType::Table:    return "table";
+      case TiriType::Array:    return "array";
+      case TiriType::Func:     return "func";
+      case TiriType::Struct:   return "struct";
+      case TiriType::Object:   return "obj";
+      case TiriType::Range:    return "range";
+      case TiriType::Userdata: return "userdata";
       case TiriType::Any:
       default: return "any";
    }
@@ -68,6 +70,7 @@ uint8_t tiri_type_to_lj_tag(TiriType Type)
       case TiriType::Range:  return 12;  // ~12 = LJ_TUDATA (ranges are userdata at runtime)
       case TiriType::Array:  return 13;  // ~13 = LJ_TARRAY
       case TiriType::Num:    return 14;  // ~14 = LJ_TNUMX
+      case TiriType::Userdata:
       case TiriType::Any:
       case TiriType::Unknown:
       default: return 0xFF;  // Unknown - needs evaluation

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "lexer.h"
+#include "../static_type_descriptor.h"
 
 class ParserDiagnostics;
 
@@ -60,6 +61,7 @@ using StmtNodeList = std::vector<StmtNodePtr>;
 struct FunctionReturnTypes {
    std::array<TiriType, MAX_RETURN_TYPES> types{};  // Return types (Unknown = unused slot)
    std::array<struct_record *, MAX_RETURN_TYPES> struct_defs{}; // Resolved layouts for struct<Name> results
+   std::array<StaticValueHandle, MAX_RETURN_TYPES> descriptors{};
    uint8_t count = 0;           // Number of declared types (0 = not declared)
    bool is_variadic = false;    // True if declaration ends with ... (last type repeats)
    bool is_explicit = false;    // True if explicitly declared, false if inferred
@@ -209,6 +211,8 @@ struct Identifier {
    bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
+   mutable StaticBindingID binding_id = 0;
+   mutable StaticValueHandle static_value = 0;
 
    // Default constructor
    Identifier() = default;
@@ -235,6 +239,7 @@ struct NameRef {
    Identifier identifier;
    NameResolution resolution = NameResolution::Unresolved;
    uint16_t slot = 0;
+   mutable StaticBindingID binding_id = 0;
 };
 
 struct LiteralValue {
@@ -412,6 +417,8 @@ struct CallExprPayload {
    mutable TiriType result_type = TiriType::Unknown;  // Inferred return type (e.g., Object for obj.new())
    mutable CLASSID object_class_id = CLASSID::NIL; // CLASSID if result is Object
    mutable struct_record *struct_def = nullptr; // Resolved layout if result is Struct, or callable struct definition
+   mutable StaticCallableHandle callable = 0;
+   mutable StaticResultSetHandle results = 0;
    ~CallExprPayload();
 };
 
@@ -519,6 +526,7 @@ struct FunctionExprPayload {
    bool is_thunk = false;              // Marks function as thunk
    TiriType thunk_return_type = TiriType::Any;  // Return type for thunk (kept for IR emission compatibility)
    FunctionReturnTypes return_types{};            // General return type tracking for type checking
+   mutable StaticCallableHandle callable = 0;
    std::unique_ptr<BlockStmt> body;
    std::vector<AnnotationEntry> annotations;  // Annotations attached to this function
    ~FunctionExprPayload();
@@ -613,6 +621,8 @@ struct ExprNode {
    AstNodeKind kind = AstNodeKind::LiteralExpr;
    SourceSpan span{};
    bool is_grouped = false;
+   mutable StaticValueHandle static_value = 0;
+   mutable StaticResultSetHandle static_results = 0;
    std::variant<LiteralValue, NameRef, VarArgExprPayload, UnaryExprPayload,
       UpdateExprPayload, BinaryExprPayload, ComparisonChainExprPayload, TernaryExprPayload,
       PresenceExprPayload, PipeExprPayload, CallExprPayload, MemberExprPayload,

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -278,6 +278,7 @@ struct FunctionParameter {
    Identifier name;
    TiriType type = TiriType::Any;
    struct_record *struct_def = nullptr;
+   bool type_is_explicit = false;
    bool is_self = false;
 };
 

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -75,6 +75,14 @@ struct FuncState {
    bool return_contract_variadic = false;
    bool return_contract_explicit = false;
 
+   // Canonical prototype signature under construction.  Parameter entries are populated before body emission.
+   // Result entries are populated from explicit declarations or reserved for BC_TYPEFIX in fs_finish().
+   std::vector<ProtoTypeEntry> signature_parameters;
+   std::array<ProtoTypeEntry, MAX_RETURN_TYPES> signature_results{};
+   uint8_t signature_result_count = 0;
+   uint8_t signature_result_entry_count = 0;
+   uint8_t signature_flags = 0;
+
    // Try-except metadata for bytecode-level exception handling.
    // These are populated during emit_try_except_stmt and copied to GCproto during fs_finish.
    std::vector<TryBlockDesc>   try_blocks;    // Try block descriptors

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -69,6 +69,11 @@ struct FuncState {
       for (auto& t : arr) t = TiriType::Unknown;
       return arr;
    }();
+   std::array<struct_record *, MAX_RETURN_TYPES> return_struct_defs{};
+   uint8_t return_declared_count = 0;
+   uint8_t return_contract_count = 0;
+   bool return_contract_variadic = false;
+   bool return_contract_explicit = false;
 
    // Try-except metadata for bytecode-level exception handling.
    // These are populated during emit_try_except_stmt and copied to GCproto during fs_finish.

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -287,8 +287,15 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    CLASSID callee_object_class_id = CLASSID::NIL;  // CLASSID if return type is Object
    struct_record *callee_struct_def = nullptr;
 
+   if (Payload.results) {
+      const auto &descriptor = this->ctx.descriptors().results(Payload.results).value_at(0);
+      callee_return_type = descriptor.primary;
+      callee_object_class_id = descriptor.object_class_id;
+      callee_struct_def = descriptor.struct_def;
+   }
+
    // Check if the AST has pre-computed type info (e.g., from obj.new() pattern detection)
-   if (Payload.result_type != TiriType::Unknown) {
+   if (callee_return_type IS TiriType::Unknown and Payload.result_type != TiriType::Unknown) {
       callee_return_type = Payload.result_type;
       callee_object_class_id = Payload.object_class_id;
       callee_struct_def = Payload.struct_def;
@@ -443,6 +450,7 @@ ParserResult<ExpDesc> IrEmitter::emit_call_expr(const CallExprPayload &Payload)
    result.result_type = callee_return_type;  // Propagate known return type
    result.object_class_id = callee_object_class_id;  // Propagate object class ID for Object types
    result.struct_def = callee_struct_def;
+   result.static_results = Payload.results;
    this->func_state.freereg = base + 1;
    return ParserResult<ExpDesc>::success(result);
 }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -130,6 +130,24 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    }
 
    child_state.numparams = uint8_t(param_count.raw());
+   child_state.signature_parameters.reserve(param_count.raw());
+   if (Payload.is_vararg) {
+      child_state.signature_flags |= proto_signature_flag(ProtoSignatureFlag::ParameterVariadic);
+   }
+   for (auto i = BCReg(0); i < param_count; ++i) {
+      const FunctionParameter &param = Payload.parameters[i.raw()];
+      ProtoTypeOrigin origin = param.type_is_explicit ? ProtoTypeOrigin::Declared : ProtoTypeOrigin::Unspecified;
+      ProtoTypeStrength strength = (param.type_is_explicit and param.type != TiriType::Any and
+         param.type != TiriType::Unknown) ? ProtoTypeStrength::Checked : ProtoTypeStrength::Advisory;
+      uint32_t constraint = (param.struct_def and param.type IS TiriType::Struct) ?
+         struct_key(param.struct_def->Name) : 0;
+      child_state.signature_parameters.push_back(ProtoTypeEntry{
+         .constraint = constraint,
+         .type = param.type,
+         .flags = proto_type_flags(true, false, origin, strength)
+      });
+   }
+
    this->lex_state.var_add(param_count);
    auto base = BCReg(child_state.varmap.size() - param_count.raw());
    for (auto i = BCReg(0); i < param_count; ++i) {
@@ -183,9 +201,25 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       child_state.return_contract_count = uint8_t(std::min<size_t>(
          Payload.return_types.count, child_state.return_types.size()));
       child_state.return_contract_variadic = Payload.return_types.is_variadic;
+      child_state.signature_flags |= proto_signature_flag(ProtoSignatureFlag::ExplicitResults);
+      if (Payload.return_types.is_variadic) {
+         child_state.signature_flags |= proto_signature_flag(ProtoSignatureFlag::ResultVariadic);
+      }
+      child_state.signature_result_count = Payload.return_types.count;
+      child_state.signature_result_entry_count = uint8_t(std::min<size_t>(
+         Payload.return_types.count, child_state.signature_results.size()));
       for (size_t i = 0; i < Payload.return_types.count and i < child_state.return_types.size(); ++i) {
          child_state.return_types[i] = Payload.return_types.types[i];
          child_state.return_struct_defs[i] = Payload.return_types.struct_defs[i];
+         auto type = Payload.return_types.types[i];
+         auto struct_def = Payload.return_types.struct_defs[i];
+         child_state.signature_results[i] = ProtoTypeEntry{
+            .constraint = (struct_def and type IS TiriType::Struct) ? struct_key(struct_def->Name) : 0,
+            .type = type,
+            .flags = proto_type_flags(true, false, ProtoTypeOrigin::Declared,
+               (type IS TiriType::Any or type IS TiriType::Unknown) ?
+                  ProtoTypeStrength::Advisory : ProtoTypeStrength::Checked)
+         };
       }
    }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -21,7 +21,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       //
       // Into:
       //   function compute(x, y)
-      //      return __create_thunk(function() return x * y end, type_tag)
+      //      return __create_thunk(function() return x * y end, logical_type)
       //   end
 
       // Use lastline which was set by emit_expression() to the function definition line,
@@ -48,8 +48,12 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       create_thunk_ref.resolution = NameResolution::Unresolved;
       ExprNodePtr create_thunk_fn = make_identifier_expr(span, create_thunk_ref);
 
-      // Type tag argument
-      ExprNodePtr type_arg = make_literal_expr(span, LiteralValue::number(double(tiri_type_to_lj_tag(Payload.thunk_return_type))));
+      // Logical type argument.  A VM tag cannot distinguish range from full userdata or represent both full and
+      // light userdata, so deferred values retain the language-level type.
+
+      uint8_t logical_type = (Payload.thunk_return_type IS TiriType::Any or
+         Payload.thunk_return_type IS TiriType::Unknown) ? 0xff : uint8_t(Payload.thunk_return_type);
+      ExprNodePtr type_arg = make_literal_expr(span, LiteralValue::number(double(logical_type)));
 
       // Build argument list
       ExprNodeList call_args;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -149,14 +149,39 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       child_emitter.update_local_binding(param.name.symbol, BCReg(base.raw() + i.raw()));
    }
 
+   // Parameter contracts execute inside the callee after local bindings exist and before any user statement.
+   // Blank parameters still have a boundary and must be checked.
+
+   for (auto i = BCReg(0); i < param_count; ++i) {
+      const FunctionParameter &param = Payload.parameters[i.raw()];
+      if (param.type IS TiriType::Unknown or param.type IS TiriType::Any) continue;
+
+      RuntimeContract contract{
+         .type = param.type,
+         .struct_def = param.struct_def,
+         .label = param.name.is_blank ? nullptr : param.name.symbol,
+         .boundary = ContractBoundary::Parameter,
+         .position = uint8_t(i.raw() + 1),
+         .nullable = true,
+         .required = false
+      };
+      bcemit_contract(&child_state, base + i, std::span(&contract, 1), 1);
+   }
+
    // Copy explicit return types to the function state BEFORE emitting the body.
    // This ensures emit_return_stmt can see the types when deciding whether to use tail-calls
    // and whether to emit BC_TYPEFIX instructions.
 
    child_state.funcname = funcname;
    if (Payload.return_types.is_explicit) {
+      child_state.return_contract_explicit = true;
+      child_state.return_declared_count = Payload.return_types.count;
+      child_state.return_contract_count = uint8_t(std::min<size_t>(
+         Payload.return_types.count, child_state.return_types.size()));
+      child_state.return_contract_variadic = Payload.return_types.is_variadic;
       for (size_t i = 0; i < Payload.return_types.count and i < child_state.return_types.size(); ++i) {
          child_state.return_types[i] = Payload.return_types.types[i];
+         child_state.return_struct_defs[i] = Payload.return_types.struct_defs[i];
       }
    }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -95,6 +95,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    ParserAllocator allocator = ParserAllocator::from(this->lex_state.L);
    ParserConfig inherited = this->ctx.config();
    ParserContext child_ctx = ParserContext::from(this->lex_state, child_state, allocator, inherited);
+   child_ctx.share_descriptors(this->ctx);
    ParserSession session(child_ctx, inherited);
 
    // Inherit declared globals from parent so nested functions recognize them
@@ -157,6 +158,9 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
          param_info.fixed_type = param.type;
          param_info.struct_def = param.struct_def;
       }
+      auto &param_info = child_state.var_get(base.raw() + i.raw());
+      param_info.binding_id = param.name.binding_id;
+      param_info.static_value = param.name.static_value;
    }
 
    if (child_state.varmap.size() > 0) {
@@ -375,10 +379,10 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
             : this->emit_expression(*payload.table);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
+         StaticValueHandle receiver_descriptor = table.static_value;
 
          // Save the emitted expression's result_type before discharge operations may modify it.
          // This captures type information propagated from VarInfo during variable lookup.
-         TiriType emitted_base_type = table.result_type;
          struct_record *emitted_struct_def = table.struct_def;
 
          ExpressionValue table_toval(&this->func_state, table);
@@ -395,14 +399,18 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          // Propagate known base type information for downstream optimizations.
          // When base_type is Object, emit specialised BC_OBSETF bytecodes via IndexedObject.
          // Check both AST-level base_type AND emitted expression's result_type.
-         if (payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+         bool proved_object = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
+         bool proved_struct = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Struct, true);
+         if (proved_object) {
             table.result_type = TiriType::Object;
             // Only use IndexedObject for string keys (member access always uses string keys)
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedObject;
             }
          }
-         else if (payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+         else if (proved_struct) {
             table.result_type = TiriType::Struct;
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedStruct;
@@ -423,11 +431,10 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          if (not table_result.ok()) return table_result;
 
          ExpDesc table = table_result.value_ref();
+         StaticValueHandle receiver_descriptor = table.static_value;
 
          // Save the emitted expression's result_type before discharge operations may modify it.
          // This captures type information propagated from VarInfo during variable lookup.
-         TiriType emitted_base_type = table.result_type;
-
          // Materialize table BEFORE evaluating key, so nested index expressions emit bytecode in
          // the correct order (table first, then key)
 
@@ -449,19 +456,25 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
 
          // Propagate known base type information for downstream optimizations.
          // Check both AST-level base_type AND emitted expression's result_type.
-         if (payload.base_type IS TiriType::Array or emitted_base_type IS TiriType::Array) {
+         bool proved_array = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Array, true);
+         bool proved_object = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
+         bool proved_struct = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Struct, true);
+         if (proved_array) {
             // Arrays don't support string keys, so only change kind for numeric indexing
             if (int32_t(table.u.s.aux) >= 0) {
                table.k = ExpKind::IndexedArray;
             }
          }
-         else if (payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+         else if (proved_object) {
             // Objects use string field access - only change kind for string const keys
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedObject;
             }
          }
-         else if (payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+         else if (proved_struct) {
             table.result_type = TiriType::Struct;
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedStruct;
@@ -483,8 +496,8 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
+         StaticValueHandle receiver_descriptor = table.static_value;
 
-         TiriType emitted_base_type = table.result_type;
          struct_record *emitted_struct_def = table.struct_def;
 
          ExpressionValue table_toval(&this->func_state, table);
@@ -503,13 +516,17 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          key.u.sval = payload.member.symbol;
          expr_index(&this->func_state, &table, &key);
 
-         if (payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+         bool proved_object = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
+         bool proved_struct = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Struct, true);
+         if (proved_object) {
             table.result_type = TiriType::Object;
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedObject;
             }
          }
-         else if (payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+         else if (proved_struct) {
             table.result_type = TiriType::Struct;
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedStruct;
@@ -532,8 +549,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          auto table_result = this->emit_lvalue_expr(*payload.table, false, SafeNavSkip);
          if (not table_result.ok()) return table_result;
          ExpDesc table = table_result.value_ref();
-
-         TiriType emitted_base_type = table.result_type;
+         StaticValueHandle receiver_descriptor = table.static_value;
 
          ExpressionValue table_toval_idx(&this->func_state, table);
          table_toval_idx.to_val();
@@ -556,17 +572,23 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          key = key_toval_idx.legacy();
          expr_index(&this->func_state, &table, &key);
 
-         if (payload.base_type IS TiriType::Array or emitted_base_type IS TiriType::Array) {
+         bool proved_array = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Array, true);
+         bool proved_object = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
+         bool proved_struct = can_use_static_receiver(
+            this->ctx.descriptors(), receiver_descriptor, TiriType::Struct, true);
+         if (proved_array) {
             if (int32_t(table.u.s.aux) >= 0) {
                table.k = ExpKind::IndexedArray;
             }
          }
-         else if (payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+         else if (proved_object) {
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedObject;
             }
          }
-         else if (payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+         else if (proved_struct) {
             table.result_type = TiriType::Struct;
             if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
                table.k = ExpKind::IndexedStruct;
@@ -608,6 +630,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_function_stmt(const LocalFunction
    VarInfo &var_info = this->func_state.var_get(this->func_state.varmap.size() - 1);
    var_info.startpc = this->func_state.pc;
    var_info.fixed_type = TiriType::Func;  // Function declarations have known type
+   var_info.binding_id = Payload.name.binding_id;
+   var_info.static_value = Payload.name.static_value;
+   if (Payload.name.binding_id) {
+      const auto &binding = this->ctx.descriptors().binding(Payload.name.binding_id);
+      var_info.static_callable = binding.callable;
+      if (binding.callable) var_info.static_results = this->ctx.descriptors().callable(binding.callable).results;
+   }
    if (Payload.name.symbol and not Payload.name.is_blank) this->update_local_binding(Payload.name.symbol, slot);
 
    // Copy function return types to VarInfo for compile-time type checking at call sites
@@ -700,6 +729,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
       VarInfo &var_info = this->func_state.var_get(this->func_state.varmap.size() - 1);
       var_info.startpc = this->func_state.pc;
       var_info.fixed_type = TiriType::Func;  // Function declarations have known type
+      var_info.binding_id = first_segment.binding_id;
+      var_info.static_value = first_segment.static_value;
+      if (first_segment.binding_id) {
+         const auto &binding = this->ctx.descriptors().binding(first_segment.binding_id);
+         var_info.static_callable = binding.callable;
+         if (binding.callable) var_info.static_results = this->ctx.descriptors().callable(binding.callable).results;
+      }
       this->update_local_binding(symbol, slot);
 
       // Copy function return types to VarInfo for compile-time type checking at call sites

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -959,14 +959,9 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
    if (cleanup_temp_regs > 0) return_allocator.reserve(BCReg(cleanup_temp_regs + 1));
    BCREG return_base = this->func_state.freereg;
 
-   // Check if function needs runtime type inference (no explicit return types declared)
-   bool needs_typefix = true;
-   for (size_t i = 0; i < this->func_state.return_types.size(); ++i) {
-      if (this->func_state.return_types[i] != TiriType::Unknown) {
-         needs_typefix = false;
-         break;
-      }
-   }
+   // Runtime inference applies only when there is no explicit result declaration. This distinguishes explicit void
+   // (`:<>`) from an unannotated function even though both have no stored concrete result types.
+   bool needs_typefix = not this->func_state.return_contract_explicit;
 
    if (Payload.values.empty()) {
       ins = BCINS_AD(BC_RET0, 0, 1);
@@ -1074,7 +1069,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       }
    }
 
-   if (truncate_return_results and bc_op(ins) IS BC_RET) {
+   if (truncate_return_results and this->func_state.return_declared_count IS 0) {
+      ins = BCINS_AD(BC_RET0, 0, 1);
+   }
+   else if (truncate_return_results and bc_op(ins) IS BC_RET) {
       BCREG result_count = this->func_state.return_declared_count;
       if (bc_d(ins) - 1 > result_count) setbc_d(&ins, result_count + 1);
    }

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -654,6 +654,8 @@ void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
    info->fixed_type = inferred.type;
    info->object_class_id = (inferred.type IS TiriType::Object) ? inferred.object_class_id : CLASSID::NIL;
    info->struct_def = inferred.struct_def;
+   info->static_value = Value.static_value;
+   info->static_results = Value.static_results;
 }
 
 BCReg IrEmitter::finalise_pending_local_assignment(PreparedAssignment& Target)
@@ -1217,6 +1219,15 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    for (auto i = BCReg(0); i < nvars; ++i) {
       const Identifier& identifier = Payload.names[i.raw()];
       VarInfo* info = &this->func_state.var_get(base.raw() + i.raw());
+      info->binding_id = identifier.binding_id;
+      info->static_value = identifier.static_value;
+      if (identifier.binding_id) {
+         const auto &binding = this->ctx.descriptors().binding(identifier.binding_id);
+         info->static_callable = binding.callable;
+         if (binding.callable) {
+            info->static_results = this->ctx.descriptors().callable(binding.callable).results;
+         }
+      }
 
       if (identifier.type != TiriType::Unknown) {
          // Explicit type annotation takes precedence
@@ -1790,6 +1801,15 @@ ParserResult<IrEmitUnit> IrEmitter::emit_generic_for_stmt(const GenericForStmtPa
       loop_bindings.reserve(visible.raw());
       for (auto i = BCReg(0); i < visible; ++i) {
          const Identifier& identifier = Payload.names[i.raw()];
+         auto &variable = fs->var_get(base.raw() + i.raw());
+         variable.binding_id = identifier.binding_id;
+         variable.static_value = identifier.static_value;
+         if (identifier.static_value) {
+            const auto &descriptor = this->ctx.descriptors().value(identifier.static_value);
+            variable.fixed_type = descriptor.primary;
+            variable.object_class_id = descriptor.object_class_id;
+            variable.struct_def = descriptor.struct_def;
+         }
          if (identifier.symbol and not identifier.is_blank) {
             BlockBinding binding;
             binding.symbol = identifier.symbol;
@@ -2128,31 +2148,92 @@ ParserResult<ExpDesc> IrEmitter::emit_expression(const ExprNode& expr)
       return this->emit_literal_expr(constant->to_literal());
    }
 
+   ParserResult<ExpDesc> result;
    switch (expr.kind) {
-      case AstNodeKind::LiteralExpr:      return this->emit_literal_expr(std::get<LiteralValue>(expr.data));
-      case AstNodeKind::IdentifierExpr:   return this->emit_identifier_expr(std::get<NameRef>(expr.data));
-      case AstNodeKind::VarArgExpr:       return this->emit_vararg_expr();
-      case AstNodeKind::UnaryExpr:        return this->emit_unary_expr(std::get<UnaryExprPayload>(expr.data));
-      case AstNodeKind::UpdateExpr:       return this->emit_update_expr(std::get<UpdateExprPayload>(expr.data));
-      case AstNodeKind::BinaryExpr:       return this->emit_binary_expr(std::get<BinaryExprPayload>(expr.data));
+      case AstNodeKind::LiteralExpr:
+         result = this->emit_literal_expr(std::get<LiteralValue>(expr.data));
+         break;
+      case AstNodeKind::IdentifierExpr:
+         result = this->emit_identifier_expr(std::get<NameRef>(expr.data));
+         break;
+      case AstNodeKind::VarArgExpr:
+         result = this->emit_vararg_expr();
+         break;
+      case AstNodeKind::UnaryExpr:
+         result = this->emit_unary_expr(std::get<UnaryExprPayload>(expr.data));
+         break;
+      case AstNodeKind::UpdateExpr:
+         result = this->emit_update_expr(std::get<UpdateExprPayload>(expr.data));
+         break;
+      case AstNodeKind::BinaryExpr:
+         result = this->emit_binary_expr(std::get<BinaryExprPayload>(expr.data));
+         break;
       case AstNodeKind::ComparisonChainExpr:
-         return this->emit_comparison_chain_expr(std::get<ComparisonChainExprPayload>(expr.data));
-      case AstNodeKind::TernaryExpr:      return this->emit_ternary_expr(std::get<TernaryExprPayload>(expr.data));
-      case AstNodeKind::PresenceExpr:     return this->emit_presence_expr(std::get<PresenceExprPayload>(expr.data));
-      case AstNodeKind::PipeExpr:         return this->emit_pipe_expr(std::get<PipeExprPayload>(expr.data));
-      case AstNodeKind::MemberExpr:       return this->emit_member_expr(std::get<MemberExprPayload>(expr.data));
-      case AstNodeKind::IndexExpr:        return this->emit_index_expr(std::get<IndexExprPayload>(expr.data));
-      case AstNodeKind::SafeMemberExpr:   return this->emit_safe_member_expr(std::get<SafeMemberExprPayload>(expr.data));
-      case AstNodeKind::SafeIndexExpr:    return this->emit_safe_index_expr(std::get<SafeIndexExprPayload>(expr.data));
-      case AstNodeKind::SafeCallExpr:     return this->emit_safe_call_expr(std::get<CallExprPayload>(expr.data));
-      case AstNodeKind::CallExpr:         return this->emit_call_expr(std::get<CallExprPayload>(expr.data));
-      case AstNodeKind::ResultFilterExpr: return this->emit_result_filter_expr(std::get<ResultFilterPayload>(expr.data));
-      case AstNodeKind::TableExpr:        return this->emit_table_expr(std::get<TableExprPayload>(expr.data));
-      case AstNodeKind::RangeExpr:        return this->emit_range_expr(std::get<RangeExprPayload>(expr.data));
-      case AstNodeKind::ChooseExpr:       return this->emit_choose_expr(std::get<ChooseExprPayload>(expr.data));
-      case AstNodeKind::FunctionExpr:     return this->emit_function_expr(std::get<FunctionExprPayload>(expr.data));
-      default: return this->unsupported_expr(expr.kind, expr.span);
+         result = this->emit_comparison_chain_expr(std::get<ComparisonChainExprPayload>(expr.data));
+         break;
+      case AstNodeKind::TernaryExpr:
+         result = this->emit_ternary_expr(std::get<TernaryExprPayload>(expr.data));
+         break;
+      case AstNodeKind::PresenceExpr:
+         result = this->emit_presence_expr(std::get<PresenceExprPayload>(expr.data));
+         break;
+      case AstNodeKind::PipeExpr:
+         result = this->emit_pipe_expr(std::get<PipeExprPayload>(expr.data));
+         break;
+      case AstNodeKind::MemberExpr:
+         result = this->emit_member_expr(std::get<MemberExprPayload>(expr.data));
+         break;
+      case AstNodeKind::IndexExpr:
+         result = this->emit_index_expr(std::get<IndexExprPayload>(expr.data));
+         break;
+      case AstNodeKind::SafeMemberExpr:
+         result = this->emit_safe_member_expr(std::get<SafeMemberExprPayload>(expr.data));
+         break;
+      case AstNodeKind::SafeIndexExpr:
+         result = this->emit_safe_index_expr(std::get<SafeIndexExprPayload>(expr.data));
+         break;
+      case AstNodeKind::SafeCallExpr:
+         result = this->emit_safe_call_expr(std::get<CallExprPayload>(expr.data));
+         break;
+      case AstNodeKind::CallExpr:
+         result = this->emit_call_expr(std::get<CallExprPayload>(expr.data));
+         break;
+      case AstNodeKind::ResultFilterExpr:
+         result = this->emit_result_filter_expr(std::get<ResultFilterPayload>(expr.data));
+         break;
+      case AstNodeKind::TableExpr:
+         result = this->emit_table_expr(std::get<TableExprPayload>(expr.data));
+         break;
+      case AstNodeKind::RangeExpr:
+         result = this->emit_range_expr(std::get<RangeExprPayload>(expr.data));
+         break;
+      case AstNodeKind::ChooseExpr:
+         result = this->emit_choose_expr(std::get<ChooseExprPayload>(expr.data));
+         break;
+      case AstNodeKind::FunctionExpr:
+         result = this->emit_function_expr(std::get<FunctionExprPayload>(expr.data));
+         break;
+      default:
+         result = this->unsupported_expr(expr.kind, expr.span);
+         break;
    }
+
+   if (result.ok()) {
+      ExpDesc &emitted = result.value_ref();
+      if (expr.static_value) {
+         emitted.static_value = expr.static_value;
+         const auto &descriptor = this->ctx.descriptors().value(expr.static_value);
+         emitted.result_type = descriptor.primary;
+         emitted.object_class_id = descriptor.object_class_id;
+         emitted.struct_def = descriptor.struct_def;
+      }
+      // Identifier lookup can recover a descriptor from VarInfo or an upvalue even when binding analysis has no
+      // handle.  For compound expressions, an unclaimed handle describes an operand and must not leak to the result.
+      else if (expr.kind != AstNodeKind::IdentifierExpr) emitted.static_value = 0;
+      if (expr.static_results) emitted.static_results = expr.static_results;
+      else if (expr.kind != AstNodeKind::IdentifierExpr) emitted.static_results = 0;
+   }
+   return result;
 }
 
 //********************************************************************************************************************
@@ -2945,7 +3026,6 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
    // Save the emitted expression's result_type and object_class_id before discharge operations may modify it.
    // This captures type information propagated from VarInfo during variable lookup.
 
-   TiriType emitted_base_type = table.result_type;
    CLASSID emitted_class_id = table.object_class_id;
    struct_record *emitted_struct_def = table.struct_def;
 
@@ -2961,7 +3041,12 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
    // to IndexedObject.  Check both AST-level base_type AND emitted expression's result_type (the latter captures
    // type info from variable declarations like `fl = obj.new(...)`).
 
-   if (Payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+   bool proved_object = can_use_static_receiver(
+      this->ctx.descriptors(), table.static_value, TiriType::Object, true);
+   bool proved_struct = can_use_static_receiver(
+      this->ctx.descriptors(), table.static_value, TiriType::Struct, true);
+
+   if (proved_object) {
       table.result_type = TiriType::Object;
       // Only use IndexedObject for string keys (member access always uses string keys)
 
@@ -2990,7 +3075,7 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
          // If is_call_target is true, skip type checking and let runtime handle the method/action call
       }
    }
-   else if (Payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+   else if (proved_struct) {
       table.result_type = TiriType::Struct;
       if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) table.k = ExpKind::IndexedStruct;
       apply_struct_field_metadata(table, emitted_struct_def, Payload.member.symbol);
@@ -3024,8 +3109,6 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
 
    // Save the emitted expression's result_type before discharge operations may modify it.
    // This captures type information propagated from VarInfo during variable lookup.
-   TiriType emitted_base_type = table.result_type;
-
    // Materialize table BEFORE evaluating key, so nested index expressions emit bytecode in
    // the correct order (table first, then key)
    RegisterAllocator allocator(&this->func_state);
@@ -3042,7 +3125,14 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
 
    // If base type is known to be an array, use array-specific bytecodes
    // Check both AST-level base_type AND emitted expression's result_type.
-   if (Payload.base_type IS TiriType::Array or emitted_base_type IS TiriType::Array) {
+   bool proved_array = can_use_static_receiver(
+      this->ctx.descriptors(), table.static_value, TiriType::Array, true);
+   bool proved_object = can_use_static_receiver(
+      this->ctx.descriptors(), table.static_value, TiriType::Object, true);
+   bool proved_struct = can_use_static_receiver(
+      this->ctx.descriptors(), table.static_value, TiriType::Struct, true);
+
+   if (proved_array) {
       // Arrays don't support string keys, so only change kind for numeric indexing
       // (aux >= 0 means numeric index, aux < 0 means string const key)
       if (int32_t(table.u.s.aux) >= 0) {
@@ -3051,14 +3141,14 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
    }
    // If base type is known to be an object with a string key, use object-specific bytecodes
    // Check both AST-level base_type AND emitted expression's result_type.
-   else if (Payload.base_type IS TiriType::Object or emitted_base_type IS TiriType::Object) {
+   else if (proved_object) {
       // Objects use string field access - only change kind for string const keys
       // (aux < 0 means string const key)
       if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
          table.k = ExpKind::IndexedObject;
       }
    }
-   else if (Payload.base_type IS TiriType::Struct or emitted_base_type IS TiriType::Struct) {
+   else if (proved_struct) {
       if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
          table.k = ExpKind::IndexedStruct;
       }
@@ -3140,6 +3230,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
 
    auto table_result = this->emit_expression(*Payload.table);
    if (not table_result.ok()) return table_result;
+   StaticValueHandle receiver_descriptor = table_result.value_ref().static_value;
 
    NilShortCircuitGuard guard(this, table_result.value_ref());
    if (not guard.ok()) return guard.error<ExpDesc>();
@@ -3151,14 +3242,21 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
 
    // Propagate known base type information for downstream optimizations.
    // When base_type is Object and class_id is set, field-level type resolution may be possible.
-   if (Payload.base_type IS TiriType::Object) {
+   bool proved_object = can_use_static_receiver(
+      this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
+   bool proved_struct = can_use_static_receiver(
+      this->ctx.descriptors(), receiver_descriptor, TiriType::Struct, true);
+
+   if (proved_object) {
       table.result_type = TiriType::Object;
       table.object_class_id = CLASSID::NIL;
+      if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) table.k = ExpKind::IndexedObject;
 
       // Look up the field type from the class dictionary for compile-time type checking.
 
-      if (Payload.class_id != CLASSID::NIL and Payload.member.symbol) {
-         auto field_info = lookup_field_type(Payload.class_id, Payload.member.symbol->hash);
+      CLASSID class_id = this->ctx.descriptors().value(receiver_descriptor).object_class_id;
+      if (class_id != CLASSID::NIL and Payload.member.symbol) {
+         auto field_info = lookup_field_type(class_id, Payload.member.symbol->hash);
          bool is_field = field_info.has_value() and (field_info->type != TiriType::Unknown);
 
          if (is_field) {
@@ -3167,7 +3265,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
             table.type_confirmed  = true;  // Type is confirmed from class dictionary lookup
          }
          else if (not Payload.is_call_target) {
-            auto *meta_class = FindClass(Payload.class_id);
+            auto *meta_class = FindClass(class_id);
             const char *class_name = meta_class ? meta_class->ClassName.c_str() : "Unknown";
             lj_lex_error(this->func_state.ls, 0, ErrMsg::BADFIELD, strdata(Payload.member.symbol), class_name);
             return this->unsupported_expr(AstNodeKind::SafeMemberExpr, Payload.member.span);
@@ -3175,7 +3273,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
          // If is_call_target is true, skip type checking and let runtime handle the method/action call
       }
    }
-   else if (table.result_type IS TiriType::Struct or emitted_struct_def) {
+   else if (proved_struct) {
       table.result_type = TiriType::Struct;
       if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) table.k = ExpKind::IndexedStruct;
       apply_struct_field_metadata(table, emitted_struct_def, Payload.member.symbol);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -159,6 +159,26 @@ static bool has_close_variables(FuncState* fs)
    return false;
 }
 
+static constexpr BCREG CLOSE_HANDLER_TEMP_REGS = 5 + LJ_FR2;
+
+static BCREG return_cleanup_temp_regs(FuncState *fs)
+{
+   BCREG required = has_close_variables(fs) ? CLOSE_HANDLER_TEMP_REGS : 0;
+   BCREG defer_args = 0;
+   for (BCREG i = fs->varmap.size(); i > 0;) {
+      VarInfo *variable = &fs->var_get(--i);
+      if (has_flag(variable->info, VarInfoFlag::DeferArg)) {
+         defer_args++;
+      }
+      else if (has_flag(variable->info, VarInfoFlag::Defer)) {
+         // Keep one slot beyond the call frame: CALL may initialise the callee base even when no results are requested.
+         required = std::max(required, BCREG(defer_args + 2 + LJ_FR2));
+         defer_args = 0;
+      }
+   }
+   return required;
+}
+
 //********************************************************************************************************************
 // Snapshot return register state.
 // Used by ir_emitter for return statement handling.
@@ -167,8 +187,6 @@ static bool has_close_variables(FuncState* fs)
 // Close handlers (bcemit_close) use temporary registers starting at freereg (which is set to varmap.size()).
 // They reserve 5+LJ_FR2 registers for: getmetatable function, metatable result, __close function, args.
 // If return values overlap with these temporary registers, they must be moved to safe slots.
-
-static constexpr BCREG CLOSE_HANDLER_TEMP_REGS = 5 + LJ_FR2;
 
 static void snapshot_return_regs(FuncState* fs, BCIns* ins)
 {
@@ -919,7 +937,27 @@ ParserResult<IrEmitUnit> IrEmitter::emit_conditional_shorthand_stmt(const Condit
 ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Payload)
 {
    BCIns ins;
+   RegisterAllocator return_allocator(&this->func_state);
+
    this->func_state.flags |= PROTO_HAS_RETURN;
+   bool has_return_contract = false;
+   if (this->func_state.return_contract_explicit) {
+      for (uint8_t i = 0; i < this->func_state.return_contract_count; ++i) {
+         TiriType type = this->func_state.return_types[i];
+         if (type != TiriType::Unknown and type != TiriType::Any) {
+            has_return_contract = true;
+            break;
+         }
+      }
+   }
+
+   bool truncate_return_results =
+      this->func_state.return_contract_explicit and not this->func_state.return_contract_variadic;
+   BCREG cleanup_temp_regs =
+      (has_return_contract or truncate_return_results) ? return_cleanup_temp_regs(&this->func_state) : 0;
+   BCREG multres_slot = BCREG(this->func_state.varmap.size() + cleanup_temp_regs);
+   if (cleanup_temp_regs > 0) return_allocator.reserve(BCReg(cleanup_temp_regs + 1));
+   BCREG return_base = this->func_state.freereg;
 
    // Check if function needs runtime type inference (no explicit return types declared)
    bool needs_typefix = true;
@@ -943,7 +981,14 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       // Handle tail-call case: return f() or return f(...)
       if (count IS 1 and last.k IS ExpKind::Call) {
          BCIns* ip = ir_bcptr(&this->func_state, &last);
-         if (this->func_state.try_depth > 0) {
+         if (truncate_return_results) {
+            BCREG result_count = this->func_state.return_declared_count;
+            setbc_b(ip, result_count + 1);
+            ins = result_count > 0 ?
+               BCINS_AD(BC_RET, last.u.s.aux, result_count + 1) :
+               BCINS_AD(BC_RET0, 0, 1);
+         }
+         else if (this->func_state.try_depth > 0) {
             // DISABLE TAIL-CALL inside try blocks: use CALL + RET instead of CALLT.
             // CALLT doesn't return to the caller, so if the called function throws an exception, it happens after
             // TRYLEAVE has popped the try frame - the exception escapes.  By using CALL + RET, the exception occurs
@@ -951,13 +996,18 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
 
             setbc_b(ip, 0);  // Request all results (MULTRES)
             if (needs_typefix) bcemit_AD(&this->func_state, BC_TYPEFIX, last.u.s.aux, 1);
-            ins = BCINS_AD(BC_RETM, this->func_state.varmap.size(), last.u.s.aux - this->func_state.varmap.size());
+            ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
+         }
+         else if (has_return_contract) {
+            // A return contract must observe dynamic results inside this function, so tail-call conversion is unsafe.
+            setbc_b(ip, 0);
+            ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
          else if (bc_op(*ip) IS BC_VARG) {
             // Variadic return: return ...
             setbc_b(ir_bcptr(&this->func_state, &last), 0);
             // For VARG returns, we can't know count at compile time - skip typefix
-            ins = BCINS_AD(BC_RETM, this->func_state.varmap.size(), last.u.s.aux - this->func_state.varmap.size());
+            ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
          else if (needs_typefix and bc_op(*ip) IS BC_CALL) {
             // DISABLE TAIL-CALL: emit BC_CALL + BC_TYPEFIX + BC_RET instead of BC_CALLT
@@ -975,7 +1025,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
                // No close handlers: Safe to use RETM with all results
                setbc_b(ip, 0);  // Request all results (MULTRES)
                bcemit_AD(&this->func_state, BC_TYPEFIX, last.u.s.aux, 1);
-               ins = BCINS_AD(BC_RETM, this->func_state.varmap.size(), last.u.s.aux - this->func_state.varmap.size());
+               ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
             }
          }
          else {
@@ -998,22 +1048,41 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
       else {
          // Multiple return values
          if (last.k IS ExpKind::Call) {
-            setbc_b(ir_bcptr(&this->func_state, &last), 0);
-            // Variadic tail - count unknown, skip typefix for safety
-            ins = BCINS_AD(BC_RETM, this->func_state.varmap.size(), last.u.s.aux - this->func_state.varmap.size());
+            if (truncate_return_results) {
+               BCREG result_count = this->func_state.return_declared_count;
+               BCREG fixed_count = last.u.s.aux - return_base;
+               BCREG call_count = result_count > fixed_count ? result_count - fixed_count : 0;
+               setbc_b(ir_bcptr(&this->func_state, &last), call_count + 1);
+               ins = result_count > 0 ?
+                  BCINS_AD(BC_RET, return_base, result_count + 1) :
+                  BCINS_AD(BC_RET0, 0, 1);
+            }
+            else {
+               setbc_b(ir_bcptr(&this->func_state, &last), 0);
+               // Variadic tail - count unknown, skip typefix for safety
+               ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
+            }
          }
          else {
             this->materialise_to_next_reg(last, "return tail value");
             if (needs_typefix) {
                auto typefix_count = std::min(count.raw(), BCREG(PROTO_MAX_RETURN_TYPES));
-               bcemit_AD(&this->func_state, BC_TYPEFIX, this->func_state.varmap.size(), typefix_count);
+               bcemit_AD(&this->func_state, BC_TYPEFIX, return_base, typefix_count);
             }
-            ins = BCINS_AD(BC_RET, this->func_state.varmap.size(), count + 1);
+            ins = BCINS_AD(BC_RET, return_base, count + 1);
          }
       }
    }
 
+   if (truncate_return_results and bc_op(ins) IS BC_RET) {
+      BCREG result_count = this->func_state.return_declared_count;
+      if (bc_d(ins) - 1 > result_count) setbc_d(&ins, result_count + 1);
+   }
+
    snapshot_return_regs(&this->func_state, &ins);
+   bool preserve_multres = bc_op(ins) IS BC_RETM and cleanup_temp_regs > 0;
+   if (preserve_multres) bcemit_AD(&this->func_state, BC_MRSAVE, multres_slot, 0);
+   if (preserve_multres) this->func_state.freereg = BCREG(this->func_state.varmap.size());
    // Both __close and defer handlers must run before returning from function.
    // Order: closes before defers (LIFO - most recently declared runs first).
    execute_closes(&this->func_state, 0);
@@ -1033,6 +1102,35 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
    }
 
    if (this->func_state.flags & PROTO_CHILD) bcemit_AJ(&this->func_state, BC_UCLO, 0, 0);
+   if (preserve_multres) bcemit_AD(&this->func_state, BC_MRRESTORE, multres_slot, 0);
+
+   if (has_return_contract and bc_op(ins) != BC_RET0) {
+      std::array<RuntimeContract, MAX_RETURN_TYPES> contracts;
+      for (uint8_t i = 0; i < this->func_state.return_contract_count; ++i) {
+         contracts[i] = RuntimeContract{
+            .type = this->func_state.return_types[i],
+            .struct_def = this->func_state.return_struct_defs[i],
+            .label = nullptr,
+            .boundary = ContractBoundary::Result,
+            .position = uint8_t(i + 1),
+            .nullable = true,
+            .required = false
+         };
+      }
+
+      BCOp return_op = bc_op(ins);
+      BCREG return_base = bc_a(ins);
+      bool dynamic_count = return_op IS BC_RETM;
+      BCREG static_count = 0;
+      if (return_op IS BC_RET1) static_count = 1;
+      else if (return_op IS BC_RET) static_count = bc_d(ins) - 1;
+      else if (return_op IS BC_RETM) static_count = bc_d(ins);
+
+      bcemit_contract(&this->func_state, return_base,
+         std::span(contracts.data(), this->func_state.return_contract_count), static_count, dynamic_count,
+         this->func_state.return_contract_variadic);
+   }
+
    bcemit_INS(&this->func_state, ins);
    this->func_state.reset_freereg();
    return ParserResult<IrEmitUnit>::success(IrEmitUnit{});

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1768,6 +1768,7 @@ LexState::LexState(lua_State* L, const char* BytecodePtr, GCstr* ChunkName)
    , pending_token_offset(0)
    , active_context(nullptr)
 {
+   this->bytecode_version = BCDUMP_VERSION;
    lj_buf_init(L, &this->sb);
    setnilV(&this->tokval);
    setnilV(&this->lookaheadval);

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1721,8 +1721,8 @@ LexState::LexState(lua_State* L, std::string_view Source, std::string_view Chunk
          lj_err_throw(L, LUA_ERRSYNTAX);
       }
       this->is_bytecode = 1;
-      // Set up p/pe for bytecode reader compatibility (lj_bcread uses these)
-      this->p = this->source.data();
+      // The signature byte is already held in c, matching the streaming lexer contract expected by lj_bcread.
+      this->p = this->source.data() + 1;
       this->pe = this->source.data() + this->source.size();
    }
 }

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -126,6 +126,7 @@ public:
    BCInsLine* bc_stack;       // Stack for bytecode instructions/line numbers.
    MSize      size_bc_stack;  // Size of bytecode stack.
    uint32_t   level;          // Syntactical nesting level.
+   uint8_t    bytecode_version = 0; // Private bytecode format version while reading a binary chunk.
    uint32_t   ternary_depth;  // Number of pending ternary operators.
    uint8_t    pending_if_empty_colon; // Tracks ?: misuse after ??.
    int        is_bytecode;    // Set to 1 if input is bytecode, 0 if source text.

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -158,6 +158,7 @@ public:
       TiriType primary = TiriType::Unknown;
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
+      bool explicit_contract = false;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;
    std::vector<StructFieldDocumentation> struct_field_documentation;

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include "static_type_descriptor.h"
 
 struct struct_record;
 
@@ -197,6 +198,10 @@ enum class TiriType : uint8_t;  // Forward declaration (defined in ast_nodes.h)
 typedef struct VarInfo {
    GCRef name;        //  Local variable name.
    std::array<TiriType, MAX_RETURN_TYPES> result_types{};  // Return types if this variable holds a function
+   StaticValueHandle static_value = 0;
+   StaticResultSetHandle static_results = 0;
+   StaticCallableHandle static_callable = 0;
+   StaticBindingID binding_id = 0;
    BCPOS startpc;     //  First point where the local variable is active.
    BCPOS endpc;       //  First point where the local variable is dead.
    uint8_t slot;      //  Variable slot.

--- a/src/tiri/jit/src/parser/parse_internal.h
+++ b/src/tiri/jit/src/parser/parse_internal.h
@@ -98,6 +98,8 @@ static void bcreg_bump(FuncState *, BCREG n);
 static void bcreg_reserve(FuncState *, BCREG n);
 static void bcreg_free(FuncState *, BCREG reg);
 static void expr_free(FuncState *, ExpDesc* e);
+static void bcemit_contract(FuncState *, BCREG, std::span<const RuntimeContract>, BCREG, bool = false,
+   bool = false);
 
 // Bytecode emission (lj_parse_regalloc.cpp)
 

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -547,18 +547,9 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
 {
    if (Contracts.empty()) return;
 
-   // Predicates without exact trace IR guards remain interpreter-only in Phase 1.
-   bool interpreter_only = DynamicCount;
-   for (const RuntimeContract &contract : Contracts) {
-      if (contract.type IS TiriType::Range or
-          contract.type IS TiriType::Userdata or
-          (contract.type IS TiriType::Struct and contract.struct_def) or
-          contract.type IS TiriType::Func) {
-         interpreter_only = true;
-         break;
-      }
-   }
-   if (interpreter_only) fs->flags |= PROTO_NOJIT;
+   // Dynamic result counts still require interpreter-only MRSAVE/MRRESTORE handling.  Fixed contracts have exact
+   // recorder predicates, including callable values, named structures, ranges and userdata.
+   if (DynamicCount) fs->flags |= PROTO_NOJIT;
 
    std::string descriptor;
    descriptor.reserve(5 + Contracts.size() * 8);

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -605,16 +605,17 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
    return false;
 }
 
-static void bcemit_value_contract(FuncState *fs, ExpDesc *Value, const RuntimeContract &Contract)
+static void bcemit_value_contract(
+   FuncState *fs, ExpDesc *Value, const RuntimeContract &Contract, bool ForceRuntimeCheck = false)
 {
    if (Contract.type IS TiriType::Unknown or Contract.type IS TiriType::Any) return;
-   if (contract_literal_proved(fs, Value, Contract.type)) return;
+   if (contract_literal_proved(fs, Value, Contract.type) and not ForceRuntimeCheck) return;
    if (Value->static_value and fs->ls->active_context) {
       const auto &descriptor = fs->ls->active_context->descriptors().value(Value->static_value);
       bool same_type = descriptor.primary IS Contract.type;
       bool same_struct = Contract.type != TiriType::Struct or descriptor.struct_def IS Contract.struct_def;
       bool same_nullability = descriptor.nullable IS Contract.nullable;
-      if (same_type and same_struct and same_nullability and descriptor.proved()) return;
+      if (same_type and same_struct and same_nullability and descriptor.proved() and not ForceRuntimeCheck) return;
    }
 
    BCREG source = expr_toanyreg(fs, Value);
@@ -684,7 +685,16 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
             .boundary = ContractBoundary::Global,
             .position = 1
          };
-         bcemit_value_contract(fs, RHS, contract);
+         // Global contracts must execute even for statically proved literals so the declaration is attached to the
+         // runtime environment for separately compiled chunks.
+         bcemit_value_contract(fs, RHS, contract, true);
+      }
+      else if (GCstr *contract = lj_tab_get_global_contract(tabref(fs->L->env), LHS->u.sval)) {
+         BCREG source = expr_toanyreg(fs, RHS);
+         ExpDesc descriptor(contract);
+         bcemit_AD(fs, BC_CONTRACT, source, const_str(fs, &descriptor));
+         RHS->k = ExpKind::NonReloc;
+         RHS->u.s.info = source;
       }
       BCREG ra = expr_toanyreg(fs, RHS);
       ins = BCINS_AD(BC_GSET, ra, const_str(fs, LHS));

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -618,6 +618,13 @@ static void bcemit_value_contract(FuncState *fs, ExpDesc *Value, const RuntimeCo
 {
    if (Contract.type IS TiriType::Unknown or Contract.type IS TiriType::Any) return;
    if (contract_literal_proved(fs, Value, Contract.type)) return;
+   if (Value->static_value and fs->ls->active_context) {
+      const auto &descriptor = fs->ls->active_context->descriptors().value(Value->static_value);
+      bool same_type = descriptor.primary IS Contract.type;
+      bool same_struct = Contract.type != TiriType::Struct or descriptor.struct_def IS Contract.struct_def;
+      bool same_nullability = descriptor.nullable IS Contract.nullable;
+      if (same_type and same_struct and same_nullability and descriptor.proved()) return;
+   }
 
    BCREG source = expr_toanyreg(fs, Value);
    bcemit_contract(fs, source, std::span(&Contract, 1), 1);

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -9,6 +9,7 @@
 
 #include <kotuku/main.h>
 #include <format>
+#include <string>
 
 #include "ast/nodes.h"  // For TiriType, tiri_type_to_lj_tag(), type_name()
 #include "lj_err.h"     // For lj_err_throw, ErrMsg
@@ -25,13 +26,9 @@ static void err_type_mismatch(FuncState *fs, TiriType actual_type, TiriType expe
    lj_lex_error(fs->ls, 0, ErrMsg::BADASSIGN, type_name(actual_type).data(), type_name(expected_type).data());
 }
 
-//********************************************************************************************************************
-// Emit a compile-time object class mismatch error.
-// This is called when both LHS and RHS are Object types but have different class IDs.
-
-static void err_object_class_mismatch(FuncState *fs, CLASSID actual_class_id, CLASSID expected_class_id)
+static void err_object_class_mismatch(FuncState *Fs, CLASSID ActualClassId, CLASSID ExpectedClassId)
 {
-   lj_lex_error(fs->ls, 0, ErrMsg::BADCLASS, ResolveClassID(expected_class_id), ResolveClassID(actual_class_id));
+   lj_lex_error(Fs->ls, 0, ErrMsg::BADCLASS, ResolveClassID(ExpectedClassId), ResolveClassID(ActualClassId));
 }
 
 [[nodiscard]] inline bool is_register_key(int32_t Aux) { return (Aux >= 0) and (Aux <= BCMAX_C); }
@@ -535,6 +532,107 @@ static void expr_toval(FuncState *fs, ExpDesc *e)
 }
 
 //********************************************************************************************************************
+// Encode and emit one portable runtime contract descriptor.
+
+static void contract_append_text(FuncState *fs, std::string &Descriptor, std::string_view Text,
+   const char *Description)
+{
+   if (Text.size() > UINT8_MAX) err_limit(fs, UINT8_MAX, Description);
+   Descriptor.push_back(char(uint8_t(Text.size())));
+   Descriptor.append(Text);
+}
+
+static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeContract> Contracts,
+   BCREG StaticValueCount, bool DynamicCount, bool Variadic)
+{
+   if (Contracts.empty()) return;
+
+   // Predicates without exact trace IR guards remain interpreter-only in Phase 1.
+   bool interpreter_only = DynamicCount;
+   for (const RuntimeContract &contract : Contracts) {
+      if (contract.type IS TiriType::Range or
+          (contract.type IS TiriType::Struct and contract.struct_def) or
+          contract.type IS TiriType::Func) {
+         interpreter_only = true;
+         break;
+      }
+   }
+   if (interpreter_only) fs->flags |= PROTO_NOJIT;
+
+   std::string descriptor;
+   descriptor.reserve(5 + Contracts.size() * 8);
+   descriptor.push_back(char(TIRI_CONTRACT_VERSION));
+   descriptor.push_back(char(uint8_t(Contracts.front().boundary)));
+
+   uint8_t descriptor_flags = 0;
+   if (DynamicCount) descriptor_flags |= contract_flag(ContractDescriptorFlag::DynamicCount);
+   if (Variadic) descriptor_flags |= contract_flag(ContractDescriptorFlag::Variadic);
+   descriptor.push_back(char(descriptor_flags));
+   descriptor.push_back(char(uint8_t(StaticValueCount)));
+   descriptor.push_back(char(uint8_t(Contracts.size())));
+
+   for (const RuntimeContract &contract : Contracts) {
+      descriptor.push_back(char(uint8_t(contract.type)));
+      uint8_t entry_flags = 0;
+      if (contract.nullable) entry_flags |= contract_flag(ContractEntryFlag::Nullable);
+      if (contract.required) entry_flags |= contract_flag(ContractEntryFlag::Required);
+      descriptor.push_back(char(entry_flags));
+      descriptor.push_back(char(contract.position));
+
+      std::string_view struct_name;
+      if (contract.struct_def) struct_name = contract.struct_def->Name;
+      contract_append_text(fs, descriptor, struct_name, "runtime contract structure name");
+
+      std::string_view label;
+      if (contract.label and contract.label != NAME_BLANK) {
+         label = std::string_view(strdata(contract.label), contract.label->len);
+      }
+      contract_append_text(fs, descriptor, label, "runtime contract label");
+   }
+
+   GCstr *encoded = fs->ls->keepstr(std::string_view(descriptor.data(), descriptor.size()));
+   ExpDesc constant(encoded);
+   bcemit_AD(fs, BC_CONTRACT, Base, const_str(fs, &constant));
+}
+
+//********************************************************************************************************************
+// Literal values are closed proofs.  Every other ExpDesc type is advisory and receives a runtime check.
+
+[[nodiscard]] static bool contract_literal_proved(FuncState *fs, ExpDesc *Value, TiriType Expected)
+{
+   if (Value->k IS ExpKind::Nil) return true;
+
+   TiriType actual = TiriType::Unknown;
+   if (Value->k IS ExpKind::False or Value->k IS ExpKind::True) actual = TiriType::Bool;
+   else if (Value->k IS ExpKind::Str) actual = TiriType::Str;
+   else if (Value->k IS ExpKind::Num) actual = TiriType::Num;
+   else return false;
+
+   if (actual IS Expected) return true;
+   err_type_mismatch(fs, actual, Expected);
+   return false;
+}
+
+static void bcemit_value_contract(FuncState *fs, ExpDesc *Value, const RuntimeContract &Contract)
+{
+   if (Contract.type IS TiriType::Unknown or Contract.type IS TiriType::Any) return;
+   if (contract_literal_proved(fs, Value, Contract.type)) return;
+
+   BCREG source = expr_toanyreg(fs, Value);
+   bcemit_contract(fs, source, std::span(&Contract, 1), 1);
+   Value->k = ExpKind::NonReloc;
+   Value->u.s.info = source;
+}
+
+static void check_object_class_assignment(FuncState *Fs, const VarInfo &Variable, const ExpDesc &Value)
+{
+   if (Variable.fixed_type IS TiriType::Object and Variable.object_class_id != CLASSID::NIL and
+       Value.result_type IS TiriType::Object and Value.object_class_id != Variable.object_class_id) {
+      err_object_class_mismatch(Fs, Value.object_class_id, Variable.object_class_id);
+   }
+}
+
+//********************************************************************************************************************
 // Emit store for LHS expression.
 
 static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
@@ -543,103 +641,15 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
    if (LHS->k IS ExpKind::Local) {
       fs->ls->vstack[LHS->u.s.aux].info |= VarInfoFlag::VarReadWrite;
       VarInfo *vinfo = &fs->ls->vstack[LHS->u.s.aux];
-      TiriType fixed = vinfo->fixed_type;
-
-      // Check if this variable has a defined type and needs runtime type checking
-      if ((fixed != TiriType::Unknown) and (fixed != TiriType::Any)) {
-         bool needs_check = true;
-         TiriType static_rhs_type = TiriType::Unknown; // TODO: needs_check can emit simpler tests when RHS type is known.
-
-         // Check for statically-known types - either from literals or from expression result types
-         if (RHS->k IS ExpKind::Nil) {
-            needs_check = false;  // nil is always allowed (clears the variable)
-         }
-         else if (RHS->k IS ExpKind::False or RHS->k IS ExpKind::True) {
-            static_rhs_type = TiriType::Bool;
-            if (fixed IS TiriType::Bool) needs_check = false;
-            else err_type_mismatch(fs, TiriType::Bool, fixed);
-         }
-         else if (RHS->k IS ExpKind::Str) {
-            static_rhs_type = TiriType::Str;
-            if (fixed IS TiriType::Str) needs_check = false;
-            else err_type_mismatch(fs, TiriType::Str, fixed);
-         }
-         else if (RHS->k IS ExpKind::Num) {
-            static_rhs_type = TiriType::Num;
-            if (fixed IS TiriType::Num) needs_check = false;
-            else err_type_mismatch(fs, TiriType::Num, fixed);
-         }
-         // Check if expression has known result type (e.g., from function call with declared return type,
-         // or operators with statically known result types like arithmetic, comparison, concatenation)
-         else if (RHS->result_type != TiriType::Unknown and RHS->result_type != TiriType::Any) {
-            // TODO: For maxing optimisation, uncomment this assert to help find areas where type checks aren't
-            // being handled by the compiler.  Ideally we would handle all type checking at compile time, in which
-            // case this assert is never raised.
-            //fs_check_assert(fs, RHS->result_type IS fixed, "expected function return type (RHS) to match variable (LHS)");
-
-            static_rhs_type = RHS->result_type;
-
-            // If the RHS result type matches the variable's fixed type, skip runtime check
-            // Otherwise, fall through to runtime check (we don't emit compile-time errors for
-            // expression results unless type_confirmed is set, because source location tracking
-            // isn't accurate at this point)
-            needs_check = (RHS->result_type != fixed);
-
-            // For object field accesses with confirmed types from class dictionary lookups,
-            // emit compile-time type mismatch error
-            if (needs_check and RHS->type_confirmed) {
-               err_type_mismatch(fs, RHS->result_type, fixed);
-            }
-
-            // For Object types with known class IDs, check for class mismatch at compile time
-            if (not needs_check and fixed IS TiriType::Object and vinfo->object_class_id != CLASSID::NIL) {
-               if (vinfo->object_class_id != RHS->object_class_id) {
-                  // Object class mismatch - emit compile-time error
-                  err_object_class_mismatch(fs, RHS->object_class_id, vinfo->object_class_id);
-               }
-            }
-         }
-
-         if (needs_check) {
-            // For dynamic values, emit runtime type check
-            // First materialise value to a register
-
-            BCREG src_reg = expr_toanyreg(fs, RHS);
-
-            // Skip type check for nil values (nil is always allowed as a "clear" operation)
-            // BC_ISNEP checks if value != nil, skips next instruction if true (not nil)
-            // We want to skip BC_ISTYPE when value IS nil, so use BC_ISEQP with nil primitive
-
-            ExpDesc nilv(ExpKind::Nil);
-            bcemit_INS(fs, BCINS_AD(BC_ISEQP, src_reg, const_pri(&nilv)));
-            BCPOS skip_pos = bcemit_jmp(fs);
-
-            // Emit type check instruction
-            // For numbers, use BC_ISNUM (because BC_ISTYPE doesn't work for numbers without LJ_DUALNUM)
-            // For other types, use BC_ISTYPE with (base_tag + 1) as the D operand
-
-            if (fixed IS TiriType::Num) {
-               // BC_ISNUM checks if value is a number (any floating point value)
-               // The D operand should be ~LJ_TNUMX + 2 = 16 (see lj_meta_istype which does tp--)
-               bcemit_AD(fs, BC_ISNUM, src_reg, ~LJ_TNUMX + 2);
-            }
-            else {
-               // BC_ISTYPE - the D operand is (base_tag + 1) to match the VM's itype comparison:
-               //   itype = ~base = -(base+1), so itype + (base+1) = 0 when types match
-               uint8_t lj_tag = tiri_type_to_lj_tag(fixed);
-               bcemit_AD(fs, BC_ISTYPE, src_reg, lj_tag + 1);
-            }
-
-            // Patch jump to skip over BC_ISTYPE when value is nil
-            ControlFlowGraph cfg(fs);
-            ControlFlowEdge skip_edge = cfg.make_unconditional(BCPos(skip_pos));
-            skip_edge.patch_here();
-
-            // Update expression state - value is now in src_reg
-            RHS->k = ExpKind::NonReloc;
-            RHS->u.s.info = src_reg;
-         }
-      }
+      check_object_class_assignment(fs, *vinfo, *RHS);
+      RuntimeContract contract{
+         .type = vinfo->fixed_type,
+         .struct_def = vinfo->struct_def,
+         .label = strref(vinfo->name),
+         .boundary = ContractBoundary::Local,
+         .position = uint8_t(vinfo->slot + 1)
+      };
+      bcemit_value_contract(fs, RHS, contract);
 
       expr_free(fs, RHS);
       expr_toreg(fs, RHS, LHS->u.s.info);
@@ -647,6 +657,16 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
    }
    else if (LHS->k IS ExpKind::Upval) {
       fs->ls->vstack[LHS->u.s.aux].info |= VarInfoFlag::VarReadWrite;
+      VarInfo *vinfo = &fs->ls->vstack[LHS->u.s.aux];
+      check_object_class_assignment(fs, *vinfo, *RHS);
+      RuntimeContract contract{
+         .type = vinfo->fixed_type,
+         .struct_def = vinfo->struct_def,
+         .label = strref(vinfo->name),
+         .boundary = ContractBoundary::Upvalue,
+         .position = uint8_t(LHS->u.s.info + 1)
+      };
+      bcemit_value_contract(fs, RHS, contract);
       expr_toval(fs, RHS);
       if (RHS->k <= ExpKind::True) ins = BCINS_AD(BC_USETP, LHS->u.s.info, const_pri(RHS));
       else if (RHS->k IS ExpKind::Str) ins = BCINS_AD(BC_USETS, LHS->u.s.info, const_str(fs, RHS));
@@ -656,6 +676,17 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
    else if (LHS->k IS ExpKind::Global or LHS->k IS ExpKind::Unscoped) {
       // Note: Const global reassignment is checked during type analysis phase
       // Unscoped should normally be resolved in emit_lvalue_expr(), but handle it here defensively
+      if (auto found = fs->ls->global_type_hints.find(LHS->u.sval);
+          found != fs->ls->global_type_hints.end() and found->second.explicit_contract) {
+         RuntimeContract contract{
+            .type = found->second.primary,
+            .struct_def = found->second.struct_def,
+            .label = LHS->u.sval,
+            .boundary = ContractBoundary::Global,
+            .position = 1
+         };
+         bcemit_value_contract(fs, RHS, contract);
+      }
       BCREG ra = expr_toanyreg(fs, RHS);
       ins = BCINS_AD(BC_GSET, ra, const_str(fs, LHS));
    }

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -551,6 +551,7 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
    bool interpreter_only = DynamicCount;
    for (const RuntimeContract &contract : Contracts) {
       if (contract.type IS TiriType::Range or
+          contract.type IS TiriType::Userdata or
           (contract.type IS TiriType::Struct and contract.struct_def) or
           contract.type IS TiriType::Func) {
          interpreter_only = true;

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -898,12 +898,36 @@ GCproto * LexState::fs_finish(BCLine Line)
    if (min_line < fs->linedefined) fs->linedefined = min_line;
 
    BCLine numline = line - fs->linedefined;
-   size_t sizept, ofsk, ofsuv, ofsli, ofsdbg, ofsvar;
+   size_t sizept, ofsk, ofsuv, ofssig, ofsli, ofsdbg, ofsvar;
    GCproto *pt;
 
    // Apply final fixups.
 
    fs_fixup_ret(fs);
+
+   // Finalise the canonical result signature.  Unannotated functions reserve the bounded result prefix used by
+   // BC_TYPEFIX; provenance and strength are fixed before publication so runtime inference mutates only the type byte.
+
+   if (not fs->return_contract_explicit and (fs->flags & PROTO_HAS_RETURN)) {
+      fs->signature_flags |= proto_signature_flag(ProtoSignatureFlag::DynamicResults);
+      fs->signature_result_count = 0;
+      fs->signature_result_entry_count = uint8_t(fs->signature_results.size());
+      for (auto &entry : fs->signature_results) {
+         entry = ProtoTypeEntry{
+            .constraint = 0,
+            .type = TiriType::Unknown,
+            .flags = proto_type_flags(true, false, ProtoTypeOrigin::Inferred, ProtoTypeStrength::Advisory)
+         };
+      }
+   }
+
+   lj_assertX(fs->signature_parameters.size() IS fs->numparams,
+      "prototype signature parameter count does not match numparams");
+   const bool has_signature = not fs->signature_parameters.empty() or fs->signature_result_entry_count > 0 or
+      fs->signature_flags != 0;
+   const size_t signature_size = has_signature ?
+      proto_signature_size(fs->signature_parameters.size(), fs->signature_result_entry_count) : 0;
+   lj_assertX(signature_size <= UINT16_MAX, "prototype signature size exceeds uint16_t");
 
    // Capture variable declarations if JOF::DIAGNOSE is enabled.
 
@@ -952,6 +976,9 @@ GCproto * LexState::fs_finish(BCLine Line)
    sizept += fs->nkn * sizeof(TValue);
    ofsuv  = sizept;
    sizept += ((fs->nuv + 1) & ~1) * 2;
+   ofssig = sizept;
+   lj_assertX((ofssig % alignof(ProtoTypeEntry)) IS 0, "prototype signature is not naturally aligned");
+   sizept += signature_size;
    ofsli  = sizept;
    sizept += fs_prep_line(fs);
    ofsdbg = sizept;
@@ -960,6 +987,7 @@ GCproto * LexState::fs_finish(BCLine Line)
    // Allocate prototype and initialize its fields.
 
    pt = (GCproto *)lj_mem_newgco(L, MSize(sizept));
+   proto_metadata_init(pt);
    pt->gct       = ~LJ_TPROTO;
    pt->sizept    = MSize(sizept);
    pt->trace     = 0;
@@ -968,6 +996,28 @@ GCproto * LexState::fs_finish(BCLine Line)
    pt->framesize = fs->framesize;
    pt->file_source_idx = this->current_file_index;  // FileSource tracking for error reporting
    setgcref(pt->chunk_name, obj2gco(this->chunk_name));
+
+   if (has_signature) {
+      auto signature = (ProtoSignature *)((char *)pt + ofssig);
+      signature->version = PROTO_SIGNATURE_VERSION;
+      signature->flags = fs->signature_flags;
+      signature->parameter_count = uint8_t(fs->signature_parameters.size());
+      signature->result_count = fs->signature_result_count;
+      signature->result_entry_count = fs->signature_result_entry_count;
+      memset(signature->reserved, 0, sizeof(signature->reserved));
+
+      auto parameters = (ProtoTypeEntry *)(signature + 1);
+      if (not fs->signature_parameters.empty()) {
+         memcpy(parameters, fs->signature_parameters.data(),
+            fs->signature_parameters.size() * sizeof(ProtoTypeEntry));
+      }
+      if (fs->signature_result_entry_count > 0) {
+         memcpy(parameters + fs->signature_parameters.size(), fs->signature_results.data(),
+            fs->signature_result_entry_count * sizeof(ProtoTypeEntry));
+      }
+      setmref(pt->signature, signature);
+      pt->signature_size = uint16_t(signature_size);
+   }
 
    // Register the function name if one was provided (for named function declarations).
 
@@ -985,8 +1035,6 @@ GCproto * LexState::fs_finish(BCLine Line)
          pt->closeslots |= (1ULL << slot);
       }
    }
-
-   pt->result_types = fs->return_types;
 
    // Copy try-except metadata to prototype.  These arrays are allocated separately and freed with the proto via the GC.
 
@@ -1009,20 +1057,6 @@ GCproto * LexState::fs_finish(BCLine Line)
       pt->try_block_count   = 0;
       pt->try_handler_count = 0;
    }
-
-   // Set PROTO_TYPEFIX flag for runtime type inference if:
-   // 1. The function has NO explicit return type annotations, AND
-   // 2. At least one return statement exists (has values to infer)
-
-   bool has_explicit = false;
-   for (size_t i = 0; i < fs->return_types.size(); ++i) {
-      if (fs->return_types[i] != TiriType::Unknown) {
-         has_explicit = true;
-         break;
-      }
-   }
-
-   if (not has_explicit and (fs->flags & PROTO_HAS_RETURN)) pt->flags |= PROTO_TYPEFIX;
 
    // Close potentially uninitialized gap between bc and kgc.
 

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -105,6 +105,10 @@ void LexState::var_add(BCREG nvars)
       v->object_class_id = CLASSID::NIL;
       v->struct_def = nullptr;
       v->result_types.fill(TiriType::Unknown);  // No return type info for non-functions
+      v->static_value = 0;
+      v->static_results = 0;
+      v->static_callable = 0;
+      v->binding_id = 0;
    }
 }
 
@@ -191,6 +195,8 @@ static MSize var_lookup_(LexState* ls, GCstr* name, ExpDesc* e)
          e->result_type = vinfo.fixed_type;
          e->object_class_id = vinfo.object_class_id;
          e->struct_def = vinfo.struct_def;
+         e->static_value = vinfo.static_value;
+         e->static_results = vinfo.static_results;
 
          // If found in outer function, create upvalues in all intervening functions
          if (not is_current) {

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -16,6 +16,7 @@
 #include <ranges>
 #include "../bytecode/lj_bc.h"
 #include "../runtime/lj_contract.h"
+#include "static_type_descriptor.h"
 
 // Forward declarations
 class LexState;
@@ -233,6 +234,8 @@ struct ExpDesc {
    TiriType result_type = TiriType::Unknown;  // Known result type (for Call: callee's first return type)
    CLASSID object_class_id = CLASSID::NIL; // CLASSID for Object result types
    struct_record *struct_def = nullptr; // Resolved layout for Struct result types
+   StaticValueHandle static_value = 0;
+   StaticResultSetHandle static_results = 0;
    uint32_t struct_field_index = 0xFFFFFFFFu; // Pre-resolved field index for STGETF/STSETF
    bool type_confirmed = false;  // True if result_type is confirmed from class dictionary lookup
    BCPOS t;        // True condition jump list.
@@ -295,6 +298,8 @@ struct ExpDesc {
       this->u.s.info = info;
       this->flags = ExprFlag::None;
       this->result_type = TiriType::Unknown;
+      this->static_value = 0;
+      this->static_results = 0;
       this->f = this->t = NO_JMP;
    }
 

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -15,6 +15,7 @@
 #include <variant>
 #include <ranges>
 #include "../bytecode/lj_bc.h"
+#include "../runtime/lj_contract.h"
 
 // Forward declarations
 class LexState;
@@ -78,6 +79,19 @@ enum class VarInfoFlag : uint8_t {
    DeferArg = 0x10u,
    Close = 0x20u,
    Const = 0x40u  // Variable is const (cannot be reassigned)
+};
+
+// Transient parser-side form of a runtime contract.  The raw structure definition is used only while compiling;
+// bcemit_contract() serialises its stable name into an interned descriptor before emitting bytecode.
+
+struct RuntimeContract {
+   TiriType type = TiriType::Unknown;
+   struct_record *struct_def = nullptr;
+   GCstr *label = nullptr;
+   ContractBoundary boundary = ContractBoundary::Local;
+   uint8_t position = 0;
+   bool nullable = true;
+   bool required = false;
 };
 
 // Concept for flag types that support bitwise operations

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -50,6 +50,8 @@ static const struct {
 #include "parse_internal.h"
 #include "parser_symbols.h"
 #include "parser_profiler.h"
+#include "static_type_descriptor.h"
+#include "static_descriptor_analysis.h"
 #include "value_categories.h"
 #include "../../../defs.h"
 
@@ -57,6 +59,8 @@ static const struct {
 #include "token_stream.cpp"
 #include "parser_diagnostics.cpp"
 #include "parser_context.cpp"
+#include "static_type_descriptor.cpp"
+#include "static_descriptor_analysis.cpp"
 #include "ast/nodes.cpp"
 #include "ast/builder.cpp"
 #include "parser_symbols.cpp"
@@ -191,6 +195,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
 
    trace_ast_boundary(Context, *chunk, "parse");
    collect_parser_symbols(Context.lua(), Context.lex(), *chunk);
+   discover_static_bindings(Context, *chunk);
 
    if (Context.config().enable_type_analysis) {
       ParserProfiler::StageTimer type_timer = Profiler.stage("type_analysis");
@@ -206,6 +211,8 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
          return;
       }
    }
+
+   propagate_static_descriptors(Context, *chunk);
 
    // Emit bytecode instructions
 

--- a/src/tiri/jit/src/parser/parser_context.cpp
+++ b/src/tiri/jit/src/parser/parser_context.cpp
@@ -32,6 +32,7 @@ ParserContext & ParserContext::operator=(ParserContext &&other) noexcept
       this->previous_context = other.previous_context;
       this->error_rollback_callback = other.error_rollback_callback;
       this->error_rollback_user_data = other.error_rollback_user_data;
+      this->descriptors_ = std::move(other.descriptors_);
       if (this->lex_state) this->lex_state->active_context = this;
       other.lex_state        = nullptr;
       other.func_state       = nullptr;

--- a/src/tiri/jit/src/parser/parser_context.h
+++ b/src/tiri/jit/src/parser/parser_context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -9,6 +10,7 @@
 #include "parser/parser_diagnostics.h"
 #include "parser/token_stream.h"
 #include "parser/parser_profiler.h"
+#include "parser/static_type_descriptor.h"
 
 #ifdef INCLUDE_TIPS
 class TipEmitter;
@@ -104,6 +106,7 @@ public:
       ParserAllocator allocator, ParserConfig config)
       : lex_state(&lex_state), func_state(&func_state), lua_state(&lua_state), allocator(allocator)
       , current_config(config), token_stream(lex_state)
+      , descriptors_(std::make_shared<StaticDescriptorCatalogue>())
    {
       this->diag.set_limit(config.max_diagnostics);
       this->attach_to_lex();
@@ -122,6 +125,7 @@ public:
       , token_stream(other.token_stream), previous_context(other.previous_context)
       , error_rollback_callback(other.error_rollback_callback)
       , error_rollback_user_data(other.error_rollback_user_data)
+      , descriptors_(std::move(other.descriptors_))
    {
       if (this->lex_state) this->lex_state->active_context = this;
       other.lex_state = nullptr;
@@ -150,6 +154,9 @@ public:
    inline TokenStreamAdapter & tokens() { return this->token_stream; }
    inline const TokenStreamAdapter & tokens() const { return this->token_stream; }
    inline const ParserConfig & config() const { return this->current_config; }
+   inline StaticDescriptorCatalogue & descriptors() { return *this->descriptors_; }
+   inline const StaticDescriptorCatalogue & descriptors() const { return *this->descriptors_; }
+   inline void share_descriptors(const ParserContext &Parent) { this->descriptors_ = Parent.descriptors_; }
    inline ParserProfilingResult & profiling_result() { return this->current_config.profiling_result; }
    inline const ParserProfilingResult & profiling_result() const { return this->current_config.profiling_result; }
    inline void override_config(const ParserConfig& config) { this->current_config = config; this->diag.set_limit(config.max_diagnostics); }
@@ -210,6 +217,7 @@ private:
    ErrorRollbackCallback error_rollback_callback = nullptr;
    void *error_rollback_user_data = nullptr;
    std::vector<std::string> import_stack_;  // Stack of imported file paths for circular dependency detection
+   std::shared_ptr<StaticDescriptorCatalogue> descriptors_;
 };
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2611,11 +2611,253 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
    return true;
 }
 
+//********************************************************************************************************************
+
+static bool test_static_descriptor_model(kt::Log &Log)
+{
+   StaticValueDescriptor unknown_array;
+   unknown_array.primary = TiriType::Array;
+   unknown_array.proof = StaticProof::Checked;
+
+   StaticValueDescriptor any_array = unknown_array;
+   any_array.array_element = { AET::ANY, TiriType::Any, CLASSID::NIL, nullptr, true };
+   if (unknown_array IS any_array or unknown_array.array_element.known or not any_array.array_element.known) {
+      Log.error("unknown array storage was not distinguished from array<any>");
+      return false;
+   }
+
+   StaticValueDescriptor number;
+   number.primary = TiriType::Num;
+   number.proof = StaticProof::Closed;
+   StaticValueDescriptor checked_number = number;
+   checked_number.proof = StaticProof::Checked;
+   checked_number.nullable = true;
+
+   StaticValueDescriptor joined = join_static_descriptors(number, checked_number);
+   if (joined.primary != TiriType::Num or not joined.nullable or joined.proof != StaticProof::Checked) {
+      Log.error("matching descriptor join lost type, nullability or weakest proof");
+      return false;
+   }
+
+   StaticValueDescriptor text;
+   text.primary = TiriType::Str;
+   text.proof = StaticProof::Closed;
+   joined = join_static_descriptors(number, text);
+   if (joined.primary != TiriType::Any or joined.proof != StaticProof::Advisory) {
+      Log.error("conflicting descriptor join did not degrade to advisory any");
+      return false;
+   }
+
+   struct ArrayMapping {
+      std::string_view name;
+      AET storage;
+      TiriType logical_type;
+   };
+   constexpr std::array<ArrayMapping, 14> mappings = { {
+      { "byte", AET::BYTE, TiriType::Num },
+      { "char", AET::BYTE, TiriType::Num },
+      { "int16", AET::INT16, TiriType::Num },
+      { "int", AET::INT32, TiriType::Num },
+      { "int64", AET::INT64, TiriType::Num },
+      { "float", AET::FLOAT, TiriType::Num },
+      { "double", AET::DOUBLE, TiriType::Num },
+      { "string", AET::STR_GC, TiriType::Str },
+      { "table", AET::TABLE, TiriType::Table },
+      { "array", AET::ARRAY, TiriType::Array },
+      { "object", AET::OBJECT, TiriType::Object },
+      { "any", AET::ANY, TiriType::Any },
+      { "pointer", AET::PTR, TiriType::Any },
+      { "struct<Missing>", AET::STRUCT, TiriType::Struct }
+   } };
+   for (const auto &mapping : mappings) {
+      auto element = describe_array_element(mapping.name, nullptr);
+      if (not element or element->storage != mapping.storage or element->logical_type != mapping.logical_type) {
+         Log.error("array source/storage/logical type mapping is incomplete for %s",
+            std::string(mapping.name).c_str());
+         return false;
+      }
+   }
+   if (describe_array_element("unsupported", nullptr)) {
+      Log.error("unsupported array storage name unexpectedly produced a descriptor");
+      return false;
+   }
+   return true;
+}
+
+static bool test_static_result_set_model(kt::Log &Log)
+{
+   StaticResultSet fixed;
+   fixed.declared_count = 3;
+   fixed.stored_count = 3;
+   fixed.values[0] = StaticValueDescriptor{ .primary = TiriType::Num, .proof = StaticProof::Checked };
+   fixed.values[1] = StaticValueDescriptor{ .primary = TiriType::Str, .proof = StaticProof::Checked };
+   fixed.values[2] = StaticValueDescriptor{ .primary = TiriType::Table, .proof = StaticProof::Checked };
+
+   if (fixed.value_at(3).primary != TiriType::Nil or not fixed.value_at(3).nullable) {
+      Log.error("fixed result set did not return closed nil beyond its arity");
+      return false;
+   }
+
+   fixed.variadic = true;
+   if (fixed.value_at(7).primary != TiriType::Table) {
+      Log.error("variadic result set did not repeat its suffix descriptor");
+      return false;
+   }
+
+   fixed.variadic = false;
+   fixed.dynamic = true;
+   if (fixed.value_at(7).primary != TiriType::Any or fixed.value_at(7).proof != StaticProof::Advisory) {
+      Log.error("dynamic result set did not return advisory any beyond stored positions");
+      return false;
+   }
+
+   fixed.dynamic = false;
+   StaticResultSet filtered = map_static_result_filter(fixed, uint64_t(0b101), 3, false);
+   if (filtered.stored_count != 2 or filtered.value_at(0).primary != TiriType::Num or
+       filtered.value_at(1).primary != TiriType::Table) {
+      Log.error("result filter mapping shifted or lost positional descriptors");
+      return false;
+   }
+   return true;
+}
+
+static size_t count_opcode(const BytecodeSnapshot &Snapshot, BCOp Opcode)
+{
+   size_t count = 0;
+   for (BCIns instruction : Snapshot.instructions) {
+      if (bc_op(instruction) IS Opcode) ++count;
+   }
+   return count;
+}
+
+static size_t count_opcode_tree(const BytecodeSnapshot &Snapshot, BCOp Opcode)
+{
+   size_t count = count_opcode(Snapshot, Opcode);
+   for (const auto &child : Snapshot.children) count += count_opcode_tree(child, Opcode);
+   return count;
+}
+
+static bool test_type_guided_emission(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   std::string error;
+   constexpr std::string_view source =
+      "extern array\n"
+      "local function read(Values:array):num\n"
+      "   return Values[0]\n"
+      "end\n"
+      "local alias = read\n"
+      "local alias_two = alias\n"
+      "local result:num = 0\n"
+      "result = alias_two(array<int> { 7 })\n"
+      "return result\n";
+
+   auto snapshot = compile_snapshot(L, source, true, error);
+   if (not snapshot or snapshot->children.empty()) {
+      Log.error("failed to compile stable-alias emission fixture: %s", error.c_str());
+      return false;
+   }
+   if (count_opcode(snapshot->children.front(), BC_AGETB) + count_opcode(snapshot->children.front(), BC_AGETV) IS 0) {
+      Log.error("checked array parameter did not select specialised array access");
+      return false;
+   }
+   if (count_opcode(*snapshot, BC_CONTRACT) != 0) {
+      Log.error("stable checked call result retained a redundant local store contract");
+      return false;
+   }
+
+   constexpr std::string_view mismatch =
+      "local function typed(Value:num):num return Value end\n"
+      "local callback = typed\n"
+      "return callback('wrong')\n";
+   if (compile_snapshot(L, mismatch, true, error)) {
+      Log.error("stable callable alias lost compile-time argument diagnostics");
+      return false;
+   }
+
+   constexpr std::string_view mutable_alias =
+      "local function typed(Value:num):num return Value end\n"
+      "local function invoke(Replace:any)\n"
+      "   local callback = typed\n"
+      "   if Replace then callback = (Value => Value) end\n"
+      "   return callback('runtime checked')\n"
+      "end\n"
+      "return invoke(true)\n";
+   if (not compile_snapshot(L, mutable_alias, true, error)) {
+      Log.error("mutable callable alias was incorrectly treated as a stable target: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view dead_write =
+      "local function typed(Value:num):num return Value end\n"
+      "local callback = typed\n"
+      "if false then callback = (Value => Value) end\n"
+      "return callback('still checked')\n";
+   if (compile_snapshot(L, dead_write, true, error)) {
+      Log.error("dead branch write incorrectly invalidated a stable callable alias");
+      return false;
+   }
+
+   constexpr std::string_view specialised_accesses =
+      "extern array\n"
+      "extern obj\n"
+      "struct GuidedLayout Value: int end\n"
+      "local function update_array(Values:array):num\n"
+      "   Values[0] = Values[0] + 1\n"
+      "   return Values?[0]\n"
+      "end\n"
+      "local function update_struct(Value:struct<GuidedLayout>):num\n"
+      "   Value.Value = Value.Value + 1\n"
+      "   return Value.Value\n"
+      "end\n"
+      "local function update_object():num\n"
+      "   local value = obj.new('config')\n"
+      "   value.flags = 1\n"
+      "   return value.flags\n"
+      "end\n";
+   snapshot = compile_snapshot(L, specialised_accesses, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_AGETB) IS 0 or
+       count_opcode_tree(*snapshot, BC_ASETB) IS 0 or count_opcode_tree(*snapshot, BC_ASGETB) IS 0 or
+       count_opcode_tree(*snapshot, BC_STGETF) IS 0 or count_opcode_tree(*snapshot, BC_STSETF) IS 0 or
+       count_opcode_tree(*snapshot, BC_OBGETF) IS 0 or count_opcode_tree(*snapshot, BC_OBSETF) IS 0) {
+      Log.error("proved receivers did not select the complete specialised access families: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view generic_accesses =
+      "local function update(Value:any, Key:any)\n"
+      "   Value.field = 1\n"
+      "   Value[Key] = Value[Key]\n"
+      "   return Value.field\n"
+      "end\n";
+   snapshot = compile_snapshot(L, generic_accesses, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_TGETS) IS 0 or
+       count_opcode_tree(*snapshot, BC_TSETS) IS 0 or count_opcode_tree(*snapshot, BC_TGETV) IS 0 or
+       count_opcode_tree(*snapshot, BC_TSETV) IS 0 or count_opcode_tree(*snapshot, BC_AGETB) != 0 or
+       count_opcode_tree(*snapshot, BC_STGETF) != 0 or count_opcode_tree(*snapshot, BC_OBGETF) != 0) {
+      Log.error("unproved receivers did not retain generic access bytecodes: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view dynamic_contract =
+      "local function store(Value:any):num\n"
+      "   local result:num = Value\n"
+      "   return result\n"
+      "end\n";
+   snapshot = compile_snapshot(L, dynamic_contract, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_CONTRACT) IS 0) {
+      Log.error("an advisory call result incorrectly removed its local store contract: %s", error.c_str());
+      return false;
+   }
+   return true;
+}
+
 }  // namespace
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 32> tests = { {
+   constexpr std::array<TestCase, 35> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2647,7 +2889,10 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "struct_declaration_metadata", test_struct_declaration_metadata },
       { "expdesc_is_falsey", test_expdesc_is_falsey },
       { "if_empty_operator_constants", test_if_empty_operator_constants },
-      { "ternary_falsey_semantics", test_ternary_falsey_semantics }
+      { "ternary_falsey_semantics", test_ternary_falsey_semantics },
+      { "static_descriptor_model", test_static_descriptor_model },
+      { "static_result_set_model", test_static_result_set_model },
+      { "type_guided_emission", test_type_guided_emission }
    } };
 
    // A dummy object is required to manage state.

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1250,11 +1250,13 @@ static bool test_signature_metadata_roundtrip(kt::Log &Log)
    ProtoTypeEntry *mutable_outer_params = proto_parameter_types(outer);
    mutable_outer_params[4].flags =
       proto_type_flags(false, true, ProtoTypeOrigin::Declared, ProtoTypeStrength::Checked);
-   mutable_outer_params[5].constraint = 0xf17e1234;
+   mutable_outer_params[5].constraint = uint32_t(CLASSID::TIME);
    mutable_outer_params[5].flags =
       proto_type_flags(true, false, ProtoTypeOrigin::Declared, ProtoTypeStrength::Trusted);
    if (proto_type_nullable(mutable_outer_params[4]) or not proto_type_required(mutable_outer_params[4]) or
-       proto_type_strength(mutable_outer_params[5]) != ProtoTypeStrength::Trusted) {
+       proto_type_strength(mutable_outer_params[5]) != ProtoTypeStrength::Trusted or
+       CLASSID(mutable_outer_params[5].constraint) != CLASSID::TIME or
+       not ResolveClassID(CLASSID(mutable_outer_params[5].constraint))) {
       Log.error("reserved signature entry states are not independently representable");
       return false;
    }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -10,6 +10,7 @@
 
 #include "lj_bc.h"
 #include "lj_obj.h"
+#include "bytecode/lj_bcdump.h"
 #include "runtime/lj_str.h"
 
 #include <array>
@@ -1153,6 +1154,60 @@ static std::optional<BytecodeSnapshot> compile_snapshot(lua_State* L, std::strin
    return snapshot;
 }
 
+static int bytecode_writer(lua_State *, const void *Data, size_t Size, void *Context)
+{
+   auto *dump = (std::string *)Context;
+   dump->append((const char *)Data, Size);
+   return 0;
+}
+
+static bool snapshot_has_opcode(const BytecodeSnapshot &Snapshot, BCOp Opcode)
+{
+   for (BCIns instruction : Snapshot.instructions) {
+      if (bc_op(instruction) IS Opcode) return true;
+   }
+   for (const BytecodeSnapshot &child : Snapshot.children) {
+      if (snapshot_has_opcode(child, Opcode)) return true;
+   }
+   return false;
+}
+
+static bool test_contract_bytecode_roundtrip(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   constexpr std::string_view source = "function typed(Value:num):num return Value end";
+   if (lua_load(L, source, "contract-roundtrip")) {
+      Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   std::string dump;
+   if (lua_dump(L, bytecode_writer, &dump) != 0) {
+      Log.error("failed to write contract bytecode");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   if (dump.size() < 4 or uint8_t(dump[3]) != BCDUMP_VERSION) {
+      Log.error("contract bytecode has the wrong private format version");
+      return false;
+   }
+   if (lua_load(L, std::string_view(dump.data(), dump.size()), "contract-roundtrip")) {
+      Log.error("failed to reload contract bytecode: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *restored_proto = funcproto(funcV(L->top - 1));
+   BytecodeSnapshot restored = snapshot_proto(restored_proto);
+   lua_pop(L, 1);
+   if (not snapshot_has_opcode(restored, BC_CONTRACT)) {
+      Log.error("reloaded bytecode lost BC_CONTRACT");
+      return false;
+   }
+   return true;
+}
+
 static bool parse_struct_source(lua_State *L, std::string_view Source, std::string &Error)
 {
    StringReaderCtx reader = { Source.data(), Source.size() };
@@ -2069,7 +2124,7 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 25> tests = { {
+   constexpr std::array<TestCase, 26> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2088,6 +2143,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "return_lowering", test_return_lowering },
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
+      { "contract_bytecode_roundtrip", test_contract_bytecode_roundtrip },
       { "state_local_struct_declarations", test_state_local_struct_declarations },
       { "struct_declaration_syntax", test_struct_declaration_syntax },
       { "struct_field_documentation", test_struct_field_documentation },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1161,6 +1161,470 @@ static int bytecode_writer(lua_State *, const void *Data, size_t Size, void *Con
    return 0;
 }
 
+static GCproto * first_child_proto(GCproto *Proto)
+{
+   for (ptrdiff_t i = -ptrdiff_t(Proto->sizekgc); i < 0; ++i) {
+      GCobj *object = proto_kgc(Proto, i);
+      if (object->gch.gct IS uint8_t(~LJ_TPROTO)) return gco_to_proto(object);
+   }
+   return nullptr;
+}
+
+static bool compare_proto_signatures(const GCproto *Left, const GCproto *Right)
+{
+   if (not Left or not Right or Left->signature_size != Right->signature_size) return false;
+   if (Left->signature_size > 0 and
+       memcmp(proto_signature(Left), proto_signature(Right), Left->signature_size) != 0) return false;
+
+   std::vector<const GCproto *> left_children;
+   std::vector<const GCproto *> right_children;
+   for (ptrdiff_t i = -ptrdiff_t(Left->sizekgc); i < 0; ++i) {
+      GCobj *object = proto_kgc(Left, i);
+      if (object->gch.gct IS uint8_t(~LJ_TPROTO)) left_children.push_back(gco_to_proto(object));
+   }
+   for (ptrdiff_t i = -ptrdiff_t(Right->sizekgc); i < 0; ++i) {
+      GCobj *object = proto_kgc(Right, i);
+      if (object->gch.gct IS uint8_t(~LJ_TPROTO)) right_children.push_back(gco_to_proto(object));
+   }
+   if (left_children.size() != right_children.size()) return false;
+   for (size_t i = 0; i < left_children.size(); ++i) {
+      if (not compare_proto_signatures(left_children[i], right_children[i])) return false;
+   }
+   return true;
+}
+
+static bool test_signature_metadata_roundtrip(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   constexpr std::string_view source =
+      "struct SignatureLayout\n"
+      "   Value: int\n"
+      "end\n"
+      "local function outer(Value:num, Flexible:any, Untyped, Item:struct<SignatureLayout>, Generic:struct, "
+      "Object:obj, ...):func\n"
+      "   local function inner(Text:str):<str, num, ...>\n"
+      "      return Text, Value, Value\n"
+      "   end\n"
+      "   return inner\n"
+      "end\n"
+      "return outer\n";
+
+   if (lua_load(L, source, "signature-roundtrip")) {
+      Log.error("failed to compile signature source: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *root = funcproto(funcV(L->top - 1));
+   GCproto *outer = first_child_proto(root);
+   GCproto *inner = outer ? first_child_proto(outer) : nullptr;
+   if (not outer or not inner) {
+      Log.error("signature source did not produce the expected nested prototypes");
+      return false;
+   }
+
+   const ProtoSignature *outer_signature = proto_signature(outer);
+   const ProtoSignature *inner_signature = proto_signature(inner);
+   if (not outer_signature or outer_signature->parameter_count != 6 or outer_signature->result_count != 1 or
+       not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults)) or
+       not (outer_signature->flags & proto_signature_flag(ProtoSignatureFlag::ParameterVariadic))) {
+      Log.error("outer prototype signature header is incomplete");
+      return false;
+   }
+
+   const ProtoTypeEntry *outer_params = proto_parameter_types(outer);
+   if (outer_params[0].type != TiriType::Num or
+       proto_type_origin(outer_params[0]) != ProtoTypeOrigin::Declared or
+       proto_type_strength(outer_params[0]) != ProtoTypeStrength::Checked or
+       outer_params[1].type != TiriType::Any or
+       proto_type_origin(outer_params[1]) != ProtoTypeOrigin::Declared or
+       proto_type_origin(outer_params[2]) != ProtoTypeOrigin::Unspecified or
+       outer_params[3].constraint != struct_key("SignatureLayout") or outer_params[4].type != TiriType::Struct or
+       outer_params[4].constraint != 0 or outer_params[5].type != TiriType::Object or outer_params[5].constraint != 0) {
+      Log.error("outer prototype parameter entries lost type, provenance, strength or constraint data");
+      return false;
+   }
+
+   // Exercise reserved schema states that ordinary annotations do not manufacture in this phase.
+   ProtoTypeEntry *mutable_outer_params = proto_parameter_types(outer);
+   mutable_outer_params[4].flags =
+      proto_type_flags(false, true, ProtoTypeOrigin::Declared, ProtoTypeStrength::Checked);
+   mutable_outer_params[5].constraint = 0xf17e1234;
+   mutable_outer_params[5].flags =
+      proto_type_flags(true, false, ProtoTypeOrigin::Declared, ProtoTypeStrength::Trusted);
+   if (proto_type_nullable(mutable_outer_params[4]) or not proto_type_required(mutable_outer_params[4]) or
+       proto_type_strength(mutable_outer_params[5]) != ProtoTypeStrength::Trusted) {
+      Log.error("reserved signature entry states are not independently representable");
+      return false;
+   }
+
+   if (not inner_signature or inner_signature->parameter_count != 1 or inner_signature->result_count != 2 or
+       inner_signature->result_entry_count != 2 or
+       not (inner_signature->flags & proto_signature_flag(ProtoSignatureFlag::ResultVariadic))) {
+      Log.error("inner prototype result signature is incomplete");
+      return false;
+   }
+
+   for (int strip : { 0, 1 }) {
+      std::string dump;
+      if (lj_bcwrite(L, root, bytecode_writer, &dump, strip) != 0) {
+         Log.error("failed to write %s signature dump", strip ? "stripped" : "unstripped");
+         return false;
+      }
+      if (dump.size() < 4 or uint8_t(dump[3]) != BCDUMP_VERSION) {
+         Log.error("signature dump has the wrong private format version");
+         return false;
+      }
+      if (lua_load(L, std::string_view(dump.data(), dump.size()), "signature-roundtrip")) {
+         Log.error("failed to reload %s signature dump: %s", strip ? "stripped" : "unstripped",
+            lua_tostring(L, -1));
+         return false;
+      }
+      GCproto *restored = funcproto(funcV(L->top - 1));
+      bool equal = compare_proto_signatures(root, restored);
+      lua_pop(L, 1);
+      if (not equal) {
+         Log.error("%s signature dump changed prototype metadata", strip ? "stripped" : "unstripped");
+         return false;
+      }
+   }
+
+   lua_pop(L, 1);
+   return true;
+}
+
+static bool test_legacy_signature_defaults(kt::Log &Log)
+{
+   // Generated by the 0x81 writer from:
+   // function legacy(Value:num):num return Value end
+   // SHA-256: 91f984a833f8a8045e736aea956813bf9e6f18ffc6b6bee8d5a5f55f7534d250
+   constexpr uint8_t legacy_dump[] = {
+      0x1b, 0x4c, 0x4a, 0x81, 0x08, 0x07, 0x3d, 0x73, 0x63, 0x72, 0x69, 0x70,
+      0x74, 0x5e, 0x00, 0x01, 0x02, 0x00, 0x02, 0x00, 0x04, 0x19, 0x01, 0x00,
+      0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0x01, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x74, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x5a, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x01, 0x02, 0x00,
+      0x01, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0x14, 0x01, 0x01, 0x00, 0x01,
+      0x01, 0x03, 0x01, 0x01, 0x00, 0x05, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x01,
+      0x00, 0x00, 0xff, 0x01, 0x00, 0x00, 0xff, 0x01, 0x00, 0x00, 0xff, 0x01,
+      0x00, 0x00, 0xff, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x00, 0x01, 0x04, 0x00,
+      0x00
+   };
+
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   std::string_view dump((const char *)legacy_dump, sizeof(legacy_dump));
+   if (lua_load(L, dump, "legacy-signature")) {
+      Log.error("failed to load the 0x81 signature fixture: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *restored = funcproto(funcV(L->top - 1));
+   const ProtoSignature *signature = proto_signature(restored);
+   const ProtoTypeEntry *parameters = proto_parameter_types(restored);
+   if (not signature or signature->parameter_count != 1 or signature->result_entry_count != 0 or
+       parameters[0].type != TiriType::Any or
+       proto_type_origin(parameters[0]) != ProtoTypeOrigin::Unspecified or
+       proto_type_strength(parameters[0]) != ProtoTypeStrength::Advisory) {
+      Log.error("the 0x81 fixture did not receive safe advisory signature defaults");
+      return false;
+   }
+
+   lua_pushstring(L, "wrong");
+   if (lua_pcall(L, 1, 1, 0) IS 0) {
+      Log.error("legacy BC_CONTRACT enforcement was lost");
+      return false;
+   }
+   lua_pop(L, 1);
+   return true;
+}
+
+static bool test_signature_runtime_inference(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   constexpr std::string_view source = "return function(Value) return Value end";
+   if (lua_load(L, source, "signature-inference") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the inference function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCfunc *function = funcV(L->top - 1);
+   GCproto *prototype = funcproto(function);
+   lua_pushvalue(L, -1);
+   lua_pushnumber(L, 7);
+   if (lua_pcall(L, 1, 1, 0)) {
+      Log.error("failed to execute the inference function: %s", lua_tostring(L, -1));
+      return false;
+   }
+   lua_pop(L, 1);
+
+   ProtoTypeEntry inferred = proto_result_type(prototype, 0);
+   if (inferred.type != TiriType::Num or proto_type_origin(inferred) != ProtoTypeOrigin::Inferred or
+       proto_type_strength(inferred) != ProtoTypeStrength::Advisory) {
+      Log.error("runtime inference did not remain advisory");
+      return false;
+   }
+
+   std::string dump;
+   if (lj_bcwrite(L, prototype, bytecode_writer, &dump, 1) != 0) {
+      Log.error("failed to write the inferred signature");
+      return false;
+   }
+   if (lua_load(L, std::string_view(dump.data(), dump.size()), "signature-inference")) {
+      Log.error("failed to round-trip the inferred signature: %s", lua_tostring(L, -1));
+      return false;
+   }
+   GCproto *restored = funcproto(funcV(L->top - 1));
+   bool equal = compare_proto_signatures(prototype, restored);
+   lua_pop(L, 2);
+   if (not equal) {
+      Log.error("runtime-inferred signature changed during serialisation");
+      return false;
+   }
+   return true;
+}
+
+static bool test_signature_void_and_bare_return(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+
+   constexpr std::string_view empty_source = "return function() local value = 1 end";
+   if (lua_load(L, empty_source, "signature-empty") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the empty-signature function: %s", lua_tostring(L, -1));
+      return false;
+   }
+   GCproto *empty_proto = funcproto(funcV(L->top - 1));
+   if (proto_signature(empty_proto)) {
+      Log.error("an untyped function without formal parameters or result observations received a signature");
+      return false;
+   }
+   std::string empty_dump;
+   if (lj_bcwrite(L, empty_proto, bytecode_writer, &empty_dump, 1) != 0 or
+       lua_load(L, std::string_view(empty_dump.data(), empty_dump.size()), "signature-empty")) {
+      Log.error("failed to round-trip the empty signature");
+      return false;
+   }
+   GCproto *restored_empty = funcproto(funcV(L->top - 1));
+   if (not compare_proto_signatures(empty_proto, restored_empty)) {
+      Log.error("the empty signature changed during serialisation");
+      return false;
+   }
+   lua_pop(L, 2);
+
+   constexpr std::string_view void_source = "return function():<> return 17 end";
+   if (lua_load(L, void_source, "signature-void") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the explicit-void function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *void_proto = funcproto(funcV(L->top - 1));
+   const ProtoSignature *void_signature = proto_signature(void_proto);
+   if (not void_signature or void_signature->result_count != 0 or void_signature->result_entry_count != 0 or
+       not (void_signature->flags & proto_signature_flag(ProtoSignatureFlag::ExplicitResults)) or
+       (void_signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults))) {
+      Log.error("explicit void was not preserved as a distinct signature");
+      return false;
+   }
+
+   lua_pushvalue(L, -1);
+   if (lua_pcall(L, 0, 1, 0) or not lua_isnil(L, -1)) {
+      Log.error("the explicit-void function did not truncate its result");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   std::string void_dump;
+   if (lj_bcwrite(L, void_proto, bytecode_writer, &void_dump, 1) != 0 or
+       lua_load(L, std::string_view(void_dump.data(), void_dump.size()), "signature-void")) {
+      Log.error("failed to round-trip the explicit-void signature");
+      return false;
+   }
+   GCproto *restored_void = funcproto(funcV(L->top - 1));
+   if (not compare_proto_signatures(void_proto, restored_void)) {
+      Log.error("the explicit-void signature changed during serialisation");
+      return false;
+   }
+   lua_pop(L, 2);
+
+   constexpr std::string_view bare_source = "return function() return end";
+   if (lua_load(L, bare_source, "signature-bare-return") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the bare-return function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *bare_proto = funcproto(funcV(L->top - 1));
+   const ProtoSignature *bare_signature = proto_signature(bare_proto);
+   if (not bare_signature or
+       not (bare_signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults))) {
+      Log.error("a bare return did not retain its dynamic advisory result signature");
+      return false;
+   }
+
+   std::string bare_dump;
+   if (lj_bcwrite(L, bare_proto, bytecode_writer, &bare_dump, 1) != 0 or
+       lua_load(L, std::string_view(bare_dump.data(), bare_dump.size()), "signature-bare-return")) {
+      Log.error("failed to round-trip the bare-return signature");
+      return false;
+   }
+   GCproto *restored_bare = funcproto(funcV(L->top - 1));
+   bool equal = compare_proto_signatures(bare_proto, restored_bare);
+   lua_pop(L, 2);
+   if (not equal) {
+      Log.error("the bare-return signature changed during serialisation");
+      return false;
+   }
+
+   constexpr std::string_view wide_source =
+      "return function():<num, num, num, num, num, num, num, num, num>\n"
+      "   return 1, 2, 3, 4, 5, 6, 7, 8, 9\n"
+      "end";
+   if (lua_load(L, wide_source, "signature-wide-results") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the wide-result function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *wide_proto = funcproto(funcV(L->top - 1));
+   const ProtoSignature *wide_signature = proto_signature(wide_proto);
+   ProtoTypeEntry implicit_result = proto_result_type(wide_proto, 8);
+   if (not wide_signature or wide_signature->result_count != 9 or
+       wide_signature->result_entry_count != PROTO_MAX_RETURN_TYPES or implicit_result.type != TiriType::Any or
+       proto_type_origin(implicit_result) != ProtoTypeOrigin::Declared or
+       proto_type_strength(implicit_result) != ProtoTypeStrength::Advisory) {
+      Log.error("the wide-result signature did not preserve complete arity and its implicit any suffix");
+      return false;
+   }
+
+   std::string wide_dump;
+   if (lj_bcwrite(L, wide_proto, bytecode_writer, &wide_dump, 1) != 0 or
+       lua_load(L, std::string_view(wide_dump.data(), wide_dump.size()), "signature-wide-results")) {
+      Log.error("failed to round-trip the wide-result signature");
+      return false;
+   }
+   GCproto *restored_wide = funcproto(funcV(L->top - 1));
+   equal = compare_proto_signatures(wide_proto, restored_wide);
+   lua_pop(L, 2);
+   if (not equal) {
+      Log.error("the wide-result signature changed during serialisation");
+      return false;
+   }
+   return true;
+}
+
+static bool test_malformed_signature_rejected(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   constexpr std::string_view source = "return function(Value:num):num return Value end";
+   if (lua_load(L, source, "signature-malformed") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the malformed-signature fixture: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   std::string dump;
+   if (lj_bcwrite(L, funcproto(funcV(L->top - 1)), bytecode_writer, &dump, 1) != 0) {
+      Log.error("failed to write the malformed-signature fixture");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   auto read_uleb = [&dump](size_t &Position, uint32_t &Value) {
+      Value = 0;
+      uint32_t shift = 0;
+      for (uint32_t count = 0; count < 5 and Position < dump.size(); ++count) {
+         uint8_t byte = uint8_t(dump[Position++]);
+         Value |= uint32_t(byte & 0x7f) << shift;
+         if (not (byte & 0x80)) return true;
+         shift += 7;
+      }
+      return false;
+   };
+
+   size_t position = 5;
+   uint32_t value = 0;
+   if (not read_uleb(position, value) or position + 4 > dump.size()) {
+      Log.error("could not locate the prototype header in the malformed-signature fixture");
+      return false;
+   }
+   position += 4;
+   size_t signature_length_offset = 0;
+   for (int field = 0; field < 4; ++field) {
+      if (field IS 3) signature_length_offset = position;
+      if (not read_uleb(position, value)) {
+         Log.error("could not locate the signature in the malformed-signature fixture");
+         return false;
+      }
+   }
+   size_t signature_offset = position;
+   if (signature_offset + 5 >= dump.size()) {
+      Log.error("malformed-signature fixture has no signature payload");
+      return false;
+   }
+
+   std::string bad_version = dump;
+   bad_version[signature_offset] = char(0xff);
+   if (lua_load(L, std::string_view(bad_version.data(), bad_version.size()), "signature-bad-version") IS 0) {
+      Log.error("the bytecode reader accepted an unsupported signature version");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   size_t entry_offset = signature_offset + 2;
+   for (int field = 0; field < 3; ++field) {
+      if (not read_uleb(entry_offset, value)) {
+         Log.error("could not locate the first signature entry");
+         return false;
+      }
+   }
+
+   std::string bad_flags = dump;
+   bad_flags[entry_offset + 1] = char(PROTO_TYPE_NULLABLE | PROTO_TYPE_REQUIRED);
+   if (lua_load(L, std::string_view(bad_flags.data(), bad_flags.size()), "signature-bad-flags") IS 0) {
+      Log.error("the bytecode reader accepted contradictory signature entry flags");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   std::string bad_constraint = dump;
+   bad_constraint[entry_offset + 2] = char(1);
+   if (lua_load(L, std::string_view(bad_constraint.data(), bad_constraint.size()), "signature-bad-constraint") IS 0) {
+      Log.error("the bytecode reader accepted a constraint on a scalar signature entry");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   std::string bad_parameter_count = dump;
+   bad_parameter_count[signature_offset + 2] = char(2);
+   if (lua_load(L, std::string_view(bad_parameter_count.data(), bad_parameter_count.size()),
+       "signature-bad-parameter-count") IS 0) {
+      Log.error("the bytecode reader accepted a signature parameter-count mismatch");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   if (uint8_t(dump[signature_length_offset]) >= 0x7f) {
+      Log.error("the malformed-signature fixture unexpectedly uses a multi-byte signature length");
+      return false;
+   }
+   std::string trailing_data = dump;
+   trailing_data[signature_length_offset] = char(uint8_t(trailing_data[signature_length_offset]) + 1);
+   if (lua_load(L, std::string_view(trailing_data.data(), trailing_data.size()), "signature-trailing-data") IS 0) {
+      Log.error("the bytecode reader accepted trailing signature data");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   std::string bad_type = dump;
+   bad_type[entry_offset] = char(0xff);
+   if (lua_load(L, std::string_view(bad_type.data(), bad_type.size()), "signature-bad-type") IS 0) {
+      Log.error("the bytecode reader accepted an invalid signature type");
+      return false;
+   }
+   lua_pop(L, 1);
+   return true;
+}
+
 static bool snapshot_has_opcode(const BytecodeSnapshot &Snapshot, BCOp Opcode)
 {
    for (BCIns instruction : Snapshot.instructions) {
@@ -2151,7 +2615,7 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 27> tests = { {
+   constexpr std::array<TestCase, 32> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2170,6 +2634,11 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "return_lowering", test_return_lowering },
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
+      { "signature_metadata_roundtrip", test_signature_metadata_roundtrip },
+      { "legacy_signature_defaults", test_legacy_signature_defaults },
+      { "signature_runtime_inference", test_signature_runtime_inference },
+      { "signature_void_and_bare_return", test_signature_void_and_bare_return },
+      { "malformed_signature_rejected", test_malformed_signature_rejected },
       { "contract_bytecode_roundtrip", test_contract_bytecode_roundtrip },
       { "userdata_type_annotations", test_userdata_type_annotations },
       { "state_local_struct_declarations", test_state_local_struct_declarations },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -11,6 +11,7 @@
 #include "lj_bc.h"
 #include "lj_obj.h"
 #include "bytecode/lj_bcdump.h"
+#include "runtime/lj_contract.h"
 #include "runtime/lj_str.h"
 
 #include <array>
@@ -1672,6 +1673,126 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    return true;
 }
 
+static bool test_runtime_contract_decoder(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   std::string encoded{
+      char(TIRI_CONTRACT_VERSION),
+      char(uint8_t(ContractBoundary::Parameter)),
+      char(0),
+      char(1),
+      char(1),
+      char(uint8_t(TiriType::Struct)),
+      char(contract_flag(ContractEntryFlag::Nullable)),
+      char(1),
+      char(5)
+   };
+   encoded += "Point";
+   encoded.push_back(char(5));
+   encoded += "Value";
+
+   RuntimeContractDescriptor decoded;
+   GCstr *descriptor = lj_str_new(lua, encoded.data(), encoded.size());
+   if (not decode_runtime_contract(descriptor, decoded) or
+       decoded.boundary != ContractBoundary::Parameter or decoded.dynamic_count() or decoded.variadic() or
+       decoded.static_value_count != 1 or decoded.contract_count != 1 or
+       decoded.entries[0].type != TiriType::Struct or decoded.entries[0].position != 1 or
+       decoded.entries[0].struct_name != "Point" or decoded.entries[0].label != "Value") {
+      Log.error("valid runtime contract descriptor did not round-trip through the shared decoder");
+      return false;
+   }
+
+   auto rejected = [lua](std::string Bytes) {
+      RuntimeContractDescriptor result;
+      GCstr *value = lj_str_new(lua, Bytes.data(), Bytes.size());
+      return not decode_runtime_contract(value, result);
+   };
+
+   std::string invalid_descriptor_flags = encoded;
+   invalid_descriptor_flags[2] = char(0x80);
+   std::string invalid_entry_flags = encoded;
+   invalid_entry_flags[6] = char(0x80);
+   std::string invalid_position = encoded;
+   invalid_position[7] = char(0);
+   std::string invalid_constraint = encoded;
+   invalid_constraint[5] = char(uint8_t(TiriType::Num));
+   std::string trailing = encoded + "x";
+   std::string truncated = encoded.substr(0, encoded.size() - 1);
+
+   if (not rejected(invalid_descriptor_flags) or not rejected(invalid_entry_flags) or
+       not rejected(invalid_position) or not rejected(invalid_constraint) or not rejected(trailing) or
+       not rejected(truncated)) {
+      Log.error("shared runtime contract decoder accepted malformed input");
+      return false;
+   }
+
+   constexpr std::string_view wide_source =
+      "return function():<num,num,num,num,num,num,num,num,str>\n"
+      "   return 1,2,3,4,5,6,7,8,'ninth',false\n"
+      "end\n";
+   if (lua_load(lua, wide_source, "wide-runtime-contract")) {
+      Log.error("failed to compile a wide runtime contract: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   GCproto *wide = first_child_proto(funcproto(funcV(lua->top - 1)));
+   GCstr *wide_descriptor = nullptr;
+   for (uint32_t i = 1; wide and i < wide->sizebc; ++i) {
+      BCIns instruction = proto_bc(wide)[i];
+      if (bc_op(instruction) IS BC_CONTRACT) {
+         wide_descriptor = gco_to_string(proto_kgc(wide, ~(ptrdiff_t)bc_d(instruction)));
+         break;
+      }
+   }
+   RuntimeContractDescriptor wide_decoded;
+   if (not wide_descriptor or not decode_runtime_contract(wide_descriptor, wide_decoded) or
+       wide_decoded.static_value_count != 9 or wide_decoded.contract_count != MAX_RETURN_TYPES) {
+      Log.error("a valid contract with more values than stored entries failed shared decoding");
+      return false;
+   }
+   lua_pop(lua, 1);
+   return true;
+}
+
+static bool test_complex_contract_jit_eligibility(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   auto compile_child = [lua, &Log](std::string_view Source, const char *Label) -> GCproto * {
+      if (lua_load(lua, Source, Label)) {
+         Log.error("%s failed to compile: %s", Label, lua_tostring(lua, -1));
+         lua_pop(lua, 1);
+         return nullptr;
+      }
+
+      GCproto *child = first_child_proto(funcproto(funcV(lua->top - 1)));
+      lua->top--;
+      return child;
+   };
+
+   GCproto *fixed = compile_child(
+      "return function(Value:func):func\n"
+      "   return Value\n"
+      "end\n",
+      "fixed-complex-contract");
+   if (not fixed or (fixed->flags & PROTO_NOJIT)) {
+      Log.error("a fixed complex contract remained interpreter-only");
+      return false;
+   }
+
+   GCproto *dynamic = compile_child(
+      "return function(...):<num, ...>\n"
+      "   return ...\n"
+      "end\n",
+      "dynamic-result-contract");
+   if (not dynamic or not (dynamic->flags & PROTO_NOJIT)) {
+      Log.error("a dynamic-result contract became JIT-eligible without exact multi-result recorder support");
+      return false;
+   }
+   return true;
+}
+
 //********************************************************************************************************************
 
 static bool test_userdata_type_annotations(kt::Log &Log)
@@ -2857,7 +2978,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 35> tests = { {
+   constexpr std::array<TestCase, 37> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2882,6 +3003,8 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "signature_void_and_bare_return", test_signature_void_and_bare_return },
       { "malformed_signature_rejected", test_malformed_signature_rejected },
       { "contract_bytecode_roundtrip", test_contract_bytecode_roundtrip },
+      { "runtime_contract_decoder", test_runtime_contract_decoder },
+      { "complex_contract_jit_eligibility", test_complex_contract_jit_eligibility },
       { "userdata_type_annotations", test_userdata_type_annotations },
       { "state_local_struct_declarations", test_state_local_struct_declarations },
       { "struct_declaration_syntax", test_struct_declaration_syntax },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1176,7 +1176,7 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *L = state.get();
-   constexpr std::string_view source = "function typed(Value:num):num return Value end";
+   constexpr std::string_view source = "function typed(Value:userdata):userdata return Value end";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -1203,6 +1203,33 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    lua_pop(L, 1);
    if (not snapshot_has_opcode(restored, BC_CONTRACT)) {
       Log.error("reloaded bytecode lost BC_CONTRACT");
+      return false;
+   }
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_userdata_type_annotations(kt::Log &Log)
+{
+   if (parse_type_name("userdata") != TiriType::Userdata or type_name(TiriType::Userdata) != "userdata") {
+      Log.error("userdata type name does not round-trip");
+      return false;
+   }
+   if (uint8_t(TiriType::Range) != 10 or uint8_t(TiriType::Userdata) != 11) {
+      Log.error("userdata changed an existing concrete contract type identifier");
+      return false;
+   }
+
+   constexpr std::string_view source =
+      "function identity(Value:userdata):userdata\n"
+      "   local result:userdata = Value\n"
+      "   return result\n"
+      "end";
+   auto result = build_ast_from_source(source);
+   if (not result.chunk.ok()) {
+      Log.error("failed to parse userdata annotations");
+      log_diagnostics(result.diagnostics, Log);
       return false;
    }
    return true;
@@ -2124,7 +2151,7 @@ static bool test_ternary_falsey_semantics(kt::Log &log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 26> tests = { {
+   constexpr std::array<TestCase, 27> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -2144,6 +2171,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "ast_call_lowering", test_ast_call_lowering },
       { "bytecode_equivalence", test_bytecode_equivalence },
       { "contract_bytecode_roundtrip", test_contract_bytecode_roundtrip },
+      { "userdata_type_annotations", test_userdata_type_annotations },
       { "state_local_struct_declarations", test_state_local_struct_declarations },
       { "struct_declaration_syntax", test_struct_declaration_syntax },
       { "struct_field_documentation", test_struct_field_documentation },

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1,0 +1,1334 @@
+// Stable-binding discovery and parse-time descriptor propagation.
+
+#include "static_descriptor_analysis.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "ast/nodes.h"
+#include "field_type_lookup.h"
+#include "parser_context.h"
+
+namespace {
+
+struct BindingScope {
+   std::vector<std::pair<GCstr *, StaticBindingID>> entries;
+};
+
+class StaticDescriptorAnalyser {
+public:
+   explicit StaticDescriptorAnalyser(ParserContext &Context)
+      : context_(Context), catalogue_(Context.descriptors()) {}
+
+   void discover(BlockStmt &Module)
+   {
+      this->scopes_.clear();
+      this->scopes_.push_back(BindingScope{});
+      this->discover_block(Module, false);
+      this->resolve_all_callables();
+      this->annotate_callables_block(Module);
+   }
+
+   void propagate(BlockStmt &Module)
+   {
+      this->refresh_callables();
+      this->propagate_block(Module);
+   }
+
+private:
+   [[nodiscard]] StaticBindingID resolve(GCstr *Name) const
+   {
+      for (auto scope = this->scopes_.rbegin(); scope != this->scopes_.rend(); ++scope) {
+         for (auto entry = scope->entries.rbegin(); entry != scope->entries.rend(); ++entry) {
+            if (entry->first IS Name) return entry->second;
+         }
+      }
+      return 0;
+   }
+
+   StaticBindingID declare(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition,
+      const FunctionExprPayload *Function = nullptr, bool IsParameter = false)
+   {
+      StaticBindingDescriptor binding;
+      binding.name = Name.symbol;
+      binding.initialiser = Initialiser;
+      binding.function = Function;
+      binding.result_position = ResultPosition;
+      binding.function_depth = this->function_depth_;
+      binding.is_const = Name.has_const;
+      binding.is_parameter = IsParameter;
+      StaticBindingID id = this->catalogue_.add_binding(binding);
+      Name.binding_id = id;
+      if (Name.symbol and not Name.is_blank) this->scopes_.back().entries.emplace_back(Name.symbol, id);
+      return id;
+   }
+
+   void reference(NameRef &Reference, bool Write = false)
+   {
+      StaticBindingID id = this->resolve(Reference.identifier.symbol);
+      Reference.binding_id = id;
+      Reference.identifier.binding_id = id;
+      if (not id) return;
+
+      auto &binding = this->catalogue_.binding(id);
+      if (binding.function_depth < this->function_depth_) binding.captured = true;
+      if (Write) binding.immutable = false;
+   }
+
+   void discover_function(FunctionExprPayload &Function)
+   {
+      this->function_depth_++;
+      this->scopes_.push_back(BindingScope{});
+      for (auto &parameter : Function.parameters) {
+         this->declare(parameter.name, nullptr, 0, nullptr, true);
+      }
+      if (Function.body) this->discover_block(*Function.body, false);
+      this->scopes_.pop_back();
+      this->function_depth_--;
+   }
+
+   void discover_expression(ExprNode &Expression, bool Write = false)
+   {
+      switch (Expression.kind) {
+         case AstNodeKind::IdentifierExpr:
+            this->reference(std::get<NameRef>(Expression.data), Write);
+            break;
+         case AstNodeKind::UnaryExpr: {
+            auto &payload = std::get<UnaryExprPayload>(Expression.data);
+            if (payload.operand) this->discover_expression(*payload.operand);
+            break;
+         }
+         case AstNodeKind::UpdateExpr: {
+            auto &payload = std::get<UpdateExprPayload>(Expression.data);
+            if (payload.target) this->discover_expression(*payload.target, true);
+            break;
+         }
+         case AstNodeKind::BinaryExpr: {
+            auto &payload = std::get<BinaryExprPayload>(Expression.data);
+            if (payload.left) this->discover_expression(*payload.left);
+            if (payload.right) this->discover_expression(*payload.right);
+            break;
+         }
+         case AstNodeKind::ComparisonChainExpr: {
+            for (auto &operand : std::get<ComparisonChainExprPayload>(Expression.data).operands) {
+               if (operand) this->discover_expression(*operand);
+            }
+            break;
+         }
+         case AstNodeKind::TernaryExpr: {
+            auto &payload = std::get<TernaryExprPayload>(Expression.data);
+            if (payload.condition) this->discover_expression(*payload.condition);
+            if (payload.if_true) this->discover_expression(*payload.if_true);
+            if (payload.if_false) this->discover_expression(*payload.if_false);
+            break;
+         }
+         case AstNodeKind::PresenceExpr: {
+            auto &payload = std::get<PresenceExprPayload>(Expression.data);
+            if (payload.value) this->discover_expression(*payload.value);
+            break;
+         }
+         case AstNodeKind::PipeExpr: {
+            auto &payload = std::get<PipeExprPayload>(Expression.data);
+            if (payload.lhs) this->discover_expression(*payload.lhs);
+            if (payload.rhs_call) this->discover_expression(*payload.rhs_call);
+            break;
+         }
+         case AstNodeKind::CallExpr:
+         case AstNodeKind::SafeCallExpr: {
+            auto &payload = std::get<CallExprPayload>(Expression.data);
+            if (auto *direct = std::get_if<DirectCallTarget>(&payload.target)) {
+               if (direct->callable) this->discover_expression(*direct->callable);
+            }
+            else if (auto *method = std::get_if<MethodCallTarget>(&payload.target)) {
+               if (method->receiver) this->discover_expression(*method->receiver);
+            }
+            else if (auto *safe_method = std::get_if<SafeMethodCallTarget>(&payload.target)) {
+               if (safe_method->receiver) this->discover_expression(*safe_method->receiver);
+            }
+            for (auto &argument : payload.arguments) {
+               if (argument) this->discover_expression(*argument);
+            }
+            break;
+         }
+         case AstNodeKind::MemberExpr: {
+            auto &payload = std::get<MemberExprPayload>(Expression.data);
+            if (payload.table) this->discover_expression(*payload.table);
+            break;
+         }
+         case AstNodeKind::IndexExpr: {
+            auto &payload = std::get<IndexExprPayload>(Expression.data);
+            if (payload.table) this->discover_expression(*payload.table);
+            if (payload.index) this->discover_expression(*payload.index);
+            break;
+         }
+         case AstNodeKind::SafeMemberExpr: {
+            auto &payload = std::get<SafeMemberExprPayload>(Expression.data);
+            if (payload.table) this->discover_expression(*payload.table);
+            break;
+         }
+         case AstNodeKind::SafeIndexExpr: {
+            auto &payload = std::get<SafeIndexExprPayload>(Expression.data);
+            if (payload.table) this->discover_expression(*payload.table);
+            if (payload.index) this->discover_expression(*payload.index);
+            break;
+         }
+         case AstNodeKind::ResultFilterExpr: {
+            auto &payload = std::get<ResultFilterPayload>(Expression.data);
+            if (payload.expression) this->discover_expression(*payload.expression);
+            break;
+         }
+         case AstNodeKind::TableExpr: {
+            for (auto &field : std::get<TableExprPayload>(Expression.data).fields) {
+               if (field.key) this->discover_expression(*field.key);
+               if (field.value) this->discover_expression(*field.value);
+            }
+            break;
+         }
+         case AstNodeKind::FunctionExpr:
+            this->discover_function(std::get<FunctionExprPayload>(Expression.data));
+            break;
+         case AstNodeKind::DeferredExpr: {
+            auto &payload = std::get<DeferredExprPayload>(Expression.data);
+            if (payload.inner) this->discover_expression(*payload.inner);
+            break;
+         }
+         case AstNodeKind::RangeExpr: {
+            auto &payload = std::get<RangeExprPayload>(Expression.data);
+            if (payload.start) this->discover_expression(*payload.start);
+            if (payload.stop) this->discover_expression(*payload.stop);
+            if (payload.step) this->discover_expression(*payload.step);
+            break;
+         }
+         case AstNodeKind::ChooseExpr: {
+            auto &payload = std::get<ChooseExprPayload>(Expression.data);
+            if (payload.scrutinee) this->discover_expression(*payload.scrutinee);
+            for (auto &item : payload.scrutinee_tuple) if (item) this->discover_expression(*item);
+            for (auto &choice : payload.cases) {
+               if (choice.pattern) this->discover_expression(*choice.pattern);
+               for (auto &item : choice.tuple_patterns) if (item) this->discover_expression(*item);
+               if (choice.guard) this->discover_expression(*choice.guard);
+               if (choice.result) this->discover_expression(*choice.result);
+               if (choice.result_stmt) this->discover_statement(*choice.result_stmt);
+            }
+            break;
+         }
+         default:
+            break;
+      }
+   }
+
+   void discover_block(BlockStmt &Block, bool NewScope = true)
+   {
+      if (NewScope) this->scopes_.push_back(BindingScope{});
+      for (auto &statement : Block.statements) if (statement) this->discover_statement(*statement);
+      if (NewScope) this->scopes_.pop_back();
+   }
+
+   void discover_statement(StmtNode &Statement)
+   {
+      switch (Statement.kind) {
+         case AstNodeKind::LocalDeclStmt: {
+            auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->discover_expression(*value);
+            for (size_t i = 0; i < payload.names.size(); ++i) {
+               const ExprNode *initialiser = i < payload.values.size() ? payload.values[i].get() :
+                  (payload.values.empty() ? nullptr : payload.values.back().get());
+               uint8_t result_position = i < payload.values.size() ? 0 :
+                  uint8_t(i - payload.values.size() + 1);
+               this->declare(payload.names[i], initialiser, result_position);
+            }
+            break;
+         }
+         case AstNodeKind::AssignmentStmt: {
+            auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->discover_expression(*value);
+            for (auto &target : payload.targets) if (target) this->discover_expression(*target, true);
+            break;
+         }
+         case AstNodeKind::GlobalDeclStmt: {
+            auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->discover_expression(*value);
+            break;
+         }
+         case AstNodeKind::LocalFunctionStmt: {
+            auto &payload = std::get<LocalFunctionStmtPayload>(Statement.data);
+            this->declare(payload.name, nullptr, 0, payload.function.get());
+            if (payload.function) this->discover_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::FunctionStmt: {
+            auto &payload = std::get<FunctionStmtPayload>(Statement.data);
+            bool local = not payload.name.is_explicit_global and payload.name.segments.size() IS 1 and
+               not payload.name.method.has_value();
+            if (local) this->declare(payload.name.segments.front(), nullptr, 0, payload.function.get());
+            if (payload.function) this->discover_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::IfStmt: {
+            for (auto &clause : std::get<IfStmtPayload>(Statement.data).clauses) {
+               if (clause.condition) {
+                  this->discover_expression(*clause.condition);
+                  auto truth = this->constant_truth(*clause.condition);
+                  if (truth and not *truth) continue;
+                  if (clause.block) this->discover_block(*clause.block);
+                  if (truth and *truth) break;
+               }
+               else {
+                  if (clause.block) this->discover_block(*clause.block);
+                  break;
+               }
+            }
+            break;
+         }
+         case AstNodeKind::WhileStmt:
+         case AstNodeKind::RepeatStmt: {
+            auto &payload = std::get<LoopStmtPayload>(Statement.data);
+            if (payload.condition) this->discover_expression(*payload.condition);
+            if (payload.body) this->discover_block(*payload.body);
+            break;
+         }
+         case AstNodeKind::NumericForStmt: {
+            auto &payload = std::get<NumericForStmtPayload>(Statement.data);
+            if (payload.start) this->discover_expression(*payload.start);
+            if (payload.stop) this->discover_expression(*payload.stop);
+            if (payload.step) this->discover_expression(*payload.step);
+            this->scopes_.push_back(BindingScope{});
+            this->declare(payload.control, nullptr, 0);
+            if (payload.body) this->discover_block(*payload.body, false);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::GenericForStmt: {
+            auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+            for (auto &iterator : payload.iterators) if (iterator) this->discover_expression(*iterator);
+            this->scopes_.push_back(BindingScope{});
+            for (auto &name : payload.names) this->declare(name, nullptr, 0);
+            if (payload.body) this->discover_block(*payload.body, false);
+            this->scopes_.pop_back();
+            break;
+         }
+         case AstNodeKind::ReturnStmt: {
+            for (auto &value : std::get<ReturnStmtPayload>(Statement.data).values) {
+               if (value) this->discover_expression(*value);
+            }
+            break;
+         }
+         case AstNodeKind::DeferStmt: {
+            auto &payload = std::get<DeferStmtPayload>(Statement.data);
+            if (payload.callable) this->discover_function(*payload.callable);
+            for (auto &argument : payload.arguments) if (argument) this->discover_expression(*argument);
+            break;
+         }
+         case AstNodeKind::DoStmt: {
+            auto &payload = std::get<DoStmtPayload>(Statement.data);
+            if (payload.block) this->discover_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::ConditionalShorthandStmt: {
+            auto &payload = std::get<ConditionalShorthandStmtPayload>(Statement.data);
+            if (payload.condition) this->discover_expression(*payload.condition);
+            if (payload.body) this->discover_statement(*payload.body);
+            break;
+         }
+         case AstNodeKind::TryExceptStmt: {
+            auto &payload = std::get<TryExceptPayload>(Statement.data);
+            if (payload.try_block) this->discover_block(*payload.try_block);
+            for (auto &clause : payload.except_clauses) {
+               for (auto &code : clause.filter_codes) if (code) this->discover_expression(*code);
+               this->scopes_.push_back(BindingScope{});
+               if (clause.exception_var) this->declare(*clause.exception_var, nullptr, 0);
+               if (clause.block) this->discover_block(*clause.block, false);
+               this->scopes_.pop_back();
+            }
+            if (payload.success_block) this->discover_block(*payload.success_block);
+            break;
+         }
+         case AstNodeKind::RaiseStmt: {
+            auto &payload = std::get<RaiseStmtPayload>(Statement.data);
+            if (payload.error_code) this->discover_expression(*payload.error_code);
+            if (payload.message) this->discover_expression(*payload.message);
+            break;
+         }
+         case AstNodeKind::CheckStmt: {
+            auto &payload = std::get<CheckStmtPayload>(Statement.data);
+            if (payload.error_code) this->discover_expression(*payload.error_code);
+            break;
+         }
+         case AstNodeKind::ImportStmt: {
+            for (auto &entry : std::get<ImportStmtPayload>(Statement.data).entries) {
+               if (entry.inlined_body) this->discover_block(*entry.inlined_body);
+            }
+            break;
+         }
+         case AstNodeKind::WithStmt: {
+            auto &payload = std::get<WithStmtPayload>(Statement.data);
+            for (auto &object : payload.objects) if (object) this->discover_expression(*object);
+            if (payload.block) this->discover_block(*payload.block);
+            break;
+         }
+         case AstNodeKind::ExpressionStmt: {
+            auto &payload = std::get<ExpressionStmtPayload>(Statement.data);
+            if (payload.expression) this->discover_expression(*payload.expression);
+            break;
+         }
+         default:
+            break;
+      }
+   }
+
+   [[nodiscard]] StaticResultSet function_results(const FunctionExprPayload &Function) const
+   {
+      StaticResultSet results;
+      results.declared_count = Function.return_types.count;
+      results.stored_count = uint8_t(std::min<size_t>(Function.return_types.count, MAX_RETURN_TYPES));
+      results.variadic = Function.return_types.is_variadic;
+      results.dynamic = not Function.return_types.is_explicit;
+      for (size_t i = 0; i < results.stored_count; ++i) {
+         StaticValueDescriptor value = this->catalogue_.value(Function.return_types.descriptors[i]);
+         value.primary = Function.return_types.types[i];
+         value.struct_def = Function.return_types.struct_defs[i] ?
+            Function.return_types.struct_defs[i] : value.struct_def;
+         value.nullable = true;
+         value.proof = Function.return_types.is_explicit and value.primary != TiriType::Any and
+            value.primary != TiriType::Unknown ? StaticProof::Checked : StaticProof::Advisory;
+         results.values[i] = value;
+      }
+      return results;
+   }
+
+   StaticCallableHandle function_callable(const FunctionExprPayload &Function, StaticBindingID Binding = 0)
+   {
+      if (Function.callable) return Function.callable;
+      auto &mutable_function = const_cast<FunctionExprPayload &>(Function);
+      StaticResultSetHandle results = this->catalogue_.add_results(this->function_results(Function));
+      StaticCallableDescriptor callable;
+      callable.function = &Function;
+      callable.results = results;
+      callable.binding_id = Binding;
+      callable.immutable = true;
+      mutable_function.callable = this->catalogue_.add_callable(callable);
+      return mutable_function.callable;
+   }
+
+   StaticCallableHandle resolve_binding_callable(StaticBindingID ID)
+   {
+      if (not ID) return 0;
+      auto &binding = this->catalogue_.binding(ID);
+      if (binding.callable) return binding.callable;
+      if (not binding.immutable or binding.resolving) return 0;
+
+      binding.resolving = true;
+      StaticCallableHandle callable = 0;
+      if (binding.function) callable = this->function_callable(*binding.function, ID);
+      else if (binding.initialiser) {
+         const ExprNode &initialiser = *binding.initialiser;
+         if (initialiser.kind IS AstNodeKind::FunctionExpr) {
+            callable = this->function_callable(std::get<FunctionExprPayload>(initialiser.data), ID);
+         }
+         else if (initialiser.kind IS AstNodeKind::IdentifierExpr) {
+            const auto &reference = std::get<NameRef>(initialiser.data);
+            binding.alias_of = reference.binding_id;
+            callable = this->resolve_binding_callable(reference.binding_id);
+         }
+      }
+      binding.resolving = false;
+      binding.callable = callable;
+      return callable;
+   }
+
+   void resolve_all_callables()
+   {
+      for (size_t id = 1; id < this->catalogue_.binding_count(); ++id) {
+         this->resolve_binding_callable(StaticBindingID(id));
+      }
+   }
+
+   void refresh_callables()
+   {
+      for (size_t id = 1; id < this->catalogue_.binding_count(); ++id) {
+         auto &binding = this->catalogue_.binding(StaticBindingID(id));
+         if (binding.callable) {
+            auto &callable = this->catalogue_.callable(binding.callable);
+            if (callable.function) callable.results = this->catalogue_.add_results(
+               this->function_results(*callable.function));
+         }
+         else if (binding.immutable and binding.initialiser and
+             binding.initialiser->kind IS AstNodeKind::CallExpr) {
+            const auto &call = std::get<CallExprPayload>(binding.initialiser->data);
+            if (call.result_type IS TiriType::Func and call.struct_def) {
+               StaticResultSet results;
+               results.declared_count = 1;
+               results.stored_count = 1;
+               results.values[0].primary = TiriType::Struct;
+               results.values[0].struct_def = call.struct_def;
+               results.values[0].proof = StaticProof::Closed;
+
+               StaticCallableDescriptor callable;
+               callable.results = this->catalogue_.add_results(results);
+               callable.binding_id = StaticBindingID(id);
+               callable.immutable = true;
+               binding.callable = this->catalogue_.add_callable(callable);
+            }
+         }
+      }
+   }
+
+   void annotate_call(CallExprPayload &Call)
+   {
+      if (auto *direct = std::get_if<DirectCallTarget>(&Call.target); direct and direct->callable) {
+         if (direct->callable->kind IS AstNodeKind::FunctionExpr) {
+            Call.callable = this->function_callable(std::get<FunctionExprPayload>(direct->callable->data));
+         }
+         else if (direct->callable->kind IS AstNodeKind::IdentifierExpr) {
+            const auto &reference = std::get<NameRef>(direct->callable->data);
+            Call.callable = this->resolve_binding_callable(reference.binding_id);
+         }
+      }
+      if (Call.callable) Call.results = this->catalogue_.callable(Call.callable).results;
+   }
+
+   void annotate_callables_expression(ExprNode &Expression)
+   {
+      this->walk_expression_children(Expression, [this](ExprNode &Child) {
+         this->annotate_callables_expression(Child);
+      });
+      if (Expression.kind IS AstNodeKind::CallExpr or Expression.kind IS AstNodeKind::SafeCallExpr) {
+         this->annotate_call(std::get<CallExprPayload>(Expression.data));
+      }
+   }
+
+   void annotate_callables_block(BlockStmt &Block)
+   {
+      this->walk_block_expressions(Block, [this](ExprNode &Expression) {
+         this->annotate_callables_expression(Expression);
+      });
+   }
+
+   [[nodiscard]] StaticValueHandle add_value(StaticValueDescriptor Value)
+   {
+      return this->catalogue_.add_value(Value);
+   }
+
+   [[nodiscard]] StaticValueDescriptor descriptor_of(const ExprNode &Expression) const
+   {
+      return this->catalogue_.value(Expression.static_value);
+   }
+
+   [[nodiscard]] StaticValueDescriptor global_value(GCstr *Name) const
+   {
+      for (auto entry = this->global_values_.rbegin(); entry != this->global_values_.rend(); ++entry) {
+         if (entry->first IS Name) return this->catalogue_.value(entry->second);
+      }
+      return {};
+   }
+
+   [[nodiscard]] StaticValueDescriptor literal_descriptor(const LiteralValue &Literal) const
+   {
+      StaticValueDescriptor result;
+      result.proof = StaticProof::Closed;
+      switch (Literal.kind) {
+         case LiteralKind::Nil:
+            result.primary = TiriType::Nil;
+            result.nullable = true;
+            break;
+         case LiteralKind::Boolean: result.primary = TiriType::Bool; break;
+         case LiteralKind::Number:  result.primary = TiriType::Num; break;
+         case LiteralKind::String:  result.primary = TiriType::Str; break;
+      }
+      return result;
+   }
+
+   [[nodiscard]] std::optional<bool> constant_truth(const ExprNode &Expression) const
+   {
+      if (Expression.kind != AstNodeKind::LiteralExpr) return std::nullopt;
+      const auto &literal = std::get<LiteralValue>(Expression.data);
+      if (literal.kind IS LiteralKind::Nil) return false;
+      if (literal.kind IS LiteralKind::Boolean) return literal.bool_value;
+      return true;
+   }
+
+   [[nodiscard]] StaticValueDescriptor declared_descriptor(
+      TiriType Type, struct_record *StructDef, StaticProof Proof) const
+   {
+      StaticValueDescriptor result;
+      result.primary = Type;
+      result.struct_def = StructDef;
+      result.proof = Proof;
+      result.nullable = true;
+      return result;
+   }
+
+   [[nodiscard]] std::optional<std::pair<std::string_view, bool>> array_constructor_type(
+      const CallExprPayload &Call) const
+   {
+      const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+      if (not direct or not direct->callable or direct->callable->kind != AstNodeKind::MemberExpr) return std::nullopt;
+      const auto &member = std::get<MemberExprPayload>(direct->callable->data);
+      if (not member.table or member.table->kind != AstNodeKind::IdentifierExpr or not member.member.symbol) {
+         return std::nullopt;
+      }
+      const auto &base = std::get<NameRef>(member.table->data);
+      if (base.binding_id or not base.identifier.symbol or base.identifier.symbol->hash != kt::strhash("array")) {
+         return std::nullopt;
+      }
+
+      bool is_of = member.member.symbol->hash IS kt::strhash("of");
+      bool is_new = member.member.symbol->hash IS kt::strhash("new");
+      if (not is_of and not is_new) return std::nullopt;
+      size_t position = is_of ? 0 : 1;
+      if (position >= Call.arguments.size() or Call.arguments[position]->kind != AstNodeKind::LiteralExpr) {
+         return std::nullopt;
+      }
+      const auto &literal = std::get<LiteralValue>(Call.arguments[position]->data);
+      if (literal.kind != LiteralKind::String or not literal.string_value) return std::nullopt;
+      return std::pair(std::string_view(strdata(literal.string_value), literal.string_value->len), true);
+   }
+
+   [[nodiscard]] StaticValueDescriptor call_descriptor(CallExprPayload &Call, bool Safe)
+   {
+      this->annotate_call(Call);
+      StaticValueDescriptor result;
+
+      if (Call.results) {
+         result = this->catalogue_.results(Call.results).value_at(0);
+      }
+      else if (auto array_type = this->array_constructor_type(Call)) {
+         auto element = describe_array_element(array_type->first, &this->context_.lua());
+         if (element) {
+            result.primary = TiriType::Array;
+            result.array_element = *element;
+            result.proof = StaticProof::Closed;
+         }
+      }
+      else if (const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+          direct and direct->callable and direct->callable->kind IS AstNodeKind::MemberExpr) {
+         const auto &member = std::get<MemberExprPayload>(direct->callable->data);
+         const NameRef *base = member.table and member.table->kind IS AstNodeKind::IdentifierExpr ?
+            std::get_if<NameRef>(&member.table->data) : nullptr;
+         if (base and not base->binding_id and base->identifier.symbol and member.member.symbol and
+             member.member.symbol->hash IS kt::strhash("new")) {
+            if (base->identifier.symbol->hash IS kt::strhash("obj") and
+                Call.result_type IS TiriType::Object) {
+               result.primary = TiriType::Object;
+               result.object_class_id = Call.object_class_id;
+               result.proof = StaticProof::Closed;
+            }
+            else if (base->identifier.symbol->hash IS kt::strhash("struct") and
+                Call.result_type IS TiriType::Struct) {
+               result.primary = TiriType::Struct;
+               result.struct_def = Call.struct_def;
+               result.proof = StaticProof::Closed;
+            }
+         }
+      }
+
+      if (result.primary IS TiriType::Unknown and Call.result_type != TiriType::Unknown) {
+         result.primary = Call.result_type;
+         result.object_class_id = Call.object_class_id;
+         result.struct_def = Call.struct_def;
+         result.proof = StaticProof::Advisory;
+      }
+
+      if (Safe) {
+         result.nullable = true;
+         if (Call.results) {
+            StaticResultSet safe_results = this->catalogue_.results(Call.results);
+            for (size_t i = 0; i < safe_results.stored_count; ++i) {
+               safe_results.values[i].nullable = true;
+            }
+            Call.results = this->catalogue_.add_results(safe_results);
+            result = safe_results.value_at(0);
+         }
+      }
+      return result;
+   }
+
+   [[nodiscard]] StaticValueDescriptor struct_field_descriptor(
+      struct_record *StructDef, GCstr *FieldName) const
+   {
+      StaticValueDescriptor result;
+      if (not StructDef or not FieldName) return result;
+
+      for (const auto &field : StructDef->Fields) {
+         if (field.nameHash() != kt::strihash(strdata(FieldName))) continue;
+         result.proof = StaticProof::Trusted;
+         if (field.Type & (FD_ARRAY|FD_VECTOR)) {
+            result.primary = TiriType::Array;
+            if (auto element = describe_array_element(field)) result.array_element = *element;
+         }
+         else if ((field.Type & FD_STRUCT) and not (field.Type & FD_POINTER)) {
+            result.primary = TiriType::Struct;
+            result.struct_def = field.StructDefinition;
+         }
+         else if (field.Type & FD_OBJECT) {
+            result.primary = TiriType::Object;
+            result.object_class_id = field.ObjectClassID;
+         }
+         else if (field.Type & FD_STRING) result.primary = TiriType::Str;
+         else if (field.NativeType IS NativeStructType::Bool) result.primary = TiriType::Bool;
+         else if (field.Type & (FD_FLOAT|FD_DOUBLE|FD_INT64|FD_INT|FD_WORD|FD_BYTE)) {
+            result.primary = TiriType::Num;
+         }
+         else if (field.Type & FD_FUNCTION) result.primary = TiriType::Func;
+         else result.primary = TiriType::Any;
+         return result;
+      }
+      return result;
+   }
+
+   [[nodiscard]] StaticValueDescriptor member_descriptor(
+      const StaticValueDescriptor &Base, GCstr *Member) const
+   {
+      if (not Base.proved()) return {};
+      if (Base.primary IS TiriType::Struct) return this->struct_field_descriptor(Base.struct_def, Member);
+      if (Base.primary IS TiriType::Object and Base.object_class_id != CLASSID::NIL and Member) {
+         auto field = lookup_field_type(Base.object_class_id, Member->hash);
+         if (field and field->type != TiriType::Unknown) {
+            StaticValueDescriptor result;
+            result.primary = field->type;
+            result.object_class_id = field->object_class_id;
+            result.proof = StaticProof::Trusted;
+            return result;
+         }
+      }
+      return {};
+   }
+
+   [[nodiscard]] StaticValueDescriptor array_method_descriptor(const CallExprPayload &Call) const
+   {
+      const MethodCallTarget *method = std::get_if<MethodCallTarget>(&Call.target);
+      if (not method or not method->receiver or not method->method.symbol) return {};
+      StaticValueDescriptor receiver = this->descriptor_of(*method->receiver);
+      if (receiver.primary != TiriType::Array or not receiver.array_element.known) return {};
+
+      switch (method->method.symbol->hash) {
+         case kt::strhash("each"):
+         case kt::strhash("map"):
+         case kt::strhash("filter"):
+         case kt::strhash("slice"):
+         case kt::strhash("clone"):
+            receiver.proof = StaticProof::Trusted;
+            return receiver;
+         default:
+            return {};
+      }
+   }
+
+   void propagate_expression(ExprNode &Expression)
+   {
+      this->walk_expression_children(Expression, [this](ExprNode &Child) {
+         this->propagate_expression(Child);
+      });
+
+      StaticValueDescriptor value;
+      StaticResultSetHandle results = 0;
+      switch (Expression.kind) {
+         case AstNodeKind::LiteralExpr:
+            value = this->literal_descriptor(std::get<LiteralValue>(Expression.data));
+            break;
+         case AstNodeKind::IdentifierExpr: {
+            const auto &reference = std::get<NameRef>(Expression.data);
+            if (reference.binding_id) value = this->catalogue_.value(
+               this->catalogue_.binding(reference.binding_id).value);
+            else value = this->global_value(reference.identifier.symbol);
+            break;
+         }
+         case AstNodeKind::TableExpr:
+            value.primary = TiriType::Table;
+            value.proof = StaticProof::Closed;
+            break;
+         case AstNodeKind::FunctionExpr: {
+            auto &function = std::get<FunctionExprPayload>(Expression.data);
+            value.primary = TiriType::Func;
+            value.proof = StaticProof::Closed;
+            this->function_callable(function);
+            this->propagate_function(function);
+            break;
+         }
+         case AstNodeKind::CallExpr:
+         case AstNodeKind::SafeCallExpr: {
+            auto &call = std::get<CallExprPayload>(Expression.data);
+            value = this->call_descriptor(call, Expression.kind IS AstNodeKind::SafeCallExpr);
+            StaticValueDescriptor transferred = this->array_method_descriptor(call);
+            if (transferred.primary != TiriType::Unknown) {
+               transferred.nullable = value.nullable;
+               value = transferred;
+            }
+            results = call.results;
+            break;
+         }
+         case AstNodeKind::ResultFilterExpr: {
+            auto &filter = std::get<ResultFilterPayload>(Expression.data);
+            if (filter.expression and filter.expression->static_results) {
+               StaticResultSet mapped = map_static_result_filter(
+                  this->catalogue_.results(filter.expression->static_results),
+                  filter.keep_mask, filter.explicit_count, filter.trailing_keep);
+               results = this->catalogue_.add_results(mapped);
+               value = mapped.value_at(0);
+            }
+            break;
+         }
+         case AstNodeKind::PipeExpr: {
+            auto &pipe = std::get<PipeExprPayload>(Expression.data);
+            if (pipe.deferred_iteration and pipe.lhs) {
+               value = this->descriptor_of(*pipe.lhs);
+               results = pipe.lhs->static_results;
+            }
+            else if (pipe.rhs_call) {
+               value = this->descriptor_of(*pipe.rhs_call);
+               results = pipe.rhs_call->static_results;
+            }
+            break;
+         }
+         case AstNodeKind::IndexExpr:
+         case AstNodeKind::SafeIndexExpr: {
+            ExprNode *base = nullptr;
+            bool safe = Expression.kind IS AstNodeKind::SafeIndexExpr;
+            if (safe) base = std::get<SafeIndexExprPayload>(Expression.data).table.get();
+            else base = std::get<IndexExprPayload>(Expression.data).table.get();
+            if (base) {
+               StaticValueDescriptor base_value = this->descriptor_of(*base);
+               if (base_value.primary IS TiriType::Array and base_value.array_element.known and
+                   base_value.proved() and not base_value.nullable) {
+                  value.primary = base_value.array_element.logical_type;
+                  value.object_class_id = base_value.array_element.object_class_id;
+                  value.struct_def = base_value.array_element.struct_def;
+                  value.proof = StaticProof::Trusted;
+                  value.nullable = safe;
+               }
+            }
+            break;
+         }
+         case AstNodeKind::MemberExpr:
+         case AstNodeKind::SafeMemberExpr: {
+            ExprNode *base = nullptr;
+            GCstr *member = nullptr;
+            bool safe = Expression.kind IS AstNodeKind::SafeMemberExpr;
+            if (safe) {
+               auto &payload = std::get<SafeMemberExprPayload>(Expression.data);
+               base = payload.table.get();
+               member = payload.member.symbol;
+            }
+            else {
+               auto &payload = std::get<MemberExprPayload>(Expression.data);
+               base = payload.table.get();
+               member = payload.member.symbol;
+            }
+            if (base) value = this->member_descriptor(this->descriptor_of(*base), member);
+            if (safe) value.nullable = true;
+            break;
+         }
+         case AstNodeKind::BinaryExpr: {
+            auto &payload = std::get<BinaryExprPayload>(Expression.data);
+            if ((payload.op IS AstBinaryOperator::LogicalAnd or payload.op IS AstBinaryOperator::LogicalOr or
+                 payload.op IS AstBinaryOperator::IfEmpty) and payload.left and payload.right) {
+               value = join_static_descriptors(
+                  this->descriptor_of(*payload.left), this->descriptor_of(*payload.right));
+            }
+            else {
+               TiriType inferred = infer_expression_type(Expression);
+               if (inferred != TiriType::Unknown) {
+                  value.primary = inferred;
+                  value.proof = StaticProof::Advisory;
+               }
+            }
+            break;
+         }
+         case AstNodeKind::TernaryExpr: {
+            auto &payload = std::get<TernaryExprPayload>(Expression.data);
+            if (payload.if_true and payload.if_false) {
+               value = join_static_descriptors(
+                  this->descriptor_of(*payload.if_true), this->descriptor_of(*payload.if_false));
+            }
+            break;
+         }
+         case AstNodeKind::ChooseExpr: {
+            bool have_value = false;
+            for (auto &choice : std::get<ChooseExprPayload>(Expression.data).cases) {
+               if (not choice.result) continue;
+               if (not have_value) {
+                  value = this->descriptor_of(*choice.result);
+                  have_value = true;
+               }
+               else value = join_static_descriptors(value, this->descriptor_of(*choice.result));
+            }
+            break;
+         }
+         case AstNodeKind::PresenceExpr:
+         case AstNodeKind::ComparisonChainExpr:
+            value.primary = TiriType::Bool;
+            value.proof = StaticProof::Closed;
+            break;
+         default: {
+            TiriType inferred = infer_expression_type(Expression);
+            if (inferred != TiriType::Unknown) {
+               value.primary = inferred;
+               value.proof = StaticProof::Advisory;
+            }
+            break;
+         }
+      }
+
+      if (value.primary != TiriType::Unknown or value.array_element.known) {
+         Expression.static_value = this->add_value(value);
+      }
+      Expression.static_results = results;
+   }
+
+   void set_binding_value(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition)
+   {
+      if (not Name.binding_id) return;
+      auto &binding = this->catalogue_.binding(Name.binding_id);
+      StaticValueDescriptor value;
+
+      if (Name.type != TiriType::Unknown and Name.type != TiriType::Any) {
+         value = this->declared_descriptor(Name.type, Name.struct_def, StaticProof::Checked);
+      }
+      else if (binding.function) {
+         value.primary = TiriType::Func;
+         value.proof = StaticProof::Closed;
+      }
+      else if (Initialiser) {
+         if (ResultPosition > 0 and Initialiser->static_results) {
+            value = this->catalogue_.results(Initialiser->static_results).value_at(ResultPosition);
+         }
+         else value = this->descriptor_of(*Initialiser);
+      }
+
+      if (not binding.immutable) binding.callable = 0;
+      binding.value = this->add_value(value);
+      Name.static_value = binding.value;
+   }
+
+   void update_assigned_binding(ExprNode &Target, const StaticValueDescriptor &Assigned)
+   {
+      if (Target.kind != AstNodeKind::IdentifierExpr) return;
+      auto &reference = std::get<NameRef>(Target.data);
+      if (not reference.binding_id) return;
+
+      auto &binding = this->catalogue_.binding(reference.binding_id);
+      StaticValueDescriptor previous = this->catalogue_.value(binding.value);
+      StaticValueDescriptor joined = join_static_descriptors(previous, Assigned);
+      binding.value = this->add_value(joined);
+      binding.callable = 0;
+      reference.identifier.static_value = binding.value;
+      Target.static_value = binding.value;
+   }
+
+   void propagate_function(FunctionExprPayload &Function)
+   {
+      for (auto &parameter : Function.parameters) {
+         if (not parameter.name.binding_id) continue;
+         auto value = this->declared_descriptor(parameter.type, parameter.struct_def,
+            parameter.type IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked);
+         auto &binding = this->catalogue_.binding(parameter.name.binding_id);
+         binding.value = this->add_value(value);
+         parameter.name.static_value = binding.value;
+      }
+      if (Function.body) this->propagate_block(*Function.body);
+
+      StaticResultSet inferred;
+      bool have_return = false;
+      if (Function.body) this->collect_return_descriptors(*Function.body, inferred, have_return);
+      if (have_return) {
+         if (Function.return_types.is_explicit) {
+            inferred.declared_count = Function.return_types.count;
+            inferred.stored_count = uint8_t(std::min<size_t>(
+               Function.return_types.count, MAX_RETURN_TYPES));
+            inferred.variadic = Function.return_types.is_variadic;
+            inferred.dynamic = false;
+            for (size_t i = 0; i < inferred.stored_count; ++i) {
+               auto &value = inferred.values[i];
+               value.primary = Function.return_types.types[i];
+               value.struct_def = Function.return_types.struct_defs[i] ?
+                  Function.return_types.struct_defs[i] : value.struct_def;
+               value.nullable = true;
+               value.proof = value.primary IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked;
+               Function.return_types.descriptors[i] = this->add_value(value);
+            }
+         }
+         if (Function.callable) {
+            this->catalogue_.callable(Function.callable).results = this->catalogue_.add_results(inferred);
+         }
+      }
+   }
+
+   void collect_return_descriptors(
+      BlockStmt &Block, StaticResultSet &Results, bool &HaveReturn)
+   {
+      for (auto &statement : Block.statements) {
+         if (not statement) continue;
+         if (statement->kind IS AstNodeKind::ReturnStmt) {
+            auto &payload = std::get<ReturnStmtPayload>(statement->data);
+            StaticResultSet current;
+            current.declared_count = uint16_t(payload.values.size());
+            current.stored_count = uint8_t(std::min<size_t>(payload.values.size(), MAX_RETURN_TYPES));
+            for (size_t i = 0; i < current.stored_count; ++i) {
+               current.values[i] = this->descriptor_of(*payload.values[i]);
+            }
+            if (not payload.values.empty()) {
+               ExprNode &last = *payload.values.back();
+               if (last.static_results) {
+                  const auto &tail = this->catalogue_.results(last.static_results);
+                  size_t fixed = payload.values.size() - 1;
+                  current.declared_count = uint16_t(fixed + tail.declared_count);
+                  current.dynamic = tail.dynamic;
+                  current.variadic = tail.variadic;
+                  for (size_t i = fixed; i < MAX_RETURN_TYPES; ++i) {
+                     current.values[i] = tail.value_at(i - fixed);
+                  }
+                  current.stored_count = uint8_t(std::min<size_t>(
+                     MAX_RETURN_TYPES, fixed + tail.stored_count));
+               }
+            }
+
+            if (not HaveReturn) {
+               Results = current;
+               HaveReturn = true;
+            }
+            else {
+               size_t count = std::max<size_t>(Results.stored_count, current.stored_count);
+               for (size_t i = 0; i < count; ++i) {
+                  Results.values[i] = join_static_descriptors(
+                     Results.value_at(i), current.value_at(i));
+               }
+               Results.stored_count = uint8_t(count);
+               Results.declared_count = std::max(Results.declared_count, current.declared_count);
+               Results.dynamic = Results.dynamic or current.dynamic;
+               Results.variadic = Results.variadic and current.variadic;
+            }
+            continue;
+         }
+
+         this->walk_statement_blocks(*statement, [this, &Results, &HaveReturn](BlockStmt &Nested) {
+            this->collect_return_descriptors(Nested, Results, HaveReturn);
+         });
+      }
+   }
+
+   void propagate_block(BlockStmt &Block)
+   {
+      for (auto &statement : Block.statements) {
+         if (statement) this->propagate_statement(*statement);
+      }
+   }
+
+   void propagate_statement(StmtNode &Statement)
+   {
+      switch (Statement.kind) {
+         case AstNodeKind::LocalDeclStmt: {
+            auto &payload = std::get<LocalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->propagate_expression(*value);
+            for (size_t i = 0; i < payload.names.size(); ++i) {
+               const ExprNode *initialiser = i < payload.values.size() ? payload.values[i].get() :
+                  (payload.values.empty() ? nullptr : payload.values.back().get());
+               uint8_t position = i < payload.values.size() ? 0 : uint8_t(i - payload.values.size() + 1);
+               this->set_binding_value(payload.names[i], initialiser, position);
+            }
+            break;
+         }
+         case AstNodeKind::LocalFunctionStmt: {
+            auto &payload = std::get<LocalFunctionStmtPayload>(Statement.data);
+            this->set_binding_value(payload.name, nullptr, 0);
+            if (payload.function) this->propagate_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::AssignmentStmt: {
+            auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->propagate_expression(*value);
+            for (auto &target : payload.targets) if (target) this->propagate_expression(*target);
+            if (payload.op IS AssignmentOperator::Plain) {
+               for (size_t i = 0; i < payload.targets.size(); ++i) {
+                  if (not payload.targets[i] or payload.values.empty()) continue;
+                  size_t source = std::min(i, payload.values.size() - 1);
+                  StaticValueDescriptor assigned;
+                  if (source IS payload.values.size() - 1 and i >= payload.values.size() and
+                      payload.values[source]->static_results) {
+                     assigned = this->catalogue_.results(
+                        payload.values[source]->static_results).value_at(i - source);
+                  }
+                  else assigned = this->descriptor_of(*payload.values[source]);
+                  this->update_assigned_binding(*payload.targets[i], assigned);
+               }
+            }
+            break;
+         }
+         case AstNodeKind::FunctionStmt: {
+            auto &payload = std::get<FunctionStmtPayload>(Statement.data);
+            if (payload.name.segments.size() IS 1) {
+               this->set_binding_value(payload.name.segments.front(), nullptr, 0);
+            }
+            if (payload.function) this->propagate_function(*payload.function);
+            break;
+         }
+         case AstNodeKind::IfStmt: {
+            auto &payload = std::get<IfStmtPayload>(Statement.data);
+            for (auto &clause : payload.clauses) {
+               if (clause.condition) {
+                  this->propagate_expression(*clause.condition);
+                  auto truth = this->constant_truth(*clause.condition);
+                  if (truth and not *truth) continue;
+                  if (clause.block) this->propagate_block(*clause.block);
+                  if (truth and *truth) break;
+               }
+               else {
+                  if (clause.block) this->propagate_block(*clause.block);
+                  break;
+               }
+            }
+            break;
+         }
+         case AstNodeKind::GlobalDeclStmt: {
+            auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
+            for (auto &value : payload.values) if (value) this->propagate_expression(*value);
+            for (size_t i = 0; i < payload.names.size(); ++i) {
+               auto &name = payload.names[i];
+               if (name.type IS TiriType::Any or not name.symbol) continue;
+               StaticValueDescriptor value;
+               if (name.type != TiriType::Unknown) {
+                  value = this->declared_descriptor(name.type, name.struct_def, StaticProof::Checked);
+               }
+               else if (not payload.values.empty()) {
+                  size_t source = std::min(i, payload.values.size() - 1);
+                  value = this->descriptor_of(*payload.values[source]);
+                  if (source IS payload.values.size() - 1 and i >= payload.values.size() and
+                      payload.values[source]->static_results) {
+                     value = this->catalogue_.results(
+                        payload.values[source]->static_results).value_at(i - source);
+                  }
+               }
+               if (value.primary IS TiriType::Unknown or value.primary IS TiriType::Any) continue;
+               name.static_value = this->add_value(value);
+               this->global_values_.emplace_back(name.symbol, name.static_value);
+            }
+            break;
+         }
+         case AstNodeKind::GenericForStmt: {
+            auto &payload = std::get<GenericForStmtPayload>(Statement.data);
+            for (auto &iterator : payload.iterators) if (iterator) this->propagate_expression(*iterator);
+            if (payload.iterators.size() IS 1 and not payload.names.empty()) {
+               StaticValueDescriptor iterator = this->descriptor_of(*payload.iterators.front());
+               if (iterator.primary IS TiriType::Array and iterator.array_element.known) {
+                  auto &first = this->catalogue_.binding(payload.names.front().binding_id);
+                  StaticValueDescriptor index;
+                  index.primary = TiriType::Num;
+                  index.proof = StaticProof::Trusted;
+                  first.value = this->add_value(index);
+                  payload.names.front().static_value = first.value;
+                  if (payload.names.size() > 1) {
+                     StaticValueDescriptor element;
+                     element.primary = iterator.array_element.logical_type;
+                     element.object_class_id = iterator.array_element.object_class_id;
+                     element.struct_def = iterator.array_element.struct_def;
+                     element.proof = StaticProof::Trusted;
+                     auto &second = this->catalogue_.binding(payload.names[1].binding_id);
+                     second.value = this->add_value(element);
+                     payload.names[1].static_value = second.value;
+                  }
+               }
+            }
+            if (payload.body) this->propagate_block(*payload.body);
+            break;
+         }
+         default:
+            this->walk_statement_expressions(Statement, [this](ExprNode &Expression) {
+               this->propagate_expression(Expression);
+            });
+            this->walk_statement_blocks(Statement, [this](BlockStmt &Nested) {
+               this->propagate_block(Nested);
+            });
+            break;
+      }
+   }
+
+   template<typename Visitor>
+   void walk_expression_children(ExprNode &Expression, Visitor Visit)
+   {
+      auto visit = [&](ExprNodePtr &Node) { if (Node) Visit(*Node); };
+      switch (Expression.kind) {
+         case AstNodeKind::UnaryExpr: visit(std::get<UnaryExprPayload>(Expression.data).operand); break;
+         case AstNodeKind::UpdateExpr: visit(std::get<UpdateExprPayload>(Expression.data).target); break;
+         case AstNodeKind::BinaryExpr: {
+            auto &p = std::get<BinaryExprPayload>(Expression.data); visit(p.left); visit(p.right); break;
+         }
+         case AstNodeKind::ComparisonChainExpr:
+            for (auto &v : std::get<ComparisonChainExprPayload>(Expression.data).operands) visit(v);
+            break;
+         case AstNodeKind::TernaryExpr: {
+            auto &p = std::get<TernaryExprPayload>(Expression.data);
+            visit(p.condition); visit(p.if_true); visit(p.if_false); break;
+         }
+         case AstNodeKind::PresenceExpr: visit(std::get<PresenceExprPayload>(Expression.data).value); break;
+         case AstNodeKind::PipeExpr: {
+            auto &p = std::get<PipeExprPayload>(Expression.data); visit(p.lhs); visit(p.rhs_call); break;
+         }
+         case AstNodeKind::CallExpr:
+         case AstNodeKind::SafeCallExpr: {
+            auto &p = std::get<CallExprPayload>(Expression.data);
+            if (auto *d = std::get_if<DirectCallTarget>(&p.target)) visit(d->callable);
+            else if (auto *m = std::get_if<MethodCallTarget>(&p.target)) visit(m->receiver);
+            else if (auto *m = std::get_if<SafeMethodCallTarget>(&p.target)) visit(m->receiver);
+            for (auto &v : p.arguments) visit(v);
+            break;
+         }
+         case AstNodeKind::MemberExpr: visit(std::get<MemberExprPayload>(Expression.data).table); break;
+         case AstNodeKind::IndexExpr: {
+            auto &p = std::get<IndexExprPayload>(Expression.data); visit(p.table); visit(p.index); break;
+         }
+         case AstNodeKind::SafeMemberExpr: visit(std::get<SafeMemberExprPayload>(Expression.data).table); break;
+         case AstNodeKind::SafeIndexExpr: {
+            auto &p = std::get<SafeIndexExprPayload>(Expression.data); visit(p.table); visit(p.index); break;
+         }
+         case AstNodeKind::ResultFilterExpr: visit(std::get<ResultFilterPayload>(Expression.data).expression); break;
+         case AstNodeKind::TableExpr:
+            for (auto &f : std::get<TableExprPayload>(Expression.data).fields) { visit(f.key); visit(f.value); }
+            break;
+         case AstNodeKind::DeferredExpr: visit(std::get<DeferredExprPayload>(Expression.data).inner); break;
+         case AstNodeKind::RangeExpr: {
+            auto &p = std::get<RangeExprPayload>(Expression.data); visit(p.start); visit(p.stop); visit(p.step); break;
+         }
+         case AstNodeKind::ChooseExpr: {
+            auto &p = std::get<ChooseExprPayload>(Expression.data);
+            visit(p.scrutinee);
+            for (auto &v : p.scrutinee_tuple) visit(v);
+            for (auto &c : p.cases) {
+               visit(c.pattern);
+               for (auto &v : c.tuple_patterns) visit(v);
+               visit(c.guard); visit(c.result);
+            }
+            break;
+         }
+         default: break;
+      }
+   }
+
+   template<typename Visitor>
+   void walk_statement_expressions(StmtNode &Statement, Visitor Visit)
+   {
+      auto visit = [&](ExprNodePtr &Node) { if (Node) Visit(*Node); };
+      switch (Statement.kind) {
+         case AstNodeKind::AssignmentStmt: {
+            auto &p = std::get<AssignmentStmtPayload>(Statement.data);
+            for (auto &v : p.values) visit(v);
+            for (auto &v : p.targets) visit(v);
+            break;
+         }
+         case AstNodeKind::GlobalDeclStmt:
+            for (auto &v : std::get<GlobalDeclStmtPayload>(Statement.data).values) visit(v);
+            break;
+         case AstNodeKind::IfStmt:
+            for (auto &c : std::get<IfStmtPayload>(Statement.data).clauses) visit(c.condition);
+            break;
+         case AstNodeKind::WhileStmt:
+         case AstNodeKind::RepeatStmt:
+            visit(std::get<LoopStmtPayload>(Statement.data).condition);
+            break;
+         case AstNodeKind::NumericForStmt: {
+            auto &p = std::get<NumericForStmtPayload>(Statement.data);
+            visit(p.start);
+            visit(p.stop);
+            visit(p.step);
+            break;
+         }
+         case AstNodeKind::GenericForStmt:
+            for (auto &v : std::get<GenericForStmtPayload>(Statement.data).iterators) visit(v);
+            break;
+         case AstNodeKind::ReturnStmt:
+            for (auto &v : std::get<ReturnStmtPayload>(Statement.data).values) visit(v);
+            break;
+         case AstNodeKind::DeferStmt:
+            for (auto &v : std::get<DeferStmtPayload>(Statement.data).arguments) visit(v);
+            break;
+         case AstNodeKind::ConditionalShorthandStmt:
+            visit(std::get<ConditionalShorthandStmtPayload>(Statement.data).condition);
+            break;
+         case AstNodeKind::TryExceptStmt:
+            for (auto &c : std::get<TryExceptPayload>(Statement.data).except_clauses) {
+               for (auto &v : c.filter_codes) visit(v);
+            }
+            break;
+         case AstNodeKind::RaiseStmt: {
+            auto &p = std::get<RaiseStmtPayload>(Statement.data); visit(p.error_code); visit(p.message); break;
+         }
+         case AstNodeKind::CheckStmt: visit(std::get<CheckStmtPayload>(Statement.data).error_code); break;
+         case AstNodeKind::WithStmt:
+            for (auto &v : std::get<WithStmtPayload>(Statement.data).objects) visit(v);
+            break;
+         case AstNodeKind::ExpressionStmt: visit(std::get<ExpressionStmtPayload>(Statement.data).expression); break;
+         default: break;
+      }
+   }
+
+   template<typename Visitor>
+   void walk_statement_blocks(StmtNode &Statement, Visitor Visit)
+   {
+      auto visit = [&](std::unique_ptr<BlockStmt> &Block) { if (Block) Visit(*Block); };
+      switch (Statement.kind) {
+         case AstNodeKind::IfStmt:
+            for (auto &c : std::get<IfStmtPayload>(Statement.data).clauses) visit(c.block);
+            break;
+         case AstNodeKind::WhileStmt:
+         case AstNodeKind::RepeatStmt: visit(std::get<LoopStmtPayload>(Statement.data).body); break;
+         case AstNodeKind::NumericForStmt: visit(std::get<NumericForStmtPayload>(Statement.data).body); break;
+         case AstNodeKind::GenericForStmt: visit(std::get<GenericForStmtPayload>(Statement.data).body); break;
+         case AstNodeKind::DoStmt: visit(std::get<DoStmtPayload>(Statement.data).block); break;
+         case AstNodeKind::TryExceptStmt: {
+            auto &p = std::get<TryExceptPayload>(Statement.data);
+            visit(p.try_block);
+            for (auto &c : p.except_clauses) visit(c.block);
+            visit(p.success_block);
+            break;
+         }
+         case AstNodeKind::ImportStmt:
+            for (auto &e : std::get<ImportStmtPayload>(Statement.data).entries) visit(e.inlined_body);
+            break;
+         case AstNodeKind::WithStmt: visit(std::get<WithStmtPayload>(Statement.data).block); break;
+         default: break;
+      }
+   }
+
+   template<typename Visitor>
+   void walk_block_expressions(BlockStmt &Block, Visitor Visit)
+   {
+      for (auto &statement : Block.statements) {
+         if (not statement) continue;
+         if (statement->kind IS AstNodeKind::LocalDeclStmt) {
+            for (auto &v : std::get<LocalDeclStmtPayload>(statement->data).values) if (v) Visit(*v);
+         }
+         else if (statement->kind IS AstNodeKind::LocalFunctionStmt) {
+            auto &p = std::get<LocalFunctionStmtPayload>(statement->data);
+            if (p.function and p.function->body) this->walk_block_expressions(*p.function->body, Visit);
+         }
+         else if (statement->kind IS AstNodeKind::FunctionStmt) {
+            auto &p = std::get<FunctionStmtPayload>(statement->data);
+            if (p.function and p.function->body) this->walk_block_expressions(*p.function->body, Visit);
+         }
+         else {
+            this->walk_statement_expressions(*statement, Visit);
+            this->walk_statement_blocks(*statement, [this, &Visit](BlockStmt &Nested) {
+               this->walk_block_expressions(Nested, Visit);
+            });
+         }
+      }
+   }
+
+   ParserContext &context_;
+   StaticDescriptorCatalogue &catalogue_;
+   std::vector<BindingScope> scopes_;
+   std::vector<std::pair<GCstr *, StaticValueHandle>> global_values_;
+   uint16_t function_depth_ = 0;
+};
+
+} // namespace
+
+void discover_static_bindings(ParserContext &Context, BlockStmt &Module)
+{
+   StaticDescriptorAnalyser analyser(Context);
+   analyser.discover(Module);
+}
+
+void propagate_static_descriptors(ParserContext &Context, BlockStmt &Module)
+{
+   StaticDescriptorAnalyser analyser(Context);
+   analyser.propagate(Module);
+}

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.h
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class ParserContext;
+struct BlockStmt;
+
+void discover_static_bindings(ParserContext &, BlockStmt &);
+void propagate_static_descriptors(ParserContext &, BlockStmt &);
+

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -1,0 +1,247 @@
+// Parse-time descriptor helpers.
+
+#include "static_type_descriptor.h"
+
+#include <algorithm>
+
+#include "ast/nodes.h"
+#include "../runtime/lj_struct.h"
+
+bool StaticValueDescriptor::constrained() const noexcept
+{
+   if (this->primary IS TiriType::Object) return this->object_class_id != CLASSID::NIL;
+   if (this->primary IS TiriType::Struct) return this->struct_def != nullptr;
+   if (this->primary IS TiriType::Array) return this->array_element.known;
+   return this->primary != TiriType::Unknown and this->primary != TiriType::Any;
+}
+
+bool StaticValueDescriptor::proved() const noexcept
+{
+   return this->proof IS StaticProof::Closed or this->proof IS StaticProof::Checked or
+      this->proof IS StaticProof::Trusted;
+}
+
+StaticValueDescriptor StaticResultSet::value_at(size_t Position) const
+{
+   if (Position < this->stored_count) return this->values[Position];
+   if (this->variadic and this->stored_count > 0) return this->values[this->stored_count - 1];
+
+   StaticValueDescriptor result;
+   if (not this->dynamic and Position >= this->declared_count) {
+      result.primary = TiriType::Nil;
+      result.nullable = true;
+      result.proof = StaticProof::Closed;
+   }
+   else {
+      result.primary = TiriType::Any;
+      result.nullable = true;
+      result.proof = StaticProof::Advisory;
+   }
+   return result;
+}
+
+StaticDescriptorCatalogue::StaticDescriptorCatalogue()
+{
+   this->values_.push_back(StaticValueDescriptor{});
+   this->result_sets_.push_back(StaticResultSet{});
+   this->callables_.push_back(StaticCallableDescriptor{});
+   this->bindings_.push_back(StaticBindingDescriptor{});
+}
+
+StaticValueHandle StaticDescriptorCatalogue::add_value(const StaticValueDescriptor &Value)
+{
+   for (StaticValueHandle i = 1; i < this->values_.size(); ++i) {
+      if (this->values_[i] IS Value) return i;
+   }
+   this->values_.push_back(Value);
+   return StaticValueHandle(this->values_.size() - 1);
+}
+
+StaticResultSetHandle StaticDescriptorCatalogue::add_results(const StaticResultSet &Results)
+{
+   this->result_sets_.push_back(Results);
+   return StaticResultSetHandle(this->result_sets_.size() - 1);
+}
+
+StaticCallableHandle StaticDescriptorCatalogue::add_callable(const StaticCallableDescriptor &Callable)
+{
+   this->callables_.push_back(Callable);
+   return StaticCallableHandle(this->callables_.size() - 1);
+}
+
+StaticBindingID StaticDescriptorCatalogue::add_binding(const StaticBindingDescriptor &Binding)
+{
+   this->bindings_.push_back(Binding);
+   return StaticBindingID(this->bindings_.size() - 1);
+}
+
+const StaticValueDescriptor & StaticDescriptorCatalogue::value(StaticValueHandle Handle) const
+{
+   return this->values_[Handle < this->values_.size() ? Handle : 0];
+}
+
+const StaticResultSet & StaticDescriptorCatalogue::results(StaticResultSetHandle Handle) const
+{
+   return this->result_sets_[Handle < this->result_sets_.size() ? Handle : 0];
+}
+
+const StaticCallableDescriptor & StaticDescriptorCatalogue::callable(StaticCallableHandle Handle) const
+{
+   return this->callables_[Handle < this->callables_.size() ? Handle : 0];
+}
+
+StaticCallableDescriptor & StaticDescriptorCatalogue::callable(StaticCallableHandle Handle)
+{
+   return this->callables_[Handle < this->callables_.size() ? Handle : 0];
+}
+
+const StaticBindingDescriptor & StaticDescriptorCatalogue::binding(StaticBindingID ID) const
+{
+   return this->bindings_[ID < this->bindings_.size() ? ID : 0];
+}
+
+StaticBindingDescriptor & StaticDescriptorCatalogue::binding(StaticBindingID ID)
+{
+   return this->bindings_[ID < this->bindings_.size() ? ID : 0];
+}
+
+void StaticDescriptorCatalogue::clear_analysis()
+{
+   this->values_.resize(1);
+   this->result_sets_.resize(1);
+   this->callables_.resize(1);
+   this->bindings_.resize(1);
+}
+
+static StaticProof weaker_proof(StaticProof Left, StaticProof Right)
+{
+   auto rank = [](StaticProof Proof) {
+      switch (Proof) {
+         case StaticProof::Advisory: return 0;
+         case StaticProof::Closed:   return 3;
+         case StaticProof::Checked:  return 2;
+         case StaticProof::Trusted:  return 2;
+      }
+      return 0;
+   };
+
+   return rank(Left) <= rank(Right) ? Left : Right;
+}
+
+StaticValueDescriptor join_static_descriptors(
+   const StaticValueDescriptor &Left, const StaticValueDescriptor &Right)
+{
+   StaticValueDescriptor result;
+   result.nullable = Left.nullable or Right.nullable;
+
+   if (Left.primary != Right.primary) {
+      if (Left.primary IS TiriType::Nil) {
+         result = Right;
+         result.nullable = true;
+         result.proof = weaker_proof(Left.proof, Right.proof);
+         return result;
+      }
+      if (Right.primary IS TiriType::Nil) {
+         result = Left;
+         result.nullable = true;
+         result.proof = weaker_proof(Left.proof, Right.proof);
+         return result;
+      }
+      result.primary = TiriType::Any;
+      result.proof = StaticProof::Advisory;
+      return result;
+   }
+
+   result = Left;
+   result.nullable = Left.nullable or Right.nullable;
+   result.proof = weaker_proof(Left.proof, Right.proof);
+   if (Left.object_class_id != Right.object_class_id) result.object_class_id = CLASSID::NIL;
+   if (Left.struct_def != Right.struct_def) result.struct_def = nullptr;
+   if (not (Left.array_element IS Right.array_element)) result.array_element = {};
+   return result;
+}
+
+StaticResultSet map_static_result_filter(
+   const StaticResultSet &Source, uint64_t KeepMask, uint8_t ExplicitCount, bool TrailingKeep)
+{
+   StaticResultSet result;
+   size_t output = 0;
+   size_t source_limit = Source.dynamic or Source.variadic ?
+      MAX_RETURN_TYPES : std::min<size_t>(Source.declared_count, MAX_RETURN_TYPES);
+
+   for (size_t source = 0; source < source_limit and output < MAX_RETURN_TYPES; ++source) {
+      bool keep = source < ExplicitCount ? ((KeepMask & (uint64_t(1) << source)) != 0) : TrailingKeep;
+      if (not keep) continue;
+      result.values[output++] = Source.value_at(source);
+   }
+
+   result.stored_count = uint8_t(output);
+   result.declared_count = uint16_t(output);
+   result.variadic = TrailingKeep and Source.variadic;
+   result.dynamic = TrailingKeep and Source.dynamic;
+   if (result.variadic or result.dynamic) result.declared_count = Source.declared_count;
+   return result;
+}
+
+std::optional<ArrayElementDescriptor> describe_array_element(std::string_view Name, lua_State *State)
+{
+   ArrayElementDescriptor result;
+   result.known = true;
+
+   if (Name IS "byte" or Name IS "char") result = { AET::BYTE, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "int16") result = { AET::INT16, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "int") result = { AET::INT32, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "int64") result = { AET::INT64, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "float") result = { AET::FLOAT, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "double") result = { AET::DOUBLE, TiriType::Num, CLASSID::NIL, nullptr, true };
+   else if (Name IS "string") result = { AET::STR_GC, TiriType::Str, CLASSID::NIL, nullptr, true };
+   else if (Name IS "table") result = { AET::TABLE, TiriType::Table, CLASSID::NIL, nullptr, true };
+   else if (Name IS "array") result = { AET::ARRAY, TiriType::Array, CLASSID::NIL, nullptr, true };
+   else if (Name IS "object") result = { AET::OBJECT, TiriType::Object, CLASSID::NIL, nullptr, true };
+   else if (Name IS "any") result = { AET::ANY, TiriType::Any, CLASSID::NIL, nullptr, true };
+   else if (Name IS "pointer") result = { AET::PTR, TiriType::Any, CLASSID::NIL, nullptr, true };
+   else if (Name IS "struct") result = { AET::STRUCT, TiriType::Struct, CLASSID::NIL, nullptr, true };
+   else if (Name.starts_with("struct<") and Name.ends_with('>') and Name.size() > 8) {
+      result = { AET::STRUCT, TiriType::Struct, CLASSID::NIL, nullptr, true };
+      if (State) result.struct_def = find_struct(State, Name.substr(7, Name.size() - 8));
+   }
+   else return std::nullopt;
+
+   return result;
+}
+
+std::optional<ArrayElementDescriptor> describe_array_element(const struct_field &Field)
+{
+   if (not (Field.Type & (FD_ARRAY|FD_VECTOR))) return std::nullopt;
+
+   ArrayElementDescriptor result;
+   result.known = true;
+   result.logical_type = TiriType::Num;
+
+   if ((Field.Type & FD_STRUCT) and not (Field.Type & FD_POINTER)) {
+      result.storage = AET::STRUCT;
+      result.logical_type = TiriType::Struct;
+      result.struct_def = Field.StructDefinition;
+   }
+   else if (Field.Type & FD_FLOAT) result.storage = AET::FLOAT;
+   else if (Field.Type & FD_DOUBLE) result.storage = AET::DOUBLE;
+   else if (Field.Type & FD_INT64) result.storage = AET::INT64;
+   else if (Field.Type & FD_INT) result.storage = AET::INT32;
+   else if (Field.Type & FD_WORD) result.storage = AET::INT16;
+   else if (Field.Type & FD_BYTE) result.storage = AET::BYTE;
+   else return std::nullopt;
+
+   return result;
+}
+
+bool can_use_static_receiver(
+   const StaticDescriptorCatalogue &Catalogue, StaticValueHandle Handle, TiriType Type, bool AllowNullable)
+{
+   if (not Handle) return false;
+   const auto &descriptor = Catalogue.value(Handle);
+   if (descriptor.primary != Type or not descriptor.proved() or (not AllowNullable and descriptor.nullable)) {
+      return false;
+   }
+   if (Type IS TiriType::Object) return descriptor.object_class_id != CLASSID::NIL;
+   return true;
+}

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -1,0 +1,129 @@
+// Parse-time value, result and callable descriptors for type-guided bytecode emission.
+//
+// These records never survive parsing.  Persistent prototype signatures continue to use ProtoTypeEntry.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "../runtime/lj_obj.h"
+
+struct ExprNode;
+struct FunctionExprPayload;
+struct struct_field;
+struct struct_record;
+
+using StaticValueHandle = uint32_t;
+using StaticResultSetHandle = uint32_t;
+using StaticCallableHandle = uint32_t;
+using StaticBindingID = uint32_t;
+
+enum class StaticProof : uint8_t {
+   Advisory,
+   Closed,
+   Checked,
+   Trusted
+};
+
+struct ArrayElementDescriptor {
+   AET storage = AET::ANY;
+   TiriType logical_type = TiriType::Any;
+   CLASSID object_class_id = CLASSID::NIL;
+   struct_record *struct_def = nullptr;
+   bool known = false;
+
+   [[nodiscard]] bool operator==(const ArrayElementDescriptor &) const = default;
+};
+
+struct StaticValueDescriptor {
+   TiriType primary = TiriType::Unknown;
+   CLASSID object_class_id = CLASSID::NIL;
+   struct_record *struct_def = nullptr;
+   ArrayElementDescriptor array_element{};
+   StaticProof proof = StaticProof::Advisory;
+   bool nullable = false;
+
+   [[nodiscard]] bool operator==(const StaticValueDescriptor &) const = default;
+   [[nodiscard]] bool constrained() const noexcept;
+   [[nodiscard]] bool proved() const noexcept;
+};
+
+struct StaticResultSet {
+   std::array<StaticValueDescriptor, MAX_RETURN_TYPES> values{};
+   uint16_t declared_count = 0;
+   uint8_t stored_count = 0;
+   bool variadic = false;
+   bool dynamic = false;
+
+   [[nodiscard]] StaticValueDescriptor value_at(size_t Position) const;
+};
+
+enum class StaticCallableSource : uint8_t {
+   TiriFunction,
+   NativePrototype,
+   Intrinsic
+};
+
+struct StaticCallableDescriptor {
+   const FunctionExprPayload *function = nullptr;
+   StaticResultSetHandle results = 0;
+   StaticBindingID binding_id = 0;
+   StaticCallableSource source = StaticCallableSource::TiriFunction;
+   bool immutable = false;
+};
+
+struct StaticBindingDescriptor {
+   GCstr *name = nullptr;
+   const ExprNode *initialiser = nullptr;
+   const FunctionExprPayload *function = nullptr;
+   StaticValueHandle value = 0;
+   StaticCallableHandle callable = 0;
+   StaticBindingID alias_of = 0;
+   uint8_t result_position = 0;
+   uint16_t function_depth = 0;
+   bool immutable = true;
+   bool is_const = false;
+   bool is_parameter = false;
+   bool captured = false;
+   bool resolving = false;
+};
+
+class StaticDescriptorCatalogue {
+public:
+   StaticDescriptorCatalogue();
+
+   [[nodiscard]] StaticValueHandle add_value(const StaticValueDescriptor &);
+   [[nodiscard]] StaticResultSetHandle add_results(const StaticResultSet &);
+   [[nodiscard]] StaticCallableHandle add_callable(const StaticCallableDescriptor &);
+   [[nodiscard]] StaticBindingID add_binding(const StaticBindingDescriptor &);
+
+   [[nodiscard]] const StaticValueDescriptor & value(StaticValueHandle) const;
+   [[nodiscard]] const StaticResultSet & results(StaticResultSetHandle) const;
+   [[nodiscard]] const StaticCallableDescriptor & callable(StaticCallableHandle) const;
+   [[nodiscard]] StaticCallableDescriptor & callable(StaticCallableHandle);
+   [[nodiscard]] const StaticBindingDescriptor & binding(StaticBindingID) const;
+   [[nodiscard]] StaticBindingDescriptor & binding(StaticBindingID);
+   [[nodiscard]] size_t binding_count() const noexcept { return this->bindings_.size(); }
+
+   void clear_analysis();
+
+private:
+   std::vector<StaticValueDescriptor> values_;
+   std::vector<StaticResultSet> result_sets_;
+   std::vector<StaticCallableDescriptor> callables_;
+   std::vector<StaticBindingDescriptor> bindings_;
+};
+
+[[nodiscard]] StaticValueDescriptor join_static_descriptors(
+   const StaticValueDescriptor &, const StaticValueDescriptor &);
+[[nodiscard]] StaticResultSet map_static_result_filter(
+   const StaticResultSet &, uint64_t KeepMask, uint8_t ExplicitCount, bool TrailingKeep);
+[[nodiscard]] std::optional<ArrayElementDescriptor> describe_array_element(
+   std::string_view Name, lua_State *State = nullptr);
+[[nodiscard]] std::optional<ArrayElementDescriptor> describe_array_element(const struct_field &);
+[[nodiscard]] bool can_use_static_receiver(
+   const StaticDescriptorCatalogue &, StaticValueHandle, TiriType, bool AllowNullable = false);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -146,7 +146,7 @@ private:
 
    // Symbol resolution - looks up variables and functions in scope stack
    [[nodiscard]] std::optional<InferredType> resolve_identifier(GCstr *) const;
-   [[nodiscard]] const FunctionExprPayload * resolve_call_target(const CallTarget &) const;
+   [[nodiscard]] const FunctionExprPayload * resolve_call_target(const CallExprPayload &) const;
    [[nodiscard]] const FunctionExprPayload * resolve_function(GCstr *) const;
 
    // Const checking - checks if a local variable has <const> attribute
@@ -1818,7 +1818,7 @@ void TypeAnalyser::analyse_call_expr(const CallExprPayload &Call)
       this->analyse_expression(*argument);
    }
 
-   const FunctionExprPayload* target = this->resolve_call_target(Call.target);
+   const FunctionExprPayload* target = this->resolve_call_target(Call);
    if (target) {
       if (Call.result_type IS TiriType::Unknown and target->return_types.is_explicit and
           target->return_types.count > 0) {
@@ -1940,7 +1940,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                return result;
             }
             // Otherwise try to infer from the function's declared return type
-            const FunctionExprPayload* target = this->resolve_call_target(payload->target);
+            const FunctionExprPayload* target = this->resolve_call_target(*payload);
             if (target and target->return_types.is_explicit and target->return_types.count > 0) {
                result.primary = target->return_types.types[0];
                result.struct_def = target->return_types.struct_defs[0];
@@ -2130,7 +2130,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    auto *payload = std::get_if<CallExprPayload>(&Expr.data);
    if (not payload) return result;
 
-   const FunctionExprPayload* target = this->resolve_call_target(payload->target);
+   const FunctionExprPayload* target = this->resolve_call_target(*payload);
    if (not target) return result;
 
    if (not target->return_types.is_explicit) return result;
@@ -2193,8 +2193,14 @@ void TypeAnalyser::mark_identifier_used(GCstr *Name)
 // Resolve the target of a function call to get its FunctionExprPayload.  Handles direct calls (func()) and
 // identifier references (myFunc()).
 
-const FunctionExprPayload * TypeAnalyser::resolve_call_target(const CallTarget &Target) const
+const FunctionExprPayload * TypeAnalyser::resolve_call_target(const CallExprPayload &Call) const
 {
+   if (Call.callable) {
+      const auto &callable = this->ctx_.descriptors().callable(Call.callable);
+      if (callable.immutable and callable.function) return callable.function;
+   }
+
+   const CallTarget &Target = Call.target;
    if (std::holds_alternative<DirectCallTarget>(Target)) {
       const auto &direct = std::get<DirectCallTarget>(Target);
       if (direct.callable) {

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -246,9 +246,11 @@ private:
       const FunctionExprPayload* function = nullptr;  // Non-null if declared as global function
       bool is_const = false;  // True if declared with <const> attribute
       bool implicit = false;  // True if inferred from a plain assignment rather than a 'global' declaration
+      bool explicit_contract = false; // True only for an explicit non-any annotation
    };
 
-   void declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst = false);
+   void declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst = false,
+      bool ExplicitContract = false);
    void declare_global_function(GCstr *Name, const FunctionExprPayload *Function, SourceSpan Location);
    void declare_implicit_global(GCstr *Name, const ExprNode *Value, SourceSpan Location);
    [[nodiscard]] std::optional<InferredType> lookup_global_type(GCstr *Name) const;
@@ -1126,12 +1128,9 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             else if (existing->primary IS TiriType::Object and value_type.primary IS TiriType::Object and
                existing->object_class_id != CLASSID::NIL) {
                if (existing->object_class_id != value_type.object_class_id) {
-                  // Conflicting object classes on an implicit global clear the class association.
-                  if (is_global and this->is_implicit_global(name)) {
-                     this->fix_global_type(name, TiriType::Object, CLASSID::NIL);
-                     continue;
-                  }
-
+                  // Object class identity remains sticky after inference, including for implicit globals.  Advisory
+                  // global typing permits unrelated value types to degrade to 'any'; it does not permit an Object
+                  // variable to silently change class.
                   TypeDiagnostic diag;
                   diag.location = target.span;
                   diag.expected = TiriType::Object;
@@ -1387,7 +1386,8 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
          inferred.is_fixed = false;
       }
 
-      this->declare_global(name.symbol, inferred, name.span, name.has_const);
+      this->declare_global(name.symbol, inferred, name.span, name.has_const,
+         name.type != TiriType::Unknown and name.type != TiriType::Any);
    }
 
    #ifdef INCLUDE_TIPS
@@ -2253,13 +2253,15 @@ void TypeAnalyser::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClas
 // Unlike locals which use scope-based tracking, globals use a flat map since they persist for
 // the entire script lifetime.
 
-void TypeAnalyser::declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst)
+void TypeAnalyser::declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst,
+   bool ExplicitContract)
 {
    if (not Name) return;
    GlobalTypeInfo info;
    info.type = Type;
    info.location = Location;
    info.is_const = IsConst;
+   info.explicit_contract = ExplicitContract;
    this->global_types_[Name] = info;
    this->trace_decl(this->ctx_.lex().linenumber, Name, Type.primary, Type.is_fixed);
 }
@@ -2358,7 +2360,7 @@ bool TypeAnalyser::is_global_const(GCstr *Name) const
 //
 // It implements:
 // - Type mismatch detection between returned values and declared types
-// - Return count validation (too many values returned)
+// - Declared-position validation without constraining result count
 // - First-wins inference rule for functions without explicit return type declarations
 // - Nil is always allowed as a valid return value for any type slot
 
@@ -2371,16 +2373,6 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
    if (ctx->expected_returns.is_explicit) {
       // Explicit declaration: validate against declared types
-
-      // Check for too many return values (unless variadic)
-      if (not ctx->expected_returns.is_variadic and return_count > ctx->expected_returns.count) {
-         TypeDiagnostic diag;
-         diag.location = Location;
-         diag.code     = ParserErrorCode::ReturnCountMismatch;
-         diag.message  = std::format("too many return values: function declares {} but {} returned",
-            ctx->expected_returns.count, return_count);
-         this->record_diagnostic(std::move(diag));
-      }
 
       // Validate type of each returned value
       for (size_t i = 0; i < return_count and i < MAX_RETURN_TYPES; ++i) {
@@ -2751,18 +2743,26 @@ static void publish_type_diagnostics(ParserContext& Context, const std::vector<T
 // instance, runs analysis on the module, and publishes any collected diagnostics.
 
 // Publish fixed global types to the lexer state so that IR emission (which runs after analysis) can attach type
-// metadata to global identifier reads.  Only the container types with specialised access bytecodes are published;
-// scalar hints have no emitter consumers and are withheld to avoid altering unrelated emission paths.
+// metadata to global identifier reads and explicit runtime contracts to every global store.  Inferred scalar types
+// remain advisory and have no emitter consumer.
 
 void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
 {
    for (const auto &[name, info] : this->global_types_) {
       if (not info.type.is_fixed) continue;
+      if (info.explicit_contract) {
+         Lex.global_type_hints[name] = {
+            info.type.primary, info.type.object_class_id, info.type.struct_def, true
+         };
+         continue;
+      }
       switch (info.type.primary) {
          case TiriType::Struct:
          case TiriType::Object:
          case TiriType::Array:
-            Lex.global_type_hints[name] = { info.type.primary, info.type.object_class_id, info.type.struct_def };
+            Lex.global_type_hints[name] = {
+               info.type.primary, info.type.object_class_id, info.type.struct_def, false
+            };
             break;
          default:
             break;

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -1,0 +1,38 @@
+// Runtime type-contract descriptor shared by the parser and VM.
+// Copyright © 2026 Paul Manias
+
+#pragma once
+
+#include <cstdint>
+
+inline constexpr uint8_t TIRI_CONTRACT_VERSION = 1;
+
+enum class ContractBoundary : uint8_t {
+   Parameter = 1,
+   Result,
+   Local,
+   Upvalue,
+   Global
+};
+
+enum class ContractDescriptorFlag : uint8_t {
+   None = 0,
+   DynamicCount = 1 << 0,
+   Variadic = 1 << 1
+};
+
+enum class ContractEntryFlag : uint8_t {
+   None = 0,
+   Nullable = 1 << 0,
+   Required = 1 << 1
+};
+
+[[nodiscard]] constexpr inline uint8_t contract_flag(ContractDescriptorFlag Flag) noexcept
+{
+   return uint8_t(Flag);
+}
+
+[[nodiscard]] constexpr inline uint8_t contract_flag(ContractEntryFlag Flag) noexcept
+{
+   return uint8_t(Flag);
+}

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "lj_obj.h"
+
+#include <array>
 #include <cstdint>
+#include <string_view>
 
 inline constexpr uint8_t TIRI_CONTRACT_VERSION = 1;
 
@@ -35,4 +39,120 @@ enum class ContractEntryFlag : uint8_t {
 [[nodiscard]] constexpr inline uint8_t contract_flag(ContractEntryFlag Flag) noexcept
 {
    return uint8_t(Flag);
+}
+
+struct RuntimeContractEntry {
+   TiriType type = TiriType::Unknown;
+   uint8_t flags = 0;
+   uint8_t position = 0;
+   std::string_view struct_name;
+   std::string_view label;
+};
+
+struct RuntimeContractDescriptor {
+   ContractBoundary boundary = ContractBoundary::Parameter;
+   uint8_t flags = 0;
+   uint8_t static_value_count = 0;
+   uint8_t contract_count = 0;
+   std::array<RuntimeContractEntry, MAX_RETURN_TYPES> entries{};
+
+   [[nodiscard]] bool dynamic_count() const noexcept
+   {
+      return (this->flags & contract_flag(ContractDescriptorFlag::DynamicCount)) != 0;
+   }
+
+   [[nodiscard]] bool variadic() const noexcept
+   {
+      return (this->flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
+   }
+
+   [[nodiscard]] const RuntimeContractEntry * entry_for(uint32_t Position) const noexcept
+   {
+      if (Position < this->contract_count) return &this->entries[Position];
+      if (this->variadic() and this->contract_count > 0) return &this->entries[this->contract_count - 1];
+      return nullptr;
+   }
+};
+
+enum class RuntimeContractDecodeError : uint8_t {
+   None,
+   Descriptor,
+   Entry
+};
+
+class RuntimeContractReader {
+public:
+   explicit RuntimeContractReader(const GCstr *Descriptor) noexcept
+      : cursor_(reinterpret_cast<const uint8_t *>(strdata(Descriptor))),
+        end_(this->cursor_ + Descriptor->len) {}
+
+   [[nodiscard]] bool read_byte(uint8_t &Value) noexcept
+   {
+      if (this->cursor_ >= this->end_) return false;
+      Value = *this->cursor_++;
+      return true;
+   }
+
+   [[nodiscard]] bool read_text(std::string_view &Value) noexcept
+   {
+      uint8_t length;
+      if (not this->read_byte(length) or size_t(this->end_ - this->cursor_) < length) return false;
+      Value = std::string_view(reinterpret_cast<const char *>(this->cursor_), length);
+      this->cursor_ += length;
+      return true;
+   }
+
+   [[nodiscard]] bool at_end() const noexcept
+   {
+      return this->cursor_ IS this->end_;
+   }
+
+private:
+   const uint8_t *cursor_;
+   const uint8_t *end_;
+};
+
+[[nodiscard]] inline bool decode_runtime_contract(
+   const GCstr *Descriptor, RuntimeContractDescriptor &Result,
+   RuntimeContractDecodeError *Error = nullptr) noexcept
+{
+   if (Error) *Error = RuntimeContractDecodeError::None;
+   auto fail = [Error](RuntimeContractDecodeError Value) {
+      if (Error) *Error = Value;
+      return false;
+   };
+
+   RuntimeContractReader reader(Descriptor);
+   uint8_t version;
+   uint8_t boundary;
+   if (not reader.read_byte(version) or version != TIRI_CONTRACT_VERSION or
+       not reader.read_byte(boundary) or boundary < uint8_t(ContractBoundary::Parameter) or
+       boundary > uint8_t(ContractBoundary::Global) or not reader.read_byte(Result.flags) or
+       (Result.flags & ~(contract_flag(ContractDescriptorFlag::DynamicCount) |
+          contract_flag(ContractDescriptorFlag::Variadic))) != 0 or
+       not reader.read_byte(Result.static_value_count) or not reader.read_byte(Result.contract_count) or
+       Result.contract_count > MAX_RETURN_TYPES) {
+      return fail(RuntimeContractDecodeError::Descriptor);
+   }
+   Result.boundary = ContractBoundary(boundary);
+
+   for (uint8_t i = 0; i < Result.contract_count; ++i) {
+      auto &entry = Result.entries[i];
+      uint8_t type;
+      if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
+          not reader.read_byte(entry.flags) or
+          (entry.flags & ~(contract_flag(ContractEntryFlag::Nullable) |
+             contract_flag(ContractEntryFlag::Required))) != 0 or
+          not reader.read_byte(entry.position) or entry.position IS 0 or
+          not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
+      entry.type = TiriType(type);
+      if (not entry.struct_name.empty() and entry.type != TiriType::Struct) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
+   }
+
+   if (not reader.at_end()) return fail(RuntimeContractDecodeError::Descriptor);
+   return true;
 }

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -406,6 +406,7 @@ static int gc_traverse_tab(global_State *g, GCtab* t)
    GCtab *mt = tabref(t->metatable);
 
    if (mt) gc_markobj(g, mt);
+   if (GCtab *contracts = tabref(t->global_type_contracts)) gc_markobj(g, contracts);
 
    mode = lj_meta_fastg(g, mt, MM_mode);
    if (mode and tvisstr(mode)) {  // Valid __mode field?

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -600,52 +600,6 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 
 namespace {
 
-struct RuntimeContractEntry {
-   TiriType type = TiriType::Unknown;
-   uint8_t flags = 0;
-   uint8_t position = 0;
-   std::string_view struct_name;
-   std::string_view label;
-};
-
-class RuntimeContractReader {
-public:
-   explicit RuntimeContractReader(GCstr *Descriptor)
-      : cursor(reinterpret_cast<const uint8_t *>(strdata(Descriptor))),
-        end(cursor + Descriptor->len) {}
-
-   [[nodiscard]] bool read_byte(uint8_t &Value)
-   {
-      if (this->cursor >= this->end) return false;
-      Value = *this->cursor++;
-      return true;
-   }
-
-   [[nodiscard]] bool read_text(std::string_view &Value)
-   {
-      uint8_t length;
-      if (not this->read_byte(length) or size_t(this->end - this->cursor) < length) return false;
-      Value = std::string_view(reinterpret_cast<const char *>(this->cursor), length);
-      this->cursor += length;
-      return true;
-   }
-
-   [[nodiscard]] bool read_entry(RuntimeContractEntry &Entry)
-   {
-      uint8_t type;
-      if (not this->read_byte(type) or not this->read_byte(Entry.flags) or not this->read_byte(Entry.position) or
-          not this->read_text(Entry.struct_name) or not this->read_text(Entry.label)) {
-         return false;
-      }
-      Entry.type = TiriType(type);
-      return type <= uint8_t(TiriType::Unknown);
-   }
-
-private:
-   const uint8_t *cursor;
-   const uint8_t *end;
-};
-
 [[nodiscard]] static bool contract_is_range(lua_State *L, cTValue *Value)
 {
    if (not tvisudata(Value)) return false;
@@ -769,40 +723,23 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
 extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor)
 {
    L->top = curr_topL(L);
-   RuntimeContractReader reader(Descriptor);
-   uint8_t version;
-   uint8_t boundary_value;
-   uint8_t descriptor_flags;
-   uint8_t static_count;
-   uint8_t contract_count;
-   if (not reader.read_byte(version) or version != TIRI_CONTRACT_VERSION or
-       not reader.read_byte(boundary_value) or
-       boundary_value < uint8_t(ContractBoundary::Parameter) or
-       boundary_value > uint8_t(ContractBoundary::Global) or
-       not reader.read_byte(descriptor_flags) or not reader.read_byte(static_count) or
-       not reader.read_byte(contract_count) or contract_count > MAX_RETURN_TYPES) {
-      lj_err_callermsg(L, "invalid runtime type-contract descriptor");
+   RuntimeContractDescriptor descriptor;
+   RuntimeContractDecodeError decode_error;
+   if (not decode_runtime_contract(Descriptor, descriptor, &decode_error)) {
+      if (decode_error IS RuntimeContractDecodeError::Entry) {
+         lj_err_callermsg(L, "invalid runtime type-contract entry");
+      }
+      else lj_err_callermsg(L, "invalid runtime type-contract descriptor");
    }
 
-   std::array<RuntimeContractEntry, MAX_RETURN_TYPES> entries;
-   for (uint8_t i = 0; i < contract_count; ++i) {
-      if (not reader.read_entry(entries[i])) lj_err_callermsg(L, "invalid runtime type-contract entry");
-   }
-
-   uint32_t value_count = (descriptor_flags & contract_flag(ContractDescriptorFlag::DynamicCount)) ?
-      DynamicCount + static_count : static_count;
-   bool variadic = (descriptor_flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
-   auto boundary = ContractBoundary(boundary_value);
+   uint32_t value_count = descriptor.dynamic_count() ?
+      DynamicCount + descriptor.static_value_count : descriptor.static_value_count;
    ptrdiff_t base_offset = savestack(L, Base);
 
    for (uint32_t i = 0; i < value_count; ++i) {
-      uint32_t contract_index;
-      if (i < contract_count) contract_index = i;
-      else if (variadic and contract_count > 0) contract_index = contract_count - 1;
-      else continue;
-
-      const RuntimeContractEntry &entry = entries[contract_index];
-      if (entry.type IS TiriType::Any or entry.type IS TiriType::Unknown) continue;
+      const RuntimeContractEntry *entry = descriptor.entry_for(i);
+      if (not entry) continue;
+      if (entry->type IS TiriType::Any or entry->type IS TiriType::Unknown) continue;
 
       Base = restorestack(L, base_offset);
       TValue *value = Base + i;
@@ -813,9 +750,9 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
          copyTV(L, value, resolved);
       }
 
-      if (not contract_matches(L, value, entry)) {
-         uint32_t position = boundary IS ContractBoundary::Result ? i + 1 : entry.position;
-         contract_error(L, value, boundary, entry, position);
+      if (not contract_matches(L, value, *entry)) {
+         uint32_t position = descriptor.boundary IS ContractBoundary::Result ? i + 1 : entry->position;
+         contract_error(L, value, descriptor.boundary, *entry, position);
       }
    }
 }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -47,7 +47,8 @@ static TiriType lj_tag_to_tiri_type(uint32_t tag)
       case LJ_TFUNC:   return TiriType::Func;
       case LJ_TOBJECT: return TiriType::Object;
       case LJ_TTAB:    return TiriType::Table;
-      case LJ_TUDATA:  return TiriType::Object;
+      case LJ_TLIGHTUD:
+      case LJ_TUDATA:  return TiriType::Userdata;
       case LJ_TARRAY:  return TiriType::Array;
       default:         return TiriType::Num;  // Numbers have itype < LJ_TISNUM
    }
@@ -662,6 +663,13 @@ private:
    return call and tvisfunc(call);
 }
 
+[[nodiscard]] static bool contract_is_userdata(lua_State *L, cTValue *Value)
+{
+   if (tvislightud(Value)) return true;
+   if (not tvisudata(Value) or lj_is_thunk(Value)) return false;
+   return not contract_is_range(L, Value);
+}
+
 [[nodiscard]] static bool contract_matches(lua_State *L, cTValue *Value, const RuntimeContractEntry &Entry)
 {
    bool nullable = (Entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
@@ -684,8 +692,9 @@ private:
          struct_record *definition = find_struct(L, Entry.struct_name);
          return definition and structV(Value)->def IS definition;
       }
-      case TiriType::Object: return tvisobject(Value);
-      case TiriType::Range:  return contract_is_range(L, Value);
+      case TiriType::Object:   return tvisobject(Value);
+      case TiriType::Range:    return contract_is_range(L, Value);
+      case TiriType::Userdata: return contract_is_userdata(L, Value);
    }
    return false;
 }
@@ -718,9 +727,10 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
       case TiriType::Table:   name = "table"; break;
       case TiriType::Array:   name = "array"; break;
       case TiriType::Func:    name = "func"; break;
-      case TiriType::Struct:  name = "struct"; break;
-      case TiriType::Object:  name = "obj"; break;
-      case TiriType::Range:   name = "range"; break;
+      case TiriType::Struct:   name = "struct"; break;
+      case TiriType::Object:   name = "obj"; break;
+      case TiriType::Range:    name = "range"; break;
+      case TiriType::Userdata: name = "userdata"; break;
       case TiriType::Any:
       case TiriType::Unknown: break;
    }
@@ -783,6 +793,7 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
       DynamicCount + static_count : static_count;
    bool variadic = (descriptor_flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
    auto boundary = ContractBoundary(boundary_value);
+   ptrdiff_t base_offset = savestack(L, Base);
 
    for (uint32_t i = 0; i < value_count; ++i) {
       uint32_t contract_index;
@@ -792,9 +803,19 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
 
       const RuntimeContractEntry &entry = entries[contract_index];
       if (entry.type IS TiriType::Any or entry.type IS TiriType::Unknown) continue;
-      if (not contract_matches(L, Base + i, entry)) {
+
+      Base = restorestack(L, base_offset);
+      TValue *value = Base + i;
+      if (lj_is_thunk(value)) {
+         TValue *resolved = lj_thunk_resolve(L, udataV(value));
+         Base = restorestack(L, base_offset);
+         value = Base + i;
+         copyTV(L, value, resolved);
+      }
+
+      if (not contract_matches(L, value, entry)) {
          uint32_t position = boundary IS ContractBoundary::Result ? i + 1 : entry.position;
-         contract_error(L, Base + i, boundary, entry, position);
+         contract_error(L, value, boundary, entry, position);
       }
    }
 }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -23,8 +23,14 @@
 #include "lj_strfmt.h"
 #include "lj_thunk.h"
 #include "lj_object.h"
+#include "lj_contract.h"
 #include "stack_helpers.h"
 #include "lib.h"
+#include "lib_range.h"
+#include "../../../defs.h"
+
+#include <cstdio>
+#include <string_view>
 
 //********************************************************************************************************************
 // Convert LuaJIT internal type tag to TiriType for runtime type inference.
@@ -581,6 +587,232 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
       if (not tvisbool(o)) lj_err_assigntype(L, int(ra) - 1, "boolean");
    }
    else lj_err_assigntype(L, int(ra) - 1, lj_obj_itypename[tp]);
+}
+
+//********************************************************************************************************************
+// Exact runtime type contracts.  The descriptor is an interned byte string, so it remains portable across bytecode
+// dump/write/read boundaries.  Layout:
+//
+//   version, boundary, descriptor_flags, static_value_count, contract_count,
+//   repeated { type, entry_flags, position, struct_name_length, struct_name_bytes,
+//              label_length, label_bytes }
+
+namespace {
+
+struct RuntimeContractEntry {
+   TiriType type = TiriType::Unknown;
+   uint8_t flags = 0;
+   uint8_t position = 0;
+   std::string_view struct_name;
+   std::string_view label;
+};
+
+class RuntimeContractReader {
+public:
+   explicit RuntimeContractReader(GCstr *Descriptor)
+      : cursor(reinterpret_cast<const uint8_t *>(strdata(Descriptor))),
+        end(cursor + Descriptor->len) {}
+
+   [[nodiscard]] bool read_byte(uint8_t &Value)
+   {
+      if (this->cursor >= this->end) return false;
+      Value = *this->cursor++;
+      return true;
+   }
+
+   [[nodiscard]] bool read_text(std::string_view &Value)
+   {
+      uint8_t length;
+      if (not this->read_byte(length) or size_t(this->end - this->cursor) < length) return false;
+      Value = std::string_view(reinterpret_cast<const char *>(this->cursor), length);
+      this->cursor += length;
+      return true;
+   }
+
+   [[nodiscard]] bool read_entry(RuntimeContractEntry &Entry)
+   {
+      uint8_t type;
+      if (not this->read_byte(type) or not this->read_byte(Entry.flags) or not this->read_byte(Entry.position) or
+          not this->read_text(Entry.struct_name) or not this->read_text(Entry.label)) {
+         return false;
+      }
+      Entry.type = TiriType(type);
+      return type <= uint8_t(TiriType::Unknown);
+   }
+
+private:
+   const uint8_t *cursor;
+   const uint8_t *end;
+};
+
+[[nodiscard]] static bool contract_is_range(lua_State *L, cTValue *Value)
+{
+   if (not tvisudata(Value)) return false;
+   GCtab *metatable = tabref(udataV(Value)->metatable);
+   if (not metatable) return false;
+
+   cTValue *registered = lj_tab_getstr(tabV(registry(L)), lj_str_newz(L, RANGE_METATABLE));
+   return registered and tvistab(registered) and tabV(registered) IS metatable;
+}
+
+[[nodiscard]] static bool contract_is_callable(lua_State *L, cTValue *Value)
+{
+   if (tvisfunc(Value)) return true;
+   cTValue *call = lj_meta_lookup(L, Value, MM_call);
+   return call and tvisfunc(call);
+}
+
+[[nodiscard]] static bool contract_matches(lua_State *L, cTValue *Value, const RuntimeContractEntry &Entry)
+{
+   bool nullable = (Entry.flags & contract_flag(ContractEntryFlag::Nullable)) != 0;
+   bool required = (Entry.flags & contract_flag(ContractEntryFlag::Required)) != 0;
+   if (tvisnil(Value)) return nullable and not required;
+
+   switch (Entry.type) {
+      case TiriType::Any:
+      case TiriType::Unknown: return true;
+      case TiriType::Nil:     return false;
+      case TiriType::Bool:    return tvisbool(Value);
+      case TiriType::Num:     return tvisnumber(Value);
+      case TiriType::Str:     return tvisstr(Value);
+      case TiriType::Table:   return tvistab(Value);
+      case TiriType::Array:   return tvisarray(Value);
+      case TiriType::Func:    return contract_is_callable(L, Value);
+      case TiriType::Struct: {
+         if (not tvisstruct(Value)) return false;
+         if (Entry.struct_name.empty()) return true;
+         struct_record *definition = find_struct(L, Entry.struct_name);
+         return definition and structV(Value)->def IS definition;
+      }
+      case TiriType::Object: return tvisobject(Value);
+      case TiriType::Range:  return contract_is_range(L, Value);
+   }
+   return false;
+}
+
+[[nodiscard]] static const char * contract_boundary_name(ContractBoundary Boundary)
+{
+   switch (Boundary) {
+      case ContractBoundary::Parameter: return "parameter";
+      case ContractBoundary::Result:    return "result";
+      case ContractBoundary::Local:     return "local";
+      case ContractBoundary::Upvalue:   return "upvalue";
+      case ContractBoundary::Global:    return "global";
+   }
+   return "value";
+}
+
+static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractEntry &Entry)
+{
+   if (Entry.type IS TiriType::Struct and not Entry.struct_name.empty()) {
+      std::snprintf(Buffer, Size, "struct<%.*s>", int(Entry.struct_name.size()), Entry.struct_name.data());
+      return;
+   }
+
+   const char *name = "any";
+   switch (Entry.type) {
+      case TiriType::Nil:     name = "nil"; break;
+      case TiriType::Bool:    name = "bool"; break;
+      case TiriType::Num:     name = "num"; break;
+      case TiriType::Str:     name = "str"; break;
+      case TiriType::Table:   name = "table"; break;
+      case TiriType::Array:   name = "array"; break;
+      case TiriType::Func:    name = "func"; break;
+      case TiriType::Struct:  name = "struct"; break;
+      case TiriType::Object:  name = "obj"; break;
+      case TiriType::Range:   name = "range"; break;
+      case TiriType::Any:
+      case TiriType::Unknown: break;
+   }
+   std::snprintf(Buffer, Size, "%s", name);
+}
+
+[[noreturn]] static void contract_error(lua_State *L, cTValue *Value, ContractBoundary Boundary,
+   const RuntimeContractEntry &Entry, uint32_t Position)
+{
+   char expected[280];
+   char actual[280];
+   contract_type_name(expected, sizeof(expected), Entry);
+
+   if (tvisstruct(Value) and structV(Value)->def) {
+      const auto &name = structV(Value)->def->Name;
+      std::snprintf(actual, sizeof(actual), "struct<%.*s>", int(name.size()), name.data());
+   }
+   else if (contract_is_range(L, Value)) std::snprintf(actual, sizeof(actual), "range");
+   else std::snprintf(actual, sizeof(actual), "%s", lj_typename(Value));
+
+   const char *boundary = contract_boundary_name(Boundary);
+   if (not Entry.label.empty()) {
+      CSTRING message = lj_strfmt_pushf(L, "type contract failed for %s %u ('%.*s'): expected %s, got %s",
+         boundary, Position, int(Entry.label.size()), Entry.label.data(), expected, actual);
+      lj_err_callermsg(L, message);
+   }
+   else {
+      CSTRING message = lj_strfmt_pushf(L, "type contract failed for %s %u: expected %s, got %s",
+         boundary, Position, expected, actual);
+      lj_err_callermsg(L, message);
+   }
+}
+
+} // namespace
+
+extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor)
+{
+   L->top = curr_topL(L);
+   RuntimeContractReader reader(Descriptor);
+   uint8_t version;
+   uint8_t boundary_value;
+   uint8_t descriptor_flags;
+   uint8_t static_count;
+   uint8_t contract_count;
+   if (not reader.read_byte(version) or version != TIRI_CONTRACT_VERSION or
+       not reader.read_byte(boundary_value) or
+       boundary_value < uint8_t(ContractBoundary::Parameter) or
+       boundary_value > uint8_t(ContractBoundary::Global) or
+       not reader.read_byte(descriptor_flags) or not reader.read_byte(static_count) or
+       not reader.read_byte(contract_count) or contract_count > MAX_RETURN_TYPES) {
+      lj_err_callermsg(L, "invalid runtime type-contract descriptor");
+   }
+
+   std::array<RuntimeContractEntry, MAX_RETURN_TYPES> entries;
+   for (uint8_t i = 0; i < contract_count; ++i) {
+      if (not reader.read_entry(entries[i])) lj_err_callermsg(L, "invalid runtime type-contract entry");
+   }
+
+   uint32_t value_count = (descriptor_flags & contract_flag(ContractDescriptorFlag::DynamicCount)) ?
+      DynamicCount + static_count : static_count;
+   bool variadic = (descriptor_flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
+   auto boundary = ContractBoundary(boundary_value);
+
+   for (uint32_t i = 0; i < value_count; ++i) {
+      uint32_t contract_index;
+      if (i < contract_count) contract_index = i;
+      else if (variadic and contract_count > 0) contract_index = contract_count - 1;
+      else continue;
+
+      const RuntimeContractEntry &entry = entries[contract_index];
+      if (entry.type IS TiriType::Any or entry.type IS TiriType::Unknown) continue;
+      if (not contract_matches(L, Base + i, entry)) {
+         uint32_t position = boundary IS ContractBoundary::Result ? i + 1 : entry.position;
+         contract_error(L, Base + i, boundary, entry, position);
+      }
+   }
+}
+
+extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t DynamicCount)
+{
+   GCproto *prototype = funcproto(curr_func(L));
+   const BCIns *begin = proto_bc(prototype) + 1;
+   const BCIns *cursor = PC;
+   while (cursor > begin) {
+      BCIns instruction = *--cursor;
+      if (bc_op(instruction) IS BC_CONTRACT) {
+         GCstr *descriptor = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(instruction)));
+         lj_meta_contract(L, L->base + bc_a(instruction), DynamicCount, descriptor);
+         return;
+      }
+   }
+   lj_err_callermsg(L, "invalid runtime type-contract resume point");
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -950,13 +950,14 @@ void lj_meta_typefix(lua_State *L, TValue *base, uint32_t count)
 
    GCproto *pt = funcproto(fn);
 
-   // Only process if PROTO_TYPEFIX is set (function has no explicit return types)
-   if (not (pt->flags & PROTO_TYPEFIX)) return;
+   auto signature = proto_signature(pt);
+   if (not signature or not (signature->flags & proto_signature_flag(ProtoSignatureFlag::DynamicResults))) return;
+   auto result_types = proto_result_types(pt);
 
    // Process each return value position
-   for (uint32_t pos = 0; pos < count and pos < PROTO_MAX_RETURN_TYPES; ++pos) {
+   for (uint32_t pos = 0; pos < count and pos < signature->result_entry_count; ++pos) {
       // Only fix if type is currently Unknown
-      if (pt->result_types[pos] != TiriType::Unknown) continue;
+      if (result_types[pos].type != TiriType::Unknown) continue;
 
       // Get the value being returned
       TValue *val = base + pos;
@@ -970,11 +971,9 @@ void lj_meta_typefix(lua_State *L, TValue *base, uint32_t count)
       if (tvisnumber(val)) inferred = TiriType::Num;
       else inferred = lj_tag_to_tiri_type(itype(val));
 
-      // Fix the type in the prototype
-      // Note: This is a mutation of the prototype. For thread safety, this relies on
-      // the fact that the write is atomic at the byte level and idempotent (same value
-      // would be written by any thread inferring the same type).
+      // Fix the type in the state-owned prototype. Asynchronous workers use separate Tiri states and prototype graphs,
+      // so this metadata is not published for concurrent mutation.
 
-      pt->result_types[pos] = inferred;
+      result_types[pos].type = inferred;
    }
 }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -755,6 +755,14 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
          contract_error(L, value, descriptor.boundary, *entry, position);
       }
    }
+
+   if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1) {
+      const RuntimeContractEntry &entry = descriptor.entries[0];
+      if (not entry.label.empty()) {
+         GCstr *name = lj_str_new(L, entry.label.data(), entry.label.size());
+         lj_tab_set_global_contract(L, tabref(curr_func(L)->c.env), name, Descriptor);
+      }
+   }
 }
 
 extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t DynamicCount)

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -32,6 +32,8 @@ extern "C" [[nodiscard]] TValue* lj_meta_equal_cd(lua_State* L, BCIns ins);
 extern "C" [[nodiscard]] TValue* lj_meta_equal_thunk(lua_State* L, BCIns ins);
 extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue* o2, int op);
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
+extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
+extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
 extern "C" void lj_meta_call(lua_State* L, TValue* func, TValue* top);
 extern "C" void lj_meta_for(lua_State* L, TValue* o);
 

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -619,6 +619,94 @@ inline constexpr uint8_t TRY_FLAG_TRACE = 0x01;  // Capture stack trace on excep
 
 inline constexpr int LJ_MAX_TRY_DEPTH = 32;
 
+// Function signature metadata.  Entries contain only state-portable identifiers: struct constraints use struct_key()
+// and object constraints use CLASSID.  Parameter entries are stored first, followed by result entries.
+
+inline constexpr uint8_t PROTO_SIGNATURE_VERSION = 1;
+
+enum class ProtoTypeOrigin : uint8_t {
+   Unspecified = 0,
+   Declared,
+   Inferred
+};
+
+enum class ProtoTypeStrength : uint8_t {
+   Advisory = 0,
+   Checked,
+   Trusted
+};
+
+enum class ProtoSignatureFlag : uint8_t {
+   None = 0,
+   ParameterVariadic = 1 << 0,
+   ResultVariadic = 1 << 1,
+   ExplicitResults = 1 << 2,
+   DynamicResults = 1 << 3
+};
+
+inline constexpr uint8_t PROTO_TYPE_NULLABLE = 1 << 0;
+inline constexpr uint8_t PROTO_TYPE_REQUIRED = 1 << 1;
+inline constexpr uint8_t PROTO_TYPE_ORIGIN_SHIFT = 2;
+inline constexpr uint8_t PROTO_TYPE_ORIGIN_MASK = 3 << PROTO_TYPE_ORIGIN_SHIFT;
+inline constexpr uint8_t PROTO_TYPE_STRENGTH_SHIFT = 4;
+inline constexpr uint8_t PROTO_TYPE_STRENGTH_MASK = 3 << PROTO_TYPE_STRENGTH_SHIFT;
+
+struct ProtoTypeEntry {
+   uint32_t constraint = 0;
+   TiriType type = TiriType::Unknown;
+   uint8_t flags = 0;
+   uint16_t reserved = 0;
+};
+
+struct ProtoSignature {
+   uint8_t version = PROTO_SIGNATURE_VERSION;
+   uint8_t flags = 0;
+   uint8_t parameter_count = 0;
+   uint8_t result_count = 0;
+   uint8_t result_entry_count = 0;
+   uint8_t reserved[3] = {};
+};
+
+static_assert(sizeof(ProtoTypeEntry) IS 8, "ProtoTypeEntry must remain compact");
+static_assert(sizeof(ProtoSignature) IS 8, "ProtoSignature header must remain compact");
+
+[[nodiscard]] constexpr inline uint8_t proto_signature_flag(ProtoSignatureFlag Flag) noexcept
+{
+   return uint8_t(Flag);
+}
+
+[[nodiscard]] constexpr inline uint8_t proto_type_flags(bool Nullable, bool Required, ProtoTypeOrigin Origin,
+   ProtoTypeStrength Strength) noexcept
+{
+   return uint8_t((Nullable ? PROTO_TYPE_NULLABLE : 0) | (Required ? PROTO_TYPE_REQUIRED : 0) |
+      (uint8_t(Origin) << PROTO_TYPE_ORIGIN_SHIFT) | (uint8_t(Strength) << PROTO_TYPE_STRENGTH_SHIFT));
+}
+
+[[nodiscard]] constexpr inline ProtoTypeOrigin proto_type_origin(const ProtoTypeEntry &Entry) noexcept
+{
+   return ProtoTypeOrigin((Entry.flags & PROTO_TYPE_ORIGIN_MASK) >> PROTO_TYPE_ORIGIN_SHIFT);
+}
+
+[[nodiscard]] constexpr inline ProtoTypeStrength proto_type_strength(const ProtoTypeEntry &Entry) noexcept
+{
+   return ProtoTypeStrength((Entry.flags & PROTO_TYPE_STRENGTH_MASK) >> PROTO_TYPE_STRENGTH_SHIFT);
+}
+
+[[nodiscard]] constexpr inline bool proto_type_nullable(const ProtoTypeEntry &Entry) noexcept
+{
+   return (Entry.flags & PROTO_TYPE_NULLABLE) != 0;
+}
+
+[[nodiscard]] constexpr inline bool proto_type_required(const ProtoTypeEntry &Entry) noexcept
+{
+   return (Entry.flags & PROTO_TYPE_REQUIRED) != 0;
+}
+
+[[nodiscard]] constexpr inline size_t proto_signature_size(size_t ParameterCount, size_t ResultEntryCount) noexcept
+{
+   return sizeof(ProtoSignature) + (ParameterCount + ResultEntryCount) * sizeof(ProtoTypeEntry);
+}
+
 // Exception frame for try-except blocks (runtime state)
 // Note: frame_base and saved_top are offsets from L->stack (not absolute pointers) because the Lua stack can be
 // reallocated during execution.  Use savestack(L, ptr) to convert to offset, restorestack(L, offset) to convert back.
@@ -663,8 +751,8 @@ typedef struct GCproto {
    MRef   uvinfo;     //  Upvalue names.
    MRef   varinfo;    //  Names and compressed extents of local variables.
    uint64_t closeslots;  //  Bitmap of locals with <close> attribute (max 64 slots)
-   // Return type information for runtime type checking
-   std::array<TiriType, PROTO_MAX_RETURN_TYPES> result_types{};  // Return types, set by fs_finish()
+   MRef signature;       // Co-located ProtoSignature and positional ProtoTypeEntry records.
+   uint16_t signature_size; // Total byte size of signature, or zero when absent.
    // Try-except exception handling metadata
    TryBlockDesc   *try_blocks;        // Array of try block descriptors (nullptr if none)
    TryHandlerDesc *try_handlers;      // Array of handler descriptors (nullptr if none)
@@ -681,7 +769,6 @@ inline constexpr uint8_t PROTO_ILOOP        = 0x10;   //  Patched bytecode with 
 // Only used during parsing.
 inline constexpr uint8_t PROTO_HAS_RETURN   = 0x20;   //  Already emitted a return.
 inline constexpr uint8_t PROTO_FIXUP_RETURN = 0x40;   //  Need to fixup emitted returns.
-inline constexpr uint8_t PROTO_TYPEFIX      = 0x80;   //  Runtime type inference enabled (no explicit return types).
 // Top bits used for counting created closures.
 inline constexpr uint8_t PROTO_CLCOUNT      = 0x20;   //  Base of saturating 3 bit counter.
 inline constexpr int PROTO_CLC_BITS         = 3;
@@ -709,6 +796,75 @@ inline constexpr uint16_t PROTO_UV_IMMUTABLE = 0x4000;   //  Immutable upvalue.
 
 [[nodiscard]] inline uint16_t* proto_uv(const GCproto* pt) noexcept {
    return pt->uv.get<uint16_t>();
+}
+
+[[nodiscard]] inline ProtoSignature * proto_signature(GCproto *Proto) noexcept
+{
+   return Proto->signature.get<ProtoSignature>();
+}
+
+[[nodiscard]] inline const ProtoSignature * proto_signature(const GCproto *Proto) noexcept
+{
+   return Proto->signature.get<const ProtoSignature>();
+}
+
+[[nodiscard]] inline ProtoTypeEntry * proto_parameter_types(GCproto *Proto) noexcept
+{
+   auto signature = proto_signature(Proto);
+   return signature ? (ProtoTypeEntry *)(signature + 1) : nullptr;
+}
+
+[[nodiscard]] inline const ProtoTypeEntry * proto_parameter_types(const GCproto *Proto) noexcept
+{
+   auto signature = proto_signature(Proto);
+   return signature ? (const ProtoTypeEntry *)(signature + 1) : nullptr;
+}
+
+[[nodiscard]] inline ProtoTypeEntry * proto_result_types(GCproto *Proto) noexcept
+{
+   auto signature = proto_signature(Proto);
+   return signature ? proto_parameter_types(Proto) + signature->parameter_count : nullptr;
+}
+
+[[nodiscard]] inline const ProtoTypeEntry * proto_result_types(const GCproto *Proto) noexcept
+{
+   auto signature = proto_signature(Proto);
+   return signature ? proto_parameter_types(Proto) + signature->parameter_count : nullptr;
+}
+
+[[nodiscard]] inline ProtoTypeEntry proto_result_type(const GCproto *Proto, size_t Position) noexcept
+{
+   const auto signature = proto_signature(Proto);
+   if (not signature) return {};
+   const auto results = proto_result_types(Proto);
+   if (Position < signature->result_entry_count) return results[Position];
+   if ((signature->flags & proto_signature_flag(ProtoSignatureFlag::ResultVariadic)) and
+       signature->result_entry_count > 0) {
+      return results[signature->result_entry_count - 1];
+   }
+   if (Position < signature->result_count) {
+      return ProtoTypeEntry{
+         .constraint = 0,
+         .type = TiriType::Any,
+         .flags = proto_type_flags(true, false, ProtoTypeOrigin::Declared, ProtoTypeStrength::Advisory)
+      };
+   }
+   return {};
+}
+
+inline void proto_metadata_init(GCproto *Proto) noexcept
+{
+   Proto->file_source_idx = 0;
+   setmref(Proto->lineinfo, nullptr);
+   setmref(Proto->uvinfo, nullptr);
+   setmref(Proto->varinfo, nullptr);
+   Proto->closeslots = 0;
+   setmref(Proto->signature, nullptr);
+   Proto->signature_size = 0;
+   Proto->try_blocks = nullptr;
+   Proto->try_handlers = nullptr;
+   Proto->try_block_count = 0;
+   Proto->try_handler_count = 0;
 }
 
 // Forward declarations - defined after GCobj is complete

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -976,6 +976,7 @@ typedef struct GCtab {
    uint32_t asize;     // Size of array part (keys [0, asize-1]).
    uint32_t hmask;     // Hash part mask (size of hash part - 1).
    MRef     freetop;   // Top of free elements.
+   GCRef    global_type_contracts; // Runtime contracts for globals stored in this environment table.
 } GCtab;
 
 [[nodiscard]] constexpr inline size_t sizetabcolo(MSize n) noexcept { return n * sizeof(TValue) + sizeof(GCtab); }

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -134,6 +134,7 @@ enum class TiriType : uint8_t {
    Struct,       // Kotuku struct (LJ_TSTRUCT)
    Object,       // Kotuku object (LT_TOBJECT)
    Range,        // Range expression (runtime: LJ_TUDATA)
+   Userdata,     // Ordinary full or light userdata
    Unknown
 };
 
@@ -484,7 +485,7 @@ typedef struct ThunkPayload {
    GCRef deferred_func;    // The deferred closure (GCfunc)
    TValue cached_value;    // Cached resolved value
    uint8_t resolved;       // Resolution flag (0 = not resolved, 1 = resolved)
-   uint8_t expected_type;  // LJ type tag for type() (LUA_TSTRING, LUA_TNUMBER, etc.)
+   uint8_t expected_type;  // Logical TiriType declared for the deferred result
    uint16_t padding;       // Padding for alignment
 } ThunkPayload;
 

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -90,6 +90,7 @@ static GCtab * newtab(lua_State *L, uint32_t asize, uint32_t hbits)
       t->colo = (int8_t)asize;
       setmref(t->array, (TValue*)((char*)t + sizeof(GCtab)));
       setgcrefnull(t->metatable);
+      setgcrefnull(t->global_type_contracts);
       t->asize = asize;
       t->hmask = 0;
       nilnode = &G(L)->nilnode;
@@ -104,6 +105,7 @@ static GCtab * newtab(lua_State *L, uint32_t asize, uint32_t hbits)
       t->colo = 0;
       setmref(t->array, nullptr);
       setgcrefnull(t->metatable);
+      setgcrefnull(t->global_type_contracts);
       t->asize = 0;  //  In case the array allocation fails.
       t->hmask = 0;
       nilnode = &G(L)->nilnode;
@@ -575,6 +577,37 @@ TValue * lj_tab_set(lua_State *L, GCtab *t, cTValue *key)
       if (lj_obj_equal(&n->key, key)) return &n->val;
    } while ((n = nextnode(n)));
    return lj_tab_newkey(L, t, key);
+}
+
+//********************************************************************************************************************
+// Retrieve an explicit global type contract attached to an environment table.
+
+GCstr * lj_tab_get_global_contract(GCtab *Environment, const GCstr *Name)
+{
+   if (not Environment or not Name) return nullptr;
+   GCtab *contracts = tabref(Environment->global_type_contracts);
+   if (not contracts) return nullptr;
+
+   cTValue *value = lj_tab_getstr(contracts, Name);
+   return value and tvisstr(value) ? strV(value) : nullptr;
+}
+
+//********************************************************************************************************************
+// Attach an explicit global type contract to an environment table.
+
+void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *Name, GCstr *Descriptor)
+{
+   if (not Environment or not Name or not Descriptor) return;
+
+   GCtab *contracts = tabref(Environment->global_type_contracts);
+   if (not contracts) {
+      contracts = lj_tab_new(L, 0, 1);
+      setgcref(Environment->global_type_contracts, obj2gco(contracts));
+      lj_gc_objbarrier(L, Environment, contracts);
+   }
+
+   setstrV(L, lj_tab_setstr(L, contracts, Name), Descriptor);
+   lj_gc_anybarriert(L, contracts);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -101,6 +101,12 @@ LJ_FUNCA TValue* lj_tab_setinth(lua_State* L, GCtab* t, int32_t key);
 LJ_FUNC TValue* lj_tab_setstr(lua_State* L, GCtab* t, const GCstr* key);
 LJ_FUNC TValue* lj_tab_set(lua_State* L, GCtab* t, cTValue* key);
 
+// Explicit global type contracts are attached to the environment table so separately compiled chunks that share
+// that environment can enforce the declaration.
+LJ_FUNC [[nodiscard]] GCstr* lj_tab_get_global_contract(GCtab* Environment, const GCstr* Name);
+LJ_FUNC void lj_tab_set_global_contract(
+   lua_State* L, GCtab* Environment, const GCstr* Name, GCstr* Descriptor);
+
 // 0-based indexing: valid array indices are [0, asize)
 #define inarray(t, key)      ((MSize)(key) < (MSize)(t)->asize)
 #define arrayslot(t, i)      (&tvref((t)->array)[(i)])

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -28,7 +28,7 @@ using std::pow;
 //********************************************************************************************************************
 // Create a new thunk userdata
 
-void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type)
+void lj_thunk_new(lua_State *L, GCfunc *Func, uint8_t ExpectedType)
 {
    // Allocate userdata with ThunkPayload - use global environment for GC traversal
    GCudata *ud = lj_udata_new(L, sizeof(ThunkPayload), tabref(L->env));
@@ -36,10 +36,10 @@ void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type)
 
    // Initialize payload
    ThunkPayload *payload = thunk_payload(ud);
-   setgcref(payload->deferred_func, obj2gco(func));
+   setgcref(payload->deferred_func, obj2gco(Func));
    setnilV(&payload->cached_value);
    payload->resolved = 0;
-   payload->expected_type = (uint8_t)expected_type;
+   payload->expected_type = ExpectedType;
    payload->padding = 0;
 
    // Set metatable from registry
@@ -53,7 +53,7 @@ void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type)
    incr_top(L);
 
    // GC barrier for the function reference
-   lj_gc_objbarrier(L, obj2gco(ud), obj2gco(func));
+   lj_gc_objbarrier(L, obj2gco(ud), obj2gco(Func));
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_thunk.h
+++ b/src/tiri/jit/src/runtime/lj_thunk.h
@@ -6,10 +6,10 @@
 #include "lj_obj.h"
 
 // Create a new thunk userdata on the stack
-// func: The deferred closure
-// expected_type: LJ type tag (LUA_TNUMBER, LUA_TSTRING, etc., or LUA_TNIL for unknown)
+// Func: The deferred closure
+// ExpectedType: Logical TiriType value, or 0xff when the result is not declared
 
-LJ_FUNC void lj_thunk_new(lua_State *L, GCfunc *func, int expected_type);
+LJ_FUNC void lj_thunk_new(lua_State *L, GCfunc *Func, uint8_t ExpectedType);
 
 // Resolve a thunk if not already resolved
 // thunk_udata: The thunk userdata (must be UDTYPE_THUNK)

--- a/src/tiri/jit/src/runtime/register_capture_x64.asm
+++ b/src/tiri/jit/src/runtime/register_capture_x64.asm
@@ -269,4 +269,38 @@ asm_call_and_capture PROC
     ret
 asm_call_and_capture ENDP
 
+;------------------------------------------------------------------------------
+; void asm_call_cpuid_and_capture(RegisterSnapshot* before, RegisterSnapshot* after,
+;    int (*fn)(uint32_t, uint32_t*), uint32_t* results)
+;
+; Captures registers immediately around two CPUID helper calls. Keeping this
+; sequence in assembly prevents compiler register allocation from changing the
+; snapshots between calls in optimised builds.
+;------------------------------------------------------------------------------
+asm_call_cpuid_and_capture PROC
+    ; RCX=before, RDX=after, R8=fn, R9=results
+    sub     rsp, 72                  ; shadow space, saved arguments, and alignment
+    mov     QWORD PTR [rsp + 32], rcx
+    mov     QWORD PTR [rsp + 40], rdx
+    mov     QWORD PTR [rsp + 48], r8
+    mov     QWORD PTR [rsp + 56], r9
+
+    mov     rcx, QWORD PTR [rsp + 32]
+    call    asm_capture_registers
+
+    xor     ecx, ecx
+    mov     rdx, QWORD PTR [rsp + 56]
+    call    QWORD PTR [rsp + 48]
+
+    mov     ecx, 1
+    mov     rdx, QWORD PTR [rsp + 56]
+    call    QWORD PTR [rsp + 48]
+
+    mov     rcx, QWORD PTR [rsp + 40]
+    call    asm_capture_registers
+
+    add     rsp, 72
+    ret
+asm_call_cpuid_and_capture ENDP
+
 END

--- a/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
+++ b/src/tiri/jit/src/runtime/unit_test_vm_asm.cpp
@@ -158,10 +158,14 @@ static_assert(offsetof(RegisterSnapshot, xmm15) IS 224, "RegisterSnapshot xmm15 
 static_assert(sizeof(RegisterSnapshot) IS 240, "RegisterSnapshot size mismatch");
 
 // External MASM functions defined in register_capture_x64.asm
-extern "C" void asm_capture_registers(RegisterSnapshot* snap);
-extern "C" int asm_verify_registers(const RegisterSnapshot* before, const RegisterSnapshot* after);
-extern "C" int asm_call_and_capture(RegisterSnapshot* before, RegisterSnapshot* after,
-   bool (*fn)(void*), void* ctx);
+extern "C" void asm_capture_registers(RegisterSnapshot* Snap);
+extern "C" int asm_verify_registers(const RegisterSnapshot* Before, const RegisterSnapshot* After);
+extern "C" int asm_call_and_capture(RegisterSnapshot* Before, RegisterSnapshot* After,
+   bool (*Fn)(void*), void* Context);
+extern "C" void asm_call_cpuid_and_capture(RegisterSnapshot* Before, RegisterSnapshot* After,
+   int (*Fn)(uint32_t, uint32_t*), uint32_t* Results);
+
+#define HAS_CPUID_DIRECT_CAPTURE
 
 static constexpr bool glHasRegisterCapture = true;
 
@@ -215,6 +219,46 @@ struct RegisterSnapshot {
 };
 
 static constexpr bool glHasRegisterCapture = true;
+
+#if !defined(_WIN32)
+// Capture immediately around the calls so compiler register allocation cannot alter the snapshots.
+static __attribute__((naked, noinline)) void asm_call_cpuid_and_capture(RegisterSnapshot*, RegisterSnapshot*,
+   int (*)(uint32_t, uint32_t*), uint32_t*)
+{
+   __asm__ __volatile__(
+      "subq $40, %rsp\n\t"
+      "movq %rdi, 0(%rsp)\n\t"
+      "movq %rsi, 8(%rsp)\n\t"
+      "movq %rdx, 16(%rsp)\n\t"
+      "movq %rcx, 24(%rsp)\n\t"
+      "movq 0(%rsp), %rax\n\t"
+      "movq %rbx, 0(%rax)\n\t"
+      "movq %rbp, 8(%rax)\n\t"
+      "movq %r12, 16(%rax)\n\t"
+      "movq %r13, 24(%rax)\n\t"
+      "movq %r14, 32(%rax)\n\t"
+      "movq %r15, 40(%rax)\n\t"
+      "movq %rsp, 48(%rax)\n\t"
+      "xorl %edi, %edi\n\t"
+      "movq 24(%rsp), %rsi\n\t"
+      "call *16(%rsp)\n\t"
+      "movl $1, %edi\n\t"
+      "movq 24(%rsp), %rsi\n\t"
+      "call *16(%rsp)\n\t"
+      "movq 8(%rsp), %rax\n\t"
+      "movq %rbx, 0(%rax)\n\t"
+      "movq %rbp, 8(%rax)\n\t"
+      "movq %r12, 16(%rax)\n\t"
+      "movq %r13, 24(%rax)\n\t"
+      "movq %r14, 32(%rax)\n\t"
+      "movq %r15, 40(%rax)\n\t"
+      "movq %rsp, 48(%rax)\n\t"
+      "addq $40, %rsp\n\t"
+      "ret\n\t"
+   );
+}
+#define HAS_CPUID_DIRECT_CAPTURE
+#endif
 
 static void capture_registers(RegisterSnapshot* Snap)
 {
@@ -895,17 +939,22 @@ static bool test_cpuid_register_preservation(kt::Log& Log)
    }
 
    RegisterSnapshot before, after;
-   capture_registers(&before);
-
    uint32_t res[4];
+
+#if defined(HAS_CPUID_DIRECT_CAPTURE)
+   asm_call_cpuid_and_capture(&before, &after, lj_vm_cpuid, res);
+#else
+   capture_registers(&before);
    volatile int ret1 = lj_vm_cpuid(0, res);
    volatile int ret2 = lj_vm_cpuid(1, res);
    (void)ret1; (void)ret2;
-
    capture_registers(&after);
+#endif
 
    return verify_registers(&before, &after, Log);
 }
+
+#undef HAS_CPUID_DIRECT_CAPTURE
 
 #endif // LJ_TARGET_X86ORX64
 

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -214,7 +214,7 @@ end
 -- Test the use of if-empty within a function
 
 @Test function IfEmptyArgumentLeakCapture()
-   Function = { status = 'Hello' }
+   local function_value = { status = 'Hello' }
    capture_record = { count = 0, first = nil, second = nil }
 
    function capture(...)
@@ -224,7 +224,7 @@ end
       capture_record.second = args[1]
    end
 
-   capture(Function.status ?? 'then')
+   capture(function_value.status ?? 'then')
 
    assert(capture_record.count is 1,
       "Expected a single argument after fixing the leak, got '" .. tostring(capture_record.count) .. "'")
@@ -235,9 +235,9 @@ end
 end
 
 @Test function IfEmptyStringFindError()
-   Function = { status = 'Hello' }
+   local function_value = { status = 'Hello' }
 
-   start_index, end_index = string.find((Function.status ?? 'then'), 'e')
+   start_index, end_index = string.find((function_value.status ?? 'then'), 'e')
    assert(start_index is 1, "Expected search to start at index 1, got '" .. tostring(start_index) .. "'")
    assert(end_index is 1, "Expected search to end at index 1, got '" .. tostring(end_index) .. "'")
 end
@@ -345,10 +345,10 @@ end
 end
 
 @Test function InFunction()
-   Function = { status = 'Hello' }
+   local function_value = { status = 'Hello' }
 
    -- If-empty operator within a function
-   result = string.find((Function.status ?? 'then'), 'e')
+   result = string.find((function_value.status ?? 'then'), 'e')
    assert(result is 1, "Failed test: expected 1, got " .. tostring(result))
 end
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -776,6 +776,88 @@ end
    end
 end
 
+@Test function JITDynamicResultInsideTryDoesNotRestartHandler()
+   local script = obj.new('tiri', { statement=[[
+result = 0
+
+for outer_index in {0 to 120} do
+   local function compute(Value)
+      if Value < 0 then error("Negative value not allowed") end
+      return Value * Value
+   end
+
+   local function fetch_data(Id)
+      if Id is 0 then error("Invalid ID") end
+      return { id = Id, value = Id * 10 }
+   end
+
+   for index in {0 to 300} do
+      local result = 0
+
+      try
+         result = compute(index)
+      except e
+         result = -1
+      success
+         result++
+      end
+
+      local data = nil
+      try
+         data = fetch_data(index % 100)
+      except e
+         data = { id = 0, value = 0 }
+      success
+         data.value *= 2
+      end
+
+      local first, second
+      try
+         first = compute(index)
+         second = compute(index + 1)
+      except e
+         result = 0
+      success
+         result = (first + second) * 2
+      end
+
+      local resource_acquired = false
+      try
+         resource_acquired = true
+         result = compute(index)
+      except e
+         result = -1
+      success
+         result += 100
+      end
+
+      try
+         try
+            result = compute(index)
+         except inner
+            result = 0
+         success
+            result += 10
+         end
+      except outer
+         result = -1
+      success
+         result += 20
+      end
+   end
+end
+
+local trace_count = 0
+for trace_no in {1 to 101} do
+   if jit.util.traceInfo(trace_no) != nil then trace_count++ end
+end
+assert(trace_count > 0, "Dynamic result calls inside try blocks should remain JIT traceable")
+]] })
+
+   check script.acQuery()
+   check script.acActivate()
+end
+
 @Test(hotpath=80) function JITMathClampEmitsMinMax()
    cached_trace_no = nil
    cached_trace_info = nil

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -112,6 +112,10 @@ end
          source = "function bad():<str,> return 'x' end"
       },
       {
+         name = 'variadic return without a base type',
+         source = "function bad():<...> return 1 end"
+      },
+      {
          name = 'unterminated multi-return type list',
          source = "function bad():<str, num return 'x', 1 end"
       },

--- a/src/tiri/tests/test_object.tiri
+++ b/src/tiri/tests/test_object.tiri
@@ -313,24 +313,27 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Compile-time field type checking: assigning string field to number variable should fail
+-- Typed assignment checking: assigning a string field to a number variable should fail
 
 @Test function FieldTypeCheckStrToNum()
    try
       exec([[
          c = obj.new('config')
-         count = 0
-         count = c.path
+         c.path = 'kotuku:test.cfg'
+         local count:num = 0
+         local wrong:any = c.path
+         count = wrong
       ]])
    except ex
-      assert(ex.message:find('Type mismatch'), "Expected type mismatch error, got: " .. ex.message)
+      assert(ex.message:find('Type mismatch') or ex.message:find('type contract failed'),
+         "Expected type mismatch error, got: " .. ex.message)
    success
-      error("Expected compile-time error when assigning str field to num variable")
+      error("Expected type error when assigning str field to num variable")
    end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Compile-time field type checking: assigning number field to string variable should fail
+-- Typed assignment checking: assigning a number field to a string variable should fail
 
 @Test function FieldTypeCheckNumToStr()
    try
@@ -340,9 +343,10 @@ end
          name = c.totalKeys
       ]])
    except ex
-      assert(ex.message:find('Type mismatch'), "Expected type mismatch error, got: " .. ex.message)
+      assert(ex.message:find('Type mismatch') or ex.message:find('type contract failed'),
+         "Expected type mismatch error, got: " .. ex.message)
    success
-      error("Expected compile-time error when assigning num field to str variable")
+      error("Expected type error when assigning num field to str variable")
    end
 end
 

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -226,16 +226,14 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- RETURN COUNT VALIDATION
 
-@Test function TooManyReturnsError()
-   try
-      exec([[
-         function bad():<num, str>
-            return 1, "a", "extra"
-         end
-      ]])
-   success
-      error("should detect too many return values")
+@Test function AdditionalReturnsAreTruncated()
+   function additional():<num, str>
+      return 1, "a", false
    end
+   local number, text, extra = additional()
+   assert(number is 1, "first declared result should be preserved")
+   assert(text is "a", "second declared result should be preserved")
+   assert(extra is nil, "additional undeclared results should be truncated")
 end
 
 @Test function FewerReturnsAllowed()
@@ -498,12 +496,13 @@ end
    -- 9th+ types should be treated as 'any' (no type checking)
    function manyReturns():<num, num, num, num, num, num, num, num, str>
       -- 9th type (str) should be treated as any due to MAX_RETURN_TYPES = 8
-      return 1, 2, 3, 4, 5, 6, 7, 8, "ninth"
+      return 1, 2, 3, 4, 5, 6, 7, 8, "ninth", false
    end
-   a, b, c, d, e, f, g, h, i = manyReturns()
+   a, b, c, d, e, f, g, h, i, j = manyReturns()
    assert(a is 1, "1st return should be 1")
    assert(h is 8, "8th return should be 8")
    assert(i is "ninth", "9th return should work (treated as any)")
+   assert(j is nil, "10th undeclared return should be truncated")
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -707,22 +707,6 @@ end
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- A struct annotation is a parser optimisation hint, not a replacement for runtime type dispatch. Non-struct values
--- must still fall back to the normal table metamethod path in the VM.
-
-function access_annotated_fallback(Value:struct):num
-   Value.value = 73
-   return Value.value
-end
-
-@Test function AnnotatedStructFallbackUsesTablePath()
-   local value = {}
-   local call = { access_annotated_fallback }
-   assert(call[0](value) is 73, 'A table at a struct-typed access site should use vmeta fallback')
-   assert(value.value is 73, 'The fallback setter should update the table')
-end
-
------------------------------------------------------------------------------------------------------------------------
 
 @Test function FastFieldErrorsAndHelpers()
    MAKESTRUCT('FastFieldErrors', 'lValue')

--- a/src/tiri/tests/test_thunk_contract_argument.tiri
+++ b/src/tiri/tests/test_thunk_contract_argument.tiri
@@ -1,0 +1,13 @@
+-- Regression test for resolving deferred expressions before parameter type contracts.
+
+function accept_string(String:str):str
+   return String
+end
+
+@Test function DeferredStringArgumentResolvesBeforeContract()
+   local deferred_string = <{ 'resolved string' }>
+   assert(deferred_string is 'resolved string', 'The deferred expression must resolve to a string')
+
+   local result = accept_string(<{ 'resolved string' }>)
+   assert(result is 'resolved string', 'The typed parameter must receive the resolved string')
+end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -38,6 +38,20 @@ function expect_diagnostic_failure(Callback:func)
    assert(failed, 'Expected a diagnostic contract failure')
 end
 
+function expect_userdata_diagnostic(Callback:func, Actual:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find('expected userdata') != nil,
+         'The message should identify the userdata contract: ' .. e.message)
+      assert(e.message:find('got ' .. Actual) != nil,
+         'The message should identify the actual type: ' .. e.message)
+   end
+   assert(failed, 'Expected a userdata diagnostic contract failure')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Parameter matrix and exact, non-coercing predicates.
 
@@ -52,11 +66,16 @@ end
    function accept_struct(Value:struct) return Value end
    function accept_obj(Value:obj) return Value end
    function accept_range(Value:range) return Value end
+   function accept_userdata(Value:userdata) return Value end
 
    local native_array = array<int> { 1, 2 }
    local native_struct = struct<ContractAlpha> { Value=1 }
    local object = obj.new('time')
    local sequence = {0 to 2}
+   local proxy = newproxy(true)
+   local captured = 1
+   function capture() return captured end
+   local pointer = debug.upvalueID(capture, 0)
    local callable = setmetatable({}, { __call = function(Self) return Self end })
 
    assert(accept_nil(nil) is nil, 'nil should satisfy nil')
@@ -71,6 +90,9 @@ end
    assert(accept_struct(native_struct) is native_struct, 'native structure should satisfy struct')
    assert(accept_obj(object) is object, 'Kōtuku object should satisfy obj')
    assert(accept_range(sequence) is sequence, 'range should satisfy range')
+   assert(accept_userdata(proxy) is proxy, 'full userdata should satisfy userdata')
+   assert(accept_userdata(pointer) is pointer, 'light userdata should satisfy userdata')
+   assert(accept_userdata(nil) is nil, 'nil should satisfy a nullable userdata contract')
 
    expect_contract_failure(function() accept_nil(dynamic_value(false)) end, 'parameter')
    expect_contract_failure(function() accept_bool(dynamic_value(1)) end, 'parameter')
@@ -82,6 +104,9 @@ end
    expect_contract_failure(function() accept_struct(dynamic_value({})) end, 'parameter')
    expect_contract_failure(function() accept_obj(dynamic_value({})) end, 'parameter')
    expect_contract_failure(function() accept_range(dynamic_value(native_struct)) end, 'parameter')
+   expect_userdata_diagnostic(function() accept_userdata(dynamic_value(sequence)) end, 'range')
+   expect_contract_failure(function() accept_userdata(dynamic_value({})) end, 'parameter')
+   expect_contract_failure(function() accept_range(dynamic_value(proxy)) end, 'parameter')
 end
 
 @Test function NamedStructIdentity()
@@ -169,7 +194,7 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Explicit return contracts validate declared positions without constraining result count.
+-- Explicit fixed return contracts validate declared positions and truncate undeclared results.
 
 @Test function DynamicReturnContracts()
    function wrong_single():any return 'wrong' end
@@ -182,8 +207,8 @@ end
 
    function extra_results():num return 1, 'extra', false end
    local first, second, third = extra_results()
-   assert(first is 1 and second is 'extra' and third is false,
-      'A fixed return declaration must not constrain or discard extra results')
+   assert(first is 1 and second is nil and third is nil,
+      'A fixed return declaration must truncate extra results')
 
    function missing_result():<num, str> return 2 end
    local number, missing = missing_result()
@@ -204,6 +229,11 @@ end
    function dynamic_variadic():<any, any, any> return 1, 2, 'wrong' end
    function typed_variadic():<num, ...> return dynamic_variadic() end
    expect_contract_failure(function() typed_variadic() end, 'result')
+
+   function valid_variadic():<num, ...> return 1, 2, 3 end
+   local first, second, third = valid_variadic()
+   assert(first is 1 and second is 2 and third is 3,
+      'A variadic return declaration must preserve and validate additional results')
 end
 
 @Test function ReturnContractAfterTryAndDefer()
@@ -232,8 +262,8 @@ end
       return extra_source()
    end
    local first, second, third = checked_extra()
-   assert(first is 4 and second is 'extra' and third is false,
-      'Cleanup must preserve unconstrained extra dynamic results')
+   assert(first is 4 and second is nil and third is nil,
+      'Cleanup must preserve the declared result while truncating extra dynamic results')
 
    function checked_table():table
       local result = {}
@@ -288,16 +318,70 @@ end
    assert(glContractAny is 'allowed', 'Explicit any remains the global contract opt-out')
 end
 
+@Test function UserdataContractBoundaries()
+   function userdata_source():any return newproxy(true) end
+   function typed_userdata_result():userdata return userdata_source() end
+
+   local first = typed_userdata_result()
+   assert(type(first) is 'userdata', 'a userdata result contract should preserve full userdata')
+
+   local typed_local:userdata = first
+   typed_local = userdata_source()
+   expect_contract_failure(function() typed_local = dynamic_value({}) end, 'local')
+
+   local captured:userdata = userdata_source()
+   function write_userdata(Value:any)
+      captured = Value
+   end
+   write_userdata(userdata_source())
+   expect_contract_failure(function() write_userdata('wrong') end, 'upvalue')
+   assert(type(captured) is 'userdata', 'a rejected userdata upvalue store must preserve its value')
+
+   global glContractUserdata:userdata = userdata_source()
+   glContractUserdata = userdata_source()
+   expect_contract_failure(function() glContractUserdata = dynamic_value(3) end, 'global')
+   assert(type(glContractUserdata) is 'userdata', 'a rejected userdata global store must preserve its value')
+
+   function wrong_userdata_result():userdata return dynamic_value({}) end
+   expect_contract_failure(function() wrong_userdata_result() end, 'result')
+end
+
+@Test function DeferredUserdataContracts()
+   function accept_userdata(Value:userdata):userdata return Value end
+
+   local deferred_proxy = <{ newproxy(true) }>
+   assert(type(deferred_proxy) is 'userdata', 'a typed deferred proxy should advertise userdata')
+   local resolved_proxy = accept_userdata(deferred_proxy)
+   assert(type(resolved_proxy) is 'userdata', 'a deferred proxy should resolve before its contract')
+
+   local captured = 2
+   function capture() return captured end
+   local deferred_pointer = <{ debug.upvalueID(capture, 0) }>
+   assert(type(accept_userdata(deferred_pointer)) is 'userdata',
+      'deferred light userdata should satisfy userdata after resolution')
+
+   local deferred_range = <{ {0 to 2} }>
+   expect_contract_failure(function() accept_userdata(deferred_range) end, 'parameter')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Interpreter/JIT parity, disassembly and bytecode persistence.
 
 @Test function HotContractParity()
    function hot(Value:num):num return Value + 1 end
+   function hot_results(Value:num):<num, str> return Value, 'kept', false end
+   function hot_userdata(Value:userdata):userdata return Value end
    local dynamic:any = hot
+   local proxy = newproxy(true)
    for i = 0, 200 do
       assert(dynamic(i) is i + 1, 'Valid hot call should preserve its argument')
+      local value, text, extra = hot_results(i)
+      assert(value is i and text is 'kept' and extra is nil,
+         'Hot fixed return contracts must truncate additional results')
+      assert(hot_userdata(proxy) is proxy, 'userdata contracts must remain stable on hot paths')
    end
    expect_contract_failure(function() dynamic('wrong') end, 'parameter')
+   expect_contract_failure(function() hot_userdata(dynamic_value({0 to 2})) end, 'parameter')
 end
 
 @Test function ContractDisassemblyOrder()

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -1,0 +1,316 @@
+-- Runtime contracts for parameters, explicit returns, typed stores and indirect call routes.
+
+import './type_contract_fixture'
+
+struct ContractAlpha
+   Value: int
+end
+
+struct ContractBravo
+   Value: int
+end
+
+function dynamic_value(Value):any
+   return Value
+end
+
+function expect_contract_failure(Callback:func, Boundary:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message != nil, 'A contract failure must carry a message')
+   end
+   assert(failed, 'Expected a catchable ' .. Boundary .. ' contract failure')
+end
+
+function expect_diagnostic_failure(Callback:func)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find('parameter 1') != nil, 'The message should identify parameter 1: ' .. e.message)
+      assert(e.message:find('expected num') != nil, 'The message should identify the expected type: ' .. e.message)
+      assert(e.message:find('got string') != nil, 'The message should identify the actual type: ' .. e.message)
+   end
+   assert(failed, 'Expected a diagnostic contract failure')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Parameter matrix and exact, non-coercing predicates.
+
+@Test function ParameterContractMatrix()
+   function accept_nil(Value:nil) return Value end
+   function accept_bool(Value:bool) return Value end
+   function accept_num(Value:num) return Value end
+   function accept_str(Value:str) return Value end
+   function accept_table(Value:table) return Value end
+   function accept_array(Value:array) return Value end
+   function accept_func(Value:func) return Value end
+   function accept_struct(Value:struct) return Value end
+   function accept_obj(Value:obj) return Value end
+   function accept_range(Value:range) return Value end
+
+   local native_array = array<int> { 1, 2 }
+   local native_struct = struct<ContractAlpha> { Value=1 }
+   local object = obj.new('time')
+   local sequence = {0 to 2}
+   local callable = setmetatable({}, { __call = function(Self) return Self end })
+
+   assert(accept_nil(nil) is nil, 'nil should satisfy nil')
+   assert(accept_bool(true) is true, 'true should satisfy bool')
+   assert(accept_bool(false) is false, 'false should satisfy bool')
+   assert(accept_num(3.5) is 3.5, 'number should satisfy num')
+   assert(accept_str('text') is 'text', 'string should satisfy str')
+   assert(accept_table({}) != nil, 'table should satisfy table')
+   assert(accept_array(native_array) is native_array, 'native array should satisfy array')
+   assert(type(accept_func(function() end)) is 'function', 'function should satisfy func')
+   assert(accept_func(callable) is callable, 'callable value should satisfy func')
+   assert(accept_struct(native_struct) is native_struct, 'native structure should satisfy struct')
+   assert(accept_obj(object) is object, 'Kōtuku object should satisfy obj')
+   assert(accept_range(sequence) is sequence, 'range should satisfy range')
+
+   expect_contract_failure(function() accept_nil(dynamic_value(false)) end, 'parameter')
+   expect_contract_failure(function() accept_bool(dynamic_value(1)) end, 'parameter')
+   expect_contract_failure(function() accept_num(dynamic_value('1')) end, 'parameter')
+   expect_contract_failure(function() accept_str(dynamic_value(1)) end, 'parameter')
+   expect_contract_failure(function() accept_table(dynamic_value(native_array)) end, 'parameter')
+   expect_contract_failure(function() accept_array(dynamic_value({})) end, 'parameter')
+   expect_contract_failure(function() accept_func(dynamic_value({})) end, 'parameter')
+   expect_contract_failure(function() accept_struct(dynamic_value({})) end, 'parameter')
+   expect_contract_failure(function() accept_obj(dynamic_value({})) end, 'parameter')
+   expect_contract_failure(function() accept_range(dynamic_value(native_struct)) end, 'parameter')
+end
+
+@Test function NamedStructIdentity()
+   function accept_alpha(Value:struct<ContractAlpha>)
+      return Value.Value
+   end
+
+   local alpha = struct<ContractAlpha> { Value=7 }
+   local bravo = struct<ContractBravo> { Value=7 }
+   assert(accept_alpha(alpha) is 7, 'Matching named structure should pass')
+   expect_contract_failure(function() accept_alpha(dynamic_value(bravo)) end, 'parameter')
+end
+
+@Test function NilMissingAndExtraArguments()
+   function optional(Value:num) return Value end
+   assert(optional() is nil, 'A missing argument should arrive as acceptable nil')
+   assert(optional(nil) is nil, 'Explicit nil should satisfy a non-required contract')
+   assert(optional(4, 'ignored') is 4, 'Extra arguments should remain unchanged and ignored')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Every call route must enter the same callee-side guard.
+
+@Test function IndirectCallRoutes()
+   function typed(Value:num):num return Value end
+   local alias:any = typed
+   local holder = { callback = typed }
+
+   expect_contract_failure(function() typed(dynamic_value('wrong')) end, 'parameter')
+   expect_contract_failure(function() alias('wrong') end, 'parameter')
+   expect_contract_failure(function() holder.callback('wrong') end, 'parameter')
+   expect_contract_failure(function() imported_typed(dynamic_value('wrong')) end, 'parameter')
+
+   local values = array<any> { 'wrong' }
+   function native_callback(Value:num) return Value end
+   expect_contract_failure(function() values:each(native_callback) end, 'parameter')
+end
+
+@Test function SpecialParameterForms()
+   function blank(_:num) return true end
+   local blank_alias:any = blank
+   expect_contract_failure(function() blank_alias('wrong') end, 'parameter')
+
+   local methods = {}
+   function methods:typed(Value:num) return Value end
+   local method_alias:any = methods.typed
+   assert(methods:typed(8) is 8, 'Method self and typed argument should pass')
+   expect_contract_failure(function() method_alias(methods, 'wrong') end, 'parameter')
+
+   function recurse(Value:num):num
+      if Value <= 0 then return 0 end
+      return recurse(Value - 1)
+   end
+   assert(recurse(4) is 0, 'Recursive typed parameters should pass')
+
+   thunk deferred(Value:num):num
+      return Value
+   end
+   local thunk_alias:any = deferred
+   expect_contract_failure(function() thunk_alias('wrong') end, 'parameter')
+
+   global contract_mutual_odd
+   global function contract_mutual_even(Value:num):bool
+      if Value is 0 then return true end
+      return contract_mutual_odd(Value - 1)
+   end
+   global function contract_mutual_odd(Value:num):bool
+      if Value is 0 then return false end
+      return contract_mutual_even(Value - 1)
+   end
+   assert(contract_mutual_even(4), 'Mutually recursive typed parameters should pass')
+   local mutual_alias:any = contract_mutual_even
+   expect_contract_failure(function() mutual_alias('wrong') end, 'parameter')
+end
+
+@Test function GuardPrecedesSpecialisedMutation()
+   function increment(Values:array)
+      Values[0] += 1
+   end
+
+   local plain = { 10 }
+   local indirect:any = increment
+   expect_contract_failure(function() indirect(plain) end, 'parameter')
+   assert(plain[0] is 10, 'The function body must not mutate before its parameter guard')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Explicit return contracts validate declared positions without constraining result count.
+
+@Test function DynamicReturnContracts()
+   function wrong_single():any return 'wrong' end
+   function typed_single():num return wrong_single() end
+   expect_contract_failure(function() typed_single() end, 'result')
+
+   function dynamic_pair():<any, any> return 1, false end
+   function typed_pair():<num, str> return dynamic_pair() end
+   expect_contract_failure(function() typed_pair() end, 'result')
+
+   function extra_results():num return 1, 'extra', false end
+   local first, second, third = extra_results()
+   assert(first is 1 and second is 'extra' and third is false,
+      'A fixed return declaration must not constrain or discard extra results')
+
+   function missing_result():<num, str> return 2 end
+   local number, missing = missing_result()
+   assert(number is 2 and missing is nil, 'Missing declared results should remain acceptable nil')
+
+   function filter_source():<any, any> return 'dropped', 'kept' end
+   function filtered_ok():str return [_*]filter_source() end
+   assert(filtered_ok() is 'kept', 'A return contract should inspect the filtered result')
+   function filtered_wrong():num return [*_]filter_source() end
+   expect_contract_failure(function() filtered_wrong() end, 'result')
+
+   function wrong_struct_result():any return struct<ContractBravo> { Value=5 } end
+   function typed_struct_result():struct<ContractAlpha> return wrong_struct_result() end
+   expect_contract_failure(function() typed_struct_result() end, 'result')
+end
+
+@Test function VariadicReturnSuffix()
+   function dynamic_variadic():<any, any, any> return 1, 2, 'wrong' end
+   function typed_variadic():<num, ...> return dynamic_variadic() end
+   expect_contract_failure(function() typed_variadic() end, 'result')
+end
+
+@Test function ReturnContractAfterTryAndDefer()
+   global glContractCleanup:bool = false
+
+   function source():any return 'wrong' end
+   function checked():num
+      defer
+         glContractCleanup = true
+      end
+      try
+         return source()
+      except e
+         return 0
+      end
+   end
+
+   expect_contract_failure(function() checked() end, 'result')
+   assert(glContractCleanup is true, 'Defer cleanup must execute before a return contract fails')
+
+   function extra_source():<any, any, any> return 4, 'extra', false end
+   function checked_extra():num
+      defer
+         glContractCleanup = true
+      end
+      return extra_source()
+   end
+   local first, second, third = checked_extra()
+   assert(first is 4 and second is 'extra' and third is false,
+      'Cleanup must preserve unconstrained extra dynamic results')
+
+   function checked_table():table
+      local result = {}
+      defer
+         local marker = 'cleanup'
+         assert(marker is 'cleanup')
+      end
+      return result
+   end
+   assert(type(checked_table()) is 'table', 'Defer cleanup must preserve a fixed table result')
+
+   global glContractClosed:bool = false
+   function checked_close():num
+      local resource <close> = setmetatable({}, {
+         __close = function(Self, Error)
+            glContractClosed = true
+         end
+      })
+      return source()
+   end
+   expect_contract_failure(function() checked_close() end, 'result')
+   assert(glContractClosed, '<close> cleanup must execute before a return contract fails')
+end
+
+@Test function ContractDiagnostic()
+   function diagnostic(Value:num):num return Value end
+   expect_diagnostic_failure(function() diagnostic(dynamic_value('wrong')) end)
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Other approved write boundaries.
+
+@Test function TypedLocalAndCapturedUpvalueStores()
+   local typed:num = 1
+   expect_contract_failure(function() typed = dynamic_value('wrong') end, 'local')
+
+   local captured:num = 2
+   function write_captured(Value:any)
+      captured = Value
+   end
+   expect_contract_failure(function() write_captured('wrong') end, 'upvalue')
+   assert(captured is 2, 'A rejected upvalue store must preserve the previous value')
+end
+
+@Test function ExplicitGlobalStores()
+   global glContractNumber:num = 3
+   expect_contract_failure(function() glContractNumber = dynamic_value('wrong') end, 'global')
+   assert(glContractNumber is 3, 'A rejected global store must preserve the previous value')
+
+   global glContractAny:any = 1
+   glContractAny = 'allowed'
+   assert(glContractAny is 'allowed', 'Explicit any remains the global contract opt-out')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Interpreter/JIT parity, disassembly and bytecode persistence.
+
+@Test function HotContractParity()
+   function hot(Value:num):num return Value + 1 end
+   local dynamic:any = hot
+   for i = 0, 200 do
+      assert(dynamic(i) is i + 1, 'Valid hot call should preserve its argument')
+   end
+   expect_contract_failure(function() dynamic('wrong') end, 'parameter')
+end
+
+@Test function ContractDisassemblyOrder()
+   local script = obj.new('tiri', { statement = [[
+function first(Values:array)
+   return Values[0]
+end
+]] })
+   script.acQuery()
+   script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+   local guard = disassembly:find('CONTRACT')
+   local access = disassembly:find('AGET')
+   assert(guard != nil and access != nil and guard < access,
+      'CONTRACT must precede specialised array access, got:\n' .. disassembly)
+end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -225,6 +225,55 @@ end
    expect_contract_failure(function() typed_struct_result() end, 'result')
 end
 
+@Test function ReturnContractMatrix()
+   function checked_nil(Value:any):nil return dynamic_value(Value) end
+   function checked_bool(Value:any):bool return dynamic_value(Value) end
+   function checked_num(Value:any):num return dynamic_value(Value) end
+   function checked_str(Value:any):str return dynamic_value(Value) end
+   function checked_table(Value:any):table return dynamic_value(Value) end
+   function checked_array(Value:any):array return dynamic_value(Value) end
+   function checked_func(Value:any):func return dynamic_value(Value) end
+   function checked_struct(Value:any):struct return dynamic_value(Value) end
+   function checked_alpha(Value:any):struct<ContractAlpha> return dynamic_value(Value) end
+   function checked_obj(Value:any):obj return dynamic_value(Value) end
+   function checked_range(Value:any):range return dynamic_value(Value) end
+   function checked_userdata(Value:any):userdata return dynamic_value(Value) end
+
+   local native_array = array<int> { 1, 2 }
+   local alpha = struct<ContractAlpha> { Value=3 }
+   local bravo = struct<ContractBravo> { Value=5 }
+   local object = obj.new('time')
+   local sequence = {0 to 3}
+   local proxy = newproxy(true)
+   local callable = setmetatable({}, { __call = function() return true end })
+
+   assert(checked_nil(nil) is nil, 'nil should satisfy a nil result contract')
+   assert(checked_bool(true), 'bool should satisfy a bool result contract')
+   assert(checked_num(7) is 7, 'num should satisfy a num result contract')
+   assert(checked_str('text') is 'text', 'str should satisfy a str result contract')
+   assert(type(checked_table({})) is 'table', 'table should satisfy a table result contract')
+   assert(checked_array(native_array) is native_array, 'array should satisfy an array result contract')
+   assert(checked_func(callable) is callable, 'callable tables should satisfy a func result contract')
+   assert(checked_struct(alpha) is alpha, 'a native structure should satisfy a struct result contract')
+   assert(checked_alpha(alpha) is alpha, 'a matching layout should satisfy a named-structure result contract')
+   assert(checked_obj(object) is object, 'a Kōtuku object should satisfy an obj result contract')
+   assert(checked_range(sequence) is sequence, 'a range should satisfy a range result contract')
+   assert(checked_userdata(proxy) is proxy, 'full userdata should satisfy a userdata result contract')
+
+   expect_contract_failure(function() checked_nil(false) end, 'result')
+   expect_contract_failure(function() checked_bool(1) end, 'result')
+   expect_contract_failure(function() checked_num('7') end, 'result')
+   expect_contract_failure(function() checked_str(7) end, 'result')
+   expect_contract_failure(function() checked_table(native_array) end, 'result')
+   expect_contract_failure(function() checked_array({}) end, 'result')
+   expect_contract_failure(function() checked_func({}) end, 'result')
+   expect_contract_failure(function() checked_struct({}) end, 'result')
+   expect_contract_failure(function() checked_alpha(bravo) end, 'result')
+   expect_contract_failure(function() checked_obj({}) end, 'result')
+   expect_contract_failure(function() checked_range(proxy) end, 'result')
+   expect_contract_failure(function() checked_userdata(sequence) end, 'result')
+end
+
 @Test function VariadicReturnSuffix()
    function dynamic_variadic():<any, any, any> return 1, 2, 'wrong' end
    function typed_variadic():<num, ...> return dynamic_variadic() end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -362,6 +362,17 @@ end
    expect_contract_failure(function() glContractNumber = dynamic_value('wrong') end, 'global')
    assert(glContractNumber is 3, 'A rejected global store must preserve the previous value')
 
+   expect_contract_failure(function() exec("glContractNumber = 'wrong'") end, 'global')
+   assert(glContractNumber is 3, 'A rejected store from a separately compiled chunk must preserve the global value')
+
+   global glContractArray:array = array<int> { 4, 8 }
+   function read_contract_array()
+      return glContractArray[1]
+   end
+   expect_contract_failure(function() exec("glContractArray = {}") end, 'global')
+   assert(read_contract_array() is 8,
+      'A separately compiled store must not invalidate an already-compiled specialised global reader')
+
    global glContractAny:any = 1
    glContractAny = 'allowed'
    assert(glContractAny is 'allowed', 'Explicit any remains the global contract opt-out')

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -1,0 +1,174 @@
+-- Behaviour and interpreter/JIT parity for parse-time type-guided emission.
+
+@BeforeEach(hotpath=true)
+function enforce_hotpath()
+end
+
+struct EmissionPoint
+   Value: int
+end
+
+glEmissionStructureSequence = 0
+
+function disassemble_source(Source:str):str
+   local script = obj.new('tiri', { statement=Source })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+   script.free()
+   return disassembly
+end
+
+function typed_increment(Value:num):num
+   return Value + 1
+end
+
+function make_point_pair():<str, struct<EmissionPoint>>
+   return 'point', struct<EmissionPoint> { Value=37 }
+end
+
+function make_number_array():array
+   return array<int> { 5, 10, 15 }
+end
+
+@Test function StableLocalAlias()
+   local callback = typed_increment
+   local callback_two = callback
+   assert(callback_two(41) is 42, 'Stable alias chains should preserve callable behaviour')
+end
+
+@Test function CapturedImplicitStructRetainsDescriptor()
+   glEmissionStructureSequence++
+   local structure_name = 'CapturedImplicitPoint' .. glEmissionStructureSequence
+   local disassembly = disassemble_source(string.format([[
+MAKESTRUCT('%s', 'lValue')
+captured_point = struct.new('%s')
+function read_point()
+   return captured_point.value
+end
+function write_point()
+   captured_point.value = 42
+end
+]], structure_name, structure_name))
+   assert(disassembly:find('STGETF') != nil,
+      'A captured implicit struct local should retain specialised reads, got:\n' .. disassembly)
+   assert(disassembly:find('STSETF') != nil,
+      'A captured implicit struct local should retain specialised writes, got:\n' .. disassembly)
+end
+
+@Test function ImmutableCapturedAlias()
+   local callback <const> = typed_increment
+
+   local function make_callback():func
+      return (Value => callback(Value))
+   end
+
+   local captured = make_callback()
+   assert(captured(9) is 10, 'Immutable captured aliases should preserve callable behaviour')
+end
+
+@Test function MutableAliasFallbacks()
+   local callback = typed_increment
+   local replacement = (Value => Value + 10)
+   local replace = true
+   if replace then callback = replacement end
+   assert(callback(5) is 15, 'A branch write should use the replacement callable')
+
+   local loop_callback = typed_increment
+   local result = 0
+   for index = 0, 2 do
+      result = loop_callback(index)
+      loop_callback = replacement
+   end
+   assert(result is 12, 'A loop back-edge write must not leave stale callable metadata')
+end
+
+@Test function ArrayLogicalElementTypes()
+   local numbers = array<int> { 3, 7 }
+   local strings = array<string> { 'a', 'b' }
+   local tables = array<table> { { value=11 } }
+   local nested = array<array> { array<int> { 19 } }
+   local points = array<struct<EmissionPoint>> { struct<EmissionPoint> { Value=29 } }
+   local clock = obj.new('time')
+   local objects = array<object> { clock }
+
+   assert(numbers[1] is 7, 'array<int> indexing should return a number')
+   assert(strings[0] is 'a', 'array<string> indexing should return a string')
+   assert(tables[0].value is 11, 'array<table> indexing should retain table behaviour')
+   assert(nested[0][0] is 19, 'array<array> indexing should retain nested array behaviour')
+   assert(points[0].Value is 29, 'named struct-array indexing should retain its layout')
+   assert(objects[0].id is clock.id, 'array<object> indexing should retain object behaviour')
+   clock.free()
+end
+
+@Test function ArrayPropagationPaths()
+   local values = array<int> { 2, 4, 6 }
+   local alias = values
+
+   local function captured_sum():num
+      local total = 0
+      for _, value in alias do total += value end
+      return total
+   end
+
+   local clone = alias:clone()
+   local mapped = clone:map(Value => Value * 2)
+   local returned = make_number_array()
+   assert(captured_sum() is 12, 'Array element descriptors should survive immutable capture and iteration')
+   assert(mapped[2] is 12, 'Array element descriptors should survive preserving methods')
+   assert(returned[1] is 10, 'Array element descriptors should survive function result propagation')
+end
+
+@Test function ArrayDescriptorInvalidation()
+   local values = array<int> { 1 }
+   values = array<string> { 'changed' }
+   assert(values[0] is 'changed', 'Conflicting array reassignment must not retain a stale numeric descriptor')
+
+   local branch_values = array<int> { 2 }
+   if true then branch_values = array<table> { { value=23 } } end
+   assert(branch_values[0].value is 23, 'A conflicting branch assignment must degrade the element descriptor')
+end
+
+@Test function PositionalAndFilteredStructResults()
+   local label, point = make_point_pair()
+   assert(label is 'point' and point.Value is 37,
+      'A constrained non-first result should retain its struct layout')
+
+   local filtered = [_*]make_point_pair()
+   assert(filtered.Value is 37, 'A result filter should preserve the retained position descriptor')
+end
+
+@Test function SafeIndexAndCallResults()
+   local missing
+   assert(missing?[0] is nil, 'A safe index should return nil for a nil receiver')
+
+   local holder
+   assert(holder?:unknown() is nil, 'A safe call should return nil for a nil receiver')
+end
+
+@Test function InterpreterAndJitParity()
+   local function run_case():num
+      local values = array<int> { 1, 2, 3, 4 }
+      local callback = typed_increment
+      local total = 0
+      for pass = 0, 120 do
+         total += callback(values[pass % 4])
+      end
+      return total
+   end
+
+   jit.off()
+   local interpreted = run_case()
+   jit.on()
+   local compiled = run_case()
+   assert(compiled is interpreted, 'Interpreter and JIT executions should agree for specialised paths')
+end
+
+@Test function CallableMetamethodRemainsGeneric()
+   local callable = setmetatable({ offset=8 }, {
+      __call = function(Self, Value)
+         return Self.offset + Value
+      end
+   })
+   assert(callable(4) is 12, 'Callable table metamethod semantics must remain unchanged')
+end

--- a/src/tiri/tests/test_type_guided_jit_signatures.tiri
+++ b/src/tiri/tests/test_type_guided_jit_signatures.tiri
@@ -1,0 +1,230 @@
+-- Interpreter/JIT parity for exact runtime contracts that previously disabled tracing.
+
+local ir_fload <const> = 69
+
+struct JitContractAlpha
+   Value: int
+end
+
+struct JitContractBravo
+   Value: int
+end
+
+function dynamic_contract_value(Value):any
+   return Value
+end
+
+function expect_jit_contract_failure(Callback:func, Expected:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find(Expected) != nil,
+         f"Expected contract diagnostic to contain '{Expected}', got '{e.message}'")
+   end
+   assert(failed, f"Expected a catchable contract failure for {Expected}")
+end
+
+function trace_metrics():table
+   jit.off()
+   local result = { traces=0, fieldLoads=0, guards=0, snapshots=0 }
+
+   for trace_no = 1, 100 do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+
+      result.traces++
+      result.snapshots += info.nexit
+      for instruction = 1, info.nins do
+         local _, ir_ot = jit.util.traceIR(trace_no, instruction)
+         if ir_ot is nil then continue end
+         if (ir_ot & 0x80) != 0 then result.guards++ end
+         if (ir_ot >> 8) is ir_fload then result.fieldLoads++ end
+      end
+   end
+   return result
+end
+
+function prepare_contract_trace()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=2', 'hotexit=1', 'minstitch=0')
+end
+
+@AfterEach
+function reset_contract_jit()
+   jit.on()
+   jit.flush()
+   jit.opt.start()
+end
+
+@Test function NamedStructureContractTracesAndRejectsAfterCompilation()
+   function accept_alpha(Value:struct<JitContractAlpha>):struct<JitContractAlpha>
+      return Value
+   end
+
+   local alpha = struct<JitContractAlpha> { Value=7 }
+   local bravo = struct<JitContractBravo> { Value=9 }
+   local callback:any = accept_alpha
+
+   prepare_contract_trace()
+   local total = 0
+   for _ in {0 to 120} do total += callback(alpha).Value end
+
+   local metrics = trace_metrics()
+   assert(total is 840, 'A traced named-structure contract should preserve matching values')
+   assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.guards > 0,
+      'A named-structure contract should emit a guarded trace')
+   expect_jit_contract_failure(function() callback(dynamic_contract_value(bravo)) end, 'JitContractAlpha')
+end
+
+@Test function RangeContractTracksRegistryIdentity()
+   function accept_range(Value:range):range
+      return Value
+   end
+
+   local sequence = {0 to 8}
+   local callback:any = accept_range
+   prepare_contract_trace()
+
+   local total = 0
+   for _ in {0 to 120} do total += #callback(sequence) end
+   local metrics = trace_metrics()
+   assert(total is 960 and metrics.traces > 0 and metrics.fieldLoads > 0,
+      'A matching range contract should trace with its metatable predicate')
+
+   expect_jit_contract_failure(function() callback(dynamic_contract_value(newproxy(true))) end, 'range')
+
+   local registry = debug.getRegistry()
+   local saved_metatable = registry['Tiri.range']
+   registry['Tiri.range'] = {}
+   local failed = false
+   try
+      callback(sequence)
+   except e
+      failed = e.message:find('range') != nil
+   end
+   registry['Tiri.range'] = saved_metatable
+   assert(failed, 'Changing the registered range metatable should invalidate the compiled contract guard')
+   assert(callback(sequence) is sequence, 'Restoring the range registry should restore the contract')
+end
+
+@Test function UserdataContractTracesFullAndLightValues()
+   function accept_userdata(Value:userdata):userdata
+      return Value
+   end
+
+   local proxy = newproxy(true)
+   local captured = 3
+   function capture() return captured end
+   local pointer = debug.upvalueID(capture, 0)
+   local callback:any = accept_userdata
+   prepare_contract_trace()
+
+   local result
+   for _ in {0 to 120} do result = callback(proxy) end
+   assert(result is proxy, 'A full userdata contract should preserve its value on a trace')
+   for _ in {0 to 120} do result = callback(pointer) end
+   assert(result is pointer, 'A light userdata contract should preserve its value on a side trace')
+
+   local metrics = trace_metrics()
+   assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.snapshots > 0,
+      'Full and light userdata contracts should remain traceable')
+   expect_jit_contract_failure(function() callback(dynamic_contract_value({0 to 2})) end, 'userdata')
+end
+
+@Test function CallableContractTracksMetamethodMutation()
+   function accept_callable(Value:func):func
+      return Value
+   end
+
+   local metatable = {
+      __call = function(Self, Value)
+         return Self.offset + Value
+      end
+   }
+   local callable = setmetatable({ offset=5 }, metatable)
+   local callback:any = accept_callable
+   prepare_contract_trace()
+
+   local result
+   for _ in {0 to 120} do result = callback(callable) end
+   assert(result(4) is 9, 'A callable-table contract should preserve normal dispatch')
+   local metrics = trace_metrics()
+   assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.guards > 0,
+      'A callable-table contract should trace its metatable lookup')
+
+   local saved_call = metatable.__call
+   metatable.__call = false
+   expect_jit_contract_failure(function() callback(callable) end, 'func')
+   metatable.__call = saved_call
+   assert(callback(callable)(4) is 9, 'Restoring __call should restore the callable contract')
+end
+
+@Test function NullableComplexContractUsesSideTraces()
+   function read_optional(Value:struct<JitContractAlpha>):num
+      if Value is nil then return 0 end
+      return Value.Value
+   end
+
+   local alpha = struct<JitContractAlpha> { Value=11 }
+   local callback:any = read_optional
+   prepare_contract_trace()
+
+   local total = 0
+   for index in {0 to 240} do
+      total += callback(index % 2 is 0 ? alpha :> nil)
+   end
+
+   local metrics = trace_metrics()
+   assert(total is 1320, 'Nullable named-structure calls should preserve nil and concrete paths')
+   assert(metrics.traces > 1 and metrics.snapshots > 0,
+      'Alternating nil and named structures should create restorable trace paths')
+end
+
+@Test function ComplexResultContractsTraceAndReject()
+   function dynamic_result(Value):any return Value end
+   function checked_structure(Value:any):struct<JitContractAlpha>
+      return dynamic_result(Value)
+   end
+   function checked_range(Value:any):range
+      return dynamic_result(Value)
+   end
+
+   local alpha = struct<JitContractAlpha> { Value=13 }
+   local bravo = struct<JitContractBravo> { Value=17 }
+   local sequence = {0 to 4}
+   prepare_contract_trace()
+
+   local total = 0
+   for _ in {0 to 120} do
+      total += checked_structure(alpha).Value
+      total += #checked_range(sequence)
+   end
+   local metrics = trace_metrics()
+   assert(total is 2040 and metrics.traces > 0,
+      'Named-structure and range result contracts should remain traceable')
+   expect_jit_contract_failure(function() checked_structure(bravo) end, 'JitContractAlpha')
+   expect_jit_contract_failure(function() checked_range(newproxy(true)) end, 'range')
+end
+
+@Test function ReloadedComplexContractRetainsTracingAndIdentity()
+   function factory():func
+      return function(Value:struct<JitContractAlpha>):struct<JitContractAlpha>
+         return Value
+      end
+   end
+
+   local restored = exec(string.dump(factory, true))
+   local alpha = struct<JitContractAlpha> { Value=19 }
+   local bravo = struct<JitContractBravo> { Value=23 }
+   prepare_contract_trace()
+
+   local total = 0
+   for _ in {0 to 120} do total += restored(alpha).Value end
+   local metrics = trace_metrics()
+   assert(total is 2280 and metrics.traces > 0,
+      'A stripped reloaded named-structure contract should remain traceable')
+   expect_jit_contract_failure(function() restored(dynamic_contract_value(bravo)) end, 'JitContractAlpha')
+end

--- a/src/tiri/tests/test_type_guided_jit_signatures.tiri
+++ b/src/tiri/tests/test_type_guided_jit_signatures.tiri
@@ -1,6 +1,13 @@
 -- Interpreter/JIT parity for exact runtime contracts that previously disabled tracing.
 
 local ir_fload <const> = 69
+local ir_eq <const> = 8
+local ir_ne <const> = 9
+
+local irfl_tab_meta <const> = 5
+local irfl_udata_meta <const> = 11
+local irfl_udata_udtype <const> = 12
+local irfl_struct_def <const> = 31
 
 struct JitContractAlpha
    Value: int
@@ -43,7 +50,34 @@ function trace_metrics():table
          if (ir_ot >> 8) is ir_fload then result.fieldLoads++ end
       end
    end
+   jit.on()
    return result
+end
+
+function count_guarded_field(Field:num, GuardOpcode:num):num
+   jit.off()
+   local count = 0
+
+   for trace_no = 1, 100 do
+      local info = jit.util.traceInfo(trace_no)
+      if info is nil then continue end
+
+      local field_loads = {}
+      for instruction = 1, info.nins do
+         local _, ir_ot, _, ir_op2 = jit.util.traceIR(trace_no, instruction)
+         if ir_ot != nil and (ir_ot >> 8) is ir_fload and ir_op2 is Field then
+            field_loads[instruction] = true
+         end
+      end
+
+      for instruction = 1, info.nins do
+         local _, ir_ot, ir_op1, ir_op2 = jit.util.traceIR(trace_no, instruction)
+         if ir_ot != nil and (ir_ot >> 8) is GuardOpcode and
+            (field_loads[ir_op1] or field_loads[ir_op2]) then count++ end
+      end
+   end
+   jit.on()
+   return count
 end
 
 function prepare_contract_trace()
@@ -76,6 +110,8 @@ end
    assert(total is 840, 'A traced named-structure contract should preserve matching values')
    assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.guards > 0,
       'A named-structure contract should emit a guarded trace')
+   assert(count_guarded_field(irfl_struct_def, ir_eq) > 0,
+      'A named-structure contract should guard the exact GCstruct definition field')
    expect_jit_contract_failure(function() callback(dynamic_contract_value(bravo)) end, 'JitContractAlpha')
 end
 
@@ -93,6 +129,8 @@ end
    local metrics = trace_metrics()
    assert(total is 960 and metrics.traces > 0 and metrics.fieldLoads > 0,
       'A matching range contract should trace with its metatable predicate')
+   assert(count_guarded_field(irfl_udata_meta, ir_eq) > 0,
+      'A range contract should guard the exact userdata metatable field')
 
    expect_jit_contract_failure(function() callback(dynamic_contract_value(newproxy(true))) end, 'range')
 
@@ -131,6 +169,10 @@ end
    local metrics = trace_metrics()
    assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.snapshots > 0,
       'Full and light userdata contracts should remain traceable')
+   assert(count_guarded_field(irfl_udata_udtype, ir_ne) > 0,
+      'A userdata contract should reject thunks through the exact userdata subtype field')
+   assert(count_guarded_field(irfl_udata_meta, ir_ne) > 0,
+      'A userdata contract should reject ranges through the exact userdata metatable field')
    expect_jit_contract_failure(function() callback(dynamic_contract_value({0 to 2})) end, 'userdata')
 end
 
@@ -154,12 +196,50 @@ end
    local metrics = trace_metrics()
    assert(metrics.traces > 0 and metrics.fieldLoads > 0 and metrics.guards > 0,
       'A callable-table contract should trace its metatable lookup')
+   assert(count_guarded_field(irfl_tab_meta, ir_ne) > 0,
+      'A callable contract should guard the exact table metatable field')
 
    local saved_call = metatable.__call
    metatable.__call = false
    expect_jit_contract_failure(function() callback(callable) end, 'func')
    metatable.__call = saved_call
    assert(callback(callable)(4) is 9, 'Restoring __call should restore the callable contract')
+end
+
+@Test function ComplexContractGuardExitRestoresCallerState()
+   function accept_alpha(Value:struct<JitContractAlpha>):struct<JitContractAlpha>
+      return Value
+   end
+
+   function call_with_live_state(Value:any):<num, str, bool>
+      local live_number = 37
+      local live_text = 'snapshot-live'
+      local live_table = { offset=5 }
+      try
+         local checked = accept_alpha(Value)
+         return live_number + live_table.offset + checked.Value, live_text, false
+      except e
+         return live_number + live_table.offset, live_text, e.message:find('JitContractAlpha') != nil
+      end
+   end
+
+   local alpha = struct<JitContractAlpha> { Value=7 }
+   local bravo = struct<JitContractBravo> { Value=9 }
+   prepare_contract_trace()
+
+   for _ in {0 to 120} do
+      local value, text, failed = call_with_live_state(alpha)
+      assert(value is 49 and text is 'snapshot-live' and not failed,
+         'The traced success path should preserve caller locals')
+   end
+
+   local restored_number, restored_text, failed = call_with_live_state(dynamic_contract_value(bravo))
+   assert(restored_number is 42 and restored_text is 'snapshot-live' and failed,
+      'A complex contract guard exit should restore live numeric, string and table-backed caller state')
+
+   local retry_number, retry_text, retry_failed = call_with_live_state(alpha)
+   assert(retry_number is 49 and retry_text is 'snapshot-live' and not retry_failed,
+      'Execution should recover after a failed complex contract guard')
 end
 
 @Test function NullableComplexContractUsesSideTraces()
@@ -227,4 +307,73 @@ end
    assert(total is 2280 and metrics.traces > 0,
       'A stripped reloaded named-structure contract should remain traceable')
    expect_jit_contract_failure(function() restored(dynamic_contract_value(bravo)) end, 'JitContractAlpha')
+end
+
+@Test function ComplexContractInterpreterJitParity()
+   function accept_alpha(Value:struct<JitContractAlpha>):struct<JitContractAlpha> return Value end
+   function accept_range(Value:range):range return Value end
+   function accept_userdata(Value:userdata):userdata return Value end
+   function accept_callable(Value:func):func return Value end
+
+   function run_valid_contracts(Count:num, Alpha:struct<JitContractAlpha>, Sequence:range, Proxy:userdata,
+      Callable:func):num
+      local total = 0
+      for _ in {0 to Count} do
+         total += accept_alpha(Alpha).Value
+         total += #accept_range(Sequence)
+         assert(accept_userdata(Proxy) is Proxy, 'A userdata contract should preserve identity')
+         total += accept_callable(Callable)(1)
+      end
+      return total
+   end
+
+   function failure_after_warm(Callback:func, Good:any, Bad:any, Count:num):str
+      for index in {0 to Count} do
+         local value:any = index is Count - 1 ? Bad :> Good
+         try
+            Callback(value)
+         except e
+            return e.message
+         end
+      end
+      return ''
+   end
+
+   local alpha = struct<JitContractAlpha> { Value=3 }
+   local bravo = struct<JitContractBravo> { Value=5 }
+   local sequence = {0 to 4}
+   local proxy = newproxy(true)
+   local callable = setmetatable({ offset=2 }, {
+      __call = function(Self, Value) return Self.offset + Value end
+   })
+
+   jit.off()
+   local interpreted_total = run_valid_contracts(20, alpha, sequence, proxy, callable)
+   local interpreted_messages = {
+      failure_after_warm(accept_alpha, alpha, bravo, 1),
+      failure_after_warm(accept_range, sequence, proxy, 1),
+      failure_after_warm(accept_userdata, proxy, sequence, 1),
+      failure_after_warm(accept_callable, callable, {}, 1)
+   }
+
+   prepare_contract_trace()
+   local compiled_total = run_valid_contracts(120, alpha, sequence, proxy, callable)
+   prepare_contract_trace()
+   local compiled_alpha_message = failure_after_warm(accept_alpha, alpha, bravo, 120)
+   prepare_contract_trace()
+   local compiled_range_message = failure_after_warm(accept_range, sequence, proxy, 120)
+   prepare_contract_trace()
+   local compiled_userdata_message = failure_after_warm(accept_userdata, proxy, sequence, 120)
+   prepare_contract_trace()
+   local compiled_callable_message = failure_after_warm(accept_callable, callable, {}, 120)
+   local compiled_messages = {
+      compiled_alpha_message, compiled_range_message, compiled_userdata_message, compiled_callable_message
+   }
+
+   assert(interpreted_total is 200 and compiled_total is 1200,
+      'Interpreter and JIT paths should produce the same per-iteration specialised contract result')
+   for index in {0 to 4} do
+      assert(interpreted_messages[index] is compiled_messages[index],
+         f"Interpreter and JIT contract diagnostics should match for specialised path {index}")
+   end
 end

--- a/src/tiri/tests/test_type_signature_dumps.tiri
+++ b/src/tiri/tests/test_type_signature_dumps.tiri
@@ -1,0 +1,116 @@
+-- Behavioural coverage for persistent function signatures in stripped and unstripped bytecode dumps.
+
+struct SignatureDumpRecord
+   Value: int
+end
+
+function dynamic_value(Value):any
+   return Value
+end
+
+function expect_contract_failure(Callback:func)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message != nil, 'A reloaded contract failure must carry a message')
+   end
+   assert(failed, 'Expected a reloaded function to reject the mismatching value')
+end
+
+function reload_factory(Factory:func, Stripped:bool):func
+   return exec(string.dump(Factory, Stripped))
+end
+
+@Test function ParameterAndResultRoundTrips()
+   function factory():func
+      return function(Value:num):num
+         return Value + 1
+      end
+   end
+
+   for stripped in values({ false, true }) do
+      local restored = reload_factory(factory, stripped)
+      assert(restored(4) is 5, 'A reloaded typed function must preserve matching values')
+      local dynamic:any = restored
+      expect_contract_failure(function() dynamic('wrong') end)
+   end
+end
+
+@Test function FixedAndVariadicResults()
+   function fixed_factory():func
+      return function():<num, str>
+         return 3, 'kept', false
+      end
+   end
+
+   function variadic_factory():func
+      return function():<num, ...>
+         return 1, 2, 3, 4
+      end
+   end
+
+   local restored_fixed = reload_factory(fixed_factory, true)
+   local first, second, extra = restored_fixed()
+   assert(first is 3 and second is 'kept' and extra is nil,
+      'A reloaded fixed signature must preserve its declared arity')
+
+   local restored_variadic = reload_factory(variadic_factory, false)
+   local one, two, three, four = restored_variadic()
+   assert(one is 1 and two is 2 and three is 3 and four is 4,
+      'A reloaded variadic signature must preserve and validate its suffix')
+end
+
+@Test function ExplicitVoidResult()
+   function factory():func
+      return function():<>
+         return 99
+      end
+   end
+
+   local restored = reload_factory(factory, true)
+   assert(restored() is nil, 'A reloaded explicit-void signature must truncate all results')
+end
+
+@Test function NamedStructRoundTrip()
+   function factory():func
+      return function(Value:struct<SignatureDumpRecord>):struct<SignatureDumpRecord>
+         return Value
+      end
+   end
+
+   local restored = reload_factory(factory, true)
+   local item = struct<SignatureDumpRecord> { Value=7 }
+   assert(restored(item) is item, 'A reloaded named-struct signature must accept the registered layout')
+   expect_contract_failure(function() restored(dynamic_value({})) end)
+end
+
+@Test function NestedPrototypeRoundTrip()
+   function outer_factory():func
+      return function():func
+         return function(Value:str):str
+            return Value
+         end
+      end
+   end
+
+   local restored_factory = reload_factory(outer_factory, true)
+   local restored_child = restored_factory()
+   assert(restored_child('nested') is 'nested', 'A nested signature must survive recursive serialisation')
+   expect_contract_failure(function() restored_child(dynamic_value(9)) end)
+end
+
+@Test function HotReloadedFunction()
+   function factory():func
+      return function(Value:num):num
+         return Value + 1
+      end
+   end
+
+   local restored = reload_factory(factory, true)
+   for i = 0, 250 do
+      assert(restored(i) is i + 1, 'A hot reloaded signature must remain semantically stable')
+   end
+   expect_contract_failure(function() restored(dynamic_value('wrong')) end)
+end

--- a/src/tiri/tests/type_contract_fixture.tiri
+++ b/src/tiri/tests/type_contract_fixture.tiri
@@ -1,0 +1,3 @@
+global function imported_typed(Value:num):num
+   return Value
+end

--- a/src/tiri/tiri_class_methods.cpp
+++ b/src/tiri/tiri_class_methods.cpp
@@ -26,10 +26,11 @@ static std::string_view tiri_type_name(TiriType Type)
       case TiriType::Table:   return "table";
       case TiriType::Array:   return "array";
       case TiriType::Func:    return "function";
-      case TiriType::Struct:  return "struct";
-      case TiriType::Object:  return "object";
-      case TiriType::Range:   return "range";
-      case TiriType::Unknown: return "unknown";
+      case TiriType::Struct:   return "struct";
+      case TiriType::Object:   return "object";
+      case TiriType::Range:    return "range";
+      case TiriType::Userdata: return "userdata";
+      case TiriType::Unknown:  return "unknown";
       case TiriType::Any:
       default: return "any";
    }

--- a/src/tiri/tiri_io.cpp
+++ b/src/tiri/tiri_io.cpp
@@ -892,7 +892,7 @@ void register_io_class(lua_State *Lua)
    lua_pop(Lua, 3); // Drop the Tiri.file metatable, Tiri.io metatable, and io library table
 
    // Register io interface prototypes for compile-time type inference
-   reg_iface_prototype("io", "open", { TiriType::Any }, { TiriType::Str, TiriType::Str });
+   reg_iface_prototype("io", "open", { TiriType::Userdata }, { TiriType::Str, TiriType::Str });
    reg_iface_prototype("io", "close", { TiriType::Bool }, { TiriType::Any });
    reg_iface_prototype("io", "read", { TiriType::Any }, { TiriType::Any });
    reg_iface_prototype("io", "write", {}, { TiriType::Any });
@@ -900,7 +900,7 @@ void register_io_class(lua_State *Lua)
    reg_iface_prototype("io", "input", { TiriType::Any }, { TiriType::Any });
    reg_iface_prototype("io", "output", { TiriType::Any }, { TiriType::Any });
    reg_iface_prototype("io", "lines", { TiriType::Func }, { TiriType::Any });
-   reg_iface_prototype("io", "tempFile", { TiriType::Any }, {});
+   reg_iface_prototype("io", "tempFile", { TiriType::Userdata }, {});
    reg_iface_prototype("io", "type", { TiriType::Str }, { TiriType::Any });
    reg_iface_prototype("io", "readAll", { TiriType::Str }, { TiriType::Str });
    reg_iface_prototype("io", "writeAll", {}, { TiriType::Str, TiriType::Str });

--- a/src/tiri/tiri_module.cpp
+++ b/src/tiri/tiri_module.cpp
@@ -1439,6 +1439,6 @@ void register_module_class(lua_State *Lua)
    if (stack_delta) log.warning("Module registration left %d value(s) on the Lua stack.", stack_delta);
 
    // Register mod interface prototypes for compile-time type inference
-   reg_iface_prototype("mod", "load", { TiriType::Any }, { TiriType::Str });
+   reg_iface_prototype("mod", "load", { TiriType::Userdata }, { TiriType::Str });
    reg_iface_prototype("mod", "test", { TiriType::Num, TiriType::Num }, { TiriType::Any, TiriType::Str });
 }

--- a/src/tiri/tiri_processing.cpp
+++ b/src/tiri/tiri_processing.cpp
@@ -530,7 +530,7 @@ void register_processing_class(lua_State *Lua)
    lua_pop(Lua, 2); // Drop the Tiri.processing metatable and the processing library table
 
    // Register processing interface prototypes for compile-time type inference
-   reg_iface_prototype("processing", "new", { TiriType::Any }, { TiriType::Table });
+   reg_iface_prototype("processing", "new", { TiriType::Userdata }, { TiriType::Table });
    reg_iface_prototype("processing", "collect", { TiriType::Num }, { TiriType::Str, TiriType::Table });
    reg_iface_prototype("processing", "stopCollector", {}, {});
    reg_iface_prototype("processing", "startCollector", {}, {});

--- a/src/tiri/tiri_regex.cpp
+++ b/src/tiri/tiri_regex.cpp
@@ -680,7 +680,7 @@ void register_regex_class(lua_State *Lua)
    lua_pop(Lua, 2); // Drop the Tiri.regex metatable and the regex library table
 
    // Register regex interface prototypes for compile-time type inference
-   reg_iface_prototype("regex", "new", { TiriType::Any }, { TiriType::Str, TiriType::Num });
+   reg_iface_prototype("regex", "new", { TiriType::Userdata }, { TiriType::Str, TiriType::Num });
    reg_iface_prototype("regex", "escape", { TiriType::Str }, { TiriType::Str });
    reg_iface_prototype("regex", "test", { TiriType::Bool }, { TiriType::Str, TiriType::Num });
    reg_iface_prototype("regex", "match", { TiriType::Array }, { TiriType::Str, TiriType::Num });

--- a/src/xml/xml.tdl
+++ b/src/xml/xml.tdl
@@ -159,7 +159,7 @@ struct XPathArrayStorage;]])
   structdef("XPathValue", { type="XPathValue" }, [[
     int(XPVT) Type         # Identifies the type of value stored
     double    NumberValue  # Defined if the type is Number or Boolean
-    string  StringValue  # Defined if the type is String
+    string  StringValue    # Defined if the type is String
   ]],
   [[
    kt::vector<XTag *> node_set; // Defined if the type is NodeSet

--- a/src/xquery/xquery.tdl
+++ b/src/xquery/xquery.tdl
@@ -8,6 +8,8 @@ module({ name='XQuery', src='xquery.cpp', copyright='Paul Manias © 2025-2026', 
     loadFile('../xml/constants.tdl')
   end)
 
+  privateNames({ 'XPathValue' })
+
   -- Shared enumerations for parser and evaluator state, including map/array node kinds.
   loadFile('./constants.tdl')
 

--- a/tools/benchmark/benchmark.tiri
+++ b/tools/benchmark/benchmark.tiri
@@ -161,11 +161,13 @@ end
       entry = anno[func]
 
       if rx_test then
-         if not rx_test.match(name) then continue end
+         if not rx_test.test(name) then continue end
       end
 
       local eval
       try<trace>
+         -- Keep each benchmark independent from trace limits, blacklisting and side traces created by earlier cases.
+         jit.flush()
          eval = bmark.run({
             duration     = duration,
             warmupCalls  = warmup,
@@ -177,7 +179,9 @@ end
          logMessage(f'Error in benchmark {name}: {ex.message}')
          logMessage(ex.stackTrace)
       success
-         logMessage(string.format('%s() Calls Per Second: %d; Total Calls: %d, Fastest: %.3f ms', name, eval.callsPerSecond, eval.benchmarkCalls, eval.stats.min))
+         logMessage(string.format(
+            '%s() Calls Per Second: %d; Total Calls: %d, Fastest: %.3f ms, Median: %.3f ms, Trimmed Tail: %.3f ms',
+            name, eval.callsPerSecond, eval.benchmarkCalls, eval.stats.min, eval.stats.median, eval.stats.max))
          if eval.memoryLeakRate / eval.callsPerSecond > 512 then
             logMessage(string.format('Leak Rate:  %d bytes per call', eval.memoryLeakRate / eval.callsPerSecond))
          end

--- a/tools/benchmark/benchmark_string.tiri
+++ b/tools/benchmark/benchmark_string.tiri
@@ -29,7 +29,7 @@ end
    local a, b, c = "foo", "bar", "baz"
    local checksum = 0
    local result = ""
-   for i in {0 to 1000} do
+   for i in {0 to 800} do
       -- Concatenate literals
       result ..= "Hello" .. " " .. "World" .. "!"
 

--- a/tools/idl/idl-compile.tiri
+++ b/tools/idl/idl-compile.tiri
@@ -29,7 +29,7 @@ global glConstants = { }
 global substituteReferences, sequenceStruct
 global function c_include(...) end
 global function cpp_include(...) end
-global function klass(Name:str, Options:table, Def:str, Private:bool) end
+global function klass(Name:str, Options:table, Def:str, Private:str, Custom:str) end
 global function functionNames(Prefix:str, ...) end
 global function methods(ClassName:str, Prefix:str, Methods:table) end
 global function c_insert(Raw:str) end

--- a/tools/idl/include/client_functions.tiri
+++ b/tools/idl/include/client_functions.tiri
@@ -428,8 +428,8 @@ end
 @input Names to hash into enum values
 ]])
 global function typedHash(Prefix:str, Type:str, ...)
-   Type = cType({ type=Type }, Prefix)
-   output(f'enum class {Prefix} : {Type.type} {{')
+   local ctype = cType({ type=Type }, Prefix)
+   output(f'enum class {Prefix} : {ctype.type} {{')
    output('   NIL = 0,')
    for v in values({...}) do
       local hash_name = rx_non_word.replace(v, '_')
@@ -839,8 +839,8 @@ end
 @input Private class data specification
 @input Optional custom C++ text for the generated class
 ]])
-global function klass(Name, Options:table, Spec, Private, Custom)
-   verbose('Processing class ' .. tostring(Name))
+global function klass(Name:str, Options:table, Spec:str, Private:str, Custom:str)
+   verbose('Processing class ' .. Name)
 
    forward_declared = false
    if not Options then
@@ -1057,7 +1057,7 @@ global function klass(Name, Options:table, Spec, Private, Custom)
                method.funcName ..= Name
             end
 
-            function pName(Param:str):str
+            function pName(Param:table):str
                name = Param.name
                if (Param.type is 'OBJECTID') or (Param.type is 'MEMORYID') then
                   if name:sub(-2) != 'ID' then
@@ -1281,7 +1281,7 @@ end
 @input Method definition table
 ]])
 global function methods(ClassName:str, Prefix:str, Methods)
-   verbose(<{ f'Processing {#Methods} methods for class {ClassName}' }>)
+   verbose(f'Processing {#Methods} methods for class {ClassName}')
 
    local cl = registerClass(ClassName)
    cl.methodPrefix = Prefix

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -474,7 +474,7 @@ global function saveDocuments()
                print(f'Saving XML class documentation to "{fl.path}"')
                fl.acWrite(out)
             except ex
-               print('Failed to produce documentation for class ' .. className .. ': ' .. ex.message)
+               print(f'[{ex.source}:{ex.line}] Failed to produce documentation for class ' .. className .. ': ' .. ex.message)
             end
          elseif not cl.forwardDeclared then
             print('No meta information for class ' .. className)
@@ -487,7 +487,7 @@ end
 -- Used for extracting descriptions, notes etc.  NB: <pre> should be used for multi-line preformatting, while <code>
 -- should be used for in-place code formatting.
 
-global function extractParagraph(Input:str, Caller:str, References:table)
+global function extractParagraph(Input:str, Context:table, References:table)
    assert(Input, 'No Input provided to extractParagraph()')
 
    Input = Input:trim()
@@ -599,13 +599,13 @@ global function extractParagraph(Input:str, Caller:str, References:table)
    -- Handle <field>, <method> and <action> references
 
    if output?? and output:len() > 12 then
-      if Caller and Caller.meta then
-         output = substituteReferences(output, Caller)
+      if Context and Context.meta then
+         output = substituteReferences(output, Context)
       else
          output = substituteReferences(output, nil)
       end
 
-      return cleanXMLString(output, Caller)
+      return cleanXMLString(output)
    else
       return ''
    end
@@ -655,6 +655,7 @@ global function substituteReferences(String:str, Class:table):str
    String = substituteReferenceMatches(String, rx_action_method, function(Cap, Match)
       local call_name = Cap[0]
       if not Class then
+         print('Missing class association for action/method reference "' .. call_name .. '"')
          return f'<action>{call_name}</action>'
       elseif Class.lookupMethods?[call_name] then
          return f'<method>{call_name}</method>'
@@ -692,6 +693,7 @@ global function substituteReferences(String:str, Class:table):str
 
    String = substituteReferenceMatches(String, rx_ext_func_ref, function(Cap, Match)
       -- TODO: Validate that the module and function actually exist.  Easiest way is with mod.load()
+      -- and build a cache of the function list.
       return f'<function module="{Cap[0]}">{Cap[1]}</function>'
    end)
 
@@ -1172,7 +1174,7 @@ global function docFunction(Function)
    -- Description
 
    if Function.description?? then
-      out ..= f'    <description>\n{extractParagraph(Function.description, Function)}\n    </description>\n'
+      out ..= f'    <description>\n{extractParagraph(Function.description, Function, Function.references)}\n    </description>\n'
    else
       error(f'{Function.name}() has no description.')
    end

--- a/tools/idl/include/utils.tiri
+++ b/tools/idl/include/utils.tiri
@@ -139,7 +139,7 @@ end
 
 local cxml
 
-global function cleanXMLString(String:str, Caller:str):str
+global function cleanXMLString(String:str):str
    String ?! return ''
 
    if rx_angle_brackets.test(String) then
@@ -156,7 +156,7 @@ global function cleanXMLString(String:str, Caller:str):str
          local extracted = rx_root_extract.extract(clean_str)
          if extracted then String = extracted:trim() end
       except ex
-         error(f'Failed to parse XML for {Caller ?? "undefined"}: {ex.message}')
+         error(f'Failed to parse XML: {ex.message}\n' .. debug.traceback())
       end
    end
 

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -234,7 +234,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Doc(text="Hover Support - Current Document Symbols")
-function hoverGetDocumentSymbols(Doc:table):array
+function hoverGetDocumentSymbols(Doc:table):table
    if Doc.hoverSymbolsContent is Doc.content and Doc.hoverSymbols then return Doc.hoverSymbols end
 
    local result
@@ -271,7 +271,7 @@ function hoverSymbolMatches(Symbol:table, TokenInfo:table):bool
    return false
 end
 
-function hoverAppendParamSection(Markdown:str, Params:array):str
+function hoverAppendParamSection(Markdown:str, Params:any):str
    lines = array<string>
 
    for param in values(Params or array<table>) do
@@ -292,7 +292,7 @@ function hoverAppendParamSection(Markdown:str, Params:array):str
    return Markdown
 end
 
-function hoverAppendResultSection(Markdown:str, Results:array):str
+function hoverAppendResultSection(Markdown:str, Results:any):str
    lines = array<string>
 
    for result in values(Results or array<table>) do
@@ -311,7 +311,7 @@ function hoverAppendResultSection(Markdown:str, Results:array):str
    return Markdown
 end
 
-function hoverAppendErrorSection(Markdown:str, Errors:array):str
+function hoverAppendErrorSection(Markdown:str, Errors:any):str
    lines = array<string>
 
    for err in values(Errors or array<table>) do
@@ -330,7 +330,7 @@ function hoverAppendErrorSection(Markdown:str, Errors:array):str
    return Markdown
 end
 
-function hoverAppendFieldSection(Markdown:str, Fields:array):str
+function hoverAppendFieldSection(Markdown:str, Fields:any):str
    lines = array<string>
 
    for field in values(Fields or array<table>) do

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -677,14 +677,14 @@ global function lspStart(Options)
       self._socket = obj.new('netserver', {
          port = self.port,
          flags = NSF_MULTI_CONNECT,
-         feedback = function(Server:obj, ClientSocket:obj, State:num)
+         feedback = function(Server:obj, ClientSocket:any, State:num)
             if State is NTC_CONNECTED then
                logMessage(self, 'LSP client connected')
             elseif State is NTC_DISCONNECTED then
                logMessage(self, 'LSP client disconnected')
             end
          end,
-         incoming = function(Server:obj, ClientSocket:obj)
+         incoming = function(Server:obj, ClientSocket:any)
             processIncoming(self, ClientSocket)
          end
       })

--- a/tools/tiri_lsp/include/lsp_protocol.tiri
+++ b/tools/tiri_lsp/include/lsp_protocol.tiri
@@ -94,7 +94,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Send an LSP notification (no response expected)
 
-global function sendNotification(Self:table, ClientSocket:obj, Method, Params)
+global function sendNotification(Self:table, ClientSocket:any, Method, Params)
    notification = {
       jsonrpc = '2.0',
       method = Method,
@@ -151,7 +151,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Incoming Data Handling
 
-function initClientState(Self:table, ClientSocket:obj)
+function initClientState(Self:table, ClientSocket:any)
    state = ClientSocket._state()
 
    if not state.initialised then
@@ -169,7 +169,7 @@ function initClientState(Self:table, ClientSocket:obj)
    return state
 end
 
-global function processIncomingData(Self:table, ClientSocket:obj, Data:str)
+global function processIncomingData(Self:table, ClientSocket:any, Data:str)
    state = initClientState(Self, ClientSocket)
 
    if not Data or #Data is 0 then return end
@@ -235,7 +235,7 @@ global function processIncomingData(Self:table, ClientSocket:obj, Data:str)
    end
 end
 
-global function processIncoming(Self:table, ClientSocket:obj)
+global function processIncoming(Self:table, ClientSocket:any)
    state = initClientState(Self, ClientSocket)
 
    -- Read available data

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -233,7 +233,7 @@ end
 
 -- Convert internal parameter records to LSP ParameterInformation records.
 
-function signatureBuildParameterInfo(Params:array):array
+function signatureBuildParameterInfo(Params:any):array
    result = array<table>
    for param in values(Params or array<table>) do
       label = param.label or signatureParamLabel(param)
@@ -246,7 +246,7 @@ end
 
 -- Build an LSP SignatureInformation record from a label, documentation and parameter list.
 
-function signatureBuildInfo(Label:str, Documentation:str, Params:array):table
+function signatureBuildInfo(Label:str, Documentation:str, Params:any):table
    info = {
       label = Label or '',
       parameters = signatureBuildParameterInfo(Params)
@@ -258,7 +258,7 @@ end
 
 -- Keep the active parameter index inside the bounds of the signature parameter list.
 
-function signatureClampActiveParameter(Active:num, Params:array):num
+function signatureClampActiveParameter(Active:num, Params:any):num
    if not Params or #Params is 0 then return 0 end
    if Active < 0 then return 0 end
    if Active >= #Params then return #Params - 1 end
@@ -341,7 +341,7 @@ end
 
 -- Get cached parser symbols for the document, refreshing them when the document content has changed.
 
-function signatureGetDocumentSymbols(Doc:table):array
+function signatureGetDocumentSymbols(Doc:table):table
    if Doc.signatureSymbolsContent is Doc.content and Doc.signatureSymbols then return Doc.signatureSymbols end
 
    local result
@@ -528,7 +528,7 @@ end
 
 -- Copy parameter documentation from generated API metadata onto parsed prototype parameters.
 
-function signatureCopyParamDocs(Params:array, SourceParams:array):array
+function signatureCopyParamDocs(Params:array, SourceParams:any):array
    if not SourceParams then return Params end
 
    for param in values(Params or array<table>) do


### PR DESCRIPTION
## Summary

- Enforce exact runtime contracts for typed parameters, results, locals, upvalues and globals, including named structures, ranges, callable values and full/light userdata.
- Persist portable function-signature metadata through stripped and unstripped bytecode dumps, with safe legacy defaults and disassembly/debug output.
- Propagate static type descriptors into specialised bytecode emission and retain stable JIT tracing for dynamic results.
- Record exact complex-contract guards for named structures, ranges, userdata and callable tables while preserving catchable interpreter diagnostics on trace exits.
- Update affected Tiri scripts and tooling for the stricter runtime boundaries, and add comprehensive Flute and compiled unit coverage.

## Why

Type annotations previously provided incomplete runtime guarantees: indirect or dynamically typed paths could reach typed code without a consistent boundary check, and several exact contracts prevented useful tracing. Function-signature information also lacked a portable representation across bytecode dumps.

This change makes the contracts enforceable at every supported boundary while using the same metadata to guide safe bytecode and JIT specialisation. Phase 4 measurements did not identify an ordinary signature guard that could be safely eliminated, so the implementation retains exact guards rather than weakening contract semantics.

## Impact

Typed Tiri code now reports catchable, consistent contract failures under both interpreter and JIT execution. Matching typed workloads can use specialised operations and trace complex contracts without changing observable behaviour. The private bytecode format is intentionally versioned for the new signature metadata.

## Validation

- Built the Debug `tiri` target successfully.
- Installed the updated Debug build before testing.
- Passed `tiri_unit_tests`, including all 166 embedded Tiri unit tests.
- Passed `tiri_type_contracts`.
- Passed `tiri_type_guided_jit_signatures`.

Broader platform and CI validation remains appropriate while this pull request is in draft.