### PR TITLE
[Tiri] Enforced object class identity in runtime contracts

### DIFF
--- a/src/tiri/jit/src/lj_ir.h
+++ b/src/tiri/jit/src/lj_ir.h
@@ -219,7 +219,8 @@ typedef enum {
   _(STRUCT_FLAGS, offsetof(GCstruct, flags)) \
   _(STRUCT_DATA, offsetof(GCstruct, data)) \
   _(STRUCT_DEF, offsetof(GCstruct, def)) \
-  _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts))
+  _(TAB_GCONTRACTS, offsetof(GCtab, global_type_contracts)) \
+  _(OBJ_CLASSPTR, offsetof(GCobject, classptr))
 
 typedef enum {
 #define FLENUM(name, ofs)   IRFL_##name,

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -435,6 +435,23 @@ static RecordedContract rec_contract_guard_struct(
    return RecordedContract::Basic;
 }
 
+static RecordedContract rec_contract_guard_object(
+   jit_State *J, TRef ValueRef, cTValue *Value, CLASSID ExpectedClassId)
+{
+   if (not tvisobject(Value)) return RecordedContract::Mismatch;
+   if (ExpectedClassId IS CLASSID::NIL) return RecordedContract::Basic;
+
+   GCobject *object = objectV(Value);
+   if (not object->classptr or object->classptr->ClassID != ExpectedClassId) {
+      return RecordedContract::Mismatch;
+   }
+
+   IRBuilder ir(J);
+   TRef class_ref = ir.fload(ValueRef, IRFL_OBJ_CLASSPTR, IRT_PTR);
+   ir.guard_eq(class_ref, ir.kkptr(object->classptr), IRT_PTR);
+   return RecordedContract::Basic;
+}
+
 static RecordedContract rec_contract_guard_userdata(jit_State *J, TRef ValueRef, cTValue *Value)
 {
    if (tvislightud(Value)) return RecordedContract::Basic;
@@ -489,7 +506,7 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
             if (not tvisarray(value)) result = RecordedContract::Mismatch;
             break;
          case TiriType::Object:
-            if (not tvisobject(value)) result = RecordedContract::Mismatch;
+            result = rec_contract_guard_object(J, value_ref, value, entry->object_class_id);
             break;
          case TiriType::Func:
             result = rec_contract_guard_callable(J, value_ref, value);

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -214,6 +214,7 @@ struct Identifier {
    mutable StaticBindingID binding_id = 0;
    mutable StaticValueHandle static_value = 0;
    mutable TiriType global_contract_type = TiriType::Unknown;
+   mutable CLASSID global_contract_object_class_id = CLASSID::NIL;
    mutable struct_record *global_contract_struct_def = nullptr;
    mutable GlobalContractPolicy global_contract_policy = GlobalContractPolicy::Advisory;
 

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -148,6 +148,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_global()
       // The binding category is intrinsic to this syntax and must not depend on the optional type-analysis pass.
       Identifier declaration = make_identifier(name_token.value_ref());
       declaration.global_contract_type = TiriType::Func;
+      declaration.global_contract_object_class_id = CLASSID::NIL;
       declaration.global_contract_struct_def = nullptr;
       declaration.global_contract_policy = GlobalContractPolicy::Enforced;
       name.segments.push_back(std::move(declaration));

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -12,6 +12,7 @@
 
    return RuntimeContract{
       .type = Identifier.global_contract_type,
+      .object_class_id = Identifier.global_contract_object_class_id,
       .struct_def = Identifier.global_contract_struct_def,
       .label = Identifier.symbol,
       .boundary = ContractBoundary::Global,

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -542,6 +542,16 @@ static void contract_append_text(FuncState *fs, std::string &Descriptor, std::st
    Descriptor.append(Text);
 }
 
+static void contract_append_uleb32(std::string &Descriptor, uint32_t Value)
+{
+   do {
+      uint8_t byte = uint8_t(Value & 0x7f);
+      Value >>= 7;
+      if (Value) byte |= 0x80;
+      Descriptor.push_back(char(byte));
+   } while (Value);
+}
+
 static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeContract> Contracts,
    BCREG StaticValueCount, bool DynamicCount, bool Variadic)
 {
@@ -580,6 +590,8 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       if (contract.initialising) entry_flags |= contract_flag(ContractEntryFlag::Initialising);
       descriptor.push_back(char(entry_flags));
       descriptor.push_back(char(contract.position));
+      CLASSID object_class_id = contract.type IS TiriType::Object ? contract.object_class_id : CLASSID::NIL;
+      contract_append_uleb32(descriptor, uint32_t(object_class_id));
 
       std::string_view struct_name;
       if (contract.struct_def) struct_name = contract.struct_def->Name;
@@ -631,9 +643,12 @@ static void bcemit_value_contract(
    if (Value->static_value and fs->ls->active_context) {
       const auto &descriptor = fs->ls->active_context->descriptors().value(Value->static_value);
       bool same_type = descriptor.primary IS Contract.type;
+      bool same_object_class = Contract.type != TiriType::Object or Contract.object_class_id IS CLASSID::NIL or
+         descriptor.object_class_id IS Contract.object_class_id;
       bool same_struct = Contract.type != TiriType::Struct or descriptor.struct_def IS Contract.struct_def;
       bool same_nullability = descriptor.nullable IS Contract.nullable;
-      if (same_type and same_struct and same_nullability and descriptor.proved() and not ForceRuntimeCheck) return;
+      if (same_type and same_object_class and same_struct and same_nullability and descriptor.proved() and
+          not ForceRuntimeCheck) return;
    }
 
    BCREG source = expr_toanyreg(fs, Value);
@@ -666,6 +681,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
       check_object_class_assignment(fs, *vinfo, *RHS);
       RuntimeContract contract{
          .type = vinfo->fixed_type,
+         .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Local,
@@ -683,6 +699,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
       check_object_class_assignment(fs, *vinfo, *RHS);
       RuntimeContract contract{
          .type = vinfo->fixed_type,
+         .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Upvalue,
@@ -708,6 +725,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
           found->second.contract_policy != GlobalContractPolicy::Advisory) {
          RuntimeContract contract{
             .type = found->second.primary,
+            .object_class_id = found->second.object_class_id,
             .struct_def = found->second.struct_def,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -87,6 +87,7 @@ enum class VarInfoFlag : uint8_t {
 
 struct RuntimeContract {
    TiriType type = TiriType::Unknown;
+   CLASSID object_class_id = CLASSID::NIL;
    struct_record *struct_def = nullptr;
    GCstr *label = nullptr;
    ContractBoundary boundary = ContractBoundary::Local;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1797,7 +1797,11 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *L = state.get();
-   constexpr std::string_view source = "function typed(Value:userdata):userdata return Value end";
+   constexpr std::string_view source =
+      "extern obj\n"
+      "function dynamic(Value:any):any return Value end\n"
+      "local value = obj.new('time')\n"
+      "value = dynamic(value)\n";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -1821,9 +1825,32 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
 
    GCproto *restored_proto = funcproto(funcV(L->top - 1));
    BytecodeSnapshot restored = snapshot_proto(restored_proto);
-   lua_pop(L, 1);
    if (not snapshot_has_opcode(restored, BC_CONTRACT)) {
       Log.error("reloaded bytecode lost BC_CONTRACT");
+      lua_pop(L, 1);
+      return false;
+   }
+
+   auto has_time_contract = [L](auto &Self, GCproto *Proto) -> bool {
+      for (uint32_t i = 1; i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.contract_count > 0 and
+             descriptor.entries[0].object_class_id IS CLASSID::TIME) return true;
+      }
+      GCRef *constant = mref<GCRef>(Proto->k) - 1;
+      for (uint32_t i = 0; i < Proto->sizekgc; ++i, --constant) {
+         GCobj *child = gcref(*constant);
+         if (child->gch.gct IS ~LJ_TPROTO and Self(Self, gco_to_proto(child))) return true;
+      }
+      return false;
+   };
+   bool class_survived = has_time_contract(has_time_contract, restored_proto);
+   lua_pop(L, 1);
+   if (not class_survived) {
+      Log.error("reloaded bytecode lost the multi-byte object class constraint in BC_CONTRACT");
       return false;
    }
    return true;
@@ -1833,20 +1860,37 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *lua = state.get();
-   std::string encoded{
-      char(TIRI_CONTRACT_VERSION),
-      char(uint8_t(ContractBoundary::Global)),
-      char(0),
-      char(1),
-      char(1),
-      char(uint8_t(TiriType::Struct)),
-      char(contract_flag(ContractEntryFlag::Nullable) | contract_flag(ContractEntryFlag::Const)),
-      char(1),
-      char(5)
+   auto append_uleb = [](std::string &Bytes, uint32_t Value) {
+      do {
+         uint8_t byte = uint8_t(Value & 0x7f);
+         Value >>= 7;
+         if (Value) byte |= 0x80;
+         Bytes.push_back(char(byte));
+      } while (Value);
    };
-   encoded += "Point";
-   encoded.push_back(char(5));
-   encoded += "Value";
+   auto build_descriptor = [&append_uleb](uint8_t Version, TiriType Type, CLASSID ObjectClassId,
+      std::string_view StructName, std::string_view Label, uint8_t EntryFlags) {
+      std::string result{
+         char(Version),
+         char(uint8_t(ContractBoundary::Global)),
+         char(0),
+         char(1),
+         char(1),
+         char(uint8_t(Type)),
+         char(EntryFlags),
+         char(1)
+      };
+      if (Version IS TIRI_CONTRACT_VERSION) append_uleb(result, uint32_t(ObjectClassId));
+      result.push_back(char(uint8_t(StructName.size())));
+      result.append(StructName);
+      result.push_back(char(uint8_t(Label.size())));
+      result.append(Label);
+      return result;
+   };
+
+   uint8_t const_flags = contract_flag(ContractEntryFlag::Nullable) | contract_flag(ContractEntryFlag::Const);
+   std::string encoded = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Struct, CLASSID::NIL, "Point", "Value", const_flags);
 
    RuntimeContractDescriptor decoded;
    GCstr *descriptor = lj_str_new(lua, encoded.data(), encoded.size());
@@ -1854,6 +1898,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
        decoded.boundary != ContractBoundary::Global or decoded.dynamic_count() or decoded.variadic() or
        decoded.static_value_count != 1 or decoded.contract_count != 1 or
        decoded.entries[0].type != TiriType::Struct or decoded.entries[0].position != 1 or
+       decoded.entries[0].object_class_id != CLASSID::NIL or
        not contract_entry_is_const(decoded.entries[0]) or
        decoded.entries[0].struct_name != "Point" or decoded.entries[0].label != "Value") {
       Log.error("valid runtime contract descriptor did not round-trip through the shared decoder");
@@ -1866,6 +1911,36 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       return not decode_runtime_contract(value, result);
    };
 
+   std::string object_encoded = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Object, CLASSID::TIME, {}, "Clock", const_flags);
+   RuntimeContractDescriptor object_decoded;
+   GCstr *object_descriptor = lj_str_new(lua, object_encoded.data(), object_encoded.size());
+   if (not decode_runtime_contract(object_descriptor, object_decoded) or
+       object_decoded.entries[0].type != TiriType::Object or
+       object_decoded.entries[0].object_class_id != CLASSID::TIME or
+       not object_decoded.entries[0].struct_name.empty()) {
+      Log.error("version-2 object class constraint did not round-trip through the shared decoder");
+      return false;
+   }
+
+   std::string broad_object = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Object, CLASSID::NIL, {}, "Broad", const_flags);
+   GCstr *broad_descriptor = lj_str_new(lua, broad_object.data(), broad_object.size());
+   if (not decode_runtime_contract(broad_descriptor, object_decoded) or
+       object_decoded.entries[0].object_class_id != CLASSID::NIL) {
+      Log.error("version-2 broad object contract gained a class constraint while decoding");
+      return false;
+   }
+
+   std::string legacy = build_descriptor(
+      TIRI_CONTRACT_LEGACY_VERSION, TiriType::Object, CLASSID::TIME, {}, "Legacy", const_flags);
+   GCstr *legacy_descriptor = lj_str_new(lua, legacy.data(), legacy.size());
+   if (not decode_runtime_contract(legacy_descriptor, object_decoded) or
+       object_decoded.entries[0].object_class_id != CLASSID::NIL or object_decoded.entries[0].label != "Legacy") {
+      Log.error("legacy object contract did not decode broadly or retained stale class metadata");
+      return false;
+   }
+
    std::string invalid_descriptor_flags = encoded;
    invalid_descriptor_flags[2] = char(0x80);
    std::string invalid_entry_flags = encoded;
@@ -1874,15 +1949,29 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    invalid_initialising_flag[6] = char(contract_flag(ContractEntryFlag::Initialising));
    std::string invalid_position = encoded;
    invalid_position[7] = char(0);
-   std::string invalid_constraint = encoded;
-   invalid_constraint[5] = char(uint8_t(TiriType::Num));
+   std::string invalid_scalar_class = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Num, CLASSID::TIME, {}, "Value", const_flags);
+   std::string invalid_struct_class = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Struct, CLASSID::TIME, "Point", "Value", const_flags);
+   std::string truncated_class{
+      char(TIRI_CONTRACT_VERSION), char(uint8_t(ContractBoundary::Local)), char(0), char(1), char(1),
+      char(uint8_t(TiriType::Object)), char(0), char(1), char(0x80)
+   };
+   std::string over_wide_class{
+      char(TIRI_CONTRACT_VERSION), char(uint8_t(ContractBoundary::Local)), char(0), char(1), char(1),
+      char(uint8_t(TiriType::Object)), char(0), char(1), char(0x80), char(0x80), char(0x80), char(0x80),
+      char(0x10), char(0), char(0)
+   };
    std::string trailing = encoded + "x";
    std::string truncated = encoded.substr(0, encoded.size() - 1);
+   std::string unknown_version = encoded;
+   unknown_version[0] = char(TIRI_CONTRACT_VERSION + 1);
 
    if (not rejected(invalid_descriptor_flags) or not rejected(invalid_entry_flags) or
        not rejected(invalid_initialising_flag) or
-       not rejected(invalid_position) or not rejected(invalid_constraint) or not rejected(trailing) or
-       not rejected(truncated)) {
+       not rejected(invalid_position) or not rejected(invalid_scalar_class) or not rejected(invalid_struct_class) or
+       not rejected(truncated_class) or not rejected(over_wide_class) or not rejected(trailing) or
+       not rejected(truncated) or not rejected(unknown_version)) {
       Log.error("shared runtime contract decoder accepted malformed input");
       return false;
    }
@@ -1938,6 +2027,19 @@ static bool test_complex_contract_jit_eligibility(kt::Log &Log)
       "fixed-complex-contract");
    if (not fixed or (fixed->flags & PROTO_NOJIT)) {
       Log.error("a fixed complex contract remained interpreter-only");
+      return false;
+   }
+
+   GCproto *fixed_object_class = compile_child(
+      "extern obj\n"
+      "return function(Value:any)\n"
+      "   local stored = obj.new('time')\n"
+      "   stored = Value\n"
+      "   return stored\n"
+      "end\n",
+      "fixed-object-class-contract");
+   if (not fixed_object_class or (fixed_object_class->flags & PROTO_NOJIT)) {
+      Log.error("a fixed object-class contract became interpreter-only");
       return false;
    }
 

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -1815,10 +1815,13 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       else if (inferred.is_fixed) contract_policy = GlobalContractPolicy::Enforced;
 
       name.global_contract_type = inferred.primary;
+      name.global_contract_object_class_id = inferred.primary IS TiriType::Object ?
+         inferred.object_class_id : CLASSID::NIL;
       name.global_contract_struct_def = inferred.struct_def;
       name.global_contract_policy = contract_policy;
       if (name.has_const and not inferred.is_fixed) {
          name.global_contract_type = TiriType::Any;
+         name.global_contract_object_class_id = CLASSID::NIL;
          name.global_contract_struct_def = nullptr;
          name.global_contract_policy = GlobalContractPolicy::Enforced;
       }

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -9,7 +9,8 @@
 #include <cstdint>
 #include <string_view>
 
-inline constexpr uint8_t TIRI_CONTRACT_VERSION = 1;
+inline constexpr uint8_t TIRI_CONTRACT_VERSION = 2;
+inline constexpr uint8_t TIRI_CONTRACT_LEGACY_VERSION = 1;
 
 enum class ContractBoundary : uint8_t {
    Parameter = 1,
@@ -47,6 +48,7 @@ struct RuntimeContractEntry {
    TiriType type = TiriType::Unknown;
    uint8_t flags = 0;
    uint8_t position = 0;
+   CLASSID object_class_id = CLASSID::NIL;
    std::string_view struct_name;
    std::string_view label;
 };
@@ -114,6 +116,20 @@ public:
       return true;
    }
 
+   [[nodiscard]] bool read_uleb32(uint32_t &Value) noexcept
+   {
+      Value = 0;
+      uint32_t shift = 0;
+      for (uint32_t count = 0; count < 5 and this->cursor_ < this->end_; ++count) {
+         uint8_t byte = *this->cursor_++;
+         if (count IS 4 and (byte & 0xf0)) return false;
+         Value |= uint32_t(byte & 0x7f) << shift;
+         if (not (byte & 0x80)) return true;
+         shift += 7;
+      }
+      return false;
+   }
+
    [[nodiscard]] bool at_end() const noexcept
    {
       return this->cursor_ IS this->end_;
@@ -128,8 +144,10 @@ private:
    const GCstr *Descriptor, RuntimeContractDescriptor &Result,
    RuntimeContractDecodeError *Error = nullptr) noexcept
 {
+   Result = RuntimeContractDescriptor{};
    if (Error) *Error = RuntimeContractDecodeError::None;
-   auto fail = [Error](RuntimeContractDecodeError Value) {
+   auto fail = [&Result, Error](RuntimeContractDecodeError Value) {
+      Result = RuntimeContractDescriptor{};
       if (Error) *Error = Value;
       return false;
    };
@@ -137,7 +155,8 @@ private:
    RuntimeContractReader reader(Descriptor);
    uint8_t version;
    uint8_t boundary;
-   if (not reader.read_byte(version) or version != TIRI_CONTRACT_VERSION or
+   if (not reader.read_byte(version) or
+       (version != TIRI_CONTRACT_LEGACY_VERSION and version != TIRI_CONTRACT_VERSION) or
        not reader.read_byte(boundary) or boundary < uint8_t(ContractBoundary::Parameter) or
        boundary > uint8_t(ContractBoundary::Global) or not reader.read_byte(Result.flags) or
        (Result.flags & ~(contract_flag(ContractDescriptorFlag::DynamicCount) |
@@ -151,16 +170,19 @@ private:
    for (uint8_t i = 0; i < Result.contract_count; ++i) {
       auto &entry = Result.entries[i];
       uint8_t type;
+      uint32_t object_class_id = 0;
       if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
           not reader.read_byte(entry.flags) or
           (entry.flags & ~(contract_flag(ContractEntryFlag::Nullable) |
              contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
              contract_flag(ContractEntryFlag::Initialising))) != 0 or
           not reader.read_byte(entry.position) or entry.position IS 0 or
+          (version IS TIRI_CONTRACT_VERSION and not reader.read_uleb32(object_class_id)) or
           not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
          return fail(RuntimeContractDecodeError::Entry);
       }
       entry.type = TiriType(type);
+      entry.object_class_id = CLASSID(object_class_id);
       bool is_const = contract_entry_is_const(entry);
       bool is_initialising = contract_entry_is_initialising(entry);
       if ((is_const and Result.boundary != ContractBoundary::Global) or
@@ -168,6 +190,9 @@ private:
          return fail(RuntimeContractDecodeError::Entry);
       }
       if (not entry.struct_name.empty() and entry.type != TiriType::Struct) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
+      if (entry.object_class_id != CLASSID::NIL and entry.type != TiriType::Object) {
          return fail(RuntimeContractDecodeError::Entry);
       }
    }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -617,10 +617,10 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 
 //********************************************************************************************************************
 // Exact runtime type contracts.  The descriptor is an interned byte string, so it remains portable across bytecode
-// dump/write/read boundaries.  Layout:
+// dump/write/read boundaries.  Version-2 layout:
 //
 //   version, boundary, descriptor_flags, static_value_count, contract_count,
-//   repeated { type, entry_flags, position, struct_name_length, struct_name_bytes,
+//   repeated { type, entry_flags, position, object_class_id_uleb32, struct_name_length, struct_name_bytes,
 //              label_length, label_bytes }
 
 namespace {
@@ -671,7 +671,12 @@ namespace {
          struct_record *definition = find_struct(L, Entry.struct_name);
          return definition and structV(Value)->def IS definition;
       }
-      case TiriType::Object:   return tvisobject(Value);
+      case TiriType::Object: {
+         if (not tvisobject(Value)) return false;
+         if (Entry.object_class_id IS CLASSID::NIL) return true;
+         GCobject *object = objectV(Value);
+         return object->classptr and object->classptr->ClassID IS Entry.object_class_id;
+      }
       case TiriType::Range:    return contract_is_range(L, Value);
       case TiriType::Userdata: return contract_is_userdata(L, Value);
    }
@@ -692,6 +697,14 @@ namespace {
 
 static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractEntry &Entry)
 {
+   if (Entry.type IS TiriType::Object and Entry.object_class_id != CLASSID::NIL) {
+      if (CSTRING class_name = ResolveClassID(Entry.object_class_id)) {
+         std::snprintf(Buffer, Size, "obj<%s>", class_name);
+      }
+      else std::snprintf(Buffer, Size, "obj<#%08x>", uint32_t(Entry.object_class_id));
+      return;
+   }
+
    if (Entry.type IS TiriType::Struct and not Entry.struct_name.empty()) {
       std::snprintf(Buffer, Size, "struct<%.*s>", int(Entry.struct_name.size()), Entry.struct_name.data());
       return;
@@ -723,7 +736,12 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    char actual[280];
    contract_type_name(expected, sizeof(expected), Entry);
 
-   if (tvisstruct(Value) and structV(Value)->def) {
+   if (tvisobject(Value)) {
+      GCobject *object = objectV(Value);
+      if (object->classptr) std::snprintf(actual, sizeof(actual), "obj<%s>", object->classptr->ClassName.c_str());
+      else std::snprintf(actual, sizeof(actual), "obj<invalid>");
+   }
+   else if (tvisstruct(Value) and structV(Value)->def) {
       const auto &name = structV(Value)->def->Name;
       std::snprintf(actual, sizeof(actual), "struct<%.*s>", int(name.size()), name.data());
    }

--- a/src/tiri/tests/test_object.tiri
+++ b/src/tiri/tests/test_object.tiri
@@ -389,3 +389,28 @@ end
    str_value = c.keyFilter  -- str_value is inferred as str
    assert(type(str_value) is 'string', "Expected str_value to be a string")
 end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Object class identity remains exact for inferred bindings, while explicit obj annotations remain broad.
+
+@Test function ObjectClassAssignmentControls()
+   local matching = obj.new('time')
+   matching = obj.new('time')
+   assert(matching.class.name is 'Time', 'A matching object class assignment should remain valid')
+
+   try
+      exec([[
+local value = obj.new('time')
+value = obj.new('file')
+]])
+   except ex
+      assert(ex.message:find('object class mismatch') != nil or ex.message:find('ObjectClassMismatch') != nil,
+         'A visible cross-class assignment should retain its compile-time diagnostic: ' .. ex.message)
+   success
+      error('Expected a compile-time object class mismatch')
+   end
+
+   local broad:obj = obj.new('time')
+   broad = obj.new('file')
+   assert(broad.class.name is 'File', 'An explicit obj annotation should accept either object class')
+end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -26,6 +26,20 @@ function expect_contract_failure(Callback:func, Boundary:str)
    assert(failed, 'Expected a catchable ' .. Boundary .. ' contract failure')
 end
 
+function expect_object_contract_failure(Callback:func, Boundary:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find('expected obj<Time>') != nil,
+         'The message should identify the expected Time class: ' .. e.message)
+      assert(e.message:find('got obj<File>') != nil or e.message:find('got obj<invalid>') != nil,
+         'The message should identify the actual object class: ' .. e.message)
+   end
+   assert(failed, 'Expected a catchable ' .. Boundary .. ' object-class contract failure')
+end
+
 function expect_diagnostic_failure(Callback:func)
    local failed = false
    try
@@ -520,6 +534,96 @@ end
    assert(captured is 2, 'A rejected upvalue store must preserve the previous value')
 end
 
+@Test function ObjectClassLocalAndUpvalueContracts()
+   local value = obj.new('time')
+   value = dynamic_value(obj.new('time'))
+   assert(value.class.name is 'Time', 'A dynamically sourced Time should satisfy an inferred Time local')
+
+   local file = obj.new('file')
+   expect_object_contract_failure(function() value = dynamic_value(file) end, 'local')
+   assert(value.class.name is 'Time', 'A rejected local store must preserve the previous Time object')
+
+   value = nil
+   assert(value is nil, 'Nil should clear a class-constrained local')
+   value = dynamic_value(obj.new('time'))
+   assert(value.class.name is 'Time', 'A Time should restore a nil-cleared class-constrained local')
+
+   local deferred
+   deferred = obj.new('time')
+   expect_object_contract_failure(function() deferred = dynamic_value(file) end, 'deferred local')
+   assert(deferred.class.name is 'Time', 'A deferred local should retain its first concrete object class')
+
+   local captured = obj.new('time')
+   function write_captured_object(Value:any)
+      captured = Value
+   end
+   write_captured_object(obj.new('time'))
+   expect_object_contract_failure(function() write_captured_object(file) end, 'upvalue')
+   assert(captured.class.name is 'Time', 'A rejected upvalue store must preserve the previous Time object')
+
+   local deferred_file = <{ obj.new('file') }>
+   expect_object_contract_failure(function() captured = dynamic_value(deferred_file) end, 'resolved thunk')
+   assert(captured.class.name is 'Time', 'A rejected resolved thunk must not mutate the captured object')
+
+   local invalid = obj.new('time')
+   invalid.free()
+   expect_object_contract_failure(function() captured = dynamic_value(invalid) end, 'invalid wrapper')
+
+   local broad:obj = obj.new('time')
+   broad = dynamic_value(file)
+   assert(broad.class.name is 'File', 'An explicit obj annotation should remain a broad object contract')
+end
+
+@Test function ObjectClassGlobalContracts()
+   global glContractTimeObject = obj.new('time')
+   glContractTimeObject = dynamic_value(obj.new('time'))
+   exec("glContractTimeObject = obj.new('time')")
+   assert(glContractTimeObject.class.name is 'Time', 'Matching same- and cross-chunk Time stores should pass')
+
+   local file = obj.new('file')
+   expect_object_contract_failure(
+      function() glContractTimeObject = dynamic_value(file) end, 'same-chunk global')
+   expect_object_contract_failure(
+      function() exec("glContractTimeObject = obj.new('file')") end, 'cross-chunk global')
+   local environment = _G
+   expect_object_contract_failure(
+      function() environment.glContractTimeObject = file end, 'environment alias')
+   expect_object_contract_failure(
+      function() rawset(_G, 'glContractTimeObject', file) end, 'raw global store')
+   assert(glContractTimeObject.class.name is 'Time',
+      'Rejected direct and indirect global stores must preserve the previous Time object')
+   exec("glContractTimeObject = obj.new('time')")
+
+   glContractTimeObject = nil
+   assert(glContractTimeObject is nil, 'Nil should clear a class-constrained global')
+   expect_object_contract_failure(
+      function() glContractTimeObject = dynamic_value(file) end, 'nil-cleared global')
+   exec("glContractTimeObject = obj.new('time')")
+
+   exec("global glContractTimeObject = obj.new('time')")
+   expect_object_contract_failure(
+      function() exec("global glContractTimeObject = obj.new('file')") end, 'global redeclaration')
+   assert(glContractTimeObject.class.name is 'Time',
+      'A rejected cross-class redeclaration must preserve the global value and policy')
+
+   try
+      global glContractReducedTime = obj.new('time')
+   end
+   expect_object_contract_failure(
+      function() exec("glContractReducedTime = obj.new('file')") end, 'reduced-analysis global')
+   assert(glContractReducedTime.class.name is 'Time',
+      'Reduced analysis should retain the inferred object class')
+
+   global glContractBroadObject:obj = obj.new('time')
+   glContractBroadObject = dynamic_value(file)
+   assert(glContractBroadObject.class.name is 'File', 'An explicit global obj contract should remain broad')
+
+   global glContractRelaxedObject = obj.new('time')
+   exec("global glContractRelaxedObject:any = obj.new('file')")
+   exec("glContractRelaxedObject = 42")
+   assert(glContractRelaxedObject is 42, 'An explicit global any redeclaration should relax object-class policy')
+end
+
 @Test function ExplicitGlobalStores()
    global glContractNumber:num = 3
    expect_contract_failure(function() glContractNumber = dynamic_value('wrong') end, 'global')
@@ -911,6 +1015,7 @@ end
    function hot_results(Value:num):<num, str> return Value, 'kept', false end
    function hot_userdata(Value:userdata):userdata return Value end
    global glHotInferredContract = 0
+   global glHotTimeObject = obj.new('time')
    global function glHotCallableContract():num return 1 end
    function store_hot_global(Value:any):num
       glHotInferredContract = Value
@@ -919,9 +1024,19 @@ end
    function store_hot_callable(Value:any)
       glHotCallableContract = Value
    end
+   function store_hot_object(Value:any):obj
+      glHotTimeObject = Value
+      return glHotTimeObject
+   end
+   local hot_captured = obj.new('time')
+   function store_hot_captured_object(Value:any):obj
+      hot_captured = Value
+      return hot_captured
+   end
    local dynamic:any = hot
    local compatible_callable:any = function():num return 2 end
    local proxy = newproxy(true)
+   local matching_time = obj.new('time')
    for i in {0 to 200} do
       assert(dynamic(i) is i + 1, 'Valid hot call should preserve its argument')
       local value, text, extra = hot_results(i)
@@ -929,6 +1044,10 @@ end
          'Hot fixed return contracts must truncate additional results')
       assert(hot_userdata(proxy) is proxy, 'userdata contracts must remain stable on hot paths')
       assert(store_hot_global(i) is i, 'An inferred global contract should preserve valid values on hot paths')
+      assert(store_hot_object(matching_time).class.name is 'Time',
+         'A matching global object class should remain valid on hot paths')
+      assert(store_hot_captured_object(matching_time).class.name is 'Time',
+         'A matching captured object class should remain valid on hot paths')
       store_hot_callable(compatible_callable)
       assert(glHotCallableContract() is 2, 'A hot global func contract should preserve compatible callables')
    end
@@ -936,6 +1055,11 @@ end
    expect_contract_failure(function() hot_userdata(dynamic_value({0 to 2})) end, 'parameter')
    expect_contract_failure(function() store_hot_global('wrong') end, 'global')
    expect_contract_failure(function() store_hot_callable('wrong') end, 'global function')
+   local file = obj.new('file')
+   expect_object_contract_failure(function() store_hot_object(file) end, 'hot global object')
+   expect_object_contract_failure(function() store_hot_captured_object(file) end, 'hot captured object')
+   assert(glHotTimeObject.class.name is 'Time' and hot_captured.class.name is 'Time',
+      'Rejected hot object stores must preserve both global and captured values')
    assert(glHotCallableContract() is 2, 'A rejected hot store must preserve the global callable')
 end
 


### PR DESCRIPTION
* Added versioned class-aware descriptors with legacy decoding and persistent local, upvalue and global enforcement
* Added exact interpreter diagnostics and JIT class metadata guards
* Added object identity, bytecode round-trip and hot-path regression coverage