### PR TITLE
[Tiri] Enforced sticky contracts for inferred globals

### DIFF
--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -47,6 +47,12 @@ struct LocalDeclResult {
    BCREG initialised = 0;
 };
 
+enum class GlobalContractPolicy : uint8_t {
+   Advisory,
+   Enforced,
+   Variant
+};
+
 // Lua lexer state.
 
 class LexState {
@@ -152,14 +158,14 @@ public:
    bool diagnose_mode = false;  // When true, lexer errors are collected instead of thrown
    bool had_lex_error = false;  // Set when a recoverable lexer error occurred
 
-   // Global type hints published by the type analyser after analysis completes and consumed by the IR emitter
-   // when resolving global identifier reads.  Entries exist only for globals whose type is fixed for the whole
-   // chunk, allowing member access on typed globals to select specialised bytecode (STGETF, OBGETF, AGETV).
+   // Global type hints published by the type analyser after analysis completes and consumed by the IR emitter.
+   // Fixed declared globals carry enforced sticky contracts, while explicitly variant globals suppress stale
+   // environment contracts.  Advisory entries only guide safe specialised access for host-provided globals.
    struct GlobalTypeHint {
       TiriType primary = TiriType::Unknown;
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
-      bool explicit_contract = false;
+      GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;
    std::vector<StructFieldDocumentation> struct_field_documentation;

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -608,7 +608,15 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
 static void bcemit_value_contract(
    FuncState *fs, ExpDesc *Value, const RuntimeContract &Contract, bool ForceRuntimeCheck = false)
 {
-   if (Contract.type IS TiriType::Unknown or Contract.type IS TiriType::Any) return;
+   if (Contract.type IS TiriType::Unknown) return;
+   if (Contract.type IS TiriType::Any) {
+      if (not ForceRuntimeCheck) return;
+      BCREG source = expr_toanyreg(fs, Value);
+      bcemit_contract(fs, source, std::span(&Contract, 1), 1);
+      Value->k = ExpKind::NonReloc;
+      Value->u.s.info = source;
+      return;
+   }
    if (contract_literal_proved(fs, Value, Contract.type) and not ForceRuntimeCheck) return;
    if (Value->static_value and fs->ls->active_context) {
       const auto &descriptor = fs->ls->active_context->descriptors().value(Value->static_value);
@@ -676,8 +684,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
    else if (LHS->k IS ExpKind::Global or LHS->k IS ExpKind::Unscoped) {
       // Note: Const global reassignment is checked during type analysis phase
       // Unscoped should normally be resolved in emit_lvalue_expr(), but handle it here defensively
-      if (auto found = fs->ls->global_type_hints.find(LHS->u.sval);
-          found != fs->ls->global_type_hints.end() and found->second.explicit_contract) {
+      auto found = fs->ls->global_type_hints.find(LHS->u.sval);
+      if (found != fs->ls->global_type_hints.end() and
+          found->second.contract_policy != GlobalContractPolicy::Advisory) {
          RuntimeContract contract{
             .type = found->second.primary,
             .struct_def = found->second.struct_def,
@@ -685,8 +694,8 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
             .boundary = ContractBoundary::Global,
             .position = 1
          };
-         // Global contracts must execute even for statically proved literals so the declaration is attached to the
-         // runtime environment for separately compiled chunks.
+         // Declared global contracts must execute even when no predicate is required.  Concrete contracts and the
+         // explicit 'any' opt-out are both attached to the environment for separately compiled chunks.
          bcemit_value_contract(fs, RHS, contract, true);
       }
       else if (GCstr *contract = lj_tab_get_global_contract(tabref(fs->L->env), LHS->u.sval)) {

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -332,11 +332,11 @@ private:
       const FunctionExprPayload* forward_declaration = nullptr; // Original empty declaration used as the contract
       bool is_const = false;  // True if declared with <const> attribute
       bool implicit = false;  // True if inferred from a plain assignment rather than a 'global' declaration
-      bool explicit_contract = false; // True only for an explicit non-any annotation
+      GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
    };
 
    void declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst = false,
-      bool ExplicitContract = false);
+      GlobalContractPolicy ContractPolicy = GlobalContractPolicy::Advisory);
    void declare_global_function(GCstr *Name, const FunctionExprPayload *Function, SourceSpan Location);
    void declare_implicit_global(GCstr *Name, const ExprNode *Value, SourceSpan Location);
    [[nodiscard]] std::optional<InferredType> lookup_global_type(GCstr *Name) const;
@@ -1472,8 +1472,10 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
          inferred.is_fixed = false;
       }
 
-      this->declare_global(name.symbol, inferred, name.span, name.has_const,
-         name.type != TiriType::Unknown and name.type != TiriType::Any);
+      GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
+      if (name.type IS TiriType::Any) contract_policy = GlobalContractPolicy::Variant;
+      else if (inferred.is_fixed) contract_policy = GlobalContractPolicy::Enforced;
+      this->declare_global(name.symbol, inferred, name.span, name.has_const, contract_policy);
    }
 
    #ifdef INCLUDE_TIPS
@@ -2346,14 +2348,14 @@ void TypeAnalyser::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClas
 // the entire script lifetime.
 
 void TypeAnalyser::declare_global(GCstr *Name, const InferredType &Type, SourceSpan Location, bool IsConst,
-   bool ExplicitContract)
+   GlobalContractPolicy ContractPolicy)
 {
    if (not Name) return;
    GlobalTypeInfo info;
    info.type = Type;
    info.location = Location;
    info.is_const = IsConst;
-   info.explicit_contract = ExplicitContract;
+   info.contract_policy = ContractPolicy;
    this->global_types_[Name] = info;
    this->trace_decl(this->ctx_.lex().linenumber, Name, Type.primary, Type.is_fixed);
 }
@@ -2461,6 +2463,7 @@ void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectCla
       it->second.type.is_fixed = true;
       it->second.type.object_class_id = ObjectClassId;
       it->second.type.struct_def = StructDef;
+      if (not it->second.implicit) it->second.contract_policy = GlobalContractPolicy::Enforced;
       this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
    }
 }
