### PR TITLE
[Tiri] Enforced global type contracts at a central environment mutation boundary

### DIFF
--- a/include/kotuku/modules/script.h
+++ b/include/kotuku/modules/script.h
@@ -38,9 +38,11 @@ struct ScriptArg { // For use with sc::Exec
    ScriptArg(CSTRING pName, int64_t pValue, uint32_t pType = FD_INT64) : Name(pName), Type(pType), Int64(pValue) { }
    ScriptArg(CSTRING pName, double pValue, uint32_t pType = FD_DOUBLE) : Name(pName), Type(pType), Double(pValue) { }
    // The span descriptor must outlive sc::Call(), so we store the address of a caller-owned span.
-   // The caller supplies exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
-   template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) : Name(pName), Type(pType), Address((APTR)&pValue) { }
-   template<typename T> ScriptArg(CSTRING pName, std::span<T> &pValue, uint32_t pType = FDF_SPAN) : Name(pName), Type(pType), Address((APTR)&pValue) { }
+   // Non-byte spans require exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
+   template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) :
+      Name(pName), Type(pType), Address((APTR)&pValue) { }
+   ScriptArg(CSTRING pName, std::span<std::byte> &pValue, uint32_t pType = FDF_SPAN) :
+      Name(pName), Type(pType), Address((APTR)&pValue) { }
    template<typename T> ScriptArg(CSTRING pName, std::span<T> &&pValue, uint32_t pType) = delete;
 };
 

--- a/include/kotuku/modules/script.h
+++ b/include/kotuku/modules/script.h
@@ -40,6 +40,7 @@ struct ScriptArg { // For use with sc::Exec
    // The span descriptor must outlive sc::Call(), so we store the address of a caller-owned span.
    // The caller supplies exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
    template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) : Name(pName), Type(pType), Address((APTR)&pValue) { }
+   template<typename T> ScriptArg(CSTRING pName, std::span<T> &pValue, uint32_t pType = FDF_SPAN) : Name(pName), Type(pType), Address((APTR)&pValue) { }
    template<typename T> ScriptArg(CSTRING pName, std::span<T> &&pValue, uint32_t pType) = delete;
 };
 

--- a/src/core/defs/script.tdl
+++ b/src/core/defs/script.tdl
@@ -32,6 +32,7 @@ struct ScriptArg { // For use with sc::Exec
    // The span descriptor must outlive sc::Call(), so we store the address of a caller-owned span.
    // The caller supplies exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
    template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) : Name(pName), Type(pType), Address((APTR)&pValue) { }
+   template<typename T> ScriptArg(CSTRING pName, std::span<T> &pValue, uint32_t pType = FDF_SPAN) : Name(pName), Type(pType), Address((APTR)&pValue) { }
    template<typename T> ScriptArg(CSTRING pName, std::span<T> &&pValue, uint32_t pType) = delete;
 };
 ]])

--- a/src/core/defs/script.tdl
+++ b/src/core/defs/script.tdl
@@ -30,9 +30,11 @@ struct ScriptArg { // For use with sc::Exec
    ScriptArg(CSTRING pName, int64_t pValue, uint32_t pType = FD_INT64) : Name(pName), Type(pType), Int64(pValue) { }
    ScriptArg(CSTRING pName, double pValue, uint32_t pType = FD_DOUBLE) : Name(pName), Type(pType), Double(pValue) { }
    // The span descriptor must outlive sc::Call(), so we store the address of a caller-owned span.
-   // The caller supplies exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
-   template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) : Name(pName), Type(pType), Address((APTR)&pValue) { }
-   template<typename T> ScriptArg(CSTRING pName, std::span<T> &pValue, uint32_t pType = FDF_SPAN) : Name(pName), Type(pType), Address((APTR)&pValue) { }
+   // Non-byte spans require exact element metadata; binding to a temporary is deleted to prevent a dangling descriptor.
+   template<typename T> ScriptArg(CSTRING pName, const std::span<T> &pValue, uint32_t pType) :
+      Name(pName), Type(pType), Address((APTR)&pValue) { }
+   ScriptArg(CSTRING pName, std::span<std::byte> &pValue, uint32_t pType = FDF_SPAN) :
+      Name(pName), Type(pType), Address((APTR)&pValue) { }
    template<typename T> ScriptArg(CSTRING pName, std::span<T> &&pValue, uint32_t pType) = delete;
 };
 ]])

--- a/src/core/tests/unit_tests_wait_for_objects.cpp
+++ b/src/core/tests/unit_tests_wait_for_objects.cpp
@@ -302,7 +302,8 @@ static bool mid_free_window_check(kt::Log &Log)
    object->setFlag(NF::FREE);
 
    OBJECTID object_id = object->UID;
-   auto result = msg_waitforobjects(nullptr, 0, 0, &object_id, sizeof(object_id));
+   auto result = msg_waitforobjects(nullptr, 0, MSGID::WAIT_FOR_OBJECTS,
+      std::span<std::byte>((std::byte *)&object_id, sizeof(object_id)));
 
    object->clearFlag(NF::FREE);
 

--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -356,8 +356,9 @@ Key facts when working near this machinery:
 - Routed paths: the interpreter's `BC_TSETS_Z` (shared by `BC_GSET`, `BC_TSETS` and string-keyed `BC_TSETV`)
   tests the marker and branches to `->vmeta_envcheck` before resuming the ordinary store; `lua_settable()` and
   `lua_setfield()` check before normal metamethod dispatch, while `lua_rawset()` uses the checked raw store in
-  `lj_api.cpp`; JIT recording emits an `IRCALL_lj_env_check` (see below). Direct `lj_tab_setstr()` calls from C are
-  the trusted bootstrap path and bypass the boundary deliberately.
+  `lj_api.cpp`; JIT recording emits an `IRCALL_lj_env_check` (see below). `table.clear()` rejects marked environments
+  before mutation, and its recorder guards the marker so ordinary-table traces side-exit when passed an environment.
+  Direct `lj_tab_setstr()` calls from C are the trusted bootstrap path and bypass the boundary deliberately.
 - `lj_env_check()` requires a rooted Lua stack slot. The recorder writes the trace value into its corresponding Lua
   stack slot before checking instead of using `IR_TMPREF`/`global_State::tmptv`. `lj_env_store()` also requires a stack
   slot so the raw value can be recovered after stack reallocation.

--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -343,8 +343,9 @@ When adding entries to `MMDEF` in `lj_obj.h`:
 
 ## Environment Mutation Boundary (Global Type Contracts)
 
