### PR TITLE
[Tiri] Preserved element types in array and range filters

### DIFF
--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -202,12 +202,6 @@ static void fp_range_push(lua_State *L, lua_Number Value)
    else lua_pushnumber(L, Value);
 }
 
-static void fp_range_set(TValue *Target, lua_Number Value)
-{
-   if (fp_range_is_int32(Value)) setintV(Target, int32_t(Value));
-   else setnumV(Target, Value);
-}
-
 static bool fp_range_integer_array(const tiri_range *Range)
 {
    return fp_range_is_int32(Range->start) and fp_range_is_int32(Range->stop) and fp_range_is_int32(Range->step);
@@ -296,15 +290,19 @@ static int fp_range_filter(lua_State *L)
    auto range = get_range(L, 1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
    size_t count = fp_range_count(L, range, true);
-   GCarray *array = lj_array_new(L, uint32_t(count), AET::ANY);
-   TValue *data = array->get<TValue>();
+   bool integer_array = fp_range_integer_array(range);
+   GCarray *array = lj_array_new(L, uint32_t(count), integer_array ? AET::INT32 : AET::DOUBLE);
    uint32_t result_index = 0;
    for (size_t ordinal = 0; ordinal < count; ordinal++) {
       lua_Number value = fp_range_value(range, ordinal);
       lua_pushvalue(L, 2);
       fp_range_push(L, value);
       lua_call(L, 1, 1);
-      if (lua_toboolean(L, -1)) fp_range_set(&data[result_index++], value);
+      if (lua_toboolean(L, -1)) {
+         if (integer_array) array->get<int32_t>()[result_index] = int32_t(value);
+         else array->get<double>()[result_index] = value;
+         result_index++;
+      }
       lua_pop(L, 1);
    }
    array->len = result_index;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -137,14 +137,27 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    }
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
+      TiriType parameter_type = param.type;
+      struct_record *parameter_struct = param.struct_def;
       ProtoTypeOrigin origin = param.type_is_explicit ? ProtoTypeOrigin::Declared : ProtoTypeOrigin::Unspecified;
       ProtoTypeStrength strength = (param.type_is_explicit and param.type != TiriType::Any and
          param.type != TiriType::Unknown) ? ProtoTypeStrength::Checked : ProtoTypeStrength::Advisory;
-      uint32_t constraint = (param.struct_def and param.type IS TiriType::Struct) ?
-         struct_key(param.struct_def->Name) : 0;
+
+      if (not param.type_is_explicit and param.name.static_value) {
+         const auto &descriptor = this->ctx.descriptors().value(param.name.static_value);
+         if (descriptor.primary != TiriType::Unknown and descriptor.primary != TiriType::Any) {
+            parameter_type = descriptor.primary;
+            parameter_struct = descriptor.struct_def;
+            origin = ProtoTypeOrigin::Inferred;
+            strength = descriptor.proved() ? ProtoTypeStrength::Trusted : ProtoTypeStrength::Advisory;
+         }
+      }
+
+      uint32_t constraint = (parameter_struct and parameter_type IS TiriType::Struct) ?
+         struct_key(parameter_struct->Name) : 0;
       child_state.signature_parameters.push_back(ProtoTypeEntry{
          .constraint = constraint,
-         .type = param.type,
+         .type = parameter_type,
          .flags = proto_type_flags(true, false, origin, strength)
       });
    }
@@ -153,12 +166,18 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    auto base = BCReg(child_state.varmap.size() - param_count.raw());
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
+      auto &param_info = child_state.var_get(base.raw() + i.raw());
       if (param.type != TiriType::Unknown and param.type != TiriType::Any) {
-         auto &param_info = child_state.var_get(base.raw() + i.raw());
          param_info.fixed_type = param.type;
          param_info.struct_def = param.struct_def;
       }
