### PR TITLE
[Tiri] Restored safe object calls after type-guided specialisation

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -3252,7 +3252,14 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
    if (proved_object) {
       table.result_type = TiriType::Object;
       table.object_class_id = CLASSID::NIL;
-      if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) table.k = ExpKind::IndexedObject;
+
+      // Call targets must retain generic lookup so the object metatable can resolve actions, methods and helpers.
+      // Unlike ordinary member expressions, safe member expressions materialise the lookup before emit_call_expr()
+      // can downgrade specialised expression kinds.
+
+      if (not Payload.is_call_target and table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
+         table.k = ExpKind::IndexedObject;
+      }
 
       // Look up the field type from the class dictionary for compile-time type checking.
 
@@ -3277,7 +3284,9 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
    }
    else if (proved_struct) {
       table.result_type = TiriType::Struct;
-      if (table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) table.k = ExpKind::IndexedStruct;
+      if (not Payload.is_call_target and table.k IS ExpKind::Indexed and int32_t(table.u.s.aux) < 0) {
+         table.k = ExpKind::IndexedStruct;
+      }
       apply_struct_field_metadata(table, emitted_struct_def, Payload.member.symbol);
    }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3093,6 +3093,21 @@ static bool test_type_guided_emission(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view safe_object_call =
+      "extern obj\n"
+      "try\n"
+      "   global guided_object = obj.new('time')\n"
+      "end\n"
+      "local function query_object()\n"
+      "   return guided_object?.acQuery()\n"
+      "end\n";
+   snapshot = compile_snapshot(L, safe_object_call, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_TGETS) < 2 or
+       count_opcode_tree(*snapshot, BC_OBGETF) != 0) {
+      Log.error("safe object call target bypassed generic metatable lookup: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view generic_accesses =
       "local function update(Value:any, Key:any)\n"
       "   Value.field = 1\n"

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -146,6 +146,34 @@ end
    assert(holder?:unknown() is nil, 'A safe call should return nil for a nil receiver')
 end
 
+@Test function SafeObjectCallTargetUsesMetamethod()
+   local disassembly = disassemble_source([[
+try
+   global glEmissionSafeObject = obj.new('time')
+end
+function query_safe_object()
+   return glEmissionSafeObject?.acQuery()
+end
+]])
+   assert(disassembly:find('OBGETF') is nil,
+      'A safe object call target must not use field-only object lookup, got:\n' .. disassembly)
+   assert(disassembly:find('TGETS') != nil,
+      'A safe object call target should retain generic metatable lookup, got:\n' .. disassembly)
+
+   try
+      global glEmissionSafeRuntimeObject = obj.new('time')
+   end
+
+   local function query_safe_runtime_object()
+      return glEmissionSafeRuntimeObject?.acQuery()
+   end
+
+   assert(query_safe_runtime_object() is ERR_Okay,
+      'Safe navigation should invoke an action on an object declared inside try')
+   glEmissionSafeRuntimeObject.free()
+   glEmissionSafeRuntimeObject = nil
+end
+
 @Test function InterpreterAndJitParity()
    local function run_case():num
       local values = array<int> { 1, 2, 3, 4 }


### PR DESCRIPTION
* Preserved metatable lookup for safe object and struct call targets
* Added parser and Flute regression coverage for globals declared inside try blocks