### PR TITLE
[Tiri] Improved safe array indexing under JIT compilation

### DIFF
--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -429,18 +429,23 @@ When the base operand is not a native array, array bytecodes fall back to the st
 
 ### 5.5 JIT Recording
 
-Array bytecodes record to the JIT trace using call-based IR emission:
+Ordinary array bytecodes record bounds guards and inline loads or stores for supported numeric and garbage-collected
+element types.  Other element types use the corresponding helper after the guard:
 
-- `AGETV`/`AGETB` → `IRCALL_lj_arr_getidx`
-- `ASETV`/`ASETB` → `IRCALL_lj_arr_setidx`
-- `ASGETV`/`ASGETB` → `IRCALL_lj_arr_safe_getidx`
+- `AGETV`/`AGETB` fall back to `IRCALL_lj_arr_getidx`.
+- `ASETV`/`ASETB` fall back to `IRCALL_lj_arr_setidx`.
 
-The recorder emits:
-1. Type guard ensuring operand is array
-2. Index narrowing (variable indices converted to integers)
-3. Call to helper function with bounds checking
+Safe array bytecodes use observation-specific recording:
 
-Future optimisation (Phase 5b) may inline element access for common types to eliminate function call overhead.
+- A non-array receiver, or an array with a non-integer key, records the ordinary indexed lookup and metamethod path.
+- An in-bounds `ASGETV` array access narrows the variable index, guards it against the current array length, and uses
+  the same inline load or `lj_arr_getidx` fallback as `AGETV`.
+- An observed out-of-bounds `ASGETV` access terminates the trace with an interpreter link before the bytecode.  The
+  interpreter then writes `nil` to the destination.
+- A native-array `ASGETB` observation disables JIT recording for that prototype.  This prevents installation of a
+  partial trace which can restore a stale destination slot at a later safe-navigation join.
+
+The recorder does not emit `IRCALL_lj_arr_safe_getidx`.  That helper is used by the interpreter implementations.
 
 ### 5.6 Parser Integration
 