-Every runtime write to a global environment table is policy-checked through one central function,
-`lj_env_store()` in `src/runtime/lj_meta.cpp` (protected built-ins, sticky type contracts, atomic failure).
+Every runtime write to a global environment table is policy-checked through `lj_env_check()` in
+`src/runtime/lj_meta.cpp` (protected built-ins, sticky type contracts, atomic failure). `lj_env_store()` composes that
+check with the raw write used by `rawset()`.
 Key facts when working near this machinery:
 
 - A table is "an environment" iff `GCtab.global_type_contracts` is non-null (`lj_tab_is_environment()` in
@@ -353,22 +354,21 @@ Key facts when working near this machinery:
   routed store paths reject writes to protected names afterwards. Re-running `luaL_openlibs()` on a protected
   state raises.
 - Routed paths: the interpreter's `BC_TSETS_Z` (shared by `BC_GSET`, `BC_TSETS` and string-keyed `BC_TSETV`)
-  tests the marker and branches to `->vmeta_envset`; `lua_settable`/`lua_setfield`/`lua_rawset` divert in
-  `lj_api.cpp`; JIT recording emits an `IRCALL_lj_env_store` (see below). Direct `lj_tab_setstr()` calls from C
-  are the trusted bootstrap path and bypass the boundary deliberately.
-- `lj_env_store()` requires its `Value` pointer to reference a Lua stack slot (thunk resolution and allocation
-  can reallocate the stack).
-- Both `vm_x64.dasc` and `vm_arm64.dasc` implement the `BC_TSETS_Z` marker test and `vmeta_envset` stub — keep
-  them in sync when touching either.
+  tests the marker and branches to `->vmeta_envcheck` before resuming the ordinary store; `lua_settable()` and
+  `lua_setfield()` check before normal metamethod dispatch, while `lua_rawset()` uses the checked raw store in
+  `lj_api.cpp`; JIT recording emits an `IRCALL_lj_env_check` (see below). Direct `lj_tab_setstr()` calls from C are
+  the trusted bootstrap path and bypass the boundary deliberately.
+- `lj_env_check()` requires a rooted Lua stack slot. The recorder writes the trace value into its corresponding Lua
+  stack slot before checking instead of using `IR_TMPREF`/`global_State::tmptv`. `lj_env_store()` also requires a stack
+  slot so the raw value can be recovered after stack reallocation.
+- `vm_x64.dasc`, `vm_arm64.dasc` and `vm_ppc.dasc` implement the `BC_TSETS_Z` marker test and `vmeta_envcheck` stub —
+  keep all three in sync when touching any of them.
 
 ### JIT interaction
 
 - `lj_record_idx()` guards the marker (`IRFL_TAB_GCONTRACTS` FLOAD vs null) on every recorded string-keyed table
-  store. Marked environments emit the `IRCALL`; dynamic string keys on a marked environment abort the trace
-  (`LJ_TRERR_NYIENVKEY`).
-- `fwd_aa_tab_clear()` in `lj_opt_mem.cpp` treats `IRCALL_lj_env_store` as a conflicting table store. Any new
-  IRCALL that mutates a table behind the alias analyser's back needs the same treatment, or loads after the call
-  forward stale values (symptom: hot loops read pre-store values after the trace compiles).
+  store. Marked environments emit the policy-check `IRCALL` and then use the regular recorded store and metamethod
+  path; dynamic string keys on a marked environment abort the trace (`LJ_TRERR_NYIENVKEY`).
 
 ### Append-only enum lists
 

--- a/src/tiri/jit/AGENTS.md
+++ b/src/tiri/jit/AGENTS.md
@@ -76,6 +76,9 @@ cmake --build build/agents --config <BuildType> --parallel
 cmake --install build/agents --config <BuildType>
 ```
 
+When building targeted instead of the full tree, include `origo_cmd` alongside `tiri` (e.g.
+`--target tiri origo_cmd`) so the installed `origo` executable picks up the changes.
+
 ### JIT Debugging Options
 
 Run `origo` with `--jit-options` to pass JIT engine flags as a CSV list:
@@ -337,6 +340,49 @@ When adding entries to `MMDEF` in `lj_obj.h`:
 3. **Full rebuild**: Run `cmake --build build/agents --config <BuildType> --parallel`
 
 **Note**: CMake includes `lj_obj.h` in the `DEPENDS` clause for both buildvm compilation and VM generation, ensuring automatic regeneration when `lj_obj.h` changes.
+
+## Environment Mutation Boundary (Global Type Contracts)
+
+Every runtime write to a global environment table is policy-checked through one central function,
+`lj_env_store()` in `src/runtime/lj_meta.cpp` (protected built-ins, sticky type contracts, atomic failure).
+Key facts when working near this machinery:
+
+- A table is "an environment" iff `GCtab.global_type_contracts` is non-null (`lj_tab_is_environment()` in
+  `lj_tab.h`). `lj_env_mark()` sets it eagerly from `lua_protect_globals()`, which every script state calls after
+  built-in registration. **Ordering matters**: library registration must complete before marking, because the
+  routed store paths reject writes to protected names afterwards. Re-running `luaL_openlibs()` on a protected
+  state raises.
+- Routed paths: the interpreter's `BC_TSETS_Z` (shared by `BC_GSET`, `BC_TSETS` and string-keyed `BC_TSETV`)
+  tests the marker and branches to `->vmeta_envset`; `lua_settable`/`lua_setfield`/`lua_rawset` divert in
+  `lj_api.cpp`; JIT recording emits an `IRCALL_lj_env_store` (see below). Direct `lj_tab_setstr()` calls from C
+  are the trusted bootstrap path and bypass the boundary deliberately.
+- `lj_env_store()` requires its `Value` pointer to reference a Lua stack slot (thunk resolution and allocation
+  can reallocate the stack).
+- Both `vm_x64.dasc` and `vm_arm64.dasc` implement the `BC_TSETS_Z` marker test and `vmeta_envset` stub — keep
+  them in sync when touching either.
+
+### JIT interaction
+
+- `lj_record_idx()` guards the marker (`IRFL_TAB_GCONTRACTS` FLOAD vs null) on every recorded string-keyed table
+  store. Marked environments emit the `IRCALL`; dynamic string keys on a marked environment abort the trace
+  (`LJ_TRERR_NYIENVKEY`).
+- `fwd_aa_tab_clear()` in `lj_opt_mem.cpp` treats `IRCALL_lj_env_store` as a conflicting table store. Any new
+  IRCALL that mutates a table behind the alias analyser's back needs the same treatment, or loads after the call
+  forward stale values (symptom: hot loops read pre-store values after the trace compiles).
+
+### Append-only enum lists
+
+`IRCALLDEF` (lj_ircall.h) and `IRFLDEF` (lj_ir.h) are **append-only**. Inserting mid-list shifts the numeric ids
+of every later entry, which silently degrades trace behaviour and breaks tests that assert on indices through
+`jit.util.traceIR()` (`test_type_guided_jit_signatures.tiri` hard-codes `IRFL_*` numbers). Add new entries at the
+end of each list only.
+
+## Reference Indexing Gotcha (luaL_ref)
+
+Kotuku's 0-based conversion means `luaL_ref()` must never hand out index 0: slot 0 is `FREELIST_REF`. The
+implementation in `lib/lib_aux.cpp` claims slot 0 for the freelist on first use so references start at 1. Host
+code (e.g. `MainChunkRef` in tiri_class.cpp) treats reference 0 as "no reference", so a 0-valued ref silently
+re-triggers initialisation paths.
 
 ---
 

--- a/src/tiri/jit/CLAUDE.md
+++ b/src/tiri/jit/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -712,6 +712,18 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-----------------------------------------------------------------------
   |
+  |->vmeta_envset:
+  |  // Marked-environment diversion from BC_TSETS_Z: TAB:CARG2 = GCtab *, STR:RC = GCstr *, value at BASE[RA].
+  |  // Routes global-environment stores through the central policy boundary (contracts, protected built-ins).
+  |  str BASE, L->base
+  |  mov CARG3, STR:RC
+  |  add CARG4, BASE, RA, lsl #3
+  |  mov CARG1, L
+  |  str PC, SAVE_PC
+  |  bl extern lj_vm_envset		// (lua_State *L, GCtab *t, GCstr *k, TValue *v)
+  |  ldr BASE, L->base
+  |  ins_next
+  |
   |->vmeta_tsets1:
   |  movn CARG4, #~LJ_TSTR
   |   add CARG2, BASE, RB, lsl #3
@@ -3375,6 +3387,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checktab CARG2, ->vmeta_tsets1
     |->BC_TSETS_Z:
     |  // TAB:CARG2 = GCtab *, STR:RC = GCstr *, RA = src
+    |  ldr TMP0, TAB:CARG2->global_type_contracts
+    |  cbnz TMP0, ->vmeta_envset	// Marked environment: enforce global policy centrally.
     |  ldr TMP1w, TAB:CARG2->hmask
     |   ldr TMP2w, STR:RC->sid
     |    ldr NODE:CARG3, TAB:CARG2->node

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -712,17 +712,20 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-----------------------------------------------------------------------
   |
-  |->vmeta_envset:
-  |  // Marked-environment diversion from BC_TSETS_Z: TAB:CARG2 = GCtab *, STR:RC = GCstr *, value at BASE[RA].
-  |  // Routes global-environment stores through the central policy boundary (contracts, protected built-ins).
+  |->vmeta_envcheck:
+  |  // Marked-environment check from BC_TSETS_Z: TAB:CARG2 = GCtab *, STR:RC = GCstr *, value at BASE[RA].
+  |  // The ordinary store path resumes afterwards so __newindex dispatch remains intact.
   |  str BASE, L->base
   |  mov CARG3, STR:RC
+  |  mov RC, CARG2
   |  add CARG4, BASE, RA, lsl #3
   |  mov CARG1, L
   |  str PC, SAVE_PC
-  |  bl extern lj_vm_envset		// (lua_State *L, GCtab *t, GCstr *k, TValue *v)
+  |  bl extern lj_vm_envcheck		// (lua_State *L, GCtab *t, GCstr *k, TValue *v)
   |  ldr BASE, L->base
-  |  ins_next
+  |  mov CARG2, RC
+  |  mov STR:RC, CRET1
+  |  b ->BC_TSETS_ENV
   |
   |->vmeta_tsets1:
   |  movn CARG4, #~LJ_TSTR
@@ -3388,7 +3391,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |->BC_TSETS_Z:
     |  // TAB:CARG2 = GCtab *, STR:RC = GCstr *, RA = src
     |  ldr TMP0, TAB:CARG2->global_type_contracts
-    |  cbnz TMP0, ->vmeta_envset	// Marked environment: enforce global policy centrally.
+    |  cbnz TMP0, ->vmeta_envcheck	// Marked environment: validate global policy centrally.
+    |->BC_TSETS_ENV:
     |  ldr TMP1w, TAB:CARG2->hmask
     |   ldr TMP2w, STR:RC->sid
     |    ldr NODE:CARG3, TAB:CARG2->node

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1037,6 +1037,22 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-----------------------------------------------------------------------
   |
+  |->vmeta_envcheck:
+  |  // Marked-environment check from BC_TSETS_Z: RB = GCtab *, RC = GCstr *, value at BASE[RA].
+  |  // The ordinary store path resumes afterwards so __newindex dispatch remains intact.
+  |  stp BASE, L->base
+  |  add CARG4, BASE, RA
+  |  mr SAVE0, TAB:RB
+  |  mr CARG3, STR:RC
+  |  mr CARG2, TAB:RB
+  |  mr CARG1, L
+  |  stw PC, SAVE_PC
+  |  bl extern lj_vm_envcheck		// (lua_State *L, GCtab *t, GCstr *k, TValue *v)
+  |  mr TAB:RB, SAVE0
+  |  mr STR:RC, CRET1
+  |  lp BASE, L->base
+  |  b ->BC_TSETS_ENV
+  |
   |->vmeta_tsets1:
   |  la CARG3, DISPATCH_GL(tmptv)(DISPATCH)
   |  li TMP0, LJ_TSTR
@@ -5028,6 +5044,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  bne ->vmeta_tsets1
     |->BC_TSETS_Z:
     |  // TAB:RB = GCtab *, STR:RC = GCstr *, RA = src*8
+    |  lwz TMP0, TAB:RB->global_type_contracts
+    |  cmplwi TMP0, 0
+    |  bne ->vmeta_envcheck		// Marked environment: validate global policy centrally.
+    |->BC_TSETS_ENV:
     |  lwz TMP0, TAB:RB->hmask
     |  lwz TMP1, STR:RC->sid
     |  lwz NODE:TMP2, TAB:RB->node

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -862,6 +862,23 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-----------------------------------------------------------------------
   |
+  |->vmeta_envset:
+  |  // Marked-environment diversion from BC_TSETS_Z: RB = GCtab *, RC = GCstr *, value at BASE[RA].
+  |  // Routes global-environment stores through the central policy boundary (contracts, protected built-ins).
+  |  movzx RAd, PC_RA
+  |  lea ITYPE, [BASE+RA*8]
+  |  mov TMPR, STR:RC
+  |  mov L:CARG1, SAVE_L
+  |  mov L:CARG1->base, BASE
+  |  mov SAVE_PC, PC
+  |  mov CARG2, TAB:RB
+  |  mov CARG3, TMPR
+  |  mov CARG4, ITYPE
+  |  mov L:RB, L:CARG1
+  |  call extern lj_vm_envset      // (lua_State *L, GCtab *t, GCstr *k, TValue *v)
+  |  mov BASE, L:RB->base
+  |  ins_next
+  |
   |->vmeta_tsets:
   |  settp STR:RC, LJ_TSTR    // STR:RC = GCstr *
   |  mov TMP1, STR:RC
@@ -4054,6 +4071,9 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  mov STR:RC, [KBASE+RC*8]
     |  checktab TAB:RB, ->vmeta_tsets
     |->BC_TSETS_Z:   // RB = GCtab *, RC = GCstr *
+    |  mov TMPR, TAB:RB->global_type_contracts
+    |  test TMPR, TMPR
+    |  jnz ->vmeta_envset     // Marked environment: enforce global policy centrally.
     |  mov TMPRd, TAB:RB->hmask
     |  and TMPRd, STR:RC->sid
     |  imul TMPRd, #NODE

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -862,9 +862,9 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-----------------------------------------------------------------------
   |
-  |->vmeta_envset:
-  |  // Marked-environment diversion from BC_TSETS_Z: RB = GCtab *, RC = GCstr *, value at BASE[RA].
-  |  // Routes global-environment stores through the central policy boundary (contracts, protected built-ins).
+  |->vmeta_envcheck:
+  |  // Marked-environment check from BC_TSETS_Z: RB = GCtab *, RC = GCstr *, value at BASE[RA].
+  |  // The ordinary store path resumes afterwards so __newindex dispatch remains intact.
   |  movzx RAd, PC_RA
   |  lea ITYPE, [BASE+RA*8]
   |  mov TMPR, STR:RC
@@ -874,10 +874,12 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov CARG2, TAB:RB
   |  mov CARG3, TMPR
   |  mov CARG4, ITYPE
-  |  mov L:RB, L:CARG1
-  |  call extern lj_vm_envset      // (lua_State *L, GCtab *t, GCstr *k, TValue *v)
-  |  mov BASE, L:RB->base
-  |  ins_next
+  |  call extern lj_vm_envcheck    // (lua_State *L, GCtab *t, GCstr *k, TValue *v)
+  |  mov L:CARG1, SAVE_L
+  |  mov BASE, L:CARG1->base
+  |  movzx RAd, PC_RA
+  |  // lj_vm_envcheck() returns the string key in RC; RB is callee-saved.
+  |  jmp ->BC_TSETS_ENV
   |
   |->vmeta_tsets:
   |  settp STR:RC, LJ_TSTR    // STR:RC = GCstr *
@@ -4073,7 +4075,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |->BC_TSETS_Z:   // RB = GCtab *, RC = GCstr *
     |  mov TMPR, TAB:RB->global_type_contracts
     |  test TMPR, TMPR
-    |  jnz ->vmeta_envset     // Marked environment: enforce global policy centrally.
+    |  jnz ->vmeta_envcheck   // Marked environment: validate global policy centrally.
+    |->BC_TSETS_ENV:
     |  mov TMPRd, TAB:RB->hmask
     |  and TMPRd, STR:RC->sid
     |  imul TMPRd, #NODE

--- a/src/tiri/jit/src/lib/lib_aux.cpp
+++ b/src/tiri/jit/src/lib/lib_aux.cpp
@@ -272,6 +272,12 @@ extern int luaL_ref(lua_State* L, int t)
       return LUA_REFNIL;  //  `nil' has a unique fixed reference
    }
    lua_rawgeti(L, t, FREELIST_REF);  //  get first free element