@@ -2860,17 +2863,22 @@ static void publish_type_diagnostics(ParserContext& Context, const std::vector<T
 // Entry Point: Called from the parser after AST construction to run semantic type analysis.  Creates a TypeAnalyser
 // instance, runs analysis on the module, and publishes any collected diagnostics.
 
-// Publish fixed global types to the lexer state so that IR emission (which runs after analysis) can attach type
-// metadata to global identifier reads and explicit runtime contracts to every global store.  Inferred scalar types
-// remain advisory and have no emitter consumer.
+// Publish global type policy to the lexer state so that IR emission can attach metadata to global reads, enforce
+// sticky contracts for declared globals, and preserve explicit 'any' as the variant opt-out.
 
 void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
 {
    for (const auto &[name, info] : this->global_types_) {
-      if (not info.type.is_fixed) continue;
-      if (info.explicit_contract) {
+      if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
-            info.type.primary, info.type.object_class_id, info.type.struct_def, true
+            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant
+         };
+         continue;
+      }
+      if (not info.type.is_fixed) continue;
+      if (info.contract_policy IS GlobalContractPolicy::Enforced) {
+         Lex.global_type_hints[name] = {
+            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced
          };
          continue;
       }
@@ -2879,7 +2887,7 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
          case TiriType::Object:
          case TiriType::Array:
             Lex.global_type_hints[name] = {
-               info.type.primary, info.type.object_class_id, info.type.struct_def, false
+               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory
             };
             break;
          default:

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1431,6 +1431,10 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
       this->analyse_expression(*value);
    }
 
+   size_t value_index = 0;
+   size_t call_return_index = 0;
+   const ExprNode *multi_return_call = nullptr;
+
    // Track global variable types for type checking on subsequent assignments
    for (size_t i = 0; i < Payload.names.size(); ++i) {
       const auto &name = Payload.names[i];
@@ -1452,6 +1456,26 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
       }
 
       InferredType inferred;
+      InferredType value_type;
+      bool have_value_type = false;
+
+      if (value_index < Payload.values.size()) {
+         const ExprNode &value_expr = *Payload.values[value_index];
+         value_type = this->infer_expression_type(value_expr);
+         have_value_type = true;
+
+         if (value_index IS Payload.values.size() - 1 and value_expr.kind IS AstNodeKind::CallExpr) {
+            multi_return_call = &value_expr;
+            call_return_index = 0;
+         }
+
+         value_index += 1;
+      }
+      else if (multi_return_call) {
+         call_return_index += 1;
+         value_type = this->infer_call_return_type(*multi_return_call, call_return_index);
+         have_value_type = (value_type.primary != TiriType::Any);
+      }
 
       // Explicit type annotation takes precedence
       if (name.type != TiriType::Unknown) {
@@ -1459,9 +1483,9 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
          inferred.struct_def = name.struct_def;
          inferred.is_fixed = (name.type != TiriType::Any);
       }
-      else if (i < Payload.values.size()) {
+      else if (have_value_type) {
          // Infer type from initial value
-         inferred = this->infer_expression_type(*Payload.values[i]);
+         inferred = value_type;
          // Non-nil, non-any initial values fix the type
          if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any) {
             inferred.is_fixed = true;

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -743,18 +743,46 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    }
 }
 
+static void decode_contract_or_error(lua_State *L, GCstr *Descriptor, RuntimeContractDescriptor &Result)
+{
+   RuntimeContractDecodeError decode_error;
+   if (decode_runtime_contract(Descriptor, Result, &decode_error)) return;
+
+   if (decode_error IS RuntimeContractDecodeError::Entry) {
+      lj_err_callermsg(L, "invalid runtime type-contract entry");
+   }
+   else lj_err_callermsg(L, "invalid runtime type-contract descriptor");
+}
+
 } // namespace
 
 extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor)
 {
    L->top = curr_topL(L);
    RuntimeContractDescriptor descriptor;
-   RuntimeContractDecodeError decode_error;
-   if (not decode_runtime_contract(Descriptor, descriptor, &decode_error)) {
-      if (decode_error IS RuntimeContractDecodeError::Entry) {
-         lj_err_callermsg(L, "invalid runtime type-contract entry");
+   decode_contract_or_error(L, Descriptor, descriptor);
+
+   GCtab *environment = nullptr;
+   GCstr *global_name = nullptr;
+   bool publish_global_contract = false;
+
+   if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1) {
+      const RuntimeContractEntry &incoming = descriptor.entries[0];
+      if (not incoming.label.empty()) {
+         environment = tabref(curr_func(L)->c.env);
+         global_name = lj_str_new(L, incoming.label.data(), incoming.label.size());
+
+         if (incoming.type IS TiriType::Any) {
+            // An explicit 'any' declaration is the only ordinary operation that relaxes a sticky global contract.
+            lj_tab_set_global_contract(L, environment, global_name, Descriptor);
+         }
+         else if (GCstr *current = lj_tab_get_global_contract(environment, global_name)) {
+            // Bytecode may outlive the declaration policy it was compiled against.  The environment policy is
+            // authoritative for ordinary stores and concrete redeclarations.
+            if (current != Descriptor) decode_contract_or_error(L, current, descriptor);
+         }
+         else publish_global_contract = true;
       }
-      else lj_err_callermsg(L, "invalid runtime type-contract descriptor");
    }
 
    uint32_t value_count = descriptor.dynamic_count() ?
@@ -781,13 +809,7 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
       }
    }
 
