### PR TITLE
[Tiri] JIT compilation support for explicit range object iteration

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -211,6 +211,67 @@ Operand suffixes: V=variable slot, S=string const, N=number const, P=primitive (
 | `ILOOP` | A D | LOOP interpreter-only variant |
 | `JLOOP` | A D | LOOP with JIT trace linkage |
 | `JMP` | A D | PC += D - 0x8000 (signed jump offset) |
+| `RANGEPREP` | A D | Prepare the direct range at base R(A); D is a `RANGE_PREP_*` flag mask |
+| `RANGEVAL` | A D | Generate the visible range value at R(A+7) from the prepared ordinal state; D is unused |
+
+##### Direct Range Loops (`RANGEPREP`, `RANGEVAL`)
+
+Direct ranges that require runtime preparation use `RANGEPREP` with the existing numeric `FORI`/`FORL` instructions.
+The numeric loop advances an ordinal, while `RANGEVAL` derives the visible value from the original start and step
+without accumulating floating-point error.  Safe compile-time integer ranges outside protected regions can emit
+`FORI`/`FORL` directly and omit both range-specific instructions.
+
+`RANGEPREP` uses the AD format:
+
+- `A` is the first slot in the range-loop frame.
+- `D` is a bit mask containing:
+  - `RANGE_PREP_INCLUSIVE` (`1 << 0`): include an aligned stop value.
+  - `RANGE_PREP_HAS_STEP` (`1 << 1`): read the explicit step from `R(A+2)`; otherwise infer `1` or `-1` from the
+    start and stop.
+  - `RANGE_PREP_DIRECT_INTEGER` (`1 << 2`): prepare the compact four-slot integer layout.
+- On entry, `R(A)` is the start and `R(A+1)` is the stop.  `R(A+2)` is the explicit step when
+  `RANGE_PREP_HAS_STEP` is set.
+- Preparation validates finite bounds, a finite non-zero step, the range count, and representable progress.  Invalid
+  input raises the numeric-range error instead of entering the loop.
+- The instruction otherwise falls through to the following `FORI`; it has no bytecode jump operand.
+
+The stack effects depend on `RANGE_PREP_DIRECT_INTEGER`:
+
+| Relative slot | Compact integer layout | Full ordinal layout |
+|---------------|------------------------|---------------------|
+| `R(A+0)` | Integer start/index | Ordinal index, initialised to `0` |
+| `R(A+1)` | Integer loop limit, adjusted for an exclusive stop | Final ordinal, `count - 1` |
+| `R(A+2)` | Integer step | Ordinal step, always `1` |
+| `R(A+3)` | Current integer value, initialised to nil and maintained by `FORI`/`FORL` | Current ordinal, initialised to nil and maintained by `FORI`/`FORL` |
+| `R(A+4)` | Not part of the compact frame | Original start |
+| `R(A+5)` | Not part of the compact frame | Prepared value step |
+| `R(A+6)` | Not part of the compact frame | Integer-result flag (`1` for signed 32-bit integral values, otherwise `0`) |
+| `R(A+7)` | Not part of the compact frame | Visible loop value, initialised to nil |
+
+The compact layout occupies four slots and does not use `RANGEVAL`; the visible control variable is `R(A+3)`.  The
+full layout occupies eight slots and uses `R(A+7)` as the visible control variable.
+
+`RANGEVAL` also uses the AD format, but only `A` is meaningful.  It reads the current ordinal from `R(A+3)`, the
+original start from `R(A+4)`, the value step from `R(A+5)`, and the integer-result flag from `R(A+6)`.  It writes
+`R(A+7)` as `fma(ordinal, step, start)`, tagging the result as an integer when the flag is set and as a number
+otherwise.  It then proceeds to the next instruction without branching.
+
+The emitted control-flow pattern for the full layout is:
+
+```text
+RANGEPREP A, flags
+FORI      A, loop_exit
+RANGEVAL  A
+loop_body
+FORL      A, RANGEVAL
+loop_exit:
+```
+
+`FORI` checks the prepared ordinal range.  An empty or initially out-of-bounds range transfers control to
+`loop_exit`; otherwise it sets `R(A+3)` to the first ordinal and falls through to `RANGEVAL`.  `FORL` advances the
+ordinal in `R(A)` and `R(A+3)` and jumps back to `RANGEVAL` while the ordinal remains within `R(A+1)`.  A `continue`
+targets `FORL`, while a `break` targets `loop_exit`.  This keeps range preparation outside the loop and executes
+`RANGEVAL` exactly once for every body iteration.
 
 #### Function Header Ops (internal, not emitted by parser)
 | Opcode | Format | Description |

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -1263,6 +1263,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  str TISNIL, [BASE, #-16]
   |  b ->fff_res1
   |
+  |.ffunc_2 range_iterator_next
+  |  b ->fff_fallback
+  |
   |.ffunc_1 pairs
   |  checktp TMP1, CARG1, LJ_TTAB, ->fff_fallback
   |  ldr TAB:CARG2, TAB:TMP1->metatable

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -1752,6 +1752,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  li CARG3, LJ_TNIL
   |  b ->fff_restv
   |
+  |.ffunc_2 range_iterator_next
+  |  b ->fff_fallback
+  |
   |.ffunc_1 pairs
   |  checktab CARG3
   |   lwz PC, FRAME_PC(BASE)

--- a/src/tiri/jit/src/jit/vm_x64.dasc
+++ b/src/tiri/jit/src/jit/vm_x64.dasc
@@ -1579,6 +1579,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  mov aword [BASE-16], LJ_TNIL
   |  jmp ->fff_res1
   |
+  |.ffunc_2 range_iterator_next
+  |  jmp ->fff_fallback
+  |
   |.ffunc_1 pairs
   |  mov TAB:RB, [BASE]
   |  mov TMPR, TAB:RB

--- a/src/tiri/jit/src/lib/lib_range.cpp
+++ b/src/tiri/jit/src/lib/lib_range.cpp
@@ -202,6 +202,12 @@ static void fp_range_push(lua_State *L, lua_Number Value)
    else lua_pushnumber(L, Value);
 }
 
+static void fp_range_set(TValue *Target, lua_Number Value)
+{
+   if (fp_range_is_int32(Value)) setintV(Target, int32_t(Value));
+   else setnumV(Target, Value);
+}
+
 static bool fp_range_integer_array(const tiri_range *Range)
 {
    return fp_range_is_int32(Range->start) and fp_range_is_int32(Range->stop) and fp_range_is_int32(Range->step);
@@ -232,6 +238,12 @@ int32_t lj_range_integer_values(lua_Number Start, lua_Number Stop, lua_Number St
 lua_Number lj_range_value(lua_Number Ordinal, lua_Number Start, lua_Number Step)
 {
    return std::fma(Ordinal, Step, Start);
+}
+
+lua_Number lj_range_iterator_next_ordinal(lua_Number Control, lua_Number Start, lua_Number Step)
+{
+   long double distance = ((long double)Control - (long double)Start) / (long double)Step;
+   return lua_Number(std::round(distance) + 1.0L);
 }
 
 void lj_range_prepare(lua_State *L, TValue *Base, uint32_t Flags)
@@ -569,32 +581,49 @@ static int fp_range_toarray(lua_State *L)
    return 1;
 }
 
-static int fp_range_iterator_next(lua_State *L)
+LJLIB_ASM(range_iterator_next) LJLIB_REC(.)
 {
-   auto range = (tiri_range *)lua_touserdata(L, lua_upvalueindex(1));
-   if (not range) return 0;
-   size_t ordinal = size_t(lua_tointeger(L, lua_upvalueindex(2)));
-   size_t count = fp_range_count(L, range, false);
-   if (ordinal >= count) return 0;
-   lua_pushinteger(L, lua_Integer(ordinal + 1));
-   lua_replace(L, lua_upvalueindex(2));
-   fp_range_push(L, fp_range_value(range, ordinal));
-   return 1;
+   GCtab *state = lj_lib_checktab(L, 1);
+   cTValue *start_value = lj_tab_getint(state, RANGE_ITERATOR_START);
+   cTValue *step_value = lj_tab_getint(state, RANGE_ITERATOR_STEP);
+   cTValue *count_value = lj_tab_getint(state, RANGE_ITERATOR_COUNT);
+   if (not tvisnumber(start_value) or not tvisnumber(step_value) or not tvisnumber(count_value)) {
+      lj_err_caller(L, ErrMsg::BADVAL);
+   }
+
+   lua_Number ordinal = 0.0;
+   if (not lua_isnil(L, 2)) {
+      if (not lua_isnumber(L, 2)) lj_err_caller(L, ErrMsg::BADVAL);
+      ordinal = lj_range_iterator_next_ordinal(
+         lua_tonumber(L, 2), numberVnum(start_value), numberVnum(step_value));
+   }
+   if (ordinal >= numberVnum(count_value)) return FFH_RES(0);
+
+   fp_range_set(L->base - 1 - LJ_FR2,
+      std::fma(ordinal, numberVnum(step_value), numberVnum(start_value)));
+   return FFH_RES(1);
 }
 
 static int fp_range_call(lua_State *L)
 {
-   get_range(L, 1);
+   tiri_range *range = get_range(L, 1);
    if (lua_gettop(L) >= 2) {
       int argument_type = lua_type(L, 2);
       if (argument_type IS LUA_TNIL or argument_type IS LUA_TNUMBER) {
          luaL_error(L, ERR::Syntax, "range used incorrectly in for loop; use 'for i in range()' not 'for i in range'");
       }
    }
-   lua_pushvalue(L, 1);
-   lua_pushinteger(L, 0);
-   lua_pushcclosure(L, fp_range_iterator_next, 2);
-   lua_pushnil(L);
+   size_t count = fp_range_count(L, range, false);
+   lua_pushvalue(L, lua_upvalueindex(1));
+   lua_createtable(L, RANGE_ITERATOR_STATE_SIZE, 0);
+   fp_range_push(L, range->start);
+   lua_rawseti(L, -2, RANGE_ITERATOR_START);
+   fp_range_push(L, range->step);
+   lua_rawseti(L, -2, RANGE_ITERATOR_STEP);
+   lua_pushnumber(L, lua_Number(count));
+   lua_rawseti(L, -2, RANGE_ITERATOR_COUNT);
+   lua_pushnumber(L, fp_range_integer_array(range) ? 1.0 : 0.0);
+   lua_rawseti(L, -2, RANGE_ITERATOR_INTEGER_VALUES);
    lua_pushnil(L);
    return 3;
 }
@@ -988,13 +1017,20 @@ extern "C" int luaopen_range(lua_State *L)
    lua_pushcfunction(L, range_index);
    lua_setfield(L, -2, "__index");
 
-   lua_pushcfunction(L, fp_range_call);
-   lua_setfield(L, -2, "__call");
-
    lua_pop(L, 1);  // Pop metatable
 
    // Register the library using LuaJIT's library registration system
    LJ_LIB_REG(L, "range", range);
+
+   // Keep the stable fast iterator private and capture it in the range-object __call metamethod.
+   lua_getfield(L, -1, "iterator_next");
+   lua_pushnil(L);
+   lua_setfield(L, -3, "iterator_next");
+   luaL_getmetatable(L, RANGE_METATABLE);
+   lua_pushvalue(L, -2);
+   lua_pushcclosure(L, fp_range_call, 1);
+   lua_setfield(L, -2, "__call");
+   lua_pop(L, 2);  // Pop the range metatable and private iterator.
 
    // At this point the range table is on the stack, add a metatable with __call
 

--- a/src/tiri/jit/src/lib/lib_range.h
+++ b/src/tiri/jit/src/lib/lib_range.h
@@ -20,6 +20,14 @@ struct tiri_range {
    bool inclusive;    // If true, stop is included (default: false)
 };
 
+enum RangeIteratorState {
+   RANGE_ITERATOR_START,
+   RANGE_ITERATOR_STEP,
+   RANGE_ITERATOR_COUNT,
+   RANGE_ITERATOR_INTEGER_VALUES,
+   RANGE_ITERATOR_STATE_SIZE
+};
+
 struct tiri_index_range {
    int32_t start;
    int32_t stop;
@@ -59,6 +67,7 @@ lua_Number lj_range_prepare_count(
    lua_State *L, lua_Number Start, lua_Number Stop, lua_Number Step, uint32_t Inclusive);
 int32_t lj_range_integer_values(lua_Number Start, lua_Number Stop, lua_Number Step);
 lua_Number lj_range_value(lua_Number Ordinal, lua_Number Start, lua_Number Step);
+lua_Number lj_range_iterator_next_ordinal(lua_Number Control, lua_Number Start, lua_Number Step);
 extern "C" void lj_range_prepare(lua_State *L, TValue *Base, uint32_t Flags);
 extern "C" void lj_range_value_at(TValue *Base);
 

--- a/src/tiri/jit/src/lj_dispatch.h
+++ b/src/tiri/jit/src/lj_dispatch.h
@@ -20,7 +20,7 @@ constexpr int HOTCOUNT_LOOP = 2;
 constexpr int HOTCOUNT_CALL = 1;
 
 // This solves a circular dependency problem -- bump as needed. Sigh.
-constexpr int GG_NUM_ASMFF = 54;
+constexpr int GG_NUM_ASMFF = 55;
 
 constexpr int GG_LEN_DDISP = (BC__MAX + GG_NUM_ASMFF);
 constexpr int GG_LEN_SDISP = BC_FUNCF;

--- a/src/tiri/jit/src/lj_ffrecord.cpp
+++ b/src/tiri/jit/src/lj_ffrecord.cpp
@@ -908,6 +908,75 @@ static void recff_ipairs_aux(jit_State* J, RecordFFData* rd)
 
 //********************************************************************************************************************
 
+static TRef recff_range_state_load(jit_State *J, RecordFFData *rd, int32_t Index)
+{
+   RecordIndex ix;
+   ix.tab = J->base[0];
+   ix.key = lj_ir_kint(J, Index);
+   ix.val = 0;
+   ix.idxchain = 0;
+   settabV(J->L, &ix.tabv, tabV(&rd->argv[0]));
+   setintV(&ix.keyv, Index);
+   return lj_record_idx(J, &ix);
+}
+
+static void recff_range_iterator_next(jit_State *J, RecordFFData *rd)
+{
+   if (not tref_istab(J->base[0]) or not J->base[1] or not tvistab(&rd->argv[0])) {
+      lj_trace_err(J, LJ_TRERR_BADTYPE);
+   }
+
+   GCtab *state = tabV(&rd->argv[0]);
+   cTValue *runtime_count_value = lj_tab_getint(state, RANGE_ITERATOR_COUNT);
+   cTValue *runtime_integer_value = lj_tab_getint(state, RANGE_ITERATOR_INTEGER_VALUES);
+   if (not tvisnumber(runtime_count_value) or not tvisnumber(runtime_integer_value)) {
+      lj_trace_err(J, LJ_TRERR_BADTYPE);
+   }
+
+   TRef start = lj_ir_tonum(J, recff_range_state_load(J, rd, RANGE_ITERATOR_START));
+   TRef step = lj_ir_tonum(J, recff_range_state_load(J, rd, RANGE_ITERATOR_STEP));
+   TRef count = lj_ir_tonum(J, recff_range_state_load(J, rd, RANGE_ITERATOR_COUNT));
+   TRef integer_values = lj_ir_tonum(J, recff_range_state_load(J, rd, RANGE_ITERATOR_INTEGER_VALUES));
+
+   TRef ordinal;
+   lua_Number runtime_ordinal;
+   if (tvisnil(&rd->argv[1])) {
+      ordinal = lj_ir_knum_zero(J);
+      runtime_ordinal = 0.0;
+   }
+   else {
+      if (not tvisnumber(&rd->argv[1])) lj_trace_err(J, LJ_TRERR_BADTYPE);
+      TRef control = lj_ir_tonum(J, J->base[1]);
+      ordinal = lj_ir_call(J, IRCALL_lj_range_iterator_next_ordinal, control, start, step);
+      runtime_ordinal = lj_range_iterator_next_ordinal(
+         numberVnum(&rd->argv[1]), numberVnum(lj_tab_getint(state, RANGE_ITERATOR_START)),
+         numberVnum(lj_tab_getint(state, RANGE_ITERATOR_STEP)));
+   }
+
+   bool in_bounds = runtime_ordinal < numberVnum(runtime_count_value);
+   emitir(IRTG(in_bounds ? IR_LT : IR_GE, IRT_NUM), ordinal, count);
+   if (not in_bounds) {
+      rd->nres = 0;
+      return;
+   }
+
+   int32_t integer_result = numberVnum(runtime_integer_value) != 0.0;
+   emitir(IRTG(IR_EQ, IRT_NUM), integer_values, lj_ir_knum(J, lua_Number(integer_result)));
+
+   TRef result;
+   if (integer_result) {
+      result = emitir(IRTN(IR_ADD), start, emitir(IRTN(IR_MUL), ordinal, step));
+      result = emitir(IRTGI(IR_CONV), result, IRCONV_INT_NUM | IRCONV_CHECK);
+   }
+   else {
+      result = lj_ir_call(J, IRCALL_lj_range_value, ordinal, start, step);
+   }
+   J->base[0] = result;
+   rd->nres = 1;
+}
+
+//********************************************************************************************************************
+
 static void recff_xpairs(jit_State* J, RecordFFData* rd)
 {
    TRef tr = J->base[0];

--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -223,6 +223,7 @@ typedef struct CCallInfo {
   _(ANY,        lj_range_prepare_count, 5, N, NUM, CCI_L|CCI_T) \
   _(ANY,        lj_range_integer_values,3, N, INT, 0) \
   _(ANY,        lj_range_value,         3, N, NUM, 0) \
+  _(ANY,        lj_range_iterator_next_ordinal, 3, N, NUM, 0) \
   /* Try-except exception handling */ \
   _(ANY,        lj_try_enter,      4,  FS, NIL, CCI_L|CCI_T) \
   _(ANY,        lj_try_leave,      1,  FS, NIL, CCI_L) \

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -453,6 +453,44 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
+@Test(hotpath=100) function ExplicitRangeObjectTraceStability()
+   local source = range.new(0, 100, false, 2)
+   local function range_object_sum():num
+      local total = 0
+      for value in source() do total += value end
+      return total
+   end
+
+   jit.off()
+   local expected = range_object_sum()
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=56', 'hotexit=10', 'minstitch=0')
+
+   local compiled = 0
+   local aborted = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++
+      elseif Event is 'abort' then aborted++
+      end
+   end
+
+   jit.attach(trace_event, 'trace')
+   local result = 0
+   for repetition in {1 into 200} do result = range_object_sum() end
+   jit.attach(trace_event)
+
+   local trace_count = count_jit_traces(20)
+   assert(result is expected, f'Explicit range object should match the interpreter result of {expected}, got {result}')
+   assert(compiled > 0, 'Explicit range object iteration should compile at least one trace')
+   assert(aborted is 0, f'Explicit range object iteration should not abort recording, observed {aborted} aborts')
+   assert(trace_count < 10,
+      f'Explicit range object iteration should record fewer than 10 traces, observed {trace_count}')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 @Test(hotpath=100) function ChangingRuntimeRangeBoundsRemainStable()
    local function changing_range_sum(Start, Stop):num
       local total = 0
@@ -755,38 +793,6 @@ function array_clear_then_push(Array)
    return array.getString(Array)
 end
 
-function jit_try_repeated_throwable_helpers(Pattern)
-   local stable_label = "stable-local"
-   local compiled = nil
-
-   try
-      for i in {0 to 5} do
-         compiled = regex.new("a+")
-      end
-      regex.new(Pattern)
-   except e
-      return stable_label, compiled != nil
-   end
-
-   return "missing-error", false
-end
-
-function jit_try_inner_locals_preserve_entry_local(Pattern, Iteration)
-   local entry_label = "entry-" .. tostring(Iteration % 7)
-
-   try
-      local inner_label = "inner-" .. tostring(Iteration)
-      local combined = inner_label .. ":" .. entry_label
-      if #combined < 1 then
-         return "impossible"
-      end
-      regex.new(Pattern)
-   except e
-      return entry_label
-   end
-
-   return "missing-error"
-end
 
 function jit_try_forced_materialisation_probe(Count)
    local entry_label = "entry"
@@ -821,30 +827,6 @@ function build_try_materialisation_trace()
    end
 
    error("Failed to create a try-entry materialisation trace for inspection")
-end
-
-@Test(hotpath=80) function JITTryRepeatedThrowableHelpersDoNotCorruptLocals()
-   jit.on()
-   jit.flush()
-   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
-
-   for i in {0 to 100} do
-      label, compiled = jit_try_repeated_throwable_helpers("(")
-      assert(label is "stable-local", f"Expected stable local after repeated helpers, got '{label}'")
-      assert(compiled is true, "Successful repeated regex.new() calls should update their local")
-   end
-end
-
-@Test(hotpath=80) function JITTryInnerLocalsPreserveEntryLocal()
-   jit.on()
-   jit.flush()
-   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
-
-   for i in {0 to 100} do
-      local expected = "entry-" .. tostring(i % 7)
-      local result = jit_try_inner_locals_preserve_entry_local("(", i)
-      assert(result is expected, f"Expected handler to see entry local '{expected}', got '{result}'")
-   end
 end
 
 @Test(hotpath=80) function JITTryMaterialisationTraceEmitsXStores()

--- a/src/tiri/tests/test_jit_try_regex.tiri
+++ b/src/tiri/tests/test_jit_try_regex.tiri
@@ -44,6 +44,63 @@ function jit_try_mutated_local_before_throw(Pattern, Iteration)
    return "missing-error"
 end
 
+function jit_try_inner_locals_preserve_entry_local(Pattern, Iteration)
+   local entry_label = "entry-" .. tostring(Iteration % 7)
+
+   try
+      local inner_label = "inner-" .. tostring(Iteration)
+      local combined = inner_label .. ":" .. entry_label
+      if #combined < 1 then
+         return "impossible"
+      end
+      regex.new(Pattern)
+   except e
+      return entry_label
+   end
+
+   return "missing-error"
+end
+
+function jit_try_repeated_throwable_helpers(Pattern)
+   local stable_label = "stable-local"
+   local compiled = nil
+
+   try
+      for i in {0 to 5} do
+         compiled = regex.new("a+")
+      end
+      regex.new(Pattern)
+   except e
+      return stable_label, compiled != nil
+   end
+
+   return "missing-error", false
+end
+
+@Test(hotpath=30) function JITTryInnerLocalsPreserveEntryLocal()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i in {0 to 100} do
+      local expected = "entry-" .. tostring(i % 7)
+      local result = jit_try_inner_locals_preserve_entry_local("(", i)
+      assert(result is expected, f"Expected handler to see entry local '{expected}', got '{result}'")
+   end
+end
+
+@Test(hotpath=30) function JITTryRepeatedThrowableHelpersDoNotCorruptLocals()
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=3", "hotexit=1", "minstitch=0")
+
+   for i in {0 to 100} do
+      label, compiled = jit_try_repeated_throwable_helpers("(")
+      assert(label is "stable-local", f"Expected stable local after repeated helpers, got '{label}'")
+      assert(compiled is true, "Successful repeated regex.new() calls should update their local")
+   end
+end
+
 @Test(hotpath=30) function JITTryRegexFailurePreservesParamName()
    local param = { name = 'pattern', type = 'regex' }
    local expected_message = "Intentional exception raised for parent to capture."

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1013,7 +1013,7 @@ end
    r = {1 to 5}
    iter, state, init = r()
    assert(type(iter) is "function", "first return should be function")
-   assert(state is nil, "state should be nil")
+   assert(type(state) is "table", "state should contain the prepared iterator data")
    assert(init is nil, "initial value should be nil")
 end
 
@@ -1581,6 +1581,43 @@ end
    assert(approximately({0 to 1 by 0.25}:reduce(0, (acc, v) => acc + v), 1.5))
    assert({0 to 1 by 0.2}:any(v => v > 0.7))
    assert({0 to 1 by 0.2}:all(v => v < 1))
+end
+
+@Test function ExplicitRangeObjectIteration()
+   local ascending = array<int>
+   local ascending_range = range.new(0, 10, false, 2)
+   for value in ascending_range() do ascending:push(value) end
+   assert(ascending:concat(',') is '0,2,4,6,8', 'Explicit ascending range iteration should preserve its step')
+
+   local descending = array<int>
+   local descending_range = range.new(9, 0, true, -3)
+   for value in descending_range() do descending:push(value) end
+   assert(descending:concat(',') is '9,6,3,0', 'Explicit descending range iteration should include an aligned stop')
+
+   local fractional = array<double>
+   local fractional_range = range.new(-0.5, 0.5, true, 0.2)
+   for value in fractional_range() do fractional:push(value) end
+   assert(#fractional is 6 and approximately(fractional[3], 0.1) and approximately(fractional[5], 0.5),
+      'Explicit fractional range iteration should retain ordinal FMA value generation')
+end
+
+@Test function EarlyRangeObjectExitReleasesSource()
+   local weak_sources = setmetatable({}, { __mode='v' })
+   local function iterate_once()
+      local source = range.new(0, 100, false, 2)
+      weak_sources[0] = source
+      for value in source() do
+         assert(value is 0)
+         break
+      end
+      source = nil
+   end
+
+   jit.off(iterate_once, true)
+   iterate_once()
+   processing.collect()
+   processing.collect()
+   assert(weak_sources[0] is nil, 'An early loop exit should not retain the source range')
 end
 
 @Test function FloatingRangeMaterialisationTypes()

--- a/tools/benchmark/benchmark_control.tiri
+++ b/tools/benchmark/benchmark_control.tiri
@@ -503,9 +503,8 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Iterate a range object created via range.new().
--- NB: Measured separately from ControlForRangeLoop because the range object iterator does not trace-compile, and
--- hoisting the range.new() call out of the loop makes no difference.  Isolating it keeps the range literal figures
--- meaningful.
+-- NB: Measured separately from ControlForRangeLoop to guard the explicit range-object iterator path.  The range is
+-- hoisted so this case measures iterator preparation and traversal rather than range construction.
 
 @Test function ControlForRangeObject()
    local sum = 0


### PR DESCRIPTION
* Replaced the upvalue-based range iterator closure with an ASM fast function backed by a table-driven iterator state (start, step, count and integer-value flag)
* Added a trace recorder for range_iterator_next that emits ordinal-based FMA value generation with integer narrowing when the range yields int32 values
* Introduced lj_range_iterator_next_ordinal to recover the ordinal from the loop control value without accumulating floating-point error
* Kept iterator_next private by capturing it in the range metatable __call metamethod rather than exposing it on the library table
* Registered the new fast function in the x64, ARM64 and PPC VM builders and bumped GG_NUM_ASMFF
* [Doc] Documented the RANGEPREP and RANGEVAL bytecode instructions, including their stack layouts and emitted control-flow pattern
* [Test] Added explicit range object iteration, trace stability and early-exit source release tests, and moved the try/regex JIT tests into test_jit_try_regex.tiri