### PR TITLE
[Script] Improved benchmark tool

### DIFF
--- a/scripts/gui/window.tiri
+++ b/scripts/gui/window.tiri
@@ -21,7 +21,7 @@ lStyle = (function()
 end)()
 
 gui.window = function(Options:table)
-   self = { -- Public variables
+   self = setmetatable({ -- Public variables
       events       = Options.events ?? { },
       aspectRatio  = Options.aspectRatio??,
       minimiseEnabled   = Options.minimise??,
@@ -29,7 +29,7 @@ gui.window = function(Options:table)
       moveToBackEnabled = Options.moveToBack??,
       theme        = nil,
       focus        = Options.focus??,
-      quit         = Options.quit is false ? nil :> true, -- Quit defaults to true, user can explicitly set false to disable
+      quit         = Options.quit is false ? nil :> true, -- Construction-only; defaults to true.
       title        = Options.title ?? 'Window',
       icon         = Options.icon ?? 'devices/monitor',
       restore      = nil, -- { x, y, width, height }
@@ -39,9 +39,20 @@ gui.window = function(Options:table)
       margins      = Options.margins,
       surface      = nil, -- Client access to the surface is permitted
       viewport     = nil -- The window's top-level viewport
-   }
+   }, {
+      __gc = function(Window)
+         local surface = Window.surface
+         Window.surface = nil
+         surface?.free()
+      end
+   })
 
-   self.clientViewport = function(self:userdata, Options:table)
+   -- Callbacks retain this record, not the public window table. Weak-value clearing may remove `window` before
+   -- `__gc` runs, while the construction-time quit policy remains available to the surface free callback.
+
+   lifecycle = setmetatable({ window=self, quit=self.quit }, { __mode='v' })
+
+   self.clientViewport = function(self:table, Options:table)
       if self._clientViewport then return self._clientViewport end
       Options ?= { }
 
@@ -57,7 +68,7 @@ gui.window = function(Options:table)
       return self._clientViewport
    end
 
-   self.getSize = function(self:userdata)
+   self.getSize = function(self:table)
       return {
          x      = self.surface.x - self.client.left,
          y      = self.surface.y - self.client.top,
@@ -66,7 +77,7 @@ gui.window = function(Options:table)
       }
    end
 
-   self.getClientSize = function(self:userdata)
+   self.getClientSize = function(self:table)
       return {
          x = self.surface.x, y = self.surface.y, width = self.surface.width, height = self.surface.height
       }
@@ -74,7 +85,7 @@ gui.window = function(Options:table)
 
    -- Resize the window via the client area
 
-   self.resizeClientArea = function(self:userdata, ClientWidth:num, ClientHeight:num)
+   self.resizeClientArea = function(self:table, ClientWidth:num, ClientHeight:num)
       ClientWidth ?= self.surface.width
       ClientHeight ?= self.surface.height
       self.surface.acResize(ClientWidth, ClientHeight, 0)
@@ -83,7 +94,7 @@ gui.window = function(Options:table)
    -- Changes the size of the position of the window in relation to its parent.  All dimensions refer to the
    -- border of the window.
 
-   self.resize = function(self:userdata, X:num, Y:num, Width:num, Height:num)
+   self.resize = function(self:table, X:num, Y:num, Width:num, Height:num)
       Width ?= self.surface.width
       Height ?= self.surface.height
 
@@ -96,7 +107,7 @@ gui.window = function(Options:table)
 
    -- Define window sizing limits.
 
-   self.sizeHints = function(self:userdata, MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect)
+   self.sizeHints = function(self:table, MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect)
       if self.surface.display.mtSizeHints(MinWidth, MinHeight, MaxWidth, MaxHeight, EnforceAspect) != ERR_Okay then
          self.surface.maxWidth  = MaxWidth
          self.surface.minWidth  = MinWidth
@@ -107,13 +118,13 @@ gui.window = function(Options:table)
 
    -- Smart limits are used to prevent the window from moving completely outside of the visible display area.
 
-   self.applySmartLimits = function(self:userdata)
+   self.applySmartLimits = function(self:table)
       self.smartLimitsEnabled = true
    end
 
    -- Run the minimise procedure for the window (environment dependent).
 
-   self.minimise = function(self:userdata)
+   self.minimise = function(self:table)
       if self.MinimiseEnabled then
          self?.events?.minimise(self)
       end
@@ -125,7 +136,7 @@ gui.window = function(Options:table)
    --
    -- If Toggle is true, the window is restored to its original position if the window is already maximised.
 
-   self.maximise = function(self:userdata, Toggle)
+   self.maximise = function(self:table, Toggle)
       if not self.maximiseEnabled then
          msg('Maximisation for this window is turned off.')
          return
@@ -140,20 +151,20 @@ gui.window = function(Options:table)
       display.flags = display.flags | SCR_MAXIMISE
    end
 
-   self.moveToBack = function(self:userdata)
+   self.moveToBack = function(self:table)
       self.surface.acMoveToBack()
    end
 
-   self.moveToFront = function(self:userdata)
+   self.moveToFront = function(self:table)
       self.surface.acMoveToFront()
    end
 