-   if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1) {
-      const RuntimeContractEntry &entry = descriptor.entries[0];
-      if (not entry.label.empty()) {
-         GCstr *name = lj_str_new(L, entry.label.data(), entry.label.size());
-         lj_tab_set_global_contract(L, tabref(curr_func(L)->c.env), name, Descriptor);
-      }
-   }
+   if (publish_global_contract) lj_tab_set_global_contract(L, environment, global_name, Descriptor);
 }
 
 extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t DynamicCount)

--- a/src/tiri/tests/test_compound.tiri
+++ b/src/tiri/tests/test_compound.tiri
@@ -252,8 +252,8 @@ end
    assert(gTestNilVar2 is 'existing', 'global ?= should not overwrite existing value')
 
    -- Test global ?= does not overwrite false (unlike ??=)
-   global gTestNilVar3 = false
-   global gTestNilVar3 ?= 'from-false'
+   global gTestNilVar3:any = false
+   gTestNilVar3 ?= 'from-false'
    assert(gTestNilVar3 is false, 'global ?= should not overwrite false')
 
    -- Test global ?= does not overwrite 0 (unlike ??=)
@@ -670,8 +670,8 @@ end
    assert(gEmptyVar is 'from empty', 'global ??= should assign when value is empty string')
 
    -- Test global ??= assigns when value is an empty table
-   global gEmptyTableVar = { }
-   global gEmptyTableVar ??= 'from empty table'
+   global gEmptyTableVar:any = { }
+   gEmptyTableVar ??= 'from empty table'
    assert(gEmptyTableVar is 'from empty table', 'global ??= should assign when value is an empty table')
 end
 

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------------------------------------------------
 -- Global type propagation: member access on typed globals must select specialised bytecode (STGETF/STSETF for
 -- structs, OBGETF for objects, AGETB/AGETV for arrays) instead of generic table access.  Types are recorded by the
