### PR TITLE
[Tiri] Prevent function calls from crossing statement line boundaries

### DIFF
--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -155,7 +155,7 @@ private:
    ParserResult<ParameterListResult> parse_parameter_list(bool);
    ParserResult<Token> parse_type_annotation(TiriType &Type, struct_record *&StructDef);
    ParserResult<std::vector<TableField>> parse_table_fields(bool *);
-   ParserResult<ExprNodeList> parse_call_arguments(bool *);
+   ParserResult<ExprNodeList> parse_call_arguments(bool *, SourceSpan *);
 
    struct ResultFilterInfo {
       uint64_t keep_mask = 0;

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -1064,10 +1064,11 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          if (not name_token.ok()) return ParserResult<ExprNodePtr>::failure(name_token.error_ref());
 
          bool forwards = false;
-         auto args = this->parse_call_arguments(&forwards);
+         SourceSpan call_end;
+         auto args = this->parse_call_arguments(&forwards, &call_end);
          if (not args.ok()) return ParserResult<ExprNodePtr>::failure(args.error_ref());
 
-         SourceSpan span = combine_spans(base->span, name_token.value_ref().span());
+         SourceSpan span = combine_spans(base->span, call_end);
          base = make_method_call_expr(span, std::move(base),
             make_identifier(name_token.value_ref()), std::move(args.value_ref()), forwards);
          continue;
@@ -1079,10 +1080,11 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          if (not name_token.ok()) return ParserResult<ExprNodePtr>::failure(name_token.error_ref());
 
          bool forwards = false;
-         auto args = this->parse_call_arguments(&forwards);
+         SourceSpan call_end;
+         auto args = this->parse_call_arguments(&forwards, &call_end);
          if (not args.ok()) return ParserResult<ExprNodePtr>::failure(args.error_ref());
 
-         SourceSpan span = combine_spans(base->span, name_token.value_ref().span());
+         SourceSpan span = combine_spans(base->span, call_end);
          base = make_safe_method_call_expr(span, std::move(base),
             make_identifier(name_token.value_ref()), std::move(args.value_ref()), forwards);
          continue;
@@ -1090,7 +1092,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
 
       if (token.kind() IS TokenKind::LeftParen or token.kind() IS TokenKind::LeftBrace or
             token.kind() IS TokenKind::String) {
-         if (token.kind() IS TokenKind::LeftBrace and token.span().line != base->span.line) break;
+         if (token.span().line != base->span.line) break;
 
          // For table tokens in a choose expression context, check if this starts a table pattern for the next case.
          // If the matching brace is followed by -> or 'when', don't treat it as a table-call argument.
@@ -1150,9 +1152,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          }
 
          bool forwards = false;
-         auto args = this->parse_call_arguments(&forwards);
+         SourceSpan call_end;
+         auto args = this->parse_call_arguments(&forwards, &call_end);
          if (not args.ok()) return ParserResult<ExprNodePtr>::failure(args.error_ref());
-         SourceSpan span = combine_spans(base->span, token.span());
+         SourceSpan span = combine_spans(base->span, call_end);
          base = make_call_expr(span, std::move(base), std::move(args.value_ref()), forwards);
          continue;
       }

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -550,12 +550,14 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
       case TokenKind::LeftParen: {
          Token open_paren = this->ctx.tokens().current();
+         Token close_paren;
          this->ctx.tokens().advance();
          ExprNodeList expressions;
          bool parsed_empty = false;
 
          if (this->ctx.check(TokenKind::RightParen)) {
             parsed_empty = true;
+            close_paren = this->ctx.tokens().current();
             this->ctx.tokens().advance();
          }
          else {
@@ -569,7 +571,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
                expressions.push_back(std::move(next_expr.value_ref()));
             }
 
-            this->ctx.consume(TokenKind::RightParen, ParserErrorCode::ExpectedToken);
+            auto close = this->ctx.consume(TokenKind::RightParen, ParserErrorCode::ExpectedToken);
+            if (not close.ok()) return ParserResult<ExprNodePtr>::failure(close.error_ref());
+            close_paren = close.value_ref();
          }
 
          if (this->ctx.check(TokenKind::Arrow)) {
@@ -589,6 +593,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          }
 
          node = std::move(expressions.front());
