### PR TITLE
[Display] Fixed stalled X11 window events

### DIFF
--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -1135,13 +1135,12 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       else return ERR::SystemCall;
 
       // Get the X11 file descriptor (for incoming events) and tell the Core to listen to it when the task is sleeping.
-      // Using ALWAYS_CALL here causes X11ManagerLoop() to run on every message-loop cycle, even when there are no X11
-      // events pending.  That can keep the UI thread active indefinitely.  A READ subscription is sufficient because
-      // X11ManagerLoop() drains the queued events whenever the X11 connection becomes readable.
+      // Xlib can read events into its private queue while waiting for replies, leaving the connection FD unreadable.
+      // ALWAYS_CALL ensures that this queue is checked before select(), while READ wakes the task for new socket data.
 
       glXFD = XConnectionNumber(XDisplay);
       fcntl(glXFD, F_SETFD, 1); // FD does not duplicate across exec()
-      RegisterFD(glXFD, RFD::READ, X11ManagerLoop, nullptr);
+      RegisterFD(glXFD, RFD::READ|RFD::ALWAYS_CALL, X11ManagerLoop, nullptr);
 
       // This function checks for DGA and also maps the video memory for us
 

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -1070,10 +1070,6 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
       }
    }
 
-   // Register a fake FD as input_event_loop() so that we can process input events on every ProcessMessages() cycle.
-
-   RegisterFD((HOSTHANDLE)-2, RFD::ALWAYS_CALL, input_event_loop, nullptr);
-
    #ifdef _GLES_
       pthread_mutexattr_t attr;
       pthread_mutexattr_init(&attr);
@@ -1299,6 +1295,10 @@ static ERR MODInit(OBJECTPTR argModule, struct CoreBase *argCoreBase)
    winInitCursors(winCursors, std::ssize(winCursors));
 
 #endif
+
+   // Register input dispatch after platform event sources so that newly queued input is handled before the task sleeps.
+
+   RegisterFD((HOSTHANDLE)-2, RFD::ALWAYS_CALL, input_event_loop, nullptr);
 
    if (create_pointer_class() != ERR::Okay) return log.warning(ERR::AddClass);
    if (create_display_class() != ERR::Okay) return log.warning(ERR::AddClass);

--- a/src/display/x11/handlers.cpp
+++ b/src/display/x11/handlers.cpp
@@ -199,7 +199,6 @@ void X11ManagerLoop(HOSTHANDLE FD, APTR Data)
 
    if (processed_events) {
       XFlush(XDisplay);
-      if (XDisplay) XSync(XDisplay, False);
    }
 }
 


### PR DESCRIPTION
* Checked Xlib internal events before waiting for new socket data
* Avoided synchronous event-loop flushes that could hide newly queued events