### PR TITLE
[Tiri] Persist global const contracts across compilation boundaries

### DIFF
--- a/src/tiri/CMakeLists.txt
+++ b/src/tiri/CMakeLists.txt
@@ -131,6 +131,7 @@ set (JIT_KOTUKU_HEADER_DEPENDENCIES
 set (JIT_TIRI_HEADER_DEPENDENCIES
    "${CMAKE_CURRENT_SOURCE_DIR}/defs.h"
    "${CMAKE_CURRENT_SOURCE_DIR}/struct_def.h"
+   "${JIT_SRC}/runtime/lj_contract.h"
 )
 
 option(KOTUKU_PARSER_TRACE "Emit parser token and expectation traces" OFF)

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -213,6 +213,9 @@ struct Identifier {
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
    mutable StaticBindingID binding_id = 0;
    mutable StaticValueHandle static_value = 0;
+   mutable TiriType global_contract_type = TiriType::Unknown;
+   mutable struct_record *global_contract_struct_def = nullptr;
+   mutable GlobalContractPolicy global_contract_policy = GlobalContractPolicy::Advisory;
 
    // Default constructor
    Identifier() = default;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -6,6 +6,23 @@
 // Emit bytecode for a global variable declaration statement, explicitly storing values in the global table.
 // Handles multi-value returns from function calls (e.g., global a, b, c = f())
 
+[[nodiscard]] static std::optional<RuntimeContract> global_declaration_contract(const Identifier &Identifier)
+{
+   if (Identifier.global_contract_policy IS GlobalContractPolicy::Advisory) return std::nullopt;
+
+   return RuntimeContract{
+      .type = Identifier.global_contract_type,
+      .struct_def = Identifier.global_contract_struct_def,
+      .label = Identifier.symbol,
+      .boundary = ContractBoundary::Global,
+      .position = 1,
+      .is_const = Identifier.has_const,
+      .initialising = Identifier.has_const
+   };
+}
+
+//********************************************************************************************************************
+
 ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPayload &Payload)
 {
    auto nvars = BCReg(BCREG(Payload.names.size()));
@@ -102,7 +119,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpDesc target;
       target.init(ExpKind::Global, 0);
       target.u.sval = name;
-      bcemit_store(&this->func_state, &target, &rhs);
+      auto contract = global_declaration_contract(identifier);
+      bcemit_store(&this->func_state, &target, &rhs, contract ? &*contract : nullptr, true);
 
       // Patch jumps
       falsey_edge.patch_to(assign_pos);
@@ -173,7 +191,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpDesc target;
       target.init(ExpKind::Global, 0);
       target.u.sval = name;
-      bcemit_store(&this->func_state, &target, &rhs);
+      auto contract = global_declaration_contract(identifier);
+      bcemit_store(&this->func_state, &target, &rhs, contract ? &*contract : nullptr, true);
 
       // Patch jumps
       check_nil.patch_to(assign_pos);
@@ -225,7 +244,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpDesc value_expr;
       value_expr.init(ExpKind::NonReloc, value_base + i);
 
-      bcemit_store(&this->func_state, &var, &value_expr); // Store to global
+      auto contract = global_declaration_contract(identifier);
+      bcemit_store(&this->func_state, &var, &value_expr, contract ? &*contract : nullptr, true);
    }
 
    this->func_state.reset_freereg();

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -21,6 +21,17 @@
    };
 }
 
+static void bcemit_skipped_global_const(FuncState *State, BCReg Value,
+   const std::optional<RuntimeContract> &Contract)
+{
+   if (not Contract or not Contract->is_const) return;
+
+   bcemit_contract(State, Value, std::span(&*Contract, 1), 1);
+   RuntimeContract finaliser = *Contract;
+   finaliser.initialising = false;
+   bcemit_contract(State, Value, std::span(&finaliser, 1), 1);
+}
+
 //********************************************************************************************************************
 
 ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPayload &Payload)
@@ -96,8 +107,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ControlFlowEdge falsey_edge = emit_falsey_jumps(
          this->func_state, this->control_flow, lhs_reg, options);
 
-      // Skip assignment if not empty
+      // A retained value still initialises a const binding.  Validate it and publish policy without storing it.
 