+         node->span = combine_spans(node->span, close_paren.span());
          node->is_grouped = true;
          break;
       }
@@ -1041,8 +1046,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          auto index = this->parse_expression();
          if (not index.ok()) return index;
 
-         this->ctx.consume(TokenKind::RightBracket, ParserErrorCode::ExpectedToken);
-         SourceSpan span = combine_spans(base->span, index.value_ref()->span);
+         auto close = this->ctx.consume(TokenKind::RightBracket, ParserErrorCode::ExpectedToken);
+         if (not close.ok()) return ParserResult<ExprNodePtr>::failure(close.error_ref());
+         SourceSpan span = combine_spans(base->span, close.value_ref().span());
          base = make_index_expr(span, std::move(base), std::move(index.value_ref()));
          continue;
       }
@@ -1052,8 +1058,9 @@ ParserResult<ExprNodePtr> AstBuilder::parse_suffixed(ExprNodePtr base)
          auto index = this->parse_expression();
          if (not index.ok()) return index;
 
-         this->ctx.consume(TokenKind::RightBracket, ParserErrorCode::ExpectedToken);
-         SourceSpan span = combine_spans(base->span, index.value_ref()->span);
+         auto close = this->ctx.consume(TokenKind::RightBracket, ParserErrorCode::ExpectedToken);
+         if (not close.ok()) return ParserResult<ExprNodePtr>::failure(close.error_ref());
+         SourceSpan span = combine_spans(base->span, close.value_ref().span());
          base = make_safe_index_expr(span, std::move(base), std::move(index.value_ref()));
          continue;
       }

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -45,8 +45,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
    --this->function_depth;
    if (not body.ok()) return ParserResult<ExprNodePtr>::failure(body.error_ref());
 