+   if (lua_isnil(L, -1)) {
+      // First use: claim slot 0 for the freelist so allocated references never alias FREELIST_REF.  Without this,
+      // 0-based objlen() hands out ref 0, which both corrupts the freelist and reads as "no reference" to callers.
+      lua_pushinteger(L, 0);
+      lua_rawseti(L, t, FREELIST_REF);
+   }
    ref = (int)lua_tointeger(L, -1);  //  ref = t[FREELIST_REF]
    lua_pop(L, 1);  //  remove it from stack
    if (ref != 0) {  // any free element?

--- a/src/tiri/jit/src/lib/lib_init.cpp
+++ b/src/tiri/jit/src/lib/lib_init.cpp
@@ -81,4 +81,7 @@ extern void lua_protect_globals(lua_State* L)
          strV(&entry->key)->flags |= STRFLAG_PROTECTED_GLOBAL;
       }
    }
+
+   // Marking must follow registration: from here on, every store route treats the environment as policy-checked.
+   lj_env_mark(L, globals);
 }

--- a/src/tiri/jit/src/lib/lib_table.cpp
+++ b/src/tiri/jit/src/lib/lib_table.cpp
@@ -290,7 +290,12 @@ LJLIB_CF(table_empty)
 
 LJLIB_CF(table_clear)   LJLIB_REC(.)
 {
-   lj_tab_clear(lj_lib_checktab(L, 1));
+   GCtab *table = lj_lib_checktab(L, 1);
+   if (lj_tab_is_environment(table)) {
+      lj_err_callermsg(L, "cannot clear a global environment");
+   }
+
+   lj_tab_clear(table);
    return 0;
 }
 

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1232,9 +1232,8 @@ extern void lua_settable(lua_State *L, int idx)
    cTValue *t = index2adr_check(L, idx);
    lj_checkapi_slot(2);
    if (tvistab(t) and lj_tab_is_environment(tabV(t)) and tvisstr(L->top - 2)) {
-      lj_env_store(L, tabV(t), strV(L->top - 2), L->top - 1);
-      L->top -= 2;
-      return;
+      lj_env_check(L, tabV(t), strV(L->top - 2), L->top - 1);
+      t = index2adr_check(L, idx);  // The policy check may reallocate the stack.
    }
    TValue *o = lj_meta_tset(L, t, L->top - 2);
    if (o) {
@@ -1257,9 +1256,8 @@ extern void lua_setfield(lua_State *L, int idx, CSTRING k)
    lj_checkapi_slot(1);
    setstrV(L, &key, lj_str_newz(L, k));
    if (tvistab(t) and lj_tab_is_environment(tabV(t))) {
-      lj_env_store(L, tabV(t), strV(&key), L->top - 1);
-      L->top--;
-      return;
+      lj_env_check(L, tabV(t), strV(&key), L->top - 1);
+      t = index2adr_check(L, idx);  // The policy check may reallocate the stack.
    }
    TValue *o = lj_meta_tset(L, t, &key);
    if (o) {

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1231,6 +1231,11 @@ extern void lua_settable(lua_State *L, int idx)
 {
    cTValue *t = index2adr_check(L, idx);
    lj_checkapi_slot(2);
+   if (tvistab(t) and lj_tab_is_environment(tabV(t)) and tvisstr(L->top - 2)) {
+      lj_env_store(L, tabV(t), strV(L->top - 2), L->top - 1);
+      L->top -= 2;
+      return;
+   }
    TValue *o = lj_meta_tset(L, t, L->top - 2);
    if (o) {
       // NOBARRIER: lj_meta_tset ensures the table is not black.
@@ -1251,6 +1256,11 @@ extern void lua_setfield(lua_State *L, int idx, CSTRING k)
    cTValue *t = index2adr_check(L, idx);
    lj_checkapi_slot(1);
    setstrV(L, &key, lj_str_newz(L, k));
+   if (tvistab(t) and lj_tab_is_environment(tabV(t))) {
+      lj_env_store(L, tabV(t), strV(&key), L->top - 1);
+      L->top--;
+      return;
+   }
    TValue *o = lj_meta_tset(L, t, &key);
    if (o) {
       // NOBARRIER: lj_meta_tset ensures the table is not black.
@@ -1270,6 +1280,11 @@ extern void lua_rawset(lua_State *L, int idx)
    TValue* dst, * key;
    lj_checkapi_slot(2);
    key = L->top - 2;
+   if (lj_tab_is_environment(t) and tvisstr(key)) {
+      lj_env_store(L, t, strV(key), key + 1);
+      L->top -= 2;  // Not via 'key': the boundary may reallocate the stack.
+      return;
+   }
    dst = lj_tab_set(L, t, key);
    copyTV(L, dst, key + 1);
    lj_gc_anybarriert(L, t);

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -350,6 +350,7 @@ static void recff_rawset(jit_State* J, RecordFFData* rd)
    ix.tab = J->base[0]; ix.key = J->base[1]; ix.val = J->base[2];
    if (tref_istab(ix.tab) and ix.key and ix.val) {
       ix.idxchain = 0;
+      ix.val_slot = 2;
       settabV(J->L, &ix.tabv, tabV(&rd->argv[0]));
       copyTV(J->L, &ix.keyv, &rd->argv[1]);
       copyTV(J->L, &ix.valv, &rd->argv[2]);

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -1682,6 +1682,9 @@ static void recff_table_clear(jit_State* J, RecordFFData* rd)
 {
    TRef tr = J->base[0];
    if (tref_istab(tr)) {
+      if (lj_tab_is_environment(tabV(&rd->argv[0]))) lj_trace_err(J, LJ_TRERR_NYIFFU);
+      TRef marker = emitir(IRT(IR_FLOAD, IRT_TAB), tr, IRFL_TAB_GCONTRACTS);
+      emitir(IRTG(IR_EQ, IRT_TAB), marker, lj_ir_knull(J, IRT_TAB));
       rd->nres = 0;
       lj_ir_call(J, IRCALL_lj_tab_clear, tr);
       J->needsnap = 1;

--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -218,7 +218,8 @@ typedef enum {
   _(OBJ_PTR,   offsetof(GCobject, ptr)) \
   _(STRUCT_FLAGS, offsetof(GCstruct, flags)) \
   _(STRUCT_DATA, offsetof(GCstruct, data)) \
-  _(STRUCT_DEF, offsetof(GCstruct, def))
+  _(STRUCT_DEF, offsetof(GCstruct, def)) \
+  _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts))
 
 typedef enum {
 #define FLENUM(name, ofs)   IRFL_##name,

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -233,7 +233,7 @@ typedef struct CCallInfo {
   _(ANY,        jit_object_getstr, 4, S, NIL, CCI_L|CCI_T) \
   _(ANY,        jit_object_getobj, 4, S, NIL, CCI_L|CCI_T) \
   /* Environment mutation boundary */ \
-  _(ANY,        lj_env_store,      4, S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_env_check,      4, S, NIL, CCI_L|CCI_T) \
   \
   // End of list.
 
@@ -268,4 +268,4 @@ extern "C" void lj_try_enter(lua_State *L, GCfunc *Func, TValue *Base, uint16_t 
 extern "C" void lj_try_leave(lua_State *L);
 
 // Environment mutation boundary (see lj_meta.cpp).
-extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value);
+extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value);

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -232,6 +232,8 @@ typedef struct CCallInfo {
   _(ANY,        jit_object_unlock, 1, S, NIL, 0) \
   _(ANY,        jit_object_getstr, 4, S, NIL, CCI_L|CCI_T) \
   _(ANY,        jit_object_getobj, 4, S, NIL, CCI_L|CCI_T) \
+  /* Environment mutation boundary */ \
+  _(ANY,        lj_env_store,      4, S, NIL, CCI_L|CCI_T) \
   \
   // End of list.
 
@@ -264,3 +266,6 @@ LJ_DATA const CCallInfo lj_ir_callinfo[IRCALL__MAX+1];
 // Try-except exception handling runtime functions
 extern "C" void lj_try_enter(lua_State *L, GCfunc *Func, TValue *Base, uint16_t TryBlockIndex);
 extern "C" void lj_try_leave(lua_State *L);
+
+// Environment mutation boundary (see lj_meta.cpp).
+extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value);

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -72,7 +72,7 @@ static AliasRet aa_table(jit_State* J, IRRef ta, IRRef tb)
    return aa_escape(J, taba, tabb);
 }
 
-// Check whether there's no aliasing table.clear.
+// Check whether there's no aliasing table.clear or environment store.
 static int fwd_aa_tab_clear(jit_State* J, IRRef lim, IRRef ta)
 {
    IRRef ref = J->chain[IR_CALLS];
@@ -81,6 +81,12 @@ static int fwd_aa_tab_clear(jit_State* J, IRRef lim, IRRef ta)
       if (calls->op2 == IRCALL_lj_tab_clear and
          (ta == calls->op1 or aa_table(J, ta, calls->op1) != ALIAS_NO))
          return 0;  //  Conflict.
+      if (calls->op2 == IRCALL_lj_env_store) {
+         // The environment mutation boundary stores into its table argument (first CARG in the chain).
+         IRRef tab = calls->op1;
+         while (IR(tab)->o == IR_CARG) tab = IR(tab)->op1;
+         if (ta == tab or aa_table(J, ta, tab) != ALIAS_NO) return 0;  //  Conflict.
+      }
       ref = calls->prev;
    }
    return 1;  //  No conflict. Can safely FOLD/CSE.

--- a/src/tiri/jit/src/lj_opt_mem.cpp
+++ b/src/tiri/jit/src/lj_opt_mem.cpp
@@ -72,7 +72,7 @@ static AliasRet aa_table(jit_State* J, IRRef ta, IRRef tb)
    return aa_escape(J, taba, tabb);
 }
 
-// Check whether there's no aliasing table.clear or environment store.
+// Check whether there's no aliasing table.clear.
 static int fwd_aa_tab_clear(jit_State* J, IRRef lim, IRRef ta)
 {
    IRRef ref = J->chain[IR_CALLS];
@@ -81,12 +81,6 @@ static int fwd_aa_tab_clear(jit_State* J, IRRef lim, IRRef ta)
       if (calls->op2 == IRCALL_lj_tab_clear and
          (ta == calls->op1 or aa_table(J, ta, calls->op1) != ALIAS_NO))
          return 0;  //  Conflict.
-      if (calls->op2 == IRCALL_lj_env_store) {
-         // The environment mutation boundary stores into its table argument (first CARG in the chain).
-         IRRef tab = calls->op1;
-         while (IR(tab)->o == IR_CARG) tab = IR(tab)->op1;
-         if (ta == tab or aa_table(J, ta, tab) != ALIAS_NO) return 0;  //  Conflict.
-      }
       ref = calls->prev;
    }
    return 1;  //  No conflict. Can safely FOLD/CSE.

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -1928,6 +1928,24 @@ handlemm:
       }
    }
 
+   // Environment mutation boundary: string-keyed stores must honour the destination's runtime policy, so the
+   // environment marker is guarded on every recorded path.  Ordinary tables prove the marker is clear before the
+   // direct store; marked environments divert the store through lj_env_store() so sticky contracts and protected
+   // built-ins hold after trace compilation.
+   if (ix->val and tvisstr(&ix->keyv) and tvistab(&ix->tabv)) {
+      IRBuilder irb(J);
+      TRef marker = irb.fload_tab(ix->tab, IRFL_TAB_GCONTRACTS);
+      if (lj_tab_is_environment(tabV(&ix->tabv))) {
+         irb.guard_ne(marker, irb.knull(IRT_TAB), IRT_TAB);
+         if (not tref_isk(ix->key)) lj_trace_err(J, LJ_TRERR_NYIENVKEY);
+         TRef tmp = rec_tmpref(J, ix->val, IRTMPREF_IN1);
+         lj_ir_call(J, IRCALL_lj_env_store, ix->tab, lj_ir_kstr(J, strV(&ix->keyv)), tmp);
+         J->needsnap = 1;
+         return 0;
+      }
+      irb.guard_eq(marker, irb.knull(IRT_TAB), IRT_TAB);
+   }
+
    // Record the key lookup.
    xref = rec_idx_key(J, ix, &rbp);
    xrefop = (IROp)IR(tref_ref(xref))->o;

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -60,7 +60,7 @@ static TRef sload(jit_State *J, int32_t Slot);
 //********************************************************************************************************************
 // Materialise live trace slots back to the Lua stack before a throwable helper runs inside a recorded try block.
 
-static TRef rec_try_stack_slot_addr(jit_State *J, IRBuilder& Ir, int32_t AbsoluteSlot)
+static TRef rec_stack_slot_addr(jit_State *J, IRBuilder& Ir, int32_t AbsoluteSlot)
 {
    lj_assertJ(AbsoluteSlot >= 0 and AbsoluteSlot < LJ_MAX_JSLOTS + LJ_STACK_EXTRA,
       "try materialisation slot out of range");
@@ -68,7 +68,7 @@ static TRef rec_try_stack_slot_addr(jit_State *J, IRBuilder& Ir, int32_t Absolut
    return Ir.emit(IRT(IR_ADD, IRT_PGC), REF_BASE, Ir.kint(byte_offset));
 }
 
-static void rec_try_emit_tvalue_store(jit_State *J, TRef SlotAddr, TRef ValueRef)
+static void rec_emit_tvalue_store(jit_State *J, TRef SlotAddr, TRef ValueRef)
 {
    if (tref_isnum(ValueRef)) {
       emitir(IRT(IR_XSTORE, IRT_NUM), SlotAddr, ValueRef);
@@ -131,8 +131,8 @@ static void rec_try_materialise_slots(jit_State *J, bool ForceLoad, BCREG SlotLi
          continue;
       }
 
-      TRef slot_addr = rec_try_stack_slot_addr(J, ir, absolute_slot);
-      rec_try_emit_tvalue_store(J, slot_addr, value_ref);
+      TRef slot_addr = rec_stack_slot_addr(J, ir, absolute_slot);
+      rec_emit_tvalue_store(J, slot_addr, value_ref);
       J->trymat[absolute_slot] = value_ref;
       J->try_stores++;
       if (ForceLoad) J->try_enter_stores++;
@@ -1930,20 +1930,22 @@ handlemm:
 
    // Environment mutation boundary: string-keyed stores must honour the destination's runtime policy, so the
    // environment marker is guarded on every recorded path.  Ordinary tables prove the marker is clear before the
-   // direct store; marked environments divert the store through lj_env_store() so sticky contracts and protected
-   // built-ins hold after trace compilation.
+   // direct store; marked environments validate the policy before continuing through the ordinary store and
+   // __newindex machinery.
    if (ix->val and tvisstr(&ix->keyv) and tvistab(&ix->tabv)) {
       IRBuilder irb(J);
       TRef marker = irb.fload_tab(ix->tab, IRFL_TAB_GCONTRACTS);
       if (lj_tab_is_environment(tabV(&ix->tabv))) {
          irb.guard_ne(marker, irb.knull(IRT_TAB), IRT_TAB);
          if (not tref_isk(ix->key)) lj_trace_err(J, LJ_TRERR_NYIENVKEY);
-         TRef tmp = rec_tmpref(J, ix->val, IRTMPREF_IN1);
-         lj_ir_call(J, IRCALL_lj_env_store, ix->tab, lj_ir_kstr(J, strV(&ix->keyv)), tmp);
+         if (ix->val_slot < 0) lj_trace_err(J, LJ_TRERR_NYIBC);
+         TRef value_slot = rec_stack_slot_addr(J, irb, int32_t(J->baseslot) + ix->val_slot);
+         rec_emit_tvalue_store(J, value_slot, ix->val);
+         emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
+         lj_ir_call(J, IRCALL_lj_env_check, ix->tab, lj_ir_kstr(J, strV(&ix->keyv)), value_slot);
          J->needsnap = 1;
-         return 0;
       }
-      irb.guard_eq(marker, irb.knull(IRT_TAB), IRT_TAB);
+      else irb.guard_eq(marker, irb.knull(IRT_TAB), IRT_TAB);
    }
 
    // Record the key lookup.
@@ -2569,10 +2571,12 @@ static void rec_decode_operands(jit_State *J, cTValue *lbase, RecordOps *ops)
    // Decode 'A' operand
    ops->ra = bc_a(ins);
    ops->ix.val = 0;
+   ops->ix.val_slot = -1;
 
    switch (bcmode_a(op)) {
       case BCMvar:
          copyTV(J->L, ops->rav(), &lbase[ops->ra]);
+         ops->ix.val_slot = int32_t(ops->ra);
          ops->ix.val = ops->ra = getslot(J, ops->ra);
          break;
       default: break;  // Handled later by opcode-specific code.

--- a/src/tiri/jit/src/lj_record.h
+++ b/src/tiri/jit/src/lj_record.h
@@ -24,7 +24,8 @@ typedef struct RecordIndex {
    TRef val;         //  Value reference for a store or 0 for a load.
    TRef mt;          //  Metatable reference.
    TRef mobj;        //  Metamethod object reference.
-   int idxchain;     //  Index indirections left or 0 for raw lookup.
+   int idxchain;              //  Index indirections left or 0 for raw lookup.
+   int32_t val_slot = -1;     //  Lua stack slot for a stored value, or -1 if the value is not stack-backed.
 } RecordIndex;
 
 LJ_FUNC int lj_record_objcmp(jit_State* J, TRef a, TRef b, cTValue* av, cTValue* bv);

--- a/src/tiri/jit/src/lj_traceerr.h
+++ b/src/tiri/jit/src/lj_traceerr.h
@@ -33,6 +33,7 @@ TREDEF(STORENN,   "store with nil or NaN key")
 TREDEF(NOMM,   "missing metamethod")
 TREDEF(IDXLOOP,   "looping index lookup")
 TREDEF(NYITMIX,   "NYI: mixed sparse/dense table")
+TREDEF(NYIENVKEY,   "NYI: dynamic key store to a global environment")
 
 // Recording C data operations.
 TREDEF(NOCACHE,   "symbol not in cache")

--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -68,17 +68,6 @@ static GCstr * protected_global_store_key(LexState &State, const ExprNode &Expr)
    return nullptr;
 }
 
-static bool computed_global_environment_store(LexState &State, const ExprNode &Expr)
-{
-   if (Expr.kind != AstNodeKind::IndexExpr) return false;
-
-   const auto &payload = std::get<IndexExprPayload>(Expr.data);
-   if (not payload.table or not payload.index or
-      not is_global_environment_reference(State, *payload.table)) return false;
-
-   return emit_literal_string_key(*payload.index) IS nullptr;
-}
-
 static void patch_safe_nav_skip_here(PreparedAssignment& Target, FuncState& State)
 {
    if (Target.safe_nav_skip.valid()) Target.safe_nav_skip.patch_to(BCPos(State.pc));
@@ -814,12 +803,8 @@ ParserResult<std::vector<PreparedAssignment>> IrEmitter::prepare_assignment_targ
             ParserErrorCode::InternalInvariant, "assignment target missing"));
       }
 
-      if (computed_global_environment_store(this->lex_state, *node)) {
-         return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(
-            ParserErrorCode::OverrideProtectedGlobal,
-            "cannot override built-in through computed _G key",
-            node->span));
-      }
+      // Computed '_G[key]' assignment is permitted: the runtime environment mutation boundary enforces sticky
+      // contracts and protected built-ins for every environment store.
 
       if (GCstr *protected_name = protected_global_store_key(this->lex_state, *node)) {
          return ParserResult<std::vector<PreparedAssignment>>::failure(this->make_error(

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -688,8 +688,7 @@ void IrEmitter::assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) 
    const auto &value = this->ctx.descriptors().value(binding.analysed_value);
    const VarInfo &info = this->func_state.var_get(Slot.raw());
    lj_assertX(info.fixed_type IS value.primary, "analysed and emitted binding types diverged");
-   lj_assertX(info.object_class_id IS value.object_class_id,
-      "analysed and emitted binding object classes diverged");
+   lj_assertX(info.object_class_id IS value.object_class_id, "analysed and emitted binding object classes diverged");
    lj_assertX(info.struct_def IS value.struct_def, "analysed and emitted binding structures diverged");
 }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -13,6 +13,7 @@
 #include "bytecode/lj_bcdump.h"
 #include "runtime/lj_contract.h"
 #include "runtime/lj_str.h"
+#include "runtime/lj_tab.h"
 
 #include <array>
 #include <chrono>
@@ -3007,6 +3008,91 @@ static bool test_static_result_set_model(kt::Log &Log)
 
 static size_t count_opcode_tree(const BytecodeSnapshot &, BCOp);
 
+static int envstore_protected_attempt(lua_State *L)
+{
+   lua_pushinteger(L, 42);
+   lua_setglobal(L, "tostring");
+   return 0;
+}
+
+static int envstore_contract_attempt(lua_State *L)
+{
+   lua_pushinteger(L, 42);
+   lua_setglobal(L, "glUnitEnvBoundary");
+   return 0;
+}
+
+static bool test_environment_store_boundary(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *L = state.get();
+   luaL_openlibs(L);
+   lua_protect_globals(L);
+
+   GCtab *environment = tabref(L->env);
+   if (not lj_tab_is_environment(environment)) {
+      Log.error("lua_protect_globals() did not mark the environment table");
+      return false;
+   }
+
+   // A protected built-in must be rejected before mutation.
+   lua_pushcfunction(L, envstore_protected_attempt);
+   if (lua_pcall(L, 0, 0, 0) IS 0) {
+      Log.error("storing over a protected built-in did not raise");
+      return false;
+   }
+   lua_pop(L, 1);  //  Pop the error message.
+   lua_getglobal(L, "tostring");
+   bool preserved = lua_isfunction(L, -1);
+   lua_pop(L, 1);
+   if (not preserved) {
+      Log.error("the rejected store mutated the protected built-in");
+      return false;
+   }
+
+   // A declared concrete global must reject an incompatible C API store and preserve its value.
+   if (lua_load(L, std::string_view("global glUnitEnvBoundary = 'text'"), "=envboundary") or
+       lua_pcall(L, 0, 0, 0)) {
+      Log.error("declaring the unit-test global failed: %s", lua_tostring(L, -1));
+      return false;
+   }
+   lua_pushcfunction(L, envstore_contract_attempt);
+   if (lua_pcall(L, 0, 0, 0) IS 0) {
+      Log.error("an incompatible C API store did not raise against the persisted contract");
+      return false;
+   }
+   lua_pop(L, 1);
+   lua_getglobal(L, "glUnitEnvBoundary");
+   bool value_kept = lua_isstring(L, -1);
+   lua_pop(L, 1);
+   if (not value_kept) {
+      Log.error("the rejected store mutated the declared global");
+      return false;
+   }
+
+   // Compatible stores and nil clears must pass through the boundary unchanged.
+   lua_pushstring(L, "replacement");
+   lua_setglobal(L, "glUnitEnvBoundary");
+   lua_pushnil(L);
+   lua_setglobal(L, "glUnitEnvBoundary");
+   lua_getglobal(L, "glUnitEnvBoundary");
+   bool cleared = lua_isnil(L, -1);
+   lua_pop(L, 1);
+   if (not cleared) {
+      Log.error("a nil store through the boundary did not clear the global");
+      return false;
+   }
+
+   // Ordinary tables must not be treated as environments.
+   lua_newtable(L);
+   if (lj_tab_is_environment(tabV(L->top - 1))) {
+      Log.error("an ordinary table reads as a marked environment");
+      return false;
+   }
+   lua_pop(L, 1);
+   return true;
+}
+
 static bool test_native_prototype_result_descriptors(kt::Log &Log)
 {
    fprototype prototype{};
@@ -3545,7 +3631,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 44> tests = { {
+   constexpr std::array<TestCase, 45> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -3585,6 +3671,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "ternary_falsey_semantics", test_ternary_falsey_semantics },
       { "static_descriptor_model", test_static_descriptor_model },
       { "static_result_set_model", test_static_result_set_model },
+      { "environment_store_boundary", test_environment_store_boundary },
       { "native_prototype_result_descriptors", test_native_prototype_result_descriptors },
       { "object_call_result_descriptors", test_object_call_result_descriptors },
       { "module_call_result_descriptors", test_module_call_result_descriptors },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3022,6 +3022,14 @@ static int envstore_contract_attempt(lua_State *L)
    return 0;
 }
 
+static int envstore_newindex_capture(lua_State *L)
+{
+   lua_pushstring(L, "glUnitEnvMetaCapture");
+   lua_pushvalue(L, 3);
+   lua_rawset(L, 1);
+   return 0;
+}
+
 static bool test_environment_store_boundary(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -3082,6 +3090,50 @@ static bool test_environment_store_boundary(kt::Log &Log)
       Log.error("a nil store through the boundary did not clear the global");
       return false;
    }
+
+   // Non-raw C API stores must validate policy without bypassing the environment's __newindex handler.
+   lua_pushvalue(L, LUA_GLOBALSINDEX);
+   lua_newtable(L);
+   lua_pushcfunction(L, envstore_newindex_capture);
+   lua_setfield(L, -2, "__newindex");
+   lua_setmetatable(L, -2);
+   lua_pop(L, 1);
+
+   lua_pushvalue(L, LUA_GLOBALSINDEX);
+   lua_pushstring(L, "glUnitEnvSetTable");
+   lua_pushinteger(L, 21);
+   lua_settable(L, -3);
+   lua_pop(L, 1);
+   lua_getglobal(L, "glUnitEnvSetTable");
+   bool settable_absent = lua_isnil(L, -1);
+   lua_pop(L, 1);
+   lua_getglobal(L, "glUnitEnvMetaCapture");
+   bool settable_routed = lua_tointeger(L, -1) IS 21;
+   lua_pop(L, 1);
+   if (not settable_absent or not settable_routed) {
+      Log.error("lua_settable() bypassed the environment __newindex handler");
+      return false;
+   }
+
+   lua_pushvalue(L, LUA_GLOBALSINDEX);
+   lua_pushinteger(L, 42);
+   lua_setfield(L, -2, "glUnitEnvSetField");
+   lua_pop(L, 1);
+   lua_getglobal(L, "glUnitEnvSetField");
+   bool setfield_absent = lua_isnil(L, -1);
+   lua_pop(L, 1);
+   lua_getglobal(L, "glUnitEnvMetaCapture");
+   bool setfield_routed = lua_tointeger(L, -1) IS 42;
+   lua_pop(L, 1);
+   if (not setfield_absent or not setfield_routed) {
+      Log.error("lua_setfield() bypassed the environment __newindex handler");
+      return false;
+   }
+
+   lua_pushvalue(L, LUA_GLOBALSINDEX);
+   lua_pushnil(L);
+   lua_setmetatable(L, -2);
+   lua_pop(L, 1);
 
    // Ordinary tables must not be treated as environments.
    lua_newtable(L);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -217,9 +217,7 @@ private:
    void analyse_call_expr(const CallExprPayload &);
    [[nodiscard]] bool is_global_environment_reference(const ExprNode &) const;
    [[nodiscard]] GCstr * protected_global_store_key(const ExprNode &) const;
-   [[nodiscard]] bool computed_global_environment_store(const ExprNode &) const;
    void report_protected_global_override(GCstr *, SourceSpan);
-   void report_computed_global_environment_store(SourceSpan);
    void report_dynamic_destination_required(GCstr *, SourceSpan, bool IsGlobal);
 
    // Argument type checking for function calls
@@ -1114,10 +1112,8 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
       if (not target_ptr) continue;
       const auto &target = *target_ptr;
 
-      if (this->computed_global_environment_store(target)) {
-         this->report_computed_global_environment_store(target.span);
-         continue;
-      }
+      // Computed '_G[key]' assignment is permitted: the runtime environment mutation boundary enforces sticky
+      // contracts and protected built-ins for every environment store.
 
       if (GCstr *protected_name = this->protected_global_store_key(target)) {
          this->report_protected_global_override(protected_name, target.span);
@@ -1692,17 +1688,6 @@ GCstr * TypeAnalyser::protected_global_store_key(const ExprNode &Expr) const
    return nullptr;
 }
 
-bool TypeAnalyser::computed_global_environment_store(const ExprNode &Expr) const
-{
-   if (Expr.kind != AstNodeKind::IndexExpr) return false;
-
-   const auto &payload = std::get<IndexExprPayload>(Expr.data);
-   if (not payload.table or not payload.index or
-      not this->is_global_environment_reference(*payload.table)) return false;
-
-   return type_literal_string_key(*payload.index) IS nullptr;
-}
-
 void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Location)
 {
    if (not Name) return;
@@ -1711,15 +1696,6 @@ void TypeAnalyser::report_protected_global_override(GCstr *Name, SourceSpan Loca
    diag.location = Location;
    diag.code = ParserErrorCode::OverrideProtectedGlobal;
    diag.message = std::format("cannot override built-in '{}'", std::string_view(strdata(Name), Name->len));
-   this->record_diagnostic(std::move(diag));
-}
-
-void TypeAnalyser::report_computed_global_environment_store(SourceSpan Location)
-{
-   TypeDiagnostic diag;
-   diag.location = Location;
-   diag.code = ParserErrorCode::OverrideProtectedGlobal;
-   diag.message = "cannot override built-in through computed _G key";
    this->record_diagnostic(std::move(diag));
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -829,29 +829,30 @@ extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t Dyna
 }
 
 //********************************************************************************************************************
-// Central environment mutation boundary.  Every runtime write to a marked global environment (VM store fast paths,
-// rawset(), the C API and JIT-recorded stores) must pass through here so sticky contracts and protected built-ins
-// are enforced regardless of source syntax or table aliasing.  Checks run strictly before mutation, so a failed
-// store leaves both the stored value and the persisted policy unchanged.
+// Central environment mutation policy check.  Every runtime write to a marked global environment (VM store fast
+// paths, rawset(), the C API and JIT-recorded stores) must pass through here so sticky contracts and protected
+// built-ins are enforced regardless of source syntax or table aliasing.  Checks run strictly before mutation, so a
+// failed store leaves both the stored value and the persisted policy unchanged.
 //
-// Value must reference a Lua stack slot: thunk resolution and table allocation can reallocate the stack.
+// Value must reference a rooted Lua stack slot and L->top must be valid.  The recorder materialises JIT values in
+// their corresponding Lua stack slot before emitting this call.
 
-extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
+extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
 {
+   TValue checked;
+   copyTV(L, &checked, Value);
+
    if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
       CSTRING message = lj_strfmt_pushf(L, "cannot override built-in '%s'", strdata(Name));
       lj_err_callermsg(L, message);
    }
 
-   ptrdiff_t value_offset = savestack(L, Value);
    if (GCstr *persisted = lj_tab_get_global_contract(Environment, Name)) {
       RuntimeContractDescriptor descriptor;
       decode_contract_or_error(L, persisted, descriptor);
       if (descriptor.contract_count >= 1) {
          const RuntimeContractEntry &entry = descriptor.entries[0];
          if (entry.type != TiriType::Any and entry.type != TiriType::Unknown) {
-            TValue checked;
-            copyTV(L, &checked, Value);
             if (lj_is_thunk(&checked)) {
                // Validate the resolved value, but store the original thunk to preserve lazy evaluation on read.
                VMHelperGuard guard(L);
@@ -864,7 +865,16 @@ extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
          }
       }
    }
+}
 
+//********************************************************************************************************************
+// Checked raw environment store.  Value must reference a Lua stack slot so it can be recovered after policy checks
+// and table allocation resize the stack.  Non-raw paths call lj_env_check() and then resume normal metamethod dispatch.
+
+extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
+{
+   ptrdiff_t value_offset = savestack(L, Value);
+   lj_env_check(L, Environment, Name, Value);
    Environment->nomm = 0;  //  Invalidate negative metamethod cache, matching the diverted VM store path.
    TValue *slot = lj_tab_setstr(L, Environment, Name);
    copyTV(L, slot, restorestack(L, value_offset));
@@ -872,13 +882,15 @@ extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
 }
 
 //********************************************************************************************************************
-// VM entry point for the environment mutation boundary, reached when BC_TSETS_Z diverts a store to a marked
-// environment (BC_GSET, BC_TSETS and string-keyed BC_TSETV all funnel through that fast path).
+// VM entry point for the environment mutation check, reached when BC_TSETS_Z encounters a marked environment.  The
+// assembly resumes its ordinary store path afterwards so __newindex behaviour remains unchanged.  Returning Name
+// lets each architecture restore the caller-clobbered key register without introducing another saved register.
 
-extern "C" void lj_vm_envset(lua_State *L, GCtab *Environment, GCstr *Name, TValue *Value)
+extern "C" GCstr * lj_vm_envcheck(lua_State *L, GCtab *Environment, GCstr *Name, TValue *Value)
 {
    L->top = curr_topL(L);
-   lj_env_store(L, Environment, Name, Value);
+   lj_env_check(L, Environment, Name, Value);
+   return Name;
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -829,6 +829,59 @@ extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t Dyna
 }
 
 //********************************************************************************************************************
+// Central environment mutation boundary.  Every runtime write to a marked global environment (VM store fast paths,
+// rawset(), the C API and JIT-recorded stores) must pass through here so sticky contracts and protected built-ins
+// are enforced regardless of source syntax or table aliasing.  Checks run strictly before mutation, so a failed
+// store leaves both the stored value and the persisted policy unchanged.
+//
+// Value must reference a Lua stack slot: thunk resolution and table allocation can reallocate the stack.
+
+extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
+{
+   if ((Name->flags & STRFLAG_PROTECTED_GLOBAL) != 0) {
+      CSTRING message = lj_strfmt_pushf(L, "cannot override built-in '%s'", strdata(Name));
+      lj_err_callermsg(L, message);
+   }
+
+   ptrdiff_t value_offset = savestack(L, Value);
+   if (GCstr *persisted = lj_tab_get_global_contract(Environment, Name)) {
+      RuntimeContractDescriptor descriptor;
+      decode_contract_or_error(L, persisted, descriptor);
+      if (descriptor.contract_count >= 1) {
+         const RuntimeContractEntry &entry = descriptor.entries[0];
+         if (entry.type != TiriType::Any and entry.type != TiriType::Unknown) {
+            TValue checked;
+            copyTV(L, &checked, Value);
+            if (lj_is_thunk(&checked)) {
+               // Validate the resolved value, but store the original thunk to preserve lazy evaluation on read.
+               VMHelperGuard guard(L);
+               cTValue *resolved = lj_thunk_resolve(L, udataV(&checked));
+               copyTV(L, &checked, resolved);
+            }
+            if (not contract_matches(L, &checked, entry)) {
+               contract_error(L, &checked, ContractBoundary::Global, entry, entry.position);
+            }
+         }
+      }
+   }
+
+   Environment->nomm = 0;  //  Invalidate negative metamethod cache, matching the diverted VM store path.
+   TValue *slot = lj_tab_setstr(L, Environment, Name);
+   copyTV(L, slot, restorestack(L, value_offset));
+   lj_gc_anybarriert(L, Environment);
+}
+
+//********************************************************************************************************************
+// VM entry point for the environment mutation boundary, reached when BC_TSETS_Z diverts a store to a marked
+// environment (BC_GSET, BC_TSETS and string-keyed BC_TSETV all funnel through that fast path).
+
+extern "C" void lj_vm_envset(lua_State *L, GCtab *Environment, GCstr *Name, TValue *Value)
+{
+   L->top = curr_topL(L);
+   lj_env_store(L, Environment, Name, Value);
+}
+
+//********************************************************************************************************************
 // Helper for calls. __call metamethod.
 
 void lj_meta_call(lua_State *L, TValue *func, TValue *top)

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -35,8 +35,9 @@ extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
 extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
+extern "C" void lj_env_check(lua_State *, GCtab *, GCstr *, cTValue *);
 extern "C" void lj_env_store(lua_State *, GCtab *, GCstr *, cTValue *);
-extern "C" void lj_vm_envset(lua_State *, GCtab *, GCstr *, TValue *);
+extern "C" GCstr * lj_vm_envcheck(lua_State *, GCtab *, GCstr *, TValue *);
 extern "C" void lj_meta_call(lua_State* L, TValue* func, TValue* top);
 extern "C" void lj_meta_for(lua_State* L, TValue* o);
 

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -35,6 +35,8 @@ extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
 extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
+extern "C" void lj_env_store(lua_State *, GCtab *, GCstr *, cTValue *);
+extern "C" void lj_vm_envset(lua_State *, GCtab *, GCstr *, TValue *);
 extern "C" void lj_meta_call(lua_State* L, TValue* func, TValue* top);
 extern "C" void lj_meta_for(lua_State* L, TValue* o);
 

--- a/src/tiri/jit/src/runtime/lj_tab.cpp
+++ b/src/tiri/jit/src/runtime/lj_tab.cpp
@@ -611,6 +611,19 @@ void lj_tab_set_global_contract(lua_State *L, GCtab *Environment, const GCstr *N
 }
 
 //********************************************************************************************************************
+// Mark a table as a global environment by eagerly attaching its contracts table.  Must run after the environment's
+// built-ins are registered and protected: from that point every store route treats the table as policy-checked.
+
+void lj_env_mark(lua_State *L, GCtab *Environment)
+{
+   if (tabref(Environment->global_type_contracts)) return;
+
+   GCtab *contracts = lj_tab_new(L, 0, 1);
+   setgcref(Environment->global_type_contracts, obj2gco(contracts));
+   lj_gc_objbarrier(L, Environment, contracts);
+}
+
+//********************************************************************************************************************
 // Table traversal indexes (0-based):
 //
 // Array key index: [0 .. t->asize-1]

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -109,7 +109,7 @@ LJ_FUNC void lj_tab_set_global_contract(
 LJ_FUNC void lj_env_mark(lua_State* L, GCtab* Environment);
 
 // A non-null contracts table doubles as the runtime marker for "this table is a global environment": every store
-// route (VM fast path, C API, rawset, JIT) must divert marked tables through lj_env_store().
+// route (VM fast path, C API, rawset, JIT) must validate marked tables through lj_env_check().
 [[nodiscard]] inline bool lj_tab_is_environment(const GCtab* Table) noexcept
 {
    return tabref(Table->global_type_contracts) != nullptr;

--- a/src/tiri/jit/src/runtime/lj_tab.h
+++ b/src/tiri/jit/src/runtime/lj_tab.h
@@ -106,6 +106,14 @@ LJ_FUNC TValue* lj_tab_set(lua_State* L, GCtab* t, cTValue* key);
 LJ_FUNC [[nodiscard]] GCstr* lj_tab_get_global_contract(GCtab* Environment, const GCstr* Name);
 LJ_FUNC void lj_tab_set_global_contract(
    lua_State* L, GCtab* Environment, const GCstr* Name, GCstr* Descriptor);
+LJ_FUNC void lj_env_mark(lua_State* L, GCtab* Environment);
+
+// A non-null contracts table doubles as the runtime marker for "this table is a global environment": every store
+// route (VM fast path, C API, rawset, JIT) must divert marked tables through lj_env_store().
+[[nodiscard]] inline bool lj_tab_is_environment(const GCtab* Table) noexcept
+{
+   return tabref(Table->global_type_contracts) != nullptr;
+}
 
 // 0-based indexing: valid array indices are [0, asize)
 #define inarray(t, key)      ((MSize)(key) < (MSize)(t)->asize)

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -174,3 +174,38 @@ end
       error('Reading a field from a nil-valued global should raise an index error')
    end
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Environment mutation boundary: separately compiled chunks writing through _G aliases must honour the persisted
+-- contract, and a declaration composes with a value seeded earlier through rawset().
+
+@Test function CrossChunkAliasStoreIsChecked()
+   global glGTCrossAlias = 'text'
+
+   local writer = exec('return function(Value) local environment = _G environment.glGTCrossAlias = Value end')
+   writer('replaced')
+   assert(glGTCrossAlias is 'replaced', 'A compatible cross-chunk aliased store should apply')
+
+   try
+      writer(42)
+      error('An incompatible cross-chunk aliased store should raise')
+   except e
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         'Expected a global contract error, got: ' .. tostring(e.message))
+   end
+   assert(glGTCrossAlias is 'replaced', 'A rejected cross-chunk store must preserve the previous value')
+end
+
+@Test function DeclarationGovernsRawsetSeededName()
+   rawset(_G, 'glGTSeeded', 'seed')
+   global glGTSeeded = 'declared'
+
+   try
+      rawset(_G, 'glGTSeeded', 42)
+      error('A rawset conflicting with the declared contract should raise')
+   except e
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         'Expected a global contract error, got: ' .. tostring(e.message))
+   end
+   assert(glGTSeeded is 'declared', 'The declared value must survive the rejected rawset')
+end

--- a/src/tiri/tests/test_protected_globals.tiri
+++ b/src/tiri/tests/test_protected_globals.tiri
@@ -7,7 +7,8 @@ function assert_activation_fails(Statement:str, Message:str)
    local script = obj.new('tiri', { statement = Statement })
    local err = script.acActivate()
 
-   assert(err != ERR_Okay, Message .. ' should fail activation')
+   -- Compile-time rejections fail the action itself; runtime boundary rejections surface through script.error.
+   assert((err != ERR_Okay) or (script.error != ERR_Okay), Message .. ' should fail activation')
    assert(script.error != ERR_Okay, Message .. ' should set a script error')
    assert(string.find(script.errorMessage, 'cannot override built-in') != nil,
       Message .. ' should report the protected-global diagnostic, got: ' .. tostring(script.errorMessage))
@@ -125,4 +126,132 @@ end
       myThing = 2
       assert(myThing is 2)
    ]], 'script-created global reassignment')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Environment mutation boundary: every runtime write route into the global environment must enforce protected names
+-- and sticky contracts, and a rejected store must leave the previous value intact.
+
+@Test function RejectsRawsetOfBuiltin()
+   assert_activation_fails([[rawset(_G, 'tostring', 42)]], 'rawset of builtin')
+end
+
+@Test function RejectsAliasStoreToBuiltin()
+   assert_activation_fails([[
+      local environment = _G
+      environment.tostring = 42
+   ]], 'alias store to builtin')
+end
+
+@Test function RejectsComputedKeyStoreToBuiltinAtRuntime()
+   assert_activation_fails([[
+      local key = 'to' .. 'string'
+      _G[key] = 42
+   ]], 'computed runtime key store to builtin')
+end
+
+function expect_global_contract_failure(Store:func, Message:str)
+   local trapped = false
+   try
+      Store()
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         Message .. ' should raise a global contract error, got: ' .. tostring(e.message))
+   end
+   assert(trapped, Message .. ' should raise')
+end
+
+@Test function ContractEnforcedThroughEveryEnvironmentRoute()
+   global glPGRoute = 'text'
+   local alias = _G
+   local key = 'glPG' .. 'Route'
+
+   expect_global_contract_failure(function() _G.glPGRoute = 42 end, '_G member store')
+   expect_global_contract_failure(function() _G['glPGRoute'] = 42 end, '_G literal index store')
+   expect_global_contract_failure(function() _G[key] = 42 end, '_G computed index store')
+   expect_global_contract_failure(function() alias.glPGRoute = 42 end, 'alias store')
+   expect_global_contract_failure(function() rawset(_G, 'glPGRoute', 42) end, 'rawset store')
+
+   assert(glPGRoute is 'text', 'A rejected store must preserve the previous value')
+end
+
+@Test function CompatibleStoresSucceedThroughEveryEnvironmentRoute()
+   global glPGOkay = 'first'
+   local alias = _G
+   local key = 'glPG' .. 'Okay'
+
+   _G.glPGOkay = 'second'
+   assert(glPGOkay is 'second', 'member store should apply')
+   _G['glPGOkay'] = 'third'
+   assert(glPGOkay is 'third', 'literal index store should apply')
+   _G[key] = 'fourth'
+   assert(glPGOkay is 'fourth', 'computed index store should apply')
+   alias.glPGOkay = 'fifth'
+   assert(glPGOkay is 'fifth', 'alias store should apply')
+   rawset(_G, 'glPGOkay', 'sixth')
+   assert(glPGOkay is 'sixth', 'rawset store should apply')
+end
+
+@Test function NilClearsWithoutClearingPolicy()
+   global glPGNil = 'text'
+
+   rawset(_G, 'glPGNil', nil)
+   assert(rawget(_G, 'glPGNil') is nil, 'rawset nil should clear the value')
+   _G.glPGNil = 'again'
+   assert(glPGNil is 'again', 'a compatible store after nil should apply')
+   _G.glPGNil = nil
+   assert(rawget(_G, 'glPGNil') is nil, 'member nil should clear the value')
+
+   expect_global_contract_failure(function() _G.glPGNil = 42 end, 'post-nil incompatible store')
+end
+
+@Test function AnyGlobalAcceptsEveryEnvironmentRoute()
+   global glPGAny:any = 'text'
+   local alias = _G
+
+   _G.glPGAny = 42
+   assert(glPGAny is 42, 'member store to any global')
+   alias.glPGAny = true
+   assert(glPGAny is true, 'alias store to any global')
+   rawset(_G, 'glPGAny', 'back')
+   assert(glPGAny is 'back', 'rawset to any global')
+end
+
+@Test function FreshNamesRemainOpenThroughEnvironmentRoutes()
+   rawset(_G, 'glPGFresh', 42)
+   assert(rawget(_G, 'glPGFresh') is 42, 'rawset may create an undeclared global')
+   _G['glPG' .. 'Fresh2'] = 'seven'
+   assert(rawget(_G, 'glPGFresh2') is 'seven', 'computed store may create an undeclared global')
+end
+
+@Test function OldBytecodeWriterIsChecked()
+   -- A function compiled before the declaration must still cross the boundary (TYP-14 residue).
+   rawset(_G, 'glPGLate', 'seed')
+   local writer = exec('return function() glPGLate = 42 end')
+   global glPGLate = 'text'
+
+   expect_global_contract_failure(function() writer() end, 'pre-declaration writer')
+   assert(glPGLate is 'text', 'The stale writer must not mutate the declared global')
+end
+
+@Test function HotEnvironmentStoresRemainChecked()
+   global glPGHot = 'text'
+   local alias = _G
+   local failures = 0
+
+   for i in {1 into 200} do
+      try
+         alias.glPGHot = i
+      except e
+         failures += 1
+      end
+   end
+   assert(failures is 200, 'Every hot aliased store must be rejected, got ' .. failures)
+   assert(glPGHot is 'text', 'Hot rejected stores must preserve the previous value')
+
+   for i in {1 into 200} do
+      alias.glPGHot = 'iteration'
+   end
+   assert(glPGHot is 'iteration', 'Hot compatible stores must apply')
 end

--- a/src/tiri/tests/test_protected_globals.tiri
+++ b/src/tiri/tests/test_protected_globals.tiri
@@ -225,6 +225,31 @@ end
    assert(rawget(_G, 'glPGFresh2') is 'seven', 'computed store may create an undeclared global')
 end
 
+@Test function EnvironmentNewIndexRemainsActive()
+   local captured = {}
+   setmetatable(_G, {
+      __newindex = function(Self, Key, Value)
+         captured[Key] = Value
+      end
+   })
+   defer
+      setmetatable(_G, nil)
+      rawset(_G, 'glPGMetaRouted', nil)
+      rawset(_G, 'glPGMetaRaw', nil)
+   end
+
+   for i in {1 into 200} do
+      _G.glPGMetaRouted = i
+   end
+
+   assert(rawget(_G, 'glPGMetaRouted') is nil, 'A non-raw environment store should not bypass __newindex')
+   assert(captured.glPGMetaRouted is 200, 'The environment __newindex handler should receive hot stores')
+
+   rawset(_G, 'glPGMetaRaw', 'raw')
+   assert(rawget(_G, 'glPGMetaRaw') is 'raw', 'rawset should continue to bypass environment __newindex')
+   assert(captured.glPGMetaRaw is nil, 'The environment __newindex handler should not receive rawset')
+end
+
 @Test function OldBytecodeWriterIsChecked()
    -- A function compiled before the declaration must still cross the boundary (TYP-14 residue).
    rawset(_G, 'glPGLate', 'seed')
@@ -254,4 +279,27 @@ end
       alias.glPGHot = 'iteration'
    end
    assert(glPGHot is 'iteration', 'Hot compatible stores must apply')
+end
+
+@Test function HotThunkEnvironmentStoreSurvivesStackGrowth()
+   global glPGHotThunk = 'seed'
+   local alias = _G
+   local resolutions = 0
+
+   function expand_store_stack(Depth:num):str
+      if Depth <= 0 then return 'resolved' end
+      return expand_store_stack(Depth - 1)
+   end
+
+   thunk deferred_store(Depth:num):str
+      resolutions += 1
+      return expand_store_stack(Depth)
+   end
+
+   for i in {1 into 200} do
+      alias.glPGHotThunk = deferred_store(i)
+   end
+
+   assert(resolutions is 200, 'Each environment policy check should resolve its thunk exactly once')
+   assert(glPGHotThunk is 'resolved', 'A hot thunk store should remain valid when resolution grows the stack')
 end

--- a/src/tiri/tests/test_protected_globals.tiri
+++ b/src/tiri/tests/test_protected_globals.tiri
@@ -21,6 +21,24 @@ function assert_activation_succeeds(Statement:str, Message:str)
    assert(err is ERR_Okay, Message .. ' should activate successfully: ' .. tostring(script.errorMessage))
 end
 
+function clear_table(Target:table)
+   table.clear(Target)
+end
+
+function expect_environment_clear_failure(Target:table, Message:str)
+   local trapped = false
+   try
+      clear_table(Target)
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'cannot clear a global environment') != nil,
+         Message .. ' should report the environment-clear diagnostic, got: ' .. tostring(e.message))
+   end
+   assert(trapped, Message .. ' should raise')
+   assert(type(rawget(_G, 'tostring')) is 'function', Message .. ' should preserve the tostring built-in')
+   assert(type(rawget(_G, 'table')) is 'table', Message .. ' should preserve the table library')
+end
+
 @Test function RejectsGlobalDeclarationOfBuiltinFunction()
    assert_activation_fails([[global tostring = 5]], 'global tostring assignment')
 end
