### PR TITLE
[Tiri] Unified analysed and emitted local type contracts

### DIFF
--- a/src/tiri/jit/src/lib/lib_array.cpp
+++ b/src/tiri/jit/src/lib/lib_array.cpp
@@ -3015,8 +3015,11 @@ extern "C" int luaopen_array(lua_State *L)
    reg_iface_prototype("array", "clear", {}, { TiriType::Array });
    reg_iface_prototype("array", "resize", {}, { TiriType::Array, TiriType::Num });
    reg_iface_prototype("array", "push", {}, { TiriType::Array, TiriType::Any });
-   // Private
-   // reg_iface_prototype("array", "append", { TiriType::Any }, { TiriType::Any, TiriType::Any });
+
+   // array.append() was created for concatenation of byte arrays, for this reason it is not documented for client use.
+   // Clients are expected to use array.push() for appending values to arrays of any type.
+   reg_iface_prototype("array", "append", { TiriType::Any }, { TiriType::Any, TiriType::Any });
+
    reg_iface_prototype("array", "pop", { TiriType::Any }, { TiriType::Array });
    reg_iface_prototype("array", "copy", {}, { TiriType::Array, TiriType::Num, TiriType::Num, TiriType::Num });
    reg_iface_prototype("array", "getString", { TiriType::Str }, { TiriType::Array, TiriType::Num, TiriType::Num });

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -365,11 +365,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
          PreparedAssignment& target = targets[i.raw()];
          if (target.pending_symbol) {
             this->update_local_binding(target.pending_symbol, base + i);
-            VarInfo *info = &this->func_state.var_get((base + i).raw());
-            info->binding_id = target.binding_id;
 
-            if (not this->apply_analysed_local_type(base + i, target.binding_id) and
-                i.raw() < values.size()) {
+            if (i.raw() < values.size()) {
                this->apply_inferred_local_type(base + i, *values[i.raw()]);
             }
          }

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -365,9 +365,11 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
          PreparedAssignment& target = targets[i.raw()];
          if (target.pending_symbol) {
             this->update_local_binding(target.pending_symbol, base + i);
+            VarInfo *info = &this->func_state.var_get((base + i).raw());
+            info->binding_id = target.binding_id;
 
-            // Infer type from initialiser expression (same logic as emit_local_decl_stmt)
-            if (i.raw() < values.size()) {
+            if (not this->apply_analysed_local_type(base + i, target.binding_id) and
+                i.raw() < values.size()) {
                this->apply_inferred_local_type(base + i, *values[i.raw()]);
             }
          }
@@ -431,8 +433,9 @@ ParserResult<IrEmitUnit> IrEmitter::emit_plain_assignment(std::vector<PreparedAs
             // Create new local for this undeclared variable
             BCReg local_slot = this->finalise_pending_local_assignment(target);
 
-            // Infer type from initialiser expression
-            if (i < values.size()) {
+            // Retain expression inference only when semantic analysis did not publish a binding result.
+            if (this->func_state.var_get(local_slot.raw()).fixed_type IS TiriType::Unknown and
+                i < values.size()) {
                this->apply_inferred_local_type(local_slot, *values[i]);
             }
 
@@ -863,6 +866,9 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
          prepared.needs_var_add  = true;
          prepared.newly_created  = true;
          prepared.pending_symbol = slot.u.sval;
+         if (const auto *name_ref = std::get_if<NameRef>(&node->data)) {
+            prepared.binding_id = name_ref->binding_id;
+         }
          prepared.pending_line   = node->span.line;
          prepared.pending_column = node->span.column;
          // Don't convert to Local yet - keep as Unscoped for now

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -659,6 +659,40 @@ void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
    info->static_results = Value.static_results;
 }
 
+bool IrEmitter::apply_analysed_local_type(BCReg Slot, StaticBindingID Binding)
+{
+   if (not Binding) return false;
+
+   const auto &binding = this->ctx.descriptors().binding(Binding);
+   if (not binding.analysed_value) return false;
+
+   const auto &value = this->ctx.descriptors().value(binding.analysed_value);
+   if (value.primary IS TiriType::Unknown or value.primary IS TiriType::Any or
+       value.primary IS TiriType::Nil) return false;
+
+   VarInfo *info = &this->func_state.var_get(Slot.raw());
+   info->fixed_type = value.primary;
+   info->object_class_id = value.object_class_id;
+   info->struct_def = value.struct_def;
+   this->assert_analysed_local_type(Slot, Binding);
+   return true;
+}
+
+void IrEmitter::assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) const
+{
+   if (not Binding) return;
+
+   const auto &binding = this->ctx.descriptors().binding(Binding);
+   if (not binding.analysed_value) return;
+
+   const auto &value = this->ctx.descriptors().value(binding.analysed_value);
+   const VarInfo &info = this->func_state.var_get(Slot.raw());
+   lj_assertX(info.fixed_type IS value.primary, "analysed and emitted binding types diverged");
+   lj_assertX(info.object_class_id IS value.object_class_id,
+      "analysed and emitted binding object classes diverged");
+   lj_assertX(info.struct_def IS value.struct_def, "analysed and emitted binding structures diverged");
+}
+
 BCReg IrEmitter::finalise_pending_local_assignment(PreparedAssignment& Target)
 {
    if (not Target.needs_var_add or not Target.pending_symbol) return BCReg(NO_REG);
@@ -672,6 +706,9 @@ BCReg IrEmitter::finalise_pending_local_assignment(PreparedAssignment& Target)
    Target.needs_var_add = false;
    Target.newly_created = false;
 
+   VarInfo *info = &this->func_state.var_get(slot.raw());
+   info->binding_id = Target.binding_id;
+   this->apply_analysed_local_type(slot, Target.binding_id);
    this->update_local_binding(Target.pending_symbol, slot);
    return slot;
 }
@@ -1272,11 +1309,15 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          info->fixed_type = identifier.type;
          info->struct_def = identifier.struct_def;
       }
+      else if (this->apply_analysed_local_type(base + i, identifier.binding_id)) {
+         // The analyser owns sticky fixation.  Its per-binding result covers deferred and secondary values.
+      }
       else if (i.raw() < Payload.values.size()) {
          // No explicit annotation - infer type from initialiser expression
          // Note: Nil is excluded because it represents absence of value, not a type constraint
          this->apply_inferred_local_type(base + i, *Payload.values[i.raw()]);
       }
+      this->assert_analysed_local_type(base + i, identifier.binding_id);
       // If no initialiser and no annotation, fixed_type remains Unknown (set in var_add)
    }
 

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.h
@@ -119,6 +119,7 @@ struct PreparedAssignment {
    bool newly_created = false;   // True if a new local was created for an undeclared variable
    bool needs_var_add = false;   // True if var_add() must be called after expression evaluation
    GCstr* pending_symbol = nullptr;  // Symbol name for deferred var_add
+   StaticBindingID binding_id = 0;
    BCLine pending_line = 0;      // Line number for deferred variable declaration
    BCLine pending_column = 0;    // Column number for deferred variable declaration
    ControlFlowEdge safe_nav_skip;
@@ -229,6 +230,8 @@ private:
    void ensure_register_balance(std::string_view usage);
    void optimise_assert(ExprNodeList &Args);
    void apply_inferred_local_type(BCReg Slot, const ExprNode& Value);
+   bool apply_analysed_local_type(BCReg Slot, StaticBindingID Binding);
+   void assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) const;
    BCReg finalise_pending_local_assignment(PreparedAssignment& Target);
    [[nodiscard]] bool can_elide_expression(const ExprNode &Expression) const;
    [[nodiscard]] bool can_elide_statement(const StmtNode &Statement, bool InLoop) const;

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -85,6 +85,7 @@ struct StaticBindingDescriptor {
    const ExprNode *initialiser = nullptr;
    const FunctionExprPayload *function = nullptr;
    StaticValueHandle value = 0;
+   StaticValueHandle analysed_value = 0;
    StaticCallableHandle callable = 0;
    StaticBindingID alias_of = 0;
    uint8_t result_position = 0;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -239,8 +239,9 @@ private:
    [[nodiscard]] bool is_local_const(GCstr *) const;
 
    // Type fixation - locks variable type after first concrete assignment
-   void fix_local_type(GCstr *, TiriType, CLASSID ObjectClassId = CLASSID::NIL,
+   void fix_local_type(GCstr *, StaticBindingID, TiriType, CLASSID ObjectClassId = CLASSID::NIL,
       struct_record *StructDef = nullptr);
+   void publish_binding_type(StaticBindingID, const InferredType &);
 
    // Usage tracking - marks variables as used for unused variable detection
    void mark_identifier_used(GCstr *);
@@ -1156,6 +1157,24 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
          else is_const = this->is_local_const(name);
 
          if (not existing) {
+            if (name_ref->binding_id and not Payload.values.empty()) {
+               size_t source = std::min(i, Payload.values.size() - 1);
+               size_t result_position = i - source;
+               InferredType inferred;
+               if (result_position IS 0) inferred = this->infer_expression_type(*Payload.values[source]);
+               else inferred = this->infer_call_return_type(*Payload.values[source], result_position);
+
+               inferred.requires_destination_type =
+                  inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown;
+               inferred.is_fixed = inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and
+                  inferred.primary != TiriType::Unknown;
+               if (Payload.op != AssignmentOperator::Plain and not inferred.requires_destination_type) {
+                  this->current_scope().declare_local(name, inferred, target.span);
+                  this->publish_binding_type(name_ref->binding_id, inferred);
+                  continue;
+               }
+            }
+
             // The name is neither a local nor a known global.  A plain assignment to a name that already exists in
             // the environment table updates that global at runtime, so record an implicit global type for it.  Only
             // simple '=' assignments are used for inference; compound operators require an existing value and never
@@ -1282,7 +1301,8 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                   this->fix_global_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def);
                }
                else {
-                  this->fix_local_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def);
+                  this->fix_local_type(name, name_ref->binding_id, value_type.primary,
+                     value_type.object_class_id, value_type.struct_def);
                }
             }
          }
