### PR TITLE
[Tiri] Enforced native structure field categories

### DIFF
--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -17,6 +17,8 @@
 
 #include <format>
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
 #include <cstring>
 #include <optional>
 #include <kotuku/main.h>
@@ -25,54 +27,132 @@
 
 #define LJLIB_MODULE_struct
 
-static bool write_primitive_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex,
-   int ElementIndex = 0)
+static NativeStructType effective_scalar_type(const struct_field &Field)
 {
-   switch (Field.NativeType) {
+   if (Field.NativeType != NativeStructType::Legacy) return Field.NativeType;
+
+   if (Field.Type & FD_FLOAT) return NativeStructType::Float;
+   if (Field.Type & FD_DOUBLE) return NativeStructType::Double;
+   if (Field.Type & FD_INT64) {
+      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt64 : NativeStructType::Int64;
+   }
+   if (Field.Type & FD_INT) {
+      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt32 : NativeStructType::Int32;
+   }
+   if (Field.Type & FD_WORD) {
+      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt16 : NativeStructType::Int16;
+   }
+   if (Field.Type & FD_BYTE) return NativeStructType::UInt8;
+   return NativeStructType::Legacy;
+}
+
+static const char * scalar_type_name(NativeStructType Type)
+{
+   switch (Type) {
+      case NativeStructType::Bool: return "bool";
+      case NativeStructType::Char: return "char";
+      case NativeStructType::Int8: return "int8";
+      case NativeStructType::UInt8: return "uint8";
+      case NativeStructType::Int16: return "int16";
+      case NativeStructType::UInt16: return "uint16";
+      case NativeStructType::Int32: return "int32";
+      case NativeStructType::UInt32: return "uint32";
+      case NativeStructType::Int64: return "int64";
+      case NativeStructType::UInt64: return "uint64";
+      case NativeStructType::Float: return "float";
+      case NativeStructType::Double: return "double";
+      default: return "unknown";
+   }
+}
+
+static double finite_integer_value(lua_State *L, int StackIndex, CSTRING FieldName, NativeStructType Type)
+{
+   if (lua_type(L, StackIndex) != LUA_TNUMBER) {
+      luaL_error(L, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
+         scalar_type_name(Type));
+   }
+
+   const double value = lua_tonumber(L, StackIndex);
+   if (not std::isfinite(value)) {
+      luaL_error(L, ERR::OutOfRange, "Field '%s' requires a finite number for %s storage.", FieldName,
+         scalar_type_name(Type));
+   }
+   return std::trunc(value);
+}
+
+template <typename T> static void write_signed_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
+   CSTRING FieldName, NativeStructType Type, int Bits)
+{
+   const double modulus = std::ldexp(1.0, Bits);
+   const double half = std::ldexp(1.0, Bits - 1);
+   double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type), modulus);
+   if (value >= half) value -= modulus;
+   else if (value < -half) value += modulus;
+   ((T *)Address)[ElementIndex] = T(value);
+}
+
+template <typename T> static void write_unsigned_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
+   CSTRING FieldName, NativeStructType Type, int Bits)
+{
+   const double modulus = std::ldexp(1.0, Bits);
+   const double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type), modulus);
+   if (value < 0) ((T *)Address)[ElementIndex] = T(uint64_t(0) - uint64_t(-value));
+   else ((T *)Address)[ElementIndex] = T(value);
+}
+
+static bool write_primitive_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex,
+   CSTRING FieldName, int ElementIndex = 0)
+{
+   const auto type = effective_scalar_type(Field);
+   switch (type) {
       case NativeStructType::Bool:
+         if (lua_type(L, StackIndex) != LUA_TBOOLEAN) {
+            luaL_error(L, ERR::InvalidType, "Field '%s' requires a bool value.", FieldName);
+         }
          ((bool *)Address)[ElementIndex] = lua_toboolean(L, StackIndex);
          return true;
       case NativeStructType::Char:
       case NativeStructType::Int8:
-         ((int8_t *)Address)[ElementIndex] = int8_t(lua_tointeger(L, StackIndex));
+         write_signed_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8);
          return true;
       case NativeStructType::UInt8:
-         ((uint8_t *)Address)[ElementIndex] = uint8_t(lua_tointeger(L, StackIndex));
+         write_unsigned_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8);
          return true;
       case NativeStructType::Int16:
-         ((int16_t *)Address)[ElementIndex] = int16_t(lua_tointeger(L, StackIndex));
+         write_signed_field<int16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16);
          return true;
       case NativeStructType::UInt16:
-         ((uint16_t *)Address)[ElementIndex] = uint16_t(lua_tointeger(L, StackIndex));
+         write_unsigned_field<uint16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16);
          return true;
       case NativeStructType::Int32:
-         ((int32_t *)Address)[ElementIndex] = int32_t(lua_tointeger(L, StackIndex));
+         write_signed_field<int32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32);
          return true;
       case NativeStructType::UInt32:
-         ((uint32_t *)Address)[ElementIndex] = uint32_t(lua_tointeger(L, StackIndex));
+         write_unsigned_field<uint32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32);
          return true;
       case NativeStructType::Int64:
-         ((int64_t *)Address)[ElementIndex] = int64_t(lua_tonumber(L, StackIndex));
+         write_signed_field<int64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64);
          return true;
       case NativeStructType::UInt64:
-         ((uint64_t *)Address)[ElementIndex] = uint64_t(lua_tonumber(L, StackIndex));
+         write_unsigned_field<uint64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64);
          return true;
+      case NativeStructType::Float:
+      case NativeStructType::Double: {
+         if (lua_type(L, StackIndex) != LUA_TNUMBER) {
+            luaL_error(L, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
+               scalar_type_name(type));
+         }
+         const double value = lua_tonumber(L, StackIndex);
+         if ((type IS NativeStructType::Float) and std::isfinite(value) and std::abs(value) > FLT_MAX) {
+            luaL_error(L, ERR::OutOfRange, "Field '%s' value is out of range for float.", FieldName);
+         }
+         if (type IS NativeStructType::Float) ((float *)Address)[ElementIndex] = float(value);
+         else ((double *)Address)[ElementIndex] = value;
+         return true;
+      }
       default:
-         break;
+         return false;
    }
-
-   int Type = Field.Type;
-   if (Type & FD_FLOAT)       ((float *)Address)[ElementIndex]   = lua_tonumber(L, StackIndex);
-   else if (Type & FD_DOUBLE) ((double *)Address)[ElementIndex]  = lua_tonumber(L, StackIndex);
-   else if (Type & FD_INT64)  ((int64_t *)Address)[ElementIndex] = lua_tonumber(L, StackIndex);
-   else if (Type & FD_INT)    ((int *)Address)[ElementIndex]     = lua_tointeger(L, StackIndex);
-   else if (Type & FD_WORD) {
-      if (Type & FD_UNSIGNED) ((uint16_t *)Address)[ElementIndex] = lua_tointeger(L, StackIndex);
-      else ((int16_t *)Address)[ElementIndex] = lua_tointeger(L, StackIndex);
-   }
-   else if (Type & FD_BYTE)   ((uint8_t *)Address)[ElementIndex] = lua_tointeger(L, StackIndex);
-   else return false;
-   return true;
 }
 
 template <typename T> static void copy_array_to_vector(APTR Address, GCarray *Source)
