### PR TITLE
Add table __gc finalisers to Tiri

### DIFF
--- a/src/display/class_display.cpp
+++ b/src/display/class_display.cpp
@@ -33,12 +33,20 @@ static ERR DISPLAY_Resize(extDisplay *, struct acResize *);
 static void alloc_display_buffer(extDisplay *Self);
 
 #ifdef __xwindows__
-static void set_x11_input_hints(Window WindowHandle)
+static void set_x11_application_hints(Window WindowHandle)
 {
    XWMHints hints = { };
    hints.flags = InputHint;
    hints.input = True;
    XSetWMHints(XDisplay, WindowHandle, &hints);
+
+   char resource_name[] = "origo";
+   char resource_class[] = "Origo";
+   XClassHint class_hint = {
+      .res_name = resource_name,
+      .res_class = resource_class
+   };
+   XSetClassHint(XDisplay, WindowHandle, &class_hint);
 }
 #endif
 
@@ -821,7 +829,7 @@ static ERR DISPLAY_Init(extDisplay *Self)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         set_x11_input_hints(Self->XWindowHandle);
+         set_x11_application_hints(Self->XWindowHandle);
 
          Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
          XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));
@@ -2339,7 +2347,7 @@ static ERR SET_Flags(extDisplay *Self, SCR Value)
          }
          else XStoreName(XDisplay, Self->XWindowHandle, "Kotuku");
 
-         set_x11_input_hints(Self->XWindowHandle);
+         set_x11_application_hints(Self->XWindowHandle);
 
          Atom protocols[2] = { XWADeleteWindow, XWATakeFocus };
          XSetWMProtocols(XDisplay, Self->XWindowHandle, protocols, std::ssize(protocols));

--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -765,6 +765,7 @@ if (UNIT_TESTS)
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_arrays.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_allocator.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_bulk.cpp")
+   list (APPEND TIRI_SOURCES "${JIT_SRC}/runtime/unit_tests_gc.cpp")
    list (APPEND TIRI_SOURCES "${JIT_SRC}/jit/jit_unit_tests.cpp")
 
    # Add MASM assembly file for register capture on MSVC x64