@@ -448,10 +453,12 @@ When the parser can determine at compile time that an expression is an array (vi
 
 - Known array + variable index → `BC_AGETV` / `BC_ASETV`
 - Known array + literal index (0-255) → `BC_AGETB` / `BC_ASETB`
-- Safe navigation (`?[]`) with variable index → `BC_ASGETV`
-- Safe navigation (`?[]`) with literal index (0-255) → `BC_ASGETB`
+- Safe navigation on a known array with a variable numeric-capable index → `BC_ASGETV`
+- Safe navigation on a known array with a literal numeric index (0-255) → `BC_ASGETB`
 
-When the base type is unknown, standard table bytecodes (`TGETV`, `TSETV`, etc.) are emitted, relying on runtime type dispatch.
+Safe indexing on a statically proved table uses ordinary `TGETV`, `TGETB` or `TGETS` bytecodes.  A proved string key
+also uses ordinary table indexing.  When the receiver type is unresolved and the key may be numeric, the parser
+retains `ASGETV` or `ASGETB` so a native-array value can preserve safe out-of-bounds semantics at run time.
 
 ### 5.7 Example: Array Access Pattern
 

--- a/src/tiri/jit/src/jit/vm_arm64.dasc
+++ b/src/tiri/jit/src/jit/vm_arm64.dasc
@@ -3710,7 +3710,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
   case BC_ASGETV:
     |  // Safe array get with variable index - returns nil for out-of-bounds on arrays.
-    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetb.
+    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetv.
     |  // RA = dst, RB = table/array, RC = key
     |  ldr TMP2, [BASE, RB, lsl #3]	// Load table/array
     |  ldr TMP1, [BASE, RC, lsl #3]	// Load key
@@ -3731,7 +3731,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
   case BC_ASGETB:
     |  // Safe array get with literal index - returns nil for out-of-bounds on arrays.
-    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetv.
+    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetb.
     |  // RA = dst, RB = table/array, RC = literal index (0-255, 0-based)
     |  ldr TMP2, [BASE, RB, lsl #3]	// Load table/array
     |  asr ITYPE, TMP2, #47

--- a/src/tiri/jit/src/jit/vm_ppc.dasc
+++ b/src/tiri/jit/src/jit/vm_ppc.dasc
@@ -5459,7 +5459,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
   case BC_ASGETV:
     |  // Safe array get with variable index - returns nil for out-of-bounds on arrays.
-    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetb.
+    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetv.
     |  // RA = dst, RB = table/array, RC = key
     |  lpx  TMP1, BASE, RB		// Load table/array
     |  lpx  TMP2, BASE, RC		// Load key (hi word)
@@ -5483,7 +5483,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
 
   case BC_ASGETB:
     |  // Safe array get with literal index - returns nil for out-of-bounds on arrays.
-    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetv.
+    |  // For non-arrays, falls back to regular table indexing via vmeta_tgetb.
     |  // RA = dst, RB = table/array, RC = literal index (0-255, 0-based)
     |  lpx TMP1, BASE, RB		// Load table/array
     |  lwz ITYPE, 0(TMP1)

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3001,7 +3001,7 @@ static bool rec_array_xstore(jit_State *J, TRef ArrayRef, TRef IdxRef, TRef ValR
 // Handle native array ops: BC_AGETV, BC_AGETB, BC_ASETV, BC_ASETB
 //
 // Native arrays (GCarray) are different from tables - they have typed elements and 0-based indexing internally.
-// We emit calls to helper functions that handle the element type conversion.
+// Record guarded typed loads and stores directly where supported, with helper calls for the remaining element types.
 
 static TRef rec_array_op(jit_State *J, RecordOps *ops)
 {
@@ -3061,6 +3061,88 @@ static TRef rec_array_op(jit_State *J, RecordOps *ops)
    TRef tmp_ref = rec_tmpref(J, ops->ra, IRTMPREF_IN1);
    lj_ir_call(J, IRCALL_lj_arr_setidx, array_ref, idx_ref, tmp_ref);
    return 0;
+}
+
+//********************************************************************************************************************
+// Handle safe native array gets: BC_ASGETV, BC_ASGETB
+//
+// These bytecodes select safe native-array indexing only when the observed receiver is an array and the key is an
+// integer.  All other observations retain ordinary indexed lookup and metamethod behaviour.
+
+static TRef rec_safe_array_get(jit_State *J, RecordOps *Ops)
+{
+   IRBuilder ir(J);
+   RecordIndex *ix = &Ops->ix;
+   bool is_lit = Ops->op IS BC_ASGETB;
+
+   if (is_lit) {
+      setintV(&ix->keyv, int32_t(Ops->rc));
+      ix->key = ir.kint(int32_t(Ops->rc));
+   }
+
+   if (not tref_isarray(Ops->rb)) {
+      ix->idxchain = LJ_MAX_IDXCHAIN;
+      return lj_record_idx(J, ix);
+   }
+
+   int32_t idx_int;
+
+   if (is_lit) idx_int = int32_t(Ops->rc);
+   else {
+      cTValue *key_tv = Ops->rcv();
+      if (tvisint(key_tv)) idx_int = intV(key_tv);
+#if !LJ_DUALNUM
+      else if (tvisnum(key_tv)) {
+         lua_Number key_num = numV(key_tv);
+         idx_int = int32_t(lj_num2int(key_num));
+         if (not (lua_Number(idx_int) IS key_num)) {
+            ix->idxchain = LJ_MAX_IDXCHAIN;
+            return lj_record_idx(J, ix);
+         }
+      }
+#endif
+      else {
+         ix->idxchain = LJ_MAX_IDXCHAIN;
+         return lj_record_idx(J, ix);
+      }
+
+      if (not tref_isnumber(Ops->rc)) {
+         ix->idxchain = LJ_MAX_IDXCHAIN;
+         return lj_record_idx(J, ix);
+      }
+   }
+
+   if (is_lit) {
+      // A safe-navigation join after a literal native-array get can restore a stale destination slot.  Do not install
+      // a partial trace for this prototype until that snapshot interaction can be represented safely.
+      J->pt->flags |= PROTO_NOJIT;
+      lj_trace_err(J, LJ_TRERR_CJITOFF);
+   }
+
+   GCarray *arr = arrayV(Ops->rbv());
+   if (idx_int < 0 or MSize(idx_int) >= arr->len) {
+      // Continuing an out-of-bounds trace across the safe-navigation join leaves the destination slot stale when a
+      // later entry observes an in-bounds index.  End the trace before this bytecode so the VM produces nil directly.
+      lj_snap_add(J);
+      lj_record_stop(J, TraceLink::INTERP, 0);
+      return 0;
+   }
+
+   TRef idx_ref = lj_opt_narrow_index(J, Ops->rc);
+   TRef len_ref = ir.fload_int(Ops->rb, IRFL_ARRAY_LEN);
+   rec_idx_abc(J, len_ref, idx_ref, arr->len);
+   TRef result_ref = rec_array_xload(J, Ops->rb, idx_ref, arr, idx_int);
+   if (not result_ref) {
+      TValue result_tv;
+      lj_arr_getidx(J->L, arr, idx_int, &result_tv);
+      IRType result_type = itype2irt(&result_tv);
+      if (!LJ_DUALNUM and result_type IS IRT_INT) result_type = IRT_NUM;
+      TRef tmp_ref = rec_tmpref(J, TREF_NIL, IRTMPREF_OUT1);
+      lj_ir_call(J, IRCALL_lj_arr_getidx, Ops->rb, idx_ref, tmp_ref);
+      result_ref = lj_record_vload(J, tmp_ref, 0, result_type);
+   }
+   J->needsnap = 1;
+   return result_ref;
 }
 
 //********************************************************************************************************************
@@ -3833,6 +3915,10 @@ void lj_record_ins(jit_State *J)
    // Array ops - native array access
    case BC_AGETV: case BC_AGETB:
       rc = rec_array_op(J, &ops);
+      break;
+
+   case BC_ASGETV: case BC_ASGETB:
+      rc = rec_safe_array_get(J, &ops);
       break;
 
    case BC_ASETV: case BC_ASETB:

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -137,9 +137,9 @@ static bool block_contains_try(const BlockStmt *Block)
 // Usage:
 //   NilShortCircuitGuard guard(emitter, base_expression);
 //   if (not guard.ok()) return guard.error<ExpDesc>();
-//   // ... perform operation using guard.base_register() ...
-//   materialise_to_reg(result, guard.base_register(), "...");
-//   return guard.complete();
+//   // ... perform operation using guard.base_expression() ...
+//   BCReg result_reg = materialise_result(...);
+//   return guard.complete(result_reg);
 
 class NilShortCircuitGuard {
 public:
@@ -147,11 +147,11 @@ public:
       : emitter(Emitter), register_guard(&Emitter->func_state), allocator(&Emitter->func_state)
    {
       ExpressionValue base_value(&this->emitter->func_state, BaseExpr);
-      this->result_reg = base_value.discharge_to_any_reg(this->allocator);
+      this->base_reg = base_value.discharge_to_any_reg(this->allocator);
       this->base_expr = base_value.legacy();
 
       ExpDesc nilv(ExpKind::Nil);
-      bcemit_INS(&this->emitter->func_state, BCINS_AD(BC_ISEQP, this->result_reg, const_pri(&nilv)));
+      bcemit_INS(&this->emitter->func_state, BCINS_AD(BC_ISEQP, this->base_reg, const_pri(&nilv)));
       this->nil_jump = this->emitter->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->emitter->func_state)));
       this->setup_ok = true;
    }
@@ -166,38 +166,34 @@ public:
       return ParserResult<T>::failure(err);
    }
 
-   [[nodiscard]] inline BCREG base_register() const { return this->result_reg; }
    [[nodiscard]] inline ExpDesc base_expression() const { return this->base_expr; }
    [[nodiscard]] inline RegisterAllocator& reg_allocator() { return this->allocator; }
-   [[nodiscard]] inline ControlFlowEdge& nil_jump_edge() { return this->nil_jump; }
 
    // Complete the nil short-circuit: emit nil path, patch jumps, return result.
-   // The result is stored in base_register() as a NonReloc expression.
+   // The result is stored in ResultReg as a NonReloc expression.
 
-   ParserResult<ExpDesc> complete()
+   ParserResult<ExpDesc> complete(BCReg ResultReg)
    {
-      this->allocator.collapse_freereg(BCReg(this->result_reg));
+      this->allocator.collapse_freereg(ResultReg);
 
       ControlFlowEdge skip_nil = this->emitter->control_flow.make_unconditional(
          BCPos(bcemit_jmp(&this->emitter->func_state)));
 
       BCPos nil_path = BCPos(this->emitter->func_state.pc);
       this->nil_jump.patch_to(nil_path);
-      bcemit_nil(&this->emitter->func_state, this->result_reg, 1);
+      bcemit_nil(&this->emitter->func_state, ResultReg.raw(), 1);
 
       skip_nil.patch_to(BCPos(this->emitter->func_state.pc));
 
       this->register_guard.disarm();
 
       ExpDesc result;
-      result.init(ExpKind::NonReloc, this->result_reg);
+      result.init(ExpKind::NonReloc, ResultReg);
       return ParserResult<ExpDesc>::success(result);
    }
 
-   // Complete with a custom result register (for call expressions where result may differ).
-   // Note: Unlike complete(), we don't call collapse_freereg(result_reg) here because CallBase
-   // may differ from result_reg after method dispatch setup, and we explicitly set freereg to
-   // CallBase + 1 at the end, which is the correct final state for call expressions.
+   // Complete a call expression, whose method-dispatch frame may move CallBase beyond base_reg.
+   // The final free-register boundary must retain the whole call result frame.
 
    ParserResult<ExpDesc> complete_call(BCReg CallBase, BCPos CallPc)
    {
@@ -226,7 +222,7 @@ private:
    RegisterAllocator allocator;
    ControlFlowEdge nil_jump;
    ExpDesc base_expr;
-   BCReg result_reg = BCReg(0);
+   BCReg base_reg = BCReg(0);
    bool setup_ok = false;
 };
 
@@ -3586,32 +3582,17 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
       apply_struct_field_metadata(table, emitted_struct_def, Payload.member.symbol);
    }
 
-   // Materialize the indexed result to a new register.
-   // Do NOT reuse base_register() as that would clobber the table variable
+   // Materialise to a separate register so the receiver remains available for the lookup.
 
    ExpressionValue indexed_value(&this->func_state, table);
    BCReg result_reg = indexed_value.discharge_to_any_reg(guard.reg_allocator());
 
-   // Collapse freereg to include the result register
-   guard.reg_allocator().collapse_freereg(result_reg);
-
-   // Emit the nil path
-   ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
-
-   BCPos nil_path = BCPos(this->func_state.pc);
-   guard.nil_jump_edge().patch_to(nil_path);
-   bcemit_nil(&this->func_state, result_reg.raw(), 1);
-
-   skip_nil.patch_to(BCPos(this->func_state.pc));
-
-   ExpDesc result;
-   result.init(ExpKind::NonReloc, result_reg);
-   return ParserResult<ExpDesc>::success(result);
+   return guard.complete(result_reg);
 }
 
 //********************************************************************************************************************
 // Emit bytecode for a safe index expression (table?[key]), returning nil if the table is nil.
