### PR TITLE
Enforce deterministic static return inference

### DIFF
--- a/scripts/net/httpserver.tiri
+++ b/scripts/net/httpserver.tiri
@@ -111,7 +111,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function timestamp()
+function timestamp():str
    return tempus.now():toZonedDateTime(tempus.zone.local()):format('yyyy-MM-dd HH:mm:ss')
 end
 
@@ -1064,7 +1064,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function printableTime(Time)
+function printableTime(Time):str
    return tempus.localDateTime(Time.Year, Time.Month, Time.Day, Time.Hour, Time.Minute, Time.Second):format(
       'yyyy-MM-dd HH:mm:ss')
 end
@@ -1261,19 +1261,19 @@ function loggingMiddleware(request:table, response:table, next:func)
       logMessage(response._self, response._statusCode .. ' ' .. request.path .. ' (' .. string.format('%.2f', duration) .. 'ms)')
    end
 
-   response.send = function(...)
+   response.send = function(...):table
       result = originalSend(...)
       logResponse()
       return result
    end
 
-   response.json = function(...)
+   response.json = function(...):table
       result = originalJson(...)
       logResponse()
       return result
    end
 
-   response.redirect = function(...)
+   response.redirect = function(...):table
       result = originalRedirect(...)
       logResponse()
       return result
@@ -1380,7 +1380,7 @@ function extractParams(pattern:str, matchResults):table
 end
 
 @Doc(text="Find matching route for a request from a server instance")
-function matchRoute(serverInstance, method, path)
+function matchRoute(serverInstance, method, path):<table, table>
    serverInstance._routes ?! return
 
    methodRoutes = serverInstance._routes[method]

