### PR TITLE
[Tiri] Collapsed extended falsey checks into one bytecode

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -75,7 +75,7 @@ Operand suffixes: V=variable slot, S=string const, N=number const, P=primitive (
 | `ISF` | D | Skip next if R(D) is falsey |
 | `ISTYPE` | A D | Assert R(A) is type D (debug) |
 | `ISNUM` | A D | Assert R(A) is number (debug) |
-| `ISEMPTYARR` | A | R(A) is an empty array or table → execute next JMP; else skip JMP |
+| `ISFALSEY` | A D | Execute next JMP if R(A) is nil or matches falsey mask D; otherwise skip JMP |
 
 #### Unary Ops
 | Opcode | Format | Description |
@@ -466,15 +466,20 @@ end:
 
 ### 7.3 Presence Operator (`x?`) – Extended Falsey Check
 - Falsey set: `nil`, `false`, numeric zero, empty string, empty arrays, and empty tables. If operand is in this set, result is `false` and RHS (if any) is skipped.
-- Emission: chain `BC_ISEQP`/`BC_ISEQN`/`BC_ISEQS`/`BC_ISEMPTYARR` comparisons, each followed by a `JMP` to the falsey path. A matching equality branches to that path; non-matching comparisons fall through to the next check. If all checks fall through (truthy value), execution continues past the chain.
-- Jump lists patch the falsey exit after the chain; truthy fallthrough sets the result and collapses `freereg`.
-- `BC_ISEMPTYARR` is used to check if the value is an empty collection. Semantics: if `R(A)` is a native array with `len == 0` or a table with no entries, execute the following `JMP` (falsey); otherwise skip the `JMP` (truthy).
+- Emission: one `BC_ISFALSEY` followed by a `JMP` to the falsey path. Nil is always checked. Its D operand is a
+  mask containing `ISFALSEY_FALSE` (0x1), `ISFALSEY_ZERO` (0x2), `ISFALSEY_EMPTY_STR` (0x4), and
+  `ISFALSEY_EMPTY_COLL` (0x8).
+- Known operand types narrow the mask to the one applicable value check. Object, function, and struct operands
+  degrade to the existing nil-only `BC_ISEQP` check.
+- The JIT recorder specialises on the observed runtime type and records at most one value guard. Empty tables retain
+  the previous NYI behaviour because determining table emptiness requires traversal.
+- The falsey jump is patched after the truthy result path; truthy fallthrough sets the result and collapses `freereg`.
 
 ### 7.4 If-Empty Operator (`lhs ?? rhs`) – Short-Circuiting with Extended Falsey Semantics
 - Evaluate `lhs`; if it is nil/false/0/""/empty array/empty table, evaluate `rhs` and return it; otherwise return `lhs` without touching `rhs`.
-- Implemented in `IrEmitter::emit_if_empty_expr` plus helper routines in `operator_emitter.cpp`. The compare chain mirrors the presence operator: a matching falsey value branches to RHS evaluation; a truthy value falls through all checks and skips RHS entirely.
+- Implemented in `IrEmitter::emit_if_empty_expr` plus helper routines in `operator_emitter.cpp`. `BC_ISFALSEY`
+  branches directly to RHS evaluation for a selected falsey value; a truthy value skips the following `JMP`.
 - The result register is the original `lhs` slot; RHS evaluation reuses it and collapses `freereg` afterward to avoid leaked arguments or vararg tails.
-- Uses `BC_ISEMPTYARR` to check for empty arrays and tables as part of the extended falsey semantics. If `R(A)` is a native array with `len == 0` or a table with no entries, the following `JMP` is executed (falsey path); otherwise the `JMP` is skipped (truthy path).
 
 ## 8. Register Semantics and Multi-Value Behaviour
 ### 8.1 Register Lifetimes, `freereg`, and `nactvar`
@@ -495,7 +500,9 @@ end:
 ## 9. Common Emission Patterns and Anti-Patterns
 ### 9.1 Canonical Patterns (Do This)
 - Compare + `JMP` for "branch on not-equal": `ISEQP A,const; JMP target` with true skipping the jump; see the relevant compare/jump emission logic in `operator_emitter.cpp`.
-- Presence / if-empty chains: sequential `ISEQP/ISEQN/ISEQS/ISEMPTYARR` with shared jump list patched to the truthy or RHS path; see `operator_emitter.emit_presence_check` (called from `IrEmitter::emit_presence_expr`) and `IrEmitter::emit_if_empty_expr`.
+- Presence / if-empty checks: `ISFALSEY A,mask; JMP target`, with nil-only cases using
+  `ISEQP A,nil; JMP target`; see `operator_emitter.emit_presence_check` (called from
+  `IrEmitter::emit_presence_expr`) and `IrEmitter::emit_if_empty_expr`.
 - Logical short-circuit: `a or b` uses compare + `JMP` into RHS only when falsey; `a and b` jumps over RHS when falsey. Implemented via general binary operator emission in `operator_emitter.cpp` and `ir_emitter.cpp`.
 - Ternary layout: condition in place, compare chain, then true/false blocks writing back into the same register, with end jump to merge; see `IrEmitter::emit_ternary_expr`.
 

--- a/src/tiri/jit/src/bytecode/lj_bc.h
+++ b/src/tiri/jit/src/bytecode/lj_bc.h
@@ -27,6 +27,12 @@ constexpr uint16_t BCBIAS_J = 0x8000;
 constexpr uint8_t  NO_REG = BCMAX_A;
 #define NO_JMP      (~(BCPOS)0)
 
+// Mask bits for BC_ISFALSEY. Nil is always tested.
+#define ISFALSEY_FALSE       0x01
+#define ISFALSEY_ZERO        0x02
+#define ISFALSEY_EMPTY_STR   0x04
+#define ISFALSEY_EMPTY_COLL  0x08
+
 // Inline functions to get instruction fields (defined after BCOp enum).
 
 #define bc_op(i)   ((BCOp)((i)&0xff))
@@ -127,7 +133,7 @@ constexpr uint8_t  NO_REG = BCMAX_A;
   _(ISF,    ___, ___, var, ___) \
   _(ISTYPE, var, ___, lit, ___) \
   _(ISNUM,  var, ___, lit, ___) \
-  _(ISEMPTYARR, var, ___, ___, ___) \
+  _(ISFALSEY, var, ___, lit, ___) \
   \
   /* Unary ops. */ \
   _(MOV, dst, ___, var, ___) \
@@ -285,7 +291,7 @@ typedef enum {
    BC_ISF     = 15,
    BC_ISTYPE  = 16,
    BC_ISNUM   = 17,
-   BC_ISEMPTYARR = 18,  // Check if RA is an empty array or table (for ?? operator)
+   BC_ISFALSEY = 18,  // Check RA against the falsey conditions selected by RD; nil is always checked
 
    // Unary ops (19-22)
    BC_MOV     = 19,

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -35,7 +35,7 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // If you perform *any* kind of private modifications to the bytecode itself
 // or to the dump format, you *must* set BCDUMP_VERSION to 0x80 or higher.
 
-constexpr int BCDUMP_VERSION = 3;
+constexpr int BCDUMP_VERSION = 0x80;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2703,6 +2703,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bls >3
     |  cmn ITYPE, #-LJ_TSTR
     |  beq >4
+    |  cmn ITYPE, #-LJ_TUDATA
+    |  beq >7
     |  cmn ITYPE, #-LJ_TARRAY
     |  beq >5
     |  cmn ITYPE, #-LJ_TTAB
@@ -2743,6 +2745,16 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  and CARG1, CARG1, #LJ_GCVMASK
     |  ldr TMP0w, ARRAY:CARG1->len
     |  cbnz TMP0w, >1
+    |  b >9
+    |7:
+    |  str BASE, L->base
+    |  mov CARG1, L
+    |  ldr CARG2, [PC, #-16]
+    |  str PC, SAVE_PC
+    |  bl extern lj_meta_isfalsey  // (lua_State *L, BCIns ins)
+    |  ldr BASE, L->base
+    |  cbnz CRET1w, >9
+    |  b >1
     |9:
     |  ldrh RCw, [PC, #-6]		// Load RD from JMP at [PC-8+OFS_RD]
     |  add PC, PC, RC, lsl #3		// Branch target: PC + RD*8

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -2688,27 +2688,62 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
-  case BC_ISEMPTYARR:
-    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
-    // Empty collections execute the following JMP (value is falsey); all other values skip it.
-    |  // RA = src, followed by JMP with RC = target
+  case BC_ISFALSEY:
+    // Execute the following JMP when RA matches one of the falsey conditions selected by RC.
+    // Nil is always falsey; the mask controls false, zero, empty string, and empty collection checks.
+    |  // RA = src, RC = falsey mask, followed by JMP
     |  ldr CARG1, [BASE, RA, lsl #3]
-    |  add PC, PC, #8			// Advance past following JMP (64-bit BCIns)
+    |  add PC, PC, #8			// Advance past following JMP (64-bit BCIns).
     |  asr ITYPE, CARG1, #47
-    |  cmn ITYPE, #-LJ_TARRAY
+    |  cmn ITYPE, #-LJ_TNIL
+    |  beq >9
+    |  cmn ITYPE, #-LJ_TFALSE
     |  beq >2
+    |  cmn ITYPE, #-LJ_TISNUM
+    |  bls >3
+    |  cmn ITYPE, #-LJ_TSTR
+    |  beq >4
+    |  cmn ITYPE, #-LJ_TARRAY
+    |  beq >5
     |  cmn ITYPE, #-LJ_TTAB
-    |  bne >1				// Not a collection - skip JMP (truthy)
+    |  bne >1
+    |  tst RCw, #ISFALSEY_EMPTY_COLL
+    |  beq >1
     |  and CARG1, CARG1, #LJ_GCVMASK
     |  bl extern lj_tab_empty
-    |  cbz CRET1w, >1			// Non-empty table - skip JMP (truthy)
-    |  b >3				// Empty table - execute JMP (falsey)
+    |  cbnz CRET1w, >9
+    |  b >1
     |2:
+    |  tst RCw, #ISFALSEY_FALSE
+    |  bne >9
+    |  b >1
+    |3:
+    |  tst RCw, #ISFALSEY_ZERO
+    |  beq >1
+    |.if DUALNUM
+    |  cmn ITYPE, #-LJ_TISNUM
+    |  bne >6
+    |  cbz CARG1w, >9
+    |  b >1
+    |6:
+    |.endif
+    |  lsl TMP0, CARG1, #1
+    |  cbz TMP0, >9
+    |  b >1
+    |4:
+    |  tst RCw, #ISFALSEY_EMPTY_STR
+    |  beq >1
+    |  and CARG1, CARG1, #LJ_GCVMASK
+    |  ldr TMP0w, STR:CARG1->len
+    |  cbz TMP0w, >9
+    |  b >1
+    |5:
+    |  tst RCw, #ISFALSEY_EMPTY_COLL
+    |  beq >1
     |  and CARG1, CARG1, #LJ_GCVMASK
     |  ldr TMP0w, ARRAY:CARG1->len
-    |  cbnz TMP0w, >1			// Non-empty array - skip JMP (truthy)
-    |3:
-    |  // Empty collection - execute JMP (falsey)
+    |  cbnz TMP0w, >1
+    |9:
     |  ldrh RCw, [PC, #-6]		// Load RD from JMP at [PC-8+OFS_RD]
     |  add PC, PC, RC, lsl #3		// Branch target: PC + RD*8
     |  sub PC, PC, #0x40000		// Subtract BCBIAS_J*8

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -3909,17 +3909,28 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next2
     break;
 
-  case BC_ISEMPTYARR:
-    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
-    // Empty collections execute the following JMP (value is falsey); all other values skip it.
-    |  // RA = src*8, followed by JMP with RD = target
-    |  lwzx TMP0, BASE, RA		// Load type tag
-    |   ld INS, 0(PC)                      // Load full 64-bit instruction (next JMP)
+  case BC_ISFALSEY:
+    // Execute the following JMP when RA matches one of the falsey conditions selected by RD.
+    // Nil is always falsey; the mask controls false, zero, empty string, and empty collection checks.
+    |  // RA = src*8, RD = falsey mask*8, followed by JMP
+    |  lwzx TMP0, BASE, RA		// Load type tag.
+    |   srwi RC, RD, 3
+    |    ld INS, 0(PC)                     // Load full 64-bit instruction (next JMP).
     |   addi PC, PC, 8			// Advance past following JMP (64-bit)
-    |  checkarray TMP0
+    |  cmpwi TMP0, LJ_TNIL
+    |  beq >9
+    |  cmpwi TMP0, LJ_TFALSE
     |  beq >2
+    |  cmplw TMP0, TISNUM
+    |  ble >3
+    |  cmpwi TMP0, LJ_TSTR
+    |  beq >4
+    |  checkarray TMP0
+    |  beq >5
     |  checktab TMP0
-    |  bne >1				// Not a collection - skip JMP (truthy)
+    |  bne >1
+    |  andi. TMP1, RC, ISFALSEY_EMPTY_COLL
+    |  beq >1
     |  mr SAVE0, INS
 |.if GPR64
     |  ldx CARG1, BASE, RA
@@ -3931,9 +3942,56 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bl extern lj_tab_empty
     |  mr INS, SAVE0
     |  cmpwi CRET1, 0
-    |  beq >1				// Non-empty table - skip JMP (truthy)
-    |  b >3				// Empty table - execute JMP (falsey)
+    |  bne >9
+    |  b >1
     |2:
+    |  andi. TMP1, RC, ISFALSEY_FALSE
+    |  bne >9
+    |  b >1
+    |3:
+    |  andi. TMP1, RC, ISFALSEY_ZERO
+    |  beq >1
+    |.if DUALNUM
+    |  cmplw TMP0, TISNUM
+    |  bne >6
+    |  add TMP1, BASE, RA
+    |  lwz TMP1, 4(TMP1)
+    |  cmpwi TMP1, 0
+    |  beq >9
+    |  b >1
+    |6:
+    |.endif
+|.if GPR64
+    |  ldx TMP1, BASE, RA
+    |  sldi TMP1, TMP1, 1
+    |  cmpdi TMP1, 0
+|.else
+    |  add TMP1, BASE, RA
+    |  lwz TMP2, 0(TMP1)
+    |  lwz TMP1, 4(TMP1)
+    |  rlwinm TMP2, TMP2, 1, 0, 31
+    |  or TMP1, TMP1, TMP2
+    |  cmpwi TMP1, 0
+|.endif
+    |  beq >9
+    |  b >1
+    |4:
+    |  andi. TMP1, RC, ISFALSEY_EMPTY_STR
+    |  beq >1
+|.if GPR64
+    |  ldx TMP1, BASE, RA
+    |  clrldi TMP1, TMP1, 17
+|.else
+    |  add TMP1, BASE, RA
+    |  lwz TMP1, 4(TMP1)
+|.endif
+    |  lwz TMP2, STR:TMP1->len
+    |  cmpwi TMP2, 0
+    |  beq >9
+    |  b >1
+    |5:
+    |  andi. TMP1, RC, ISFALSEY_EMPTY_COLL
+    |  beq >1
 |.if GPR64
     |  ldx TMP1, BASE, RA		// Load full value for pointer
     |  clrldi TMP1, TMP1, 17		// Clear type tag bits
@@ -3943,12 +4001,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |.endif
     |  lwz TMP2, ARRAY:TMP1->len
     |  cmpwi TMP2, 0
-    |  bne >1				// Non-empty array - skip JMP (truthy)
-    |3:
-    |  // Empty collection - execute JMP (falsey)
-    |  decode_RD8 TMP0, INS
-    |  addis TMP0, TMP0, -(BCBIAS_J*8 >> 16)
-    |  add PC, PC, TMP0
+    |  bne >1
+    |9:
+    |  decode_RD8 TMP2, INS
+    |  addis TMP2, TMP2, -(BCBIAS_J*8 >> 16)
+    |  add PC, PC, TMP2
     |1:
     |  ins_next
     break;

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -3925,6 +3925,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ble >3
     |  cmpwi TMP0, LJ_TSTR
     |  beq >4
+    |  cmpwi TMP0, LJ_TUDATA
+    |  beq >7
     |  checkarray TMP0
     |  beq >5
     |  checktab TMP0
@@ -4002,6 +4004,19 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  lwz TMP2, ARRAY:TMP1->len
     |  cmpwi TMP2, 0
     |  bne >1
+    |  b >9
+    |7:
+    |  mr SAVE0, INS
+    |  ld CARG2, -16(PC)
+    |  stp BASE, L->base
+    |  mr CARG1, L
+    |  stw PC, SAVE_PC
+    |  bl extern lj_meta_isfalsey  // (lua_State *L, BCIns ins)
+    |  mr INS, SAVE0
+    |  lp BASE, L->base
+    |  cmpwi CRET1, 0
+    |  bne >9
+    |  b >1
     |9:
     |  decode_RD8 TMP2, INS
     |  addis TMP2, TMP2, -(BCBIAS_J*8 >> 16)

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3303,6 +3303,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  jbe >3
     |  cmp ITYPEd, LJ_TSTR
     |  je >4
+    |  cmp ITYPEd, LJ_TUDATA
+    |  je >7
     |  cmp ITYPEd, LJ_TARRAY
     |  je >5
     |  cmp ITYPEd, LJ_TTAB
@@ -3348,6 +3350,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  cleartp RB
     |  cmp dword ARRAY:RB->len, 0
     |  jne >1
+    |  jmp >9
+    |7:
+    |  mov L:RB, SAVE_L
+    |  mov L:RB->base, BASE
+    |  mov CARG1, L:RB
+    |  mov CARG2, qword [PC-16]
+    |  mov SAVE_PC, PC
+    |  call extern lj_meta_isfalsey  // (lua_State *L, BCIns ins)
+    |  mov BASE, L:RB->base
+    |  test RCd, RCd
+    |  jnz >9
+    |  jmp >1
     |9:
     |  movzx RDd, PC_RD
     |  branchPC RD

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -3286,35 +3286,72 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_next
     break;
 
-  case BC_ISEMPTYARR:
-    // Check if RA is an empty array or table. Used by ?? operator for extended falsey semantics.
-    // Empty collections execute the following JMP (value is falsey); all other values skip it.
-    |  ins_AD  // RA = src, followed by JMP with RD = target
+  case BC_ISFALSEY:
+    // Execute the following JMP when RA matches one of the falsey conditions selected by RD.
+    // Nil is always falsey; the mask controls false, zero, empty string, and empty collection checks.
+    |  ins_AD  // RA = src, RD = falsey mask, followed by JMP
     |  mov RB, [BASE+RA*8]
+    |  mov RCd, RDd
     |  mov ITYPE, RB
-    |  add PC, 8        // Advance past following JMP
+    |  add PC, 8        // Advance past following JMP.
     |  sar ITYPE, 47
-    |  cmp ITYPEd, LJ_TARRAY
+    |  cmp ITYPEd, LJ_TNIL
+    |  je >9
+    |  cmp ITYPEd, LJ_TFALSE
     |  je >2
+    |  cmp ITYPEd, LJ_TISNUM
+    |  jbe >3
+    |  cmp ITYPEd, LJ_TSTR
+    |  je >4
+    |  cmp ITYPEd, LJ_TARRAY
+    |  je >5
     |  cmp ITYPEd, LJ_TTAB
-    |  jne >1        // Not a collection - skip JMP (truthy)
+    |  jne >1
+    |  test RCd, ISFALSEY_EMPTY_COLL
+    |  jz >1
     |  mov CARG1, RB
     |  cleartp CARG1
     |  mov RB, BASE
     |  call extern lj_tab_empty
     |  mov BASE, RB
     |  test RDd, RDd
-    |  jz >1         // Non-empty table - skip JMP (truthy)
-    |  jmp >3        // Empty table - execute JMP (falsey)
+    |  jnz >9
+    |  jmp >1
     |2:
+    |  test RCd, ISFALSEY_FALSE
+    |  jnz >9
+    |  jmp >1
+    |3:
+    |  test RCd, ISFALSEY_ZERO
+    |  jz >1
+    |.if DUALNUM
+    |  cmp ITYPEd, LJ_TISNUM
+    |  jne >6
+    |  test RBd, RBd
+    |  jz >9
+    |  jmp >1
+    |6:
+    |.endif
+    |  shl RB, 1
+    |  jz >9
+    |  jmp >1
+    |4:
+    |  test RCd, ISFALSEY_EMPTY_STR
+    |  jz >1
+    |  cleartp RB
+    |  cmp dword STR:RB->len, 0
+    |  je >9
+    |  jmp >1
+    |5:
+    |  test RCd, ISFALSEY_EMPTY_COLL
+    |  jz >1
     |  cleartp RB
     |  cmp dword ARRAY:RB->len, 0
-    |  jne >1        // Non-empty array - skip JMP (truthy)
-    |3:
-    |  // Empty collection - execute JMP (falsey)
+    |  jne >1
+    |9:
     |  movzx RDd, PC_RD
     |  branchPC RD
-    |1:           // Fallthrough - skip the JMP
+    |1:
     |  ins_next
     break;
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3366,29 +3366,41 @@ void lj_record_ins(jit_State *J)
       J->base[bc_a(ins)] = ra;
       break;
 
-   case BC_ISEMPTYARR: {
-      // Empty collection check for ?? operator.
-      // If value is an array, we must guard on its length being 0 or non-zero.
-      // Table emptiness needs full traversal, so leave that path to the interpreter.
-      if (bc_a(pc[1]) < J->maxslot) J->maxslot = bc_a(pc[1]);  // Shrink used slots.
-      if (tref_isarray(ra)) {
-         // Load array length and compare to 0
-         TRef arrlen = emitir(IRTI(IR_FLOAD), ra, IRFL_ARRAY_LEN);
-         TRef zero = lj_ir_kint(J, 0);
-         // Determine if array is empty at recording time
-         GCarray *arr = arrayV(rav);
-         int is_empty = (arr->len IS 0);
+   case BC_ISFALSEY: {
+      // Type specialisation reduces this instruction to at most one value guard.
+      if (bc_a(pc[1]) < J->maxslot) J->maxslot = bc_a(pc[1]);
+
+      int is_falsey = tref_isnil(ra) or (tref_isfalse(ra) and (rc & ISFALSEY_FALSE));
+
+      if (tref_isnumber(ra) and (rc & ISFALSEY_ZERO)) {
+         IRType number_type = tref_isinteger(ra) ? IRT_INT : IRT_NUM;
+         TRef zero = number_type IS IRT_INT ? lj_ir_kint(J, 0) : lj_ir_knum_zero(J);
+         is_falsey = numberVnum(rav) IS 0.0;
          rec_comp_prep(J);
-         // Emit EQ comparison (arrlen == 0)
-         // If array was empty when recorded, guard that it stays empty
-         // If array was non-empty when recorded, guard that it stays non-empty
-         emitir(IRTG(is_empty ? IR_EQ : IR_NE, IRT_INT), arrlen, zero);
-         rec_comp_fixup(J, J->pc, !is_empty);
+         emitir(IRTG(is_falsey ? IR_EQ : IR_NE, number_type), ra, zero);
+         rec_comp_fixup(J, J->pc, not is_falsey);
       }
-      else if (tref_istab(ra)) {
+      else if (tref_isstr(ra) and (rc & ISFALSEY_EMPTY_STR)) {
+         TRef length = emitir(IRTI(IR_FLOAD), ra, IRFL_STR_LEN);
+         is_falsey = strV(rav)->len IS 0;
+         rec_comp_prep(J);
+         emitir(IRTG(is_falsey ? IR_EQ : IR_NE, IRT_INT), length, lj_ir_kint(J, 0));
+         rec_comp_fixup(J, J->pc, not is_falsey);
+      }
+      else if (tref_isarray(ra) and (rc & ISFALSEY_EMPTY_COLL)) {
+         TRef length = emitir(IRTI(IR_FLOAD), ra, IRFL_ARRAY_LEN);
+         is_falsey = arrayV(rav)->len IS 0;
+         rec_comp_prep(J);
+         emitir(IRTG(is_falsey ? IR_EQ : IR_NE, IRT_INT), length, lj_ir_kint(J, 0));
+         rec_comp_fixup(J, J->pc, not is_falsey);
+      }
+      else if (tref_istab(ra) and (rc & ISFALSEY_EMPTY_COLL)) {
          lj_trace_err_info(J, LJ_TRERR_NYIBC);
       }
-      // For other non-arrays, no additional guard needed - type specialisation handles it
+      else {
+         rec_comp_prep(J);
+         rec_comp_fixup(J, J->pc, not is_falsey);
+      }
       break;
    }
 

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3541,6 +3541,10 @@ void lj_record_ins(jit_State *J)
       // Type specialisation reduces this instruction to at most one value guard.
       if (bc_a(pc[1]) < J->maxslot) J->maxslot = bc_a(pc[1]);
 
+      // Thunk resolution enters a protected call and cannot be recorded.  Abort this trace so the interpreter can
+      // resolve the deferred value before applying the falsey mask.
+      if (tref_isudata(ra) and lj_is_thunk(rav)) lj_trace_err_info(J, LJ_TRERR_NYIBC);
+
       int is_falsey = tref_isnil(ra) or (tref_isfalse(ra) and (rc & ISFALSEY_FALSE));
 
       if (tref_isnumber(ra) and (rc & ISFALSEY_ZERO)) {

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -678,7 +678,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_if_empty_assignment(PreparedAssignment 
    FalseyJumpOptions options;
    options.include_empty_array = true;
    ControlFlowEdge falsey_edge = emit_falsey_jumps(
-      this->func_state, this->lex_state, this->control_flow, lhs_reg, options);
+      this->func_state, this->control_flow, lhs_reg, options);
 
    // Safe-nav targets may already carry a skip edge from target preparation. Those jumps bypass this
    // whole conditional-assignment block. The checks below are only for the terminal lvalue once the
@@ -763,7 +763,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_if_nil_assignment(PreparedAssignment ta
    nil_only.include_zero = false;
    nil_only.include_empty_string = false;
    ControlFlowEdge check_nil = emit_falsey_jumps(
-      this->func_state, this->lex_state, this->control_flow, lhs_reg, nil_only);
+      this->func_state, this->control_flow, lhs_reg, nil_only);
 
    // As with ??= above, any safe-nav skip edge lands after this emitter's store path. The nil check here
    // runs only when target preparation proved that the guarded chain itself was non-nil.

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -77,7 +77,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       FalseyJumpOptions options;
       options.include_empty_array = true;
       ControlFlowEdge falsey_edge = emit_falsey_jumps(
-         this->func_state, this->lex_state, this->control_flow, lhs_reg, options);
+         this->func_state, this->control_flow, lhs_reg, options);
 
       // Skip assignment if not empty
 
@@ -148,7 +148,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       nil_only.include_zero = false;
       nil_only.include_empty_string = false;
       ControlFlowEdge check_nil = emit_falsey_jumps(
-         this->func_state, this->lex_state, this->control_flow, lhs_reg, nil_only);
+         this->func_state, this->control_flow, lhs_reg, nil_only);
 
       // Skip assignment if not nil
 

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -550,36 +550,37 @@ struct FalseyJumpOptions {
 };
 
 static ControlFlowEdge emit_falsey_jumps(
-   FuncState &State, LexState &Lexer, ControlFlowGraph &Graph, BCREG Register, FalseyJumpOptions Options)
+   FuncState &State, ControlFlowGraph &Graph, BCREG Register, FalseyJumpOptions Options,
+   TiriType ResultType = TiriType::Unknown)
 {
    ControlFlowEdge edge = Graph.make_unconditional();
 
-   ExpDesc nilv(ExpKind::Nil);
-   bcemit_INS(&State, BCINS_AD(BC_ISEQP, Register, const_pri(&nilv)));
+   uint16_t mask = 0;
+   if (Options.include_false) mask |= ISFALSEY_FALSE;
+   if (Options.include_zero) mask |= ISFALSEY_ZERO;
+   if (Options.include_empty_string) mask |= ISFALSEY_EMPTY_STR;
+   if (Options.include_empty_array) mask |= ISFALSEY_EMPTY_COLL;
+
+   switch (ResultType) {
+      case TiriType::Num:    mask &= ISFALSEY_ZERO; break;
+      case TiriType::Str:    mask &= ISFALSEY_EMPTY_STR; break;
+      case TiriType::Bool:   mask &= ISFALSEY_FALSE; break;
+      case TiriType::Array:
+      case TiriType::Table:  mask &= ISFALSEY_EMPTY_COLL; break;
+      case TiriType::Object:
+      case TiriType::Func:
+      case TiriType::Struct: mask = 0; break;
+      default: break;
+   }
+
+   if (mask) {
+      bcemit_INS(&State, BCINS_AD(BC_ISFALSEY, Register, mask));
+   }
+   else {
+      ExpDesc nilv(ExpKind::Nil);
+      bcemit_INS(&State, BCINS_AD(BC_ISEQP, Register, const_pri(&nilv)));
+   }
    edge.append(BCPos(bcemit_jmp(&State)));
-
-   if (Options.include_false) {
-      ExpDesc falsev(ExpKind::False);
-      bcemit_INS(&State, BCINS_AD(BC_ISEQP, Register, const_pri(&falsev)));
-      edge.append(BCPos(bcemit_jmp(&State)));
-   }
-
-   if (Options.include_zero) {
-      ExpDesc zerov(0.0);
-      bcemit_INS(&State, BCINS_AD(BC_ISEQN, Register, const_num(&State, &zerov)));
-      edge.append(BCPos(bcemit_jmp(&State)));
-   }
-
-   if (Options.include_empty_string) {
-      ExpDesc emptyv(Lexer.intern_empty_string());
-      bcemit_INS(&State, BCINS_AD(BC_ISEQS, Register, const_str(&State, &emptyv)));
-      edge.append(BCPos(bcemit_jmp(&State)));
-   }
-
-   if (Options.include_empty_array) {
-      bcemit_INS(&State, BCINS_AD(BC_ISEMPTYARR, Register, 0));
-      edge.append(BCPos(bcemit_jmp(&State)));
-   }
 
    return edge;
 }
@@ -894,7 +895,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_conditional_shorthand_stmt(const Condit
    FalseyJumpOptions options;
    options.include_empty_array = true;
    ControlFlowEdge falsey_edge = emit_falsey_jumps(
-      this->func_state, this->lex_state, this->control_flow, cond_reg, options);
+      this->func_state, this->control_flow, cond_reg, options, condition.result_type);
 
    ControlFlowEdge skip_body = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
 
@@ -2439,7 +2440,7 @@ ParserResult<ExpDesc> IrEmitter::emit_if_empty_expr(ExpDesc lhs, const ExprNode&
    FalseyJumpOptions options;
    options.include_empty_array = true;
    ControlFlowEdge falsey_edge = emit_falsey_jumps(
-      this->func_state, this->lex_state, this->control_flow, lhs_reg, options);
+      this->func_state, this->control_flow, lhs_reg, options, lhs.result_type);
 
    // LHS is truthy - it's already in lhs_reg, just skip RHS
    ControlFlowEdge skip_rhs = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
@@ -2731,7 +2732,8 @@ ParserResult<ExpDesc> IrEmitter::emit_ternary_expr(const TernaryExprPayload &Pay
       FalseyJumpOptions options;
       options.include_empty_array = true;
       false_edge.append(emit_falsey_jumps(
-         this->func_state, this->lex_state, this->control_flow, condition_reg, options));
+         this->func_state, this->control_flow, condition_reg, options,
+         condition_result.value_ref().result_type));
    }
    else {
       ExpDesc condition = condition_result.value_ref();

--- a/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/operator_emitter.cpp
@@ -1017,21 +1017,15 @@ void OperatorEmitter::prepare_if_empty(ExprValue left)
          BCReg reg = left_inner.discharge_to_any_reg(local_alloc);
          *left_desc = left_inner.legacy();
 
-         // Extended falsey check sequence
-         // ISEQ* skips the JMP when values ARE equal (falsey), executes JMP when NOT equal (truthy)
-         // Strategy: When value is truthy, NO checks match → all JMPs execute → skip RHS
-         //          When value is falsey, ONE check matches → that JMP skipped → fall through to RHS
+         // A selected falsey value executes the following JMP; a truthy value skips it.
 
          FalseyJumpOptions options;
          options.include_empty_array = true;
          ControlFlowEdge skip_rhs = emit_falsey_jumps(
-            *this->func_state, *this->func_state->ls, *this->cfg, reg, options);
+            *this->func_state, *this->cfg, reg, options, left_desc->result_type);
 
          // RHS will be emitted after this prepare phase
-         // The jumps above will skip RHS when value is truthy (all JMPs execute)
-         // Fall through to RHS when value is falsey (one JMP is skipped)
-
-         // Collect all these jumps - they should skip RHS when value is truthy
+         // Collect the falsey edge so the finish phase can patch it to the RHS.
          pc = skip_rhs.head().raw();
 
          // Mark that we need to preserve LHS value and reserve register for RHS
@@ -1217,7 +1211,7 @@ void OperatorEmitter::emit_presence_check(ExprValue operand)
 
    FalseyJumpOptions options;
    options.include_empty_array = true;
-   ControlFlowEdge falsey_edge = emit_falsey_jumps(*fs, *fs->ls, *this->cfg, reg, options);
+   ControlFlowEdge falsey_edge = emit_falsey_jumps(*fs, *this->cfg, reg, options, e->result_type);
 
    expr_free(fs, e);  // Free the expression register
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -538,6 +538,31 @@ TValue * lj_meta_equal_thunk(lua_State *L, BCIns ins)
 }
 
 //********************************************************************************************************************
+// Resolve a thunk before applying the extended falsey test.  BC_ISFALSEY handles ordinary values inline in the VM
+// and calls this helper only for userdata, since a thunk's container is userdata but its logical value may be falsey.
+
+int lj_meta_isfalsey(lua_State *L, BCIns Ins)
+{
+   VMHelperGuard guard(L);
+
+   cTValue *value = &L->base[bc_a(Ins)];
+   if (not lj_is_thunk(value)) return 0;
+
+   value = lj_thunk_resolve(L, udataV(value));
+   uint32_t mask = bc_d(Ins);
+
+   if (tvisnil(value)) return 1;
+   if (tvisfalse(value)) return (mask & ISFALSEY_FALSE) != 0;
+   if (tvisnumber(value)) {
+      return (mask & ISFALSEY_ZERO) and (tvisint(value) ? intV(value) IS 0 : tviszero(value));
+   }
+   if (tvisstr(value)) return (mask & ISFALSEY_EMPTY_STR) and strV(value)->len IS 0;
+   if (tvisarray(value)) return (mask & ISFALSEY_EMPTY_COLL) and arrayV(value)->len IS 0;
+   if (tvistab(value)) return (mask & ISFALSEY_EMPTY_COLL) and lj_tab_empty(tabV(value));
+   return 0;
+}
+
+//********************************************************************************************************************
 // Helper for ordered comparisons. String compare, __lt/__le metamethods.
 
 TValue * lj_meta_comp(lua_State *L, cTValue *o1, cTValue *o2, int op)

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -30,6 +30,7 @@ extern "C" [[nodiscard]] TValue* lj_meta_len(lua_State* L, cTValue* o);
 extern "C" [[nodiscard]] TValue* lj_meta_equal(lua_State* L, GCobj* o1, GCobj* o2, int ne);
 extern "C" [[nodiscard]] TValue* lj_meta_equal_cd(lua_State* L, BCIns ins);
 extern "C" [[nodiscard]] TValue* lj_meta_equal_thunk(lua_State* L, BCIns ins);
+extern "C" [[nodiscard]] int lj_meta_isfalsey(lua_State* L, BCIns Ins);
 extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue* o2, int op);
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);

--- a/src/tiri/tests/test_if_empty.tiri
+++ b/src/tiri/tests/test_if_empty.tiri
@@ -211,6 +211,36 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Deferred values must be resolved before the consolidated falsey bytecode tests their logical value.
+
+@Test function ThunkFalseyChecks()
+   evaluation_count = 0
+   available = thunk():bool
+      evaluation_count++
+      return true
+   end
+
+   function accept(Value):bool
+      Value ?! return false
+      return true
+   end
+
+   assert(accept(available), "A truthy thunk must not activate a falsey guard")
+   assert(evaluation_count is 1, "The falsey guard must resolve its thunk exactly once")
+
+   missing = thunk():bool
+      return false
+   end
+   result = missing ?? "fallback"
+   assert(result is "fallback", "A thunk returning false must select the fallback")
+
+   zero = thunk():num
+      return 0
+   end
+   assert((zero??) is false, "A thunk returning zero must fail a postfix presence check")
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Test the use of if-empty within a function
 
 @Test function IfEmptyArgumentLeakCapture()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -30,6 +30,39 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+@Test function FalseyBytecodeDisassembly()
+   local script = obj.new('tiri', { statement=[[
+function numberPresent(Value:num):bool return Value?? end
+function stringPresent(Value:str):bool return Value?? end
+function booleanPresent(Value:bool):bool return Value?? end
+function arrayPresent(Value:array):bool return Value?? end
+function tablePresent(Value:table):bool return Value?? end
+function anyPresent(Value:any):bool return Value?? end
+]] })
+   check script.acQuery()
+   check script.acActivate()
+   local _, disassembly = script.mtDebugLog('disasm')
+
+   assert(disassembly:count('ISFALSEY') is 6,
+      'Each runtime presence check should emit one ISFALSEY instruction')
+   assert(disassembly:count('ISFALSEY  A=R0 D=#1\n') is 1,
+      'A boolean operand should narrow the falsey mask to false')
+   assert(disassembly:count('ISFALSEY  A=R0 D=#2\n') is 1,
+      'A numeric operand should narrow the falsey mask to zero')
+   assert(disassembly:count('ISFALSEY  A=R0 D=#4\n') is 1,
+      'A string operand should narrow the falsey mask to empty string')
+   assert(disassembly:count('ISFALSEY  A=R0 D=#8\n') is 2,
+      'Array and table operands should narrow the falsey mask to empty collection')
+   assert(disassembly:count('ISFALSEY  A=R0 D=#15\n') is 1,
+      'An any operand should retain the full falsey mask')
+   assert(disassembly:find('ISEMPTYARR') is nil,
+      'The retired collection-only falsey instruction must not be emitted')
+   assert(disassembly:find('ISEQN') is nil and disassembly:find('ISEQS') is nil,
+      'Presence checks must not emit the former numeric and string comparison cascade')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test function LayoutAwareStructBytecodeDisassembly()
    local script = obj.new('tiri', { statement=[[
 struct PhaseTwoLayout First: int, Second: int end

--- a/src/tiri/tests/test_presence.tiri
+++ b/src/tiri/tests/test_presence.tiri
@@ -191,36 +191,70 @@ end
    assert((v2??) is false, "Failed negative zero test: expected false for -0.0")
 end
 
--- Tests to verify bytecode semantics claimed in PR comment
--- PR comment claims: BC_ISEQP/BC_ISEQN/BC_ISEQS skip next instruction when comparison succeeds
--- These tests verify the actual runtime behavior
+@Test(hotpath=50) function JitFalseySideExits()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   function countNumericPresence(Count:num):num
+      local total = 0
+      for index = 0, Count - 1 do
+         local value:num = index % 2
+         if value?? then total++ end
+      end
+      return total
+   end
+
+   function countMixedPresence(Count:num):num
+      local total = 0
+      local value:any
+      for index = 0, Count - 1 do
+         local selector = index % 3
+         if selector is 0 then value = 0
+         elseif selector is 1 then value = ''
+         else value = 'present' end
+         if value?? then total++ end
+      end
+      return total
+   end
+
+   assert(countNumericPresence(300) is 150,
+      'Numeric falsey guards should side-exit correctly when zero and non-zero values alternate')
+   assert(countMixedPresence(300) is 100,
+      'Type-specialised falsey traces should side-exit correctly when the runtime type changes')
+
+   jit.flush()
+   jit.opt.start()
+end
+
+-- Runtime checks for the falsey bytecode's branch polarity and type dispatch.
 
 -- Test: Verify truthy string returns true (proves jumps don't fire incorrectly)
 @Test function BytecodeSemanticsTruthyString()
    s = "test"
    result = s??
-   assert(result is true, "Truthy string must return true - if false, BC_ISEQS may be skipping when equal (wrong)")
+   assert(result is true, "Truthy string must return true")
 end
 
 -- Test: Verify truthy number returns true
 @Test function BytecodeSemanticsTruthyNumber()
    n = 42
    result = n??
-   assert(result is true, "Truthy number must return true - if false, BC_ISEQN may be skipping when equal (wrong)")
+   assert(result is true, "Truthy number must return true")
 end
 
 -- Test: Verify falsey string returns false (proves jumps fire correctly)
 @Test function BytecodeSemanticsFalseyString()
    s = ""
    result = s??
-   assert(result is false, "Falsey string must return false - if true, BC_ISEQS may not be jumping when equal")
+   assert(result is false, "Falsey string must return false")
 end
 
 -- Test: Verify falsey number returns false
 @Test function BytecodeSemanticsFalseyNumber()
    n = 0
    result = n??
-   assert(result is false, "Falsey number must return false - if true, BC_ISEQN may not be jumping when equal")
+   assert(result is false, "Falsey number must return false")
 end
 
 -- Test: Verify type mismatch doesn't cause false positives (string vs number comparison)
@@ -243,14 +277,14 @@ end
 @Test function BytecodeSemanticsNil()
    v = nil
    result = v??
-   assert(result is false, "Nil must return false - verifies BC_ISEQP behavior")
+   assert(result is false, "Nil must return false")
 end
 
 -- Test: Verify false returns false correctly
 @Test function BytecodeSemanticsFalse()
    v = false
    result = v??
-   assert(result is false, "False must return false - verifies BC_ISEQP behavior")
+   assert(result is false, "False must return false")
 end
 
 -- Test: Comprehensive runtime truthy values


### PR DESCRIPTION
* Added architecture-specific BC_ISFALSEY dispatch and type-specialised JIT recording
* Narrowed emitted falsey masks using known operand types while preserving nil-only checks
* Added bytecode disassembly and JIT side-exit coverage for presence semantics