@@ -85,7 +165,7 @@ template <typename T> static void copy_array_to_vector(APTR Address, GCarray *So
 static void write_array_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName)
 {
    if ((Field.Type & FD_CUSTOM) and (Field.Type & FD_BYTE) and (not (Field.Type & FD_VECTOR)) and
-         lua_isstring(L, StackIndex)) {
+         lua_type(L, StackIndex) IS LUA_TSTRING) {
       size_t length = 0;
       auto source = lua_tolstring(L, StackIndex, &length);
       size_t copied = std::min(length, size_t(Field.ArraySize - 1));
@@ -203,8 +283,11 @@ static void write_field(lua_State *L, APTR Address, const struct_field &Field, i
    }
    else if (Field.Type & FD_STRING) {
       if ((Field.Type & FD_CPP) and (not (Field.Type & FD_VECTOR))) {
+         if (lua_type(L, StackIndex) != LUA_TSTRING) {
+            luaL_error(L, ERR::InvalidType, "Field '%s' requires a string value.", FieldName);
+         }
          size_t length;
-         auto value = luaL_checklstring(L, StackIndex, &length);
+         auto value = lua_tolstring(L, StackIndex, &length);
          ((std::string *)Address)[0].assign(value, length);
          return;
       }
@@ -237,7 +320,7 @@ static void write_field(lua_State *L, APTR Address, const struct_field &Field, i
       else luaL_error(L, ERR::InvalidType, "Field '%s' requires an object, lightuserdata or nil.", FieldName);
       return;
    }
-   else if (write_primitive_field(L, Address, Field, StackIndex)) return;
+   else if (write_primitive_field(L, Address, Field, StackIndex, FieldName)) return;
 
    luaL_error(L, ERR::InvalidType, "Field '%s' does not support assignment (type %x).", FieldName, Field.Type);
 }

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -403,8 +403,14 @@ static bool read_primitive_field(lua_State *L, APTR Address, const struct_field 
    else if (Field.NativeType IS NativeStructType::UInt64) lua_pushnumber(L, ((uint64_t *)Address)[0]);
    else if (Type & FD_FLOAT)  lua_pushnumber(L, ((float *)Address)[0]);
    else if (Type & FD_DOUBLE) lua_pushnumber(L, ((double *)Address)[0]);
-   else if (Type & FD_INT64)  lua_pushnumber(L, ((int64_t *)Address)[0]);
-   else if (Type & FD_INT)    lua_pushinteger(L, ((int *)Address)[0]);
+   else if (Type & FD_INT64) {
+      if (Type & FD_UNSIGNED) lua_pushnumber(L, ((uint64_t *)Address)[0]);
+      else lua_pushnumber(L, ((int64_t *)Address)[0]);
+   }
+   else if (Type & FD_INT) {
+      if (Type & FD_UNSIGNED) lua_pushinteger(L, ((uint32_t *)Address)[0]);
+      else lua_pushinteger(L, ((int32_t *)Address)[0]);
+   }
    else if (Type & FD_WORD) {
       if (Type & FD_UNSIGNED) lua_pushinteger(L, ((uint16_t *)Address)[0]);
       else lua_pushinteger(L, ((int16_t *)Address)[0]);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3359,13 +3359,43 @@ static TRef rec_struct_payload_guard(jit_State *J, TRef StructRef, GCstruct *Val
    return data_ref;
 }
 
-static bool rec_struct_scalar_field(uint32_t FieldFlags)
+static NativeStructType rec_struct_scalar_type(uint32_t FieldFlags, NativeStructType NativeType)
 {
-   constexpr uint32_t supported = FD_FLOAT|FD_DOUBLE|FD_INT64|FD_INT|FD_WORD|FD_BYTE;
+   if (NativeType != NativeStructType::Legacy) return NativeType;
+   if (FieldFlags & FD_FLOAT) return NativeStructType::Float;
+   if (FieldFlags & FD_DOUBLE) return NativeStructType::Double;
+   if (FieldFlags & FD_INT64) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt64 : NativeStructType::Int64;
+   }
+   if (FieldFlags & FD_INT) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt32 : NativeStructType::Int32;
+   }
+   if (FieldFlags & FD_WORD) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt16 : NativeStructType::Int16;
+   }
+   if (FieldFlags & FD_BYTE) return NativeStructType::UInt8;
+   return NativeStructType::Legacy;
+}
+
+static bool rec_struct_scalar_field(uint32_t FieldFlags, NativeStructType NativeType)
+{
    constexpr uint32_t unsupported = FD_ARRAY|FD_VECTOR|FD_STRUCT|FD_POINTER|FD_STRING|FD_OBJECT|FD_FUNCTION|FD_CPP;
    if (FieldFlags & unsupported) return false;
-   if ((FieldFlags & FD_UNSIGNED) and not (FieldFlags & (FD_WORD|FD_BYTE))) return false;
-   return (FieldFlags & supported) != 0;
+
+   switch (rec_struct_scalar_type(FieldFlags, NativeType)) {
+      case NativeStructType::Char:
+      case NativeStructType::Int8:
+      case NativeStructType::UInt8:
+      case NativeStructType::Int16:
+      case NativeStructType::UInt16:
+      case NativeStructType::Int32:
+      case NativeStructType::Int64:
+      case NativeStructType::Float:
+      case NativeStructType::Double:
+         return true;
+      default:
+         return false;
+   }
 }
 
 static TRef rec_struct_get(jit_State *J, RecordOps *ops)
@@ -3377,34 +3407,43 @@ static TRef rec_struct_get(jit_State *J, RecordOps *ops)
    GCstr *key = strV(ops->rcv());
    int field_offset;
    uint32_t field_flags = 0;
-   int field_type = ir_struct_field_type(value, key, field_offset, field_flags);
+   NativeStructType native_type = NativeStructType::Legacy;
+   int field_type = ir_struct_field_type(value, key, field_offset, field_flags, native_type);
    if (field_type < 0) lj_trace_err(J, LJ_TRERR_BADTYPE);
 
-   if (not value->is_lifecycle_bound() and rec_struct_scalar_field(field_flags)) {
+   const auto scalar_type = rec_struct_scalar_type(field_flags, native_type);
+   if (scalar_type IS NativeStructType::Bool or scalar_type IS NativeStructType::UInt32 or
+         scalar_type IS NativeStructType::UInt64) {
+      lj_trace_err(J, LJ_TRERR_BADTYPE);
+   }
+
+   if (not value->is_lifecycle_bound() and rec_struct_scalar_field(field_flags, native_type)) {
       TRef data_ref = rec_struct_payload_guard(J, struct_ref, value);
       TRef addr_ref = emitir(IRT(IR_ADD, IRT_PTR), data_ref, lj_ir_kintp(J, field_offset));
 
-      if (field_flags & FD_FLOAT) {
+      if (scalar_type IS NativeStructType::Float) {
          TRef result_ref = emitir(IRT(IR_XLOAD, IRT_FLOAT), addr_ref, 0);
          return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_FLOAT);
       }
-      else if (field_flags & FD_DOUBLE) return emitir(IRT(IR_XLOAD, IRT_NUM), addr_ref, 0);
-      else if (field_flags & FD_INT64) {
+      else if (scalar_type IS NativeStructType::Double) return emitir(IRT(IR_XLOAD, IRT_NUM), addr_ref, 0);
+      else if (scalar_type IS NativeStructType::Int64) {
          TRef result_ref = emitir(IRT(IR_XLOAD, IRT_I64), addr_ref, 0);
          return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_I64);
       }
-      else if (field_flags & FD_WORD) {
-         IRType load_type = (field_flags & FD_UNSIGNED) ? IRT_U16 : IRT_I16;
+      else if (scalar_type IS NativeStructType::Int16 or scalar_type IS NativeStructType::UInt16) {
+         IRType load_type = (scalar_type IS NativeStructType::UInt16) ? IRT_U16 : IRT_I16;
          TRef result_ref = emitir(IRT(IR_XLOAD, load_type), addr_ref, 0);
          if (not LJ_DUALNUM) result_ref = emitir(IRTN(IR_CONV), result_ref, IRCONV_NUM_INT);
          return result_ref;
       }
-      else if (field_flags & FD_BYTE) {
-         TRef result_ref = emitir(IRT(IR_XLOAD, IRT_U8), addr_ref, 0);
+      else if (scalar_type IS NativeStructType::Char or scalar_type IS NativeStructType::Int8 or
+            scalar_type IS NativeStructType::UInt8) {
+         IRType load_type = (scalar_type IS NativeStructType::UInt8) ? IRT_U8 : IRT_I8;
+         TRef result_ref = emitir(IRT(IR_XLOAD, load_type), addr_ref, 0);
          if (not LJ_DUALNUM) result_ref = emitir(IRTN(IR_CONV), result_ref, IRCONV_NUM_INT);
          return result_ref;
       }
-      else {
+      else if (scalar_type IS NativeStructType::Int32) {
          TRef result_ref = emitir(IRT(IR_XLOAD, IRT_INT), addr_ref, 0);
          if (not LJ_DUALNUM) result_ref = emitir(IRTN(IR_CONV), result_ref, IRCONV_NUM_INT);
          return result_ref;
@@ -3426,61 +3465,28 @@ static void rec_struct_set(jit_State *J, RecordOps *ops)
    GCstr *key = strV(ops->rcv());
    int field_offset;
    uint32_t field_flags = 0;
-   int field_type = ir_struct_field_type(value, key, field_offset, field_flags);
+   NativeStructType native_type = NativeStructType::Legacy;
+   int field_type = ir_struct_field_type(value, key, field_offset, field_flags, native_type);
    if (field_type < 0) {
       lj_trace_err(J, LJ_TRERR_BADTYPE);
    }
 
    TRef val_ref = ops->ra;
-   if (not value->is_lifecycle_bound() and rec_struct_scalar_field(field_flags) and tref_isnumber(val_ref)) {
+   const auto scalar_type = rec_struct_scalar_type(field_flags, native_type);
+   if (not value->is_lifecycle_bound() and scalar_type IS NativeStructType::Double and tref_isnumber(val_ref)) {
       TRef data_ref = rec_struct_payload_guard(J, struct_ref, value);
       TRef addr_ref = emitir(IRT(IR_ADD, IRT_PTR), data_ref, lj_ir_kintp(J, field_offset));
 
-      if (field_flags & FD_FLOAT) {
-         TRef store_ref = val_ref;
-         if (tref_isint(val_ref)) store_ref = emitir(IRTN(IR_CONV), val_ref, IRCONV_NUM_INT);
-         store_ref = emitir(IRT(IR_CONV, IRT_FLOAT), store_ref, (IRT_FLOAT << IRCONV_DSH) | IRT_NUM);
-         emitir(IRT(IR_XSTORE, IRT_FLOAT), addr_ref, store_ref);
-      }
-      else if (field_flags & FD_DOUBLE) {
-         TRef store_ref = val_ref;
-         if (tref_isint(val_ref)) store_ref = emitir(IRTN(IR_CONV), val_ref, IRCONV_NUM_INT);
-         emitir(IRT(IR_XSTORE, IRT_NUM), addr_ref, store_ref);
-      }
-      else if (field_flags & FD_INT64) {
-         TRef store_ref;
-         if (tref_isint(val_ref)) {
-            store_ref = emitir(IRT(IR_CONV, IRT_I64), val_ref,
-               (IRT_I64 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
-         }
-         else {
-            store_ref = emitir(IRT(IR_CONV, IRT_I64), val_ref,
-               (IRT_I64 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
-         }
-         emitir(IRT(IR_XSTORE, IRT_I64), addr_ref, store_ref);
-      }
-      else if (field_flags & FD_WORD) {
-         TRef store_ref = val_ref;
-         if (tref_isnum(val_ref)) store_ref = emitir(IRTI(IR_CONV), val_ref, IRCONV_INT_NUM | IRCONV_ANY);
-         IRType store_type = (field_flags & FD_UNSIGNED) ? IRT_U16 : IRT_I16;
-         emitir(IRT(IR_XSTORE, store_type), addr_ref, store_ref);
-      }
-      else if (field_flags & FD_BYTE) {
-         TRef store_ref = val_ref;
-         if (tref_isnum(val_ref)) store_ref = emitir(IRTI(IR_CONV), val_ref, IRCONV_INT_NUM | IRCONV_ANY);
-         emitir(IRT(IR_XSTORE, IRT_U8), addr_ref, store_ref);
-      }
-      else {
-         TRef store_ref = val_ref;
-         if (tref_isnum(val_ref)) store_ref = emitir(IRTI(IR_CONV), val_ref, IRCONV_INT_NUM | IRCONV_ANY);
-         emitir(IRT(IR_XSTORE, IRT_INT), addr_ref, store_ref);
-      }
+      TRef store_ref = val_ref;
+      if (tref_isint(val_ref)) store_ref = emitir(IRTN(IR_CONV), val_ref, IRCONV_NUM_INT);
+      emitir(IRT(IR_XSTORE, IRT_NUM), addr_ref, store_ref);
       return;
    }
 
    TRef tmp_ref = rec_tmpref(J, ops->ra, IRTMPREF_IN1);
    TRef null_ref = lj_ir_kkptr(J, nullptr);
    lj_ir_call(J, IRCALL_bc_struct_setfield, struct_ref, ops->rc, tmp_ref, null_ref);
+   emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
 }
 
 //********************************************************************************************************************

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -159,7 +159,8 @@ static struct_field * find_cached_field(GCstruct *Struct, GCstr *Key, BCIns *Ins
 // JIT field type lookup.  Struct definitions are immutable for the lifetime of the Lua state, so the recorder can
 // derive a stable result type without reading the field payload or invoking any field access behaviour.
 
-extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, int &Offset, uint32_t &Flags)
+extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, int &Offset, uint32_t &Flags,
+   NativeStructType &NativeType)
 {
    if (not Struct or not Key) return -1;
 
@@ -167,6 +168,7 @@ extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, int &Offset, u
       const uint32_t flags = uint32_t(field->Type);
       Offset = field->Offset;
       Flags = flags;
+      NativeType = field->NativeType;
 
       // Order is significant because array, struct and object fields also carry element/storage flags.
       if ((flags & FD_CUSTOM) and (flags & FD_BYTE) and (flags & FD_ARRAY)) return IRT_STR;

--- a/src/tiri/jit/src/runtime/lj_struct.h
+++ b/src/tiri/jit/src/runtime/lj_struct.h
@@ -27,4 +27,4 @@ extern "C" void bc_struct_setfield(lua_State *, GCstruct *, GCstr *, TValue *, B
 
 // Side-effect-free field type lookup for JIT recording.
 
-extern "C" int ir_struct_field_type(GCstruct *, GCstr *, int &, uint32_t &);
+extern "C" int ir_struct_field_type(GCstruct *, GCstr *, int &, uint32_t &, NativeStructType &);

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -15,6 +15,12 @@ local ir_calla <const> = 96
 local ir_calll <const> = 97
 local ir_calls <const> = 98
 
+struct JITValidatedStructFields
+   Flag: bool
+   Signed: int8
+   Unsigned: uint8
+end
+
 @BeforeAll
 function SetupJitTests()
    jit.on()
@@ -2115,15 +2121,15 @@ end
 
 function traced_struct_numeric_write(Value:struct, Count:num)
    for i in {1 into Count} do
-      Value.value = i + 0.75
+      Value.value = i
       Value.ratio = i + 0.5
-      Value.large = (i * 1000000) + 0.75
+      Value.large = i * 1000000
       Value.single = i + 0.25
       Value.integral = i
-      Value.word = -(i + 0.75)
-      Value.byte = i + 250.75
-      Value.unsignedWord = i + 65525.75
-      Value.unsignedByte = i + 250.75
+      Value.word = -i
+      Value.byte = i + 200
+      Value.unsignedWord = i + 65000
+      Value.unsignedByte = i + 200
    end
 end
 
@@ -2145,22 +2151,20 @@ end
    assert(value.single is 10.25, f"Expected traced float write to retain 10.25, got {value.single}")
    assert(value.integral is 10, f"Expected traced integer-to-float write to retain 10, got {value.integral}")
    assert(value.word is -10, f"Expected traced word write to retain -10, got {value.word}")
-   assert(value.byte is 4, f"Expected traced byte write to wrap to 4, got {value.byte}")
-   assert(value.unsignedWord is 65535,
-      f"Expected traced unsigned word write to retain 65535, got {value.unsignedWord}")
-   assert(value.unsignedByte is 4,
-      f"Expected traced qualified byte write to wrap to 4, got {value.unsignedByte}")
+   assert(value.byte is 210, f"Expected traced byte write to retain 210, got {value.byte}")
+   assert(value.unsignedWord is 65010,
+      f"Expected traced unsigned word write to retain 65010, got {value.unsignedWord}")
+   assert(value.unsignedByte is 210,
+      f"Expected traced qualified byte write to retain 210, got {value.unsignedByte}")
 
    local store_trace_found = false
    for trace_no in {1 into 30} do
       local info = jit.util.traceInfo(trace_no)
-      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 9 then
+      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 1 then
          store_trace_found = true
-         assert(count_trace_calls(trace_no, info) is 0,
-            "Expected scalar struct writes to avoid the helper-call fallback")
       end
    end
-   assert(store_trace_found, "Expected scalar struct writes to emit direct XSTORE instructions")
+   assert(store_trace_found, "Expected validated double stores to retain a direct XSTORE path")
 
    -- Reuse the compiled access sites with a different definition whose fields have different offsets.
    for i in {1 into 20} do
@@ -2178,19 +2182,19 @@ end
       f"Expected guarded alternate integer-to-float write to retain 10, got {alternate.integral}")
    assert(alternate.word is -10,
       f"Expected guarded alternate word write to retain -10, got {alternate.word}")
-   assert(alternate.byte is 4,
-      f"Expected guarded alternate byte write to wrap to 4, got {alternate.byte}")
-   assert(alternate.unsignedWord is 65535,
-      f"Expected guarded alternate unsigned word write to retain 65535, got {alternate.unsignedWord}")
-   assert(alternate.unsignedByte is 4,
-      f"Expected guarded alternate qualified byte write to wrap to 4, got {alternate.unsignedByte}")
+   assert(alternate.byte is 210,
+      f"Expected guarded alternate byte write to retain 210, got {alternate.byte}")
+   assert(alternate.unsignedWord is 65010,
+      f"Expected guarded alternate unsigned word write to retain 65010, got {alternate.unsignedWord}")
+   assert(alternate.unsignedByte is 210,
+      f"Expected guarded alternate qualified byte write to retain 210, got {alternate.unsignedByte}")
 
    jit.flush()
    local result = 0
    for i in {0 to 20} do
       result = traced_struct_numeric_read(value, 10)
    end
-   assert(result is 100655737.5, f"Expected traced scalar struct sum 100655737.5, got {result}")
+   assert(result is 100654607.5, f"Expected traced scalar struct sum 100654607.5, got {result}")
 
    local load_trace_found = false
    for trace_no in {1 into 30} do
@@ -2206,6 +2210,49 @@ end
    local alternate_result = traced_struct_numeric_read(alternate, 10)
    assert(alternate_result is result,
       f"Expected guarded alternate struct read {result}, got {alternate_result}")
+end
+
+function traced_validated_signed_write(Value:struct, Input:any, Count:num)
+   for i in {1 into Count} do
+      Value.Signed = Input
+   end
+end
+
+@Test(hotpath=50) function JITStructFiniteNarrowingAndRejectedCategories()
+   local value = struct<JITValidatedStructFields> { Flag=true, Signed=12, Unsigned=34 }
+
+   jit.on()
+   jit.flush()
+   jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
+   for i in {1 into 20} do
+      traced_validated_signed_write(value, 12, 10)
+   end
+
+   traced_validated_signed_write(value, 140.75, 10)
+   assert(value.Signed is -116, 'A hot finite int8 store should truncate and wrap')
+
+   try
+      traced_validated_signed_write(value, math.huge, 10)
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f"Expected a hot non-finite store to raise ERR_OutOfRange, got {error_value.code}")
+   success
+      error('A hot non-finite int8 store should fail')
+   end
+   assert(value.Signed is -116, 'A rejected hot non-finite store should preserve the signed field')
+
+   value.Unsigned = 300
+   assert(value.Unsigned is 44, 'A specialised finite uint8 store should wrap')
+
+   try
+      value.Flag = 2
+   except error_value
+      assert(error_value.code is ERR_InvalidType,
+         f"Expected a specialised bool store to raise ERR_InvalidType, got {error_value.code}")
+   success
+      error('A numeric bool store should fail')
+   end
+   assert(value.Flag is true, 'A rejected specialised bool store should preserve the boolean field')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -219,8 +219,12 @@ end
       'bByte,wWord,uwUnsignedWord,lInteger,ulUnsigned,xWide,uxUnsignedWide,fFloat,dDouble')
    local legacy = struct.new('LegacyScalarValidation', {
       byte=255, word=-32768, unsignedWord=65535, integer=-2147483648, unsigned=4294967295,
-      wide=-9007199254740992, unsignedWide=9007199254740992, float=1.5, double=2.5
+      wide=-9007199254740992, unsignedWide=9223372036854777856, float=1.5, double=2.5
    })
+   assert(legacy.unsigned is 4294967295,
+      'Legacy unsigned int fields should preserve values with the high bit set')
+   assert(legacy.unsignedWide is 9223372036854777856,
+      'Legacy unsigned int64 fields should preserve values above the signed range')
    legacy.byte = 256
    legacy.word = 1.5
    legacy.unsignedWord = -1

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -57,6 +57,18 @@ function create_declared_user():struct<DeclaredUser>
    return struct<DeclaredUser> { }
 end
 
+function expect_struct_error(Action:func, ExpectedCode:num, Description:str)
+   local caught = false
+   try
+      Action()
+   except error_value
+      assert(error_value.code is ExpectedCode,
+         f"{Description}: expected error {ExpectedCode}, got {error_value.code}: {error_value.message}")
+      caught = true
+   end
+   assert(caught is true, Description .. ': assignment should have failed')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Retrieve a known struct from a function and test the field values.
 
@@ -83,6 +95,139 @@ end
    local empty_user = struct<DeclaredUser> { }
    assert(empty_user.Age is 0 and empty_user.Name is '', 'Empty initialisers should zero-initialise fields')
    assert(struct.new('DeclaredUser').Age is 0, 'struct.new() should interoperate with declarations')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+-- Primitive fields validate exact Tiri categories and native numeric domains before changing storage.
+
+@Test function NativeStructPrimitiveValidation()
+   local value = struct<DeclaredLayout> {
+      Bool=true, Char=-128, Byte=255, Int8=127, UInt8=0, Int16=-32768, UInt16=65535,
+      Int=-2147483648, UInt=4294967295, Int32=2147483647, UInt32=0,
+      Int64=-9223372036854775808, UInt64=9007199254740992, Float=1.25, Double=math.huge,
+      String='valid', Buffer='buffer'
+   }
+
+   assert(value.Bool is true and value.Char is -128 and value.Byte is 255,
+      'Constructor assignment should preserve valid bool and byte-sized values')
+   assert(value.Int16 is -32768 and value.UInt16 is 65535 and value.Int is -2147483648,
+      'Constructor assignment should preserve valid signed and unsigned integer boundaries')
+   assert(value.UInt is 4294967295 and value.Int32 is 2147483647 and value.UInt64 is 9007199254740992,
+      'Constructor assignment should preserve valid wide integer values')
+   assert(value.Float is 1.25 and value.Double is math.huge and value.String is 'valid' and value.Buffer is 'buffer',
+      'Constructor assignment should preserve floating, string and character-buffer values')
+
+   value.Bool = false
+   value.Char = 127
+   value.Byte = 0
+   value.Int8 = -128
+   value.UInt8 = 255
+   value.Int16 = 32767
+   value.UInt16 = 0
+   value.Int = 2147483647
+   value.UInt = 0
+   value.Int32 = -2147483648
+   value.UInt32 = 4294967295
+   value.Int64 = 9007199254740992
+   value.UInt64 = 18446744073709549568
+   value.Float = math.huge
+   assert(value.Float is math.huge, 'Float fields should accept positive infinity')
+   value.Float = 0 / 0
+   value.Double = -math.huge
+   value.String = 'updated'
+   assert(value.Bool is false and value.Char is 127 and value.UInt8 is 255 and value.Int16 is 32767,
+      'Later assignment should accept valid scalar boundaries')
+   assert(value.UInt32 is 4294967295 and value.UInt64 is 18446744073709549568,
+      'Later assignment should accept representable unsigned wide values below their exclusive upper bounds')
+   assert(value.Float != value.Float and value.Double is -math.huge and value.String is 'updated',
+      'Floating special values and exact strings should remain valid')
+
+   value.Bool = true
+   expect_struct_error(() => do value.Bool = 1 end, ERR_InvalidType, 'bool should reject numbers')
+   expect_struct_error(() => do value.Bool = nil end, ERR_InvalidType, 'bool should reject nil')
+   assert(value.Bool is true, 'Rejected bool assignment should preserve the prior value')
+
+   value.Int8 = 12
+   value.Int8 = 12.5
+   assert(value.Int8 is 12, 'Integer fields should truncate finite fractional values toward zero')
+   expect_struct_error(() => do value.Int8 = 0 / 0 end, ERR_OutOfRange, 'int8 should reject NaN')
+   expect_struct_error(() => do value.Int8 = math.huge end, ERR_OutOfRange, 'int8 should reject infinity')
+   value.Int8 = 128
+   assert(value.Int8 is -128, 'Signed integer overflow should wrap through the destination width')
+   value.Int8 = -129
+   assert(value.Int8 is 127, 'Signed integer underflow should wrap through the destination width')
+   expect_struct_error(() => do value.Int8 = '12' end, ERR_InvalidType, 'int8 should reject numeric strings')
+   expect_struct_error(() => do value.Int8 = nil end, ERR_InvalidType, 'integer fields should reject nil')
+   assert(value.Int8 is 127, 'Rejected wrong-category assignments should preserve the prior value')
+
+   value.UInt8 = -1
+   assert(value.UInt8 is 255, 'Unsigned integer underflow should wrap through the destination width')
+   value.UInt8 = 256
+   assert(value.UInt8 is 0, 'Unsigned integer overflow should wrap through the destination width')
+
+   value.Int16 = -32769
+   assert(value.Int16 is 32767, 'int16 underflow should wrap')
+   value.Int16 = 32768
+   assert(value.Int16 is -32768, 'int16 overflow should wrap')
+   value.UInt16 = -1
+   assert(value.UInt16 is 65535, 'uint16 underflow should wrap')
+   value.UInt16 = 65536
+   assert(value.UInt16 is 0, 'uint16 overflow should wrap')
+   value.Int32 = -2147483649
+   assert(value.Int32 is 2147483647, 'int32 underflow should wrap')
+   value.Int32 = 2147483648
+   assert(value.Int32 is -2147483648, 'int32 overflow should wrap')
+   value.UInt32 = -1
+   assert(value.UInt32 is 4294967295, 'uint32 underflow should wrap')
+   value.UInt32 = 4294967296
+   assert(value.UInt32 is 0, 'uint32 overflow should wrap')
+   value.Int64 = 9223372036854775808
+   assert(value.Int64 is -9223372036854775808, 'int64 overflow should wrap')
+   value.UInt64 = -2048
+   assert(value.UInt64 is 18446744073709549568, 'uint64 underflow should wrap to a representable result')
+   value.UInt64 = 18446744073709551616
+   assert(value.UInt64 is 0, 'uint64 overflow should wrap')
+
+   value.Float = 2.5
+   expect_struct_error(() => do value.Float = '2.5' end, ERR_InvalidType, 'float should reject numeric strings')
+   expect_struct_error(() => do value.Float = nil end, ERR_InvalidType, 'float should reject nil')
+   expect_struct_error(() => do value.Float = 3.5e38 end, ERR_OutOfRange, 'float should reject finite overflow')
+   assert(value.Float is 2.5, 'Rejected float assignments should preserve the prior value')
+   expect_struct_error(() => do value.Double = '2.5' end, ERR_InvalidType, 'double should reject numeric strings')
+
+   value.String = 'sentinel'
+   expect_struct_error(() => do value.String = 42 end, ERR_InvalidType, 'owned strings should reject numbers')
+   expect_struct_error(() => do value.String = nil end, ERR_InvalidType, 'owned strings should reject nil')
+   assert(value.String is 'sentinel', 'Rejected string assignment should preserve the prior value')
+   expect_struct_error(() => do value.Buffer = 42 end, ERR_InvalidType, 'character buffers should reject numbers')
+   expect_struct_error(() => do value.Char = 'A' end, ERR_InvalidType, 'scalar char should reject strings')
+end
+
+----------------------------------------------------------------------------------------------------------------------
+
+@Test function NativeStructConstructorAndLegacyValidation()
+   local wrong_bool:any = 2
+   expect_struct_error(() => do struct<DeclaredLayout> { Bool=wrong_bool } end, ERR_InvalidType,
+      'Declared constructor expressions should validate primitive fields')
+   expect_struct_error(() => do struct.new('DeclaredLayout', { String=42 }) end, ERR_InvalidType,
+      'struct.new() should use the same exact string validation')
+   local narrowed = struct.new('DeclaredLayout', { String='temporary', Int=1.5 })
+   assert(narrowed.Int is 1 and narrowed.String is 'temporary',
+      'constructors should apply the same finite numeric narrowing as later assignment')
+
+   MAKESTRUCT('LegacyScalarValidation',
+      'bByte,wWord,uwUnsignedWord,lInteger,ulUnsigned,xWide,uxUnsignedWide,fFloat,dDouble')
+   local legacy = struct.new('LegacyScalarValidation', {
+      byte=255, word=-32768, unsignedWord=65535, integer=-2147483648, unsigned=4294967295,
+      wide=-9007199254740992, unsignedWide=9007199254740992, float=1.5, double=2.5
+   })
+   legacy.byte = 256
+   legacy.word = 1.5
+   legacy.unsignedWord = -1
+   expect_struct_error(() => do legacy.integer = {} end, ERR_InvalidType,
+      'legacy integer fields should reject non-number categories')
+   assert(legacy.byte is 0 and legacy.word is 1 and legacy.unsignedWord is 65535,
+      'Legacy fields should use the same deterministic truncation and wrapping contract')
 end
 
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Added exact boolean, numeric and string category checks for native structure writes

* Defined safe finite integer truncation and width-based wrapping without undefined native casts

* Routed unsupported JIT scalar stores through validated helpers while retaining safe direct access paths

* Added declared, legacy and hot-trace coverage for conversion parity and rejected mutations