### PR TITLE
[Tiri] Corrected exponentiation precedence for unary expressions

### DIFF
--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -372,10 +372,12 @@ ParserResult<ExprNodePtr> AstBuilder::parse_expression(uint8_t precedence)
 
 ParserResult<ExprNodePtr> AstBuilder::parse_unary()
 {
+   constexpr uint8_t unary_precedence = 10;
+
    Token current = this->ctx.tokens().current();
    if (current.kind() IS TokenKind::NotToken) {
       this->ctx.tokens().advance();
-      auto operand = this->parse_unary();
+      auto operand = this->parse_expression(unary_precedence);
       if (not operand.ok()) return operand;
 
       return ParserResult<ExprNodePtr>::success(make_unary_expr(current.span(), AstUnaryOperator::Not, std::move(operand.value_ref())));
@@ -383,7 +385,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_unary()
 
    if (current.kind() IS TokenKind::Minus) {
       this->ctx.tokens().advance();
-      auto operand = this->parse_unary();
+      auto operand = this->parse_expression(unary_precedence);
       if (not operand.ok()) return operand;
 
       return ParserResult<ExprNodePtr>::success(make_unary_expr(current.span(), AstUnaryOperator::Negate, std::move(operand.value_ref())));
@@ -391,14 +393,14 @@ ParserResult<ExprNodePtr> AstBuilder::parse_unary()
 
    if (current.raw() IS '#') {
       this->ctx.tokens().advance();
-      auto operand = this->parse_unary();
+      auto operand = this->parse_expression(unary_precedence);
       if (not operand.ok()) return operand;
       return ParserResult<ExprNodePtr>::success(make_unary_expr(current.span(), AstUnaryOperator::Length, std::move(operand.value_ref())));
    }
 
    if (current.raw() IS '~') {
       this->ctx.tokens().advance();
-      auto operand = this->parse_unary();
+      auto operand = this->parse_expression(unary_precedence);
       if (not operand.ok()) return operand;
 
       return ParserResult<ExprNodePtr>::success(make_unary_expr(current.span(), AstUnaryOperator::BitNot, std::move(operand.value_ref())));

--- a/src/tiri/tests/test_numeric_limits.tiri
+++ b/src/tiri/tests/test_numeric_limits.tiri
@@ -379,6 +379,15 @@ end
    assert((-1) ** 0 is 1, '(-1)^0 should be 1')
 end
 
+@Test function PowerBindingAndAssociativity()
+   assert(-2 ** 2 is -4, '** should bind more tightly than unary negation')
+   assert((-2) ** 2 is 4, 'parentheses should apply negation before exponentiation')
+   assert(2 ** -2 is 0.25, '** should accept a unary expression as its right operand')
+   assert(2 ** 3 ** 2 is 512, '** should associate from right to left')
+   assert(~2 ** 2 is ~4, '** should bind more tightly than unary bitwise NOT')
+   assert((not 2 ** 2) is false, '** should bind more tightly than logical NOT')
+end
+
 @Test function PowerOverflow()
    result = 2 ** 1024
    assert(result is math.huge, '2^1024 should overflow to infinity')


### PR DESCRIPTION
* Parsed unary operands at the precedence required for power expressions
* Added regression coverage for power binding and right associativity