@@ -1411,6 +1431,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       #endif
 
       this->current_scope().declare_local(name.symbol, inferred, name.span, name.has_const);
+      this->publish_binding_type(name.binding_id, inferred);
       this->trace_decl(this->ctx_.lex().linenumber, name.symbol, inferred.primary, inferred.is_fixed);
    }
 
@@ -2509,12 +2530,30 @@ bool TypeAnalyser::is_local_const(GCstr *Name) const
    return false;
 }
 
-void TypeAnalyser::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef)
+void TypeAnalyser::publish_binding_type(StaticBindingID Binding, const InferredType &Type)
+{
+   if (not Binding or not Type.is_fixed or Type.primary IS TiriType::Unknown or
+       Type.primary IS TiriType::Any or Type.primary IS TiriType::Nil) return;
+
+   StaticValueDescriptor value;
+   value.primary = Type.primary;
+   value.object_class_id = Type.object_class_id;
+   value.struct_def = Type.struct_def;
+   value.nullable = Type.is_nullable;
+   value.proof = StaticProof::Advisory;
+   this->ctx_.descriptors().binding(Binding).analysed_value = this->ctx_.descriptors().add_value(value);
+}
+
+void TypeAnalyser::fix_local_type(GCstr *Name, StaticBindingID Binding, TiriType Type,
+   CLASSID ObjectClassId, struct_record *StructDef)
 {
    for (auto it = this->scope_stack_.rbegin(); it != this->scope_stack_.rend(); ++it) {
       auto existing = it->lookup_local_type(Name);
       if (existing) {
          it->fix_local_type(Name, Type, ObjectClassId, StructDef);
+         InferredType fixed(Type, false, false, true, ObjectClassId);
+         fixed.struct_def = StructDef;
+         this->publish_binding_type(Binding, fixed);
          this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
          return;
       }

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -441,6 +441,72 @@ end
       'Initialiser and assignment contract failures must unwind defer state consistently')
 end
 
+@Test function InferredLocalBindingContracts()
+   expect_contract_failure(function()
+      local value
+      value = 'text'
+      value = dynamic_value(42)
+   end, 'deferred local')
+
+   function inferred_pair():<str, str>
+      return 'first', 'second'
+   end
+   expect_contract_failure(function()
+      local first, second = inferred_pair()
+      second = dynamic_value(42)
+   end, 'secondary local result')
+
+   expect_contract_failure(function()
+      local first, second
+      first, second = inferred_pair()
+      second = dynamic_value(42)
+   end, 'deferred secondary local result')
+
+   expect_contract_failure(function()
+      local task = obj.new('task')
+      check task.acSetKey('ProductName', 'Kotuku')
+      local err, value = task.acGetKey('ProductName')
+      value = dynamic_value(42)
+   end, 'native secondary local result')
+
+   expect_contract_failure(function()
+      local value
+      value = struct<ContractAlpha> { Value=1 }
+      value = dynamic_value(struct<ContractBravo> { Value=2 })
+   end, 'deferred named-structure local')
+
+   expect_contract_failure(function()
+      local value
+      value ?= 'text'
+      value = dynamic_value(42)
+   end, 'predeclared if-nil local')
+
+   expect_contract_failure(function()
+      local value
+      value ??= 'text'
+      value = dynamic_value(42)
+   end, 'predeclared if-empty local')
+
+   expect_contract_failure(function()
+      value ?= 'text'
+      value = dynamic_value(42)
+   end, 'implicit if-nil local')
+
+   expect_contract_failure(function()
+      value ??= 'text'
+      value = dynamic_value(42)
+   end, 'implicit if-empty local')
+
+   expect_contract_failure(function()
+      local value
+      value = 'text'
+      function overwrite(Value:any)
+         value = Value
+      end
+      overwrite(42)
+   end, 'captured deferred local')
+end
+
 @Test function TypedLocalAndCapturedUpvalueStores()
    local typed:num = 1
    expect_contract_failure(function() typed = dynamic_value('wrong') end, 'local')


### PR DESCRIPTION
* Published canonical fixed binding metadata through stable binding identifiers
* Enforced deferred, multi-result, conditional and captured local contracts
* [Test] Added runtime regressions for inferred binding contract paths