-   self.parentSize = function(self:any)
+   self.parentSize = function(self:table)
       err, info = mGfx.getDisplayInfo(self.surface.display)
       return info.monitorWidth, info.monitorHeight
    end
 
-   self.show = function(self:userdata, Centre:bool)
+   self.show = function(self:table, Centre:bool)
       if Centre then
          x, y = (function()
             if self.surface.popOver then
@@ -205,13 +216,13 @@ gui.window = function(Options:table)
       self.events?.show(self)
    end
 
-   self.hide = function(self:userdata)
+   self.hide = function(self:table)
       self.visible = false
       self.surface.acHide()
       self.events?.hide(self)
    end
 
-   self.setTitle = function(self:userdata, Title:str)
+   self.setTitle = function(self:table, Title:str)
       self.surface.display.title = Title
       self.title = Title
    end
@@ -309,11 +320,14 @@ gui.window = function(Options:table)
    end
 
    self.viewport.mtSubscribeFeedback(FM_HAS_FOCUS | FM_CHILD_HAS_FOCUS | FM_LOST_FOCUS, function(Viewport, Event)
+      local window = lifecycle.window
+      if not window then return ERR_Terminate end
+
       if Event is FM_LOST_FOCUS then
-         self.events?.lostFocus(self)
+         window.events?.lostFocus(window)
       else
-         if not self.disabled then
-            self.events?.focus(self)
+         if not window.disabled then
+            window.events?.focus(window)
          end
       end
 
@@ -321,43 +335,42 @@ gui.window = function(Options:table)
    end)
 
    mGfx.windowHook(self.surface.id, WH_CLOSE, function()
-      result = self.events?.close(self)
+      local window = lifecycle.window
+      if not window then return ERR_Terminate end
+
+      result = window.events?.close(window)
       if result != nil then -- If client returns something, the window stays open
          msg('Client requested that the window stay open.')
          raise ERR_Cancelled
       end
    end)
 
-   self.surface.subscribe('focus', function(Surface, Args, self)
+   self.surface.subscribe('focus', function(Surface, Args, Lifecycle)
+      local window = Lifecycle.window
+      if not window then return end
+
       Surface.acMoveToFront()
-      if self.visible and not (Surface.flags has RNF_VISIBLE) then
+      if window.visible and not (Surface.flags has RNF_VISIBLE) then
          Surface.acShow()
       end
 
-      self.events?.focus(self)
-   end, self)
+      window.events?.focus(window)
+   end, lifecycle)
 
-   self.surface.subscribe('lostfocus', function(Surface, Args, self)
-      self.events?.lostFocus(self)
-   end, self)
+   self.surface.subscribe('lostfocus', function(Surface, Args, Lifecycle)
+      local window = Lifecycle.window
+      if not window then return end
+      window.events?.lostFocus(window)
+   end, lifecycle)
 
-   self.surface.subscribe('free', function(Surface, Args, self)
-      if self.quit then
+   self.surface.subscribe('free', function(Surface, Args, Lifecycle)
+      if Lifecycle.quit then
          mSys.SendMessage(MSGID_QUIT)
       end
-      table.clear(self)
-   end, self)
 
-   self.surface.detach() -- Keeps the surface unlocked so that window management code can terminate it.
+      local window = Lifecycle.window
+      if window then table.clear(window) end
+   end, lifecycle)
 
-   -- Return an interface for the window so that garbage collection is correctly managed
-
-   proxy = newproxy(true)
-   m = getmetatable(proxy)
-
-   m.__index = function(t, k) return self[k] end
-   m.__newindex = function(t, k, v) self[k] = v end
-   m.__gc = function() if self.surface then self.surface.free() end end
-
-   return proxy
+   return self
 end

--- a/tools/benchmark/benchmark.tiri
+++ b/tools/benchmark/benchmark.tiri
@@ -14,6 +14,7 @@ Parameters:
   hotloop=[n]  - Cycles required before performing JIT optimisation.
   calls=[n]    - Limit each test to this many calls.
   save[=all]   - Saves the results to the log.  Use save=all to store the full result tables.
+  traces       - Report on JIT trace compilation for each test instead of timing it.
  --]]
 
    import 'benchmark'
@@ -62,6 +63,8 @@ Examples:
   origo tools/benchmark/benchmark.tiri test=String duration=5s calls=500
   origo tools/benchmark/benchmark.tiri test="^Regex" save
   origo tools/benchmark/benchmark.tiri save=all