+      auto contract = global_declaration_contract(identifier);
+      bcemit_skipped_global_const(&this->func_state, lhs_reg, contract);
       ControlFlowEdge skip_assign = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
       BCPos assign_pos = BCPos(this->func_state.pc);
 
@@ -119,7 +132,6 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpDesc target;
       target.init(ExpKind::Global, 0);
       target.u.sval = name;
-      auto contract = global_declaration_contract(identifier);
       bcemit_store(&this->func_state, &target, &rhs, contract ? &*contract : nullptr, true);
 
       // Patch jumps
@@ -168,8 +180,10 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ControlFlowEdge check_nil = emit_falsey_jumps(
          this->func_state, this->control_flow, lhs_reg, nil_only);
 
-      // Skip assignment if not nil
+      // A retained value still initialises a const binding.  Validate it and publish policy without storing it.
 
+      auto contract = global_declaration_contract(identifier);
+      bcemit_skipped_global_const(&this->func_state, lhs_reg, contract);
       ControlFlowEdge skip_assign = this->control_flow.make_unconditional(BCPos(bcemit_jmp(&this->func_state)));
       BCPos assign_pos = BCPos(this->func_state.pc);
 
@@ -191,7 +205,6 @@ ParserResult<IrEmitUnit> IrEmitter::emit_global_decl_stmt(const GlobalDeclStmtPa
       ExpDesc target;
       target.init(ExpKind::Global, 0);
       target.u.sval = name;
-      auto contract = global_declaration_contract(identifier);
       bcemit_store(&this->func_state, &target, &rhs, contract ? &*contract : nullptr, true);
 
       // Patch jumps

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -166,7 +166,6 @@ public:
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
-      bool is_const = false;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;
    std::vector<StructFieldDocumentation> struct_field_documentation;

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -166,6 +166,7 @@ public:
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
+      bool is_const = false;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;
    std::vector<StructFieldDocumentation> struct_field_documentation;

--- a/src/tiri/jit/src/parser/parse_internal.h
+++ b/src/tiri/jit/src/parser/parse_internal.h
@@ -209,7 +209,7 @@ static void expr_toreg(FuncState *, ExpDesc* e, BCREG reg);
 static void expr_tonextreg(FuncState *, ExpDesc* e);
 static BCREG expr_toanyreg(FuncState *, ExpDesc* e);
 static void expr_toval(FuncState *, ExpDesc* e);
-static void bcemit_store(FuncState *, ExpDesc* var, ExpDesc* e);
+static void bcemit_store(FuncState *, ExpDesc* var, ExpDesc* e, const RuntimeContract * = nullptr, bool = false);
 static void bcemit_method(FuncState *, ExpDesc* e, ExpDesc* key);
 // These are now exported (non-static) for use by OperatorEmitter facade
 extern BCPOS bcemit_jmp(FuncState *);

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -550,6 +550,14 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
    // Dynamic result counts still require interpreter-only MRSAVE/MRRESTORE handling.  Fixed contracts have exact
    // recorder predicates, including callable values, named structures, ranges and userdata.
    if (DynamicCount) fs->flags |= PROTO_NOJIT;
+   for (const RuntimeContract &contract : Contracts) {
+      // Global const descriptors validate before the store and publish environment policy afterwards.  The recorder
+      // only emits type guards for BC_CONTRACT, so the post-store side effect must remain interpreter-only.
+      if (contract.is_const) {
+         fs->flags |= PROTO_NOJIT;
+         break;
+      }
+   }
 
    std::string descriptor;
    descriptor.reserve(5 + Contracts.size() * 8);
@@ -568,6 +576,8 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       uint8_t entry_flags = 0;
       if (contract.nullable) entry_flags |= contract_flag(ContractEntryFlag::Nullable);
       if (contract.required) entry_flags |= contract_flag(ContractEntryFlag::Required);
+      if (contract.is_const) entry_flags |= contract_flag(ContractEntryFlag::Const);
+      if (contract.initialising) entry_flags |= contract_flag(ContractEntryFlag::Initialising);
       descriptor.push_back(char(entry_flags));
       descriptor.push_back(char(contract.position));
 
@@ -646,6 +656,9 @@ static void check_object_class_assignment(FuncState *Fs, const VarInfo &Variable
 static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
 {
    BCIns ins;
+   RuntimeContract global_const_finaliser;
+   BCREG global_const_base = 0;
+   bool finalise_global_const = false;
    if (LHS->k IS ExpKind::Local) {
       fs->ls->vstack[LHS->u.s.aux].info |= VarInfoFlag::VarReadWrite;
       VarInfo *vinfo = &fs->ls->vstack[LHS->u.s.aux];
@@ -692,7 +705,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
             .struct_def = found->second.struct_def,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,
-            .position = 1
+            .position = 1,
+            .is_const = found->second.is_const,
+            .initialising = found->second.is_const
          };
          // Declared global contracts must execute even when no predicate is required.  Concrete contracts and the
          // explicit 'any' opt-out are both attached to the environment for separately compiled chunks.
@@ -707,6 +722,18 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       }
       BCREG ra = expr_toanyreg(fs, RHS);
       ins = BCINS_AD(BC_GSET, ra, const_str(fs, LHS));
+      if (found != fs->ls->global_type_hints.end() and found->second.is_const) {
+         global_const_finaliser = {
+            .type = found->second.primary,
+            .struct_def = found->second.struct_def,
+            .label = LHS->u.sval,
+            .boundary = ContractBoundary::Global,
+            .position = 1,
+            .is_const = true
+         };
+         global_const_base = ra;
+         finalise_global_const = true;
+      }
    }
    else if (LHS->k IS ExpKind::IndexedArray or LHS->k IS ExpKind::SafeIndexedArray) {
       // Array index assignment - emit BC_ASETV or BC_ASETB
@@ -774,6 +801,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       }
    }
    bcemit_INS(fs, ins);