@@ -148,6 +166,19 @@ end
       local key = 'to' .. 'string'
       _G[key] = 42
    ]], 'computed runtime key store to builtin')
+end
+
+@Test function RejectsBulkClearOfGlobalEnvironment()
+   expect_environment_clear_failure(_G, 'direct global environment clear')
+
+   for i in {1 into 200} do
+      local ordinary = { value = i }
+      clear_table(ordinary)
+      assert(table.empty(ordinary), 'table.clear should continue to clear ordinary tables')
+   end
+
+   local alias = _G
+   expect_environment_clear_failure(alias, 'hot aliased global environment clear')
 end
 
 function expect_global_contract_failure(Store:func, Message:str)


### PR DESCRIPTION
* Added lj_env_store(), which validates protected built-ins and persisted global contracts before mutation, with environment tables identified by an eagerly attached contracts table
* Diverted the BC_TSETS_Z store fast path to the boundary for marked environments in the x64 and arm64 VMs, covering _G member, index and alias stores plus pre-declaration GSET bytecode
* Routed lua_settable(), lua_setfield() and lua_rawset() through the boundary, covering rawset(), lua_setglobal() and host SetVariable() stores
* JIT recording now guards the environment marker on string-keyed table stores and calls the boundary from traces; alias analysis treats the call as a conflicting table store
* Relaxed the syntactic ban on computed _G[key] assignment now that runtime enforcement is uniform
* Fixed luaL_ref() handing out reference 0, which aliased FREELIST_REF and silently re-initialised queried scripts
* Added boundary regressions to test_protected_globals.tiri, test_global_types.tiri and the compiled parser unit tests
* [Core] Added a defaulted-type ScriptArg span constructor and migrated a unit test to the span-based msg_waitforobjects() signature
* [Doc] Documented the environment boundary and append-only IRCALL/IRFL lists in AGENTS.md; replaced the stale jit/CLAUDE.md with a symlink