-      auto &param_info = child_state.var_get(base.raw() + i.raw());
+      else if (param.name.static_value) {
+         const auto &descriptor = this->ctx.descriptors().value(param.name.static_value);
+         if (descriptor.primary != TiriType::Unknown and descriptor.primary != TiriType::Any) {
+            param_info.fixed_type = descriptor.primary;
+            param_info.struct_def = descriptor.struct_def;
+         }
+      }
       param_info.binding_id = param.name.binding_id;
       param_info.static_value = param.name.static_value;
    }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2954,6 +2954,30 @@ static bool test_type_guided_emission(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view implicit_filter =
+      "extern array\n"
+      "inner = array<int> { 1 }\n"
+      "items = array<array> { inner }\n"
+      "filtered = items:filter(Value => Value[0] > 0)\n"
+      "return filtered[0][0]\n";
+   snapshot = compile_snapshot(L, implicit_filter, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_AGETB) < 3) {
+      Log.error("array filter lost implicit-local result or predicate element descriptors: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view direct_filter =
+      "extern array\n"
+      "local inner = array<int> { 1 }\n"
+      "local items = array<array> { inner }\n"
+      "local filtered = array.filter(items, Value => true)\n"
+      "return filtered[0][0]\n";
+   snapshot = compile_snapshot(L, direct_filter, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_AGETB) < 2) {
+      Log.error("direct array.filter call lost its source element descriptor: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view mismatch =
       "local function typed(Value:num):num return Value end\n"
       "local callback = typed\n"

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -23,6 +23,7 @@ public:
    void discover(BlockStmt &Module)
    {
       this->scopes_.clear();
+      this->global_names_.clear();
       this->scopes_.push_back(BindingScope{});
       this->discover_block(Module, false);
       this->resolve_all_callables();
@@ -44,6 +45,11 @@ private:
          }
       }
       return 0;
+   }
+
+   [[nodiscard]] bool is_declared_global(GCstr *Name) const
+   {
+      return std::find(this->global_names_.begin(), this->global_names_.end(), Name) != this->global_names_.end();
    }
 
    StaticBindingID declare(Identifier &Name, const ExprNode *Initialiser, uint8_t ResultPosition,
@@ -242,12 +248,43 @@ private:
          case AstNodeKind::AssignmentStmt: {
             auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
             for (auto &value : payload.values) if (value) this->discover_expression(*value);
-            for (auto &target : payload.targets) if (target) this->discover_expression(*target, true);
+            for (size_t i = 0; i < payload.targets.size(); ++i) {
+               auto &target = payload.targets[i];
+               if (not target) continue;
+
+               if (payload.op IS AssignmentOperator::Plain and target->kind IS AstNodeKind::IdentifierExpr) {
+                  auto &reference = std::get<NameRef>(target->data);
+                  GCstr *name = reference.identifier.symbol;
+                  bool protected_global = name and ((name->flags & STRFLAG_PROTECTED_GLOBAL) != 0);
+                  if (name and not reference.identifier.is_blank and not protected_global and
+                      not this->is_declared_global(name) and not this->resolve(name)) {
+                     const ExprNode *initialiser = i < payload.values.size() ? payload.values[i].get() :
+                        (payload.values.empty() ? nullptr : payload.values.back().get());
+                     uint8_t position = i < payload.values.size() ? 0 :
+                        uint8_t(i - payload.values.size() + 1);
+                     reference.binding_id = this->declare(
+                        reference.identifier, initialiser, position);
+                     continue;
+                  }
+               }
+
+               this->discover_expression(*target, true);
+            }
             break;
          }
          case AstNodeKind::GlobalDeclStmt: {
             auto &payload = std::get<GlobalDeclStmtPayload>(Statement.data);
             for (auto &value : payload.values) if (value) this->discover_expression(*value);
+            for (auto &name : payload.names) {
+               if (name.symbol) this->global_names_.push_back(name.symbol);
+            }
+            break;
+         }
+         case AstNodeKind::ExternStmt: {
+            auto &payload = std::get<ExternDeclStmtPayload>(Statement.data);
+            for (auto &name : payload.names) {
+               if (name.symbol) this->global_names_.push_back(name.symbol);
+            }
             break;
          }
          case AstNodeKind::LocalFunctionStmt: {
@@ -261,6 +298,10 @@ private:
             bool local = not payload.name.is_explicit_global and payload.name.segments.size() IS 1 and
                not payload.name.method.has_value();
             if (local) this->declare(payload.name.segments.front(), nullptr, 0, payload.function.get());
+            else if (payload.name.is_explicit_global and not payload.name.segments.empty() and
+                     payload.name.segments.front().symbol) {
+               this->global_names_.push_back(payload.name.segments.front().symbol);
+            }
             if (payload.function) this->discover_function(*payload.function);
             break;
          }
@@ -694,14 +735,75 @@ private:
       return {};
    }
 
-   [[nodiscard]] StaticValueDescriptor array_method_descriptor(const CallExprPayload &Call) const
+   struct ArrayFilterCall {
+      ExprNode *source = nullptr;
+      size_t predicate_index = 0;
+   };
+
+   [[nodiscard]] static bool array_interface_member(
+      const DirectCallTarget &Direct, uint32_t MemberHash)
    {
-      const MethodCallTarget *method = std::get_if<MethodCallTarget>(&Call.target);
-      if (not method or not method->receiver or not method->method.symbol) return {};
-      StaticValueDescriptor receiver = this->descriptor_of(*method->receiver);
+      if (not Direct.callable or Direct.callable->kind != AstNodeKind::MemberExpr) return false;
+      const auto &member = std::get<MemberExprPayload>(Direct.callable->data);
+      if (not member.table or member.table->kind != AstNodeKind::IdentifierExpr or
+          not member.member.symbol or member.member.symbol->hash != MemberHash) return false;
+      const auto &base = std::get<NameRef>(member.table->data);
+      return not base.binding_id and base.identifier.symbol and
+         base.identifier.symbol->hash IS kt::strhash("array");
+   }
+
+   [[nodiscard]] static std::optional<ArrayFilterCall> array_filter_call(CallExprPayload &Call)
+   {
+      if (auto *method = std::get_if<MethodCallTarget>(&Call.target)) {
+         if (method->receiver and method->method.symbol and
+             method->method.symbol->hash IS kt::strhash("filter") and not Call.arguments.empty()) {
+            return ArrayFilterCall{ method->receiver.get(), 0 };
+         }
+      }
+      else if (auto *method = std::get_if<SafeMethodCallTarget>(&Call.target)) {
+         if (method->receiver and method->method.symbol and
+             method->method.symbol->hash IS kt::strhash("filter") and not Call.arguments.empty()) {
+            return ArrayFilterCall{ method->receiver.get(), 0 };
+         }
+      }
+      else if (auto *direct = std::get_if<DirectCallTarget>(&Call.target)) {
+         if (array_interface_member(*direct, kt::strhash("filter")) and Call.arguments.size() > 1) {
+            return ArrayFilterCall{ Call.arguments[0].get(), 1 };
+         }
+      }
+      return std::nullopt;
+   }
+
+   [[nodiscard]] StaticValueDescriptor array_preserving_call_descriptor(const CallExprPayload &Call) const
+   {
+      const ExprNode *source = nullptr;
+      GCstr *operation = nullptr;
+
+      if (const auto *method = std::get_if<MethodCallTarget>(&Call.target)) {
+         source = method->receiver.get();
+         operation = method->method.symbol;
+      }
+      else if (const auto *method = std::get_if<SafeMethodCallTarget>(&Call.target)) {
+         source = method->receiver.get();
+         operation = method->method.symbol;
+      }
+      else if (const auto *direct = std::get_if<DirectCallTarget>(&Call.target);
+               direct and direct->callable and direct->callable->kind IS AstNodeKind::MemberExpr) {
+         const auto &member = std::get<MemberExprPayload>(direct->callable->data);
+         const auto *base = member.table and member.table->kind IS AstNodeKind::IdentifierExpr ?
+            std::get_if<NameRef>(&member.table->data) : nullptr;
+         if (base and not base->binding_id and base->identifier.symbol and
+             base->identifier.symbol->hash IS kt::strhash("array") and not Call.arguments.empty()) {
+            source = Call.arguments.front().get();
+            operation = member.member.symbol;
+         }
+      }
+
+      if (not source or not operation) return {};
+      StaticValueDescriptor receiver = this->descriptor_of(*source);
       if (receiver.primary != TiriType::Array or not receiver.array_element.known) return {};
 
-      switch (method->method.symbol->hash) {
+      switch (operation->hash) {
          case kt::strhash("each"):
          case kt::strhash("map"):
          case kt::strhash("filter"):
@@ -714,11 +816,74 @@ private:
       }
    }
 
+   [[nodiscard]] static StaticValueDescriptor array_element_value(
+      const ArrayElementDescriptor &Element)
+   {
+      StaticValueDescriptor result;
+      result.primary = Element.logical_type;
+      result.object_class_id = Element.object_class_id;
+      result.struct_def = Element.struct_def;
+      result.proof = StaticProof::Trusted;
+      result.nullable = Element.storage IS AET::STR_GC or Element.storage IS AET::OBJECT or
+         Element.storage IS AET::TABLE or Element.storage IS AET::ARRAY;
+      return result;
+   }
+
+   void propagate_function_expression(
+      ExprNode &Expression, std::span<const StaticValueDescriptor> ContextParameters)
+   {
+      auto &function = std::get<FunctionExprPayload>(Expression.data);
+      StaticValueDescriptor value;
+      value.primary = TiriType::Func;
+      value.proof = StaticProof::Closed;
+      this->function_callable(function);
+      this->propagate_function(function, ContextParameters);
+      Expression.static_value = this->add_value(value);
+      Expression.static_results = 0;
+   }
+
+   void propagate_call_children(CallExprPayload &Call)
+   {
+      if (auto *direct = std::get_if<DirectCallTarget>(&Call.target)) {
+         if (direct->callable) this->propagate_expression(*direct->callable);
+      }
+      else if (auto *method = std::get_if<MethodCallTarget>(&Call.target)) {
+         if (method->receiver) this->propagate_expression(*method->receiver);
+      }
+      else if (auto *method = std::get_if<SafeMethodCallTarget>(&Call.target)) {
+         if (method->receiver) this->propagate_expression(*method->receiver);
+      }
+
+      auto filter = array_filter_call(Call);
+      for (size_t i = 0; i < Call.arguments.size(); ++i) {
+         auto &argument = Call.arguments[i];
+         if (not argument) continue;
+
+         bool contextual_filter = filter and i IS filter->predicate_index and filter->source and
+            argument->kind IS AstNodeKind::FunctionExpr;
+         StaticValueDescriptor source = contextual_filter ? this->descriptor_of(*filter->source) :
+            StaticValueDescriptor{};
+         if (contextual_filter and source.primary IS TiriType::Array and source.array_element.known) {
+            std::array<StaticValueDescriptor, 2> parameters;
+            parameters[0] = array_element_value(source.array_element);
+            parameters[1].primary = TiriType::Num;
+            parameters[1].proof = StaticProof::Trusted;
+            this->propagate_function_expression(*argument, parameters);
+         }
+         else this->propagate_expression(*argument);
+      }
+   }
+
    void propagate_expression(ExprNode &Expression)
    {
-      this->walk_expression_children(Expression, [this](ExprNode &Child) {
-         this->propagate_expression(Child);
-      });
+      if (Expression.kind IS AstNodeKind::CallExpr or Expression.kind IS AstNodeKind::SafeCallExpr) {
+         this->propagate_call_children(std::get<CallExprPayload>(Expression.data));
+      }
+      else {
+         this->walk_expression_children(Expression, [this](ExprNode &Child) {
+            this->propagate_expression(Child);
+         });
+      }
 
       StaticValueDescriptor value;
       StaticResultSetHandle results = 0;
@@ -749,7 +914,7 @@ private:
          case AstNodeKind::SafeCallExpr: {
             auto &call = std::get<CallExprPayload>(Expression.data);
             value = this->call_descriptor(call, Expression.kind IS AstNodeKind::SafeCallExpr);
-            StaticValueDescriptor transferred = this->array_method_descriptor(call);
+            StaticValueDescriptor transferred = this->array_preserving_call_descriptor(call);
             if (transferred.primary != TiriType::Unknown) {
                transferred.nullable = value.nullable;
                value = transferred;
@@ -908,19 +1073,28 @@ private:
 
       auto &binding = this->catalogue_.binding(reference.binding_id);
       StaticValueDescriptor previous = this->catalogue_.value(binding.value);
-      StaticValueDescriptor joined = join_static_descriptors(previous, Assigned);
+      StaticValueDescriptor joined = previous.primary IS TiriType::Unknown and not previous.array_element.known ?
+         Assigned : join_static_descriptors(previous, Assigned);
       binding.value = this->add_value(joined);
       binding.callable = 0;
       reference.identifier.static_value = binding.value;
       Target.static_value = binding.value;
    }
 
-   void propagate_function(FunctionExprPayload &Function)
+   void propagate_function(
+      FunctionExprPayload &Function, std::span<const StaticValueDescriptor> ContextParameters = {})
    {
-      for (auto &parameter : Function.parameters) {
+      for (size_t i = 0; i < Function.parameters.size(); ++i) {
+         auto &parameter = Function.parameters[i];
          if (not parameter.name.binding_id) continue;
-         auto value = this->declared_descriptor(parameter.type, parameter.struct_def,
-            parameter.type IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked);
+         StaticValueDescriptor value;
+         if (not parameter.type_is_explicit and i < ContextParameters.size()) {
+            value = ContextParameters[i];
+         }
+         else {
+            value = this->declared_descriptor(parameter.type, parameter.struct_def,
+               parameter.type IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked);
+         }
          auto &binding = this->catalogue_.binding(parameter.name.binding_id);
          binding.value = this->add_value(value);
          parameter.name.static_value = binding.value;
@@ -1316,6 +1490,7 @@ private:
    StaticDescriptorCatalogue &catalogue_;
    std::vector<BindingScope> scopes_;
    std::vector<std::pair<GCstr *, StaticValueHandle>> global_values_;
+   std::vector<GCstr *> global_names_;
    uint16_t function_depth_ = 0;
 };
 

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1146,10 +1146,17 @@ end
 
 @Test function RangeFilterBasic()
    result = {1 to 10}:filter(i => i % 2 is 0)
+   assert(result:type() is "int", "filtering an integral range should return array<int>")
    assert(#result is 4, "filter even numbers from {1 to 10} should have 4 elements, got " .. #result)
    assert(result[0] is 2, "first even should be 2")
    assert(result[1] is 4, "second even should be 4")
    assert(result[3] is 8, "fourth even should be 8")
+end
+
+@Test function RangeFilterPreservesIntegerType()
+   result = {0 to 10}:filter(v => v % 2)
+   assert(tostring(result) is "array<int, 10>",
+      "filtering an integral range should preserve its storage type, got " .. tostring(result))
 end
 
 @Test function RangeFilterNoneMatch()
@@ -1549,7 +1556,7 @@ end
    filtered = {0 to 1 by 0.2}:filter(v => v >= 0.4)
    mapped = {0 to 1 by 0.25}:map(v => v * 2)
    taken = {0 to 1 by 0.2}:take(3)
-   assert(#filtered is 3 and approximately(filtered[0], 0.4))
+   assert(filtered:type() is "double" and #filtered is 3 and approximately(filtered[0], 0.4))
    assert(#mapped is 4 and approximately(mapped[3], 1.5))
    assert(taken:type() is "double" and #taken is 3 and approximately(taken[2], 0.4))
    assert(approximately({0 to 1 by 0.25}:reduce(0, (acc, v) => acc + v), 1.5))


### PR DESCRIPTION
* Propagated array element descriptors through filter results and inferred predicate parameters
* Materialised filtered ranges with integer or double storage and added regression coverage