--- a/scripts/net/proxyserver.tiri
+++ b/scripts/net/proxyserver.tiri
@@ -49,7 +49,7 @@ glMimeTypes = {
 ----------------------------------------------------------------------------------------------------------------------
 -- Utility Functions
 
-function timestamp()
+function timestamp():str
    return tempus.now():toZonedDateTime(tempus.zone.local()):format('yyyy-MM-dd HH:mm:ss.SSS')
 end
 
@@ -147,7 +147,7 @@ function invokeProxyHook(self, HookName:str, State:table, Callback:func, ...):an
 end
 
 -- URL-decode percent-encoded characters
-function urlDecode(str)
+function urlDecode(str:str):str
    if not str then return str end
    str = str:replace('+', ' ')
    result = ''
@@ -372,17 +372,17 @@ function createFlowManager(self)
    end
 
    -- Get all recorded flows
-   manager.getFlows = function()
+   manager.getFlows = function():table
       return manager._flows
    end
 
    -- Get specific flow by ID
-   manager.getFlow = function(id)
+   manager.getFlow = function(id):table
       return manager._flows[id]
    end
 
    -- Clear all flows
-   manager.clear = function()
+   manager.clear = function():nil
       manager._flows = {}
       manager._flowId = 0
    end
@@ -523,7 +523,7 @@ function createCertificateManager(self)
    end
 
    -- Get or generate certificate for domain
-   manager.getCertificate = function(domain)
+   manager.getCertificate = function(domain):obj
       if manager._certificates[domain] then
          return manager._certificates[domain]
       end
@@ -572,7 +572,7 @@ function createInterceptorEngine(self)
    end
 
    -- Process request through interceptors
-   engine.interceptRequest = function(request, flow)
+   engine.interceptRequest = function(request, flow):<table, bool>
       modified = false
       for interceptor in values(engine._requestInterceptors) do
          try
@@ -596,7 +596,7 @@ function createInterceptorEngine(self)
    end
 
    -- Process response through interceptors
-   engine.interceptResponse = function(response, flow)
+   engine.interceptResponse = function(response, flow):<table, bool>
       modified = false
       for interceptor in values(engine._responseInterceptors) do
          try
@@ -1513,32 +1513,32 @@ proxylib.start = function(Options:table)
    end
 
    -- Flow management API
-   self.getFlows = function()
+   self.getFlows = function():table
       return self._flowManager.getFlows()
    end
 
-   self.clearFlows = function()
+   self.clearFlows = function():nil
       return self._flowManager.clear()
    end
 
-   self.exportFlows = function(filename)
+   self.exportFlows = function(filename):bool
       return self._flowManager.export(filename)
    end
 
-   self.loadFlows = function(filename)
+   self.loadFlows = function(filename):bool
       return self._flowManager.load(filename)
    end
 
    -- Interceptor API
-   self.addRequestInterceptor = function(interceptor)
+   self.addRequestInterceptor = function(interceptor):nil
       return self._interceptor.addRequestInterceptor(interceptor)
    end
 
-   self.addResponseInterceptor = function(interceptor)
+   self.addResponseInterceptor = function(interceptor):nil
       return self._interceptor.addResponseInterceptor(interceptor)
    end
 
-   self.clearInterceptors = function()
+   self.clearInterceptors = function():nil
       return self._interceptor.clear()
    end
 

--- a/src/document/tests/test_roundtrip.tiri
+++ b/src/document/tests/test_roundtrip.tiri
@@ -29,7 +29,7 @@ function parseXML(XmlStr:str)
    return xml
 end
 
-function xpath(Xml, Expr:str)
+function xpath(Xml, Expr:str):str
    err_xp, result = Xml.mtEvaluate(Expr)
    assert(err_xp is ERR_Okay, 'XPath failed: ' .. Expr .. ', err=' .. tostring(err_xp))
    return result

--- a/src/document/tests/test_roundtrip.tiri
+++ b/src/document/tests/test_roundtrip.tiri
@@ -12,7 +12,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Helpers
 
-function feedAndRead(Content:str, PageWidth:num)
+function feedAndRead(Content:str, PageWidth:num):str
    scene = obj.new('VectorScene', { pageWidth=PageWidth ?? 1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp })

--- a/src/document/tests/test_stream.tiri
+++ b/src/document/tests/test_stream.tiri
@@ -5,7 +5,7 @@
    global glDocFolder = State.folder
 end
 
-function loadXMLMarkup(Markup:str, PageWidth:num)
+function loadXMLMarkup(Markup:str, PageWidth:num):<num, str>
    scene = obj.new('VectorScene', { pageWidth=PageWidth ?? 1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp })
@@ -14,7 +14,7 @@ function loadXMLMarkup(Markup:str, PageWidth:num)
    return err, xml_str
 end
 
-function loadXML(Path:str)
+function loadXML(Path:str):<num, str>
    scene = obj.new('VectorScene', { pageWidth=1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp, path=glDocFolder .. Path })
@@ -22,7 +22,7 @@ function loadXML(Path:str)
    return err, xml_str
 end
 
-function loadXMLWidth(Path:str, PageWidth:num)
+function loadXMLWidth(Path:str, PageWidth:num):<num, str>
    scene = obj.new('VectorScene', { pageWidth=PageWidth, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp, path=glDocFolder .. Path })
@@ -36,7 +36,7 @@ function parseXML(XmlStr:str)
    return xml
 end
 
-function xpath(Xml, Expr:str)
+function xpath(Xml, Expr:str):str
    err_xp, result = Xml.mtEvaluate(Expr)
    assert(err_xp is ERR_Okay, 'XPath failed: ' .. Expr .. ', err=' .. tostring(err_xp))
    return result

--- a/src/document/tests/test_xquery.tiri
+++ b/src/document/tests/test_xquery.tiri
@@ -10,11 +10,11 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 -- Helpers
 
-function contains(Haystack:str, Needle:str)
+function contains(Haystack:str, Needle:str):bool
    return regex.new(Needle).test(Haystack)
 end
 
-function feedAndRead(Content:str, PageWidth:num, Username:str, ObjectName:str)
+function feedAndRead(Content:str, PageWidth:num, Username:str, ObjectName:str):str
    scene = obj.new('VectorScene', { pageWidth=PageWidth ?? 1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp })
@@ -29,7 +29,7 @@ function feedAndRead(Content:str, PageWidth:num, Username:str, ObjectName:str)
    return xml_str
 end
 
-function feedExpectError(Content:str, PageWidth:num, Username:str, ObjectName:str)
+function feedExpectError(Content:str, PageWidth:num, Username:str, ObjectName:str):num
    scene = obj.new('VectorScene', { pageWidth=PageWidth ?? 1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document', { viewport=vp })
@@ -43,7 +43,7 @@ function feedExpectError(Content:str, PageWidth:num, Username:str, ObjectName:st
    return err
 end
 
-function loadAndRead(Path:str, PageWidth:num, Username:str, ObjectName:str, Unrestricted:any)
+function loadAndRead(Path:str, PageWidth:num, Username:str, ObjectName:str, Unrestricted:any):str
    scene = obj.new('VectorScene', { pageWidth=PageWidth ?? 1024, pageHeight=768 })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })
    doc = vp.new('document')

--- a/src/network/tests/test_performance.tiri
+++ b/src/network/tests/test_performance.tiri
@@ -33,7 +33,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-@Test(priority=10) function MessageThroughput()
+@Test(priority=10) function MessageThroughput():num
    start_time = 0
    messages_sent = 0
    read_chunks = 0

--- a/src/svg/tests/test_meshgradient_roundtrip.tiri
+++ b/src/svg/tests/test_meshgradient_roundtrip.tiri
@@ -18,12 +18,12 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function absValue(Value)
+function absValue(Value:num):num
    if Value < 0 then return -Value end
    return Value
 end
 
-function assertNear(Actual, Expected, Message)
+function assertNear(Actual, Expected, Message:str)
    assert(Actual ≈ Expected, Message .. ' expected ' .. Expected .. ', got ' .. Actual)
 end
 

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -18,7 +18,7 @@ glWhite = struct.new('RGB8', { red = 255, green = 255, blue = 255, alpha = 255 }
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function renderSVGToBitmap(Path:str, Stable:bool)
+function renderSVGToBitmap(Path:str, Stable:bool):obj
    -- Some tests require Stable to be true when the hashes differ due to compiler/platform differences
    scene = obj.new('VectorScene', { name='TestSceneRender', pageWidth=1024, pageHeight=768, flags=Stable ? VPF_STABLE_RENDER :> nil })
    vp = scene.new('VectorViewport', { x=0, y=0, width='100%', height='100%' })

--- a/src/tiri/jit/BYTECODE.md
+++ b/src/tiri/jit/BYTECODE.md
@@ -623,7 +623,8 @@ Each `TryHandlerDesc` contains:
 
 ### 10.2 Runtime Type Fixing (`BC_TYPEFIX`)
 
-`BC_TYPEFIX` enables runtime type inference for function return types when the function has no explicit return type annotations.
+`BC_TYPEFIX` records advisory runtime observations for dynamic prototype result entries.  It does not enforce or prove
+the source language's static return-inference rule.
 
 **Opcode semantics:**
 - `BC_TYPEFIX A, D`: Fixes return types at runtime. `A` is the base register, `D` is the count of return values to process.
@@ -633,14 +634,13 @@ Each `TryHandlerDesc` contains:
   remain unchanged.
 
 **When emitted:**
-The parser sets the canonical signature's `DynamicResults` flag on function prototypes when:
-1. The function has NO explicit return type annotations, AND
-2. At least one return statement exists
+Validated statically inferred results do not use this opcode.  Dynamic signatures retained for compatibility or
+tooling may set `DynamicResults` and use `BC_TYPEFIX` to gather advisory observations.
 
 **Purpose:**
-Enables type inference for untyped functions, allowing the VM to optimise subsequent calls based on observed return
-types. The inferred types are stored in the canonical signature's result entries (up to
-`PROTO_MAX_RETURN_TYPES` positions).
+Supplies optional optimisation metadata for dynamic result positions.  The observations are stored in the canonical
+signature's result entries (up to `PROTO_MAX_RETURN_TYPES` positions), but consumers must not treat them as checked
+contracts or as evidence that all control-flow paths return the observed type.
 
 **Implementation:** See [vm_x64.dasc:4901-4922](src/tiri/jit/src/jit/vm_x64.dasc#L4901-L4922), [lj_meta.cpp:664-685](src/tiri/jit/src/runtime/lj_meta.cpp#L664-L685), [parse_scope.cpp:1012-1024](src/tiri/jit/src/parser/parse_scope.cpp#L1012-L1024).
 
@@ -658,8 +658,9 @@ Every typed function prototype carries one versioned signature containing:
   strength.
 
 Constraints use stable 32-bit structure keys or class identifiers, never process-local pointers. Declared non-`any`
-contracts have checked strength, while omitted, explicit `any` and runtime-inferred positions remain advisory.
-`BC_TYPEFIX` changes only the type of a reserved inferred result entry.
+contracts have checked strength, statically validated inferred results have trusted strength, and explicit `any` or
+runtime-observed dynamic positions remain advisory.  `BC_TYPEFIX` changes only the type of a reserved dynamic result
+entry.
 
 The signature is stored in the prototype allocation between upvalue descriptors and debug metadata. Its fields are
 written explicitly because bytecode-loaded prototypes are allocated as raw GC memory. Both stripped and unstripped

--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -421,7 +421,8 @@ static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCRea
    if ((explicit_results and dynamic_results) or (variadic_results and (not explicit_results or result_count IS 0)) or
        (dynamic_results and (result_count != 0 or result_entry_count != PROTO_MAX_RETURN_TYPES)) or
        (explicit_results and result_entry_count != std::min<uint32_t>(result_count, PROTO_MAX_RETURN_TYPES)) or
-       (not explicit_results and not dynamic_results and (result_count != 0 or result_entry_count != 0))) {
+       (not explicit_results and not dynamic_results and
+          result_entry_count != std::min<uint32_t>(result_count, PROTO_MAX_RETURN_TYPES))) {
       bcread_error(State, ErrMsg::BCBAD);
    }
 
@@ -435,6 +436,11 @@ static void bcread_signature(LexState *State, MSize Size, MSize NumParams, BCRea
    }
    for (uint32_t i = 0; i < result_entry_count; ++i) {
       bcread_signature_entry(State, cursor, end, Result.results[i]);
+      if (not explicit_results and not dynamic_results and
+          (proto_type_origin(Result.results[i]) != ProtoTypeOrigin::Inferred or
+           proto_type_strength(Result.results[i]) != ProtoTypeStrength::Trusted)) {
+         bcread_error(State, ErrMsg::BCBAD);
+      }
    }
    if (cursor != end) bcread_error(State, ErrMsg::BCBAD);
 }

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -897,8 +897,14 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          body_stmts.push_back(std::move(return_stmt));
          auto body = make_block(span, std::move(body_stmts));
 
-         // Build anonymous thunk function (no parameters, is_thunk=true)
-         ExprNodePtr thunk_func = make_function_expr(span, {}, false, std::move(body), true, explicit_type);
+         // Build anonymous thunk function (no parameters, is_thunk=true).  Preserve the deferred annotation as an
+         // explicit function result contract so dynamic captured expressions are validated at the thunk boundary.
+         FunctionReturnTypes return_types;
+         return_types.types[0] = explicit_type;
+         return_types.count = 1;
+         return_types.is_explicit = true;
+         ExprNodePtr thunk_func = make_function_expr(
+            span, {}, false, std::move(body), true, explicit_type, return_types);
 
          // Build immediate call to thunk (no arguments)
          ExprNodeList call_args;
@@ -944,6 +950,22 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
    FunctionReturnTypes return_types;
    FunctionNameScope function_name_scope(*this, nullptr);
 
+   // An explicit result precedes either an expression or block body: `=> type: expr` and `=> type: do ... end`.
+   Token current = this->ctx.tokens().current();
+   if (current.kind() IS TokenKind::Identifier) {
+      GCstr *type_name_str = current.identifier();
+      std::string_view type_str(strdata(type_name_str), type_name_str->len);
+      TiriType parsed = parse_type_name(type_str);
+      Token next = this->ctx.tokens().peek(1);
+      if (parsed != TiriType::Unknown and next.kind() IS TokenKind::Colon) {
+         this->ctx.tokens().advance();
+         this->ctx.tokens().advance();
+         return_types.types[0] = parsed;
+         return_types.count = 1;
+         return_types.is_explicit = true;
+      }
+   }
+
    if (this->ctx.check(TokenKind::DoToken)) {
       this->ctx.tokens().advance();
       auto block = this->parse_scoped_block({ TokenKind::EndToken });
@@ -952,34 +974,6 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
       body = std::move(block.value_ref());
    }
    else {
-      // Expression body - check for optional type annotation: => type: expr
-      // The syntax is: => type: expr (where type is a known type name like num, str, bool, etc.)
-      // We must distinguish this from method calls like: => value:method()
-      // Only consume as type annotation if the identifier is a KNOWN type name.
-      Token current = this->ctx.tokens().current();
-      if (current.kind() IS TokenKind::Identifier) {
-         // Check if this identifier is a known type name
-         GCstr *type_name_str = current.identifier();
-         std::string_view type_str(strdata(type_name_str), type_name_str->len);
-         TiriType parsed = parse_type_name(type_str);
-
-         // Only treat as type annotation if:
-         // 1. The identifier is a known type name (not Unknown)
-         // 2. It's followed by a colon
-         if (not (parsed IS TiriType::Unknown)) {
-            Token next = this->ctx.tokens().peek(1);
-            if (next.kind() IS TokenKind::Colon) {
-               // This is a type annotation: "=> type: expr"
-               this->ctx.tokens().advance();  // consume type identifier
-               this->ctx.tokens().advance();  // consume ':'
-
-               return_types.types[0] = parsed;
-               return_types.count = 1;
-               return_types.is_explicit = true;
-            }
-         }
-      }
-
       auto expr = this->parse_expression();
       if (not expr.ok()) return ParserResult<ExprNodePtr>::failure(expr.error_ref());
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -60,11 +60,13 @@ using StmtNodeList = std::vector<StmtNodePtr>;
 // Function return type declaration for static analysis
 struct FunctionReturnTypes {
    std::array<TiriType, MAX_RETURN_TYPES> types{};  // Return types (Unknown = unused slot)
+   std::array<CLASSID, MAX_RETURN_TYPES> object_class_ids{}; // Inferred object-class constraints
    std::array<struct_record *, MAX_RETURN_TYPES> struct_defs{}; // Resolved layouts for struct<Name> results
    std::array<StaticValueHandle, MAX_RETURN_TYPES> descriptors{};
    uint8_t count = 0;           // Number of declared types (0 = not declared)
    bool is_variadic = false;    // True if declaration ends with ... (last type repeats)
    bool is_explicit = false;    // True if explicitly declared, false if inferred
+   bool is_inferred = false;    // True when semantic analysis validated every returned position
 
    [[nodiscard]] bool is_void() const { return count IS 0 and is_explicit; }
    [[nodiscard]] bool is_any() const { return count IS 1 and types[0] IS TiriType::Any; }
@@ -529,7 +531,7 @@ struct FunctionExprPayload {
    bool is_vararg = false;
    bool is_thunk = false;              // Marks function as thunk
    TiriType thunk_return_type = TiriType::Any;  // Return type for thunk (kept for IR emission compatibility)
-   FunctionReturnTypes return_types{};            // General return type tracking for type checking
+   mutable FunctionReturnTypes return_types{};    // Declared or validated inferred result metadata
    mutable StaticCallableHandle callable = 0;
    std::unique_ptr<BlockStmt> body;
    std::vector<AnnotationEntry> annotations;  // Annotations attached to this function

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -1096,7 +1096,9 @@ ParserResult<ReturnStmtPayload> AstBuilder::parse_return_payload(const Token& re
    if (parse_values) {
       auto exprs = this->parse_expression_list();
       if (not exprs.ok()) return ParserResult<ReturnStmtPayload>::failure(exprs.error_ref());
-      if (exprs.value_ref().size() IS 1 and exprs.value_ref()[0]->kind IS AstNodeKind::CallExpr) {
+      if (not exprs.value_ref().empty() and
+          (exprs.value_ref().back()->kind IS AstNodeKind::CallExpr or
+           exprs.value_ref().back()->kind IS AstNodeKind::SafeCallExpr)) {
          forwards_call = true;
       }
       values = std::move(exprs.value_ref());

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -74,9 +74,11 @@ struct FuncState {
    uint8_t return_contract_count = 0;
    bool return_contract_variadic = false;
    bool return_contract_explicit = false;
+   bool return_inference_validated = false;
 
    // Canonical prototype signature under construction.  Parameter entries are populated before body emission.
-   // Result entries are populated from explicit declarations or reserved for BC_TYPEFIX in fs_finish().
+   // Result entries are populated from explicit declarations, validated inference, or reserved for advisory
+   // BC_TYPEFIX observations in fs_finish().
    std::vector<ProtoTypeEntry> signature_parameters;
    std::array<ProtoTypeEntry, MAX_RETURN_TYPES> signature_results{};
    uint8_t signature_result_count = 0;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -245,6 +245,24 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
          };
       }
    }
+   else if (Payload.return_types.is_inferred) {
+      child_state.return_inference_validated = true;
+      child_state.signature_result_count = Payload.return_types.count;
+      child_state.signature_result_entry_count = uint8_t(std::min<size_t>(
+         Payload.return_types.count, child_state.signature_results.size()));
+      for (size_t i = 0; i < Payload.return_types.count and i < child_state.signature_results.size(); ++i) {
+         auto type = Payload.return_types.types[i];
+         auto struct_def = Payload.return_types.struct_defs[i];
+         uint32_t constraint = 0;
+         if (struct_def and type IS TiriType::Struct) constraint = struct_key(struct_def->Name);
+         else if (type IS TiriType::Object) constraint = uint32_t(Payload.return_types.object_class_ids[i]);
+         child_state.signature_results[i] = ProtoTypeEntry{
+            .constraint = constraint,
+            .type = type,
+            .flags = proto_type_flags(true, false, ProtoTypeOrigin::Inferred, ProtoTypeStrength::Trusted)
+         };
+      }
+   }
 
    // Save the parent's lastline - function body emission will update it, but we need
    // to restore it so the BC_FNEW instruction gets the correct line (start of function, not body).
@@ -659,7 +677,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_function_stmt(const LocalFunction
    if (Payload.name.symbol and not Payload.name.is_blank) this->update_local_binding(Payload.name.symbol, slot);
 
    // Copy function return types to VarInfo for compile-time type checking at call sites
-   if (Payload.function->return_types.is_explicit) {
+   if (Payload.function->return_types.is_explicit or Payload.function->return_types.is_inferred) {
       for (size_t i = 0; i < Payload.function->return_types.count and i < var_info.result_types.size(); ++i) {
          var_info.result_types[i] = Payload.function->return_types.types[i];
       }
@@ -758,7 +776,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_function_stmt(const FunctionStmtPayload
       this->update_local_binding(symbol, slot);
 
       // Copy function return types to VarInfo for compile-time type checking at call sites
-      if (Payload.function->return_types.is_explicit) {
+      if (Payload.function->return_types.is_explicit or Payload.function->return_types.is_inferred) {
          for (size_t i = 0; i < Payload.function->return_types.count and i < var_info.result_types.size(); ++i) {
             var_info.result_types[i] = Payload.function->return_types.types[i];
          }

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1090,7 +1090,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
 
    // Runtime inference applies only when there is no explicit result declaration. This distinguishes explicit void
    // (`:<>`) from an unannotated function even though both have no stored concrete result types.
-   bool needs_typefix = not this->func_state.return_contract_explicit;
+   bool needs_typefix = not this->func_state.return_contract_explicit and
+      not this->func_state.return_inference_validated;
 
    if (Payload.values.empty()) {
       ins = BCINS_AD(BC_RET0, 0, 1);

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1128,6 +1128,13 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
             setbc_b(ip, 0);
             ins = BCINS_AD(BC_RETM, return_base, last.u.s.aux - return_base);
          }
+         else if (last.u.s.info + 1 != this->func_state.pc) {
+            // Safe calls and other call expressions with post-call control flow cannot be converted to CALLT: the
+            // conversion removes the final emitted instruction rather than the earlier CALL.  Such expressions
+            // represent one consolidated value, so retain that result and return it normally.
+            setbc_b(ip, 2);
+            ins = BCINS_AD(BC_RET1, last.u.s.aux, 2);
+         }
          else if (bc_op(*ip) IS BC_VARG) {
             // Variadic return: return ...
             setbc_b(ir_bcptr(&this->func_state, &last), 0);

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -911,10 +911,11 @@ GCproto * LexState::fs_finish(BCLine Line)
 
    fs_fixup_ret(fs);
 
-   // Finalise the canonical result signature.  Unannotated functions reserve the bounded result prefix used by
-   // BC_TYPEFIX; provenance and strength are fixed before publication so runtime inference mutates only the type byte.
+   // Finalise the canonical result signature.  Unvalidated dynamic functions reserve the bounded result prefix used
+   // by BC_TYPEFIX; provenance and strength are fixed before publication so observation mutates only the type byte.
 
-   if (not fs->return_contract_explicit and (fs->flags & PROTO_HAS_RETURN)) {
+   if (not fs->return_contract_explicit and not fs->return_inference_validated and
+       (fs->flags & PROTO_HAS_RETURN)) {
       fs->signature_flags |= proto_signature_flag(ProtoSignatureFlag::DynamicResults);
       fs->signature_result_count = 0;
       fs->signature_result_entry_count = uint8_t(fs->signature_results.size());

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -194,7 +194,6 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    }
 
    trace_ast_boundary(Context, *chunk, "parse");
-   collect_parser_symbols(Context.lua(), Context.lex(), *chunk);
    discover_static_bindings(Context, *chunk);
    // Publish the first descriptor pass before semantic type analysis so dynamic-ingress policy can distinguish
    // genuinely unknown values from concrete native and callable results.  A second pass below refreshes descriptors
@@ -217,6 +216,7 @@ static void run_ast_pipeline(ParserContext &Context, ParserProfiler &Profiler)
    }
 
    propagate_static_descriptors(Context, *chunk);
+   collect_parser_symbols(Context.lua(), Context.lex(), *chunk);
 
    // Emit bytecode instructions
 

--- a/src/tiri/jit/src/parser/parser_diagnostics.cpp
+++ b/src/tiri/jit/src/parser/parser_diagnostics.cpp
@@ -62,6 +62,7 @@ static CSTRING error_code_name(ParserErrorCode Code)
       case ParserErrorCode::TypeMismatchAssignment:    return "Type mismatch (assignment)";
       case ParserErrorCode::TypeMismatchReturn:        return "Type mismatch (return)";
       case ParserErrorCode::DeferredTypeRequired:      return "Preset type required";
+      case ParserErrorCode::ReturnTypeRequired:        return "Return type required";
       case ParserErrorCode::UndefinedVariable:         return "Undefined variable";
       case ParserErrorCode::ThunkDirectCall:           return "Thunk direct call";
       case ParserErrorCode::FunctionSignatureMismatch: return "Function signature mismatch";

--- a/src/tiri/jit/src/parser/parser_diagnostics.h
+++ b/src/tiri/jit/src/parser/parser_diagnostics.h
@@ -30,6 +30,7 @@ enum class ParserErrorCode : uint16_t {
    ObjectClassMismatch,      // Object class ID mismatch in assignment
    TypeMismatchReturn,
    DeferredTypeRequired,
+   ReturnTypeRequired,
    UndefinedVariable,
    ThunkDirectCall,         // Warning: thunk called without assignment defeats memoization
    ReturnTypeMismatch,      // Return value type doesn't match declaration

--- a/src/tiri/jit/src/parser/parser_symbols.cpp
+++ b/src/tiri/jit/src/parser/parser_symbols.cpp
@@ -564,9 +564,10 @@ static FunctionReturnTypes infer_function_results(const FunctionExprPayload &Fun
 static TiriType compact_result_type_at(const FunctionExprPayload &Function, const FunctionReturnTypes &Inferred,
    size_t Index, bool &InferredType)
 {
-   if (Function.return_types.is_explicit and (Index < Function.return_types.count or
+   if ((Function.return_types.is_explicit or Function.return_types.is_inferred) and
+       (Index < Function.return_types.count or
        (Function.return_types.is_variadic and Function.return_types.count > 0))) {
-      InferredType = false;
+      InferredType = Function.return_types.is_inferred;
       return Function.return_types.type_at(Index);
    }
 
@@ -577,12 +578,13 @@ static TiriType compact_result_type_at(const FunctionExprPayload &Function, cons
 
 static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload &Function, const ParsedDocText *Doc)
 {
-   size_t declared_count = Function.return_types.count;
+   size_t result_count = Function.return_types.count;
+   size_t explicit_count = Function.return_types.is_explicit ? result_count : 0;
    size_t doc_count = Doc ? Doc->results.size() : 0;
-   size_t count = declared_count > doc_count ? declared_count : doc_count;
+   size_t count = result_count > doc_count ? result_count : doc_count;
    FunctionReturnTypes inferred_results;
 
-   if (Doc and Doc->compact and doc_count > declared_count) {
+   if (Doc and Doc->compact and doc_count > result_count) {
       inferred_results = infer_function_results(Function);
    }
 
@@ -594,9 +596,9 @@ static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload 
          meta.type = type_to_string(compact_result_type_at(Function, inferred_results, i, inferred_type));
          meta.inferred = inferred_type;
       }
-      else if (i < declared_count) {
+      else if (i < result_count) {
          meta.type = type_to_string(Function.return_types.types[i]);
-         meta.inferred = false;
+         meta.inferred = i >= explicit_count;
       }
 
       if (Doc and i < Doc->results.size()) {
@@ -604,7 +606,7 @@ static void add_results(ParserSymbolMetadata &Symbol, const FunctionExprPayload 
          if ((not Doc->compact) and meta.type.empty()) meta.type = Doc->results[i].type;
       }
 
-      if (not (Doc and Doc->compact)) meta.inferred = i >= declared_count;
+      if (not (Doc and Doc->compact)) meta.inferred = i >= explicit_count;
       Symbol.results.push_back(std::move(meta));
    }
 }

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1500,7 +1500,7 @@ static bool test_signature_runtime_inference(kt::Log &Log)
 {
    LuaStateHolder state;
    lua_State *L = state.get();
-   constexpr std::string_view source = "return function(Value) return Value end";
+   constexpr std::string_view source = "return function(Value:num) return Value end";
    if (lua_load(L, source, "signature-inference") or lua_pcall(L, 0, 1, 0)) {
       Log.error("failed to create the inference function: %s", lua_tostring(L, -1));
       return false;
@@ -1518,8 +1518,8 @@ static bool test_signature_runtime_inference(kt::Log &Log)
 
    ProtoTypeEntry inferred = proto_result_type(prototype, 0);
    if (inferred.type != TiriType::Num or proto_type_origin(inferred) != ProtoTypeOrigin::Inferred or
-       proto_type_strength(inferred) != ProtoTypeStrength::Advisory) {
-      Log.error("runtime inference did not remain advisory");
+       proto_type_strength(inferred) != ProtoTypeStrength::Trusted) {
+      Log.error("validated static inference did not remain trusted");
       return false;
    }
 
@@ -1536,7 +1536,7 @@ static bool test_signature_runtime_inference(kt::Log &Log)
    bool equal = compare_proto_signatures(prototype, restored);
    lua_pop(L, 2);
    if (not equal) {
-      Log.error("runtime-inferred signature changed during serialisation");
+      Log.error("statically inferred signature changed during serialisation");
       return false;
    }
    return true;
@@ -2596,7 +2596,7 @@ extern math
 
 local context = { base = 5 }
 
-function context:compute(delta)
+function context:compute(delta):<any, ...>
    return self.base + math.abs(-delta)
 end
 
@@ -2637,7 +2637,7 @@ static bool test_return_lowering(kt::Log &log)
    constexpr const char* source =
       "extern math\n"
       "\n"
-      "local function retmix(flag, ...)\n"
+      "local function retmix(flag, ...):<any, ...>\n"
       "   if flag then\n"
       "      return ...\n"
       "   end\n"
@@ -2721,7 +2721,7 @@ return sum
 )" },
       { "function_stmt_closure", R"(
 local function outer(flag):any
-   local function helper(value)
+   local function helper(value):<any, ...>
       return value * 2
    end
 
@@ -2729,7 +2729,7 @@ local function outer(flag):any
       return helper(flag)
    end
 
-   return function(a, b)
+   return function(a, b):<any, ...>
       return helper(a + b)
    end
 end
@@ -3324,6 +3324,16 @@ static bool test_native_prototype_result_descriptors(kt::Log &Log)
       "wave = math.cos(wave)\n"
       "local text = string.trim(' value ')\n"
       "text = string.upper(text)\n"
+      "local function allocated_text()\n"
+      "   local buffer = string.alloc(16)\n"
+      "   return buffer\n"
+      "end\n"
+      "local function sliced_text()\n"
+      "   local buffer = string.alloc(16)\n"
+      "   return buffer:sub(0, 1)\n"
+      "end\n"
+      "text = allocated_text()\n"
+      "text = sliced_text()\n"
       "local first, last = string.find('abc', 'b')\n"
       "first = first + 1\n"
       "last = last + 1\n"
@@ -3881,9 +3891,9 @@ static bool test_type_guided_emission(kt::Log &Log)
 
    constexpr std::string_view mutable_alias =
       "local function typed(Value:num):num return Value end\n"
-      "local function invoke(Replace:any)\n"
+      "local function invoke(Replace:any):<any, ...>\n"
       "   local callback = typed\n"
-      "   if Replace then callback = (Value => Value) end\n"
+      "   if Replace then callback = (Value => any: Value) end\n"
       "   return callback('runtime checked')\n"
       "end\n"
       "return invoke(true)\n";
@@ -3895,7 +3905,7 @@ static bool test_type_guided_emission(kt::Log &Log)
    constexpr std::string_view dead_write =
       "local function typed(Value:num):num return Value end\n"
       "local callback = typed\n"
-      "if false then callback = (Value => Value) end\n"
+      "if false then callback = (Value => any: Value) end\n"
       "return callback('still checked')\n";
    if (compile_snapshot(L, dead_write, true, error)) {
       Log.error("dead branch write incorrectly invalidated a stable callable alias");
@@ -3933,7 +3943,7 @@ static bool test_type_guided_emission(kt::Log &Log)
       "try\n"
       "   global guided_object = obj.new('time')\n"
       "end\n"
-      "local function query_object()\n"
+      "local function query_object():<any, ...>\n"
       "   return guided_object?.acQuery()\n"
       "end\n";
    snapshot = compile_snapshot(L, safe_object_call, true, error);
@@ -3944,7 +3954,7 @@ static bool test_type_guided_emission(kt::Log &Log)
    }
 
    constexpr std::string_view generic_accesses =
-      "local function update(Value:any, Key:any)\n"
+      "local function update(Value:any, Key:any):<any, ...>\n"
       "   Value.field = 1\n"
       "   Value[Key] = Value[Key]\n"
       "   return Value.field\n"

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1539,6 +1539,79 @@ static bool test_signature_runtime_inference(kt::Log &Log)
       Log.error("statically inferred signature changed during serialisation");
       return false;
    }
+
+   constexpr std::string_view forwarded_source =
+      "local function declared():<num, str> return 7, 'forwarded' end\n"
+      "return function() return declared() end\n";
+   if (lua_load(L, forwarded_source, "signature-forwarded-results") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the forwarded-result function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *forwarded = funcproto(funcV(L->top - 1));
+   const ProtoSignature *forwarded_signature = proto_signature(forwarded);
+   ProtoTypeEntry first = proto_result_type(forwarded, 0);
+   ProtoTypeEntry second = proto_result_type(forwarded, 1);
+   if (not forwarded_signature or forwarded_signature->result_count != 2 or
+       forwarded_signature->result_entry_count != 2 or first.type != TiriType::Num or second.type != TiriType::Str or
+       proto_type_origin(first) != ProtoTypeOrigin::Inferred or
+       proto_type_origin(second) != ProtoTypeOrigin::Inferred) {
+      Log.error("tail-call result inference lost a declared positional result");
+      return false;
+   }
+
+   std::string forwarded_dump;
+   if (lj_bcwrite(L, forwarded, bytecode_writer, &forwarded_dump, 1) != 0 or
+       lua_load(L, std::string_view(forwarded_dump.data(), forwarded_dump.size()), "signature-forwarded-results")) {
+      Log.error("failed to round-trip the forwarded-result signature: %s", lua_tostring(L, -1));
+      return false;
+   }
+   GCproto *restored_forwarded = funcproto(funcV(L->top - 1));
+   if (not compare_proto_signatures(forwarded, restored_forwarded)) {
+      Log.error("forwarded-result inference changed during serialisation");
+      return false;
+   }
+   lua_pop(L, 2);
+
+   constexpr std::string_view forwarded_any_source =
+      "local function declared():<num, any> return 7, nil end\n"
+      "return function() return declared() end\n";
+   if (lua_load(L, forwarded_any_source, "signature-forwarded-any") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the forwarded-any function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *forwarded_any = funcproto(funcV(L->top - 1));
+   const ProtoSignature *forwarded_any_signature = proto_signature(forwarded_any);
+   ProtoTypeEntry forwarded_any_first = proto_result_type(forwarded_any, 0);
+   ProtoTypeEntry forwarded_any_second = proto_result_type(forwarded_any, 1);
+   if (not forwarded_any_signature or forwarded_any_signature->result_count != 2 or
+       forwarded_any_first.type != TiriType::Num or forwarded_any_second.type != TiriType::Any or
+       proto_type_origin(forwarded_any_first) != ProtoTypeOrigin::Inferred or
+       proto_type_origin(forwarded_any_second) != ProtoTypeOrigin::Inferred) {
+      Log.error("tail-call result inference refined an explicit any result from the first result");
+      return false;
+   }
+   lua_pop(L, 1);
+
+   constexpr std::string_view forwarded_with_prefix_source =
+      "local function declared():<num, str> return 7, 'forwarded' end\n"
+      "return function() return true, declared() end\n";
+   if (lua_load(L, forwarded_with_prefix_source, "signature-forwarded-prefix") or lua_pcall(L, 0, 1, 0)) {
+      Log.error("failed to create the prefixed forwarded-result function: %s", lua_tostring(L, -1));
+      return false;
+   }
+
+   GCproto *forwarded_with_prefix = funcproto(funcV(L->top - 1));
+   const ProtoSignature *forwarded_with_prefix_signature = proto_signature(forwarded_with_prefix);
+   if (not forwarded_with_prefix_signature or forwarded_with_prefix_signature->result_count != 3 or
+       proto_result_type(forwarded_with_prefix, 0).type != TiriType::Bool or
+       proto_result_type(forwarded_with_prefix, 1).type != TiriType::Num or
+       proto_result_type(forwarded_with_prefix, 2).type != TiriType::Str) {
+      Log.error("tail-call result inference dropped results after a fixed return prefix");
+      return false;
+   }
+   lua_pop(L, 1);
    return true;
 }
 

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -673,6 +673,18 @@ private:
       StaticValueDescriptor base = this->descriptor_of(*receiver);
       if (base.primary IS TiriType::Object and base.proved()) {
          std::string_view exposed_name(strdata(member), member->len);
+         if (member->hash IS kt::strhash("new")) {
+            const fprototype *prototype = get_prototype("obj", exposed_name);
+            if (not prototype) return 0;
+
+            StaticResultSet results = describe_native_prototype_results(prototype);
+            if (results.stored_count > 0) {
+               StaticValueDescriptor &child = results.values[0];
+               child.nullable = false;
+            }
+            return this->catalogue_.add_results(results);
+         }
+
          ObjectCallMemberKind kind = classify_object_call_member(exposed_name);
          if (kind IS ObjectCallMemberKind::None) return 0;
          std::string_view native_name = exposed_name.substr(2);

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -713,6 +713,18 @@ private:
          return 0;
       }
 
+      if (base.primary IS TiriType::Array and base.proved()) {
+         const fprototype *prototype = get_prototype(
+            "array", std::string_view(strdata(member), member->len));
+         if (not prototype) return 0;
+
+         StaticResultSet results = describe_native_prototype_results(prototype);
+         if (results.stored_count > 0 and results.values[0].primary != TiriType::Array) {
+            return this->catalogue_.add_results(results);
+         }
+         return 0;
+      }
+
       if (not direct_member or base.primary != TiriType::Userdata or not base.proved() or not base.module) return 0;
       const FunctionField *fields = static_module_function(
          base.module, std::string_view(strdata(member), member->len));

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -441,15 +441,20 @@ private:
       results.declared_count = Function.return_types.count;
       results.stored_count = uint8_t(std::min<size_t>(Function.return_types.count, MAX_RETURN_TYPES));
       results.variadic = Function.return_types.is_variadic;
-      results.dynamic = not Function.return_types.is_explicit;
+      results.dynamic = not Function.return_types.is_explicit and not Function.return_types.is_inferred;
       for (size_t i = 0; i < results.stored_count; ++i) {
          StaticValueDescriptor value = this->catalogue_.value(Function.return_types.descriptors[i]);
          value.primary = Function.return_types.types[i];
+         value.object_class_id = Function.return_types.object_class_ids[i];
          value.struct_def = Function.return_types.struct_defs[i] ?
             Function.return_types.struct_defs[i] : value.struct_def;
          value.nullable = true;
-         value.proof = Function.return_types.is_explicit and value.primary != TiriType::Any and
-            value.primary != TiriType::Unknown ? StaticProof::Checked : StaticProof::Advisory;
+         if (Function.return_types.is_explicit and value.primary != TiriType::Any and
+             value.primary != TiriType::Unknown) {
+            value.proof = StaticProof::Checked;
+         }
+         else if (Function.return_types.is_inferred) value.proof = StaticProof::Closed;
+         else value.proof = StaticProof::Advisory;
          results.values[i] = value;
       }
       return results;
@@ -695,6 +700,15 @@ private:
                fields = methods[i].Args;
                return this->catalogue_.add_results(describe_object_call_results(fields));
             }
+         }
+         return 0;
+      }
+
+      if (base.primary IS TiriType::Str and base.proved()) {
+         const fprototype *prototype = get_prototype(
+            "string", std::string_view(strdata(member), member->len));
+         if (prototype) {
+            return this->catalogue_.add_results(describe_native_prototype_results(prototype));
          }
          return 0;
       }
@@ -1311,7 +1325,7 @@ private:
       bool have_return = false;
       if (Function.body) this->collect_return_descriptors(*Function.body, inferred, have_return);
       if (have_return) {
-         if (Function.return_types.is_explicit) {
+         if (Function.return_types.is_explicit or Function.return_types.is_inferred) {
             inferred.declared_count = Function.return_types.count;
             inferred.stored_count = uint8_t(std::min<size_t>(
                Function.return_types.count, MAX_RETURN_TYPES));
@@ -1320,10 +1334,13 @@ private:
             for (size_t i = 0; i < inferred.stored_count; ++i) {
                auto &value = inferred.values[i];
                value.primary = Function.return_types.types[i];
+               value.object_class_id = Function.return_types.object_class_ids[i];
                value.struct_def = Function.return_types.struct_defs[i] ?
                   Function.return_types.struct_defs[i] : value.struct_def;
                value.nullable = true;
-               value.proof = value.primary IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked;
+               value.proof = Function.return_types.is_explicit ?
+                  (value.primary IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked) :
+                  StaticProof::Closed;
                Function.return_types.descriptors[i] = this->add_value(value);
             }
          }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -626,7 +626,13 @@ void TypeAnalyser::leave_function()
 
    FunctionContext &ctx = this->function_stack_.back();
    if (ctx.function and not ctx.expected_returns.is_explicit) {
-      for (size_t i = 0; i < ctx.observed_return_count; ++i) {
+      size_t inferred_return_count = ctx.observed_return_count;
+      while (inferred_return_count > 0 and
+          ctx.inferred_returns[inferred_return_count - 1].state IS ReturnInferenceState::NilOnly) {
+         inferred_return_count--;
+      }
+
+      for (size_t i = 0; i < inferred_return_count; ++i) {
          const InferredReturnPosition &position = ctx.inferred_returns[i];
          if (position.state IS ReturnInferenceState::NilOnly) {
             TypeDiagnostic diag;
@@ -640,12 +646,12 @@ void TypeAnalyser::leave_function()
          }
       }
 
-      if (ctx.observed_return_count > 0 and not ctx.inference_failed) {
+      if (inferred_return_count > 0 and not ctx.inference_failed) {
          FunctionReturnTypes &published = ctx.function->return_types;
-         published.count = ctx.observed_return_count;
+         published.count = uint8_t(inferred_return_count);
          published.is_inferred = true;
          published.is_variadic = false;
-         for (size_t i = 0; i < ctx.observed_return_count; ++i) {
+         for (size_t i = 0; i < inferred_return_count; ++i) {
             const InferredType &inferred = ctx.inferred_returns[i].concrete;
             published.types[i] = inferred.primary;
             published.object_class_ids[i] = inferred.object_class_id;

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -229,6 +229,7 @@ private:
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
    [[nodiscard]] InferredType refine_static_expression_type(const ExprNode &, InferredType) const;
+   [[nodiscard]] bool is_explicit_variant_expression(const ExprNode &) const;
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
 
    // Symbol resolution - looks up variables and functions in scope stack
@@ -630,6 +631,30 @@ void TypeAnalyser::leave_function()
       while (inferred_return_count > 0 and
           ctx.inferred_returns[inferred_return_count - 1].state IS ReturnInferenceState::NilOnly) {
          inferred_return_count--;
+      }
+
+      for (size_t i = 0; i < inferred_return_count; ++i) {
+         const InferredReturnPosition &position = ctx.inferred_returns[i];
+         if (position.state != ReturnInferenceState::Dynamic) continue;
+
+         TypeDiagnostic diag;
+         diag.location = position.dynamic_location;
+         diag.actual = position.dynamic_type;
+         diag.code = ParserErrorCode::ReturnTypeRequired;
+         if (position.concrete.primary != TiriType::Any and position.concrete.primary != TiriType::Unknown) {
+            diag.expected = position.concrete.primary;
+            diag.message = std::format(
+               "cannot infer result {} as '{}' from a dynamic value; declare ': {}' to check it at runtime or "
+               "': any' to allow a variant result",
+               i + 1, type_name(position.concrete.primary), type_name(position.concrete.primary));
+         }
+         else {
+            diag.message = std::format(
+               "cannot infer result {} from a dynamic value; declare a concrete result type to check it at "
+               "runtime or ': any' to allow a variant result", i + 1);
+         }
+         this->record_diagnostic(std::move(diag));
+         ctx.inference_failed = true;
       }
 
       if (inferred_return_count > 0 and not ctx.inference_failed) {
@@ -2694,6 +2719,26 @@ InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, I
    return Type;
 }
 
+bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr) const
+{
+   if (Expr.kind IS AstNodeKind::IdentifierExpr) {
+      const auto &reference = std::get<NameRef>(Expr.data);
+      if (reference.binding_id) return this->explicit_variant_bindings_.contains(reference.binding_id);
+      if (reference.identifier.symbol) {
+         auto global = this->global_types_.find(reference.identifier.symbol);
+         return global != this->global_types_.end() and
+            global->second.contract_policy IS GlobalContractPolicy::Variant;
+      }
+   }
+   else if (Expr.kind IS AstNodeKind::CallExpr or Expr.kind IS AstNodeKind::SafeCallExpr) {
+      const auto &call = std::get<CallExprPayload>(Expr.data);
+      const FunctionExprPayload *target = this->resolve_call_target(call);
+      return target and target->return_types.is_explicit and target->return_types.count > 0 and
+         target->return_types.types[0] IS TiriType::Any;
+   }
+   return false;
+}
+
 //********************************************************************************************************************
 // Multi-Value Return Type Inference: Infers the return type at a specific position from a function call expression.
 // Used for multi-value assignments like: local a, b, c = func()
@@ -3113,26 +3158,19 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             continue;
          }
 
+         if (actual.primary IS TiriType::Any and this->is_explicit_variant_expression(*Return.values[i])) {
+            position.concrete = actual;
+            position.concrete.primary = TiriType::Any;
+            position.state = ReturnInferenceState::ExplicitAny;
+            continue;
+         }
+
+         if (position.state IS ReturnInferenceState::ExplicitAny) continue;
+
          if (actual.primary IS TiriType::Any or actual.primary IS TiriType::Unknown) {
-            TypeDiagnostic diag;
-            diag.location = Return.values[i]->span;
-            diag.actual = actual.primary;
-            diag.code = ParserErrorCode::ReturnTypeRequired;
-            if (position.concrete.primary != TiriType::Any and position.concrete.primary != TiriType::Unknown) {
-               diag.expected = position.concrete.primary;
-               diag.message = std::format(
-                  "cannot infer result {} as '{}' from a dynamic value; declare ': {}' to check it at runtime or "
-                  "': any' to allow a variant result",
-                  i + 1, type_name(position.concrete.primary), type_name(position.concrete.primary));
-            }
-            else {
-               diag.message = std::format(
-                  "cannot infer result {} from a dynamic value; declare a concrete result type to check it at "
-                  "runtime or ': any' to allow a variant result", i + 1);
-            }
-            this->record_diagnostic(std::move(diag));
             position.state = ReturnInferenceState::Dynamic;
-            ctx->inference_failed = true;
+            position.dynamic_location = Return.values[i]->span;
+            position.dynamic_type = actual.primary;
             continue;
          }
 

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -228,6 +228,7 @@ private:
 
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
+   [[nodiscard]] InferredType refine_static_expression_type(const ExprNode &, InferredType) const;
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
 
    // Symbol resolution - looks up variables and functions in scope stack
@@ -359,6 +360,7 @@ private:
    uint32_t unanalysed_depth_{0};                   // Reduced-traversal nesting depth; non-zero suppresses tips
    uint8_t current_file_index_{0};                  // FileSource index of the file being analysed
    ankerl::unordered_dense::map<GCstr*, GlobalTypeInfo> global_types_{};  // Type info for global variables
+   ankerl::unordered_dense::set<StaticBindingID> explicit_variant_bindings_{};
    #ifdef INCLUDE_TIPS
    std::vector<GCstr*> declared_globals_{};         // Globals explicitly declared with 'global' keyword
    #endif
@@ -611,7 +613,6 @@ void TypeAnalyser::enter_function(const FunctionExprPayload &Function, GCstr *Na
    // If function has explicit return types, use them
    if (Function.return_types.is_explicit) {
       ctx.expected_returns = Function.return_types;
-      ctx.return_type_inferred = true;  // Explicit types are considered "inferred" for validation purposes
    }
 
    this->function_stack_.push_back(ctx);
@@ -621,9 +622,39 @@ void TypeAnalyser::enter_function(const FunctionExprPayload &Function, GCstr *Na
 
 void TypeAnalyser::leave_function()
 {
-   if (not this->function_stack_.empty()) {
-      this->function_stack_.pop_back();
+   if (this->function_stack_.empty()) return;
+
+   FunctionContext &ctx = this->function_stack_.back();
+   if (ctx.function and not ctx.expected_returns.is_explicit) {
+      for (size_t i = 0; i < ctx.observed_return_count; ++i) {
+         const InferredReturnPosition &position = ctx.inferred_returns[i];
+         if (position.state IS ReturnInferenceState::NilOnly) {
+            TypeDiagnostic diag;
+            diag.location = position.location;
+            diag.code = ParserErrorCode::ReturnTypeRequired;
+            diag.message = std::format(
+               "cannot infer result {} because it has no concrete value; declare a concrete result type to check it "
+               "at runtime or ': any' to allow a variant result", i + 1);
+            this->record_diagnostic(std::move(diag));
+            ctx.inference_failed = true;
+         }
+      }
+
+      if (ctx.observed_return_count > 0 and not ctx.inference_failed) {
+         FunctionReturnTypes &published = ctx.function->return_types;
+         published.count = ctx.observed_return_count;
+         published.is_inferred = true;
+         published.is_variadic = false;
+         for (size_t i = 0; i < ctx.observed_return_count; ++i) {
+            const InferredType &inferred = ctx.inferred_returns[i].concrete;
+            published.types[i] = inferred.primary;
+            published.object_class_ids[i] = inferred.object_class_id;
+            published.struct_defs[i] = inferred.struct_def;
+         }
+      }
    }
+
+   this->function_stack_.pop_back();
 }
 
 FunctionContext * TypeAnalyser::current_function()
@@ -1648,6 +1679,9 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       #endif
 
       this->current_scope().declare_local(name.symbol, inferred, name.span, name.has_const);
+      if (name.type IS TiriType::Any and name.binding_id) {
+         this->explicit_variant_bindings_.insert(name.binding_id);
+      }
       this->publish_binding_type(name.binding_id, inferred);
       this->trace_decl(this->ctx_.lex().linenumber, name.symbol, inferred.primary, inferred.is_fixed);
    }
@@ -1967,6 +2001,9 @@ void TypeAnalyser::analyse_function_payload(const FunctionExprPayload &Function,
 
    for (const auto &param : Function.parameters) {
       this->current_scope().declare_parameter(param.name.symbol, param.type, param.struct_def, param.name.span);
+      if (param.type_is_explicit and param.type IS TiriType::Any and param.name.binding_id) {
+         this->explicit_variant_bindings_.insert(param.name.binding_id);
+      }
    }
 
    // Check for recursive functions without explicit return types
@@ -2232,9 +2269,11 @@ void TypeAnalyser::analyse_call_expr(const CallExprPayload &Call)
 
    const FunctionExprPayload* target = this->resolve_call_target(Call);
    if (target) {
-      if (Call.result_type IS TiriType::Unknown and target->return_types.is_explicit and
+      if (Call.result_type IS TiriType::Unknown and
+          (target->return_types.is_explicit or target->return_types.is_inferred) and
           target->return_types.count > 0) {
          Call.result_type = target->return_types.types[0];
+         Call.object_class_id = target->return_types.object_class_ids[0];
          Call.struct_def = target->return_types.struct_defs[0];
       }
       this->check_arguments(*target, Call);
@@ -2305,6 +2344,12 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
             this->mark_identifier_used(payload->identifier.symbol);
             auto resolved = this->resolve_identifier(payload->identifier.symbol);
             if (resolved) return *resolved;
+            if (type_is_registered_constant(payload->identifier.symbol)) {
+               result.primary = TiriType::Num;
+               result.is_constant = true;
+               result.is_fixed = true;
+               return result;
+            }
             resolved = this->lookup_global_type(payload->identifier.symbol);
             if (resolved) return *resolved;
          }
@@ -2334,8 +2379,10 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                }
             }
             const FunctionExprPayload* target = this->resolve_call_target(*payload);
-            if (target and target->return_types.is_explicit and target->return_types.count > 0) {
+            if (target and (target->return_types.is_explicit or target->return_types.is_inferred) and
+                target->return_types.count > 0) {
                result.primary = target->return_types.types[0];
+               result.object_class_id = target->return_types.object_class_ids[0];
                result.struct_def = target->return_types.struct_defs[0];
                payload->struct_def = result.struct_def;
                return result;
@@ -2540,17 +2587,35 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   result.primary = TiriType::Num;
                   return result;
                // IfEmpty returns type of the operands
-               case AstBinaryOperator::IfEmpty:
-                  if (payload->left) {
-                     result = this->infer_expression_type(*payload->left);
-                     if (result.primary != TiriType::Any and result.primary != TiriType::Unknown) {
-                        return result;
-                     }
+               case AstBinaryOperator::IfEmpty: {
+                  InferredType left_type, right_type;
+                  if (payload->left) left_type = this->infer_expression_type(*payload->left);
+                  if (payload->right) right_type = this->infer_expression_type(*payload->right);
+
+                  if (payload->left and payload->left->kind IS AstNodeKind::LiteralExpr) {
+                     const auto &literal = std::get<LiteralValue>(payload->left->data);
+                     bool is_empty = literal.kind IS LiteralKind::Nil or
+                        (literal.kind IS LiteralKind::Boolean and not literal.bool_value) or
+                        (literal.kind IS LiteralKind::Number and literal.number_value IS 0) or
+                        (literal.kind IS LiteralKind::String and literal.string_value and
+                           literal.string_value->len IS 0);
+                     return is_empty ? right_type : left_type;
                   }
-                  if (payload->right) {
-                     return this->infer_expression_type(*payload->right);
+
+                  if (left_type.primary IS TiriType::Nil) return right_type;
+                  if (left_type.primary IS TiriType::Any or left_type.primary IS TiriType::Unknown or
+                      right_type.primary IS TiriType::Any or right_type.primary IS TiriType::Unknown or
+                      left_type.primary != right_type.primary or
+                      (left_type.primary IS TiriType::Object and
+                         left_type.object_class_id != right_type.object_class_id) or
+                      (left_type.primary IS TiriType::Struct and left_type.struct_def != right_type.struct_def)) {
+                     result.primary = TiriType::Any;
+                     return result;
                   }
-                  break;
+
+                  left_type.is_nullable = right_type.is_nullable;
+                  return left_type;
+               }
             }
          }
          result.primary = TiriType::Any;
@@ -2610,6 +2675,26 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    return result;
 }
 
+InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, InferredType Type) const
+{
+   if ((Type.primary != TiriType::Any and Type.primary != TiriType::Unknown) or not Expr.static_value) return Type;
+
+   if (Expr.kind IS AstNodeKind::IdentifierExpr) {
+      const auto &reference = std::get<NameRef>(Expr.data);
+      if (reference.binding_id and this->explicit_variant_bindings_.contains(reference.binding_id)) return Type;
+   }
+
+   const StaticValueDescriptor &descriptor = this->ctx_.descriptors().value(Expr.static_value);
+   if (descriptor.primary IS TiriType::Unknown or descriptor.primary IS TiriType::Any) return Type;
+
+   Type.primary = descriptor.primary;
+   Type.is_nullable = descriptor.nullable;
+   Type.object_class_id = descriptor.object_class_id;
+   Type.struct_def = descriptor.struct_def;
+   Type.is_fixed = true;
+   return Type;
+}
+
 //********************************************************************************************************************
 // Multi-Value Return Type Inference: Infers the return type at a specific position from a function call expression.
 // Used for multi-value assignments like: local a, b, c = func()
@@ -2637,7 +2722,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    const FunctionExprPayload* target = this->resolve_call_target(*payload);
    if (not target) return result;
 
-   if (not target->return_types.is_explicit) return result;
+   if (not target->return_types.is_explicit and not target->return_types.is_inferred) return result;
 
    if (Position >= target->return_types.count and not target->return_types.is_variadic) {
       result.primary = TiriType::Nil;
@@ -2648,10 +2733,11 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
    // Get the type at the requested position
    TiriType type = target->return_types.type_at(Position);
    if (type != TiriType::Unknown) {
+      const size_t type_position = Position < target->return_types.count ?
+         Position : size_t(target->return_types.count - 1);
       result.primary = type;
-      if (Position < target->return_types.struct_defs.size()) {
-         result.struct_def = target->return_types.struct_defs[Position];
-      }
+      result.object_class_id = target->return_types.object_class_ids[type_position];
+      result.struct_def = target->return_types.struct_defs[type_position];
    }
 
    return result;
@@ -2734,6 +2820,9 @@ const FunctionExprPayload * TypeAnalyser::resolve_function(GCstr *Name) const
    for (auto it = this->scope_stack_.rbegin(); it != this->scope_stack_.rend(); ++it) {
       const FunctionExprPayload* fn = it->lookup_function(Name);
       if (fn) return fn;
+   }
+   if (auto global = this->global_types_.find(Name); global != this->global_types_.end()) {
+      return global->second.function;
    }
    return nullptr;
 }
@@ -2991,10 +3080,12 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
          // Nil is always allowed as a "clear" or "no value" return
          if (actual.primary IS TiriType::Nil) continue;
-         // Any can be assigned to any type
-         if (actual.primary IS TiriType::Any) continue;
+         // A concrete declaration supplies the destination type for runtime validation of dynamic values.
+         if (actual.primary IS TiriType::Any or actual.primary IS TiriType::Unknown) continue;
 
-         if (actual.primary != expected) {
+         const bool struct_matches = expected != TiriType::Struct or not ctx->expected_returns.struct_defs[i] or
+            actual.struct_def IS ctx->expected_returns.struct_defs[i];
+         if (actual.primary != expected or not struct_matches) {
             TypeDiagnostic diag;
             diag.location = Return.values[i]->span;
             diag.expected = expected;
@@ -3007,58 +3098,69 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
       }
    }
    else {
-      // Inference mode: first non-nil return statement fixes types (first-wins rule)
-      // Nil returns don't establish a type - they're compatible with any future type
-      if (not ctx->return_type_inferred and return_count > 0) {
-         // First return: infer types from returned values
-         bool has_non_nil = false;
-         for (size_t i = 0; i < std::min(return_count, MAX_RETURN_TYPES); ++i) {
-            InferredType inferred = this->infer_expression_type(*Return.values[i]);
-            ctx->expected_returns.types[i] = inferred.primary;
-            if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any) {
-               has_non_nil = true;
+      const size_t check_count = std::min(return_count, size_t(MAX_RETURN_TYPES));
+      ctx->observed_return_count = uint8_t(std::max<size_t>(ctx->observed_return_count, check_count));
+
+      for (size_t i = 0; i < check_count; ++i) {
+         InferredReturnPosition &position = ctx->inferred_returns[i];
+         InferredType actual = this->infer_expression_type(*Return.values[i]);
+         actual = this->refine_static_expression_type(*Return.values[i], actual);
+         position.location = Return.values[i]->span;
+
+         if (actual.primary IS TiriType::Nil) {
+            if (position.state IS ReturnInferenceState::Unobserved) {
+               position.state = ReturnInferenceState::NilOnly;
             }
+            continue;
          }
-         ctx->expected_returns.count = uint8_t(std::min(return_count, MAX_RETURN_TYPES));
-         // Only mark as inferred if we have at least one concrete (non-nil) type
-         // This allows a later return with concrete types to establish the actual types
-         ctx->return_type_inferred = has_non_nil;
-      }
-      else if (return_count > 0) {
-         // Subsequent return: check consistency with inferred types
-         size_t check_count = std::min(return_count, size_t(ctx->expected_returns.count));
 
-         for (size_t i = 0; i < check_count; ++i) {
-            TiriType expected = ctx->expected_returns.types[i];
-            InferredType actual = this->infer_expression_type(*Return.values[i]);
-
-            // If expected is nil/any/unknown, and actual is concrete, upgrade the expected type
-            if ((expected IS TiriType::Nil or expected IS TiriType::Any or expected IS TiriType::Unknown) and
-                actual.primary != TiriType::Nil and actual.primary != TiriType::Any and
-                actual.primary != TiriType::Unknown) {
-               ctx->expected_returns.types[i] = actual.primary;
-               ctx->return_type_inferred = true;
-               continue;
+         if (actual.primary IS TiriType::Any or actual.primary IS TiriType::Unknown) {
+            TypeDiagnostic diag;
+            diag.location = Return.values[i]->span;
+            diag.actual = actual.primary;
+            diag.code = ParserErrorCode::ReturnTypeRequired;
+            if (position.concrete.primary != TiriType::Any and position.concrete.primary != TiriType::Unknown) {
+               diag.expected = position.concrete.primary;
+               diag.message = std::format(
+                  "cannot infer result {} as '{}' from a dynamic value; declare ': {}' to check it at runtime or "
+                  "': any' to allow a variant result",
+                  i + 1, type_name(position.concrete.primary), type_name(position.concrete.primary));
             }
-
-            if (expected IS TiriType::Any or expected IS TiriType::Unknown) continue;
-
-            // Nil is always allowed as a "clear" or "no value" return
-            if (actual.primary IS TiriType::Nil) continue;
-            // Any can match any type
-            if (actual.primary IS TiriType::Any) continue;
-
-            if (actual.primary != expected) {
-               TypeDiagnostic diag;
-               diag.location = Return.values[i]->span;
-               diag.expected = expected;
-               diag.actual = actual.primary;
-               diag.code = ParserErrorCode::ReturnTypeMismatch;
-               diag.message = std::format("inconsistent return type at position {}: first return established '{}', but this returns '{}'",
-                  i + 1, type_name(expected), type_name(actual.primary));
-               this->record_diagnostic(std::move(diag));
+            else {
+               diag.message = std::format(
+                  "cannot infer result {} from a dynamic value; declare a concrete result type to check it at "
+                  "runtime or ': any' to allow a variant result", i + 1);
             }
+            this->record_diagnostic(std::move(diag));
+            position.state = ReturnInferenceState::Dynamic;
+            ctx->inference_failed = true;
+            continue;
          }
+
+         if (position.concrete.primary IS TiriType::Any or position.concrete.primary IS TiriType::Unknown) {
+            position.concrete = actual;
+            if (position.state != ReturnInferenceState::Dynamic) position.state = ReturnInferenceState::Concrete;
+            continue;
+         }
+
+         const bool type_matches = actual.primary IS position.concrete.primary;
+         const bool class_matches = position.concrete.primary != TiriType::Object or
+            position.concrete.object_class_id IS CLASSID::NIL or
+            actual.object_class_id IS position.concrete.object_class_id;
+         const bool struct_matches = position.concrete.primary != TiriType::Struct or
+            not position.concrete.struct_def or actual.struct_def IS position.concrete.struct_def;
+         if (type_matches and class_matches and struct_matches) continue;
+
+         TypeDiagnostic diag;
+         diag.location = Return.values[i]->span;
+         diag.expected = position.concrete.primary;
+         diag.actual = actual.primary;
+         diag.code = ParserErrorCode::ReturnTypeMismatch;
+         diag.message = std::format(
+            "inconsistent return type at position {}: first return established '{}', but this returns '{}'",
+            i + 1, type_name(position.concrete.primary), type_name(actual.primary));
+         this->record_diagnostic(std::move(diag));
+         ctx->inference_failed = true;
       }
    }
 }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -632,30 +632,23 @@ void TypeAnalyser::leave_function()
          inferred_return_count--;
       }
 
-      for (size_t i = 0; i < inferred_return_count; ++i) {
-         const InferredReturnPosition &position = ctx.inferred_returns[i];
-         if (position.state IS ReturnInferenceState::NilOnly) {
-            TypeDiagnostic diag;
-            diag.location = position.location;
-            diag.code = ParserErrorCode::ReturnTypeRequired;
-            diag.message = std::format(
-               "cannot infer result {} because it has no concrete value; declare a concrete result type to check it "
-               "at runtime or ': any' to allow a variant result", i + 1);
-            this->record_diagnostic(std::move(diag));
-            ctx.inference_failed = true;
-         }
-      }
-
       if (inferred_return_count > 0 and not ctx.inference_failed) {
          FunctionReturnTypes &published = ctx.function->return_types;
          published.count = uint8_t(inferred_return_count);
          published.is_inferred = true;
          published.is_variadic = false;
          for (size_t i = 0; i < inferred_return_count; ++i) {
-            const InferredType &inferred = ctx.inferred_returns[i].concrete;
-            published.types[i] = inferred.primary;
-            published.object_class_ids[i] = inferred.object_class_id;
-            published.struct_defs[i] = inferred.struct_def;
+            const InferredReturnPosition &position = ctx.inferred_returns[i];
+            if (position.state IS ReturnInferenceState::NilOnly) {
+               published.types[i] = TiriType::Nil;
+               published.object_class_ids[i] = CLASSID::NIL;
+               published.struct_defs[i] = nullptr;
+            }
+            else {
+               published.types[i] = position.concrete.primary;
+               published.object_class_ids[i] = position.concrete.object_class_id;
+               published.struct_defs[i] = position.concrete.struct_def;
+            }
          }
       }
    }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -229,7 +229,7 @@ private:
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
    [[nodiscard]] InferredType refine_static_expression_type(const ExprNode &, InferredType) const;
-   [[nodiscard]] bool is_explicit_variant_expression(const ExprNode &) const;
+   [[nodiscard]] bool is_explicit_variant_expression(const ExprNode &, size_t Position = 0) const;
    [[nodiscard]] InferredType infer_call_return_type(const ExprNode &, size_t Position) const;
 
    // Symbol resolution - looks up variables and functions in scope stack
@@ -2719,7 +2719,7 @@ InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, I
    return Type;
 }
 
-bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr) const
+bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t Position) const
 {
    if (Expr.kind IS AstNodeKind::IdentifierExpr) {
       const auto &reference = std::get<NameRef>(Expr.data);
@@ -2733,8 +2733,8 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr) const
    else if (Expr.kind IS AstNodeKind::CallExpr or Expr.kind IS AstNodeKind::SafeCallExpr) {
       const auto &call = std::get<CallExprPayload>(Expr.data);
       const FunctionExprPayload *target = this->resolve_call_target(call);
-      return target and target->return_types.is_explicit and target->return_types.count > 0 and
-         target->return_types.types[0] IS TiriType::Any;
+      return target and target->return_types.is_explicit and Position < target->return_types.count and
+         target->return_types.types[Position] IS TiriType::Any;
    }
    return false;
 }
@@ -3111,6 +3111,33 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
    if (not ctx) return;  // Not inside a function (shouldn't happen in valid code)
 
    size_t return_count = Return.values.size();
+   size_t fixed_count = return_count;
+   const ExprNode *tail_expression = nullptr;
+   const StaticResultSet *tail_results = nullptr;
+   if (not ctx->expected_returns.is_explicit and Return.forwards_call and not Return.values.empty()) {
+      tail_expression = Return.values.back().get();
+      if (tail_expression->static_results) {
+         const StaticResultSet &results = this->ctx_.descriptors().results(tail_expression->static_results);
+         if (not results.dynamic and not results.variadic) {
+            fixed_count--;
+            tail_results = &results;
+            return_count = fixed_count + results.declared_count;
+         }
+      }
+   }
+
+   auto expression_at = [&](size_t Position) -> const ExprNode & {
+      return Position < fixed_count ? *Return.values[Position] : *tail_expression;
+   };
+
+   auto infer_position = [&](size_t Position) {
+      const ExprNode &expression = expression_at(Position);
+      if (tail_results and Position >= fixed_count) {
+         return this->infer_call_return_type(expression, Position - fixed_count);
+      }
+      InferredType actual = this->infer_expression_type(expression);
+      return this->refine_static_expression_type(expression, actual);
+   };
 
    if (ctx->expected_returns.is_explicit) {
       // Explicit declaration: validate against declared types
@@ -3120,7 +3147,8 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
          TiriType expected = ctx->expected_returns.type_at(i);
          if (expected IS TiriType::Any or expected IS TiriType::Unknown) continue;
 
-         InferredType actual = this->infer_expression_type(*Return.values[i]);
+         const ExprNode &expression = expression_at(i);
+         InferredType actual = this->infer_expression_type(expression);
 
          // Nil is always allowed as a "clear" or "no value" return
          if (actual.primary IS TiriType::Nil) continue;
@@ -3131,7 +3159,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             actual.struct_def IS ctx->expected_returns.struct_defs[i];
          if (actual.primary != expected or not struct_matches) {
             TypeDiagnostic diag;
-            diag.location = Return.values[i]->span;
+            diag.location = expression.span;
             diag.expected = expected;
             diag.actual = actual.primary;
             diag.code = ParserErrorCode::ReturnTypeMismatch;
@@ -3147,9 +3175,10 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
       for (size_t i = 0; i < check_count; ++i) {
          InferredReturnPosition &position = ctx->inferred_returns[i];
-         InferredType actual = this->infer_expression_type(*Return.values[i]);
-         actual = this->refine_static_expression_type(*Return.values[i], actual);
-         position.location = Return.values[i]->span;
+         const ExprNode &expression = expression_at(i);
+         const size_t expression_position = tail_results and i >= fixed_count ? i - fixed_count : 0;
+         InferredType actual = infer_position(i);
+         position.location = expression.span;
 
          if (actual.primary IS TiriType::Nil) {
             if (position.state IS ReturnInferenceState::Unobserved) {
@@ -3158,7 +3187,8 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             continue;
          }
 
-         if (actual.primary IS TiriType::Any and this->is_explicit_variant_expression(*Return.values[i])) {
+         if (actual.primary IS TiriType::Any and
+             this->is_explicit_variant_expression(expression, expression_position)) {
             position.concrete = actual;
             position.concrete.primary = TiriType::Any;
             position.state = ReturnInferenceState::ExplicitAny;
@@ -3169,7 +3199,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
          if (actual.primary IS TiriType::Any or actual.primary IS TiriType::Unknown) {
             position.state = ReturnInferenceState::Dynamic;
-            position.dynamic_location = Return.values[i]->span;
+            position.dynamic_location = expression.span;
             position.dynamic_type = actual.primary;
             continue;
          }
@@ -3189,7 +3219,7 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
          if (type_matches and class_matches and struct_matches) continue;
 
          TypeDiagnostic diag;
-         diag.location = Return.values[i]->span;
+         diag.location = expression.span;
          diag.expected = position.concrete.primary;
          diag.actual = actual.primary;
          diag.code = ParserErrorCode::ReturnTypeMismatch;

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -49,10 +49,25 @@ struct TypeDiagnostic {
 };
 
 // Context for tracking function return type validation during type analysis
+enum class ReturnInferenceState : uint8_t {
+   Unobserved,
+   NilOnly,
+   Concrete,
+   Dynamic
+};
+
+struct InferredReturnPosition {
+   ReturnInferenceState state = ReturnInferenceState::Unobserved;
+   InferredType concrete{};
+   SourceSpan location{};
+};
+
 struct FunctionContext {
    const FunctionExprPayload* function = nullptr;  // The function being analysed
    FunctionReturnTypes expected_returns{};         // Declared or inferred return types
-   bool return_type_inferred = false;              // True once first return statement sets types
+   std::array<InferredReturnPosition, MAX_RETURN_TYPES> inferred_returns{};
+   uint8_t observed_return_count = 0;
+   bool inference_failed = false;
    GCstr *function_name = nullptr;                 // Function name (for recursive detection)
 
    FunctionContext() = default;

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -53,6 +53,7 @@ enum class ReturnInferenceState : uint8_t {
    Unobserved,
    NilOnly,
    Concrete,
+   ExplicitAny,
    Dynamic
 };
 
@@ -60,6 +61,8 @@ struct InferredReturnPosition {
    ReturnInferenceState state = ReturnInferenceState::Unobserved;
    InferredType concrete{};
    SourceSpan location{};
+   SourceSpan dynamic_location{};
+   TiriType dynamic_type = TiriType::Unknown;
 };
 
 struct FunctionContext {

--- a/src/tiri/tests/compile_if_helper.tiri
+++ b/src/tiri/tests/compile_if_helper.tiri
@@ -3,8 +3,8 @@
 
 global helper_always_visible = true
 global helper_message = "Hello from imported module!"
-global function add_numbers(a, b) return a + b end
-global function multiply(a, b) return a * b end
+global function add_numbers(a, b):num return a + b end
+global function multiply(a, b):num return a * b end
 
 @if(imported=false)
    -- Only runs when this file is executed directly

--- a/src/tiri/tests/test_anonymous_for.tiri
+++ b/src/tiri/tests/test_anonymous_for.tiri
@@ -160,7 +160,7 @@ end
 
 @Test function AnonymousForFunctionCall()
    -- Test calling functions inside anonymous for
-   function increment(val)
+   function increment(val:num):num
       return val + 1
    end
 

--- a/src/tiri/tests/test_array_any.tiri
+++ b/src/tiri/tests/test_array_any.tiri
@@ -214,7 +214,7 @@ end
 
 @Test function ArrayAnyReduce()
    arr = array<any> { 1, 2, 3, 4 }
-   sum = array.reduce(arr, 0, function(acc, v)
+   sum = array.reduce(arr, 0, function(acc, v):num
       return acc + v
    end)
 

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -73,7 +73,7 @@ end
 
 @Test function MapDoubleValues()
    arr = array<int> { 1, 2, 3, 4, 5 }
-   doubled = arr:map(v => v * 2)
+   doubled = arr:map(v => num: v * 2)
    assert(#doubled is 5, "map() should return array of same length")
    assert(doubled[0] is 2 and doubled[1] is 4 and doubled[2] is 6 and doubled[3] is 8 and doubled[4] is 10,
       "map() should transform each element")
@@ -81,19 +81,19 @@ end
 
 @Test function MapPreservesOriginal()
    arr = array<int> { 1, 2, 3 }
-   doubled = arr:map(v => v * 2)
+   doubled = arr:map(v => num: v * 2)
    assert(arr[0] is 1 and arr[1] is 2 and arr[2] is 3, "map() should not modify original array")
 end
 
 @Test function MapEmptyArray()
    arr = array<int>
-   result = arr:map(v => v * 2)
+   result = arr:map(v => num: v * 2)
    assert(#result is 0, "map() on empty array should return empty array")
 end
 
 @Test function MapWithIndex()
    arr = array<int> { 10, 20, 30 }
-   indexed = arr:map(function(v, i)
+   indexed = arr:map(function(v, i):num
       return v + i
    end)
    assert(indexed[0] is 10 and indexed[1] is 21 and indexed[2] is 32, "map() should pass index as second argument")
@@ -101,14 +101,14 @@ end
 
 @Test function MapFloatArray()
    arr = array<float> { 1.5, 2.5, 3.5 }
-   squared = arr:map(v => v * v)
+   squared = arr:map(v => num: v * v)
    assert(math.abs(squared[0] - 2.25) < 0.001, "map() should work with float arrays")
    assert(math.abs(squared[1] - 6.25) < 0.001, "map() should work with float arrays")
 end
 
 @Test function MapStringArray()
    arr = array<string> { 'hello', 'world' }
-   upper = arr:map(v => v:upper())
+   upper = arr:map(v => str: v:upper())
    assert(upper[0] is 'HELLO' and upper[1] is 'WORLD', "map() should work with string arrays")
 end
 
@@ -245,7 +245,7 @@ end
 
 @Test function ReduceWithIndex()
    arr = array<int> { 10, 20, 30 }
-   result = arr:reduce(0, function(acc, v, i)
+   result = arr:reduce(0, function(acc, v, i):num
       return acc + v * i
    end)
    -- 10*0 + 20*1 + 30*2 = 0 + 20 + 60 = 80
@@ -254,7 +254,7 @@ end
 
 @Test function ReduceToTable()
    arr = array<int> { 1, 2, 3 }
-   result = arr:reduce({}, function(acc, v, i)
+   result = arr:reduce({}, function(acc, v, i):num
       acc[i] = v * v
       return acc
    end)

--- a/src/tiri/tests/test_array_functional.tiri
+++ b/src/tiri/tests/test_array_functional.tiri
@@ -116,7 +116,7 @@ end
    obj_one = obj.new('time')
    obj_two = obj.new('file')
    arr = array<object> { obj_one, obj_two }
-   copied = arr:map(Value => Value)
+   copied = arr:map(Value => object: Value)
    assert(copied[0].id is obj_one.id and copied[1].id is obj_two.id, "map() should preserve objects")
    obj_one.free()
    obj_two.free()
@@ -254,7 +254,7 @@ end
 
 @Test function ReduceToTable()
    arr = array<int> { 1, 2, 3 }
-   result = arr:reduce({}, function(acc, v, i):num
+   result = arr:reduce({}, function(acc, v, i):table
       acc[i] = v * v
       return acc
    end)
@@ -269,7 +269,7 @@ end
 
 @Test function ReduceMax()
    arr = array<int> { 3, 1, 4, 1, 5, 9, 2, 6 }
-   maxVal = arr:reduce(arr[0], (acc, v) => v > acc ? v :> acc)
+   maxVal = arr:reduce(arr[0], (acc, v) => num: v > acc ? v :> acc)
    assert(maxVal is 9, "reduce() should find maximum value")
 end
 

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -162,7 +162,7 @@ end
 
 @Test function ArrayTypedAsArgument()
    -- Pass typed array as function argument
-   function sum_array(a)
+   function sum_array(a):num
       total = 0
       for i in {0 to #a} do
          total += a[i]
@@ -379,7 +379,7 @@ end
 
 @Test function ArrayTypedAsReturnValue()
    -- Function returning typed array
-   function makeNumbers(n)
+   function makeNumbers(n):array
       result = array<int, n>
       for i in {0 to n} do
          result[i] = i + 1

--- a/src/tiri/tests/test_async.tiri
+++ b/src/tiri/tests/test_async.tiri
@@ -14,7 +14,7 @@ function enforce_hotpath() end
 
    callback = function()
       msg('Thread has finished execution.')
-      work_list:each(o => o.acSignal())
+      work_list:each(o => num: o.acSignal())
    end
 
    proc = processing.new({ timeout=1.0, signals = work_list })

--- a/src/tiri/tests/test_choose_from.tiri
+++ b/src/tiri/tests/test_choose_from.tiri
@@ -970,7 +970,7 @@ end
 end
 
 @Test(hotpath=true) function StateTransition()
-   function nextState(current, action)
+   function nextState(current, action):str
       return choose (current, action) from
          ('idle', 'start') -> 'running'
          ('running', 'pause') -> 'paused'

--- a/src/tiri/tests/test_const.tiri
+++ b/src/tiri/tests/test_const.tiri
@@ -51,7 +51,7 @@ end
 -- Test const with function values
 
 @Test function ConstWithFunction()
-   add <const> = function(a, b)
+   add <const> = function(a:num, b:num)
       return a + b
    end
 

--- a/src/tiri/tests/test_const_optimisation.tiri
+++ b/src/tiri/tests/test_const_optimisation.tiri
@@ -247,13 +247,13 @@ end
    local captured = disassemble([[
 function sample()
    local value <const> = 37
-   return function()
+   return function():num
       return value
    end
 end
 ]])
    local non_primitive = disassemble([[
-function sample()
+function sample():num
    local value <const> = { count = 1 }
    value.count++
    return value.count

--- a/src/tiri/tests/test_constant_shadowing.tiri
+++ b/src/tiri/tests/test_constant_shadowing.tiri
@@ -43,7 +43,7 @@ end
 end
 
 @Test function AllowsParameterShadowOfConstant()
-   local function use_constant_name(ERR_Okay)
+   local function use_constant_name(ERR_Okay:str)
       return ERR_Okay
    end
 

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -598,7 +598,7 @@ end
 
    symbol = result.symbols[0]
    assert(symbol.params[0].doc is "Value to format", "Expected compact @input doc to be positional")
-   assert(symbol.results[0].type is "num", "Expected first compact result type to be inferred as num")
+   assert(symbol.results[0].type is "num", "Expected first compact result type to be inferred as num, got " .. tostring(symbol.results[0].type))
    assert(symbol.results[0].doc is "Incremented value", "Expected first inferred compact @result doc")
    assert(symbol.results[0].inferred is true, "Inferred compact result type should be marked inferred")
    assert(symbol.results[1].type is "str", "Expected second compact result type to be inferred as str")
@@ -616,7 +616,7 @@ end
          @input Callback that produces a value
          @result Callback result
       ]])
-      function compactFallback(Callback)
+      function compactFallback(Callback:func):any
          return Callback()
       end
    ]=]
@@ -628,9 +628,8 @@ end
 
    symbol = result.symbols[0]
    assert(symbol.params[0].doc is "Callback that produces a value", "Expected fallback compact @input doc")
-   assert(symbol.results[0].type is "any", "Unknown compact result type should fall back to any")
+   assert(symbol.results[0].type is "any", "Compact result type expected to be any")
    assert(symbol.results[0].doc is "Callback result", "Expected fallback compact @result doc")
-   assert(symbol.results[0].inferred is true, "Fallback compact result type should be marked inferred")
 end
 
 @Test function ValidateSymbolsWithAnnotatedFunctionAssignment()
@@ -700,7 +699,7 @@ struct ValidateUser
    List: ptr<ValidatePoint[]>
 end
 
-function validateGreet(U)
+function validateGreet(U):str
    return U.Name
 end
 ]=]

--- a/src/tiri/tests/test_debug.tiri
+++ b/src/tiri/tests/test_debug.tiri
@@ -609,6 +609,75 @@ end
    assert(symbol.results[2].inferred is true, "Inferred compact result type should be marked inferred")
 end
 
+@Test function ValidateSymbolsWithForwardedCallResults()
+   code = [=[
+      function declaredPair():<num, str>
+         return 7, "forwarded"
+      end
+
+      function inferredWrapper()
+         return declaredPair()
+      end
+   ]=]
+
+   result = debug.validate(code, { symbols = true })
+   assert(result.success is true, "A wrapper forwarding declared results should succeed")
+   assert(#result.symbols is 2, "Expected the declared function and its wrapper")
+
+   symbol = result.symbols[1]
+   assert(symbol.name is "inferredWrapper", "Expected the inferred wrapper symbol")
+   assert(#symbol.results is 2, "Expected both forwarded results in parser symbols")
+   assert(symbol.results[0].type is "num", "Expected the first forwarded result to remain num")
+   assert(symbol.results[1].type is "str", "Expected the second forwarded result to remain str")
+   assert(symbol.results[0].inferred is true, "Expected the first forwarded result to be inferred")
+   assert(symbol.results[1].inferred is true, "Expected the second forwarded result to be inferred")
+end
+
+@Test function ValidateSymbolsWithForwardedAnyResult()
+   code = [=[
+      function declaredPair():<num, any>
+         return 7, nil
+      end
+
+      function inferredWrapper()
+         return declaredPair()
+      end
+   ]=]
+
+   result = debug.validate(code, { symbols = true })
+   assert(result.success is true, "A wrapper forwarding an explicit any result should succeed")
+   assert(#result.symbols is 2, "Expected the declared function and its wrapper")
+
+   symbol = result.symbols[1]
+   assert(symbol.name is "inferredWrapper", "Expected the inferred wrapper symbol")
+   assert(#symbol.results is 2, "Expected both forwarded results in parser symbols")
+   assert(symbol.results[0].type is "num", "Expected the first forwarded result to remain num")
+   assert(symbol.results[1].type is "any", "Expected the second forwarded result to remain any")
+end
+
+@Test function ValidateSymbolsWithPrefixedForwardedCallResults()
+   code = [=[
+      function declaredPair():<num, str>
+         return 7, "forwarded"
+      end
+
+      function inferredWrapper()
+         return true, declaredPair()
+      end
+   ]=]
+
+   result = debug.validate(code, { symbols = true })
+   assert(result.success is true, "A wrapper with a fixed return prefix should succeed")
+   assert(#result.symbols is 2, "Expected the declared function and its wrapper")
+
+   symbol = result.symbols[1]
+   assert(symbol.name is "inferredWrapper", "Expected the inferred wrapper symbol")
+   assert(#symbol.results is 3, "Expected the fixed result and both forwarded results")
+   assert(symbol.results[0].type is "bool", "Expected the fixed result to remain bool")
+   assert(symbol.results[1].type is "num", "Expected the first forwarded result to remain num")
+   assert(symbol.results[2].type is "str", "Expected the second forwarded result to remain str")
+end
+
 @Test function ValidateSymbolsWithCompactDocUnknownResultFallback()
    code = [=[
       @Doc(text=[[

--- a/src/tiri/tests/test_debuglog.tiri
+++ b/src/tiri/tests/test_debuglog.tiri
@@ -8,7 +8,7 @@ rx_debuglog = regex.new('test_debuglog\\.tiri:\\d+')
 -- Test default behaviour (stack trace only)
 
 @Test function DefaultStackTrace()
-   function innerFunc()
+   function innerFunc():str
       err, result = glSelf.mtDebugLog()
       return result
    end
@@ -45,7 +45,6 @@ end
 
    script.acQuery()
    err, result = script.mtDebugLog('locals')
-   print(result)
 
    assert(result, 'DebugLog should return a result')
    assert(string.find(result, ':x:'), 'Should contain variable x')
@@ -63,7 +62,7 @@ end
    counter = 10
    config = { enabled = true }
 
-   function closure()
+   function closure():str
       counter++
       if config.enabled then end  -- Use config so it becomes an upvalue
       err, result = glSelf.mtDebugLog('upvalues')
@@ -150,7 +149,7 @@ end
 -- Test compact mode
 
 @Test function CompactMode()
-   function compactTest()
+   function compactTest():str
       x = 42
       err, result = glSelf.mtDebugLog('stack,locals,compact')
       return result
@@ -167,7 +166,7 @@ end
 -- Test with long strings (truncation)
 
 @Test function LongString()
-   function longStringTest()
+   function longStringTest():str
       longStr = 'This is a very long string that should be truncated to forty characters maximum'
       err, result = glSelf.mtDebugLog('locals')
       return result
@@ -184,7 +183,7 @@ end
 -- Test with various data types
 
 @Test function VariousTypes()
-   function typeTest()
+   function typeTest():str
       numVar = 3.14
       strVar = 'hello'
       boolVar = false
@@ -197,7 +196,7 @@ end
    end
 
    result = typeTest()
-print(result)
+
    assert(result, 'DebugLog should return a result')
    assert(string.find(result, 'numVar'), 'Should contain numVar')
    assert(string.find(result, '3.14'), 'Should contain number value')
@@ -215,7 +214,7 @@ end
 -- Test nested function calls in stack trace
 
 @Test function NestedStack()
-   function level3()
+   function level3():str
       err, result = glSelf.mtDebugLog('stack')
       msg(result)
       return result
@@ -241,7 +240,7 @@ end
 -- Test funcinfo option
 
 @Test function FuncInfo()
-   function calculateTotal(a, b, c)
+   function calculateTotal(a, b, c):str
       sum = a + b + c
       err, result = glSelf.mtDebugLog('funcinfo')
       return result
@@ -271,7 +270,7 @@ end
 -- Test disassembly option
 
 @Test function Disassembly()
-   function sampleFunction(a, b)
+   function sampleFunction(a, b):str
       scale = b * 2
       total = a + scale
       err, result = glSelf.mtDebugLog('disasm')
@@ -319,7 +318,7 @@ end
 -- Test binary dump option
 
 @Test function BytecodeDump()
-   function captureDump(a, b)
+   function captureDump(a, b):str
       temp = a + b
       err, result = glSelf.mtDebugLog('dump')
       msg(result)

--- a/src/tiri/tests/test_deferred_expr.tiri
+++ b/src/tiri/tests/test_deferred_expr.tiri
@@ -217,7 +217,7 @@ end
 end
 
 @Test function DeferredAsArgument()
-   function identity(val)
+   function identity(val:str):str
       return resolve(val)
    end
    x = <{ 'test' }>

--- a/src/tiri/tests/test_ellipsis.tiri
+++ b/src/tiri/tests/test_ellipsis.tiri
@@ -16,7 +16,7 @@ function enforce_hotpath() end
 end
 
 @Test function AsciiVarargsWithNamedParams()
-   function variadic(a, b, ...)
+   function variadic(a, b, ...):<any, ...>
       return a, b, {...}
    end
 

--- a/src/tiri/tests/test_fstring.tiri
+++ b/src/tiri/tests/test_fstring.tiri
@@ -183,7 +183,7 @@ end
 @Test function MethodCall()
    t = {
       name = "Method",
-      getName = function(self) return self.name end
+      getName = function(self):str return self.name end
    }
    result = f"Name: {t:getName()}"
    assert(result is "Name: Method", "Method call failed: " .. tostring(result))
@@ -197,7 +197,7 @@ end
 end
 
 @Test function ArrowFunction()
-   fn = x => x * 2
+   fn = x => num: x * 2
    result = f"{fn(3)}"
    assert(result is "6", "Arrow function failed: " .. tostring(result))
 end

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -144,7 +144,7 @@ end
    local disasm = disassemble([[
 MAKESTRUCT('GTImplicitRec', 'lAlpha,lBravo')
 global glGTRec = struct.new('GTImplicitRec')
-function readField()
+function readField():num
    return glGTRec.alpha
 end
 function writeField()
@@ -163,7 +163,7 @@ end
    local disasm = disassemble([[
 MAKESTRUCT('GTExplicitRec', 'lAlpha')
 global glGTExplicit = struct.new('GTExplicitRec')
-function readField()
+function readField():num
    return glGTExplicit.alpha
 end
 ]])
@@ -178,7 +178,7 @@ end
 MAKESTRUCT('GTConflictRec', 'lAlpha')
 global glGTMixed:any = struct.new('GTConflictRec')
 glGTMixed = 'text'
-function readField()
+function readField():num
    return glGTMixed.alpha
 end
 ]])
@@ -206,7 +206,7 @@ end
 @Test function GlobalObjectUnknownFieldRejected()
    local script = obj.new('tiri', { statement = [[
 global glGTTime2 = obj.new('time')
-function readBad()
+function readBad():num
    return glGTTime2.no_such_field
 end
 ]] })
@@ -236,7 +236,7 @@ end
    local disasm = disassemble([[
 MAKESTRUCT('GTShadowRec', 'lAlpha')
 global glGTShadow = struct.new('GTShadowRec')
-function readShadowed()
+function readShadowed():num
    local glGTShadow = { alpha = 1 }
    return glGTShadow.alpha
 end

--- a/src/tiri/tests/test_if_empty_guard.tiri
+++ b/src/tiri/tests/test_if_empty_guard.tiri
@@ -20,7 +20,7 @@ end
 
 -- Test return with value
 @Test function ShortHandReturnValue()
-   function getValue(Input)
+   function getValue(Input:any)
       Input ?! return "default"
       return Input
    end
@@ -48,7 +48,7 @@ end
 end
 
 @Test function ShortHandTableValues()
-   function describeTable(Value)
+   function describeTable(Value):str
       Value ?! return 'empty'
       return Value.name ?? 'present'
    end

--- a/src/tiri/tests/test_io.tiri
+++ b/src/tiri/tests/test_io.tiri
@@ -14,7 +14,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Test helper functions
 
-function createTestFile(name, content)
+function createTestFile(name, content):str
    path = glTestFolder .. name
    file = obj.new('file', { path=path, flags=FL_NEW|FL_WRITE })
    content and file.acWrite(content)

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -259,7 +259,7 @@ function count_trace_calls(TraceNo, Info)
       count_trace_opcode(TraceNo, Info, ir_calll) + count_trace_opcode(TraceNo, Info, ir_calls)
 end
 
-function canonical_array_workload(Count)
+function canonical_array_workload(Count):str
    local values = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
 
    for pass in {1 into Count} do
@@ -271,7 +271,7 @@ function canonical_array_workload(Count)
    return values:concat(',', '%d')
 end
 
-function canonical_array_try_workload(Count)
+function canonical_array_try_workload(Count):str
    local values = array<int, 8>
 
    try
@@ -337,7 +337,7 @@ function reassign_during_array_loop(Array:array, Reassign:bool)
    end
 end
 
-function push_during_array_loop(Array:array)
+function push_during_array_loop(Array:array):<num, num, num>
    local original_length = #Array
    for index in {0 to #Array} do
       if index is 0 then Array:push(99) end
@@ -346,7 +346,7 @@ function push_during_array_loop(Array:array)
    return original_length, #Array, Array[#Array - 1]
 end
 
-function run_array_method_trace(Workload, Count)
+function run_array_method_trace(Workload, Count):<num, num, num>
    jit.off()
    local expected = Workload(Count)
 
@@ -362,7 +362,7 @@ function run_array_method_trace(Workload, Count)
    return expected, result, count_jit_traces(30)
 end
 
-function run_safe_index_trace(Workload, Count)
+function run_safe_index_trace(Workload, Count):<num, num, num, num, num>
    jit.off()
    local expected = Workload(Count)
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -346,7 +346,7 @@ function push_during_array_loop(Array:array):<num, num, num>
    return original_length, #Array, Array[#Array - 1]
 end
 
-function run_array_method_trace(Workload, Count):<num, num, num>
+function run_array_method_trace(Workload, Count):<str, str, num>
    jit.off()
    local expected = Workload(Count)
 
@@ -354,7 +354,7 @@ function run_array_method_trace(Workload, Count):<num, num, num>
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
 
-   local result = nil
+   local result:str = nil
    for i in {0 to 80} do
       result = Workload(Count)
    end
@@ -991,7 +991,7 @@ function constant_target(Value)
    return offset, label
 end
 
-function array_method_clear_workload(Count)
+function array_method_clear_workload(Count):str
    local result = array.new("")
 
    for i in {1 into Count} do
@@ -1002,7 +1002,7 @@ function array_method_clear_workload(Count)
    return array.getString(result)
 end
 
-function array_method_resize_workload(Count)
+function array_method_resize_workload(Count):str
    local result = array.new("abcdef")
 
    for i in {1 into Count} do
@@ -1013,7 +1013,7 @@ function array_method_resize_workload(Count)
    return array.getString(result)
 end
 
-function array_method_push_workload(Count)
+function array_method_push_workload(Count):str
    local result = array.new("")
 
    for i in {1 into Count} do

--- a/src/tiri/tests/test_malformed_syntax.tiri
+++ b/src/tiri/tests/test_malformed_syntax.tiri
@@ -85,7 +85,7 @@ end
    result = debug.validate("extern externalValue\nlocal something = externalValue")
    assert(result.success is true, "Extern read should validate")
 
-   result = debug.validate("extern externalValue\nfunction nested()\n   return externalValue\nend")
+   result = debug.validate("extern externalValue\nfunction nested():any\n   return externalValue\nend")
    assert(result.success is true, "Extern read inside nested function should validate")
 
    assertInvalidCode("local something = externalValue", 'UndefinedVariable',
@@ -94,7 +94,7 @@ end
    result = debug.validate("extern *\nlocal value = anyMissingSymbol")
    assert(result.success is true, "Extern wildcard read should validate")
 
-   result = debug.validate("extern *\nfunction nested()\n   return anyMissingSymbol\nend")
+   result = debug.validate("extern *\nfunction nested():any\n   return anyMissingSymbol\nend")
    assert(result.success is true, "Extern wildcard read inside nested function should validate")
 
    assertInvalidCode("local value = anyMissingSymbol", 'UndefinedVariable',

--- a/src/tiri/tests/test_metatables.tiri
+++ b/src/tiri/tests/test_metatables.tiri
@@ -56,7 +56,7 @@ end
 
 -- Helper: create a simple 2D vector type with arithmetic metamethods
 
-function newVec(X, Y)
+function newVec(X, Y):table
    vec_mt = {
       __add = function(A, B) return newVec(A.x + B.x, A.y + B.y) end,
       __sub = function(A, B) return newVec(A.x - B.x, A.y - B.y) end,
@@ -233,7 +233,7 @@ end
 end
 
 @Test function MetaLen()
-   mt = { __len = function(Self) return Self.custom_size end }
+   mt = { __len = function(Self):num return Self.custom_size end }
    local obj = setmetatable({ custom_size = 42 }, mt)
    assert(#obj is 42, "__len should return custom length, got " .. #obj)
 end
@@ -246,7 +246,7 @@ end
 
 @Test function MetaConcat()
    mt = {
-      __concat = function(A, B)
+      __concat = function(A, B):table
          if type(A) is 'table' and type(B) is 'table' then
             return setmetatable({ val = A.val .. B.val }, getmetatable(A))
          end
@@ -376,7 +376,7 @@ end
    -- Classic proxy pattern: separate storage from the proxy object
    storage = {}
    mt = {
-      __index = function(Self, Key)
+      __index = function(Self, Key):any
          return storage[Key]
       end,
       __newindex = function(Self, Key, Value)
@@ -412,7 +412,7 @@ end
 end
 
 @Test function MetaCallMultipleReturns()
-   mt = { __call = function(Self, X) return X, X * 2, X * 3 end }
+   mt = { __call = function(Self, X):<num, num, num> return X, X * 2, X * 3 end }
    t = setmetatable({}, mt)
    a, b, c = t(5)
    assert(a is 5, "__call first return should be 5, got " .. a)
@@ -422,7 +422,7 @@ end
 
 @Test function MetaCallSelfAccess()
    mt = {
-      __call = function(Self, Key)
+      __call = function(Self, Key):any
          return Self.data[Key]
       end
    }
@@ -522,11 +522,11 @@ end
    function createCounting()
       state = { reads = 0, writes = 0, data = {} }
       mt = {
-         __index = function(Self, Key)
+         __index = function(Self, Key):any
             state.reads++
             return state.data[Key]
          end,
-         __newindex = function(Self, Key, Value)
+         __newindex = function(Self, Key, Value):any
             state.writes++
             state.data[Key] = Value
          end
@@ -605,12 +605,12 @@ function newWrapped(Val)
    return setmetatable({ val = Val }, wrapped_mt)
 end
 
-wrapped_mt.__add      = function(A, B) return newWrapped(A.val + B.val) end
-wrapped_mt.__tostring = function(Self) return 'Wrapped(' .. Self.val .. ')' end
-wrapped_mt.__eq       = function(A, B) return A.val is B.val end
-wrapped_mt.__len      = function(Self) return Self.val end
-wrapped_mt.__call     = function(Self) return Self.val end
-wrapped_mt.__unm      = function(Self) return newWrapped(-Self.val) end
+wrapped_mt.__add      = function(A, B):table return newWrapped(A.val + B.val) end
+wrapped_mt.__tostring = function(Self):str return 'Wrapped(' .. Self.val .. ')' end
+wrapped_mt.__eq       = function(A, B):bool return A.val is B.val end
+wrapped_mt.__len      = function(Self):num return Self.val end
+wrapped_mt.__call     = function(Self):num return Self.val end
+wrapped_mt.__unm      = function(Self):table return newWrapped(-Self.val) end
 
 @Test function CombinedMetamethods()
 

--- a/src/tiri/tests/test_overflow.tiri
+++ b/src/tiri/tests/test_overflow.tiri
@@ -280,7 +280,7 @@ end
    local result = exec([[
       import 'tempus'
 
-      @Test function GeneratedAnnotationAfterTempusImport()
+      @Test function GeneratedAnnotationAfterTempusImport():num
          return tempus.instant(0):toUnixSeconds()
       end
 
@@ -294,7 +294,7 @@ end
    local result = exec(source_after_large_constant_pool([[
       local target = { marker = 'method-ok' }
 
-      function target:overflowMethod()
+      function target:overflowMethod():str
          return self.marker
       end
 

--- a/src/tiri/tests/test_overflow.tiri
+++ b/src/tiri/tests/test_overflow.tiri
@@ -265,7 +265,7 @@ constant_pool[255] = 'constant_255'
    assert(#constant_pool is 256, 'constant pool should remain populated')
 end
 
-function source_after_large_constant_pool(Tail)
+function source_after_large_constant_pool(Tail):str
    local lines = array<string> { 'local constant_pool = {}' }
 
    for i in {0 to 256} do

--- a/src/tiri/tests/test_pipe.tiri
+++ b/src/tiri/tests/test_pipe.tiri
@@ -49,7 +49,7 @@ end
       return 1, 2, 3, 4, 5
    end
 
-   function first_arg(a)
+   function first_arg(a):num
       return a
    end
 
@@ -120,7 +120,7 @@ end
 
 @Test function PipePrecedence()
    -- Pipe should have lower precedence than comparison, so this parses as (5 > 3) |> func()
-   function identity(x)
+   function identity(x):num
       return x
    end
 

--- a/src/tiri/tests/test_ranges.tiri
+++ b/src/tiri/tests/test_ranges.tiri
@@ -1235,7 +1235,7 @@ end
 end
 
 @Test function RangeReduceReverse()
-   result = {5 into 1}:reduce({}, function(acc, i)
+   result = {5 into 1}:reduce({}, function(acc, i):table
       acc[#acc] = i
       return acc
    end)
@@ -1387,7 +1387,7 @@ end
 @Test function RangeMethodChaining()
    -- Use reduce directly on a range (filter returns a table, so can't chain reduce on it)
    -- Sum even numbers by filtering in the reducer
-   sum = {1 to 20}:reduce(0, function(acc, i)
+   sum = {1 to 20}:reduce(0, function(acc, i):num
       if i % 2 is 0 then return acc + i end
       return acc
    end)

--- a/src/tiri/tests/test_regex.tiri
+++ b/src/tiri/tests/test_regex.tiri
@@ -61,7 +61,7 @@ end
    end
 
    do
-      local r = function(Value) return Value end
+      local r = function(Value:str) return Value end
       assert(r 'text' is 'text', 'Whitespace-separated r string call syntax should remain unchanged')
    end
 end

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -280,6 +280,15 @@ end
    assert(omitted is nil, "a trailing nil-only result should behave like an omitted result")
 end
 
+@Test function LeadingNilResultIsPreserved()
+   function nil_then_value()
+      return nil, 'success'
+   end
+   local empty, value = nil_then_value()
+   assert(empty is nil, "a leading nil result should retain its position")
+   assert(value is 'success', "a concrete result after nil should retain its position and type")
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- RECURSIVE FUNCTIONS REQUIRE EXPLICIT TYPE
 

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -164,7 +164,7 @@ end
 end
 
 @Test function InferredMultipleReturns()
-   function pair(A, B)
+   function pair(A:num, B:num)
       return A, B
    end
    x, y = pair(1, 2)
@@ -262,6 +262,22 @@ end
    end
    result = bareReturn()
    assert(result is nil, "bare return should return nil")
+end
+
+@Test function NilOnlyReturnIsVoid()
+   function nil_only()
+      return nil
+   end
+   assert(nil_only() is nil, "an explicit nil-only return should behave like a bare return")
+end
+
+@Test function TrailingNilOnlyResultIsOmitted()
+   function value_with_trailing_nil()
+      return 42, nil
+   end
+   local value, omitted = value_with_trailing_nil()
+   assert(value is 42, "the concrete leading result should be inferred")
+   assert(omitted is nil, "a trailing nil-only result should behave like an omitted result")
 end
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_return_types.tiri
+++ b/src/tiri/tests/test_return_types.tiri
@@ -138,6 +138,38 @@ end
    assert(alternate() is 3, "third call returns number")
 end
 
+@Test function ExplicitAnyParameterInfersVariantResult()
+   function get_value(Input:any)
+      Input ?! return 'default'
+      return Input
+   end
+
+   assert(get_value(nil) is 'default', 'an empty explicit-any parameter should use the concrete fallback')
+   assert(get_value('value') is 'value', 'an explicit-any parameter should permit an inferred variant result')
+   assert(get_value(42) is 42, 'the inferred any result should accept values of different types')
+
+   function variant_first(Input:any)
+      if Input then return Input end
+      return 'default'
+   end
+
+   assert(variant_first(false) is 'default', 'a later concrete fallback should not narrow an inferred any result')
+   assert(variant_first(42) is 42, 'explicit-any inference should be independent of return source order')
+end
+
+@Test function ImplicitDynamicStillRequiresResultAnnotation()
+   try
+      exec([[
+         extern glUnspecifiedValue
+         function unresolved_value()
+            return glUnspecifiedValue
+         end
+      ]])
+   success
+      error('an unspecified dynamic return should still require an explicit result annotation')
+   end
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- TYPE INFERENCE FROM RETURN STATEMENTS (no explicit declaration)
 

--- a/src/tiri/tests/test_safe_nav.tiri
+++ b/src/tiri/tests/test_safe_nav.tiri
@@ -89,7 +89,7 @@ end
 
 @Test function testSafeMethodChain()
    account = { profile = { email = "user@example.com" } }
-   function account:getProfile()
+   function account:getProfile():table
       return self.profile
    end
    email = account?:getProfile()?.email
@@ -136,7 +136,7 @@ end
 
 @Test function testSafeNavPresenceInsideCallLosesFallback()
    guest = nil
-   function capture(value)
+   function capture(value):any
       return value
    end
 
@@ -152,7 +152,7 @@ end
 
 @Test function testSafeNavPresenceWithSiblingArgumentLosesFallback()
    guest = nil
-   function capture(first, second)
+   function capture(first, second):<any, any>
       return first, second
    end
 
@@ -275,7 +275,7 @@ end
             return 0xff
          end
       },
-      getData = function(self)
+      getData = function(self):table
          return self.data
       end
    }

--- a/src/tiri/tests/test_stress.tiri
+++ b/src/tiri/tests/test_stress.tiri
@@ -209,7 +209,7 @@ end
    assert(result is 832040, "Fibonacci calculation failed")
 
    -- Test mutual recursion
-   global is_odd
+   global function is_odd(N):bool end
    global function is_even(N)
       if N is 0 then
          return true
@@ -218,7 +218,7 @@ end
       end
    end
 
-   global function is_odd(N)
+   global function is_odd(N):bool
       if N is 0 then
          return false
       else

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -539,7 +539,7 @@ end
    MAKESTRUCT('AnchoredBranch', 'eLeaf:AnchoredLeaf')
    MAKESTRUCT('AnchoredRoot', 'eBranch:AnchoredBranch')
 
-   function create_view()
+   function create_view():any
       local root = struct.new('AnchoredRoot')
       root.branch.leaf.value = 417
       root.branch.leaf.name = 'parent payload remains alive'
@@ -734,7 +734,7 @@ end
 @Test function FastFieldBytecodeDisassembly()
    MAKESTRUCT('FastFieldDisassembly', 'lValue')
 
-   function capture_struct_disassembly()
+   function capture_struct_disassembly():<num, str>
       local value = struct.new('FastFieldDisassembly')
       value.value = 19
       local result = value.value

--- a/src/tiri/tests/test_ternary.tiri
+++ b/src/tiri/tests/test_ternary.tiri
@@ -434,7 +434,7 @@ end
    v = process(true ? 5 :> 10)
    assert(v is 10, "Failed ternary as function argument: expected 10, got " .. tostring(v))
 
-   function myFunc(value)
+   function myFunc(value):num
       return value
    end
 
@@ -466,7 +466,7 @@ end
 -- combination of both
 
 @Test function Concat()
-   function returnString(Arg)
+   function returnString(Arg:str):str
       if Arg then return Arg else return "Result" end
    end
 

--- a/src/tiri/tests/test_tips.tiri
+++ b/src/tiri/tests/test_tips.tiri
@@ -54,20 +54,20 @@ glConcatScript = [[
 glFunctionLoopScript = [[
    -- Function expression in range loop (should warn)
    for i in {0 into 10} do
-      callback = function() return i end
+      callback = function():num return i end
    end
 
    -- Function expression in while loop (should warn)
    count = 0
    while count < 5 do
-      handler = function() return count end
+      handler = function():num return count end
       count = count + 1
    end
 
    -- Function expression in generic for loop (should warn)
    data = { a = 1, b = 2 }
    for k, v in pairs(data) do
-      processor = function() return v end
+      processor = function():num return v end
    end
 
    -- Arrow function in loop (should warn)
@@ -267,9 +267,9 @@ end
 @Test function NestedLoops()
    statement = [[
    for i in {0 into 3} do
-      outer_fn = function() return i end  -- Warning: function in loop
+      outer_fn = function():num return i end  -- Warning: function in loop
       for j in {0 into 3} do
-         inner_fn = function() return i + j end  -- Warning: function in nested loop
+         inner_fn = function():num return i + j end  -- Warning: function in nested loop
       end
    end
 ]]

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -25,7 +25,7 @@ function build_source(Signature)
    return "local function typed(" .. Signature .. ") return " .. returns .. " end return typed"
 end
 
-function compile_signature(Signature)
+function compile_signature(Signature:str):func
    factory = exec(build_source(Signature))
    assert(type(factory) is "function", "Chunk did not produce a function")
    return factory
@@ -40,7 +40,7 @@ end
 end
 
 @Test function MixedParameters()
-   mixed = compile_signature("Untyped, Typed:bool")
+   mixed = compile_signature("Untyped:any, Typed:bool")
    results = { mixed("anything", true) }
    assert(results[0] is "anything", "Untyped parameter should accept any value")
    assert(results[1] is true, "Typed boolean parameter should pass through")

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -91,7 +91,7 @@ end
    local captured = 1
    function capture() return captured end
    local pointer = debug.upvalueID(capture, 0)
-   local callable = setmetatable({}, { __call = function(Self) return Self end })
+   local callable = setmetatable({}, { __call = function(Self):table return Self end })
 
    assert(accept_nil(nil) is nil, 'nil should satisfy nil')
    assert(accept_bool(true) is true, 'true should satisfy bool')
@@ -633,7 +633,7 @@ end
    assert(glContractNumber is 3, 'A rejected store from a separately compiled chunk must preserve the global value')
 
    global glContractArray:array = array<int> { 4, 8 }
-   function read_contract_array()
+   function read_contract_array():num
       return glContractArray[1]
    end
    expect_contract_failure(function() exec("glContractArray = {}") end, 'global')
@@ -1065,7 +1065,7 @@ end
 
 @Test function ContractDisassemblyOrder()
    local script = obj.new('tiri', { statement = [[
-function first(Values:array)
+function first(Values:array):any
    return Values[0]
 end
 ]] })

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -129,6 +129,19 @@ end
    assert(byte_text() is 'hello', 'Registered array method results should participate in return inference')
 end
 
+@Test function NativeObjectConstructorResultIsInferred()
+   local parent = obj.new('time')
+
+   local function make_child()
+      local child = parent.new('time')
+      return child
+   end
+
+   local child = make_child()
+   assert(type(child) is 'object', 'An object new() member call should infer an object result')
+   parent.free()
+end
+
 @Test function ArrayDescriptorInvalidation()
    local values = array<int> { 1 }
    values = array<string> { 'changed' }

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -43,7 +43,7 @@ end
    local disassembly = disassemble_source(string.format([[
 MAKESTRUCT('%s', 'lValue')
 captured_point = struct.new('%s')
-function read_point()
+function read_point():num
    return captured_point.value
 end
 function write_point()

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -119,6 +119,16 @@ end
    assert(returned[1] is 10, 'Array element descriptors should survive function result propagation')
 end
 
+@Test function NativeArrayMethodResultIsInferred()
+   local function byte_text()
+      local bytes = array<byte>
+      bytes ..= 'hello'
+      return bytes:getString()
+   end
+
+   assert(byte_text() is 'hello', 'Registered array method results should participate in return inference')
+end
+
 @Test function ArrayDescriptorInvalidation()
    local values = array<int> { 1 }
    values = array<string> { 'changed' }

--- a/src/vector/tests/test_dash_array.tiri
+++ b/src/vector/tests/test_dash_array.tiri
@@ -73,7 +73,7 @@ end
    except e when ERR_SetValueNotArray
       caught = true
       assert(e.message:contains('array<double>'),
-         'The DashArray type mismatch should identify array<double> as the expected field type.')
+         'The DashArray type mismatch should identify array<double> as the expected field type, got: ' .. e.message)
    end
 
    assert(caught, 'An array<int> should not be accepted by the DashArray field.')

--- a/src/xquery/tests/test_math.tiri
+++ b/src/xquery/tests/test_math.tiri
@@ -8,7 +8,7 @@
 local MATH_NAMESPACE = 'http://www.w3.org/2005/xpath-functions/math'
 local MATH_DECLARE = 'declare namespace math = "' .. MATH_NAMESPACE .. '"; '
 
-local function executeMath(Expression)
+local function executeMath(Expression:str):<obj, num>
    local query = obj.new('xquery', {
       statement = MATH_DECLARE .. Expression
    })
@@ -16,7 +16,7 @@ local function executeMath(Expression)
    return query, err
 end
 
-local function describeError(Query, Err)
+local function describeError(Query:obj, Err:num):str
    if Query and Query.errorMsg and Query.errorMsg != '' then
       return Query.errorMsg
    end

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -209,7 +209,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Process a class XML file and extract method/action/field information
 
-function processClassXML(FilePath, DocPath)
+function processClassXML(FilePath:str, DocPath:str):<str, table>
    content = io.readAll(FilePath)
    content ?! return
 
@@ -304,7 +304,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-global function buildDocCache(DocPath)
+global function buildDocCache(DocPath):table
    -- Build the documentation cache from XML files
 
    cache = {
@@ -413,7 +413,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-global function loadDocCache(DocPath)
+global function loadDocCache(DocPath):table
    -- Attempt to load the cache, returns nil if invalid
    msg('Loading document cache from ' .. CACHE_PATH)
 
@@ -422,11 +422,11 @@ global function loadDocCache(DocPath)
       cache = loadFile(CACHE_PATH)
    except ex
       msg('Failed to run cache file.  Error: ' .. ex.message)
-      return nil
+      return
    end
 
-   if cache.version != 6 then msg('Unsupported version'); return nil end
-   if cache.sdkPath != DocPath then msg('Path mismatch: ' .. cache.sdkPath .. ' != ' .. DocPath); return nil end
+   if cache.version != 6 then msg('Unsupported version'); return end
+   if cache.sdkPath != DocPath then msg('Path mismatch: ' .. cache.sdkPath .. ' != ' .. DocPath); return end
 
    module_count = 0
    class_count = 0
@@ -434,7 +434,7 @@ global function loadDocCache(DocPath)
    for k, v in pairs(cache.classes or {}) do class_count++ end
    if module_count is 0 or class_count is 0 then
       msg('Documentation cache is empty; rebuilding.')
-      return nil
+      return
    end
 
    return cache

--- a/tools/tiri_lsp/include/lsp_handlers.tiri
+++ b/tools/tiri_lsp/include/lsp_handlers.tiri
@@ -172,7 +172,6 @@ global function registerCoreHandlers(Self)
    -- initialized: Client confirms handshake complete (notification, no response)
    Self._handlers['initialized'] = function(Msg, State)
       logMessage(Self, 'LSP initialized notification received - handshake complete')
-      return nil
    end
 
    -- shutdown: Client requests shutdown preparation
@@ -195,14 +194,12 @@ global function registerCoreHandlers(Self)
          logMessage(Self, 'LSP exit notification - unexpected (no prior shutdown)')
       end
       State.should_disconnect = true
-      return nil
    end
 
    -- $/cancelRequest: Client wants to cancel a pending request (notification)
    -- Since we process requests synchronously, we just acknowledge and ignore
    Self._handlers['$/cancelRequest'] = function(Msg, State)
       logVerbose(Self, 'Cancel request received for id: ' .. tostring(Msg.params.id))
-      return nil  -- Notification, no response
    end
 
    -------------------------------------------------------------------------------------------------------------------
@@ -223,8 +220,6 @@ global function registerCoreHandlers(Self)
       -- Compute and publish diagnostics
       params = computeDiagnostics(glDocuments[doc.uri])
       sendNotification(Self, State.clientSocket, 'textDocument/publishDiagnostics', params)
-
-      return nil  -- Notification, no response
    end
 
    -- textDocument/didChange: Document content changed
@@ -263,7 +258,6 @@ global function registerCoreHandlers(Self)
          params = computeDiagnostics(glDocuments[uri])
          sendNotification(Self, State.clientSocket, 'textDocument/publishDiagnostics', params)
       end
-      return nil  -- Notification, no response
    end
 
    -- textDocument/didClose: Client closed a document
@@ -279,8 +273,6 @@ global function registerCoreHandlers(Self)
          uri = uri,
          diagnostics = array<table>
       })
-
-      return nil  -- Notification, no response
    end
 
    -------------------------------------------------------------------------------------------------------------------

--- a/tools/tiri_lsp/include/lsp_hover.tiri
+++ b/tools/tiri_lsp/include/lsp_hover.tiri
@@ -101,7 +101,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Doc(text="Hover Support - Type Inference")
-function buildTypeMap(Doc)
+function buildTypeMap(Doc):table
    -- Build a mapping of variable names to class types based on obj.new() calls
    typeMap = {}
 
@@ -157,7 +157,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 
 @Doc(text="Hover Support - Content Resolution and Formatting")
-function formatClassHover(ClassName, ClassDoc)
+function formatClassHover(ClassName, ClassDoc):str
    md = '**class ' .. ClassName .. '**\n\n'
    md ..= ClassDoc.comment
    if ClassDoc.module and #ClassDoc.module > 0 then
@@ -208,7 +208,7 @@ function formatModuleFunctionHover(ModuleName, FuncName, FuncDoc)
    return md
 end
 
-function formatBuiltinHover(FuncName, BuiltinDoc)
+function formatBuiltinHover(FuncName, BuiltinDoc):str
    md = f'**{FuncName}** _(Built-in)_\n\n'
    if BuiltinDoc.prototype?? then
       md ..= '```lua\n' .. BuiltinDoc.prototype .. '\n```\n\n'
@@ -217,12 +217,12 @@ function formatBuiltinHover(FuncName, BuiltinDoc)
    return md
 end
 
-function formatKeywordHover(Keyword, KeywordDoc)
+function formatKeywordHover(Keyword, KeywordDoc):str
    md = f'**{Keyword}** _(Keyword)_\n\n' .. KeywordDoc.comment
    return md
 end
 
-function formatParserAnnotationHover(AnnotationName, AnnotationDoc)
+function formatParserAnnotationHover(AnnotationName, AnnotationDoc):str
    md = f'**@{AnnotationName}** _(Parser annotation)_\n\n'
    if AnnotationDoc.prototype?? then
       md ..= '```lua\n' .. AnnotationDoc.prototype .. '\n```\n\n'
@@ -430,7 +430,7 @@ function resolveStructFieldHover(TokenInfo:table, Doc:table, Position:table):str
 end
 
 @Doc(text="Resolve hover content for a token")
-global function resolveHoverContent(TokenInfo, Doc, Position)
+global function resolveHoverContent(TokenInfo, Doc, Position):str
    -- Priority: keywords, builtins, class names, module functions, object methods/fields
 
    if not TokenInfo then return nil end

--- a/tools/tiri_lsp/include/lsp_lib.tiri
+++ b/tools/tiri_lsp/include/lsp_lib.tiri
@@ -378,7 +378,7 @@ end
 -- Compute start and end columns for an error range based on context
 -- Returns: start_col, end_col
 
-global function computeErrorRange(Doc:table, Line:num, Column:num)
+global function computeErrorRange(Doc:table, Line:num, Column:num):<num, num>
    -- Find the target line
    if Line >= getTotalLines(Doc) then return Column, Column + 1 end
 
@@ -632,7 +632,7 @@ function runStdioServer(Self:table)
    end
 end
 
-global function lspStart(Options)
+global function lspStart(Options):table
    Options ?= {}
 
    self.port            = Options.port or 5007

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -98,11 +98,11 @@ global function tokenizeTiri(Source:str):array
       return Char is ')' or Char is ']' or Char is '}'
    end
 
-   function isRangeWord(Ident)
+   function isRangeWord(Ident:str):bool
       return Ident is 'to' or Ident is 'into'
    end
 
-   function previousNonWhitespace(Pos)
+   function previousNonWhitespace(Pos:num):num
       while Pos >= 0 do
          c = Source:sub(Pos, Pos + 1)
          if c is ' ' or c is '\t' then Pos -= 1 else break end
@@ -110,7 +110,7 @@ global function tokenizeTiri(Source:str):array
       return Pos
    end
 
-   function nextNonWhitespace(Pos)
+   function nextNonWhitespace(Pos:num):num
       while Pos < len do
          c = Source:sub(Pos, Pos + 1)
          if c is ' ' or c is '\t' then Pos++ else break end
@@ -118,7 +118,7 @@ global function tokenizeTiri(Source:str):array
       return Pos
    end
 
-   function skipQuotedSource(Pos, Quote)
+   function skipQuotedSource(Pos:num, Quote):num
       Pos++
       while Pos < len do
          c = Source:sub(Pos, Pos + 1)
@@ -896,7 +896,7 @@ global function extractFoldingRanges(Doc:table):array
       comment_pos = line_text:find('--')
 
       -- Check for block openers (only if not in a comment)
-      function checkKeyword(RxPattern)
+      function checkKeyword(RxPattern):num
          start_pos, stop_pos = RxPattern.findFirst(line_text)
          if start_pos and (not comment_pos or start_pos < comment_pos) then
             return start_pos

--- a/tools/tiri_lsp/include/lsp_protocol.tiri
+++ b/tools/tiri_lsp/include/lsp_protocol.tiri
@@ -49,7 +49,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse a JSON-RPC 2.0 message
 
-function parseMessage(JsonBody)
+function parseMessage(JsonBody):<any, str>
    local msg
    try
       msg = json.decode(JsonBody)
@@ -151,7 +151,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Incoming Data Handling
 
-function initClientState(Self:table, ClientSocket:any)
+function initClientState(Self:table, ClientSocket:any):table
    state = ClientSocket._state()
 
    if not state.initialised then

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -280,7 +280,7 @@ end
    }
    state = {
       clientSocket = {
-         acWrite = function(Text) return ERR_Okay end
+         acWrite = function(Text):num return ERR_Okay end
       }
    }
 


### PR DESCRIPTION
## Summary

- enforce deterministic compile-time inference for unannotated function results
- preserve inferred result metadata through callable descriptors, bytecode signatures, parser symbols, safe calls, arrays, native conversions, and child-object construction
- require explicit concrete or `any` result declarations when a dynamic value cannot be proven compatible
- migrate affected Tiri scripts and extend focused regression coverage

## Root cause

Unannotated results were validated and propagated through several independent mechanisms. Dynamic values could bypass inferred contracts, while static descriptor, parser-symbol, and runtime signature paths did not consistently retain proven result types.

## Impact

Functions with deterministic results now expose trusted inferred signatures to callers and tooling. Intentional variants still require an explicit `any`, and concrete declarations continue to provide runtime checking for dynamic sources.

## Validation

- Debug modular build and install
- parser unit tests
- return-type and type-contract suites
- type-guided emission and JIT signature suites
- Tiri LSP suites
- object and mesh-gradient regressions
- full CTest sweep during the primary implementation, with timing-sensitive network tests passing on focused rerun