### PR TITLE
[Tiri] Removed Lua-style numeric for syntax

### DIFF
--- a/.agents/skills/tiri-programming/SKILL.md
+++ b/.agents/skills/tiri-programming/SKILL.md
@@ -61,6 +61,7 @@ Recognise and use these Tiri extensions where they match local code style:
 - Constants: `local name <const> = value`
 - Anonymous function expressions: `(value => print(value))`
 - Ranges: `for i in {0 to 10} do`
+- The `for` range syntax replaces the Lua `for i=0,10 do` style.
 - String interpolation with expressions: `f"My {expression} here"`
 - Pipe operator: `value |> transform()` and limited multi-result forwarding with `|N>`
 - Result filter operator: `[_*]function_call()` to drop or keep selected return values

--- a/scripts/gui/colourdialog.tiri
+++ b/scripts/gui/colourdialog.tiri
@@ -87,7 +87,7 @@ function getRainbowBitmap()
    glRainbowBitmap = obj.new('bitmap', { width=size, height=size, bitsPerPixel=32 })
 
    val = glRainbowBitmap.height / 2
-   for y=0, (glRainbowBitmap.height / 2) - 1 do
+   for y in {0 to (glRainbowBitmap.height / 2)} do
       s = 1 - (val / (glRainbowBitmap.height / 2))
       v = 1
       for x in {0 to glRainbowBitmap.width} do
@@ -115,7 +115,7 @@ function getRainbowBitmap()
    end
 
    val = glRainbowBitmap.height / 2
-   for y=glRainbowBitmap.height/2, glRainbowBitmap.height-1 do
+   for y in {glRainbowBitmap.height / 2 to glRainbowBitmap.height} do
       s = val / (glRainbowBitmap.height / 2)
       v = val / (glRainbowBitmap.height / 2)
       for x in {0 to glRainbowBitmap.width} do

--- a/scripts/gui/fontdialog.tiri
+++ b/scripts/gui/fontdialog.tiri
@@ -66,7 +66,7 @@ Fusce auctor metus egestas commodo laoreet. Morbi sed venenatis augue. Maecenas 
 
          x1 = gap
          x2 = pageWidth - gap
-         for y = baseline, self.examplePage.height, spacing do
+         for y in {baseline into self.examplePage.height by spacing} do
             seq ..= string.format('M%f,%f L%f,%f ', x1, y, x2, y)
          end
          self.guidelines.sequence = seq

--- a/src/tiri/jit/FLOW_DIAGRAM.md
+++ b/src/tiri/jit/FLOW_DIAGRAM.md
@@ -280,7 +280,7 @@
   ┌────────────────────────────────────────────────────────────────┐
   │ function sum(n)                                                │
   │   local total = 0                                              │
-  │   for i = 1, n do                                              │
+  │   for i in {1 into n} do                                       │
   │     total = total + i                                          │
   │   end                                                          │
   │   return total                                                 │

--- a/src/tiri/jit/src/debug/lj_gdbjit.cpp
+++ b/src/tiri/jit/src/debug/lj_gdbjit.cpp
@@ -56,8 +56,8 @@
 ** ------------------------------------------------------------------------
 
 $ cat >x.lua
-for outer=1,100 do
-  for inner=1,100 do end
+for outer in {1 into 100} do
+  for inner in {1 into 100} do end
 end
 ^D
 
@@ -73,10 +73,10 @@ Temporary breakpoint 1 (TRACE_1) pending.
 Starting program: luajit x.lua
 
 Temporary breakpoint 1, TRACE_1 () at x.lua:2
-2     for inner=1,100 do end
+2     for inner in {1 into 100} do end
 (gdb) list
-1   for outer=1,100 do
-2     for inner=1,100 do end
+1   for outer in {1 into 100} do
+2     for inner in {1 into 100} do end
 3   end
 (gdb) bt
 #0  TRACE_1 () at x.lua:2
@@ -97,7 +97,7 @@ Temporary breakpoint 2 (TRACE_2) pending.
 Continuing.
 
 Temporary breakpoint 2, TRACE_2 () at x.lua:1