-   this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
-   ExprNodePtr node = make_function_expr(FunctionToken.span(), std::move(params.value_ref().parameters),
+   auto end_token = this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
+   if (not end_token.ok()) return ParserResult<ExprNodePtr>::failure(end_token.error_ref());
+   SourceSpan span = combine_spans(FunctionToken.span(), end_token.value_ref().span());
+   ExprNodePtr node = make_function_expr(span, std::move(params.value_ref().parameters),
       params.value_ref().is_vararg, std::move(body.value_ref()), IsThunk, thunk_return_type, return_types);
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
@@ -73,8 +75,10 @@ ParserResult<ExprNodePtr> AstBuilder::parse_table_literal(bool AllowRange)
    auto fields = this->parse_table_fields(&has_array);
    if (not fields.ok()) return ParserResult<ExprNodePtr>::failure(fields.error_ref());
 
-   this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
-   ExprNodePtr node = make_table_expr(token.span(), std::move(fields.value_ref()), has_array);
+   auto close = this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   if (not close.ok()) return ParserResult<ExprNodePtr>::failure(close.error_ref());
+   SourceSpan span = combine_spans(token.span(), close.value_ref().span());
+   ExprNodePtr node = make_table_expr(span, std::move(fields.value_ref()), has_array);
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -351,7 +351,7 @@ ParserResult<std::vector<TableField>> AstBuilder::parse_table_fields(bool *has_a
 //********************************************************************************************************************
 // Parses function call arguments, handling parenthesised expressions, table constructors, and string literals.
 
-ParserResult<ExprNodeList> AstBuilder::parse_call_arguments(bool *ForwardsMultret)
+ParserResult<ExprNodeList> AstBuilder::parse_call_arguments(bool *ForwardsMultret, SourceSpan *EndSpan)
 {
    ExprNodeList args;
    *ForwardsMultret = false;
@@ -371,7 +371,9 @@ ParserResult<ExprNodeList> AstBuilder::parse_call_arguments(bool *ForwardsMultre
          }
       }
 
-      this->ctx.consume(TokenKind::RightParen, ParserErrorCode::ExpectedToken);
+      auto close = this->ctx.consume(TokenKind::RightParen, ParserErrorCode::ExpectedToken);
+      if (not close.ok()) return ParserResult<ExprNodeList>::failure(close.error_ref());
+      *EndSpan = close.value_ref().span();
       return ParserResult<ExprNodeList>::success(std::move(args));
    }
 
@@ -379,12 +381,14 @@ ParserResult<ExprNodeList> AstBuilder::parse_call_arguments(bool *ForwardsMultre
       auto table = this->parse_table_literal();
       if (not table.ok()) return ParserResult<ExprNodeList>::failure(table.error_ref());
 
+      *EndSpan = table.value_ref()->span;
       args.push_back(std::move(table.value_ref()));
       return ParserResult<ExprNodeList>::success(std::move(args));
    }
 
    if (this->ctx.check(TokenKind::String)) {
       Token literal = this->ctx.tokens().current();
+      *EndSpan = literal.span();
       args.push_back(make_literal_expr(literal.span(), make_literal(literal)));
       this->ctx.tokens().advance();
       return ParserResult<ExprNodeList>::success(std::move(args));

--- a/src/tiri/jit/src/parser/ast/loops.cpp
+++ b/src/tiri/jit/src/parser/ast/loops.cpp
@@ -53,9 +53,11 @@ ParserResult<ExprNodePtr> AstBuilder::parse_scanned_range_in_braces(bool HasStep
       step_expr = std::move(step.value_ref());
    }
 
-   this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   auto close = this->ctx.consume(TokenKind::RightBrace, ParserErrorCode::ExpectedToken);
+   if (not close.ok()) return ParserResult<ExprNodePtr>::failure(close.error_ref());
 
-   ExprNodePtr node = make_range_expr(brace_token.span(), std::move(start_expr.value_ref()),
+   SourceSpan span = combine_spans(brace_token.span(), close.value_ref().span());
+   ExprNodePtr node = make_range_expr(span, std::move(start_expr.value_ref()),
       std::move(stop_expr.value_ref()), is_inclusive, std::move(step_expr));
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -413,6 +413,32 @@ static bool test_empty_comment_appended_to_variable(kt::Log &log)
 
 //********************************************************************************************************************
 
+static bool test_call_suffix_requires_same_line(kt::Log &Log)
+{
+   auto result = build_ast_from_source("a = f\n(g).x = 1");
+   if (not result.chunk.ok()) {
+      Log.error("newline-separated assignments failed to parse");
+      log_diagnostics(result.diagnostics, Log);
+      return false;
+   }
+
+   StatementListView statements = result.chunk.value_ref()->view();
+   if (statements.size() != 2) {
+      Log.error("expected two newline-separated assignments, got %" PRId64, int64_t(statements.size()));
+      return false;
+   }
+
+   if (not (statements[0].kind IS AstNodeKind::AssignmentStmt) or
+       not (statements[1].kind IS AstNodeKind::AssignmentStmt)) {
+      Log.error("newline-separated expressions were not parsed as assignments");
+      return false;
+   }
+
+   return true;
+}
+
+//********************************************************************************************************************
+
 static bool test_loop_ast(kt::Log &log)
 {
    constexpr const char* source = R"(
@@ -3845,13 +3871,14 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 47> tests = { {
+   constexpr std::array<TestCase, 48> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
       { "expression_entry_point", test_expression_entry_point },
       { "expression_list_entry_point", test_expression_list_entry_point },
       { "empty_comment_appended_to_variable", test_empty_comment_appended_to_variable },
+      { "call_suffix_requires_same_line", test_call_suffix_requires_same_line },
       { "loop_ast", test_loop_ast },
       { "if_stmt_with_elseif_ast", test_if_stmt_with_elseif_ast },
       { "local_function_table_ast", test_local_function_table_ast },

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -434,6 +434,41 @@ static bool test_call_suffix_requires_same_line(kt::Log &Log)
       return false;
    }
 
+   struct MultilineCalleeCase {
+      const char *name;
+      const char *source;
+   };
+
+   constexpr std::array<MultilineCalleeCase, 5> cases = { {
+      { "grouped", "a = (\nf\n)(g)" },
+      { "grouped_iife", "a = (function()\n   return 1\nend)()" },
+      { "function_literal", "a = function()\n   return 1\nend()" },
+      { "table", "a = {\n   callback = f\n}(g)" },
+      { "index", "a = f[\n   g\n](42)" }
+   } };
+
+   for (const auto &test_case : cases) {
+      auto call_result = build_ast_from_source(test_case.source);
+      if (not call_result.chunk.ok()) {
+         Log.error("%s multiline callee failed to parse", test_case.name);
+         log_diagnostics(call_result.diagnostics, Log);
+         return false;
+      }
+
+      StatementListView call_statements = call_result.chunk.value_ref()->view();
+      if (call_statements.size() != 1 or not (call_statements[0].kind IS AstNodeKind::AssignmentStmt)) {
+         Log.error("%s multiline callee did not produce one assignment", test_case.name);
+         return false;
+      }
+
+      const auto *assignment = std::get_if<AssignmentStmtPayload>(&call_statements[0].data);
+      if (not assignment or assignment->values.size() != 1 or
+          not (assignment->values[0]->kind IS AstNodeKind::CallExpr)) {
+         Log.error("%s multiline callee was not called", test_case.name);
+         return false;
+      }
+   }
+
    return true;
 }
 

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -280,6 +280,21 @@ end
    chained_call = debug.validate("extern f, g\na = f(\n   g\n)(g)")
    assert(chained_call.success is true, 'A chained call should be valid beside the preceding closing parenthesis')
 
+   grouped_callee = debug.validate("extern f, g\na = (\n   f\n)(g)")
+   assert(grouped_callee.success is true, 'A grouped multiline callee should remain callable')
+
+   grouped_iife = debug.validate("a = (function()\n   return 1\nend)()")
+   assert(grouped_iife.success is true, 'A grouped multiline function literal should remain callable')
+
+   function_literal = debug.validate("a = function()\n   return 1\nend()")
+   assert(function_literal.success is true, 'A multiline function literal should remain callable')
+
+   table_callee = debug.validate("extern f, g\na = {\n   callback = f\n}(g)")
+   assert(table_callee.success is true, 'A multiline table callee should remain callable')
+
+   index_callee = debug.validate("extern f, g\na = f[\n   g\n](42)")
+   assert(index_callee.success is true, 'A multiline index callee should remain callable')
+
    fluent_chain = debug.validate("extern response\nresponse.status(200)\n   .header('Name', 'Value')\n   .send('OK')")
    assert(fluent_chain.success is true, 'Fluent method chains should remain valid across lines')
 end

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -267,6 +267,23 @@ end
    })
 end
 
+@Test function ValidateCallStatementBoundaries()
+   separate_statements = debug.validate("extern f, g\na = f\n(g).x = 1")
+   assert(separate_statements.success is true, 'A call must not start on the line after its callee')
+
+   same_line_spacing = debug.validate("extern f, g\na = f (g)")
+   assert(same_line_spacing.success is true, 'Same-line whitespace before call arguments should remain valid')
+
+   multiline_arguments = debug.validate("extern f, g\na = f(\n   g\n)")
+   assert(multiline_arguments.success is true, 'Call arguments should remain multiline after the opening parenthesis')
+
+   chained_call = debug.validate("extern f, g\na = f(\n   g\n)(g)")
+   assert(chained_call.success is true, 'A chained call should be valid beside the preceding closing parenthesis')
+
+   fluent_chain = debug.validate("extern response\nresponse.status(200)\n   .header('Name', 'Value')\n   .send('OK')")
+   assert(fluent_chain.success is true, 'Fluent method chains should remain valid across lines')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Malformed conditionals and pattern selection
 


### PR DESCRIPTION
* Require call argument openers to share the callee's ending line
* Track complete call spans and cover multiline calls and fluent chains