### PR TITLE
[Tiri] Enforced typed local initialiser contracts

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1185,6 +1185,43 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    this->lex_state.var_add(nvars);
    auto base = BCReg(this->func_state.varmap.size() - nvars.raw());
 
+   // Declaration initialisers are placed directly into their local slots, so they do not pass through
+   // bcemit_store().  Validate every concrete annotation after result-count adjustment and before publishing the
+   // binding's checked metadata.  This also covers values supplied by calls, varargs and result filters.
+   for (auto i = BCReg(0); i < nvars; ++i) {
+      const Identifier &identifier = Payload.names[i.raw()];
+      if (identifier.type IS TiriType::Unknown or identifier.type IS TiriType::Any) continue;
+
+      StaticValueDescriptor initialiser;
+      if (Payload.values.empty()) {
+         initialiser.primary = TiriType::Nil;
+         initialiser.proof = StaticProof::Closed;
+         initialiser.nullable = true;
+      }
+      else {
+         size_t source = std::min(size_t(i.raw()), Payload.values.size() - 1);
+         const ExprNode &value = *Payload.values[source];
+         if (source IS Payload.values.size() - 1 and i.raw() >= Payload.values.size() and value.static_results) {
+            initialiser = this->ctx.descriptors().results(value.static_results).value_at(i.raw() - source);
+         }
+         else if (value.static_value) initialiser = this->ctx.descriptors().value(value.static_value);
+      }
+
+      bool matching_type = initialiser.primary IS TiriType::Nil or initialiser.primary IS identifier.type;
+      bool matching_struct = identifier.type != TiriType::Struct or initialiser.primary IS TiriType::Nil or
+         initialiser.struct_def IS identifier.struct_def;
+      if (initialiser.proved() and matching_type and matching_struct) continue;
+
+      RuntimeContract contract{
+         .type = identifier.type,
+         .struct_def = identifier.struct_def,
+         .label = is_blank_symbol(identifier) ? nullptr : identifier.symbol,
+         .boundary = ContractBoundary::Local,
+         .position = uint8_t(base.raw() + i.raw() + 1)
+      };
+      bcemit_contract(&this->func_state, base + i, std::span(&contract, 1), 1);
+   }
+
    for (auto i = BCReg(0); i < nvars; ++i) {
       const Identifier& identifier = Payload.names[i.raw()];
       if (not identifier.has_close) continue;

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -345,6 +345,102 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Other approved write boundaries.
 
+@Test function TypedLocalInitialiserContracts()
+   expect_contract_failure(function()
+      local value:num = dynamic_value('wrong')
+   end, 'local initialiser')
+
+   expect_contract_failure(function()
+      local value <const>:num = dynamic_value('wrong')
+   end, 'const local initialiser')
+
+   function dynamic_pair():<any, any>
+      return 1, 'wrong'
+   end
+   expect_contract_failure(function()
+      local first:num, second:num = dynamic_pair()
+   end, 'secondary local initialiser')
+
+   function dynamic_single():any
+      return 1
+   end
+   local present:num, absent:str = dynamic_single()
+   assert(present is 1 and absent is nil,
+      'Result-count adjustment should supply an acceptable nil to a missing annotated position')
+
+   function dynamic_triple():<any, any, any>
+      return 'drop', 2, 'wrong'
+   end
+   expect_contract_failure(function()
+      local first:num, second:num = [_*]dynamic_triple()
+   end, 'filtered local initialiser')
+
+   function accept_varargs(...)
+      local first:num, second:num = ...
+      return first + second
+   end
+   assert(accept_varargs(2, 3) is 5, 'Matching vararg initialisers should pass local contracts')
+   expect_contract_failure(function() accept_varargs(2, 'wrong') end, 'vararg local initialiser')
+
+   local holder:any = { value='wrong' }
+   expect_contract_failure(function()
+      local value:num = holder.value
+   end, 'direct local initialiser expression')
+
+   local bravo = struct<ContractBravo> { Value=7 }
+   expect_contract_failure(function()
+      local value:struct<ContractAlpha> = dynamic_value(bravo)
+   end, 'named-structure local initialiser')
+
+   local missing:num = dynamic_value(nil)
+   assert(missing is nil, 'Nil should remain valid for a concrete local annotation')
+
+   local variant:any = dynamic_value('text')
+   variant = 42
+   assert(variant is 42, 'Explicit any local initialisers must remain variant')
+
+   function typed_initialiser(Value:any):num
+      local result:num = Value
+      return result
+   end
+   for i in {0 to 200} do
+      assert(typed_initialiser(i) is i, 'Matching initialisers should remain valid on a hot path')
+   end
+   expect_contract_failure(function() typed_initialiser('wrong') end, 'hot local initialiser')
+
+   local closed = false
+   expect_contract_failure(function()
+      local resource <close>:num = dynamic_value(setmetatable({}, {
+         __close = function(Self, Error)
+            closed = true
+         end
+      }))
+   end, 'to-be-closed local initialiser')
+   assert(closed, 'A rejected local initialiser must unwind its <close> value')
+
+   local initialiser_deferred = false
+   function fail_initialiser()
+      defer
+         initialiser_deferred = true
+      end
+      local value:num = dynamic_value('wrong')
+   end
+
+   local assignment_deferred = false
+   function fail_assignment()
+      defer
+         assignment_deferred = true
+      end
+      local value:num = 1
+      value = dynamic_value('wrong')
+   end
+
+   expect_contract_failure(fail_initialiser, 'deferred local initialiser')
+   expect_contract_failure(fail_assignment, 'deferred local assignment')
+   assert(initialiser_deferred is assignment_deferred,
+      'Initialiser and assignment contract failures must unwind defer state consistently')
+end
+
 @Test function TypedLocalAndCapturedUpvalueStores()
    local typed:num = 1
    expect_contract_failure(function() typed = dynamic_value('wrong') end, 'local')


### PR DESCRIPTION
* Added runtime contracts for unproved annotated local declaration values while retaining proved-value optimisations
* Added regression coverage for dynamic, multi-result, vararg, structure, JIT and cleanup paths