--- a/src/tiri/jit/src/debug/try_except.cpp
+++ b/src/tiri/jit/src/debug/try_except.cpp
@@ -86,6 +86,7 @@ static void attach_exception_metatable(lua_State *L, GCtab *Table)
 {
    GCtab *mt = lj_tab_new(L, 0, 4);
    lj_assertL(mt != nullptr, "attach_exception_metatable: metatable allocation failed");
+   // Internal exception metatables are built here and never define __gc.
    setgcref(Table->metatable, obj2gco(mt));
    lj_gc_objbarriert(L, Table, mt);
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1163,21 +1163,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  ldr TAB:RB, [TMP1, #offsetof(global_State, gcroot[GCROOT_BASEMT])-8]
   |  b <2
   |
-  |.ffunc_2 setmetatable
-  |  // Fast path: no mt for table yet and not clearing the mt.
-  |  checktp TMP1, CARG1, LJ_TTAB, ->fff_fallback
-  |   ldr TAB:TMP0, TAB:TMP1->metatable
-  |  asr ITYPE, CARG2, #47
-  |   ldrb TMP2w, TAB:TMP1->marked
-  |  cmn ITYPE, #-LJ_TTAB
-  |    and TAB:CARG2, CARG2, #LJ_GCVMASK
-  |  ccmp TAB:TMP0, #0, #0, eq
-  |  bne ->fff_fallback
-  |    str TAB:CARG2, TAB:TMP1->metatable
-  |   tbz TMP2w, #2, ->fff_restv	// isblack(table)
-  |  barrierback TAB:TMP1, TMP2w, TMP0
-  |  b ->fff_restv
-  |
   |.ffunc rawget
   |  ldr CARG2, [BASE]
   |   cmp NARGS8:RC, #16

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1631,20 +1631,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  lwzx TAB:CARG1, TMP2, TMP1
   |  b <2
   |
-  |.ffunc_2 setmetatable
-  |  // Fast path: no mt for table yet and not clearing the mt.
-  |   checktab CARG3; bne ->fff_fallback
-  |  lwz TAB:TMP1, TAB:CARG1->metatable
-  |   checktab CARG4; bne ->fff_fallback
-  |  cmplwi TAB:TMP1, 0
-  |   lbz TMP3, TAB:CARG1->marked
-  |  bne ->fff_fallback
-  |   andix. TMP0, TMP3, LJ_GC_BLACK	// isblack(table)
-  |    stw TAB:CARG2, TAB:CARG1->metatable
-  |   beq ->fff_restv
-  |  barrierback TAB:CARG1, TMP3, TMP0
-  |  b ->fff_restv
-  |
   |.ffunc rawget
   |  cmplwi NARGS8:RC, 16
   |   lwz CARG4, 0(BASE)

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1421,24 +1421,6 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov TAB:RB, [DISPATCH+ITYPE*8+DISPATCH_GL(gcroot[GCROOT_BASEMT])]
   |  jmp <2
   |
-  |.ffunc_2 setmetatable
-  |  mov TAB:RB, [BASE]
-  |  mov TAB:TMPR, TAB:RB
-  |  checktab TAB:RB, ->fff_fallback
-  |  // Fast path: no mt for table yet and not clearing the mt.
-  |  cmp aword TAB:RB->metatable, 0; jne ->fff_fallback
-  |  mov TAB:RA, [BASE+8]
-  |  checktab TAB:RA, ->fff_fallback
-  |  mov TAB:RB->metatable, TAB:RA
-  |  mov PC, [BASE-8]
-  |  mov [BASE-16], TAB:TMPR        // Return original table.
-  |  test byte TAB:RB->marked, LJ_GC_BLACK   // isblack(table)
-  |  jz >1
-  |  // Possible write barrier. Table is black, but skip iswhite(mt) check.
-  |  barrierback TAB:RB, RC
-  |1:
-  |  jmp ->fff_res1
-  |
   |.ffunc_2 rawget
   |.if X64WIN
   |  mov TAB:RA, [BASE]

--- a/src/tiri/jit/src/lib/lib_base.cpp
+++ b/src/tiri/jit/src/lib/lib_base.cpp
@@ -408,15 +408,14 @@ LJLIB_ASM_(getmetatable)   LJLIB_REC(.)
 //********************************************************************************************************************
 // Recycle the lj_lib_checkany(L, 1) from assert.
 
-LJLIB_ASM(setmetatable)      LJLIB_REC(.)
+LJLIB_CF(setmetatable)
 {
-   GCtab* t = lj_lib_checktab(L, 1);
-   GCtab* mt = lj_lib_checktabornil(L, 2);
+   lj_lib_checktab(L, 1);
+   lj_lib_checktabornil(L, 2);
    if (!tvisnil(lj_meta_lookup(L, L->base, MM_metatable))) lj_err_caller(L, ErrMsg::PROTMT);
-   setgcref(t->metatable, obj2gco(mt));
-   if (mt) { lj_gc_objbarriert(L, t, mt); }
-   settabV(L, L->base - 2, t);
-   return FFH_RES(1);
+   L->top = L->base + 2;
+   lua_setmetatable(L, 1);
+   return 1;
 }
 
 //********************************************************************************************************************
@@ -1006,7 +1005,7 @@ LJLIB_CF(ltr)
 
 static void newproxy_weaktable(lua_State* L)
 {
-   // NOBARRIER: The table is new (marked white).
+   // NOBARRIER: The table is new (marked white). This internal metatable only defines __mode.
    GCtab *t = lj_tab_new(L, 0, 1);
    settabV(L, L->top++, t);
    setgcref(t->metatable, obj2gco(t));

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1323,12 +1323,16 @@ extern int lua_setmetatable(lua_State *L, int idx)
 
    auto g = G(L);
    if (tvistab(o)) {
-      setgcref(tabV(o)->metatable, obj2gco(mt));
-      if (mt) lj_gc_objbarriert(L, tabV(o), mt);
+      GCtab* table = tabV(o);
+      setgcref(table->metatable, obj2gco(mt));
+      if (mt) lj_gc_objbarriert(L, table, mt);
+      lj_gc_checkfinaliser(L, obj2gco(table), mt);
    }
    else if (tvisudata(o)) {
-      setgcref(udataV(o)->metatable, obj2gco(mt));
-      if (mt) lj_gc_objbarrier(L, udataV(o), mt);
+      GCudata* userdata = udataV(o);
+      setgcref(userdata->metatable, obj2gco(mt));
+      if (mt) lj_gc_objbarrier(L, userdata, mt);
+      lj_gc_checkfinaliser(L, obj2gco(userdata), mt);
    }
    else if (tvisarray(o)) {
       setgcref(arrayV(o)->metatable, obj2gco(mt));

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -20,7 +20,7 @@ constexpr int HOTCOUNT_LOOP = 2;
 constexpr int HOTCOUNT_CALL = 1;
 
 // This solves a circular dependency problem -- bump as needed. Sigh.
-constexpr int GG_NUM_ASMFF = 55;
+constexpr int GG_NUM_ASMFF = 54;
 
 constexpr int GG_LEN_DDISP = (BC__MAX + GG_NUM_ASMFF);
 constexpr int GG_LEN_SDISP = BC_FUNCF;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -147,8 +147,8 @@ static void recff_nyi(jit_State* J, RecordFFData* rd)
          // Stitched trace cannot start with an op that consumes MULTRES, because recff_stitch() rewrites the frame
          // and the continuation re-enters at the caller's next instruction with MULTRES no longer valid. BC_TYPEFIX
          // is emitted directly after a call in return position, so it belongs with the *M ops here.
-         if (!(op == BC_CALLM or op == BC_CALLMT or
-            op == BC_RETM or op == BC_TSETM or op == BC_TYPEFIX)) {
+         if (!(op IS BC_CALLM or op IS BC_CALLMT or
+            op IS BC_RETM or op IS BC_TSETM or op IS BC_TYPEFIX)) {
             switch (J->fn->c.ffid) {
                case FF_error:
                case FF_debug_setHook:
@@ -1042,7 +1042,7 @@ static void recff_math_round(jit_State* J, RecordFFData* rd)
       // Result is integral (or NaN/Inf), but may not fit an int32_t.
       if (LJ_DUALNUM) {  // Try to narrow using a guarded conversion to int.
          lua_Number n = lj_vm_foldfpm(numberVnum(&rd->argv[0]), rd->data);
-         if (n == (lua_Number)lj_num2int(n))
+         if (n IS (lua_Number)lj_num2int(n))
             tr = emitir(IRTGI(IR_CONV), tr, IRCONV_INT_NUM | IRCONV_CHECK);
       }
       J->base[0] = tr;
@@ -1247,8 +1247,8 @@ static void recff_bit_shift(jit_State* J, RecordFFData* rd)
          !tref_isk(tsh))
          tsh = emitir(IRTI(IR_BAND), tsh, lj_ir_kint(J, 31));
 #ifdef LJ_TARGET_UNIFYROT
-      if (op == (LJ_TARGET_UNIFYROT == 1 ? IR_BROR : IR_BROL)) {
-         op = LJ_TARGET_UNIFYROT == 1 ? IR_BROL : IR_BROR;
+      if (op IS (LJ_TARGET_UNIFYROT IS 1 ? IR_BROR : IR_BROL)) {
+         op = LJ_TARGET_UNIFYROT IS 1 ? IR_BROL : IR_BROR;
          tsh = emitir(IRTI(IR_NEG), tsh, tsh);
       }
 #endif
@@ -1418,7 +1418,7 @@ static void recff_string_char(jit_State* J, RecordFFData* rd)
          tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, J->base[i]);
       J->base[0] = emitir(IRTG(IR_BUFSTR, IRT_STR), tr, hdr);
    }
-   else if (i == 0) J->base[0] = lj_ir_kstr(J, &J2G(J)->strempty);
+   else if (i IS 0) J->base[0] = lj_ir_kstr(J, &J2G(J)->strempty);
 }
 
 //********************************************************************************************************************
@@ -1535,7 +1535,7 @@ static void recff_format(jit_State* J, RecordFFData* rd, TRef hdr, int sbufx)
    emitir(IRTG(IR_EQ, IRT_STR), trfmt, lj_ir_kstr(J, fmt));
    lj_strfmt_init(&fs, strdata(fmt), fmt->len);
    while ((sf = lj_strfmt_parse(&fs)) != STRFMT_EOF) {  // Parse format.
-      TRef tra = sf == STRFMT_LIT ? 0 : J->base[++arg];
+      TRef tra = sf IS STRFMT_LIT ? 0 : J->base[++arg];
       TRef trsf = lj_ir_kint(J, (int32_t)sf);
       IRCallID id;
       switch (STRFMT_TYPE(sf)) {
@@ -1548,7 +1548,7 @@ static void recff_format(jit_State* J, RecordFFData* rd, TRef hdr, int sbufx)
          if (!tref_isinteger(tra)) {
             goto handle_num;
          }
-         if (sf == STRFMT_INT) {  // Shortcut for plain %d.
+         if (sf IS STRFMT_INT) {  // Shortcut for plain %d.
             tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr,
                emitir(IRT(IR_TOSTR, IRT_STR), tra, IRTOSTR_INT));
          }
@@ -1572,14 +1572,14 @@ static void recff_format(jit_State* J, RecordFFData* rd, TRef hdr, int sbufx)
             // NYI: also buffers.
             return;
          }
-         if (sf == STRFMT_STR)  //  Shortcut for plain %s.
+         if (sf IS STRFMT_STR)  //  Shortcut for plain %s.
             tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, tra);
          else if ((sf & STRFMT_T_QUOTED)) tr = lj_ir_call(J, IRCALL_lj_strfmt_putquoted, tr, tra);
          else tr = lj_ir_call(J, IRCALL_lj_strfmt_putfstr, tr, trsf, tra);
          break;
       case STRFMT_CHAR:
          tra = lj_opt_narrow_toint(J, tra);
-         if (sf == STRFMT_CHAR)  //  Shortcut for plain %c.
+         if (sf IS STRFMT_CHAR)  //  Shortcut for plain %c.
             tr = emitir(IRTG(IR_BUFPUT, IRT_PGC), tr, emitir(IRT(IR_TOSTR, IRT_STR), tra, IRTOSTR_CHAR));
          else tr = lj_ir_call(J, IRCALL_lj_strfmt_putfchar, tr, trsf, tra);
          break;
@@ -1719,7 +1719,7 @@ void lj_ffrecord_func(jit_State* J)
    J->base[J->maxslot] = 0;  //  Mark end of arguments.
    (recff_func[m >> 8])(J, &rd);  //  Call recff_* handler.
    if (rd.nres >= 0) {
-      if (J->postproc == LJ_POST_NONE) J->postproc = LJ_POST_FFRETRY;
+      if (J->postproc IS LJ_POST_NONE) J->postproc = LJ_POST_FFRETRY;
       lj_record_ret(J, 0, rd.nres);
    }
 }

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -309,27 +309,6 @@ static void recff_getmetatable(jit_State* J, RecordFFData* rd)
 
 //********************************************************************************************************************
 
-static void recff_setmetatable(jit_State* J, RecordFFData* rd)
-{
-   TRef tr = J->base[0];
-   TRef mt = J->base[1];
-   if (tref_istab(tr) and (tref_istab(mt) or (mt and tref_isnil(mt)))) {
-      TRef fref, mtref;
-      RecordIndex ix;
-      ix.tab = tr;
-      copyTV(J->L, &ix.tabv, &rd->argv[0]);
-      lj_record_mm_lookup(J, &ix, MM_metatable); //  Guard for no __metatable.
-      fref = emitir(IRT(IR_FREF, IRT_PGC), tr, IRFL_TAB_META);
-      mtref = tref_isnil(mt) ? lj_ir_knull(J, IRT_TAB) : mt;
-      emitir(IRT(IR_FSTORE, IRT_TAB), fref, mtref);
-      if (!tref_isnil(mt)) emitir(IRT(IR_TBAR, IRT_TAB), tr, 0);
-      J->base[0] = tr;
-      J->needsnap = 1;
-   }  // else: Interpreter will throw.
-}
-
-//********************************************************************************************************************
-
 static void recff_rawget(jit_State* J, RecordFFData* rd)
 {
    RecordIndex ix;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -144,18 +144,20 @@ static void recff_nyi(jit_State* J, RecordFFData* rd)
       // Can only stitch from Lua call.
       if (J->framedepth and frame_islua(J->L->base - 1)) {
          BCOp op = bc_op(*frame_pc(J->L->base - 1));
-         // Stitched trace cannot start with *M op with variable # of args.
+         // Stitched trace cannot start with an op that consumes MULTRES, because recff_stitch() rewrites the frame
+         // and the continuation re-enters at the caller's next instruction with MULTRES no longer valid. BC_TYPEFIX
+         // is emitted directly after a call in return position, so it belongs with the *M ops here.
          if (!(op == BC_CALLM or op == BC_CALLMT or
-            op == BC_RETM or op == BC_TSETM)) {
+            op == BC_RETM or op == BC_TSETM or op == BC_TYPEFIX)) {
             switch (J->fn->c.ffid) {
-            case FF_error:
-            case FF_debug_setHook:
-            case FF_jit_flush:
-               break;  //  Don't stitch across special builtins.
-            default:
-               recff_stitch(J);  //  Use trace stitching.
-               rd->nres = -1;
-               return;
+               case FF_error:
+               case FF_debug_setHook:
+               case FF_jit_flush:
+                  break;  //  Don't stitch across special builtins.
+               default:
+                  recff_stitch(J);  //  Use trace stitching.
+                  rd->nres = -1;
+                  return;
             }
          }
       }

--- a/src/tiri/jit/src/lj_snap.cpp
+++ b/src/tiri/jit/src/lj_snap.cpp
@@ -767,7 +767,9 @@ static void snap_unsink(jit_State *J, GCtrace *T, ExitState *ex, SnapNo snapno, 
                lj_assertJ(irk->op2 IS IRFL_TAB_META, "sunk store with bad field %d", irk->op2);
                snap_restoreval(J, T, ex, snapno, rfilt, irs->op2, &tmp);
                // NOBARRIER: The table is new (marked white).
-               setgcref(t->metatable, obj2gco(tabV(&tmp)));
+               GCtab* metatable = tabV(&tmp);
+               setgcref(t->metatable, obj2gco(metatable));
+               lj_gc_checkfinaliser(J->L, obj2gco(t), metatable);
             }
             else {
                irk = &T->ir[irk->op2];

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -338,35 +338,39 @@ static void gc_mark_uv(global_State *g)
 //********************************************************************************************************************
 // Mark objects in the pending-finaliser queue.
 
-static void gc_mark_mmudata(global_State *g)
+static void gc_mark_pending_finalisers(global_State* G)
 {
-   GCobj *root = gcref(g->gc.mmudata);
+   GCobj *tail = gcref(G->gc.mmudata);
 
-   if (GCobj *u = root) {
+   if (GCobj *object = tail) {
       do {
-         u = gcnext(u);
-         makewhite(g, u);  //  Could be from previous GC.
-         gc_mark(g, u);
-      } while (u != root);
+         object = gcnext(object);
+         makewhite(G, object);  //  Could be from a previous GC.
+         gc_mark(G, object);
+      } while (object != tail);
    }
 }
 
 //********************************************************************************************************************
 // Helper to move an object to the pending-finaliser queue.
 
-static void gc_move_to_mmudata(global_State *g, GCobj *o, GCRef *p)
+static void gc_move_to_pending(global_State *G, GCobj *Object, GCRef *Source)
 {
-   markfinalized(o);
-   *p = o->gch.nextgc;
-   if (gcref(g->gc.mmudata)) {  // Link to end of mmudata list.
-      GCobj *root = gcref(g->gc.mmudata);
-      setgcrefr(o->gch.nextgc, root->gch.nextgc);
-      setgcref(root->gch.nextgc, o);
-      setgcref(g->gc.mmudata, o);
+   // The legacy finalised bit aliases LJ_GC_WEAKKEY for tables. Their one-shot state is carried exclusively by
+   // LJ_GC_FINALISER_SEEN.
+
+   if (Object->gch.gct != ~LJ_TTAB) markfinalized(Object);
+
+   *Source = Object->gch.nextgc;
+   if (gcref(G->gc.mmudata)) {  // Append without reversing registration order.
+      GCobj *tail = gcref(G->gc.mmudata);
+      setgcrefr(Object->gch.nextgc, tail->gch.nextgc);
+      setgcref(tail->gch.nextgc, Object);
+      setgcref(G->gc.mmudata, Object);
    }
    else {  // Create circular list.
-      setgcref(o->gch.nextgc, o);
-      setgcref(g->gc.mmudata, o);
+      setgcref(Object->gch.nextgc, Object);
+      setgcref(G->gc.mmudata, Object);
    }
 }
 
@@ -410,32 +414,34 @@ void lj_gc_checkfinaliser(lua_State* L, GCobj* Object, GCtab* Metatable)
 }
 
 //********************************************************************************************************************
-// Separate userdata objects to be finalized to mmudata list.
+// Move unreachable registered tables and full userdata to the pending-finaliser queue.
 
-size_t lj_gc_separateudata(global_State *g, int all)
+size_t lj_gc_separatefinalisers(global_State* G, int All)
 {
-   size_t m = 0;
-   GCRef *p = &mainthread(g)->nextgc;
-   GCobj *o;
-   while ((o = gcref(*p)) != nullptr) {
-      if (not (iswhite(o) or all) or isfinalized(gco_to_userdata(o))) {
-         p = &o->gch.nextgc;  //  Nothing to do.
+   size_t separated_size = 0;
+   GCRef *source = &G->gc.finobj;
+   GCobj *object;
+
+   while ((object = gcref(*source)) != nullptr) {
+      lj_assertG_(G, ismetamethodfinalisable(object), "unsupported object in registered-finaliser list");
+      lj_assertG_(G, isfinaliserseen(object), "registered finaliser is missing one-shot flag");
+
+      if (not (iswhite(object) or All)) {
+         source = &object->gch.nextgc;
       }
-      else if (not lj_meta_fastg(g, tabref(gco_to_userdata(o)->metatable), MM_gc)) {
-         markfinalized(o);  //  Done, as there's no __gc metamethod.
-         p = &o->gch.nextgc;
-      }
-      else {  // Otherwise move userdata to be finalized to mmudata list.
-         m += sizeudata(gco_to_userdata(o));
-         gc_move_to_mmudata(g, o, p);
+      else {
+         // Table array/hash storage is accounted for when the queued table is propagated below.
+         if (object->gch.gct IS ~LJ_TUDATA) separated_size += sizeudata(gco_to_userdata(object));
+         gc_move_to_pending(G, object, source);
       }
    }
-   return m;
+
+   return separated_size;
 }
 
 //********************************************************************************************************************
-// Separate GCobject (native Kotuku objects) to be finalized to mmudata list.
-// All GCobject instances require finalization via lj_object_finalize() to free the Kotuku object.
+// Move unreachable native Kōtuku objects to the pending-finaliser queue.
+// Every GCobject instance requires direct finalisation through lj_object_finalize().
 
 static size_t gc_separateobjects(global_State *g, int all)
 {
@@ -450,9 +456,10 @@ static size_t gc_separateobjects(global_State *g, int all)
             p = &o->gch.nextgc;  //  Nothing to do.
          }
          else {
-            // Move GCobject to mmudata list for finalization.
+            // Queue the native object for direct finalisation.
             m += sizeof(GCobject);
-            gc_move_to_mmudata(g, o, p);
+            gc_move_to_pending(g, o, p);
+            gc_mark(g, o);
          }
       }
       else p = &o->gch.nextgc;
@@ -953,7 +960,7 @@ void lj_gc_freeall(global_State *g)
 
 static void atomic(global_State *g, lua_State *L)
 {
-   size_t udsize;
+   size_t finaliser_size;
 
    gc_mark_uv(g);  //  Need to remark open upvalues (the thread may be dead).
    gc_propagate_gray(g);  //  Propagate any left-overs.
@@ -970,10 +977,13 @@ static void atomic(global_State *g, lua_State *L)
    setgcrefnull(g->gc.grayagain);
    gc_propagate_gray(g);  //  Propagate it.
 
-   udsize = lj_gc_separateudata(g, 0);  //  Separate userdata to be finalized.
-   udsize += gc_separateobjects(g, 0);  //  Separate GCobjects to be finalized.
-   gc_mark_mmudata(g);  //  Mark them.
-   udsize += gc_propagate_gray(g);  //  And propagate the marks.
+   finaliser_size = lj_gc_separatefinalisers(g, 0);
+   gc_mark_pending_finalisers(g);
+   finaliser_size += gc_propagate_gray(g);
+
+   // Native objects reachable only through a queued table must remain alive for that table's finaliser.
+   finaliser_size += gc_separateobjects(g, 0);
+   finaliser_size += gc_propagate_gray(g);
 
    // All marking done, clear weak tables.
    gc_clearweak(g, gcref(g->gc.weak));
@@ -984,7 +994,7 @@ static void atomic(global_State *g, lua_State *L)
    g->gc.currentwhite = (uint8_t)otherwhite(g);  //  Flip current white.
    g->strempty.marked = g->gc.currentwhite;
    setmref(g->gc.sweep, &g->gc.root);
-   g->gc.estimate = g->gc.total - (GCSize)udsize;  //  Initial estimate.
+   g->gc.estimate = g->gc.total - (GCSize)finaliser_size;  //  Initial estimate.
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -49,6 +49,7 @@
 #include "lj_struct.h"
 #include <kotuku/main.h>
 
+#include <algorithm>
 #include <array>
 #include <span>
 
@@ -924,6 +925,8 @@ static void gc_call_finaliser(global_State *G, lua_State *L, cTValue* Metamethod
    GCstr *saved_exception_source = L->pending_exception_source;
    int saved_exception_line = L->pending_exception_line;
    int saved_try_depth = L->try_stack.depth;
+   std::array<TryFrame, LJ_MAX_TRY_DEPTH> saved_try_frames;
+   std::copy_n(L->try_stack.frames, saved_try_depth, saved_try_frames.begin());
    ERR saved_caught_error = L->CaughtError;
    bool saved_exception_valid = L->pending_exception_valid;
    bool saved_traceback_state = L->sent_traceback;
@@ -947,7 +950,13 @@ static void gc_call_finaliser(global_State *G, lua_State *L, cTValue* Metamethod
       L->top = top + 1;
 
       // Call the finaliser. Stack: |metamethod|object| -> |
+      // Suspend the caller's Tiri try handlers so finaliser errors unwind to this protected-call frame.
+      L->try_stack.depth = 0;
+      L->try_handler_pc = nullptr;
       errcode = lj_vm_pcall(L, argument, 1, -1);
+      std::copy_n(saved_try_frames.begin(), saved_try_depth, L->try_stack.frames);
+      L->try_stack.depth = saved_try_depth;
+      L->try_handler_pc = saved_try_handler;
       setgcref(G->cur_L, obj2gco(L));
    }
    if (LJ_HASPROFILE and (saved_hook & HOOK_PROFILE)) lj_dispatch_update(G);
@@ -960,12 +969,10 @@ static void gc_call_finaliser(global_State *G, lua_State *L, cTValue* Metamethod
          lj_debug_free_trace(L, L->pending_trace);
    }
 
-   L->try_handler_pc = saved_try_handler;
    L->pending_trace = saved_pending_trace;
    L->pending_exception_message = saved_exception_message;
    L->pending_exception_source = saved_exception_source;
    L->pending_exception_line = saved_exception_line;
-   L->try_stack.depth = saved_try_depth;
    L->CaughtError = saved_caught_error;
    L->pending_exception_valid = saved_exception_valid;
    L->sent_traceback = saved_traceback_state;

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -158,6 +158,53 @@ inline void gray2black(GCobj *x) noexcept { x->gch.marked |= LJ_GC_BLACK; }
 
 [[nodiscard]] inline bool isfinalized(const GCobject* o) noexcept { return (o->marked & LJ_GC_FINALIZED) != 0; }
 
+// Find the intrusive link which refers to Object in a null-terminated GC list.
+
+[[nodiscard]] static GCRef* gc_find_list_link(GCRef* Head, const GCobj* Object) noexcept
+{
+   GCRef* link = Head;
+   while (gcref(*link)) {
+      if (gcref(*link) IS Object) return link;
+      link = &gcref(*link)->gch.nextgc;
+   }
+   return nullptr;
+}
+
+#ifdef LUA_USE_ASSERT
+// The pending-finaliser queue is circular, unlike the ordinary GC lists.
+
+[[nodiscard]] static bool gc_pending_contains(const global_State* g, const GCobj* Object) noexcept
+{
+   GCobj* tail = gcref(g->gc.mmudata);
+   if (not tail) return false;
+
+   GCobj* current = tail;
+   do {
+      current = gcnext(current);
+      if (current IS Object) return true;
+   } while (current != tail);
+   return false;
+}
+
+static void gc_assert_registration_source(global_State* g, GCobj* Object, GCRef* Source) noexcept
+{
+   GCRef* root_link = gc_find_list_link(&g->gc.root, Object);
+   GCRef* userdata_link = gc_find_list_link(&mainthread(g)->nextgc, Object);
+   GCRef* finaliser_link = gc_find_list_link(&g->gc.finobj, Object);
+
+   lj_assertG(not finaliser_link, "object is already in registered-finaliser list");
+   lj_assertG(not gc_pending_contains(g, Object), "pending object cannot be registered again");
+   lj_assertG((Source IS root_link) or (Source IS userdata_link), "object is not in its ordinary GC list");
+   if (Object->gch.gct IS ~LJ_TTAB) {
+      lj_assertG(Source IS root_link, "table is not in root GC list");
+   }
+   else {
+      lj_assertG(Object->gch.gct IS ~LJ_TUDATA, "unsupported finaliser registration type");
+      lj_assertG(Source IS userdata_link, "userdata is not in userdata GC list");
+   }
+}
+#endif
+
 // Mark a string object (strings go directly to black, never grey).
 
 inline void gc_mark_str(GCstr* s) noexcept { s->marked &= uint8_t(~LJ_GC_WHITES); }
@@ -289,7 +336,7 @@ static void gc_mark_uv(global_State *g)
 }
 
 //********************************************************************************************************************
-// Mark userdata in mmudata list.
+// Mark objects in the pending-finaliser queue.
 
 static void gc_mark_mmudata(global_State *g)
 {
@@ -305,7 +352,7 @@ static void gc_mark_mmudata(global_State *g)
 }
 
 //********************************************************************************************************************
-// Helper to move an object to the mmudata finalization list.
+// Helper to move an object to the pending-finaliser queue.
 
 static void gc_move_to_mmudata(global_State *g, GCobj *o, GCRef *p)
 {
@@ -321,6 +368,45 @@ static void gc_move_to_mmudata(global_State *g, GCobj *o, GCRef *p)
       setgcref(o->gch.nextgc, o);
       setgcref(g->gc.mmudata, o);
    }
+}
+
+// Register a table or full userdata for one-shot metamethod finalisation.
+
+void lj_gc_checkfinaliser(lua_State* L, GCobj* Object, GCtab* Metatable)
+{
+   global_State* g = G(L);
+
+   if (not Metatable or not lj_meta_fastg(g, Metatable, MM_gc) or isfinaliserseen(Object)) return;
+
+   lj_assertG(ismetamethodfinalisable(Object), "unsupported metamethod-finalisable object type");
+
+   GCRef* list = Object->gch.gct IS ~LJ_TTAB ? &g->gc.root : &mainthread(g)->nextgc;
+   GCRef* source = gc_find_list_link(list, Object);
+
+   lj_assertG(source, "finalisable object is not in its ordinary GC list");
+   if (not source) return;
+
+#ifdef LUA_USE_ASSERT
+   gc_assert_registration_source(g, Object, source);
+#endif
+
+   // A sweep cursor may point at the moved object's nextgc field after that object has already been swept.
+   // Redirect it to the predecessor link before nextgc is reused for finobj.
+
+   if (mref<GCRef>(g->gc.sweep) IS &Object->gch.nextgc) setmref(g->gc.sweep, source);
+
+   *source = Object->gch.nextgc;
+   markfinaliserseen(Object);
+
+   // finobj sweeping is introduced separately. Until then, objects registered during either sweep phase must be
+   // made current-white immediately so their colour is valid for the next marking cycle.
+
+   if (g->gc.state IS GCPhase::SweepString or g->gc.state IS GCPhase::Sweep) makewhite(g, Object);
+
+   setgcrefr(Object->gch.nextgc, g->gc.finobj);
+   setgcref(g->gc.finobj, Object);
+
+   lj_assertG(gc_find_list_link(&g->gc.finobj, Object), "registered object is missing from finaliser list");
 }
 
 //********************************************************************************************************************
@@ -807,7 +893,7 @@ static void gc_call_finaliser(global_State *g, lua_State *L, cTValue* mo, GCobj*
 }
 
 //********************************************************************************************************************
-// Finalize one object from the mmudata list (handles both userdata and GCobject).
+// Finalise one object from the pending queue (handles both userdata and native Kōtuku objects).
 
 static void gc_finalize(lua_State *L)
 {
@@ -840,7 +926,7 @@ static void gc_finalize(lua_State *L)
 }
 
 //********************************************************************************************************************
-// Finalize all userdata objects from mmudata list.
+// Finalise all objects in the pending queue.
 
 void lj_gc_finalize_udata(lua_State *L)
 {
@@ -856,6 +942,7 @@ void lj_gc_freeall(global_State *g)
    // Free everything, except super-fixed objects (the main thread).
    g->gc.currentwhite = LJ_GC_WHITES | LJ_GC_SFIXED;
    gc_fullsweep(g, &g->gc.root);
+   gc_fullsweep(g, &g->gc.finobj);
    strmask = g->str.mask;
    for (i = 0; i <= strmask; i++)  //  Free all string hash chains.
       gc_sweepstr(g, &g->str.tab[i]);

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -870,37 +870,70 @@ static void gc_clearweak(global_State *g, GCobj* o)
 }
 
 //********************************************************************************************************************
-// Call a userdata finaliser.
+// Call a table or userdata finaliser.
 
-static void gc_call_finaliser(global_State *g, lua_State *L, cTValue* mo, GCobj* o)
+static void gc_call_finaliser(global_State *G, lua_State *L, cTValue* Metamethod, GCobj* Object)
 {
-   lj_trace_abort(g);
+   lj_assertG_(G, tvisfunc(Metamethod), "attempt to call a non-function finaliser");
+   lj_trace_abort(G);
 
-   // Use RAII guard for hook state and GC threshold preservation.
-   GCFinaliserGuard guard(g);
+   ptrdiff_t saved_top = savestack(L, L->top);
+   const BCIns *saved_try_handler = L->try_handler_pc;
+   CapturedStackTrace *saved_pending_trace = L->pending_trace;
+   GCstr *saved_exception_message = L->pending_exception_message;
+   GCstr *saved_exception_source = L->pending_exception_source;
+   int saved_exception_line = L->pending_exception_line;
+   int saved_try_depth = L->try_stack.depth;
+   ERR saved_caught_error = L->CaughtError;
+   bool saved_exception_valid = L->pending_exception_valid;
+   bool saved_traceback_state = L->sent_traceback;
+   lj_state_checkstack(L, 2 + LJ_FR2);
 
-   if (LJ_HASPROFILE and (guard.savedHook() & HOOK_PROFILE)) lj_dispatch_update(g);
+   int errcode;
+   uint8_t saved_hook;
+   {
+      GCFinaliserGuard guard(G);
+      saved_hook = guard.savedHook();
 
-   // Set up the stack for the finaliser call.
+      if (LJ_HASPROFILE and (saved_hook & HOOK_PROFILE)) lj_dispatch_update(G);
 
-   TValue *top = L->top;
-   copyTV(L, top++, mo);
-   if (LJ_FR2) setnilV(top++);
-   setgcV(L, top, o, ~o->gch.gct);
-   L->top = top + 1;
+      // Set up the stack for the finaliser call.
 
-   // Call the finaliser. Stack: |mo|o| -> |
-   int errcode = lj_vm_pcall(L, top, 1 + 0, -1);
+      TValue *top = restorestack(L, saved_top);
+      copyTV(L, top++, Metamethod);
+      if (LJ_FR2) setnilV(top++);
+      TValue *argument = top;
+      setgcV(L, top, Object, ~Object->gch.gct);
+      L->top = top + 1;
 
-   if (LJ_HASPROFILE and (guard.savedHook() & HOOK_PROFILE)) lj_dispatch_update(g);
+      // Call the finaliser. Stack: |metamethod|object| -> |
+      errcode = lj_vm_pcall(L, argument, 1, -1);
+      setgcref(G->cur_L, obj2gco(L));
+   }
+   if (LJ_HASPROFILE and (saved_hook & HOOK_PROFILE)) lj_dispatch_update(G);
 
-   // Guard destructor restores hook state and threshold here.  Propagate errors after state restoration.
+   if (errcode) {
+      CSTRING message = L->top > restorestack(L, saved_top) and tvisstr(L->top - 1) ?
+         strVdata(L->top - 1) : "non-string finaliser error";
+      kt::Log("gc_call_finaliser").warning("Ignoring finaliser error: %s", message);
+      if (L->pending_trace and L->pending_trace != saved_pending_trace)
+         lj_debug_free_trace(L, L->pending_trace);
+   }
 
-   if (errcode) lj_err_throw(L, errcode);
+   L->try_handler_pc = saved_try_handler;
+   L->pending_trace = saved_pending_trace;
+   L->pending_exception_message = saved_exception_message;
+   L->pending_exception_source = saved_exception_source;
+   L->pending_exception_line = saved_exception_line;
+   L->try_stack.depth = saved_try_depth;
+   L->CaughtError = saved_caught_error;
+   L->pending_exception_valid = saved_exception_valid;
+   L->sent_traceback = saved_traceback_state;
+   L->top = restorestack(L, saved_top);
 }
 
 //********************************************************************************************************************
-// Finalise one object from the pending queue (handles both userdata and native Kōtuku objects).
+// Finalise one object from the pending queue.
 
 static void gc_finalize(lua_State *L)
 {
@@ -912,30 +945,36 @@ static void gc_finalize(lua_State *L)
    if (o IS gcref(g->gc.mmudata)) setgcrefnull(g->gc.mmudata);
    else setgcrefr(gcref(g->gc.mmudata)->gch.nextgc, o->gch.nextgc);
 
-   // Add object back to its original list and make it white.
-   if (o->gch.gct IS ~LJ_TOBJECT) {
-      // GCobject goes back to the main GC root list.
+   // Restore the object to its ordinary list before calling its finaliser, keeping it and its graph usable throughout
+   // the call. The one-shot registration bit remains set after makewhite().
+
+   if (o->gch.gct IS ~LJ_TTAB or o->gch.gct IS ~LJ_TOBJECT) {
       setgcrefr(o->gch.nextgc, g->gc.root);
       setgcref(g->gc.root, o);
-      makewhite(g, o);
-      // Call the finalization function directly (no metamethod lookup).
-      lj_object_finalize(L, gco_to_object(o));
    }
    else {
-      // Userdata goes back to the main userdata list.
+      lj_assertG(o->gch.gct IS ~LJ_TUDATA, "unsupported object in pending-finaliser queue");
       setgcrefr(o->gch.nextgc, mainthread(g)->nextgc);
       setgcref(mainthread(g)->nextgc, o);
-      makewhite(g, o);
-      // Resolve the __gc metamethod from userdata's metatable.
-      cTValue *mo = lj_meta_fastg(g, tabref(gco_to_userdata(o)->metatable), MM_gc);
-      if (mo) gc_call_finaliser(g, L, mo, o);
    }
+   makewhite(g, o);
+
+   if (o->gch.gct IS ~LJ_TOBJECT) {
+      // Native Kōtuku objects have a mandatory direct finaliser.
+      lj_object_finalize(L, gco_to_object(o));
+      return;
+   }
+
+   GCtab *metatable = o->gch.gct IS ~LJ_TTAB ?
+      tabref(gco_to_table(o)->metatable) : tabref(gco_to_userdata(o)->metatable);
+   cTValue *metamethod = lj_meta_fastg(g, metatable, MM_gc);
+   if (metamethod and tvisfunc(metamethod)) gc_call_finaliser(g, L, metamethod, o);
 }
 
 //********************************************************************************************************************
 // Finalise all objects in the pending queue.
 
-void lj_gc_finalize_udata(lua_State *L)
+void lj_gc_finalize_pending(lua_State *L)
 {
    while (gcref(G(L)->gc.mmudata) != nullptr) gc_finalize(L);
 }
@@ -1053,7 +1092,7 @@ static size_t gc_onestep(lua_State *L)
          if (gcref(g->gc.mmudata) != nullptr) {
             GCSize old = g->gc.total;
             if (tvref(g->jit_base)) return LJ_MAX_MEM; //  Don't call finalisers on trace.
-            gc_finalize(L);  //  Finalize one userdata object.
+            gc_finalize(L);
             if (old >= g->gc.total and g->gc.estimate > old - g->gc.total) g->gc.estimate -= old - g->gc.total;
             if (g->gc.estimate > GCFINALIZECOST) g->gc.estimate -= GCFINALIZECOST;
             return GCFINALIZECOST;

--- a/src/tiri/jit/src/runtime/lj_gc.cpp
+++ b/src/tiri/jit/src/runtime/lj_gc.cpp
@@ -402,8 +402,8 @@ void lj_gc_checkfinaliser(lua_State* L, GCobj* Object, GCtab* Metatable)
    *source = Object->gch.nextgc;
    markfinaliserseen(Object);
 
-   // finobj sweeping is introduced separately. Until then, objects registered during either sweep phase must be
-   // made current-white immediately so their colour is valid for the next marking cycle.
+   // Objects registered after their ordinary-list sweep position has passed, including during finobj sweeping, will
+   // not be visited by either active cursor. Make them current-white immediately for the next marking cycle.
 
    if (g->gc.state IS GCPhase::SweepString or g->gc.state IS GCPhase::Sweep) makewhite(g, Object);
 
@@ -411,6 +411,8 @@ void lj_gc_checkfinaliser(lua_State* L, GCobj* Object, GCtab* Metatable)
    setgcref(g->gc.finobj, Object);
 
    lj_assertG(gc_find_list_link(&g->gc.finobj, Object), "registered object is missing from finaliser list");
+   lj_assertG(not gc_find_list_link(&g->gc.root, Object), "registered object is still in root GC list");
+   lj_assertG(not gc_pending_contains(g, Object), "registered object is also pending finalisation");
 }
 
 //********************************************************************************************************************
@@ -798,6 +800,26 @@ static GCRef* gc_sweep(global_State *g, GCRef* p, uint32_t lim)
 }
 
 //********************************************************************************************************************
+// Sweep registered finalisers without providing a path that can free them before separation.
+
+static GCRef* gc_sweep_finalisers(global_State* G, GCRef* List, uint32_t Limit)
+{
+   GCobj* object;
+   while ((object = gcref(*List)) and Limit-- > 0) {
+      lj_assertG_(G, ismetamethodfinalisable(object), "unsupported object in registered-finaliser sweep");
+      lj_assertG_(G, isfinaliserseen(object), "registered-finaliser sweep found an unregistered object");
+      lj_assertG_(G, not isdead(G, object), "unreachable registered object escaped finaliser separation");
+      lj_assertG_(G, not gc_find_list_link(&G->gc.root, object),
+         "registered object is also present in root GC list");
+      lj_assertG_(G, not gc_pending_contains(G, object), "registered object is also pending finalisation");
+
+      makewhite(G, object);
+      List = &object->gch.nextgc;
+   }
+   return List;
+}
+
+//********************************************************************************************************************
 // Sweep one string interning table chain. Preserves hashalg bit.
 
 static void gc_sweepstr(global_State *g, GCRef* chain)
@@ -841,31 +863,49 @@ static void gc_sweepstr(global_State *g, GCRef* chain)
 }
 
 //********************************************************************************************************************
-// Clear collected entries from weak tables.
+// Clear collected values from weak tables up to, but excluding, Stop.
 
-static void gc_clearweak(global_State *g, GCobj* o)
+static void gc_clearweakvalues(global_State* G, GCobj* Object, GCobj* Stop)
 {
-   while (o) {
-      GCtab* t = gco_to_table(o);
-      lj_assertG((t->marked & LJ_GC_WEAK), "clear of non-weak table");
+   while (Object and Object != Stop) {
+      GCtab* table = gco_to_table(Object);
+      lj_assertG_(G, (table->marked & LJ_GC_WEAK), "clear of non-weak table");
 
       // Clear array part (TValue has alignment attributes incompatible with std::span).
-      if ((t->marked & LJ_GC_WEAKVAL) and t->asize > 0) {
-         TValue *array_start = arrayslot(t, 0);
-         for (MSize i = 0; i < t->asize; i++) {
+      if ((table->marked & LJ_GC_WEAKVAL) and table->asize > 0) {
+         TValue* array_start = arrayslot(table, 0);
+         for (MSize i = 0; i < table->asize; i++) {
             if (gc_mayclear(&array_start[i], 1)) setnilV(&array_start[i]);
          }
       }
 
-      // Clear hash part using std::span.
-      if (t->hmask > 0) {
-         std::span<Node> hash_part(noderef(t->node), t->hmask + 1);
+      if ((table->marked & LJ_GC_WEAKVAL) and table->hmask > 0) {
+         // Clear hash values without considering weak keys at this stage.
+         std::span<Node> hash_part(noderef(table->node), table->hmask + 1);
          for (Node &n : hash_part) {
-            if (not tvisnil(&n.val) and (gc_mayclear(&n.key, 0) or gc_mayclear(&n.val, 1)))
-               setnilV(&n.val);
+            if (not tvisnil(&n.val) and gc_mayclear(&n.val, 1)) setnilV(&n.val);
          }
       }
-      o = gcref(t->gclist);
+      Object = gcref(table->gclist);
+   }
+   lj_assertG_(G, not Stop or Object IS Stop, "weak-table boundary is not present in weak list");
+}
+
+// Clear collected keys from every weak-key table.
+
+static void gc_clearweakkeys(global_State* G, GCobj* Object)
+{
+   while (Object) {
+      GCtab* table = gco_to_table(Object);
+      lj_assertG_(G, (table->marked & LJ_GC_WEAK), "clear of non-weak table");
+
+      if ((table->marked & LJ_GC_WEAKKEY) and table->hmask > 0) {
+         std::span<Node> hash_part(noderef(table->node), table->hmask + 1);
+         for (Node& n : hash_part) {
+            if (not tvisnil(&n.val) and gc_mayclear(&n.key, 0)) setnilV(&n.val);
+         }
+      }
+      Object = gcref(table->gclist);
    }
 }
 
@@ -1016,6 +1056,10 @@ static void atomic(global_State *g, lua_State *L)
    setgcrefnull(g->gc.grayagain);
    gc_propagate_gray(g);  //  Propagate it.
 
+   // Weak values must not retain objects solely because those objects are about to be finalised.
+   gc_clearweakvalues(g, gcref(g->gc.weak), nullptr);
+   GCobj* original_weak = gcref(g->gc.weak);
+
    finaliser_size = lj_gc_separatefinalisers(g, 0);
    gc_mark_pending_finalisers(g);
    finaliser_size += gc_propagate_gray(g);
@@ -1024,8 +1068,10 @@ static void atomic(global_State *g, lua_State *L)
    finaliser_size += gc_separateobjects(g, 0);
    finaliser_size += gc_propagate_gray(g);
 
-   // All marking done, clear weak tables.
-   gc_clearweak(g, gcref(g->gc.weak));
+   // All marking is complete. Clear dead weak keys everywhere, then clear values from weak tables discovered while
+   // propagating objects preserved for finalisation. Existing weak values were already cleared before separation.
+   gc_clearweakkeys(g, gcref(g->gc.weak));
+   gc_clearweakvalues(g, gcref(g->gc.weak), original_weak);
 
    lj_buf_shrink(L, &g->tmpbuf);  //  Shrink temp buffer.
 
@@ -1033,6 +1079,7 @@ static void atomic(global_State *g, lua_State *L)
    g->gc.currentwhite = (uint8_t)otherwhite(g);  //  Flip current white.
    g->strempty.marked = g->gc.currentwhite;
    setmref(g->gc.sweep, &g->gc.root);
+   setmref(g->gc.sweepfin, &g->gc.finobj);
    g->gc.estimate = g->gc.total - (GCSize)finaliser_size;  //  Initial estimate.
 }
 
@@ -1071,10 +1118,18 @@ static size_t gc_onestep(lua_State *L)
 
       case GCPhase::Sweep: {
          GCSize old = g->gc.total;
-         setmref(g->gc.sweep, gc_sweep(g, mref<GCRef>(g->gc.sweep), GCSWEEPMAX));
+         GCRef* root_sweep = mref<GCRef>(g->gc.sweep);
+         if (gcref(*root_sweep)) {
+            setmref(g->gc.sweep, gc_sweep(g, root_sweep, GCSWEEPMAX));
+         }
+         else {
+            GCRef* finaliser_sweep = mref<GCRef>(g->gc.sweepfin);
+            setmref(g->gc.sweepfin, gc_sweep_finalisers(g, finaliser_sweep, GCSWEEPMAX));
+         }
          lj_assertG(old >= g->gc.total, "sweep increased memory");
          g->gc.estimate -= old - g->gc.total;
-         if (gcref(*mref<GCRef>(g->gc.sweep)) IS nullptr) {
+         if (gcref(*mref<GCRef>(g->gc.sweep)) IS nullptr and
+               gcref(*mref<GCRef>(g->gc.sweepfin)) IS nullptr) {
             if (g->str.num <= (g->str.mask >> 2) and g->str.mask > LJ_MIN_STRTAB * 2 - 1)
                lj_str_resize(L, g->str.mask >> 1);  //  Shrink string table.
             if (gcref(g->gc.mmudata)) {  // Need any finalizations?
@@ -1168,6 +1223,7 @@ void lj_gc_fullgc(lua_State *L)
 
    if (g->gc.state <= (GCPhase::Atomic)) {  // Caught somewhere in the middle.
       setmref(g->gc.sweep, &g->gc.root);  // Sweep everything (preserving it).
+      setmref(g->gc.sweepfin, &g->gc.finobj);
       setgcrefnull(g->gc.gray);  // Reset lists from partial propagation.
       setgcrefnull(g->gc.grayagain);
       setgcrefnull(g->gc.weak);

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -144,7 +144,7 @@ inline void markfinaliserseen(GCobj* Object) noexcept
 }
 
 // Collector.
-extern "C" size_t lj_gc_separateudata(global_State* g, int all);
+extern "C" size_t lj_gc_separatefinalisers(global_State* G, int All);
 extern "C" void lj_gc_finalize_udata(lua_State* L);
 extern "C" void lj_gc_freeall(global_State* g);
 extern "C" int lj_gc_step(lua_State* L);
@@ -334,10 +334,9 @@ public:
 
    // -- Finalisation --
 
-   // Separate currently supported finalisable objects to the pending queue.
-   // This delegates to the legacy userdata pass until finobj separation is introduced.
-   size_t separateFinalisers(int all) noexcept {
-      return lj_gc_separateudata(gs, all);
+   // Move unreachable registered objects to the pending-finaliser queue.
+   size_t separateFinalisers(int All) noexcept {
+      return lj_gc_separatefinalisers(gs, All);
    }
 
    // Finalise all objects in the pending queue.

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -54,6 +54,9 @@ concept GCObjectType = requires(T* obj) {
 #define LJ_GC_COLORS   (LJ_GC_WHITES | LJ_GC_BLACK)
 #define LJ_GC_WEAK   (LJ_GC_WEAKKEY | LJ_GC_WEAKVAL)
 
+static_assert((LJ_GC_FINALISER_SEEN & LJ_GC_WEAK) IS 0,
+   "finaliser registration and table weakness flags must remain independent");
+
 // Modern constexpr GC colour test functions (C++20)
 [[nodiscard]] constexpr inline bool iswhite(const GCobj* x) noexcept
 {

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -48,6 +48,7 @@ concept GCObjectType = requires(T* obj) {
 #define LJ_GC_WEAKVAL   0x10
 #define LJ_GC_FIXED     0x20
 #define LJ_GC_SFIXED    0x40
+#define LJ_GC_FINALISER_SEEN 0x80
 
 #define LJ_GC_WHITES   (LJ_GC_WHITE0 | LJ_GC_WHITE1)
 #define LJ_GC_COLORS   (LJ_GC_WHITES | LJ_GC_BLACK)
@@ -119,6 +120,29 @@ inline void markfinalized(GCobj* x) noexcept
    x->gch.marked |= LJ_GC_FINALIZED;
 }
 
+// Metamethod finalisation supports tables and full userdata. Native Kōtuku
+// objects use their mandatory direct finaliser instead.
+
+[[nodiscard]] inline bool ismetamethodfinalisable(const GCobj* Object) noexcept
+{
+   return Object->gch.gct IS ~LJ_TTAB or Object->gch.gct IS ~LJ_TUDATA;
+}
+
+[[nodiscard]] inline bool isnativefinalisable(const GCobj* Object) noexcept
+{
+   return Object->gch.gct IS ~LJ_TOBJECT;
+}
+
+[[nodiscard]] inline bool isfinaliserseen(const GCobj* Object) noexcept
+{
+   return (Object->gch.marked & LJ_GC_FINALISER_SEEN) != 0;
+}
+
+inline void markfinaliserseen(GCobj* Object) noexcept
+{
+   Object->gch.marked |= LJ_GC_FINALISER_SEEN;
+}
+
 // Collector.
 extern "C" size_t lj_gc_separateudata(global_State* g, int all);
 extern "C" void lj_gc_finalize_udata(lua_State* L);
@@ -127,6 +151,7 @@ extern "C" int lj_gc_step(lua_State* L);
 extern "C" void lj_gc_step_fixtop(lua_State* L);
 extern "C" int lj_gc_step_jit(global_State* g, MSize steps);
 extern "C" void lj_gc_fullgc(lua_State* L);
+void lj_gc_checkfinaliser(lua_State* L, GCobj* Object, GCtab* Metatable);
 
 // GC check: drive collector forward if the GC threshold has been reached.
 #define lj_gc_check(L) { if (LJ_UNLIKELY(G(L)->gc.total >= G(L)->gc.threshold)) lj_gc_step(L); }
@@ -166,7 +191,7 @@ static LJ_AINLINE void lj_gc_barrierback(global_State* g, GCtab* t)
 // - State Queries: phase(), totalMemory(), isPaused(), isMarking(), etc.
 // - Collection Control: step(), fullCycle(), check()
 // - Write Barriers: barrierForward(), barrierBack(), barrierUpvalue()
-// - Finalization: separateUdata(), finalizeUdata(), freeAll()
+// - Finalisation: separateFinalisers(), finalizePending(), freeAll()
 // - Upvalue Management: closeUpvalue()
 // - JIT Integration: barrierTrace(), stepJit()
 //
@@ -307,16 +332,16 @@ public:
       return gs->gc.stepmul;
    }
 
-   // -- Finalization --
+   // -- Finalisation --
 
-   // Separate userdata with finalisers to the mmudata list.
-   // Returns the total size of userdata to be finalized.
-   size_t separateUdata(int all) noexcept {
+   // Separate currently supported finalisable objects to the pending queue.
+   // This delegates to the legacy userdata pass until finobj separation is introduced.
+   size_t separateFinalisers(int all) noexcept {
       return lj_gc_separateudata(gs, all);
    }
 
-   // Finalize all pending userdata objects.
-   void finalizeUdata(lua_State* L) noexcept {
+   // Finalise all objects in the pending queue.
+   void finalizePending(lua_State* L) noexcept {
       lj_gc_finalize_udata(L);
    }
 

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -342,6 +342,12 @@ public:
       return lj_gc_separatefinalisers(gs, All);
    }
 
+   // Snapshot every finaliser registered before state shutdown into the pending queue.
+   // Objects registered by shutdown-time finalisers remain in finobj and are freed without another finalisation pass.
+   void prepareFinalisersForShutdown() noexcept {
+      lj_gc_separatefinalisers(gs, 1);
+   }
+
    // Finalise all objects in the pending queue.
    void finalizePending(lua_State* L) noexcept {
       lj_gc_finalize_pending(L);

--- a/src/tiri/jit/src/runtime/lj_gc.h
+++ b/src/tiri/jit/src/runtime/lj_gc.h
@@ -145,7 +145,7 @@ inline void markfinaliserseen(GCobj* Object) noexcept
 
 // Collector.
 extern "C" size_t lj_gc_separatefinalisers(global_State* G, int All);
-extern "C" void lj_gc_finalize_udata(lua_State* L);
+extern "C" void lj_gc_finalize_pending(lua_State* L);
 extern "C" void lj_gc_freeall(global_State* g);
 extern "C" int lj_gc_step(lua_State* L);
 extern "C" void lj_gc_step_fixtop(lua_State* L);
@@ -341,7 +341,7 @@ public:
 
    // Finalise all objects in the pending queue.
    void finalizePending(lua_State* L) noexcept {
-      lj_gc_finalize_udata(L);
+      lj_gc_finalize_pending(L);
    }
 
    // Free all GC objects (called during state shutdown).

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -1273,11 +1273,13 @@ typedef struct GCState {
    uint8_t lightudnum;   //  Number of lightuserdata segments - 1 (64-bit only).
    MSize   sweepstr;     // Sweep position in string table.
    GCRef   root;         // List of all collectable objects.
+   GCRef   finobj;       // Objects registered for metamethod finalisation.
    MRef    sweep;        // Sweep position in root list.
+   MRef    sweepfin;     // Sweep position in registered-finaliser list.
    GCRef   gray;         // List of gray objects.
    GCRef   grayagain;    // List of objects for atomic traversal.
    GCRef   weak;         // List of weak tables (to be cleared).
-   GCRef   mmudata;      // List of userdata (to be finalized).
+   GCRef   mmudata;      // Circular queue of pending finalisers.
    GCSize  debt;         // Debt (how much GC is behind schedule).
    GCSize  estimate;     // Estimate of memory actually in use.
    MSize   stepmul;      // Incremental GC step granularity.

--- a/src/tiri/jit/src/runtime/lj_serialize.cpp
+++ b/src/tiri/jit/src/runtime/lj_serialize.cpp
@@ -11,6 +11,7 @@
 #include "lj_obj.h"
 
 #if LJ_HASBUFFER
+#include "lj_gc.h"
 #include "lj_err.h"
 #include "lj_buf.h"
 #include "lj_str.h"
@@ -365,6 +366,7 @@ static char* serialize_get(char* r, SBufExt* sbx, TValue* o)
 
       // NOBARRIER: The table is new (marked white).
       setgcref(t->metatable, obj2gco(mt));
+      lj_gc_checkfinaliser(sbufL(sbx), obj2gco(t), mt);
       settabV(sbufL(sbx), o, t);
       if (narray) {
          TValue* oa = tvref(t->array) + (tp >= SER_TAG_TAB + 4);

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -330,45 +330,29 @@ extern lua_State * lua_newstate(lua_Alloc allocf, void* allocd)
 
 //********************************************************************************************************************
 
-static TValue* cpfinalize(lua_State *L, lua_CFunction dummy, void* ud)
-{
-   GarbageCollector collector = gc(G(L));
-   collector.finalizePending(L);
-   // Frame pop omitted.
-   return nullptr;
-}
-
-//********************************************************************************************************************
-
 extern void lua_close(lua_State *L)
 {
    global_State* g = G(L);
    GarbageCollector collector = gc(g);
-   int i;
    L = mainthread(g);  //  Only the main thread can be closed.
    setgcrefnull(g->cur_L);
    lj_func_closeuv(L, tvref(L->stack));
 
-   // Separate objects which have pending metamethod finalisers.
-   collector.separateFinalisers(1);
+   // Snapshot pre-shutdown registrations once. Finalisers created while this queue is drained remain in finobj and are
+   // freed by close_state() without being run during this shutdown.
+   collector.prepareFinalisersForShutdown();
 
    G2J(g)->flags &= ~JIT_F_ON;
    G2J(g)->state = TraceState::IDLE;
    lj_dispatch_update(g);
-   for (i = 0;;) {
-      hook_enter(g);
-      L->status = LUA_OK;
-      L->base = L->top = tvref(L->stack) + 1 + LJ_FR2;
-      L->cframe = nullptr;
-      if (lj_vm_cpcall(L, nullptr, nullptr, cpfinalize) IS LUA_OK) {
-         if (++i >= 10) break;
+   hook_enter(g);
+   L->status = LUA_OK;
+   L->base = L->top = tvref(L->stack) + 1 + LJ_FR2;
+   L->cframe = nullptr;
 
-         // Separate any newly registered finalisers.
-         collector.separateFinalisers(1);
-
-         if (gcref(g->gc.mmudata) IS nullptr) break;  //  Until nothing is left to do.
-      }
-   }
+   // Metamethod failures are contained by gc_call_finaliser(), so every object in the snapshot is drained.
+   collector.finalizePending(L);
+   lj_assertG(gcref(g->gc.mmudata) IS nullptr, "pending finaliser queue was not drained during shutdown");
    close_state(L);
 }
 

--- a/src/tiri/jit/src/runtime/lj_state.cpp
+++ b/src/tiri/jit/src/runtime/lj_state.cpp
@@ -311,7 +311,9 @@ extern lua_State * lua_newstate(lua_Alloc allocf, void* allocd)
    lj_buf_init(nullptr, &g->tmpbuf);
    g->gc.state = GCPhase::Pause;
    setgcref(g->gc.root, obj2gco(L));
+   setgcrefnull(g->gc.finobj);
    setmref(g->gc.sweep, &g->gc.root);
+   setmref(g->gc.sweepfin, &g->gc.finobj);
    g->gc.total = sizeof(GG_State);
    g->gc.pause = LUAI_GCPAUSE;
    g->gc.stepmul = LUAI_GCMUL;
@@ -331,7 +333,7 @@ extern lua_State * lua_newstate(lua_Alloc allocf, void* allocd)
 static TValue* cpfinalize(lua_State *L, lua_CFunction dummy, void* ud)
 {
    GarbageCollector collector = gc(G(L));
-   collector.finalizeUdata(L);
+   collector.finalizePending(L);
    // Frame pop omitted.
    return nullptr;
 }
@@ -347,8 +349,8 @@ extern void lua_close(lua_State *L)
    setgcrefnull(g->cur_L);
    lj_func_closeuv(L, tvref(L->stack));
 
-   // Separate userdata which have GC metamethods
-   collector.separateUdata(1);
+   // Separate objects which have pending metamethod finalisers.
+   collector.separateFinalisers(1);
 
    G2J(g)->flags &= ~JIT_F_ON;
    G2J(g)->state = TraceState::IDLE;
@@ -361,8 +363,8 @@ extern void lua_close(lua_State *L)
       if (lj_vm_cpcall(L, nullptr, nullptr, cpfinalize) IS LUA_OK) {
          if (++i >= 10) break;
 
-         // Separate userdata again
-         collector.separateUdata(1);
+         // Separate any newly registered finalisers.
+         collector.separateFinalisers(1);
 
          if (gcref(g->gc.mmudata) IS nullptr) break;  //  Until nothing is left to do.
       }

--- a/src/tiri/jit/src/runtime/lj_thunk.cpp
+++ b/src/tiri/jit/src/runtime/lj_thunk.cpp
@@ -45,6 +45,7 @@ void lj_thunk_new(lua_State *L, GCfunc *Func, uint8_t ExpectedType)
    // Set metatable from registry
    cTValue *tv = lj_tab_getstr(tabV(registry(L)), lj_str_newz(L, THUNK_METATABLE_NAME));
    if (tv and tvistab(tv)) {
+      // The trusted thunk metatable is created internally without __gc.
       setgcref(ud->metatable, obj2gco(tabV(tv)));
    }
 

--- a/src/tiri/jit/src/runtime/unit_tests_gc.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_gc.cpp
@@ -1,0 +1,167 @@
+// Unit tests for Tiri garbage-collector lifecycle behaviour.
+// Copyright (C) 2026 Paul Manias
+
+#include <kotuku/main.h>
+
+#ifdef UNIT_TESTS
+
+#include "lua.h"
+#include "lauxlib.h"
+
+#include <array>
+#include <cstddef>
+
+namespace {
+
+struct TestCase {
+   const char* name;
+   bool (*fn)(kt::Log &Log);
+};
+
+static thread_local std::array<int, 8> glShutdownFinaliserCalls = { };
+static thread_local size_t glShutdownFinaliserCallCount = 0;
+static thread_local bool glShutdownFinaliserCreationSucceeded = false;
+
+static void reset_shutdown_finaliser_state()
+{
+   glShutdownFinaliserCalls.fill(0);
+   glShutdownFinaliserCallCount = 0;
+   glShutdownFinaliserCreationSucceeded = false;
+}
+
+static void record_shutdown_finaliser_call(int Identifier)
+{
+   if (glShutdownFinaliserCallCount < glShutdownFinaliserCalls.size()) {
+      glShutdownFinaliserCalls[glShutdownFinaliserCallCount++] = Identifier;
+   }
+}
+
+static int table_identifier(lua_State *Lua)
+{
+   lua_getfield(Lua, 1, "identifier");
+   int identifier = int(lua_tointeger(Lua, -1));
+   lua_pop(Lua, 1);
+   return identifier;
+}
+
+static int shutdown_recording_finaliser(lua_State *Lua)
+{
+   record_shutdown_finaliser_call(table_identifier(Lua));
+   return 0;
+}
+
+static int shutdown_failing_finaliser(lua_State *Lua)
+{
+   record_shutdown_finaliser_call(table_identifier(Lua));
+   luaL_error(Lua, "expected shutdown finaliser failure");
+}
+
+static bool push_finalisable_table(lua_State *Lua, lua_CFunction Finaliser, int Identifier)
+{
+   lua_newtable(Lua);
+   int table_index = lua_gettop(Lua);
+   lua_pushinteger(Lua, Identifier);
+   lua_setfield(Lua, table_index, "identifier");
+
+   lua_newtable(Lua);
+   lua_pushcfunction(Lua, Finaliser);
+   lua_setfield(Lua, -2, "__gc");
+   return lua_setmetatable(Lua, table_index) != 0;
+}
+
+static int shutdown_creating_finaliser(lua_State *Lua)
+{
+   record_shutdown_finaliser_call(table_identifier(Lua));
+   glShutdownFinaliserCreationSucceeded = push_finalisable_table(Lua, shutdown_recording_finaliser, 2);
+   return 0;
+}
+
+template<size_t Size>
+static bool calls_match(const std::array<int, Size>& Expected)
+{
+   if (glShutdownFinaliserCallCount != Expected.size()) return false;
+   for (size_t i = 0; i < Expected.size(); i++) {
+      if (glShutdownFinaliserCalls[i] != Expected[i]) return false;
+   }
+   return true;
+}
+
+static bool test_shutdown_drains_pre_registered_finalisers_after_error(kt::Log &Log)
+{
+   reset_shutdown_finaliser_state();
+   lua_State *lua = luaL_newstate(nullptr);
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   bool setup_ok = push_finalisable_table(lua, shutdown_recording_finaliser, 1);
+   lua_pop(lua, 1);
+   setup_ok = push_finalisable_table(lua, shutdown_failing_finaliser, 2) and setup_ok;
+   lua_pop(lua, 1);
+   setup_ok = push_finalisable_table(lua, shutdown_recording_finaliser, 3) and setup_ok;
+   lua_pop(lua, 1);
+   lua_close(lua);
+
+   constexpr std::array<int, 3> expected = { 3, 2, 1 };
+   if (not setup_ok) {
+      Log.error("failed to register the shutdown finalisers");
+      return false;
+   }
+   if (not calls_match(expected)) {
+      Log.error("shutdown finaliser order/count was incorrect");
+      return false;
+   }
+   return true;
+}
+
+static bool test_shutdown_does_not_run_new_finalisers(kt::Log &Log)
+{
+   reset_shutdown_finaliser_state();
+   lua_State *lua = luaL_newstate(nullptr);
+   if (not lua) {
+      Log.error("failed to create Lua state");
+      return false;
+   }
+
+   bool setup_ok = push_finalisable_table(lua, shutdown_creating_finaliser, 1);
+   lua_pop(lua, 1);
+   lua_close(lua);
+
+   constexpr std::array<int, 1> expected = { 1 };
+   if (not setup_ok or not glShutdownFinaliserCreationSucceeded) {
+      Log.error("failed to create a finalisable table for the shutdown lifecycle test");
+      return false;
+   }
+   if (not calls_match(expected)) {
+      Log.error("a shutdown-time finaliser ran during the same shutdown");
+      return false;
+   }
+   return true;
+}
+
+} // namespace
+
+extern void gc_unit_tests(int &Passed, int &Total)
+{
+   constexpr std::array<TestCase, 2> Tests = { {
+      { "shutdown_drains_pre_registered_finalisers_after_error",
+         test_shutdown_drains_pre_registered_finalisers_after_error },
+      { "shutdown_does_not_run_new_finalisers", test_shutdown_does_not_run_new_finalisers }
+   } };
+
+   for (const TestCase& Test : Tests) {
+      kt::Log Log("GcTests");
+      Log.branch("Running %s", Test.name);
+      ++Total;
+      if (Test.fn(Log)) {
+         ++Passed;
+         Log.msg("%s passed", Test.name);
+      }
+      else {
+         Log.error("%s failed", Test.name);
+      }
+   }
+}
+
+#endif // UNIT_TESTS

--- a/src/tiri/tests/test_close.tiri
+++ b/src/tiri/tests/test_close.tiri
@@ -462,3 +462,37 @@ end
    assert(caught_ex, 'Exception should be caught')
    assert(caught_ex.message:find('close2 error'), 'Last __close error should win: ' .. caught_ex.message)
 end
+
+-- An error from __gc must remain contained by the collector's protected call, even when collection is requested from
+-- inside a Tiri try block.
+
+@Test function FinaliserErrorInsideTryIsContained()
+   finalised = false
+   continued_after_collection = false
+   caught_message = nil
+
+   try
+      value = setmetatable({}, {
+         __gc = function()
+            try
+               error('finaliser-local handled error')
+            except ex
+               finalised = true
+            end
+            error('intentional finaliser error')
+         end
+      })
+      value = nil
+      processing.collect('full')
+      continued_after_collection = true
+      error('caller error after collection')
+   except ex
+      caught_message = ex.message
+   end
+
+   assert(finalised, 'The unreachable table should have been finalised')
+   assert(continued_after_collection, 'Collection should return after containing the finaliser error')
+   assert(caught_message != nil, "The caller's restored try handler should catch the post-collection error")
+   assert(caught_message:find('caller error after collection'),
+      "The caller's restored try handler should catch only the post-collection error: " .. caught_message)
+end

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -185,8 +185,6 @@ function TeardownJitTests()
    glCfg.free()
 end
 
-cached_trace_no = nil
-cached_trace_info = nil
 outer_upvalue = 37
 
 function build_trace()
@@ -209,20 +207,11 @@ function build_trace()
    for trace_no in {1 into 20} do
       info = jit.util.traceInfo(trace_no)
       if info then
-         cached_trace_no = trace_no
-         cached_trace_info = info
          return trace_no, info
       end
    end
 
    error("Failed to create a JIT trace for inspection")
-end
-
-function get_trace()
-   if cached_trace_no != nil and cached_trace_info != nil then
-      return cached_trace_no, cached_trace_info
-   end
-   return build_trace()
 end
 
 function ir_opcode(IrOt)
@@ -676,9 +665,6 @@ function jit_try_forced_materialisation_probe(Count)
 end
 
 function build_try_materialisation_trace()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -859,9 +845,6 @@ assert(trace_count > 0, "Dynamic result calls inside try blocks should remain JI
 end
 
 @Test(hotpath=80) function JITMathClampEmitsMinMax()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1027,7 +1010,7 @@ end
 end
 
 @Test function TraceInfoAndIR()
-   trace_no, info = get_trace()
+   trace_no, info = build_trace()
 
    assert(type(info.nins) is "number" and info.nins > 0, "traceInfo should report instruction count")
    assert(type(info.link) is "number", "traceInfo link should be numeric")
@@ -1060,18 +1043,28 @@ end
 end
 
 @Test function TraceConstantsAndSnapshot()
-   trace_no, info = get_trace()
+   trace_no, info = build_trace()
    if type(info.nk) is "number" and info.nk <= 0 then
       error("Trace did not expose any constants for verification")
    end
 
    k_value, k_type, k_slot = nil, nil, nil
-   for idx in {-info.nk to 0} do
-      value, kind, slot = jit.util.traceK(trace_no, idx)
-      if value != nil then
-         k_value, k_type, k_slot = value, kind, slot
-         break
+
+   -- The raw constant pool includes payload slots for wide constants. Inspect only negative references used by IR
+   -- instructions so traceK() always receives a constant header.
+
+   for idx in {1 into info.nins} do
+      local _, _, op1, op2 = jit.util.traceIR(trace_no, idx)
+
+      if op1 != nil and op1 < 0 then
+         k_value, k_type, k_slot = jit.util.traceK(trace_no, op1)
       end
+
+      if k_value is nil and op2 != nil and op2 < 0 then
+         k_value, k_type, k_slot = jit.util.traceK(trace_no, op2)
+      end
+
+      if k_value != nil then break end
    end
    assert(k_value != nil, "traceK should return at least one constant for available trace constants")
    assert(type(k_type) is "number", "traceK should return a type tag")
@@ -1087,7 +1080,7 @@ end
 end
 
 @Test function TraceMachineCodeAndExitStub()
-   trace_no = get_trace()
+   trace_no = build_trace()
    mcode, addr, loop_flag = jit.util.traceMC(trace_no)
    assert(mcode != nil, "traceMC should return machine code for hot traces")
    assert(type(addr) is "number", "traceMC should return a code address")
@@ -1114,9 +1107,6 @@ end
 end
 
 @Test(hotpath=100) function JitAttachTraceEvent()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    trace_events = 0
    function trace_handler(TraceNo, Reason)
       trace_events++
@@ -1130,9 +1120,6 @@ end
 end
 
 @Test(hotpath=100) function JitAttachTraceEventAllocatingHandler()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    records = {}
    trace_events = 0
    function trace_handler(TraceNo, Reason)
@@ -1149,9 +1136,6 @@ end
 end
 
 @Test(hotpath=100) function ArrayIteratorTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    function ensure_trace(IterFunc)
       jit.on()
       jit.flush()
@@ -1187,9 +1171,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayMethodClearLookupTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    local expected, result, trace_count = run_array_method_trace(array_method_clear_workload, 12)
 
    assert(result is expected, f"Expected traced array:clear() result '{expected}', got '{result}'")
@@ -1197,9 +1178,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayMethodResizeLookupTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    local expected, result, trace_count = run_array_method_trace(array_method_resize_workload, 12)
 
    assert(result is expected, f"Expected traced array:resize() result '{expected}', got '{result}'")
@@ -1207,9 +1185,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayMethodPushLookupTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    local expected, result, trace_count = run_array_method_trace(array_method_push_workload, 12)
 
    assert(result is expected, f"Expected traced array:push() result '{expected}', got '{result}'")
@@ -1346,9 +1321,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayNewLiteralTypeTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1382,9 +1354,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayClearTracesAndInvalidatesLength()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1425,9 +1394,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayResizeTracesAndInvalidatesLength()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1472,9 +1438,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayGetStringTracesWithRuntimeRemainingLength()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1514,9 +1477,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayPushSingleValueTracesAndReturnsLength()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1558,9 +1518,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayAppendFlattenedConcatChainTraces()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1598,9 +1555,6 @@ end
 end
 
 @Test(hotpath=80) function ArrayAppendMultiPieceConcatUsesBufferTrace()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1648,9 +1602,6 @@ end
 -- Without JIT support, the trace recorder would abort with NYIBC (Not Yet Implemented Bytecode).
 
 @Test(hotpath=50) function JITObjectFieldGet()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
@@ -1687,9 +1638,6 @@ end
 -- Test JIT recording of BC_OBSETF (object field set)
 
 @Test(hotpath=50) function JITObjectFieldSet()
-   cached_trace_no = nil
-   cached_trace_info = nil
-
    jit.on()
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")

--- a/src/tiri/tiri.cpp
+++ b/src/tiri/tiri.cpp
@@ -357,6 +357,7 @@ extern void parser_unit_tests(int &, int &);
 extern void array_unit_tests(int &, int &);
 extern void allocator_unit_tests(int &, int &);
 extern void bulk_unit_tests(int &, int &);
+extern void gc_unit_tests(int &, int &);
 #endif
 
 static void MODTest(std::string_view Options, int *Passed, int *Total)
@@ -396,6 +397,11 @@ static void MODTest(std::string_view Options, int *Passed, int *Total)
       kt::Log log("TiriTests");
       log.branch("Running bulk TValue unit tests...");
       bulk_unit_tests(*Passed, *Total);
+   }
+   {
+      kt::Log log("TiriTests");
+      log.branch("Running garbage collector unit tests...");
+      gc_unit_tests(*Passed, *Total);
    }
 #else
    kt::Log("TiriTests").warning("Unit tests are disabled in this build.");


### PR DESCRIPTION
## Summary

- add type-independent finaliser registration for Tiri tables and full userdata
- integrate registered objects with incremental marking, sweeping, weak-table processing, resurrection and pending finalisation
- make state shutdown deterministic by snapshotting pre-existing registrations and draining them in reverse registration order
- add compiled shutdown lifecycle coverage
- make JIT trace introspection tests independent of execution order

## Why

Tiri tables could not previously participate in `__gc` finalisation. This prevented table-backed interfaces from owning resources without a userdata proxy and left shutdown finalisation dependent on an arbitrary retry loop.

The JIT test suite also cached trace metadata between cases. Other tests could flush or reuse those trace numbers, and `traceK()` could be called on wide-constant payload slots rather than constant headers, causing order-dependent failures.

## Impact

Tables whose metatable contains `__gc` when assigned are now registered for one-shot finalisation. Finalisers can inspect and resurrect their table, weak-table ordering remains defined, errors are contained, and shutdown runs all objects registered before shutdown in reverse registration order. Objects registered by shutdown-time finalisers are freed without another finalisation pass, matching Lua 5.2+ semantics.

The JIT introspection cases now build a fresh trace and inspect only constant references used by recorded IR instructions.

## Validation

- built and installed Debug `tiri` and `origo_cmd`
- passed `tiri_unit_tests`, including shutdown ordering, error-continuation and shutdown-registration coverage
- passed `tiri_close` and `tiri_processing`
- passed all 97 `tiri_*` integration tests after the collector changes
- passed the focused JIT introspection case in three fresh processes
- passed all 54 `tiri_jit` cases