+   if (finalise_global_const) {
+      bcemit_contract(fs, global_const_base, std::span(&global_const_finaliser, 1), 1);
+   }
    expr_free(fs, RHS);
 }
 

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -653,7 +653,8 @@ static void check_object_class_assignment(FuncState *Fs, const VarInfo &Variable
 //********************************************************************************************************************
 // Emit store for LHS expression.
 
-static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
+static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
+   const RuntimeContract *GlobalDeclarationContract, bool IsGlobalDeclaration)
 {
    BCIns ins;
    RuntimeContract global_const_finaliser;
@@ -698,19 +699,20 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       // Note: Const global reassignment is checked during type analysis phase
       // Unscoped should normally be resolved in emit_lvalue_expr(), but handle it here defensively
       auto found = fs->ls->global_type_hints.find(LHS->u.sval);
-      if (found != fs->ls->global_type_hints.end() and
+      if (GlobalDeclarationContract) {
+         // Declared global contracts must execute even when no predicate is required.  Concrete contracts and the
+         // explicit 'any' opt-out are both attached to the environment for separately compiled chunks.
+         bcemit_value_contract(fs, RHS, *GlobalDeclarationContract, true);
+      }
+      else if (not IsGlobalDeclaration and found != fs->ls->global_type_hints.end() and
           found->second.contract_policy != GlobalContractPolicy::Advisory) {
          RuntimeContract contract{
             .type = found->second.primary,
             .struct_def = found->second.struct_def,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,
-            .position = 1,
-            .is_const = found->second.is_const,
-            .initialising = found->second.is_const
+            .position = 1
          };
-         // Declared global contracts must execute even when no predicate is required.  Concrete contracts and the
-         // explicit 'any' opt-out are both attached to the environment for separately compiled chunks.
          bcemit_value_contract(fs, RHS, contract, true);
       }
       else if (GCstr *contract = lj_tab_get_global_contract(tabref(fs->L->env), LHS->u.sval)) {
@@ -722,15 +724,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS)
       }
       BCREG ra = expr_toanyreg(fs, RHS);
       ins = BCINS_AD(BC_GSET, ra, const_str(fs, LHS));
-      if (found != fs->ls->global_type_hints.end() and found->second.is_const) {
-         global_const_finaliser = {
-            .type = found->second.primary,
-            .struct_def = found->second.struct_def,
-            .label = LHS->u.sval,
-            .boundary = ContractBoundary::Global,
-            .position = 1,
-            .is_const = true
-         };
+      if (GlobalDeclarationContract and GlobalDeclarationContract->is_const) {
+         global_const_finaliser = *GlobalDeclarationContract;
+         global_const_finaliser.initialising = false;
          global_const_base = ra;
          finalise_global_const = true;
       }

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -93,6 +93,8 @@ struct RuntimeContract {
    uint8_t position = 0;
    bool nullable = true;
    bool required = false;
+   bool is_const = false;
+   bool initialising = false;
 };
 
 // Concept for flag types that support bitwise operations

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1795,12 +1795,12 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    lua_State *lua = state.get();
    std::string encoded{
       char(TIRI_CONTRACT_VERSION),
-      char(uint8_t(ContractBoundary::Parameter)),
+      char(uint8_t(ContractBoundary::Global)),
       char(0),
       char(1),
       char(1),
       char(uint8_t(TiriType::Struct)),
-      char(contract_flag(ContractEntryFlag::Nullable)),
+      char(contract_flag(ContractEntryFlag::Nullable) | contract_flag(ContractEntryFlag::Const)),
       char(1),
       char(5)
    };
@@ -1811,9 +1811,10 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    RuntimeContractDescriptor decoded;
    GCstr *descriptor = lj_str_new(lua, encoded.data(), encoded.size());
    if (not decode_runtime_contract(descriptor, decoded) or
-       decoded.boundary != ContractBoundary::Parameter or decoded.dynamic_count() or decoded.variadic() or
+       decoded.boundary != ContractBoundary::Global or decoded.dynamic_count() or decoded.variadic() or
        decoded.static_value_count != 1 or decoded.contract_count != 1 or
        decoded.entries[0].type != TiriType::Struct or decoded.entries[0].position != 1 or
+       not contract_entry_is_const(decoded.entries[0]) or
        decoded.entries[0].struct_name != "Point" or decoded.entries[0].label != "Value") {
       Log.error("valid runtime contract descriptor did not round-trip through the shared decoder");
       return false;
@@ -1829,6 +1830,8 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    invalid_descriptor_flags[2] = char(0x80);
    std::string invalid_entry_flags = encoded;
    invalid_entry_flags[6] = char(0x80);
+   std::string invalid_initialising_flag = encoded;
+   invalid_initialising_flag[6] = char(contract_flag(ContractEntryFlag::Initialising));
    std::string invalid_position = encoded;
    invalid_position[7] = char(0);
    std::string invalid_constraint = encoded;
@@ -1837,6 +1840,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    std::string truncated = encoded.substr(0, encoded.size() - 1);
 
    if (not rejected(invalid_descriptor_flags) or not rejected(invalid_entry_flags) or
+       not rejected(invalid_initialising_flag) or
        not rejected(invalid_position) or not rejected(invalid_constraint) or not rejected(trailing) or
        not rejected(truncated)) {
       Log.error("shared runtime contract decoder accepted malformed input");
@@ -1904,6 +1908,16 @@ static bool test_complex_contract_jit_eligibility(kt::Log &Log)
       "dynamic-result-contract");
    if (not dynamic or not (dynamic->flags & PROTO_NOJIT)) {
       Log.error("a dynamic-result contract became JIT-eligible without exact multi-result recorder support");
+      return false;
+   }
+
+   GCproto *global_const = compile_child(
+      "return function()\n"
+      "   global glRecordedConst <const> = 1\n"
+      "end\n",
+      "global-const-contract");
+   if (not global_const or not (global_const->flags & PROTO_NOJIT)) {
+      Log.error("a global const contract became JIT-eligible despite its post-store policy side effect");
       return false;
    }
    return true;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -3138,14 +3138,21 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
    for (const auto &[name, info] : this->global_types_) {
       if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant
+            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant, info.is_const
+         };
+         continue;
+      }
+      if (info.is_const and not info.type.is_fixed) {
+         Lex.global_type_hints[name] = {
+            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Enforced, true
          };
          continue;
       }
       if (not info.type.is_fixed) continue;
       if (info.contract_policy IS GlobalContractPolicy::Enforced) {
          Lex.global_type_hints[name] = {
-            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced
+            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced,
+            info.is_const
          };
          continue;
       }
@@ -3154,7 +3161,8 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
          case TiriType::Object:
          case TiriType::Array:
             Lex.global_type_hints[name] = {
-               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory
+               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory,
+               info.is_const
             };
             break;
          default:

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1596,6 +1596,15 @@ void TypeAnalyser::analyse_global_decl(const GlobalDeclStmtPayload &Payload)
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
       if (name.type IS TiriType::Any) contract_policy = GlobalContractPolicy::Variant;
       else if (inferred.is_fixed) contract_policy = GlobalContractPolicy::Enforced;
+
+      name.global_contract_type = inferred.primary;
+      name.global_contract_struct_def = inferred.struct_def;
+      name.global_contract_policy = contract_policy;
+      if (name.has_const and not inferred.is_fixed) {
+         name.global_contract_type = TiriType::Any;
+         name.global_contract_struct_def = nullptr;
+         name.global_contract_policy = GlobalContractPolicy::Enforced;
+      }
       this->declare_global(name.symbol, inferred, name.span, name.has_const, contract_policy);
    }
 
@@ -3138,21 +3147,20 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
    for (const auto &[name, info] : this->global_types_) {
       if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant, info.is_const
+            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant
          };
          continue;
       }
       if (info.is_const and not info.type.is_fixed) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Enforced, true