-// If base_type is TiriType::Array, emits array-specific bytecodes (BC_AGETV/BC_AGETB).
+// Emits safe array bytecodes when the receiver may be a native array and the key may be numeric.
 
 ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload &Payload)
 {
@@ -3621,6 +3602,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload
 
    auto table_result = this->emit_expression(*Payload.table);
    if (not table_result.ok()) return table_result;
+   StaticValueHandle receiver_descriptor = table_result.value_ref().static_value;
 
    NilShortCircuitGuard guard(this, table_result.value_ref());
    if (not guard.ok()) return guard.error<ExpDesc>();
@@ -3628,6 +3610,7 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload
    // Index expression is evaluated only on non-nil path (short-circuit)
    auto key_result = this->emit_expression(*Payload.index);
    if (not key_result.ok()) return key_result;
+   StaticValueHandle key_descriptor = key_result.value_ref().static_value;
 
    ExpDesc key = key_result.value_ref();
    ExpressionValue key_toval(&this->func_state, key);
@@ -3637,35 +3620,24 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_index_expr(const SafeIndexExprPayload
    ExpDesc table = guard.base_expression();
    expr_index(&this->func_state, &table, &key);
 
-   // For safe index expressions (?[]), always use SafeIndexedArray for numeric keys.
-   // This emits BC_ASGETV/BC_ASGETB which:
-   // - For arrays: return nil for out-of-bounds instead of throwing
-   // - For non-arrays: fall back to regular table indexing
-   // We only do this for numeric keys (aux >= 0); string keys use regular table indexing.
+   bool proved_table = can_use_static_receiver(
+      this->ctx.descriptors(), receiver_descriptor, TiriType::Table, true);
+   bool proved_string_key = can_use_static_receiver(
+      this->ctx.descriptors(), key_descriptor, TiriType::Str, true);
 
-   if (int32_t(table.u.s.aux) >= 0) table.k = ExpKind::SafeIndexedArray;
+   // String constants are encoded with a negative aux value. Non-negative aux values also include register-held
+   // keys, so the encoding alone does not prove that a key is numeric. Proved tables and proved string keys can use
+   // ordinary table bytecodes. Native arrays and unresolved receivers retain ASGETV/ASGETB so out-of-bounds access
+   // returns nil while non-array runtime values fall back to generic indexing.
 
-   // Materialize the indexed result to a new register.
-   // Do NOT reuse base_register() as that would clobber the table variable,
-   // causing issues if the table is referenced again.
+   bool key_may_be_numeric = int32_t(table.u.s.aux) >= 0 and not proved_string_key;
+   if (key_may_be_numeric and not proved_table) table.k = ExpKind::SafeIndexedArray;
+
+   // Materialise to a separate register so the receiver remains available for the lookup.
    ExpressionValue indexed_value(&this->func_state, table);
    BCReg result_reg = indexed_value.discharge_to_any_reg(guard.reg_allocator());
 
-   // Collapse freereg to include the result register
-   guard.reg_allocator().collapse_freereg(result_reg);
-
-   // Emit the nil path
-   ControlFlowEdge skip_nil = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
-
-   BCPos nil_path = BCPos(this->func_state.pc);
-   guard.nil_jump_edge().patch_to(nil_path);
-   bcemit_nil(&this->func_state, result_reg.raw(), 1);
-
-   skip_nil.patch_to(BCPos(this->func_state.pc));
-
-   ExpDesc result;
-   result.init(ExpKind::NonReloc, result_reg);
-   return ParserResult<ExpDesc>::success(result);
+   return guard.complete(result_reg);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3584,6 +3584,82 @@ static bool test_runtime_range_for_emission(kt::Log &Log)
    return true;
 }
 
+static bool test_safe_index_bytecode_selection(kt::Log &Log)
+{
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   std::string error;
+   bool passed = true;
+
+   auto expect_access = [&](std::string_view Source, BCOp Required, BCOp Forbidden,
+      CSTRING Description) -> bool {
+      auto snapshot = compile_snapshot(lua, Source, true, error);
+      if (not snapshot) {
+         Log.error("failed to compile %s safe-index fixture: %s", Description, error.c_str());
+         return false;
+      }
+
+      size_t required_count = count_opcode_tree(*snapshot, Required);
+      size_t forbidden_count = count_opcode_tree(*snapshot, Forbidden);
+      if (required_count IS 0 or forbidden_count != 0) {
+         Log.error("%s safe-index fixture selected the wrong bytecode family (required=%d, forbidden=%d)",
+            Description, int(required_count), int(forbidden_count));
+         return false;
+      }
+      return true;
+   };
+
+   constexpr std::string_view native_literal =
+      "local function read(Values:array):any\n"
+      "   return Values?[0]\n"
+      "end\n";
+   if (not expect_access(native_literal, BC_ASGETB, BC_TGETB, "native-array literal-key")) passed = false;
+
+   constexpr std::string_view native_variable =
+      "local function read(Values:array, Index:num):any\n"
+      "   return Values?[Index]\n"
+      "end\n";
+   if (not expect_access(native_variable, BC_ASGETV, BC_TGETV, "native-array variable-key")) passed = false;
+
+   constexpr std::string_view table_literal =
+      "local function read(Values:table):any\n"
+      "   return Values?[0]\n"
+      "end\n";
+   if (not expect_access(table_literal, BC_TGETB, BC_ASGETB, "table literal-key")) passed = false;
+
+   constexpr std::string_view table_variable =
+      "local function read(Values:table, Key:any):any\n"
+      "   return Values?[Key]\n"
+      "end\n";
+   if (not expect_access(table_variable, BC_TGETV, BC_ASGETV, "table variable-key")) passed = false;
+
+   constexpr std::string_view dynamic_literal =
+      "local function read(Values:any):any\n"
+      "   return Values?[0]\n"
+      "end\n";
+   if (not expect_access(dynamic_literal, BC_ASGETB, BC_TGETB, "dynamic-receiver literal-key")) passed = false;
+
+   constexpr std::string_view dynamic_variable =
+      "local function read(Values:any, Key:any):any\n"
+      "   return Values?[Key]\n"
+      "end\n";
+   if (not expect_access(dynamic_variable, BC_ASGETV, BC_TGETV, "dynamic-receiver variable-key")) passed = false;
+
+   constexpr std::string_view literal_string =
+      "local function read(Values:any):any\n"
+      "   return Values?['name']\n"
+      "end\n";
+   if (not expect_access(literal_string, BC_TGETS, BC_ASGETV, "literal-string-key")) passed = false;
+
+   constexpr std::string_view variable_string =
+      "local function read(Values:any, Key:str):any\n"
+      "   return Values?[Key]\n"
+      "end\n";
+   if (not expect_access(variable_string, BC_TGETV, BC_ASGETV, "variable-string-key")) passed = false;
+
+   return passed;
+}
+
 static bool test_type_guided_emission(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -3769,7 +3845,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 46> tests = { {
+   constexpr std::array<TestCase, 47> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -3815,6 +3891,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "module_call_result_descriptors", test_module_call_result_descriptors },
       { "compile_time_signed_range_for_emission", test_compile_time_signed_range_for_emission },
       { "runtime_range_for_emission", test_runtime_range_for_emission },
+      { "safe_index_bytecode_selection", test_safe_index_bytecode_selection },
       { "type_guided_emission", test_type_guided_emission }
    } };
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -245,6 +245,15 @@ function count_jit_traces(MaxTraceNo)
    return count
 end
 
+function count_trace_link_type(MaxTraceNo, LinkType)
+   local count = 0
+   for trace_no in {1 into MaxTraceNo} do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil and info.linktype is LinkType then count++ end
+   end
+   return count
+end
+
 function count_trace_calls(TraceNo, Info)
    return count_trace_opcode(TraceNo, Info, ir_calln) + count_trace_opcode(TraceNo, Info, ir_calla) +
       count_trace_opcode(TraceNo, Info, ir_calll) + count_trace_opcode(TraceNo, Info, ir_calls)
@@ -351,6 +360,243 @@ function run_array_method_trace(Workload, Count)
    end
 
    return expected, result, count_jit_traces(30)
+end
+
+function run_safe_index_trace(Workload, Count)
+   jit.off()
+   local expected = Workload(Count)
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+
+   local compiled = 0
+   local aborted = 0
+   local function trace_event(Event)
+      if Event is "stop" then compiled++
+      elseif Event is "abort" then aborted++
+      end
+   end
+
+   jit.attach(trace_event, "trace")
+   local result = Workload(Count)
+   jit.attach(trace_event)
+
+   return expected, result, compiled, aborted, count_jit_traces(30)
+end
+
+function safe_table_index_workload(Count:num):num
+   local values = { [0] = 3, [1] = 5, label = 7 }
+   local numeric_key = 1
+   local string_key = "label"
+   local total = 0
+
+   for repetition in {1 into Count} do
+      total += values?[0]
+      total += values?[numeric_key]
+      total += values?["label"]
+      total += values?[string_key]
+   end
+
+   return total
+end
+
+function safe_array_literal_workload(Count:num):num
+   local values = array<int> { 3, 5, 7 }
+   local total = 0
+   for repetition in {1 into Count} do total += values?[1] end
+   return total
+end
+
+function safe_array_variable_workload(Count:num):num
+   local values = array<int> { 3, 5, 7 }
+   local total = 0
+   for repetition in {0 to Count} do
+      local index = repetition % #values
+      total += values?[index]
+   end
+   return total
+end
+
+function safe_array_literal_oob_workload(Count:num):num
+   local values = array<int> { 3, 5, 7 }
+   local total = 0
+   for repetition in {1 into Count} do total += values?[9] ?? -1 end
+   return total
+end
+
+function safe_array_variable_oob_workload(Count:num):num
+   local values = array<int> { 3, 5, 7 }
+   local index = #values
+   local total = 0
+   for repetition in {1 into Count} do total += values?[index] ?? -1 end
+   return total
+end
+
+function safe_array_mixed_bounds_workload(Count:num):num
+   local values = array<int> { 3, 5, 7 }
+   local total = 0
+   for repetition in {0 to Count} do
+      local index = repetition % 5
+      total += values?[index] ?? -1
+   end
+   return total
+end
+
+function nil_safe_index_workload(Count:num):num
+   local values = nil
+   local key_evaluations = 0
+   local function next_index():num
+      key_evaluations++
+      return 0
+   end
+
+   local nil_results = 0
+   for repetition in {1 into Count} do
+      if values?[next_index()] is nil then nil_results++ end
+   end
+   return nil_results * 1000 + key_evaluations
+end
+
+function dynamic_safe_index_workload(Receiver:any, Key:any, Count:num):num
+   local total = 0
+   for repetition in {1 into Count} do total += Receiver?[Key] ?? -1 end
+   return total
+end
+
+function dynamic_table_safe_index_workload(Count:num):num
+   return dynamic_safe_index_workload({ label = 11 }, "label", Count)
+end
+
+function dynamic_array_safe_index_workload(Count:num):num
+   return dynamic_safe_index_workload(array<int> { 11, 13 }, 1, Count)
+end
+
+global glSafeIndexJoinDefinitions = {
+   keywords = { alpha = true },
+   annotations = { bravo = true }
+}
+
+function resolve_safe_index_join(Key:str):str
+   if glSafeIndexJoinDefinitions?.keywords?[Key] then return 'keyword' end
+   if glSafeIndexJoinDefinitions?.annotations?[Key] then return 'annotation' end
+   return 'missing'
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function SafeTableIndexTraceParity()
+   local expected, result, compiled, aborted, trace_count = run_safe_index_trace(safe_table_index_workload, 200)
+
+   assert(result is expected, f"Safe table indexing should match the interpreter result {expected}, got {result}")
+   assert(compiled > 0, "Safe table literal and variable keys should compile at least one trace")
+   assert(aborted is 0, f"Safe table literal and variable keys should not abort, observed {aborted} aborts")
+   assert(trace_count < 10, f"Safe table indexing should remain below 10 traces, observed {trace_count}")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function SafeArrayInBoundsTraceParity()
+   local literal_expected, literal_result, literal_compiled, literal_aborted =
+      run_safe_index_trace(safe_array_literal_workload, 200)
+   assert(literal_result is literal_expected,
+      f"Literal safe array indexing should match the interpreter result {literal_expected}, got {literal_result}")
+   assert(literal_compiled is 0, "Literal safe array indexing should retain its conservative interpreter execution")
+   assert(literal_aborted <= 1,
+      f"Literal safe array indexing should disable recording without repeated aborts, observed {literal_aborted}")
+
+   local variable_expected, variable_result, variable_compiled, variable_aborted, variable_trace_count =
+      run_safe_index_trace(safe_array_variable_workload, 200)
+   assert(variable_result is variable_expected,
+      f"Variable safe array indexing should match the interpreter result {variable_expected}, got {variable_result}")
+   assert(variable_compiled > 0, "Variable in-bounds safe array indexing should compile at least one trace")
+   assert(variable_aborted is 0,
+      f"Variable in-bounds safe array indexing should not abort, observed {variable_aborted} aborts")
+   assert(count_trace_link_type(30, "loop") > 0,
+      "Variable in-bounds safe array indexing should remain in a compiled loop trace")
+   assert(variable_trace_count < 10,
+      f"Variable in-bounds safe array indexing should remain below 10 traces, observed {variable_trace_count}")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function SafeArrayOutOfBoundsTraceParity()
+   local literal_expected, literal_result, literal_compiled, literal_aborted =
+      run_safe_index_trace(safe_array_literal_oob_workload, 200)
+   assert(literal_result is literal_expected,
+      f"Literal out-of-bounds safe indexing should produce {literal_expected}, got {literal_result}")
+   assert(literal_compiled is 0,
+      "Literal out-of-bounds safe indexing should retain its conservative interpreter execution")
+   assert(literal_aborted <= 1,
+      f"Literal out-of-bounds safe indexing repeatedly aborted: {literal_aborted}")
+
+   local variable_expected, variable_result, variable_compiled, variable_aborted =
+      run_safe_index_trace(safe_array_variable_oob_workload, 200)
+   assert(variable_result is variable_expected,
+      f"Variable out-of-bounds safe indexing should produce {variable_expected}, got {variable_result}")
+   assert(variable_compiled > 0, "Variable out-of-bounds safe indexing should compile up to its boundary")
+   assert(variable_aborted is 0,
+      f"Variable out-of-bounds safe indexing should terminate cleanly, observed {variable_aborted} aborts")
+   assert(count_trace_link_type(30, "interpreter") > 0,
+      "Variable out-of-bounds safe indexing should retain its conservative interpreter trace boundary")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function SafeArrayMixedBoundsTraceStability()
+   local expected, result, compiled, aborted, trace_count = run_safe_index_trace(safe_array_mixed_bounds_workload, 400)
+
+   assert(result is expected, f"Mixed-bound safe indexing should match the interpreter result {expected}, got {result}")
+   assert(compiled > 0, "Mixed-bound safe indexing should compile at least one trace")
+   assert(aborted is 0, f"Mixed-bound safe indexing should not abort, observed {aborted} aborts")
+   assert(trace_count < 10, f"Mixed-bound safe indexing should remain below 10 traces, observed {trace_count}")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function NilAndDynamicSafeIndexTraceParity()
+   local nil_expected, nil_result, nil_compiled, nil_aborted =
+      run_safe_index_trace(nil_safe_index_workload, 200)
+   assert(nil_result is nil_expected, f"Nil safe indexing should produce {nil_expected}, got {nil_result}")
+   assert(nil_result is 200000, "Nil safe indexing should not evaluate its key expression on the hot path")
+   assert(nil_compiled > 0, "Nil safe indexing should compile at least one surrounding loop trace")
+   assert(nil_aborted < 3, f"Nil safe indexing should settle without repeated aborts, observed {nil_aborted} aborts")
+
+   local table_expected, table_result, table_compiled, table_aborted =
+      run_safe_index_trace(dynamic_table_safe_index_workload, 200)
+   assert(table_result is table_expected,
+      f"Dynamic table safe indexing should match the interpreter result {table_expected}, got {table_result}")
+   assert(table_compiled > 0, "Dynamic table safe indexing should compile at least one trace")
+   assert(table_aborted < 2,
+      f"Dynamic table safe indexing should settle without repeated aborts, observed {table_aborted} aborts")
+
+   local array_expected, array_result, array_compiled, array_aborted =
+      run_safe_index_trace(dynamic_array_safe_index_workload, 200)
+   assert(array_result is array_expected,
+      f"Dynamic array safe indexing should match the interpreter result {array_expected}, got {array_result}")
+   assert(array_compiled > 0, "Dynamic array safe indexing should compile at least one trace")
+   assert(array_aborted < 2,
+      f"Dynamic array safe indexing should settle without repeated aborts, observed {array_aborted} aborts")
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+@Test(hotpath=100) function SafeIndexJoinRestoresDestinationSlot()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=3', 'hotexit=1', 'minstitch=0')
+
+   local keys = array<string> { 'alpha', 'missing', 'bravo', 'missing' }
+   for iteration in {0 to 500} do
+      local key = keys[iteration % #keys]
+      local expected = key is 'alpha' ? 'keyword' :> key is 'bravo' ? 'annotation' :> 'missing'
+      local result = resolve_safe_index_join(key)
+      assert(result is expected,
+         f'Safe-index join failed at iteration {iteration}: key={key}, expected={expected}, result={result}')
+   end
+
+   assert(count_jit_traces(30) > 0, 'Alternating safe-index branches should execute through a compiled trace')
+   jit.opt.start()
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -230,6 +230,7 @@ end
    object = { mykey = "myvalue" }
    v = object?[key]
    assert(v is "myvalue", "Safe index should work with variable keys")
+   assert(object?["mykey"] is "myvalue", "Safe index should work with literal string keys")
 
    object2 = nil
    v2 = object2?[key]
@@ -304,6 +305,9 @@ end
    arr = { 10, 20, 30, 40 }
    v = arr?[2]
    assert(v is 30, "Safe index should work with numeric keys")
+
+   idx = 1
+   assert(arr?[idx] is 20, "Safe index should work with variable numeric table keys")
 
    nilArr = nil
    v2 = nilArr?[1]
@@ -384,6 +388,18 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
+@Test function testTiriArraySafeIndexBoundaries()
+   arr = array<int> { 10, 20, 30 }
+   equal_to_length = #arr
+   far_out_of_bounds = #arr + 100
+
+   assert(arr?[-1] is nil, "Safe index should return nil for a negative native-array index")
+   assert(arr?[equal_to_length] is nil, "Safe index should return nil when the index equals the array length")
+   assert(arr?[far_out_of_bounds] is nil, "Safe index should return nil for a far out-of-bounds variable index")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
 @Test function testTiriArraySafeIndexVariable()
    -- Test safe navigation with variable indices
    arr = array<string> { "zero", "one", "two", "three" }
@@ -401,6 +417,15 @@ end
    base = 1
    assert(arr?[base + 1] is "two", "Safe index with computed index should work")
    assert(arr?[base + 100] is nil, "Safe index with out-of-bounds computed index should return nil")
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function testTiriArraySafeMethodLookup()
+   arr = array<int> { 10, 20, 30 }
+   concat_method = arr?["concat"]
+
+   assert(type(concat_method) is "function", "Safe array string lookup should retain array method fallback")
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/tools/benchmark/benchmark_control.tiri
+++ b/tools/benchmark/benchmark_control.tiri
@@ -738,10 +738,8 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Goal: Measure overhead of the safe navigation operator (?.) vs direct access
 
--- NB: Safe field access (?.) and safe index access (?[]) are measured separately because they have very
--- different JIT characteristics.  At the time of writing ?. compiles cleanly and matches direct field access,
--- whereas ?[] aborts trace compilation and is therefore orders of magnitude slower.  Combining them into one
--- benchmark would hide that distinction.
+-- NB: Safe field access (?.) and safe index access (?[]) are measured separately because they exercise distinct
+-- bytecode and lookup paths.  Keeping paired direct and safe forms makes their individual overhead visible.
 
 @Test function ControlSafeNavigationFieldFastCmp()
    local obj = { name = "Alice", addr = { city = "London", geo = { lat = 51.5 } } }
@@ -772,15 +770,11 @@ end
    return acc
 end
 
--- NB: The index pair uses a lower iteration count than the field pair because ?[] does not currently trace-compile.
--- At 1M iterations it is slow enough to exhaust the benchmark harness warmup budget.  Both functions in the pair
--- must keep the same count for the comparison to remain valid.
-
 @Test function ControlSafeNavigationIndexFastCmp()
    local arr = { 10, 20, 30, 40, 50 }
 
    local acc = 0
-   for i in {0 to 100000} do
+   for i in {0 to 1000000} do
       local v1 = arr[0]
       local v2 = arr[2]
       acc += v1 + v2
@@ -793,7 +787,7 @@ end
    local arr = { 10, 20, 30, 40, 50 }
 
    local acc = 0
-   for i in {0 to 100000} do
+   for i in {0 to 1000000} do
       local v1 = arr?[0]
       local v2 = arr?[2]
       acc += v1 + v2


### PR DESCRIPTION
* Selected safe array bytecodes using receiver and key type descriptors
* Recorded variable safe array reads with guarded bounds checks and interpreter fallbacks
* Added parser, runtime and trace coverage for safe indexing behaviour