--- type analyser from explicit 'global' declarations, then attached to global identifier reads during IR emission.
+-- type analyser from 'global' declarations, then attached to global identifier reads and stores during IR emission.
 --
 -- Bytecode assertions compile a nested tiri object and inspect its disassembly; acQuery() must precede
 -- acActivate() so the main chunk reference is retained for DebugLog('disasm').
@@ -13,6 +13,21 @@ local function disassemble(Statement)
    local _, disasm = script.mtDebugLog('disasm')
    assert(disasm != nil, 'Expected DebugLog to return a disassembly')
    return disasm
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Inferred scalar globals must emit sticky contracts for their declaration and later dynamic stores.
+
+@Test function InferredScalarGlobalContractBytecode()
+   local disasm = disassemble([[
+global glGTSticky = 'first'
+local dynamic:any = 'second'
+glGTSticky = dynamic
+]])
+   assert(disasm:count('CONTRACT') is 2,
+      'An inferred global declaration and dynamic store must each emit CONTRACT, got:\n' .. disasm)
+   assert(disasm:count('GSET') is 2,
+      'The inferred global declaration and reassignment should each emit GSET, got:\n' .. disasm)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -29,6 +44,7 @@ function writeField()
    glGTRec.bravo = 5
 end
 ]])
+   assert(disasm:find('CONTRACT') != nil, 'Inferred global struct declaration should emit CONTRACT, got:\n' .. disasm)
    assert(disasm:find('STGETF') != nil, 'Global struct read should emit STGETF, got:\n' .. disasm)
    assert(disasm:find('STSETF') != nil, 'Global struct write should emit STSETF, got:\n' .. disasm)
 end
@@ -73,6 +89,7 @@ function readYear()
    return glGTTime.year
 end
 ]])
+   assert(disasm:find('CONTRACT') != nil, 'Inferred global object declaration should emit CONTRACT, got:\n' .. disasm)
    assert(disasm:find('OBGETF') != nil, 'Global object field read should emit OBGETF, got:\n' .. disasm)
 end
 
@@ -100,6 +117,7 @@ function readNum()
    return glGTNums[1]
 end
 ]])
+   assert(disasm:find('CONTRACT') != nil, 'Inferred global array declaration should emit CONTRACT, got:\n' .. disasm)
    assert(disasm:find('AGETB') != nil or disasm:find('AGETV') != nil,
       'Global array indexing should emit AGETB/AGETV, got:\n' .. disasm)
 end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -413,6 +413,50 @@ end
    assert(glInferredContract is 'nested', 'A rejected nested-function store must preserve the inferred global value')
 end
 
+@Test function GlobalContractRedeclarationPolicy()
+   global glContractRedeclaration = 1
+
+   exec('global glContractRedeclaration = 2')
+   assert(glContractRedeclaration is 2, 'A matching concrete redeclaration should preserve the sticky contract')
+
+   expect_contract_failure(
+      function() exec("global glContractRedeclaration = 'wrong'") end, 'global')
+   assert(glContractRedeclaration is 2,
+      'A rejected concrete redeclaration must preserve the global value and its existing contract')
+end
+
+@Test function CompiledGlobalWriterObservesVariantPolicy()
+   global glContractWriter:num = 1
+
+   function write_contract_global(Value:any)
+      glContractWriter = Value
+   end
+
+   for i in {0 to 200} do
+      write_contract_global(i)
+   end
+
+   exec("global glContractWriter:any = 'variant'")
+   write_contract_global('allowed')
+   assert(glContractWriter is 'allowed',
+      'A writer compiled against an older concrete contract must observe a later explicit any declaration')
+end
+
+@Test function MultiReturnGlobalContracts()
+   function global_contract_pair():<num, str>
+      return 2, 'text'
+   end
+
+   global glContractPairNumber, glContractPairText = global_contract_pair()
+
+   exec('glContractPairText = "updated"')
+   assert(glContractPairText is 'updated', 'A matching store should satisfy the secondary global contract')
+
+   expect_contract_failure(function() exec('glContractPairText = 42') end, 'global')
+   assert(glContractPairText is 'updated',
+      'A rejected store must preserve a secondary multi-return global and its contract')
+end
+
 @Test function UserdataContractBoundaries()
    function userdata_source():any return newproxy(true) end
    function typed_userdata_result():userdata return userdata_source() end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -376,6 +376,41 @@ end
    global glContractAny:any = 1
    glContractAny = 'allowed'
    assert(glContractAny is 'allowed', 'Explicit any remains the global contract opt-out')