+  origo tools/benchmark/benchmark.tiri traces
+  origo tools/benchmark/benchmark.tiri traces test="^Control"
 ]],
    args = array<table> {
       { name = 'test', type = 'regex', group = 'Selection',
@@ -78,6 +81,9 @@ Examples:
 
       { name = 'save', type = saveOption, implicit = true, default = false, group = 'Output',
         comment = 'Save summary results to the log. Use "all" to include exhaustive benchmark statistics.' },
+      { name = 'traces', kind = 'flag', group = 'Output',
+        comment = 'Analyse JIT trace compilation for each benchmark and report whether it is being optimised. ' ..
+                  'Replaces the normal timing run; results are not saved or compared.' },
       { name = 'help', kind = 'flag', hidden = true,
         exec = function(Parser:table)
            Parser.printHelp()
@@ -108,6 +114,83 @@ function comparisonP99(Eval:table):any
    return nil
 end
 
+----------------------------------------------------------------------------------------------------------------------
+-- JIT trace analysis.
+--
+-- A benchmark is only meaningful if the code under test is actually being compiled.  Two independent failure modes
+-- are detected, because neither one implies the other:
+--
+--   1. Aborted traces.  The recorder gave up and the code runs in the interpreter.  A small number of aborts is
+--      normal (side exits on cold paths), so this is judged as a proportion of recording attempts.
+--   2. Trace explosion.  Every recording succeeds, but the same code is recorded over and over because the
+--      generated trace is not being reused.  This produces no aborts at all yet is severely slow, so a healthy
+--      abort count alone is not evidence of a healthy benchmark.
+--
+-- A well behaved benchmark records a handful of traces once and then stays on them.
+
+global glTraceStart = 0
+global glTraceStop  = 0
+global glTraceAbort = 0
+
+-- Above this many recordings the benchmark is recording far more than a stable loop nest requires.  Measured
+-- across the existing suite, healthy cases sit well under 30 while pathological cases exceed 300, so the exact
+-- value is not sensitive.
+global glTraceExplosion <const> = 100
+
+-- Proportion of recording attempts that may abort before the code is considered to be running interpreted.
+global glAbortRatioWarn <const> = 0.25
+
+-- The abort ratio is meaningless over a handful of recordings, where a single cold-path abort is both normal and
+-- enough to breach any sensible proportion.  Require an absolute number of aborts before the ratio is applied.
+global glAbortMinimum <const> = 4
+
+function traceAnalysis(Callback:func, Calls:num, HotLoop:num):table
+   -- Discard traces, blacklisting and side traces inherited from earlier benchmarks
+   jit.flush()
+   jit.opt.start(f'hotloop={HotLoop}')
+
+   glTraceStart = 0
+   glTraceStop  = 0
+   glTraceAbort = 0
+
+   local start_time = mSys.PreciseTime()
+   for i in {0 to Calls} do
+      Callback()
+   end
+   local elapsed = (mSys.PreciseTime() - start_time) / 1000.0
+
+   local result = {
+      recorded = glTraceStart,
+      compiled = glTraceStop,
+      aborted  = glTraceAbort,
+      time     = elapsed / Calls
+   }
+
+   result.abortRatio = result.recorded > 0 and (result.aborted / result.recorded) or 0
+
+   -- Classify the outcome.  Order matters: an interpreted benchmark is the more serious diagnosis, so it is
+   -- reported ahead of a trace explosion when a benchmark somehow manages both.
+   if result.recorded is 0 then
+      result.status = 'NO TRACES'
+      result.advice = 'No trace was recorded.  The body may be too short to reach the hot loop threshold, or the ' ..
+                      'JIT may have discarded it as doing no observable work.'
+   elseif result.compiled is 0 then
+      result.status = 'INTERPRETED'
+      result.advice = 'Every recording aborted, so this runs in the interpreter.'
+   elseif result.aborted >= glAbortMinimum and result.abortRatio >= glAbortRatioWarn then
+      result.status = 'PARTIAL'
+      result.advice = string.format('%.0f%% of recordings aborted, so part of this runs in the interpreter.',
+                                    result.abortRatio * 100)
+   elseif result.recorded > glTraceExplosion then
+      result.status = 'CHURNING'
+      result.advice = 'Traces compile but are not reused, so the same code is recorded repeatedly.'
+   else
+      result.status = 'OPTIMISED'
+   end
+
+   return result
+end
+
    global glArgs = glParser.process()
    if glArgs is nil then return end
 
@@ -125,6 +208,7 @@ end
    local hotloop      = glArgs.hotloop
    local call_limit   = glArgs.calls
    local save_results = glArgs.save
+   local trace_mode   = glArgs.traces
 
    local test_match = glArgs.test
    if test_match then
@@ -154,6 +238,69 @@ end
    table.sort(name_list, function(a:table, b:table):bool
       return (a.name < b.name)
    end)
+
+   if trace_mode then
+      jit.attach(function(What:str)
+         if What is 'start' then glTraceStart++
+         elseif What is 'stop' then glTraceStop++
+         elseif What is 'abort' then glTraceAbort++
+         end
+      end, 'trace')
+
+      logMessage('JIT trace analysis')
+      logMessage('')
+      logMessage(string.format('%-*s  %-11s %8s %8s %8s %10s', longest_name, 'BENCHMARK', 'STATUS',
+         'RECORDED', 'COMPILED', 'ABORTED', 'MS/CALL'))
+      logMessage(string.rep('-', longest_name + 50))
+
+      local advice = { }
+      local tally = { OPTIMISED=0, CHURNING=0, PARTIAL=0, INTERPRETED=0, ['NO TRACES']=0, ERROR=0 }
+
+      for entry in values(name_list) do
+         local name = entry.name
+
+         if rx_test then
+            if not rx_test.test(name) then continue end
+         end
+
+         -- A handful of calls is enough for the trace behaviour to settle, and keeps analysis of the slowest
+         -- benchmarks fast.  Trace counts are a property of the code, not of how long it is exercised.
+         local analysis
+         try<trace>
+            analysis = traceAnalysis(entry.func, 3, hotloop)
+         except ex
+            tally.ERROR++
+            logMessage(string.format('%-*s  %-11s %s', longest_name, name, 'ERROR', ex.message))
+            continue
+         end
+
+         tally[analysis.status] += 1
+
+         logMessage(string.format('%-*s  %-11s %8d %8d %8d %10.3f', longest_name, name, analysis.status,
+            analysis.recorded, analysis.compiled, analysis.aborted, analysis.time))
+
+         if analysis.advice then
+            table.insert(advice, { name = name, status = analysis.status, advice = analysis.advice })
+         end
+      end
+
+      logMessage('')
+      logMessage(string.format('Optimised: %d, Churning: %d, Partial: %d, Interpreted: %d, No traces: %d, Errors: %d',
+         tally.OPTIMISED, tally.CHURNING, tally.PARTIAL, tally.INTERPRETED, tally['NO TRACES'], tally.ERROR))
+
+      if #advice > 0 then
+         logMessage('')
+         logMessage('Benchmarks not fully optimised:')
+         logMessage('')
+         for item in values(advice) do
+            logMessage(f'  {item.name} [{item.status}]')
+            logMessage(f'    {item.advice}')
+         end
+      end
+
+      -- Trace analysis replaces the timing run, so there is nothing to save or compare against.
+      return
+   end
 
    for entry in values(name_list) do
       func = entry.func

--- a/tools/benchmark/benchmark_control.tiri
+++ b/tools/benchmark/benchmark_control.tiri
@@ -10,27 +10,37 @@ function result_series()
 end
 
 @Test function NullificationRetain()
+   local acc = 0
    for i in {0 to 10000000} do
       local a, b, c = result_series()
+      acc += #a + b + c.three
    end
+   return acc
 end
 
 @Test function NullificationBlank()
+   local acc = 0
    for i in {0 to 10000000} do
       local _, _, c = result_series()
+      acc += c.three
    end
+   return acc
 end
 
 @Test function NullificationMask()
+   local acc = 0
    for i in {0 to 10000000} do
       local c = [__*]result_series()
+      acc += c.three
    end
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Execute branching logic with if/elseif/else chains
 
 @Test function ControlIfElseChains()
+   local acc = 0
    for i in {0 to 1000000} do
       local result = 0
       local x = i % 100
@@ -88,13 +98,18 @@ end
       elseif x >= 60 or x < 10 then
          result = 300
       end
+
+      acc += result
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Use ternary conditional operator for inline branching
 
 @Test function ControlTernaryOperator()
+   local acc = 0
    for i in {0 to 100000} do
       local x = i % 100
       local result = 0
@@ -120,13 +135,20 @@ end
       -- Ternary with boolean results
       local is_even = x % 2 is 0 ? true :> false
       local in_range = (x >= 25 and x <= 75) ? true :> false
+
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += result + a + b + min_val + max_val + clamped +
+             (is_even ? 1 :> 0) + (in_range ? 1 :> 0)
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Use nil coalescing operators for default values
 
 @Test function ControlNilCoalescing()
+   local acc = 0
    for i in {0 to 100000} do
       local result = 0
 
@@ -149,19 +171,38 @@ end
       local x = i % 7 is 0 ? nil :> i * 2
       result = (x ?? 0) + 10
 
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += result
+   end
+
+   return acc
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Measure nil coalescing over conditionally allocated tables.
+-- NB: Kept separate from ControlNilCoalescing because allocating a table with a conditionally-nil field causes
+-- trace aborts.  Measured in isolation, the ?? operator itself compiles cleanly, so merging the two cases would
+-- wrongly attribute the allocation cost to ??.
+
+@Test function ControlNilCoalescingNested()
+   local acc = 0
+   for i in {0 to 100000} do
       -- Nested nil coalescing
       local outer = i % 4 is 0 ? nil :> { inner = i % 2 is 0 ? nil :> i }
       local safe_val = outer ?? { inner = 0 }
+
+      acc += (safe_val.inner ?? 0)
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Execute range loops with start, end, step
 
 @Test function ControlForNumericLoop()
+   local sum = 0
    for i in {0 to 10000} do
-      local sum = 0
-
       -- Simple ascending loop
       for j in {0 into 99} do
          sum += j
@@ -172,39 +213,269 @@ end
          sum += j
       end
 
-      -- Descending loop
-      for j in {99 into 0 by -1} do
-         sum += j
-      end
-
-      -- Descending with step
-      for j in {100 into 0 by -5} do
-         sum += j
-      end
-
       -- Nested numeric loops
       for x in {0 into 9} do
          for y in {0 into 9} do
             sum += x * y
          end
       end
+   end
 
-      -- Loop with computed bounds
-      local start = i % 10
-      local finish = start + 50
+   return sum
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Execute range loops whose bounds are computed at runtime.
+-- NB: Measured separately from ControlForNumericLoop because a range bound supplied by a variable rather than a
+-- literal currently defeats trace compilation, regardless of whether the trip count actually varies.  Each
+-- comparison performs the same outer and inner iteration counts so its timing can be compared directly.
+
+@Test function ControlForComputedBoundsLiteral()
+   local sum = 0
+   local start = 0
+   local finish = 0
+   for i in {0 to 1000} do
+      start = i % 10
+      finish = start + 50
+      for j in {0 into 50} do
+         sum += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+@Test function ControlForVariableBoundsStable()
+   local sum = 0
+   local start = 0
+   local finish = 50
+   for i in {0 to 1000} do
       for j in {start into finish} do
          sum += 1
       end
    end
+
+   return sum + start + finish
+end
+
+@Test function ControlForVariableBoundsStableLiteral()
+   local sum = 0
+   local start = 0
+   local finish = 50
+   for i in {0 to 1000} do
+      for j in {0 into 50} do
+         sum += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+@Test function ControlForVariableBoundsStableWhile()
+   local sum = 0
+   local start = 0
+   local finish = 50
+   for i in {0 to 1000} do
+      local j = start
+      while j <= finish do
+         sum += 1
+         j += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+@Test function ControlForComputedBounds()
+   local sum = 0
+   local start = 0
+   local finish = 0
+   for i in {0 to 1000} do
+      start = i % 10
+      finish = start + 50
+      for j in {start into finish} do
+         sum += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+@Test function ControlForComputedBoundsWhile()
+   local sum = 0
+   local start = 0
+   local finish = 0
+   for i in {0 to 1000} do
+      start = i % 10
+      finish = start + 50
+      local j = start
+      while j <= finish do
+         sum += 1
+         j += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Execute range loops whose direction changes with their runtime bounds.
+
+@Test function ControlForVariableDirection()
+   local sum = 0
+   local start = 0
+   local finish = 0
+   for i in {0 to 1000} do
+      if i % 2 is 0 then
+         start = 0
+         finish = 50
+      else
+         start = 50
+         finish = 0
+      end
+
+      for j in {start into finish} do
+         sum += 1
+      end
+   end
+
+   return sum + start + finish
+end
+
+@Test function ControlForVariableDirectionWhile()
+   local sum = 0
+   local start = 0
+   local finish = 0
+   for i in {0 to 1000} do
+      if i % 2 is 0 then
+         start = 0
+         finish = 50
+      else
+         start = 50
+         finish = 0
+      end
+
+      local j = start
+      if start <= finish then
+         while j <= finish do
+            sum += 1
+            j += 1
+         end
+      else
+         while j >= finish do
+            sum += 1
+            j -= 1
+         end
+      end
+   end
+
+   return sum + start + finish
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Execute a runtime-bound fractional range.
+-- The quarter step is exactly representable, allowing the while control to yield the same number of iterations.
+
+@Test function ControlForFractionalBounds()
+   local sum = 0
+   local start = 0.0
+   local finish = 10.0
+   local step = 0.25
+   for i in {0 to 1000} do
+      for j in {start into finish by step} do
+         sum += 1
+      end
+   end
+
+   return sum + start + finish + step
+end
+
+@Test function ControlForFractionalBoundsWhile()
+   local sum = 0
+   local start = 0.0
+   local finish = 10.0
+   local step = 0.25
+   for i in {0 to 1000} do
+      local j = start
+      while j <= finish do
+         sum += 1
+         j += step
+      end
+   end
+
+   return sum + start + finish + step
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Execute descending range loops.
+-- The implicit, explicit and while forms perform identical work.  This isolates the parser's handling of the unary
+-- negative step from the numeric loop recorder's handling of descending iteration.
+
+@Test function ControlForDescendingImplicit()
+   local sum = 0
+   for i in {0 to 1000} do
+      for j in {99 into 0} do
+         sum += j
+      end
+   end
+
+   return sum
+end
+
+@Test function ControlForDescendingLoop()
+   local sum = 0
+   for i in {0 to 1000} do
+      for j in {99 into 0 by -1} do
+         sum += j
+      end
+   end
+
+   return sum
+end
+
+@Test function ControlForDescendingWhile()
+   local sum = 0
+   for i in {0 to 1000} do
+      local j = 99
+      while j >= 0 do
+         sum += j
+         j -= 1
+      end
+   end
+
+   return sum
+end
+
+@Test function ControlForDescendingStride()
+   local sum = 0
+   for i in {0 to 1000} do
+      for j in {100 into 0 by -5} do
+         sum += j
+      end
+   end
+
+   return sum
+end
+
+@Test function ControlForDescendingStrideWhile()
+   local sum = 0
+   for i in {0 to 1000} do
+      local j = 100
+      while j >= 0 do
+         sum += j
+         j -= 5
+      end
+   end
+
+   return sum
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Execute range-based for loops
 
 @Test function ControlForRangeLoop()
-   for i in {0 to 100} do
-      local sum = 0
-
+   local sum = 0
+   for i in {0 to 10000} do
       -- Simple range loop (exclusive end)
       for j in {0 to 100} do
          sum += j
@@ -215,12 +486,6 @@ end
          sum += j
       end
 
-      -- Range with step (using range.new)
-      nr = range.new(0, 100, false, 2)
-      for j in nr() do
-         sum += j
-      end
-
       -- Nested range loops
       for x in {0 to 10} do
          for y in {0 to 10} do
@@ -228,26 +493,65 @@ end
          end
       end
 
-      -- Range with negative indices
-      for j in {-10 to 10} do
-         sum += j
-      end
-
       -- Short ranges
       for j in {0 to 5} do
          sum += j
       end
    end
+   return sum
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Iterate a range object created via range.new().
+-- NB: Measured separately from ControlForRangeLoop because the range object iterator does not trace-compile, and
+-- hoisting the range.new() call out of the loop makes no difference.  Isolating it keeps the range literal figures
+-- meaningful.
+
+@Test function ControlForRangeObject()
+   local sum = 0
+   local nr = range.new(0, 100, false, 2)
+   for i in {0 to 1000} do
+      for j in nr() do
+         sum += j
+      end
+   end
+   return sum
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Goal: Iterate a range literal that starts from a negative bound.
+-- NB: Measured separately because a negative start bound currently defeats trace compilation, whereas an
+-- equivalent-width range starting at zero or above compiles in a handful of traces.  The trigger is the negative
+-- start value itself, not the range crossing zero -- {-20 to -1} behaves the same as {-10 to 10}.  Both controls
+-- count iterations so their return values and loop bodies are identical.
+
+@Test function ControlForNonNegativeRange()
+   local sum = 0
+   for i in {0 to 1000} do
+      for j in {0 to 20} do
+         sum += 1
+      end
+   end
+   return sum
+end
+
+@Test function ControlForNegativeRange()
+   local sum = 0
+   for i in {0 to 1000} do
+      for j in {-10 to 10} do
+         sum += 1
+      end
+   end
+   return sum
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Execute while loops with varying conditions
 
 @Test function ControlWhileLoop()
+   local sum = 0
+   local count = 0
    for i in {0 to 10000} do
-      local sum = 0
-      local count = 0
-
       -- Simple counting while
       count = 0
       while count < 100 do
@@ -291,16 +595,17 @@ end
          n = n - 3
       end
    end
+
+   return sum, count
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Execute repeat-until loops
 
 @Test function ControlRepeatUntil()
+   local sum = 0
+   local count = 0
    for i in {0 to 10000} do
-      local sum = 0
-      local count = 0
-
       -- Simple repeat-until
       count = 0
       repeat
@@ -342,12 +647,14 @@ end
          end
       until found or count >= 100
    end
+   return sum, count
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Use break and continue statements in loops
 
 @Test function ControlBreakContinue()
+   local acc = 0
    for i in {0 to 1000} do
       local sum = 0
       local count = 0
@@ -422,36 +729,76 @@ end
          end
          sum += j
       end
+
+      acc += sum + count
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Measure overhead of the safe navigation operator (?.) vs direct access
 
-@Test function ControlSafeNavigationFastCmp()
-   local obj = { name = "Alice", addr = { city = "London", geo = { lat = 51.5 } } }
-   local arr = { 10, 20, 30, 40, 50 }
+-- NB: Safe field access (?.) and safe index access (?[]) are measured separately because they have very
+-- different JIT characteristics.  At the time of writing ?. compiles cleanly and matches direct field access,
+-- whereas ?[] aborts trace compilation and is therefore orders of magnitude slower.  Combining them into one
+-- benchmark would hide that distinction.
 
+@Test function ControlSafeNavigationFieldFastCmp()
+   local obj = { name = "Alice", addr = { city = "London", geo = { lat = 51.5 } } }
+
+   local acc = 0
    for i in {0 to 1000000} do
       local v1 = obj.name
       local v2 = obj.addr.city
       local v3 = obj.addr.geo.lat
-      local v4 = arr[0]
-      local v5 = arr[2]
+      acc += #v1 + #v2 + v3
    end
+
+   return acc
 end
 
-@Test function ControlSafeNavigation()
+@Test function ControlSafeNavigationField()
    local obj = { name = "Alice", addr = { city = "London", geo = { lat = 51.5 } } }
-   local arr = { 10, 20, 30, 40, 50 }
-   local missing = nil
 
+   local acc = 0
    for i in {0 to 1000000} do
       -- Safe access on valid paths (should behave like direct access)
       local v1 = obj?.name
       local v2 = obj?.addr?.city
       local v3 = obj?.addr?.geo?.lat
-      local v4 = arr?[0]
-      local v5 = arr?[2]
+      acc += #v1 + #v2 + v3
    end
+
+   return acc
+end
+
+-- NB: The index pair uses a lower iteration count than the field pair because ?[] does not currently trace-compile.
+-- At 1M iterations it is slow enough to exhaust the benchmark harness warmup budget.  Both functions in the pair
+-- must keep the same count for the comparison to remain valid.
+
+@Test function ControlSafeNavigationIndexFastCmp()
+   local arr = { 10, 20, 30, 40, 50 }
+
+   local acc = 0
+   for i in {0 to 100000} do
+      local v1 = arr[0]
+      local v2 = arr[2]
+      acc += v1 + v2
+   end
+
+   return acc
+end
+
+@Test function ControlSafeNavigationIndex()
+   local arr = { 10, 20, 30, 40, 50 }
+
+   local acc = 0
+   for i in {0 to 100000} do
+      local v1 = arr?[0]
+      local v2 = arr?[2]
+      acc += v1 + v2
+   end
+
+   return acc
 end

--- a/tools/benchmark/benchmark_language.tiri
+++ b/tools/benchmark/benchmark_language.tiri
@@ -5,42 +5,43 @@
 
 @Test function ExceptionTryExcept()
    -- Function that may throw an error
-   local function mayFail(shouldFail)
-      if shouldFail then
+   local function mayFail(ShouldFail:bool):num
+      if ShouldFail then
          error("Intentional error")
       end
       return 42
    end
 
    -- Function that always succeeds
-   local function alwaysSucceeds(x)
-      return x * 2
+   local function alwaysSucceeds(Value:num):num
+      return Value * 2
    end
 
+   local acc = 0
    for i in {0 to 10000} do
       -- Try-except with no exception thrown
       try
-         local result = alwaysSucceeds(i)
+         acc += alwaysSucceeds(i)
       except ex
-         local msg = ex.message
+         acc += #ex.message
       end
 
       -- Try-except with exception thrown occasionally
       try
-         local result = mayFail(i % 100 is 0)
+         acc += mayFail(i % 100 is 0)
       except ex
-         local msg = ex.message
+         acc += #ex.message
       end
 
       -- Nested try-except blocks
       try
          try
-            local result = alwaysSucceeds(i)
+            acc += alwaysSucceeds(i)
          except inner
-            local msg = inner.message
+            acc += #inner.message
          end
       except outer
-         local msg = outer.message
+         acc += #outer.message
       end
 
       -- Try-except with multiple operations
@@ -48,9 +49,9 @@
          local a = alwaysSucceeds(i)
          local b = alwaysSucceeds(i + 1)
          local c = alwaysSucceeds(i + 2)
-         local sum = a + b + c
+         acc += a + b + c
       except ex
-         local msg = ex.message
+         acc += #ex.message
       end
 
       -- Try-except with conditional exception
@@ -58,31 +59,34 @@
          if i % 50 is 0 then
             error("Periodic error")
          end
-         local result = i * 2
+         acc += i * 2
       except ex
-         local recovered = 0
+         acc += 1
       end
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Use try-success pattern for handling successful completion
 
 @Test function ExceptionTrySuccess()
-   local function compute(x)
-      if x < 0 then
+   local function compute(Value:num):num
+      if Value < 0 then
          error("Negative value not allowed")
       end
-      return x * x
+      return Value * Value
    end
 
-   local function fetchData(id)
-      if id is 0 then
+   local function fetchData(Id:num):table
+      if Id is 0 then
          error("Invalid ID")
       end
-      return { id = id, value = id * 10 }
+      return { id = Id, value = Id * 10 }
    end
 
+   local acc = 0
    for i in {0 to 30000} do
       local result = 0
 
@@ -104,6 +108,7 @@ end
       success
          data.value = data.value * 2
       end
+      acc += data.value
 
       -- Chained operations in success block
       local a, b
@@ -143,13 +148,18 @@ end
       success
          result = result + 20
       end
+
+      acc += result
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Measure overhead of defer statement for cleanup
 
 @Test function ExceptionDefer()
+   local acc = 0
    for i in {0 to 5000} do
       local cleanup_count = 0
 
@@ -209,24 +219,37 @@ end
       end
 
       -- Defer simulating resource cleanup pattern
+      local data = 0
       do
          local resource = { open = true }
          defer()
             resource.open = false
          end
-         local data = resource.open and i or 0
+         data = resource.open and i or 0
       end
+
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += cleanup_count + value + result + data
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- VARIABLE SCOPE
 ----------------------------------------------------------------------------------------------------------------------
 -- These benchmarks perform identical operations to enable direct performance comparison
--- between different variable scoping mechanisms.
+-- between different variable scoping mechanisms.  They must all share the same iteration count, and each returns
+-- an accumulator so that the JIT cannot discard the loop body.  Verify a change here by checking that ScopeLocal,
+-- ScopeGlobal and ScopeUpvalueAccess still return an identical value.
+--
+-- NB: The iteration count is capped at 20k because global access is roughly two orders of magnitude slower than
+-- local access.  At higher counts ScopeGlobal takes long enough per call that it cannot complete the benchmark
+-- harness warmup phase within a typical duration limit, and the benchmark is reported as an error.
 
 @Test function ScopeLocal()
-   for i in {0 to 1000000} do
+   local acc = 0
+   for i in {0 to 20000} do
       -- Declare local variables
       local a = 10
       local b = 20
@@ -267,7 +290,12 @@ end
       c *= 2
       d /= 2
       e %= 100
+
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += r1 + r2 + r3 + r4 + r5 + sum + product + diff + quotient + a + b + c + d + e
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -281,7 +309,8 @@ global glScopeD = 40
 global glScopeE = 50
 
 @Test function ScopeGlobal()
-   for i in {0 to 1000000} do
+   local acc = 0
+   for i in {0 to 20000} do
       -- Reset global variables
       glScopeA = 10
       glScopeB = 20
@@ -322,21 +351,26 @@ global glScopeE = 50
       glScopeC *= 2
       glScopeD /= 2
       glScopeE %= 100
+
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += r1 + r2 + r3 + r4 + r5 + sum + product + diff + quotient +
+             glScopeA + glScopeB + glScopeC + glScopeD + glScopeE
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Measure performance of const-annotated local variable access
 
 @Test function ScopeConstantAccess()
-   for i in {0 to 1000000} do
-      -- Declare const local variables
-      local a <const> = 10
-      local b <const> = 20
-      local c <const> = 30
-      local d <const> = 40
-      local e <const> = 50
-
+   local a <const> = 10
+   local b <const> = 20
+   local c <const> = 30
+   local d <const> = 40
+   local e <const> = 50
+   local acc = 0
+   for i in {0 to 20000} do
       -- Read operations (const can only be read, not written)
       local r1 = a
       local r2 = b
@@ -371,13 +405,11 @@ end
       md /= 2
       me %= 100
 
-      -- Additional const reads to match operation count
-      local x1 = a + b
-      local x2 = c + d
-      local x3 = e + a
-      local x4 = b + c
-      local x5 = d + e
+      -- Consume the results so that the loop body cannot be eliminated by the JIT
+      acc += r1 + r2 + r3 + r4 + r5 + sum + product + diff + quotient + ma + mb + mc + md + me
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -392,7 +424,7 @@ end
    local e = 50
 
    -- Create closure that captures upvalues
-   local function accessUpvalues(iter)
+   local function accessUpvalues(Iter:num):num
       -- Read operations
       local r1 = a
       local r2 = b
@@ -407,11 +439,11 @@ end
       local quotient = d / a
 
       -- Write operations
-      a = iter
-      b = iter + 1
-      c = iter + 2
-      d = iter + 3
-      e = iter + 4
+      a = Iter
+      b = Iter + 1
+      c = Iter + 2
+      d = Iter + 3
+      e = Iter + 4
 
       -- Mixed read/write
       a = b + c
@@ -426,9 +458,13 @@ end
       c *= 2
       d /= 2
       e %= 100
+
+      -- Returning the results prevents the JIT from eliminating the upvalue accesses
+      return r1 + r2 + r3 + r4 + r5 + sum + product + diff + quotient + a + b + c + d + e
    end
 
-   for i in {0 to 1000000} do
+   local acc = 0
+   for i in {0 to 20000} do
       -- Reset upvalues
       a = 10
       b = 20
@@ -437,8 +473,10 @@ end
       e = 50
 
       -- Call function that accesses upvalues
-      accessUpvalues(i)
+      acc += accessUpvalues(i)
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -458,6 +496,7 @@ end
    local bool_false = false
    local nil_val = nil
 
+   local acc = 0
    for i in {0 to 500} do
       -- Check type of numbers
       local t1 = type(num_int)
@@ -497,13 +536,20 @@ end
       -- Conditional based on type
       local val = i % 3 is 0 and str or (i % 3 is 1 and num_int or tbl)
       if type(val) is "string" then
-         local _ = #val
+         acc += #val
       elseif type(val) is "number" then
-         local _ = val * 2
+         acc += val * 2
       elseif type(val) is "table" then
-         local _ = val.a
+         acc += val.a
       end
+
+      -- Consume the type results so that the loop body cannot be eliminated by the JIT
+      acc += #t1 + #t2 + #t3 + #t4 + #t5 + #t6 + #t7 + #t8 + #t9 + #t10 + #t11 + #t12 + #t13 + #t14
+      acc += (is_num and 1 or 0) + (is_str and 1 or 0) + (is_tbl and 1 or 0) +
+             (is_func and 1 or 0) + (is_bool and 1 or 0)
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -520,6 +566,7 @@ end
    local str_invalid = "not_a_number"
    local str_mixed = "123abc"
 
+   local acc = 0
    for i in {0 to 1000} do
       -- Convert integer strings
       local n1 = tonumber(str_int)
@@ -559,7 +606,15 @@ end
       -- Conditional conversion with fallback
       local val = tonumber(str_int) ?? 0
       local val2 = tonumber(str_invalid) ?? -1
+
+      -- Consume the results so that the loop body cannot be eliminated by the JIT.
+      -- n14..n16 are intentionally nil (invalid conversions), so they are counted rather than summed.
+      acc += n1 + n2 + n3 + n4 + n5 + n6 + n7 + n8 + n9 + n10 + n11 + n12 + n13
+      acc += (n14 ?? 0) + (n15 ?? 0) + (n16 ?? 0)
+      acc += n17 + n18 + n19 + val + val2
    end
+
+   return acc
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Introduced a `traces` mode in benchmark.tiri that attaches to the JIT trace hook and classifies each benchmark as OPTIMISED, CHURNING, PARTIAL, INTERPRETED or NO TRACES, with advice for cases that are not fully optimised
* Reworked control and language benchmarks to accumulate and return their results, preventing the JIT from eliminating loop bodies and reporting misleading timings
* [GUI] Replaced the window newproxy interface with a metatable-based `__gc` finaliser, and routed surface and viewport callbacks through a weak-valued lifecycle record so that they terminate cleanly once the window is collected