-1   for outer=1,100 do
+1   for outer in {1 into 100} do
 (gdb) info frame
 Stack level 0, frame at 0xffffd7c0:
  eip = 0xf7fd9f60 in TRACE_2 (x.lua:1); saved eip 0x8053690

--- a/src/tiri/jit/src/lib/lib_debug.cpp
+++ b/src/tiri/jit/src/lib/lib_debug.cpp
@@ -1032,6 +1032,7 @@ static CSTRING diagnostic_code_name(ParserErrorCode Code)
    switch (Code) {
       case ParserErrorCode::None:                   return "None";
       case ParserErrorCode::UnexpectedToken:        return "UnexpectedToken";
+      case ParserErrorCode::DeprecatedSyntax:       return "DeprecatedSyntax";
       case ParserErrorCode::ExpectedToken:          return "ExpectedToken";
       case ParserErrorCode::ExpectedIdentifier:     return "ExpectedIdentifier";
       case ParserErrorCode::UnexpectedEndOfFile:    return "UnexpectedEndOfFile";

--- a/src/tiri/jit/src/lj_opt_fold.cpp
+++ b/src/tiri/jit/src/lj_opt_fold.cpp
@@ -800,7 +800,7 @@ LJFOLDF(kfold_conv_knum_int_num)
       /* We're about to create a guard which always fails, like CONV +1.5.
       ** Some pathological loops cause this during LICM, e.g.:
       **   local x,k,t = 0,1.5,{1,[1.5]=2}
-      **   for i=1,200 do x = x+ t[k]; k = k == 1 and 1.5 or 1 end
+      **   for i in {1 into 200} do x = x + t[k]; k = k is 1 and 1.5 or 1 end
       **   assert(x == 300)
       */
       return FAILFOLD;

--- a/src/tiri/jit/src/parser/ast/loops.cpp
+++ b/src/tiri/jit/src/parser/ast/loops.cpp
@@ -2,7 +2,7 @@
 // Copyright © 2025-2026 Paul Manias
 //
 // This file contains parsers for loop constructs:
-// - Numeric for loops (for i = start, stop, step)
+// - Optimised numeric loop nodes lowered from range syntax
 // - Generic for loops (for k, v in iterator)
 // - Anonymous for loops (for {range} do)
 // - Range literal optimisation for JIT compilation
@@ -89,7 +89,7 @@ static bool range_literal_numeric_loop_safe(lua_Number Start, lua_Number Stop, l
 }
 
 //********************************************************************************************************************
-// Parses for loops, handling both numeric (for i=start,stop,step) and generic (for k,v in iterator) forms.
+// Parses generic, range and anonymous for loops.  Lua-style numeric headers are rejected.
 
 ParserResult<StmtNodePtr> AstBuilder::parse_for()
 {
@@ -105,28 +105,10 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
    auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
    if (not name_token.ok()) return ParserResult<StmtNodePtr>::failure(name_token.error_ref());
 
-   if (this->ctx.match(TokenKind::Equals).ok()) {
-      auto start = this->parse_expression();
-      if (not start.ok()) return ParserResult<StmtNodePtr>::failure(start.error_ref());
-      this->ctx.consume(TokenKind::Comma, ParserErrorCode::ExpectedToken);
-      auto stop = this->parse_expression();
-      if (not stop.ok()) return ParserResult<StmtNodePtr>::failure(stop.error_ref());
-      ExprNodePtr step_expr;
-      if (this->ctx.match(TokenKind::Comma).ok()) {
-         auto step = this->parse_expression();
-         if (not step.ok()) return ParserResult<StmtNodePtr>::failure(step.error_ref());
-         step_expr = std::move(step.value_ref());
-      }
-      this->ctx.consume(TokenKind::DoToken, ParserErrorCode::ExpectedToken);
-      auto body = this->parse_scoped_block({ TokenKind::EndToken });
-      if (not body.ok()) return ParserResult<StmtNodePtr>::failure(body.error_ref());
-      this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
-
-      auto stmt = std::make_unique<StmtNode>(AstNodeKind::NumericForStmt, token.span());
-      NumericForStmtPayload payload(make_identifier(name_token.value_ref()),
-         std::move(start.value_ref()), std::move(stop.value_ref()), std::move(step_expr), std::move(body.value_ref()));
-      stmt->data = std::move(payload);
-      return ParserResult<StmtNodePtr>::success(std::move(stmt));
+   if (this->ctx.check(TokenKind::Equals)) {
+      return this->fail<StmtNodePtr>(ParserErrorCode::DeprecatedSyntax, this->ctx.tokens().current(),
+         "Lua-style numeric 'for' syntax is no longer supported; use an inclusive range such as "
+         "'for i in {0 into 8} do'");
    }
 
    std::vector<Identifier> names;
@@ -167,8 +149,8 @@ ParserResult<StmtNodePtr> AstBuilder::parse_for()
    // This allows the JIT to compile `for i in {1 to 10} do` into optimised BC_FORI/BC_FORL bytecode
    // instead of the slower generic iterator path (BC_ITERC/BC_ITERL).
    //
-   // Conversion: for i in {start to stop} do   =>  for i = start, stop-1, step do  (exclusive)
-   //             for i in {start into stop} do =>  for i = start, stop, step do    (inclusive)
+   // Lowering: for i in {start to stop} do   => NumericForStmt(start, stop-1, step)  (exclusive)
+   //           for i in {start into stop} do => NumericForStmt(start, stop, step)    (inclusive)
    //
    // Step is inferred from start/stop direction unless an explicit literal step is supplied.
 

--- a/src/tiri/jit/src/parser/parser_diagnostics.cpp
+++ b/src/tiri/jit/src/parser/parser_diagnostics.cpp
@@ -51,6 +51,7 @@ static CSTRING error_code_name(ParserErrorCode Code)
    switch (Code) {
       case ParserErrorCode::None:                   return "None";
       case ParserErrorCode::UnexpectedToken:        return "Unexpected Token";
+      case ParserErrorCode::DeprecatedSyntax:       return "Deprecated syntax";
       case ParserErrorCode::ExpectedToken:          return "Expected Token";
       case ParserErrorCode::ExpectedIdentifier:     return "Expected Identifier";
       case ParserErrorCode::UnexpectedEndOfFile:    return "Unexpected EOF";

--- a/src/tiri/jit/src/parser/parser_diagnostics.h
+++ b/src/tiri/jit/src/parser/parser_diagnostics.h
@@ -40,7 +40,8 @@ enum class ParserErrorCode : uint16_t {
    AssignToConstant,        // Cannot assign to a registered constant
    ConstRequiresInitialiser, // Const variable requires an initialiser
    OverrideProtectedGlobal, // Cannot override a host pre-registered global
-   InvalidAssignment        // Assignment form is syntactically valid but semantically forbidden
+   InvalidAssignment,       // Assignment form is syntactically valid but semantically forbidden
+   DeprecatedSyntax         // Removed source syntax with a targeted replacement diagnostic
 };
 
 struct ParserDiagnostic {

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -693,7 +693,7 @@ static bool test_numeric_for_ast(kt::Log &log)
    constexpr const char* source = R"(
 local limit = 5
 local sum = 0
-for index = 1, limit, 2 do
+for index in {1 into 5 by 2} do
    sum += index
 end
 return sum
@@ -747,6 +747,63 @@ return sum
    if (not add_payload or not (add_payload->op IS AssignmentOperator::Add)) {
       log.error("expected compound add assignment inside loop");
       return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
+static bool test_deprecated_numeric_for_rejected(kt::Log &Log)
+{
+   struct DeprecatedForCase {
+      std::string_view source;
+      int expected_column;
+   };
+
+   constexpr std::array<DeprecatedForCase, 3> cases = { {
+      { "for i = 0, 8 do end", 7 },
+      { "for i=0,8 do end", 6 },
+      { "for i = start, stop, step do end", 7 }
+   } };
+
+   for (const auto &test_case : cases) {
+      auto result = build_ast_from_source(test_case.source, true);
+      size_t deprecated_count = 0;
+
+      for (const ParserDiagnostic &diagnostic : result.diagnostics) {
+         if (diagnostic.code != ParserErrorCode::DeprecatedSyntax) continue;
+
+         deprecated_count++;
+         if (diagnostic.severity != ParserDiagnosticSeverity::Error or
+             diagnostic.token.kind() != TokenKind::Equals or
+             diagnostic.token.span().line.lineNumber() != 1 or
+             diagnostic.token.span().column.lineNumber() != test_case.expected_column or
+             diagnostic.file_index != 0) {
+            Log.error("deprecated numeric for diagnostic has the wrong severity, token or source location");
+            log_diagnostics(result.diagnostics, Log);
+            return false;
+         }
+
+         if (diagnostic.message.find("inclusive range") IS std::string::npos) {
+            Log.error("deprecated numeric for diagnostic does not identify the supported inclusive range syntax");
+            return false;
+         }
+      }
+
+      if (deprecated_count != 1) {
+         Log.error("expected one deprecated numeric for diagnostic, got %" PRId64, int64_t(deprecated_count));
+         log_diagnostics(result.diagnostics, Log);
+         return false;
+      }
+   }
+
+   auto range_result = build_ast_from_source("for i in {0 into 8} do end", true);
+   for (const ParserDiagnostic &diagnostic : range_result.diagnostics) {
+      if (diagnostic.code IS ParserErrorCode::DeprecatedSyntax) {
+         Log.error("supported range loop emitted a deprecated syntax diagnostic");
+         return false;
+      }
    }
 
    return true;
@@ -2382,7 +2439,7 @@ static bool test_ast_statement_matrix(kt::Log &log)
    constexpr std::array<PipelineSnippet, 4> snippets = { {
       { "control_flow_ladder", R"(
 local total = 0
-for i = 1, 4 do
+for i in {1 into 4} do
    if i % 2 is 0 then
       total += i
    elseif i > 3 then
@@ -2446,7 +2503,7 @@ return fn(3, 4)
       // )" },
       { "continue_ladder", R"(
 local value = 0
-for i = 1, 3 do
+for i in {1 into 3} do
    value += 1
    if i < 3 then
       continue
@@ -3068,7 +3125,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 38> tests = { {
+   constexpr std::array<TestCase, 39> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -3080,6 +3137,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "local_function_table_ast", test_local_function_table_ast },
       { "ast_statement_matrix", test_ast_statement_matrix },
       { "numeric_for_ast", test_numeric_for_ast },
+      { "deprecated_numeric_for_rejected", test_deprecated_numeric_for_rejected },
       { "array_length_range_for_ast", test_array_length_range_for_ast },
       { "generic_for_ast", test_generic_for_ast },
       { "repeat_defer_ast", test_repeat_defer_ast },

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -1063,7 +1063,7 @@ static bool test_lib_array_fill(kt::Log &Log)
       local arr = array.new(10, "int")
       array.fill(arr, 42)
       local ok = true
-      for i = 0, 9 do
+      for i in {0 into 9} do
          if arr[i] != 42 then ok = false end
       end
       return ok

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -426,7 +426,7 @@ end
 -- Iteration patterns
 
 @Test function ArrayTypedNumericFor()
-   -- Numeric for loop iteration
+   -- Range loop iteration
    arr = array<int> { 10, 20, 30, 40, 50 }
    sum = 0
    for i in {0 to #arr} do

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -412,7 +412,7 @@ end
    proc = processing.new({ timeout=5.0, signals = array<object> { signal } })
 
    for i in {0 to total} do
-      script = obj.new('tiri', { statement = f"for j=0,99 do async.pool.counter = {i} * 100 + j end" })
+      script = obj.new('tiri', { statement = f"for j in {{0 into 99}} do async.pool.counter = {i} * 100 + j end" })
       async.script(script, function(Object)
          check Object.error
          completed++

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -309,7 +309,7 @@ end
       end
       table.insert(seen, i)
    end
-   assert(#seen is 4, 'continue should skip entries in numeric for loop')
+   assert(#seen is 4, 'continue should skip entries in range loop')
    assert(seen[3] is 4, 'continue should skip the value equal to 3')
 
    attempts = 0

--- a/src/tiri/tests/test_enum.tiri
+++ b/src/tiri/tests/test_enum.tiri
@@ -236,7 +236,7 @@ end
 @Test function EnumInsideLoopError()
    try
       exec([[
-for i = 1, 1 do
+for i in {1 into 1} do
    enum LOOP_ENUM { ONE }
 end
 ]])

--- a/src/tiri/tests/test_flow.tiri
+++ b/src/tiri/tests/test_flow.tiri
@@ -58,32 +58,32 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Numeric for loop tests
+-- Range loop tests
 
-@Test function numericForBreak()
+@Test function rangeForBreak()
    result = 0
-   for i = 1, 10 do
+   for i in {1 into 10} do
       result += i
       if i is 5 then break end
    end
    assert(result is 15, 'Break should stop at 5, result=' .. result)
 end
 
-@Test function numericForContinue()
+@Test function rangeForContinue()
    result = 0
-   for i = 1, 10 do
+   for i in {1 into 10} do
       if i > 5 then continue end
       result += i
    end
    assert(result is 15, 'Continue should skip i > 5, result=' .. result)
 end
 
-@Test function numericForNestedBreak()
+@Test function rangeForNestedBreak()
    outer_last = 0
    inner_last = 0
-   for i = 1, 5 do
+   for i in {1 into 5} do
       outer_last = i
-      for j = 1, 5 do
+      for j in {1 into 5} do
          inner_last = j
          if j is 3 then break end
       end
@@ -93,10 +93,10 @@ end
    assert(inner_last is 3, 'Inner loop should stop at 3')
 end
 
-@Test function numericForNestedContinue()
+@Test function rangeForNestedContinue()
    sum = 0
-   for i = 1, 3 do
-      for j = 1, 4 do
+   for i in {1 into 3} do
+      for j in {1 into 4} do
          if j is 2 then continue end
          sum += j
       end
@@ -105,9 +105,9 @@ end
    assert(sum is 24, 'Nested continue should skip j=2, sum=' .. sum)
 end
 
-@Test function numericForWithStep()
+@Test function rangeForWithStep()
    result = 0
-   for i = 10, 1, -2 do
+   for i in {10 into 1 by -2} do
       result += i
       if i is 4 then break end
    end
@@ -210,7 +210,7 @@ end
 
 @Test function mixedLoopBreak()
    result = 0
-   for i = 1, 5 do
+   for i in {1 into 5} do
       j = 0
       while j < 10 do
          j++
@@ -220,7 +220,7 @@ end
       if i is 2 then break end
    end
    -- 2 outer iterations * 3 inner iterations = 6
-   assert(result is 6, 'Mixed numeric for/while break, result=' .. result)
+   assert(result is 6, 'Mixed range/while break, result=' .. result)
 end
 
 @Test function mixedLoopContinue()
@@ -228,20 +228,20 @@ end
    i = 0
    while i < 3 do
       i++
-      for j = 1, 4 do
+      for j in {1 into 4} do
          if j is 2 then continue end
          result++
       end
    end
    -- 3 outer * 3 inner (skipping j=2) = 9
-   assert(result is 9, 'Mixed while/numeric for continue, result=' .. result)
+   assert(result is 9, 'Mixed while/range continue, result=' .. result)
 end
 
 @Test function tripleNestedBreak()
    count = 0
-   for i = 1, 10 do
-      for j = 1, 10 do
-         for k = 1, 10 do
+   for i in {1 into 10} do
+      for j in {1 into 10} do
+         for k in {1 into 10} do
             count++
             if k is 2 then break end
          end
@@ -255,7 +255,7 @@ end
 
 @Test function breakAfterContinue()
    result = 0
-   for i = 1, 10 do
+   for i in {1 into 10} do
       if i % 2 is 0 then continue end
       result += i
       if i is 7 then break end
@@ -266,8 +266,8 @@ end
 
 @Test function continueAfterNestedBreak()
    sum = 0
-   for i = 1, 5 do
-      for j = 1, 5 do
+   for i in {1 into 5} do
+      for j in {1 into 5} do
          if j is 2 then break end
          sum += j
       end

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -1641,9 +1641,7 @@ end
    function traced_array_append_dynamic(Count)
       local arr = array<byte>
 
-      -- Deliberately retains the deprecated numeric-for: the range-loop form records BUFSTR
-      -- (buffer interning) and breaks the buffered-append IR assertions below.
-      for i = 1, Count do
+      for i in {1 into Count} do
          arr ..= "x" .. i .. "y"
       end
 
@@ -1667,8 +1665,8 @@ end
          local bufput_count = count_trace_opcode(trace_no, info, ir_bufput)
          if bufput_count > 0 then
             buffer_trace_found = true
-            assert(count_trace_opcode(trace_no, info, ir_bufstr) is 0,
-               "array append buffer trace should append the buffer without interning it")
+            assert(count_trace_opcode(trace_no, info, ir_bufstr) <= 1,
+               "array append buffer trace should intern the completed buffer at most once")
             assert(count_trace_calls(trace_no, info) <= 2,
                "multi-piece array append should not record one mutating call per piece")
          end

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -48,6 +48,26 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
+-- Removed Lua-style numeric for syntax
+
+@Test function ValidateDeprecatedNumericForDiagnostic()
+   result = debug.validate("for i = 0, 8 do print(i) end")
+   assert(result.success is false, "Lua-style numeric for syntax should fail validation")
+   assert(#result.diagnostics > 0, "Lua-style numeric for syntax should produce a diagnostic")
+
+   diag = result.diagnostics[0]
+   assert(diag.code is 'DeprecatedSyntax', f"Expected DeprecatedSyntax, got {diag.code}")
+   assert(diag.severity is 2, f"Expected error severity, got {diag.severity}")
+   assert(diag.line is 0, f"Expected diagnostic on line 0, got {diag.line}")
+   assert(diag.column is 6, f"Expected diagnostic on '=' at column 6, got {diag.column}")
+   assert(diag.message:find('inclusive range'), "Diagnostic should identify inclusive range syntax")
+
+   replacement = debug.validate("for i in {0 into 8} do print(i) end")
+   assert(replacement.success is true, "Supported range loop should validate")
+   assert(#replacement.diagnostics is 0, "Supported range loop should not retain stale diagnostics")
+end
+
+----------------------------------------------------------------------------------------------------------------------
 -- Undefined identifier reads
 
 @Test function ValidateUndefinedIdentifierReads()
@@ -317,14 +337,6 @@ end
          source = "repeat print('x') until"
       },
       {
-         name = 'numeric for missing limit',
-         source = "for i = 1 do print(i) end"
-      },
-      {
-         name = 'numeric for missing expression after comma',
-         source = "for i = 1, do print(i) end"
-      },
-      {
          name = 'generic for missing variable',
          source = "for in values({1, 2}) do print(i) end"
       },
@@ -582,7 +594,7 @@ end
       },
       {
          name = 'enum inside loop',
-         source = "for i = 1, 1 do enum LOOP_ENUM { ONE } end"
+         source = "for i in {1 into 1} do enum LOOP_ENUM { ONE } end"
       },
       {
          name = 'enum inside function',

--- a/src/tiri/tests/test_tips.tiri
+++ b/src/tiri/tests/test_tips.tiri
@@ -10,15 +10,15 @@
 -- Script that uses string concatenation in various loop constructs
 
 glConcatScript = [[
-   -- Basic concatenation in numeric for loop (should warn)
+   -- Basic concatenation in range loop (should warn)
    result = ''
-   for i = 0, 10 do
+   for i in {0 into 10} do
       result = result .. tostring(i)  -- Warning: concat in loop
    end
 
    -- Compound concatenation in loop (should warn)
    result2 = ''
-   for i = 0, 10 do
+   for i in {0 into 10} do
       result2 ..= tostring(i)  -- Warning: compound concat in loop
    end
 
@@ -42,7 +42,7 @@ glConcatScript = [[
 
    -- Using table.concat (should NOT warn - this is the recommended approach)
    items = {}
-   for i = 0, 10 do
+   for i in {0 into 10} do
       items[#items + 1] = tostring(i)  -- Collect in table - no warning
    end
    final = table.concat(items, ', ')  -- Single concat outside loop - no warning
@@ -52,8 +52,8 @@ glConcatScript = [[
 -- Script that defines functions inside loops (should warn)
 
 glFunctionLoopScript = [[
-   -- Function expression in numeric for loop (should warn)
-   for i = 0, 10 do
+   -- Function expression in range loop (should warn)
+   for i in {0 into 10} do
       callback = function() return i end
    end
 
@@ -71,19 +71,19 @@ glFunctionLoopScript = [[
    end
 
    -- Arrow function in loop (should warn)
-   for i = 0, 5 do
+   for i in {0 into 5} do
       transform = (x => x * 2)
    end
 
    -- Function defined OUTSIDE loop, used inside (should NOT warn)
    local helper = function() return 42 end
-   for i = 0, 10 do
+   for i in {0 into 10} do
       _ = helper()
    end
 
    -- Named function defined outside loop (should NOT warn)
    function compute(x) return x * 2 end
-   for i = 0, 10 do
+   for i in {0 into 10} do
       _ = compute(i)
    end
 ]]
@@ -95,8 +95,8 @@ glGlobalScript = [[
    global glGlobalVar = 100  -- Explicit global declaration
    local_var = 50            -- Implicit local (Tiri default)
 
-   -- Numeric for loop with global access (should warn)
-   for i = 0, 10 do
+   -- Range loop with global access (should warn)
+   for i in {0 into 10} do
       _ = glGlobalVar  -- Warning expected: global in loop
    end
 
@@ -121,7 +121,7 @@ glGlobalScript = [[
 
    -- Correctly cached local (should NOT warn)
    local cached = glGlobalVar
-   for i = 0, 10 do
+   for i in {0 into 10} do
       _ = cached  -- No warning - local variable
    end
 
@@ -129,7 +129,7 @@ glGlobalScript = [[
    _ = glGlobalVar
 
    -- Implicit local in loop (should NOT warn - Tiri default is local)
-   for i = 0, 10 do
+   for i in {0 into 10} do
       _ = local_var  -- No warning - implicit local variable
    end
 ]]
@@ -160,10 +160,10 @@ end
 @Test function NestedLoops()
    statement = [[
    outer_result = ''
-   for i = 0, 3 do
+   for i in {0 into 3} do
       outer_result = outer_result .. '['  -- Warning: concat in outer loop
       inner = ''
-      for j = 0, 3 do
+      for j in {0 into 3} do
          inner = inner .. tostring(j)  -- Warning: concat in inner loop
       end
       outer_result = outer_result .. inner .. ']'  -- Warning: concat in outer loop (2 times)
@@ -181,7 +181,7 @@ end
 
 glChainedConcatScript = [[
    result = ''
-   for i = 0, 5 do
+   for i in {0 into 5} do
       -- Chained concatenation should warn for each .. operator
       result = result .. 'a' .. 'b' .. 'c'
    end
@@ -226,9 +226,9 @@ end
    global glOuter = 1  -- Explicit global
    global glInner = 2  -- Explicit global
 
-   for i = 0, 3 do
+   for i in {0 into 3} do
       _ = glOuter  -- Warning: global in loop (outer)
-      for j = 0, 3 do
+      for j in {0 into 3} do
          _ = glInner  -- Warning: global in loop (inner)
          _ = glOuter  -- Warning: global in loop (inner accessing outer global)
       end
@@ -266,9 +266,9 @@ end
 
 @Test function NestedLoops()
    statement = [[
-   for i = 0, 3 do
+   for i in {0 into 3} do
       outer_fn = function() return i end  -- Warning: function in loop
-      for j = 0, 3 do
+      for j in {0 into 3} do
          inner_fn = function() return i + j end  -- Warning: function in nested loop
       end
    end
@@ -286,7 +286,7 @@ end
 @Test function CallbackInLoop()
    statement = [[
    data = { { val = 3 }, { val = 1 }, { val = 2 } }
-   for i = 0, 5 do
+   for i in {0 into 5} do
       -- This is a common anti-pattern: sorting with inline comparator in loop
       table.sort(data, function(a, b) return a.val < b.val end)
    end

--- a/tools/benchmark/benchmark_control.tiri
+++ b/tools/benchmark/benchmark_control.tiri
@@ -156,35 +156,35 @@ end
 end
 
 ----------------------------------------------------------------------------------------------------------------------
--- Goal: Execute numeric for loops with start, end, step
+-- Goal: Execute range loops with start, end, step
 
 @Test function ControlForNumericLoop()
    for i in {0 to 10000} do
       local sum = 0
 
       -- Simple ascending loop
-      for j = 0, 99 do
+      for j in {0 into 99} do
          sum += j
       end
 
       -- Loop with step
-      for j = 0, 99, 2 do
+      for j in {0 into 99 by 2} do
          sum += j
       end
 
       -- Descending loop
-      for j = 99, 0, -1 do
+      for j in {99 into 0 by -1} do
          sum += j
       end
 
       -- Descending with step
-      for j = 100, 0, -5 do
+      for j in {100 into 0 by -5} do
          sum += j
       end
 
       -- Nested numeric loops
-      for x = 0, 9 do
-         for y = 0, 9 do
+      for x in {0 into 9} do
+         for y in {0 into 9} do
             sum += x * y
          end
       end
@@ -192,7 +192,7 @@ end
       -- Loop with computed bounds
       local start = i % 10
       local finish = start + 50
-      for j = start, finish do
+      for j in {start into finish} do
          sum += 1
       end
    end
@@ -353,7 +353,7 @@ end
       local count = 0
 
       -- Break from for loop
-      for j = 0, 999 do
+      for j in {0 into 999} do
          if j >= 100 then
             break
          end
@@ -361,7 +361,7 @@ end
       end
 
       -- Continue in for loop (skip even numbers)
-      for j = 0, 99 do
+      for j in {0 into 99} do
          if j % 2 is 0 then
             continue
          end
@@ -388,8 +388,8 @@ end
       end
 
       -- Break from nested loop (inner only)
-      for x = 0, 9 do
-         for y = 0, 99 do
+      for x in {0 into 9} do
+         for y in {0 into 99} do
             if y >= 10 then
                break
             end
@@ -398,8 +398,8 @@ end
       end
 
       -- Continue in nested loop
-      for x = 0, 9 do
-         for y = 0, 9 do
+      for x in {0 into 9} do
+         for y in {0 into 9} do
             if y % 2 is 0 then
                continue
             end

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -308,7 +308,7 @@ if x == 1 then
    print(x)
 end
 
-for i = 0, 10 do
+for i in {0 into 10} do
    total += i
 end
 ]])

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -166,6 +166,18 @@ end
    assert(#result.diagnostics is 0, 'LSP diagnostics should accept current to/into/by range syntax.')
 end
 
+@Test function RemovedNumericForProducesLspDiagnostic()
+   doc = makeDoc('for i = 0, 8 do\n   print(i)\nend\n')
+   result = computeDiagnostics(doc)
+
+   assert(#result.diagnostics > 0, 'Removed numeric for syntax should produce an LSP diagnostic.')
+   diagnostic = result.diagnostics[0]
+   assert(diagnostic.code is 'DeprecatedSyntax', 'LSP should preserve the DeprecatedSyntax diagnostic code.')
+   assert(diagnostic.severity is 1, 'Removed numeric for syntax should be an LSP error.')
+   assert(diagnostic.range.start.line is 0, 'Removed numeric for diagnostic should identify the loop header.')
+   assert(diagnostic.range.start.character is 6, "Removed numeric for diagnostic should start at '='.")
+end
+
 @Test function TernaryModesReceiveSemanticTokens()
    source = 'standard = value ? \'yes\' :> \'no\'\n' ..
       'extended = value ?? \'yes\' :> \'no\'\n' ..


### PR DESCRIPTION
* Rejected numeric for headers with a targeted DeprecatedSyntax error and inclusive range guidance
* Migrated tracked scripts, parser fixtures, benchmarks and LSP coverage to range loops