+
+   global glContractRedeclared:num = 1
+   exec("global glContractRedeclared:any = 'variant'")
+   exec("glContractRedeclared = {}")
+   assert(type(glContractRedeclared) is 'table',
+      'An explicit any redeclaration must replace a previously persisted concrete contract')
+end
+
+@Test function InferredGlobalStores()
+   global glInferredContract = 'original'
+
+   local matching:any = 'updated'
+   glInferredContract = matching
+   assert(glInferredContract is 'updated', 'A matching dynamic value should satisfy an inferred global contract')
+
+   local wrong:any = 42
+   expect_contract_failure(function() glInferredContract = wrong end, 'global')
+   assert(glInferredContract is 'updated', 'A rejected inferred global store must preserve the previous value')
+
+   glInferredContract = nil
+   assert(glInferredContract is nil, 'Nil should clear an inferred global without removing its contract')
+   glInferredContract = dynamic_value('restored')
+   assert(glInferredContract is 'restored', 'The inferred global contract should survive a nil clear')
+
+   expect_contract_failure(function() exec('glInferredContract = 42') end, 'global')
+   assert(glInferredContract is 'restored',
+      'A separately compiled rejected store must preserve the inferred global value')
+
+   function write_inferred_global(Value:any)
+      glInferredContract = Value
+   end
+   write_inferred_global('nested')
+   assert(glInferredContract is 'nested', 'A matching nested-function store should satisfy the inferred contract')
+   expect_contract_failure(function() write_inferred_global(false) end, 'global')
+   assert(glInferredContract is 'nested', 'A rejected nested-function store must preserve the inferred global value')
 end
 
 @Test function UserdataContractBoundaries()
@@ -431,6 +466,11 @@ end
    function hot(Value:num):num return Value + 1 end
    function hot_results(Value:num):<num, str> return Value, 'kept', false end
    function hot_userdata(Value:userdata):userdata return Value end
+   global glHotInferredContract = 0
+   function store_hot_global(Value:any):num
+      glHotInferredContract = Value
+      return glHotInferredContract
+   end
    local dynamic:any = hot
    local proxy = newproxy(true)
    for i in {0 to 200} do
@@ -439,9 +479,11 @@ end
       assert(value is i and text is 'kept' and extra is nil,
          'Hot fixed return contracts must truncate additional results')
       assert(hot_userdata(proxy) is proxy, 'userdata contracts must remain stable on hot paths')
+      assert(store_hot_global(i) is i, 'An inferred global contract should preserve valid values on hot paths')
    end
    expect_contract_failure(function() dynamic('wrong') end, 'parameter')
    expect_contract_failure(function() hot_userdata(dynamic_value({0 to 2})) end, 'parameter')
+   expect_contract_failure(function() store_hot_global('wrong') end, 'global')
 end
 
 @Test function ContractDisassemblyOrder()

--- a/src/tiri/tests/test_type_fixing.tiri
+++ b/src/tiri/tests/test_type_fixing.tiri
@@ -263,6 +263,28 @@ end
 end
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function TypeMismatchWithInferredGlobal()
+   try
+      exec("global glStickyMismatch = 'text'; glStickyMismatch = 42")
+   success
+      error("should have thrown type error for inferred global")
+   end
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function InferredGlobalFixesAfterNil()
+   exec([[
+global glStickyDeferred
+glStickyDeferred = nil
+glStickyDeferred = 'first'
+glStickyDeferred = 'second'
+assert(glStickyDeferred is 'second', 'The first concrete global assignment should fix its sticky type')
+]])
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function TypeMismatchInitialValue()
    -- Explicit annotation with mismatched initial value
    try

--- a/tools/tiri_lsp/include/lsp_protocol.tiri
+++ b/tools/tiri_lsp/include/lsp_protocol.tiri
@@ -70,7 +70,7 @@ end
 -- base protocol, https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.17/specification.md
 
 function formatResponse(ResponseTable:table, TextOutput:bool):str
-   body = json.encode(ResponseTable)
+   local body = json.encode(ResponseTable)
    return 'Content-Length: ' .. #body .. '\r\n\r\n' .. body
 end
 


### PR DESCRIPTION
* Added global contract policies to persist inferred types and allow explicit any redeclarations
* Expanded Flute coverage for inferred global stores, hot paths, and variant globals
* [LSP] Scoped response payload encoding locally