+            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Enforced
          };
          continue;
       }
       if (not info.type.is_fixed) continue;
       if (info.contract_policy IS GlobalContractPolicy::Enforced) {
          Lex.global_type_hints[name] = {
-            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced,
-            info.is_const
+            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced
          };
          continue;
       }
@@ -3161,8 +3169,7 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
          case TiriType::Object:
          case TiriType::Array:
             Lex.global_type_hints[name] = {
-               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory,
-               info.is_const
+               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory
             };
             break;
          default:

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -28,7 +28,9 @@ enum class ContractDescriptorFlag : uint8_t {
 enum class ContractEntryFlag : uint8_t {
    None = 0,
    Nullable = 1 << 0,
-   Required = 1 << 1
+   Required = 1 << 1,
+   Const = 1 << 2,
+   Initialising = 1 << 3
 };
 
 [[nodiscard]] constexpr inline uint8_t contract_flag(ContractDescriptorFlag Flag) noexcept
@@ -73,6 +75,16 @@ struct RuntimeContractDescriptor {
       return nullptr;
    }
 };
+
+[[nodiscard]] constexpr inline bool contract_entry_is_const(const RuntimeContractEntry &Entry) noexcept
+{
+   return (Entry.flags & contract_flag(ContractEntryFlag::Const)) != 0;
+}
+
+[[nodiscard]] constexpr inline bool contract_entry_is_initialising(const RuntimeContractEntry &Entry) noexcept
+{
+   return (Entry.flags & contract_flag(ContractEntryFlag::Initialising)) != 0;
+}
 
 enum class RuntimeContractDecodeError : uint8_t {
    None,
@@ -142,12 +154,19 @@ private:
       if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
           not reader.read_byte(entry.flags) or
           (entry.flags & ~(contract_flag(ContractEntryFlag::Nullable) |
-             contract_flag(ContractEntryFlag::Required))) != 0 or
+             contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
+             contract_flag(ContractEntryFlag::Initialising))) != 0 or
           not reader.read_byte(entry.position) or entry.position IS 0 or
           not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
          return fail(RuntimeContractDecodeError::Entry);
       }
       entry.type = TiriType(type);
+      bool is_const = contract_entry_is_const(entry);
+      bool is_initialising = contract_entry_is_initialising(entry);
+      if ((is_const and Result.boundary != ContractBoundary::Global) or
+          (is_initialising and not is_const)) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
       if (not entry.struct_name.empty() and entry.type != TiriType::Struct) {
          return fail(RuntimeContractDecodeError::Entry);
       }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -754,6 +754,12 @@ static void decode_contract_or_error(lua_State *L, GCstr *Descriptor, RuntimeCon
    else lj_err_callermsg(L, "invalid runtime type-contract descriptor");
 }
 
+[[noreturn]] static void const_global_error(lua_State *L, const GCstr *Name)
+{
+   CSTRING message = lj_strfmt_pushf(L, "cannot assign to const global '%s'", strdata(Name));
+   lj_err_callermsg(L, message);
+}
+
 } // namespace
 
 extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor)
@@ -772,11 +778,32 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
          environment = tabref(curr_func(L)->c.env);
          global_name = lj_str_new(L, incoming.label.data(), incoming.label.size());
 
-         if (incoming.type IS TiriType::Any) {
+         GCstr *current = lj_tab_get_global_contract(environment, global_name);
+         if (current) {
+            RuntimeContractDescriptor current_descriptor;
+            decode_contract_or_error(L, current, current_descriptor);
+            if (current_descriptor.contract_count >= 1 and
+                contract_entry_is_const(current_descriptor.entries[0])) {
+               const_global_error(L, global_name);
+            }
+         }
+
+         if (contract_entry_is_const(incoming) and not contract_entry_is_initialising(incoming)) {
+            // This descriptor follows a successful global store.  Publishing here makes const initialisation
+            // transactional: a failed store never reaches this instruction and leaves no policy behind.
+            lj_tab_set_global_contract(L, environment, global_name, Descriptor);
+            return;
+         }
+         if (contract_entry_is_initialising(incoming)) {
+            // Validate the initial value before its store, but defer publishing the const policy until the matching
+            // post-store descriptor executes.
+            if (current and current != Descriptor) decode_contract_or_error(L, current, descriptor);
+         }
+         else if (incoming.type IS TiriType::Any) {
             // An explicit 'any' declaration is the only ordinary operation that relaxes a sticky global contract.
             lj_tab_set_global_contract(L, environment, global_name, Descriptor);
          }
-         else if (GCstr *current = lj_tab_get_global_contract(environment, global_name)) {
+         else if (current) {
             // Bytecode may outlive the declaration policy it was compiled against.  The environment policy is
             // authoritative for ordinary stores and concrete redeclarations.
             if (current != Descriptor) decode_contract_or_error(L, current, descriptor);
@@ -852,6 +879,9 @@ extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
       decode_contract_or_error(L, persisted, descriptor);
       if (descriptor.contract_count >= 1) {
          const RuntimeContractEntry &entry = descriptor.entries[0];
+         if (contract_entry_is_const(entry) and not contract_entry_is_initialising(entry)) {
+            const_global_error(L, Name);
+         }
          if (entry.type != TiriType::Any and entry.type != TiriType::Unknown) {
             if (lj_is_thunk(&checked)) {
                // Validate the resolved value, but store the original thunk to preserve lazy evaluation on read.

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -795,9 +795,9 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
             return;
          }
          if (contract_entry_is_initialising(incoming)) {
-            // Validate the initial value before its store, but defer publishing the const policy until the matching
-            // post-store descriptor executes.
-            if (current and current != Descriptor) decode_contract_or_error(L, current, descriptor);
+            // Validate the declaration that will be published while leaving the current environment contract in
+            // place.  BC_GSET validates the same value against that existing policy before the post-store const
+            // descriptor commits the transition.
          }
          else if (incoming.type IS TiriType::Any) {
             // An explicit 'any' declaration is the only ordinary operation that relaxes a sticky global contract.

--- a/src/tiri/tests/test_const.tiri
+++ b/src/tiri/tests/test_const.tiri
@@ -189,6 +189,84 @@ X = 2
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Global const policy persists in the environment and applies to every mutation route.
+
+function expect_const_global_failure(Store:func, Message:str)
+   local trapped = false
+   try
+      Store()
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'cannot assign to const global') != nil,
+         Message .. ' should raise a const-global error, got: ' .. tostring(e.message))
+   end
+   assert(trapped, Message .. ' should raise')
+end
+
+function const_dynamic_source(Value:any):any return Value end
+
+local failed_const_test_id = 0
+
+global glConstAcrossChunks <const> = 1
+global glConstEnvironment <const> = 'original'
+global glConstTable <const> = { value = 1 }
+global glConstDynamic <const> = const_dynamic_source('dynamic')
+
+@Test function GlobalConstPersistsAcrossChunks()
+   expect_const_global_failure(function() exec('glConstAcrossChunks = 2') end, 'exec assignment')
+   expect_const_global_failure(
+      function() exec('global glConstAcrossChunks = 2') end, 'exec redeclaration')
+   expect_const_global_failure(
+      function() exec("global glConstAcrossChunks:any = 'variant'") end, 'explicit any redeclaration')
+
+   assert(glConstAcrossChunks is 1, 'Rejected cross-chunk stores should preserve the const value')
+end
+
+@Test function GlobalConstRejectsEnvironmentMutationRoutes()
+   local alias = _G
+
+   expect_const_global_failure(function() _G.glConstEnvironment = 'member' end, '_G member store')
+   expect_const_global_failure(function() _G['glConstEnvironment'] = 'index' end, '_G index store')
+   expect_const_global_failure(function() alias.glConstEnvironment = 'alias' end, 'environment alias store')
+   expect_const_global_failure(function() rawset(_G, 'glConstEnvironment', 'raw') end, 'rawset store')
+
+   assert(glConstEnvironment is 'original', 'Rejected environment stores should preserve the const value')
+end
+
+@Test function GlobalConstIsShallow()
+   glConstTable.value = 2
+   assert(glConstTable.value is 2, 'Global const should protect the binding, not table contents')
+end
+
+@Test function DynamicGlobalConstPersistsAcrossChunks()
+   expect_const_global_failure(function() exec("glConstDynamic = 'changed'") end, 'dynamic const assignment')
+   assert(glConstDynamic is 'dynamic', 'A rejected store should preserve a dynamically initialised const')
+end
+
+@Test function FailedGlobalConstInitialisationCanRetry()
+   local previous_metatable = getmetatable(_G)
+   local trapped = false
+   local global_name = f"glRetriedConst{failed_const_test_id}"
+   failed_const_test_id++
+
+   setmetatable(_G, { __newindex = function(Table, Key, Value) error('blocked const store') end })
+   try
+      exec(f"global {global_name} <const> = 'first'")
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'blocked const store') != nil,
+         'The failed initialisation should preserve the store error')
+   end
+   setmetatable(_G, previous_metatable)
+
+   assert(trapped, 'The first const initialisation should fail')
+   exec(f"global {global_name} <const> = 'second'")
+   assert(_G[global_name] is 'second', 'A failed store should not leave a persisted const policy')
+   expect_const_global_failure(function() exec(f"{global_name} = 'third'") end,
+      'assignment after retried const initialisation')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 -- Test that local const without initialiser fails at compile time
 
 @Test function LocalConstRequiresInitialiser()

--- a/src/tiri/tests/test_const.tiri
+++ b/src/tiri/tests/test_const.tiri
@@ -312,6 +312,45 @@ end
    assert(_G[global_name] is 'retryable', 'A rejected store should not publish const policy')
 end
 
+@Test function ConditionalGlobalConstPersistsWhenStoreIsSkipped()
+   local if_nil_name = f"glConstIfNil{failed_const_test_id}"
+   failed_const_test_id++
+   local if_empty_name = f"glConstIfEmpty{failed_const_test_id}"
+   failed_const_test_id++
+
+   rawset(_G, if_nil_name, 'retained-if-nil')
+   exec(f"global {if_nil_name} <const> ?= 'fallback'")
+   assert(_G[if_nil_name] is 'retained-if-nil', '?= should retain an existing non-nil value')
+   expect_const_global_failure(function() exec(f"{if_nil_name} = 'changed'") end,
+      'cross-chunk assignment after skipped ?= const store')
+
+   rawset(_G, if_empty_name, 'retained-if-empty')
+   exec(f"global {if_empty_name} <const> ??= 'fallback'")
+   assert(_G[if_empty_name] is 'retained-if-empty', '??= should retain an existing non-empty value')
+   expect_const_global_failure(function() exec(f"{if_empty_name} = 'changed'") end,
+      'cross-chunk assignment after skipped ??= const store')
+end
+
+@Test function SkippedConditionalConstValidatesRetainedValue()
+   local global_name = f"glConstConditionalMismatch{failed_const_test_id}"
+   failed_const_test_id++
+   local trapped = false
+
+   rawset(_G, global_name, 'wrong')
+   try
+      exec(f"global {global_name} <const>:num ?= 1")
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         'The retained value should be checked against the const declaration: ' .. tostring(e.message))
+   end
+
+   assert(trapped, 'An incompatible retained value should reject the const declaration')
+   assert(_G[global_name] is 'wrong', 'Rejected validation should preserve the retained value')
+   exec(f"{global_name} = 'changed'")
+   assert(_G[global_name] is 'changed', 'Rejected validation should not publish const policy')
+end
+
 @Test function FailedGlobalConstInitialisationCanRetry()
    local previous_metatable = getmetatable(_G)
    local trapped = false

--- a/src/tiri/tests/test_const.tiri
+++ b/src/tiri/tests/test_const.tiri
@@ -243,6 +243,75 @@ end
    assert(glConstDynamic is 'dynamic', 'A rejected store should preserve a dynamically initialised const')
 end
 
+@Test function GlobalConstDeclarationOrderIsPreserved()
+   local const_first = f"glConstFirst{failed_const_test_id}"
+   failed_const_test_id++
+   local const_second = f"glConstSecond{failed_const_test_id}"
+   failed_const_test_id++
+
+   expect_const_global_failure(
+      function() exec(f"global {const_first} <const> = 1 global {const_first} = 2") end,
+      'non-const declaration after const declaration')
+   assert(_G[const_first] is 1, 'The rejected later declaration should preserve the first const value')
+
+   exec(f"global {const_second} = 1 global {const_second} <const> = 2")
+   assert(_G[const_second] is 2, 'The later const declaration should store its own initial value')
+   expect_const_global_failure(function() _G[const_second] = 3 end,
+      'assignment after a later const declaration')
+end
+
+@Test function ConstTransitionValidatesPublishedContract()
+   local global_name = f"glConstTransition{failed_const_test_id}"
+   failed_const_test_id++
+   local source_name = f"glConstTransitionSource{failed_const_test_id}"
+   failed_const_test_id++
+   local trapped = false
+
+   exec(f"global {global_name}:any = 1")
+   rawset(_G, source_name, 'wrong')
+   try
+      exec(f"global {global_name} <const>:num = _G['{source_name}']")
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         'The incoming const contract should reject its mismatched initial value: ' .. tostring(e.message))
+   end
+
+   assert(trapped, 'A mismatched const initialiser should raise')
+   assert(_G[global_name] is 1, 'A rejected const initialiser should preserve the old value')
+   _G[global_name] = 2
+   assert(_G[global_name] is 2, 'Failed validation should not publish const policy')
+
+   rawset(_G, source_name, 3)
+   exec(f"global {global_name} <const>:num = _G['{source_name}']")
+   assert(_G[global_name] is 3, 'A corrected const initialiser should be retryable')
+   expect_const_global_failure(function() _G[global_name] = 4 end,
+      'assignment after a retried const transition')
+end
+
+@Test function ConstTransitionRetainsExistingContractUntilStore()
+   local global_name = f"glConstExistingContract{failed_const_test_id}"
+   failed_const_test_id++
+   local source_name = f"glConstExistingSource{failed_const_test_id}"
+   failed_const_test_id++
+   local trapped = false
+
+   exec(f"global {global_name} = 'original'")
+   rawset(_G, source_name, 7)
+   try
+      exec(f"global {global_name} <const>:num = _G['{source_name}']")
+   except e
+      trapped = true
+      assert(string.find(tostring(e.message), 'type contract failed for global') != nil,
+         'The existing environment contract should reject an incompatible transition: ' .. tostring(e.message))
+   end
+
+   assert(trapped, 'An incompatible existing contract should reject the const transition')
+   assert(_G[global_name] is 'original', 'The rejected transition should preserve the old value')
+   _G[global_name] = 'retryable'
+   assert(_G[global_name] is 'retryable', 'A rejected store should not publish const policy')
+end
+
 @Test function FailedGlobalConstInitialisationCanRetry()
    local previous_metatable = getmetatable(_G)
    local trapped = false


### PR DESCRIPTION
* Store constness with environment contracts and reject reassignment through every global mutation route

* Preserve failed initialisation retry semantics and keep const contract side effects outside JIT traces

* Add regression coverage for cross-chunk, indirect, dynamic and shallow const behaviour