### PR TITLE
[Tiri] Added member-specialised array type contracts

### DIFF
--- a/apps/tests/test_find.tiri
+++ b/apps/tests/test_find.tiri
@@ -2,7 +2,7 @@
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array):str
+function resolveFirstPath(Candidates:array<string>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -35,7 +35,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runFind(Parameters:array):table
+function runFind(Parameters:array<string>):table
    local output = ''
    local errors = ''
    local task_params = array<string> { quoteTaskParam(glFindPath:replace('\\', '/')) }
@@ -51,10 +51,10 @@ function runFind(Parameters:array):table
       args = task_params:concat(' '),
       flags = TSF_WAIT|TSF_SHELL,
       timeout = 10,
-      outputCallback = function(Task:obj, Buffer:array)
+      outputCallback = function(Task:obj, Buffer:array<byte>)
          output ..= Buffer:getString()
       end,
-      errorCallback = function(Task:obj, Buffer:array)
+      errorCallback = function(Task:obj, Buffer:array<byte>)
          errors ..= Buffer:getString()
       end
    })

--- a/apps/tests/test_proximity.tiri
+++ b/apps/tests/test_proximity.tiri
@@ -773,6 +773,11 @@ function ConnectTunnelPassesSSLHandshake()
    check socket.mtConnect('127.0.0.1', PROXY_PORT, 3.0)
    local err = proc.sleep()
 
+   -- The client socket is switched to SSL mid-connection by SetSSL(), so it must be freed explicitly rather than
+   -- left to garbage collection.  A surviving SSL socket keeps encrypting subsequent plain-HTTP proxy requests,
+   -- which the proxy then rejects as malformed.
+
+   socket.free()
    ssl_server.free()
 
    assert(err is ERR_Okay, 'SSL CONNECT tunnel timed out or failed: ' .. mSys.GetErrorMsg(err))

--- a/apps/tests/test_tuku.tiri
+++ b/apps/tests/test_tuku.tiri
@@ -10,7 +10,7 @@ glUploadFile <const> = 'temp:tuku-test-upload.txt'
 
 glTask = mSys.CurrentTask()
 
-function resolveFirstPath(Candidates:array):str
+function resolveFirstPath(Candidates:array<string>):str
    for candidate in values(Candidates) do
       err, resolved = mSys.ResolvePath(candidate, RSF_APPROXIMATE)
       if err is ERR_Okay then return resolved end
@@ -278,7 +278,7 @@ end
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function runTuku(Parameters:array):table
+function runTuku(Parameters:array<string>):table
    local output = ''
    local errors = ''
    local task_params = array<string> { quoteTaskParam(glTukuPath:replace('\\', '/')) }
@@ -294,10 +294,10 @@ function runTuku(Parameters:array):table
       args = task_params:concat(' '),
       flags = TSF_WAIT|TSF_SHELL, -- The SHELL option keeps the DOS window from opening.
       timeout = 10,
-      outputCallback = function(Task:obj, Buffer:array)
+      outputCallback = function(Task:obj, Buffer:array<byte>)
          output ..= Buffer:getString()
       end,
-      errorCallback = function(Task:obj, Buffer:array)
+      errorCallback = function(Task:obj, Buffer:array<byte>)
          errors ..= Buffer:getString()
       end
    })

--- a/apps/tuku.tiri
+++ b/apps/tuku.tiri
@@ -103,7 +103,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value form arguments into application/x-www-form-urlencoded request content.
 
-function encodeFormBody(Form:array):str
+function encodeFormBody(Form:array<string>):str
    params = array<table>
 
    for field in values(Form) do
@@ -132,7 +132,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Converts an array of name=value or name=@file arguments into multipart/form-data request content.
 
-function buildMultipartBody(Fields:array):<str, str>
+function buildMultipartBody(Fields:array<string>):<str, str>
    boundary = '----TukuBoundary' .. tostring(math.floor(mSys.PreciseTime())) .. string.format('%08x', math.random(0, 0x7FFFFFFF))
    crlf <const> = '\r\n'
    body = ''
@@ -429,7 +429,7 @@ function makeRequestConfig(Args:table):table
 
    if Args._captureBody then
       Args._bodyBuffer = ''
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          Args._bodyBuffer ..= Buffer:getString()
       end
    elseif output_file != nil then
@@ -438,12 +438,12 @@ function makeRequestConfig(Args:table):table
       -- Redirect probes only need status and headers.
    elseif Args['include'] and not Args.status then
       Args._bodyBuffer = ''
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          Args._bodyBuffer ..= Buffer:getString()
       end
    elseif not Args.status then
       -- Streams response body chunks to standard output when the body is not redirected or suppressed.
-      request.incoming = function(HTTP:obj, Buffer:array)
+      request.incoming = function(HTTP:obj, Buffer:array<byte>)
          io.write(Buffer:getString())
       end
    end
@@ -554,7 +554,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Returns available response header names, falling back to the phase 3 common keys on older HTTP builds.
 
-function readResponseHeaderNames(HTTP:obj):array
+function readResponseHeaderNames(HTTP:obj):array<string>
    names = array<string>
    seen = {}
 
@@ -627,7 +627,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Removes sensitive headers (Authorization, Cookie) from a custom header array.
 
-function filterSensitiveHeaders(Headers:array):array
+function filterSensitiveHeaders(Headers:array<string>):array<string>
    result = array<string>
    for header in values(Headers) do
       name = tostring(header)

--- a/examples/gradients.tiri
+++ b/examples/gradients.tiri
@@ -66,7 +66,7 @@ end
 -- The mesh is rebuilt from fresh struct values each time rather than read-modify-written, which keeps the nested
 -- FRGB colours marshalling cleanly back into the gradient.
 
-function gouraudVertex(X:num, Y:num, Col:array):any
+function gouraudVertex(X:num, Y:num, Col:array<double>):any
    v = struct.new('GouraudVertex')
    v.x = X
    v.y = Y

--- a/scripts/benchmark.tiri
+++ b/scripts/benchmark.tiri
@@ -25,7 +25,7 @@ end
 
 -- Generate a text report from benchmark statistics
 
-bmark.textReport = function(Results:table):array
+bmark.textReport = function(Results:table):array<string>
    assert(Results, "Results are required")
    local msg = array<string>
    msg:push('=== BENCHMARK RESULTS ===')
@@ -312,7 +312,7 @@ end
 -- Calculate 95% confidence interval for an array of values.
 -- Returns table with lower, upper bounds and margin of error.
 
-bmark.confidenceInterval = function(Values:array, Confidence:num):table
+bmark.confidenceInterval = function(Values:array<double>, Confidence:num):table
    Confidence ??= 0.95
 
    local n = #Values
@@ -366,7 +366,7 @@ end
 -- are considered outliers.  Default multiplier k is 1.5 (standard), use 3.0 for extreme outliers only.  Returns
 -- table with filtered values and outlier information.
 
-bmark.removeOutliers = function(Values:array, Multiplier:num):table
+bmark.removeOutliers = function(Values:array<double>, Multiplier:num):table
    Multiplier ??= 1.5
 
    local n = #Values
@@ -445,7 +445,7 @@ end
 -- Generate a histogram from an array of values.
 -- Returns table with bins, counts, and distribution information.
 
-bmark.histogram = function(Values:array, BinCount:num):table
+bmark.histogram = function(Values:array<double>, BinCount:num):table
    BinCount ??= 10
 
    local n = #Values
@@ -531,7 +531,7 @@ end
 
 -- Generate an ASCII histogram representation for console output.
 
-bmark.histogramText = function(Histogram:table, Width:num):array
+bmark.histogramText = function(Histogram:table, Width:num):array<string>
    Width ??= 40
 
    local msg = array<string>
@@ -718,7 +718,7 @@ end
 
 -- Generate a text report from a comparison result
 
-bmark.comparisonReport = function(Comparison:table):array
+bmark.comparisonReport = function(Comparison:table):array<string>
    local msg = array<string>
 
    local function formatChange(Change:num, Improved:boolean):string

--- a/scripts/gui/colourdialog.tiri
+++ b/scripts/gui/colourdialog.tiri
@@ -217,7 +217,7 @@ function buildLayout(self, Options)
       align     = 'left'
    })
 
-   self._colourNodes = array<any>
+   self._colourNodes = array<object>
 
    dy += gui.getFontHeight(gui.fonts.window) + WIDGET_GAP
    y = dy

--- a/scripts/gui/fileview.tiri
+++ b/scripts/gui/fileview.tiri
@@ -215,7 +215,7 @@ function updateFileAttributes(Item:table, Info)
    end
 end
 
-function defineViewColumns(Path:str):array
+function defineViewColumns(Path:str):array<table>
    if not Path then
       return array<table> {
          { attrib='name',      title='Name',       width=16, showIcons=true },
@@ -242,7 +242,7 @@ end
 
 -- Return allowed file extensions as a string list, which is cached.
 
-function getFilters(self):array
+function getFilters(self):array<string>
    if self._filters then return self._filters end
    self._filters = array<string>
    if self.filterList then
@@ -870,7 +870,7 @@ gui.fileview = function(Options)
    -- Execute a command with a given Mode.  All files listed in the Items argument will be passed to the object as
    -- a mass execution operation.
 
-   function openFiles(Items:array, Mode:str)
+   function openFiles(Items:array<table>, Mode:str)
       Items ?! return
       self.path ?! return
 

--- a/scripts/gui/libview.tiri
+++ b/scripts/gui/libview.tiri
@@ -476,7 +476,7 @@ gui.initView = function(Options:table, BuildUI, NewItems)
 
    -- Return a table of all selected items
 
-   vw.selectedItems = function():array
+   vw.selectedItems = function():array<table>
       list = array<table> { }
       for item in values(vw.items) do
          if item._selected then

--- a/scripts/net/url.tiri
+++ b/scripts/net/url.tiri
@@ -182,7 +182,7 @@ end
 @input Query string without a leading question mark
 @result Array of decoded key-value tables
 ]])
-url.parseQueryList = function(Query:str):array
+url.parseQueryList = function(Query:str):array<table>
    params = array<table>
    Query ?! return params
 

--- a/scripts/options.tiri
+++ b/scripts/options.tiri
@@ -78,7 +78,7 @@ rx_css_colour <const> = regex.new(
 ----------------------------------------------------------------------------------------------------------------------
 -- Build the canonical name and alias list for a parameter definition.
 
-function normalise_names(Definition:table):array
+function normalise_names(Definition:table):array<string>
    names = array<string>
    seen = {}
 
@@ -221,7 +221,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert an existing array or table into an array of strings.
 
-function string_array(Value:any):array
+function string_array(Value:any):array<string>
    result = array<string>
 
    for item in values(Value) do
@@ -234,7 +234,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a comma-separated string into an array of trimmed strings.
 
-function convert_csv(Value:any, Param:table):array
+function convert_csv(Value:any, Param:table):array<string>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -254,7 +254,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Convert a raw value into an array of strings.
 
-function convert_array(Value:any, Param:table):array
+function convert_array(Value:any, Param:table):array<string>
    if type(Value) is 'array' or type(Value) is 'table' then
       return string_array(Value)
    end
@@ -549,7 +549,7 @@ function add_result_value(Result:table, ArgNames:table, Presence:table, Param:ta
    IsExplicit:bool):table
 
    if Param.multiple then
-      local param_values:array = Result[Param.name]
+      local param_values:array<any> = Result[Param.name]
       if param_values is nil then
          param_values = array<any>
          Result[Param.name] = param_values
@@ -721,7 +721,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Remove launcher options and the script path from ordered task parameters.
 
-function get_script_arguments(Parameters:array):array
+function get_script_arguments(Parameters:array<string>):array<string>
    result = array<string>
    index = 0
    script_seen = false
@@ -755,7 +755,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Read ordered arguments from the active task, or return nil if they are unavailable.
 
-function get_task_parameters(Options:table):array
+function get_task_parameters(Options:table):array<string>
    if Options and Options.taskParameters != nil then
       assert(type(Options.taskParameters) is 'array', 'Options.taskParameters must be an array.')
       return Options.taskParameters
@@ -774,7 +774,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered command-line tokens, preserving the order of named and positional input.
 
-function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array)
+function parse_ordered_input(Parser:table, Result:table, ArgNames:table, Presence:table, Input:array<string>)
    -- Parse one ordered command-line token and apply it to the result table.
 
    function parse_ordered_token(Parser:table, Result:table, ArgNames:table, Presence:table, Token:str, PosIndex:num):num
@@ -932,7 +932,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Join prepared text lines into one help string.
 
-function append_help_line(Output:array, Line:str)
+function append_help_line(Output:array<string>, Line:str)
    if Line:trim() is '' then
       if #Output > 0 and Output[#Output - 1] != '' then
          Output:push('')
@@ -944,7 +944,7 @@ function append_help_line(Output:array, Line:str)
    Output:push(Line:rtrim())
 end
 
-function line_list(Lines:array):str
+function line_list(Lines:array<string>):str
    output = array<string>
 
    for line in values(Lines) do
@@ -1070,7 +1070,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Append parser metadata fields to help output.
 
-function append_metadata(Lines:array, Parser:table)
+function append_metadata(Lines:array<string>, Parser:table)
    if Parser.epilog then
       Lines:push('')
       Lines:push(Parser.epilog)
@@ -1524,7 +1524,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Normalise a relationship field to an array of canonical parameter names.
 
-function relationship_names(Parser:table, Param:table, Field:str, Value:any):array
+function relationship_names(Parser:table, Param:table, Field:str, Value:any):array<string>
    names = array<string>
 
    if type(Value) is 'string' then
@@ -1869,7 +1869,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse a non-command parser context from explicit ordered input.
 
-function parse_context_ordered_input(Parser:table, Input:array):table
+function parse_context_ordered_input(Parser:table, Input:array<string>):table
    input_result = {}
    input_arg_names = {}
    input_presence = {}
@@ -1929,7 +1929,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse ordered input for a parser that defines subcommands.
 
-function parse_command_ordered_input(Parser:table, Input:array):table
+function parse_command_ordered_input(Parser:table, Input:array<string>):table
    global_input = array<string>
    command_input = array<string>
    command = nil

--- a/scripts/tempus.tiri
+++ b/scripts/tempus.tiri
@@ -662,7 +662,7 @@ end
 
 function convert_time_zone_info(Info:table):table
    local transitions = array<table> {}
-   local source_transitions:array = Info.transitions
+   local source_transitions:array<table> = Info.transitions
    if source_transitions is nil then source_transitions = array<table> {} end
 
    for _, transition in ipairs(source_transitions) do

--- a/scripts/vfx.tiri
+++ b/scripts/vfx.tiri
@@ -562,7 +562,7 @@ vfx.wipes.radial.init = function(State, Options)
 
    State.interval    = 1.0 / State.segments
    State.stroke_size = State.max_radius / State.segments
-   State.ellipses    = array<any>
+   State.ellipses    = array<object>
    State.clip.flags  = 'ApplyStrokes|ApplyFills'
 
    State.center = State.clip.viewport.new('VectorEllipse', {

--- a/src/backstage/interface.tiri
+++ b/src/backstage/interface.tiri
@@ -441,7 +441,7 @@ function bool_literal(Value:any):str
    return Value ? 'true' :> 'false'
 end
 
-function sorted_field_names(Fields:table):array
+function sorted_field_names(Fields:table):array<string>
    names = array<string> { }
    if not Fields then return names end
 
@@ -453,7 +453,7 @@ function sorted_field_names(Fields:table):array
    return names
 end
 
-function route_param_array(Name:str, Names:array, Fields:table):str
+function route_param_array(Name:str, Names:array<string>, Fields:table):str
    out = f"static constexpr std::array<BackstageParam, {#Names}> {Name} = {{"
 
    if #Names > 0 then

--- a/src/backstage/tests/test_backstage.tiri
+++ b/src/backstage/tests/test_backstage.tiri
@@ -114,7 +114,7 @@ function websocket_frame(Payload:str, Opcode:num):str
    return frame
 end
 
-function websocket_exchange(Frames:array, ExpectedTokens:array):str
+function websocket_exchange(Frames:array<string>, ExpectedTokens:array<string>):str
    response = ''
    frames_sent = false
 

--- a/src/regex/tests/test_quantifiers.tiri
+++ b/src/regex/tests/test_quantifiers.tiri
@@ -5,7 +5,7 @@
    local lazy = regex.new("<.+?>")
    local text = "<em>bold</em>"
 
-   local match:array = greedy.search(text)
+   local match:array<any> = greedy.search(text)
    assert(match[0][0] is "<em>bold</em>", "Greedy quantifier should consume closing tag, got " .. tostring(match[0][0]))
 
    match = lazy.search(text)

--- a/src/svg/tests/test_svg.tiri
+++ b/src/svg/tests/test_svg.tiri
@@ -67,7 +67,7 @@ end
 -- an 8x8 discrete cosine transform.  Bitmap.data is an external byte-array view over the pixel buffer, so this avoids
 -- the overhead of calling a pixel reader for every source pixel.
 
-function pHash(Bitmap:obj):array
+function pHash(Bitmap:obj):array<byte>
    local sample_size <const> = 32
    local dct_size <const> = 8
    local pixels = Bitmap.data
@@ -148,7 +148,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashString(Hash:array):str
+function pHashString(Hash:array<byte>):str
    local result = ''
    for i in {0 to #Hash} do result ..= string.format('%d,', Hash[i]) end
    return result
@@ -156,7 +156,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashDistance(Left:array, Right:array):num
+function pHashDistance(Left:array<byte>, Right:array<byte>):num
    assert(#Left is #Right, 'Perceptual hashes must have the same length')
    local set_bits <const> = array<byte> { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 }
    local distance = 0
@@ -171,7 +171,7 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 
-function pHashTestSVG(Path:str, ExpectedHash:array, MaxDistance:num, Stable:bool)
+function pHashTestSVG(Path:str, ExpectedHash:array<byte>, MaxDistance:num, Stable:bool)
    local bmp = renderSVGToBitmap(glSVGFolder .. Path, Stable)
    local hash = pHash(bmp)
    local distance = pHashDistance(hash, ExpectedHash)

--- a/src/tiri/jit/src/bytecode/lj_bcdump.h
+++ b/src/tiri/jit/src/bytecode/lj_bcdump.h
@@ -38,7 +38,7 @@ constexpr uint8_t BCDUMP_HEAD3 = 0x4a;
 // or to the dump format, you *must* set BCDUMP_VERSION to 0x80 or higher.
 
 constexpr uint8_t BCDUMP_VERSION_LEGACY = 0x81;
-constexpr uint8_t BCDUMP_VERSION = 0x83;
+constexpr uint8_t BCDUMP_VERSION = 0x84;
 
 // Compatibility flags.
 

--- a/src/tiri/jit/src/lj_api.cpp
+++ b/src/tiri/jit/src/lj_api.cpp
@@ -1198,6 +1198,11 @@ extern void lua_upvaluejoin(lua_State *L, int idx1, int n1, int idx2, int n2)
    lj_checkapi((uint32_t)n2 < fn2->l.nupvalues, "bad upvalue %d", n2 + 1);
    setgcrefr(fn1->l.uvptr[n1], fn2->l.uvptr[n2]);
    lj_gc_objbarrier(L, fn1, gcref(fn1->l.uvptr[n1]));
+
+   // Repointing the upvalue invalidates any trace that constified the previous cell or guarded on its address, so
+   // discard compiled code for the same reason as lua_setupvalue().
+
+   lj_trace_flushall(L);
 }
 
 //********************************************************************************************************************
@@ -1424,6 +1429,19 @@ extern CSTRING lua_setupvalue(lua_State *L, int idx, int n)
       L->top--;
       copyTV(L, val, L->top);
       lj_gc_barrier(L, o, L->top);
+
+      // The parser marks an upvalue immutable when no assignment to it appears in the source, which allows the
+      // recorder to constify it into a trace (see rec_upvalue_constify()).  Writing through the debug API breaks that
+      // assumption, so the flag must be cleared and any trace that already baked in the old value discarded.
+      // Otherwise compiled code keeps returning the stale constant.
+
+      if (tvisfunc(f) and isluafunc(funcV(f))) {
+         GCupval *uv = &o->uv;
+         if (uv->immutable) {
+            uv->immutable = 0;
+            lj_trace_flushall(L);
+         }
+      }
    }
    return name;
 }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -465,6 +465,31 @@ static RecordedContract rec_contract_guard_userdata(jit_State *J, TRef ValueRef,
    return rec_contract_guard_range(J, ValueRef, Value, false);
 }
 
+static RecordedContract rec_contract_guard_array(
+   jit_State *J, TRef ValueRef, cTValue *Value, const RuntimeContractEntry &Entry)
+{
+   if (not tvisarray(Value)) return RecordedContract::Mismatch;
+   if (Entry.array_element_type IS AET::MAX or Entry.array_element_type IS AET::ANY) {
+      return RecordedContract::Basic;
+   }
+
+   GCarray *array = arrayV(Value);
+   auto string_storage = [](AET Storage) {
+      return Storage IS AET::CSTR or Storage IS AET::STR_CPP or Storage IS AET::STR_GC;
+   };
+   bool matching_storage = array->elemtype IS Entry.array_element_type or
+      (string_storage(array->elemtype) and string_storage(Entry.array_element_type));
+   if (not matching_storage) return RecordedContract::Mismatch;
+   if (Entry.array_element_type IS AET::STRUCT and not Entry.array_struct_name.empty()) {
+      return RecordedContract::Complex;
+   }
+
+   IRBuilder ir(J);
+   TRef element_type = ir.fload(ValueRef, IRFL_ARRAY_ELEMTYPE, IRT_U8);
+   ir.guard_eq(element_type, ir.kint(int32_t(array->elemtype)), IRT_U8);
+   return RecordedContract::Basic;
+}
+
 static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Encoded)
 {
    RuntimeContractDescriptor descriptor;
@@ -505,7 +530,7 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
             if (not tvistab(value)) result = RecordedContract::Mismatch;
             break;
          case TiriType::Array:
-            if (not tvisarray(value)) result = RecordedContract::Mismatch;
+            result = rec_contract_guard_array(J, value_ref, value, *entry);
             break;
          case TiriType::Object:
             result = rec_contract_guard_object(J, value_ref, value, entry->object_class_id);

--- a/src/tiri/jit/src/parser/ast/builder.h
+++ b/src/tiri/jit/src/parser/ast/builder.h
@@ -153,7 +153,8 @@ private:
    }
 
    ParserResult<ParameterListResult> parse_parameter_list(bool);
-   ParserResult<Token> parse_type_annotation(TiriType &Type, struct_record *&StructDef);
+   ParserResult<Token> parse_type_annotation(
+      TiriType &Type, struct_record *&StructDef, ArrayElementDescriptor &ArrayElement);
    ParserResult<std::vector<TableField>> parse_table_fields(bool *);
    ParserResult<ExprNodeList> parse_call_arguments(bool *);
 

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -647,7 +647,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
 
          Token start = this->ctx.tokens().current();
          GCstr *type_str = start.payload().as_string();
-         int64_t specified_size = this->ctx.lex().array_typed_size;
+         int64_t specified_size = this->ctx.lex().current_array_typed_size;
          this->ctx.tokens().advance();
 
          // If size is -2, the lexer found a comma followed by a non-literal expression

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -99,11 +99,39 @@ ParserResult<ExprNodeList> AstBuilder::parse_expression_list()
 //********************************************************************************************************************
 // Parses comma-separated lists of identifiers with optional attributes (e.g., <close>).
 
-ParserResult<Token> AstBuilder::parse_type_annotation(TiriType &Type, struct_record *&StructDef)
+ParserResult<Token> AstBuilder::parse_type_annotation(
+   TiriType &Type, struct_record *&StructDef, ArrayElementDescriptor &ArrayElement)
 {
    Token type_token = this->ctx.tokens().current();
    auto kind = type_token.kind();
    std::string_view type_view;
+
+   if (kind IS TokenKind::ArrayTyped) {
+      int64_t array_size = this->ctx.lex().current_array_typed_size;
+      bool nested_specialisation = this->ctx.lex().current_array_typed_nested;
+      this->ctx.tokens().advance();
+      if (array_size != -1) {
+         return this->fail<Token>(ParserErrorCode::UnexpectedToken, type_token,
+            "Array type annotations cannot declare a size");
+      }
+      if (nested_specialisation) {
+         return this->fail<Token>(ParserErrorCode::UnexpectedToken, type_token,
+            "Nested array member specialisation is not supported; use 'array<array>'");
+      }
+
+      GCstr *element_symbol = type_token.payload().as_string();
+      std::string_view element_name(strdata(element_symbol), element_symbol->len);
+      auto element = describe_array_element(element_name, &this->ctx.lua());
+      if (not element or (element->storage IS AET::STRUCT and element_name.starts_with("struct<") and
+          not element->struct_def)) {
+         return this->fail<Token>(ParserErrorCode::UnknownTypeName, type_token,
+            std::format("Unknown array member type '{}'", element_name));
+      }
+
+      Type = TiriType::Array;
+      ArrayElement = *element;
+      return ParserResult<Token>::success(type_token);
+   }
 
    if (kind IS TokenKind::StructTyped) {
       // struct<Name> lexes as a single token carrying the referenced struct name
@@ -137,6 +165,11 @@ ParserResult<Token> AstBuilder::parse_type_annotation(TiriType &Type, struct_rec
          std::format("Unknown type name '{}'; expected a valid type name", type_view));
    }
 
+   if (Type IS TiriType::Array) {
+      return this->fail<Token>(ParserErrorCode::ExpectedTypeName, type_token,
+         "Array type annotations require a member type, for example 'array<string>' or 'array<any>'");
+   }
+
    if (Type IS TiriType::Struct and this->ctx.check(TokenKind::Less)) {
       this->ctx.tokens().advance();
       auto name_token = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);
@@ -168,7 +201,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       // Parse optional type annotation (:type)
       if (this->ctx.check(TokenKind::Colon)) {
          this->ctx.tokens().advance();
-         auto parsed = this->parse_type_annotation(identifier.type, identifier.struct_def);
+         auto parsed = this->parse_type_annotation(
+            identifier.type, identifier.struct_def, identifier.array_element);
          if (not parsed.ok()) return ParserResult<Identifier>::failure(parsed.error_ref());
       }
 
@@ -231,7 +265,8 @@ ParserResult<std::vector<Identifier>> AstBuilder::parse_name_list()
       // Parse optional type annotation (:type) after attribute (supports `name <const>:type` syntax)
       if (identifier.type IS TiriType::Unknown and this->ctx.check(TokenKind::Colon)) {
          this->ctx.tokens().advance();
-         auto parsed = this->parse_type_annotation(identifier.type, identifier.struct_def);
+         auto parsed = this->parse_type_annotation(
+            identifier.type, identifier.struct_def, identifier.array_element);
          if (not parsed.ok()) return ParserResult<Identifier>::failure(parsed.error_ref());
       }
 
@@ -276,7 +311,7 @@ ParserResult<AstBuilder::ParameterListResult> AstBuilder::parse_parameter_list(b
 
          if (this->ctx.check(TokenKind::Colon)) {
             this->ctx.tokens().advance();
-            auto parsed = this->parse_type_annotation(param.type, param.struct_def);
+            auto parsed = this->parse_type_annotation(param.type, param.struct_def, param.array_element);
             if (not parsed.ok()) return ParserResult<ParameterListResult>::failure(parsed.error_ref());
             param.type_is_explicit = true;
          }
@@ -581,10 +616,12 @@ ParserResult<FunctionReturnTypes> AstBuilder::parse_return_type_annotation()
 
          TiriType parsed = TiriType::Unknown;
          struct_record *struct_def = nullptr;
-         auto type_token = this->parse_type_annotation(parsed, struct_def);
+         ArrayElementDescriptor array_element;
+         auto type_token = this->parse_type_annotation(parsed, struct_def, array_element);
          if (not type_token.ok()) return ParserResult<FunctionReturnTypes>::failure(type_token.error_ref());
          result.types[result.count] = parsed;
-         result.struct_defs[result.count++] = struct_def;
+         result.struct_defs[result.count] = struct_def;
+         result.array_elements[result.count++] = array_element;
 
       } while (this->ctx.match(TokenKind::Comma).ok());
 
@@ -594,7 +631,8 @@ ParserResult<FunctionReturnTypes> AstBuilder::parse_return_type_annotation()
       else return this->fail<FunctionReturnTypes>(ParserErrorCode::ExpectedToken, current, "expected '>' to close return type list");
    }
    else {
-      auto type_token = this->parse_type_annotation(result.types[0], result.struct_defs[0]);
+      auto type_token = this->parse_type_annotation(
+         result.types[0], result.struct_defs[0], result.array_elements[0]);
       if (not type_token.ok()) return ParserResult<FunctionReturnTypes>::failure(type_token.error_ref());
       result.count = 1;
    }

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -62,6 +62,7 @@ struct FunctionReturnTypes {
    std::array<TiriType, MAX_RETURN_TYPES> types{};  // Return types (Unknown = unused slot)
    std::array<CLASSID, MAX_RETURN_TYPES> object_class_ids{}; // Inferred object-class constraints
    std::array<struct_record *, MAX_RETURN_TYPES> struct_defs{}; // Resolved layouts for struct<Name> results
+   std::array<ArrayElementDescriptor, MAX_RETURN_TYPES> array_elements{}; // Array member constraints
    std::array<StaticValueHandle, MAX_RETURN_TYPES> descriptors{};
    uint8_t count = 0;           // Number of declared types (0 = not declared)
    bool is_variadic = false;    // True if declaration ends with ... (last type repeats)
@@ -213,11 +214,13 @@ struct Identifier {
    bool is_future_reserved = false;  // True when parsed from a keyword reserved for future syntax
    TiriType type = TiriType::Unknown;  // Explicit type annotation (Unknown = no annotation)
    struct_record *struct_def = nullptr; // Resolved layout for struct<Name> annotations
+   ArrayElementDescriptor array_element{}; // Resolved member type for array<Element> annotations
    mutable StaticBindingID binding_id = 0;
    mutable StaticValueHandle static_value = 0;
    mutable TiriType global_contract_type = TiriType::Unknown;
    mutable CLASSID global_contract_object_class_id = CLASSID::NIL;
    mutable struct_record *global_contract_struct_def = nullptr;
+   mutable ArrayElementDescriptor global_contract_array_element{};
    mutable GlobalContractPolicy global_contract_policy = GlobalContractPolicy::Advisory;
 
    // Default constructor
@@ -289,6 +292,7 @@ struct FunctionParameter {
    Identifier name;
    TiriType type = TiriType::Any;
    struct_record *struct_def = nullptr;
+   ArrayElementDescriptor array_element{};
    bool type_is_explicit = false;
    bool is_self = false;
 };

--- a/src/tiri/jit/src/parser/ast/statements.cpp
+++ b/src/tiri/jit/src/parser/ast/statements.cpp
@@ -385,7 +385,7 @@ ParserResult<StmtNodePtr> AstBuilder::parse_struct_declaration()
       Token type_token = this->ctx.tokens().current();
       bool array_type = type_token.kind() IS TokenKind::ArrayTyped;
       bool struct_typed = type_token.kind() IS TokenKind::StructTyped;
-      int64_t array_dimension = array_type ? this->ctx.lex().array_typed_size : -1;
+      int64_t array_dimension = array_type ? this->ctx.lex().current_array_typed_size : -1;
       if (array_type or struct_typed) this->ctx.tokens().advance();
       else {
          auto type_result = this->ctx.expect_identifier(ParserErrorCode::ExpectedIdentifier);

--- a/src/tiri/jit/src/parser/func_state.h
+++ b/src/tiri/jit/src/parser/func_state.h
@@ -70,6 +70,7 @@ struct FuncState {
       return arr;
    }();
    std::array<struct_record *, MAX_RETURN_TYPES> return_struct_defs{};
+   std::array<ArrayElementDescriptor, MAX_RETURN_TYPES> return_array_elements{};
    uint8_t return_declared_count = 0;
    uint8_t return_contract_count = 0;
    bool return_contract_variadic = false;

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -170,12 +170,14 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       if (param.type != TiriType::Unknown and param.type != TiriType::Any) {
          param_info.fixed_type = param.type;
          param_info.struct_def = param.struct_def;
+         param_info.array_element = param.array_element;
       }
       else if (param.name.static_value) {
          const auto &descriptor = this->ctx.descriptors().value(param.name.static_value);
          if (descriptor.primary != TiriType::Unknown and descriptor.primary != TiriType::Any) {
             param_info.fixed_type = descriptor.primary;
             param_info.struct_def = descriptor.struct_def;
+            param_info.array_element = descriptor.array_element;
          }
       }
       param_info.binding_id = param.name.binding_id;
@@ -204,6 +206,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       RuntimeContract contract{
          .type = param.type,
          .struct_def = param.struct_def,
+         .array_element = param.array_element,
          .label = param.name.is_blank ? nullptr : param.name.symbol,
          .boundary = ContractBoundary::Parameter,
          .position = uint8_t(i.raw() + 1),
@@ -234,6 +237,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       for (size_t i = 0; i < Payload.return_types.count and i < child_state.return_types.size(); ++i) {
          child_state.return_types[i] = Payload.return_types.types[i];
          child_state.return_struct_defs[i] = Payload.return_types.struct_defs[i];
+         child_state.return_array_elements[i] = Payload.return_types.array_elements[i];
          auto type = Payload.return_types.types[i];
          auto struct_def = Payload.return_types.struct_defs[i];
          child_state.signature_results[i] = ProtoTypeEntry{

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -14,6 +14,7 @@
       .type = Identifier.global_contract_type,
       .object_class_id = Identifier.global_contract_object_class_id,
       .struct_def = Identifier.global_contract_struct_def,
+      .array_element = Identifier.global_contract_array_element,
       .label = Identifier.symbol,
       .boundary = ContractBoundary::Global,
       .position = 1,

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -741,6 +741,9 @@ void IrEmitter::apply_inferred_local_type(BCReg Slot, const ExprNode& Value)
    info->fixed_type = inferred.type;
    info->object_class_id = (inferred.type IS TiriType::Object) ? inferred.object_class_id : CLASSID::NIL;
    info->struct_def = inferred.struct_def;
+   if (Value.static_value) {
+      info->array_element = this->ctx.descriptors().value(Value.static_value).array_element;
+   }
    info->static_value = Value.static_value;
    info->static_results = Value.static_results;
 }
@@ -760,6 +763,7 @@ bool IrEmitter::apply_analysed_local_type(BCReg Slot, StaticBindingID Binding)
    info->fixed_type = value.primary;
    info->object_class_id = value.object_class_id;
    info->struct_def = value.struct_def;
+   info->array_element = value.array_element;
    this->assert_analysed_local_type(Slot, Binding);
    return true;
 }
@@ -776,6 +780,8 @@ void IrEmitter::assert_analysed_local_type(BCReg Slot, StaticBindingID Binding) 
    lj_assertX(info.fixed_type IS value.primary, "analysed and emitted binding types diverged");
    lj_assertX(info.object_class_id IS value.object_class_id, "analysed and emitted binding object classes diverged");
    lj_assertX(info.struct_def IS value.struct_def, "analysed and emitted binding structures diverged");
+   lj_assertX(info.array_element IS value.array_element,
+      "analysed and emitted binding array members diverged");
 }
 
 BCReg IrEmitter::finalise_pending_local_assignment(PreparedAssignment& Target)
@@ -1245,6 +1251,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
          contracts[i] = RuntimeContract{
             .type = this->func_state.return_types[i],
             .struct_def = this->func_state.return_struct_defs[i],
+            .array_element = this->func_state.return_array_elements[i],
             .label = nullptr,
             .boundary = ContractBoundary::Result,
             .position = uint8_t(i + 1),
@@ -1344,11 +1351,14 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
       bool matching_type = initialiser.primary IS TiriType::Nil or initialiser.primary IS identifier.type;
       bool matching_struct = identifier.type != TiriType::Struct or initialiser.primary IS TiriType::Nil or
          initialiser.struct_def IS identifier.struct_def;
-      if (initialiser.proved() and matching_type and matching_struct) continue;
+      bool matching_array = identifier.type != TiriType::Array or initialiser.primary IS TiriType::Nil or
+         array_element_matches(identifier.array_element, initialiser.array_element);
+      if (initialiser.proved() and matching_type and matching_struct and matching_array) continue;
 
       RuntimeContract contract{
          .type = identifier.type,
          .struct_def = identifier.struct_def,
+         .array_element = identifier.array_element,
          .label = is_blank_symbol(identifier) ? nullptr : identifier.symbol,
          .boundary = ContractBoundary::Local,
          .position = uint8_t(base.raw() + i.raw() + 1)
@@ -1405,6 +1415,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          // Explicit type annotation takes precedence
          info->fixed_type = identifier.type;
          info->struct_def = identifier.struct_def;
+         info->array_element = identifier.array_element;
       }
       else if (this->apply_analysed_local_type(base + i, identifier.binding_id)) {
          // The analyser owns sticky fixation.  Its per-binding result covers deferred and secondary values.

--- a/src/tiri/jit/src/parser/lexer.cpp
+++ b/src/tiri/jit/src/parser/lexer.cpp
@@ -1068,6 +1068,7 @@ static LexToken lex_current_char_token(const LexState *State) noexcept
 
 static LexToken lex_array_typed(LexState *State, TValue *tv)
 {
+   State->array_typed_nested = false;
    lex_next(State);  // Consume '<'
    lex_skip_inline_ws(State);
 
@@ -1092,6 +1093,7 @@ static LexToken lex_array_typed(LexState *State, TValue *tv)
    // determined when individual inner arrays are created.
 
    if (type_str == "array" and State->c IS '<') {
+      State->array_typed_nested = true;
       int depth = 1;
       lex_next(State);  // Consume inner '<'
       while (depth > 0) {
@@ -1458,11 +1460,21 @@ static LexToken lex_scan(LexState *State, TValue *tv)
                // Not a typed deferred expression (e.g., "x < y" comparison)
                // Push the identifier as a buffered token to be returned after '<'
                auto str_view = std::string_view(State->sb.b, sbuflen(&State->sb));
-               GCstr *s = State->keepstr(str_view);
-
                LexState::BufferedToken buffered;
-               buffered.token = (s->reserved > 0) ? (TK_OFS + s->reserved) : TK_name;
-               setstrV(State->L, &buffered.value, s);
+               setnilV(&buffered.value);
+               if (str_view IS "array" and State->c IS '<') {
+                  buffered.token = lex_array_typed(State, &buffered.value);
+                  buffered.array_typed_size = State->array_typed_size;
+                  buffered.array_typed_nested = State->array_typed_nested;
+               }
+               else if (str_view IS "struct" and State->c IS '<') {
+                  buffered.token = lex_struct_typed(State, &buffered.value);
+               }
+               else {
+                  GCstr *s = State->keepstr(str_view);
+                  buffered.token = (s->reserved > 0) ? (TK_OFS + s->reserved) : TK_name;
+                  setstrV(State->L, &buffered.value, s);
+               }
                buffered.line = ident_line;
                buffered.column = ident_column;
                buffered.offset = ident_offset;
@@ -1852,6 +1864,8 @@ void LexState::next()
       this->current_token_line = this->lookahead_line;
       this->current_token_column = this->lookahead_column;
       this->current_token_offset = this->lookahead_offset;
+      this->current_array_typed_size = this->lookahead_array_typed_size;
+      this->current_array_typed_nested = this->lookahead_array_typed_nested;
       this->lastline = this->current_token_line;
       this->lookahead = TK_eof;
       setnilV(&this->lookaheadval);
@@ -1872,6 +1886,8 @@ void LexState::next()
    this->current_token_line = this->pending_token_line;
    this->current_token_column = this->pending_token_column;
    this->current_token_offset = this->pending_token_offset;
+   this->current_array_typed_size = this->array_typed_size;
+   this->current_array_typed_nested = this->array_typed_nested;
    this->lastline = this->current_token_line;
 }
 
@@ -1890,6 +1906,8 @@ LexToken LexState::lookahead_token()
       this->lookahead_line = buffered.line;
       this->lookahead_column = buffered.column;
       this->lookahead_offset = buffered.offset;
+      this->lookahead_array_typed_size = buffered.array_typed_size;
+      this->lookahead_array_typed_nested = buffered.array_typed_nested;
       return this->lookahead;
    }
 
@@ -1898,6 +1916,8 @@ LexToken LexState::lookahead_token()
    this->lookahead_line = this->pending_token_line;
    this->lookahead_column = this->pending_token_column;
    this->lookahead_offset = this->pending_token_offset;
+   this->lookahead_array_typed_size = this->array_typed_size;
+   this->lookahead_array_typed_nested = this->array_typed_nested;
    return this->lookahead;
 }
 
@@ -1937,6 +1957,8 @@ void LexState::apply_buffered_token(const BufferedToken& token)
    this->current_token_line = token.line;
    this->current_token_column = token.column;
    this->current_token_offset = token.offset;
+   this->current_array_typed_size = token.array_typed_size;
+   this->current_array_typed_nested = token.array_typed_nested;
    this->lastline = this->current_token_line;
 }
 
@@ -1948,6 +1970,8 @@ LexState::BufferedToken LexState::scan_buffered_token()
    buffered.line = this->pending_token_line;
    buffered.column = this->pending_token_column;
    buffered.offset = this->pending_token_offset;
+   buffered.array_typed_size = this->array_typed_size;
+   buffered.array_typed_nested = this->array_typed_nested;
    return buffered;
 }
 

--- a/src/tiri/jit/src/parser/lexer.h
+++ b/src/tiri/jit/src/parser/lexer.h
@@ -97,6 +97,8 @@ public:
       BCLine line = 0;
       BCLine column = 0;
       size_t offset = 0;
+      int64_t array_typed_size = -1;
+      bool array_typed_nested = false;
    };
 
    struct FuncState *fs;              // Current FuncState (points to func_stack.back()).
@@ -137,6 +139,9 @@ public:
    uint8_t    pending_if_empty_colon; // Tracks ?: misuse after ??.
    int        is_bytecode;    // Set to 1 if input is bytecode, 0 if source text.
    int64_t    array_typed_size = -1;  // Size parameter for array<type, size> (-1 = no size specified)
+   bool       array_typed_nested = false; // The most recent array token contained nested specialisation
+   int64_t    current_array_typed_size = -1;
+   bool       current_array_typed_nested = false;
 
    size_t   current_offset = 0;
    size_t   line_start_offset = 0;
@@ -148,6 +153,8 @@ public:
    BCLine   lookahead_line = 1;
    BCLine   lookahead_column = 1;
    size_t   lookahead_offset = 0;
+   int64_t  lookahead_array_typed_size = -1;
+   bool     lookahead_array_typed_nested = false;
 
    BCLine   pending_token_line = 1;
    BCLine   pending_token_column = 1;
@@ -165,6 +172,7 @@ public:
       TiriType primary = TiriType::Unknown;
       CLASSID  object_class_id = CLASSID::NIL;
       struct_record *struct_def = nullptr;
+      ArrayElementDescriptor array_element{};
       GlobalContractPolicy contract_policy = GlobalContractPolicy::Advisory;
    };
    ankerl::unordered_dense::map<GCstr*, GlobalTypeHint> global_type_hints;

--- a/src/tiri/jit/src/parser/lexer_types.h
+++ b/src/tiri/jit/src/parser/lexer_types.h
@@ -208,6 +208,7 @@ typedef struct VarInfo {
    TiriType fixed_type;  // Type once established (Unknown = not yet fixed)
    CLASSID object_class_id = CLASSID::NIL;  // CLASSID for Object types (0 = unknown class)
    struct_record *struct_def = nullptr; // Resolved layout for struct values and callable definitions
+   ArrayElementDescriptor array_element{}; // Native-array member constraint
    BCLine line = 0;    // Line number where the variable was declared (for diagnostics)
    BCLine column = 0;  // Column number where the variable was declared (for diagnostics)
 } VarInfo;

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -593,6 +593,15 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       CLASSID object_class_id = contract.type IS TiriType::Object ? contract.object_class_id : CLASSID::NIL;
       contract_append_uleb32(descriptor, uint32_t(object_class_id));
 
+      AET array_element_type = contract.type IS TiriType::Array and contract.array_element.known ?
+         contract.array_element.storage : AET::MAX;
+      descriptor.push_back(char(uint8_t(array_element_type)));
+      std::string_view array_struct_name;
+      if (array_element_type IS AET::STRUCT and contract.array_element.struct_def) {
+         array_struct_name = contract.array_element.struct_def->Name;
+      }
+      contract_append_text(fs, descriptor, array_struct_name, "runtime contract array structure name");
+
       std::string_view struct_name;
       if (contract.struct_def) struct_name = contract.struct_def->Name;
       contract_append_text(fs, descriptor, struct_name, "runtime contract structure name");
@@ -646,8 +655,10 @@ static void bcemit_value_contract(
       bool same_object_class = Contract.type != TiriType::Object or Contract.object_class_id IS CLASSID::NIL or
          descriptor.object_class_id IS Contract.object_class_id;
       bool same_struct = Contract.type != TiriType::Struct or descriptor.struct_def IS Contract.struct_def;
+      bool same_array = Contract.type != TiriType::Array or
+         array_element_matches(Contract.array_element, descriptor.array_element);
       bool same_nullability = descriptor.nullable IS Contract.nullable;
-      if (same_type and same_object_class and same_struct and same_nullability and descriptor.proved() and
+      if (same_type and same_object_class and same_struct and same_array and same_nullability and descriptor.proved() and
           not ForceRuntimeCheck) return;
    }
 
@@ -683,6 +694,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
          .type = vinfo->fixed_type,
          .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
+         .array_element = vinfo->array_element,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Local,
          .position = uint8_t(vinfo->slot + 1)
@@ -701,6 +713,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
          .type = vinfo->fixed_type,
          .object_class_id = vinfo->object_class_id,
          .struct_def = vinfo->struct_def,
+         .array_element = vinfo->array_element,
          .label = strref(vinfo->name),
          .boundary = ContractBoundary::Upvalue,
          .position = uint8_t(LHS->u.s.info + 1)
@@ -727,6 +740,7 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
             .type = found->second.primary,
             .object_class_id = found->second.object_class_id,
             .struct_def = found->second.struct_def,
+            .array_element = found->second.array_element,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,
             .position = 1

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -89,6 +89,7 @@ struct RuntimeContract {
    TiriType type = TiriType::Unknown;
    CLASSID object_class_id = CLASSID::NIL;
    struct_record *struct_def = nullptr;
+   ArrayElementDescriptor array_element{};
    GCstr *label = nullptr;
    ContractBoundary boundary = ContractBoundary::Local;
    uint8_t position = 0;

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1872,9 +1872,12 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    lua_State *L = state.get();
    constexpr std::string_view source =
       "extern obj\n"
+      "extern array\n"
       "function dynamic(Value:any):any return Value end\n"
       "local value = obj.new('time')\n"
-      "value = dynamic(value)\n";
+      "value = dynamic(value)\n"
+      "local values:array<int> = array<int> { 1 }\n"
+      "values = dynamic(values)\n";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -1921,9 +1924,31 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       return false;
    };
    bool class_survived = has_time_contract(has_time_contract, restored_proto);
+   auto has_int_array_contract = [L](auto &Self, GCproto *Proto) -> bool {
+      for (uint32_t i = 1; i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.contract_count > 0 and
+             descriptor.entries[0].type IS TiriType::Array and
+             descriptor.entries[0].array_element_type IS AET::INT32) return true;
+      }
+      GCRef *constant = mref<GCRef>(Proto->k) - 1;
+      for (uint32_t i = 0; i < Proto->sizekgc; ++i, --constant) {
+         GCobj *child = gcref(*constant);
+         if (child->gch.gct IS ~LJ_TPROTO and Self(Self, gco_to_proto(child))) return true;
+      }
+      return false;
+   };
+   bool array_survived = has_int_array_contract(has_int_array_contract, restored_proto);
    lua_pop(L, 1);
    if (not class_survived) {
       Log.error("reloaded bytecode lost the multi-byte object class constraint in BC_CONTRACT");
+      return false;
+   }
+   if (not array_survived) {
+      Log.error("reloaded bytecode lost the array member constraint in BC_CONTRACT");
       return false;
    }
    return true;
@@ -1942,7 +1967,8 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       } while (Value);
    };
    auto build_descriptor = [&append_uleb](uint8_t Version, TiriType Type, CLASSID ObjectClassId,
-      std::string_view StructName, std::string_view Label, uint8_t EntryFlags) {
+      std::string_view StructName, std::string_view Label, uint8_t EntryFlags,
+      AET ArrayElementType = AET::MAX, std::string_view ArrayStructName = {}) {
       std::string result{
          char(Version),
          char(uint8_t(ContractBoundary::Global)),
@@ -1953,7 +1979,12 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
          char(EntryFlags),
          char(1)
       };
-      if (Version IS TIRI_CONTRACT_VERSION) append_uleb(result, uint32_t(ObjectClassId));
+      if (Version >= TIRI_CONTRACT_OBJECT_VERSION) append_uleb(result, uint32_t(ObjectClassId));
+      if (Version IS TIRI_CONTRACT_VERSION) {
+         result.push_back(char(uint8_t(ArrayElementType)));
+         result.push_back(char(uint8_t(ArrayStructName.size())));
+         result.append(ArrayStructName);
+      }
       result.push_back(char(uint8_t(StructName.size())));
       result.append(StructName);
       result.push_back(char(uint8_t(Label.size())));
@@ -1992,7 +2023,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
        object_decoded.entries[0].type != TiriType::Object or
        object_decoded.entries[0].object_class_id != CLASSID::TIME or
        not object_decoded.entries[0].struct_name.empty()) {
-      Log.error("version-2 object class constraint did not round-trip through the shared decoder");
+      Log.error("object class constraint did not round-trip through the shared decoder");
       return false;
    }
 
@@ -2001,7 +2032,30 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    GCstr *broad_descriptor = lj_str_new(lua, broad_object.data(), broad_object.size());
    if (not decode_runtime_contract(broad_descriptor, object_decoded) or
        object_decoded.entries[0].object_class_id != CLASSID::NIL) {
-      Log.error("version-2 broad object contract gained a class constraint while decoding");
+      Log.error("broad object contract gained a class constraint while decoding");
+      return false;
+   }
+
+   std::string array_encoded = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Array, CLASSID::NIL, {}, "Values", const_flags, AET::INT32);
+   RuntimeContractDescriptor array_decoded;
+   GCstr *array_descriptor = lj_str_new(lua, array_encoded.data(), array_encoded.size());
+   if (not decode_runtime_contract(array_descriptor, array_decoded) or
+       array_decoded.entries[0].type != TiriType::Array or
+       array_decoded.entries[0].array_element_type != AET::INT32 or
+       not array_decoded.entries[0].array_struct_name.empty()) {
+      Log.error("array member constraint did not round-trip through the shared decoder");
+      return false;
+   }
+
+   std::string struct_array_encoded = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Array, CLASSID::NIL, {}, "Points", const_flags,
+      AET::STRUCT, "Point");
+   GCstr *struct_array_descriptor = lj_str_new(lua, struct_array_encoded.data(), struct_array_encoded.size());
+   if (not decode_runtime_contract(struct_array_descriptor, array_decoded) or
+       array_decoded.entries[0].array_element_type != AET::STRUCT or
+       array_decoded.entries[0].array_struct_name != "Point") {
+      Log.error("named-structure array constraint did not round-trip through the shared decoder");
       return false;
    }
 
@@ -2026,6 +2080,10 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       TIRI_CONTRACT_VERSION, TiriType::Num, CLASSID::TIME, {}, "Value", const_flags);
    std::string invalid_struct_class = build_descriptor(
       TIRI_CONTRACT_VERSION, TiriType::Struct, CLASSID::TIME, "Point", "Value", const_flags);
+   std::string invalid_scalar_array_member = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Num, CLASSID::NIL, {}, "Value", const_flags, AET::INT32);
+   std::string invalid_named_non_struct_array = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Array, CLASSID::NIL, {}, "Value", const_flags, AET::INT32, "Point");
    std::string truncated_class{
       char(TIRI_CONTRACT_VERSION), char(uint8_t(ContractBoundary::Local)), char(0), char(1), char(1),
       char(uint8_t(TiriType::Object)), char(0), char(1), char(0x80)
@@ -2043,6 +2101,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    if (not rejected(invalid_descriptor_flags) or not rejected(invalid_entry_flags) or
        not rejected(invalid_initialising_flag) or
        not rejected(invalid_position) or not rejected(invalid_scalar_class) or not rejected(invalid_struct_class) or
+       not rejected(invalid_scalar_array_member) or not rejected(invalid_named_non_struct_array) or
        not rejected(truncated_class) or not rejected(over_wide_class) or not rejected(trailing) or
        not rejected(truncated) or not rejected(unknown_version)) {
       Log.error("shared runtime contract decoder accepted malformed input");
@@ -3849,13 +3908,13 @@ static bool test_safe_index_bytecode_selection(kt::Log &Log)
    };
 
    constexpr std::string_view native_literal =
-      "local function read(Values:array):any\n"
+      "local function read(Values:array<any>):any\n"
       "   return Values?[0]\n"
       "end\n";
    if (not expect_access(native_literal, BC_ASGETB, BC_TGETB, "native-array literal-key")) passed = false;
 
    constexpr std::string_view native_variable =
-      "local function read(Values:array, Index:num):any\n"
+      "local function read(Values:array<any>, Index:num):any\n"
       "   return Values?[Index]\n"
       "end\n";
    if (not expect_access(native_variable, BC_ASGETV, BC_TGETV, "native-array variable-key")) passed = false;
@@ -3906,7 +3965,7 @@ static bool test_type_guided_emission(kt::Log &Log)
    std::string error;
    constexpr std::string_view source =
       "extern array\n"
-      "local function read(Values:array):num\n"
+      "local function read(Values:array<any>):num\n"
       "   return Values[0]\n"
       "end\n"
       "local alias = read\n"
@@ -3989,7 +4048,7 @@ static bool test_type_guided_emission(kt::Log &Log)
       "extern array\n"
       "extern obj\n"
       "struct GuidedLayout Value: int end\n"
-      "local function update_array(Values:array):num\n"
+      "local function update_array(Values:array<any>):num\n"
       "   Values[0] = Values[0] + 1\n"
       "   return Values?[0]\n"
       "end\n"

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -448,6 +448,8 @@ private:
          value.object_class_id = Function.return_types.object_class_ids[i];
          value.struct_def = Function.return_types.struct_defs[i] ?
             Function.return_types.struct_defs[i] : value.struct_def;
+         value.array_element = Function.return_types.array_elements[i].known ?
+            Function.return_types.array_elements[i] : value.array_element;
          value.nullable = true;
          if (Function.return_types.is_explicit and value.primary != TiriType::Any and
              value.primary != TiriType::Unknown) {
@@ -819,11 +821,12 @@ private:
    }
 
    [[nodiscard]] StaticValueDescriptor declared_descriptor(
-      TiriType Type, struct_record *StructDef, StaticProof Proof) const
+      TiriType Type, struct_record *StructDef, const ArrayElementDescriptor &ArrayElement, StaticProof Proof) const
    {
       StaticValueDescriptor result;
       result.primary = Type;
       result.struct_def = StructDef;
+      result.array_element = ArrayElement;
       result.proof = Proof;
       result.nullable = true;
       return result;
@@ -1290,7 +1293,8 @@ private:
       StaticValueDescriptor value;
 
       if (Name.type != TiriType::Unknown and Name.type != TiriType::Any) {
-         value = this->declared_descriptor(Name.type, Name.struct_def, StaticProof::Checked);
+         value = this->declared_descriptor(
+            Name.type, Name.struct_def, Name.array_element, StaticProof::Checked);
       }
       else if (binding.function) {
          value.primary = TiriType::Func;
@@ -1336,7 +1340,7 @@ private:
             value = ContextParameters[i];
          }
          else {
-            value = this->declared_descriptor(parameter.type, parameter.struct_def,
+            value = this->declared_descriptor(parameter.type, parameter.struct_def, parameter.array_element,
                parameter.type IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked);
          }
          auto &binding = this->catalogue_.binding(parameter.name.binding_id);
@@ -1361,6 +1365,8 @@ private:
                value.object_class_id = Function.return_types.object_class_ids[i];
                value.struct_def = Function.return_types.struct_defs[i] ?
                   Function.return_types.struct_defs[i] : value.struct_def;
+               value.array_element = Function.return_types.array_elements[i].known ?
+                  Function.return_types.array_elements[i] : value.array_element;
                value.nullable = true;
                value.proof = Function.return_types.is_explicit ?
                   (value.primary IS TiriType::Any ? StaticProof::Advisory : StaticProof::Checked) :
@@ -1528,7 +1534,8 @@ private:
                if (name.type IS TiriType::Any or not name.symbol) continue;
                StaticValueDescriptor value;
                if (name.type != TiriType::Unknown) {
-                  value = this->declared_descriptor(name.type, name.struct_def, StaticProof::Checked);
+                  value = this->declared_descriptor(
+                     name.type, name.struct_def, name.array_element, StaticProof::Checked);
                }
                else if (not payload.values.empty()) {
                   size_t source = std::min(i, payload.values.size() - 1);

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -3,6 +3,7 @@
 #include "static_type_descriptor.h"
 
 #include <algorithm>
+#include <format>
 
 #include <kotuku/main.h>
 #include <kotuku/objects.h>
@@ -494,6 +495,52 @@ std::optional<ArrayElementDescriptor> describe_array_element(const struct_field 
    else return std::nullopt;
 
    return result;
+}
+
+bool array_element_matches(
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept
+{
+   if (not Expected.known) return not Actual.known;
+   if (Expected.storage IS AET::ANY) return true;
+   if (not Actual.known) return false;
+
+   auto string_storage = [](AET Storage) {
+      return Storage IS AET::CSTR or Storage IS AET::STR_CPP or Storage IS AET::STR_GC;
+   };
+   if (string_storage(Expected.storage) and string_storage(Actual.storage)) return true;
+   if (Expected.storage != Actual.storage) return false;
+   if (Expected.storage IS AET::STRUCT and Expected.struct_def) {
+      return Actual.struct_def IS Expected.struct_def;
+   }
+   if (Expected.storage IS AET::OBJECT and Expected.object_class_id != CLASSID::NIL) {
+      return Actual.object_class_id IS Expected.object_class_id;
+   }
+   return true;
+}
+
+std::string array_element_name(const ArrayElementDescriptor &Element)
+{
+   if (not Element.known) return "unknown";
+   switch (Element.storage) {
+      case AET::BYTE:    return "byte";
+      case AET::INT16:   return "int16";
+      case AET::INT32:   return "int";
+      case AET::INT64:   return "int64";
+      case AET::FLOAT:   return "float";
+      case AET::DOUBLE:  return "double";
+      case AET::CSTR:
+      case AET::STR_CPP:
+      case AET::STR_GC:  return "string";
+      case AET::TABLE:   return "table";
+      case AET::ARRAY:   return "array";
+      case AET::ANY:     return "any";
+      case AET::OBJECT:  return "object";
+      case AET::STRUCT:
+         return Element.struct_def ? std::format("struct<{}>", Element.struct_def->Name) : "struct";
+      case AET::PTR:     return "pointer";
+      case AET::MAX:     break;
+   }
+   return "unknown";
 }
 
 bool can_use_static_receiver(

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -141,5 +142,8 @@ enum class ObjectCallMemberKind : uint8_t {
 [[nodiscard]] std::optional<ArrayElementDescriptor> describe_array_element(
    std::string_view Name, lua_State *State = nullptr);
 [[nodiscard]] std::optional<ArrayElementDescriptor> describe_array_element(const struct_field &);
+[[nodiscard]] bool array_element_matches(
+   const ArrayElementDescriptor &Expected, const ArrayElementDescriptor &Actual) noexcept;
+[[nodiscard]] std::string array_element_name(const ArrayElementDescriptor &Element);
 [[nodiscard]] bool can_use_static_receiver(
    const StaticDescriptorCatalogue &, StaticValueHandle, TiriType, bool AllowNullable = false);

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -47,6 +47,21 @@
    return result;
 }
 
+[[nodiscard]] static bool array_type_mismatch(
+   const ArrayElementDescriptor &Expected, const InferredType &Actual)
+{
+   return Actual.primary IS TiriType::Array and Expected.known and Actual.array_element.known and
+      not array_element_matches(Expected, Actual.array_element);
+}
+
+[[nodiscard]] static std::string inferred_type_name(const InferredType &Type)
+{
+   if (Type.primary IS TiriType::Array and Type.array_element.known) {
+      return std::format("array<{}>", array_element_name(Type.array_element));
+   }
+   return std::string(type_name(Type.primary));
+}
+
 [[nodiscard]] static bool type_identifier_name_is(GCstr *Name, std::string_view Text)
 {
    return Name and std::string_view(strdata(Name), Name->len) IS Text;
@@ -112,6 +127,10 @@
          return std::format("parameter {} has struct type '{}', expected '{}'",
             i + 1, actual_name, expected_name);
       }
+      if (not (expected.array_element IS actual.array_element)) {
+         return std::format("parameter {} has array member type '{}', expected '{}'", i + 1,
+            array_element_name(actual.array_element), array_element_name(expected.array_element));
+      }
    }
 
    const FunctionReturnTypes &expected_results = Expected.return_types;
@@ -147,6 +166,11 @@
             actual_results.struct_defs[i]->Name : "struct";
          return std::format("return {} has struct type '{}', expected '{}'",
             i + 1, actual_name, expected_name);
+      }
+      if (not (expected_results.array_elements[i] IS actual_results.array_elements[i])) {
+         return std::format("return {} has array member type '{}', expected '{}'", i + 1,
+            array_element_name(actual_results.array_elements[i]),
+            array_element_name(expected_results.array_elements[i]));
       }
    }
 
@@ -224,7 +248,7 @@ private:
 
    // Argument type checking for function calls
    void check_arguments(const FunctionExprPayload &, const CallExprPayload &);
-   void check_argument_type(const ExprNode &, TiriType, size_t);
+   void check_argument_type(const ExprNode &, const FunctionParameter &, size_t);
 
    // Type inference - determines types from expressions and context
    [[nodiscard]] InferredType infer_expression_type(const ExprNode &);
@@ -242,7 +266,7 @@ private:
 
    // Type fixation - locks variable type after first concrete assignment
    void fix_local_type(GCstr *, StaticBindingID, TiriType, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, const ArrayElementDescriptor &ArrayElement = {});
    void publish_binding_type(StaticBindingID, const InferredType &);
 
    // Usage tracking - marks variables as used for unused variable detection
@@ -347,7 +371,7 @@ private:
    [[nodiscard]] bool is_global_const(GCstr *Name) const;
    [[nodiscard]] bool is_implicit_global(GCstr *Name) const;
    void fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, const ArrayElementDescriptor &ArrayElement = {});
    void mark_dynamic_ingress(GCstr *Name, bool IsGlobal);
    void degrade_global_type(GCstr *Name);
    void invalidate_global_flow_policy(GCstr *Name, SourceSpan Location);
@@ -668,11 +692,13 @@ void TypeAnalyser::leave_function()
                published.types[i] = TiriType::Nil;
                published.object_class_ids[i] = CLASSID::NIL;
                published.struct_defs[i] = nullptr;
+               published.array_elements[i] = {};
             }
             else {
                published.types[i] = position.concrete.primary;
                published.object_class_ids[i] = position.concrete.object_class_id;
                published.struct_defs[i] = position.concrete.struct_def;
+               published.array_elements[i] = position.concrete.array_element;
             }
          }
       }
@@ -806,7 +832,8 @@ void TypeAnalyser::lower_unanalysed_function(const FunctionExprPayload &Function
    this->unanalysed_depth_++;
    this->push_scope();
    for (const FunctionParameter &param : Function.parameters) {
-      this->current_scope().declare_parameter(param.name.symbol, param.type, param.struct_def, param.name.span);
+      this->current_scope().declare_parameter(
+         param.name.symbol, param.type, param.struct_def, param.array_element, param.name.span);
    }
    if (Function.body) {
       for (auto &statement : Function.body->statements) {
@@ -1560,6 +1587,21 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                   value_type.struct_def->Name, existing->struct_def->Name);
                this->record_diagnostic(std::move(diag));
             }
+            else if (existing->primary IS TiriType::Array and
+                array_type_mismatch(existing->array_element, value_type)) {
+               if (is_global and this->is_implicit_global(name)) {
+                  this->degrade_global_type(name);
+                  continue;
+               }
+               TypeDiagnostic diag;
+               diag.location = target.span;
+               diag.expected = TiriType::Array;
+               diag.actual = TiriType::Array;
+               diag.code = ParserErrorCode::TypeMismatchAssignment;
+               diag.message = std::format("array member mismatch: cannot assign '{}' to 'array<{}>'",
+                  inferred_type_name(value_type), array_element_name(existing->array_element));
+               this->record_diagnostic(std::move(diag));
+            }
          }
          else {
             // Unfixed variable: first non-nil assignment fixes the type
@@ -1570,11 +1612,12 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
             }
             else if ((existing->primary != TiriType::Any) and (value_type.primary != TiriType::Nil)) {
                if (is_global) {
-                  this->fix_global_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def);
+                  this->fix_global_type(name, value_type.primary, value_type.object_class_id, value_type.struct_def,
+                     value_type.array_element);
                }
                else {
                   this->fix_local_type(name, name_ref->binding_id, value_type.primary,
-                     value_type.object_class_id, value_type.struct_def);
+                     value_type.object_class_id, value_type.struct_def, value_type.array_element);
                }
             }
          }
@@ -1643,6 +1686,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       if (name.type != TiriType::Unknown) {
          inferred.primary = name.type;
          inferred.struct_def = name.struct_def;
+         inferred.array_element = name.array_element;
          // 'any' type is not fixed - it accepts any value
          inferred.is_fixed = (name.type != TiriType::Any);
 
@@ -1674,6 +1718,18 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
                diag.code = ParserErrorCode::TypeMismatchAssignment;
                diag.message = std::format("struct layout mismatch: cannot assign '{}' to '{}'",
                   value_type.struct_def->Name, name.struct_def->Name);
+               this->record_diagnostic(std::move(diag));
+            }
+            else if (name.type IS TiriType::Array and array_type_mismatch(name.array_element, value_type)) {
+               TypeDiagnostic diag;
+               if (value_index > 0 and value_index - 1 < Payload.values.size()) {
+                  diag.location = Payload.values[value_index - 1]->span;
+               }
+               diag.expected = TiriType::Array;
+               diag.actual = TiriType::Array;
+               diag.code = ParserErrorCode::TypeMismatchAssignment;
+               diag.message = std::format("cannot assign '{}' to variable of type 'array<{}>'",
+                  inferred_type_name(value_type), array_element_name(name.array_element));
                this->record_diagnostic(std::move(diag));
             }
          }
@@ -1850,6 +1906,7 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       if (name.type != TiriType::Unknown) {
          inferred.primary = name.type;
          inferred.struct_def = name.struct_def;
+         inferred.array_element = name.array_element;
          inferred.is_fixed = (name.type != TiriType::Any);
       }
       else if (have_value_type) {
@@ -1876,11 +1933,13 @@ void TypeAnalyser::discover_global_decl_policy(const GlobalDeclStmtPayload &Payl
       name.global_contract_object_class_id = inferred.primary IS TiriType::Object ?
          inferred.object_class_id : CLASSID::NIL;
       name.global_contract_struct_def = inferred.struct_def;
+      name.global_contract_array_element = inferred.array_element;
       name.global_contract_policy = contract_policy;
       if (name.has_const and not inferred.is_fixed) {
          name.global_contract_type = TiriType::Any;
          name.global_contract_object_class_id = CLASSID::NIL;
          name.global_contract_struct_def = nullptr;
+         name.global_contract_array_element = {};
          name.global_contract_policy = GlobalContractPolicy::Enforced;
       }
       if (PublishStaticPolicy) this->declare_global(name.symbol, inferred, name.span, name.has_const, contract_policy);
@@ -2024,7 +2083,8 @@ void TypeAnalyser::analyse_function_payload(const FunctionExprPayload &Function,
    this->enter_function(Function, Name);
 
    for (const auto &param : Function.parameters) {
-      this->current_scope().declare_parameter(param.name.symbol, param.type, param.struct_def, param.name.span);
+      this->current_scope().declare_parameter(
+         param.name.symbol, param.type, param.struct_def, param.array_element, param.name.span);
       if (param.type_is_explicit and param.type IS TiriType::Any and param.name.binding_id) {
          this->explicit_variant_bindings_.insert(param.name.binding_id);
       }
@@ -2312,7 +2372,7 @@ void TypeAnalyser::check_arguments(const FunctionExprPayload &Function, const Ca
    size_t param_index = 0;
    for (const auto &param : Function.parameters) {
       if (param_index >= Call.arguments.size()) break;
-      this->check_argument_type(*Call.arguments[param_index], param.type, param_index);
+      this->check_argument_type(*Call.arguments[param_index], param, param_index);
       param_index += 1;
    }
 }
@@ -2320,20 +2380,24 @@ void TypeAnalyser::check_arguments(const FunctionExprPayload &Function, const Ca
 //********************************************************************************************************************
 // Check a single argument against its expected type, reporting diagnostics for mismatches.
 
-void TypeAnalyser::check_argument_type(const ExprNode& Argument, TiriType Expected, size_t Index)
+void TypeAnalyser::check_argument_type(
+   const ExprNode& Argument, const FunctionParameter &Parameter, size_t Index)
 {
-   if (Expected IS TiriType::Any) return;
+   TiriType expected = Parameter.type;
+   if (expected IS TiriType::Any) return;
 
    InferredType actual = this->infer_expression_type(Argument);
 
-   if (not actual.matches(Expected)) {
+   if (not actual.matches(expected) or array_type_mismatch(Parameter.array_element, actual)) {
       TypeDiagnostic diag;
       diag.location = Argument.span;
-      diag.expected = Expected;
+      diag.expected = expected;
       diag.actual = actual.primary;
       diag.code = ParserErrorCode::TypeMismatchArgument;
+      std::string expected_name = expected IS TiriType::Array and Parameter.array_element.known ?
+         std::format("array<{}>", array_element_name(Parameter.array_element)) : std::string(type_name(expected));
       diag.message = std::format("type mismatch: argument {} expects '{}', got '{}'",
-         Index + 1, type_name(Expected), type_name(actual.primary));
+         Index + 1, expected_name, inferred_type_name(actual));
       this->record_diagnostic(std::move(diag));
    }
 }
@@ -2408,6 +2472,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.primary = target->return_types.types[0];
                result.object_class_id = target->return_types.object_class_ids[0];
                result.struct_def = target->return_types.struct_defs[0];
+               result.array_element = target->return_types.array_elements[0];
                payload->struct_def = result.struct_def;
                return result;
             }
@@ -2419,6 +2484,9 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   result.object_class_id = payload->object_class_id;
                }
                result.struct_def = payload->struct_def;
+               if (result.primary IS TiriType::Array and Expr.static_value) {
+                  result.array_element = this->ctx_.descriptors().value(Expr.static_value).array_element;
+               }
                if ((result.primary IS TiriType::Struct or result.primary IS TiriType::Func) and
                    not result.struct_def and not payload->arguments.empty()) {
                   const auto *literal = std::get_if<LiteralValue>(&payload->arguments[0]->data);
@@ -2437,6 +2505,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                   result.is_nullable = descriptor.nullable;
                   result.object_class_id = descriptor.object_class_id;
                   result.struct_def = descriptor.struct_def;
+                  result.array_element = descriptor.array_element;
                   return result;
                }
             }
@@ -2452,6 +2521,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.is_nullable = descriptor.nullable;
                result.object_class_id = descriptor.object_class_id;
                result.struct_def = descriptor.struct_def;
+               result.array_element = descriptor.array_element;
                return result;
             }
          }
@@ -2481,6 +2551,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.is_nullable = descriptor.nullable;
                result.object_class_id = descriptor.object_class_id;
                result.struct_def = descriptor.struct_def;
+               result.array_element = descriptor.array_element;
                return result;
             }
          }
@@ -2507,6 +2578,7 @@ InferredType TypeAnalyser::infer_expression_type(const ExprNode& Expr)
                result.is_nullable = descriptor.nullable or safe;
                result.object_class_id = descriptor.object_class_id;
                result.struct_def = descriptor.struct_def;
+               result.array_element = descriptor.array_element;
                return result;
             }
          }
@@ -2715,6 +2787,7 @@ InferredType TypeAnalyser::refine_static_expression_type(const ExprNode &Expr, I
    Type.is_nullable = descriptor.nullable;
    Type.object_class_id = descriptor.object_class_id;
    Type.struct_def = descriptor.struct_def;
+   Type.array_element = descriptor.array_element;
    Type.is_fixed = true;
    return Type;
 }
@@ -2755,6 +2828,7 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t P
       result.is_nullable = descriptor.nullable;
       result.object_class_id = descriptor.object_class_id;
       result.struct_def = descriptor.struct_def;
+      result.array_element = descriptor.array_element;
       return result;
    }
 
@@ -2782,6 +2856,7 @@ bool TypeAnalyser::is_explicit_variant_expression(const ExprNode &Expr, size_t P
       result.primary = type;
       result.object_class_id = target->return_types.object_class_ids[type_position];
       result.struct_def = target->return_types.struct_defs[type_position];
+      result.array_element = target->return_types.array_elements[type_position];
    }
 
    return result;
@@ -2892,20 +2967,22 @@ void TypeAnalyser::publish_binding_type(StaticBindingID Binding, const InferredT
    value.primary = Type.primary;
    value.object_class_id = Type.object_class_id;
    value.struct_def = Type.struct_def;
+   value.array_element = Type.array_element;
    value.nullable = Type.is_nullable;
    value.proof = StaticProof::Advisory;
    this->ctx_.descriptors().binding(Binding).analysed_value = this->ctx_.descriptors().add_value(value);
 }
 
 void TypeAnalyser::fix_local_type(GCstr *Name, StaticBindingID Binding, TiriType Type,
-   CLASSID ObjectClassId, struct_record *StructDef)
+   CLASSID ObjectClassId, struct_record *StructDef, const ArrayElementDescriptor &ArrayElement)
 {
    for (auto it = this->scope_stack_.rbegin(); it != this->scope_stack_.rend(); ++it) {
       auto existing = it->lookup_local_type(Name);
       if (existing) {
-         it->fix_local_type(Name, Type, ObjectClassId, StructDef);
+         it->fix_local_type(Name, Type, ObjectClassId, StructDef, ArrayElement);
          InferredType fixed(Type, false, false, true, ObjectClassId);
          fixed.struct_def = StructDef;
+         fixed.array_element = ArrayElement;
          this->publish_binding_type(Binding, fixed);
          this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
          return;
@@ -3046,6 +3123,7 @@ void TypeAnalyser::degrade_global_type(GCstr *Name)
       it->second.type.is_fixed = true;  // 'any' accepts every subsequent assignment
       it->second.type.object_class_id = CLASSID::NIL;
       it->second.type.struct_def = nullptr;
+      it->second.type.array_element = {};
       this->trace_fix(this->ctx_.lex().linenumber, Name, TiriType::Any);
    }
 }
@@ -3075,7 +3153,8 @@ void TypeAnalyser::invalidate_global_flow_policy(GCstr *Name, SourceSpan Locatio
    this->trace_decl(this->ctx_.lex().linenumber, Name, TiriType::Any, true);
 }
 
-void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef)
+void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef,
+   const ArrayElementDescriptor &ArrayElement)
 {
    if (not Name) return;
    if (auto it = this->global_types_.find(Name); it != this->global_types_.end()) {
@@ -3083,6 +3162,7 @@ void TypeAnalyser::fix_global_type(GCstr *Name, TiriType Type, CLASSID ObjectCla
       it->second.type.is_fixed = true;
       it->second.type.object_class_id = ObjectClassId;
       it->second.type.struct_def = StructDef;
+      it->second.type.array_element = ArrayElement;
       if (not it->second.implicit) it->second.contract_policy = GlobalContractPolicy::Enforced;
       this->trace_fix(this->ctx_.lex().linenumber, Name, Type);
    }
@@ -3157,14 +3237,20 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
 
          const bool struct_matches = expected != TiriType::Struct or not ctx->expected_returns.struct_defs[i] or
             actual.struct_def IS ctx->expected_returns.struct_defs[i];
-         if (actual.primary != expected or not struct_matches) {
+         const bool array_matches = expected != TiriType::Array or
+            not array_type_mismatch(ctx->expected_returns.array_elements[i], actual);
+         if (actual.primary != expected or not struct_matches or not array_matches) {
             TypeDiagnostic diag;
             diag.location = expression.span;
             diag.expected = expected;
             diag.actual = actual.primary;
             diag.code = ParserErrorCode::ReturnTypeMismatch;
+            std::string expected_name = expected IS TiriType::Array and
+               ctx->expected_returns.array_elements[i].known ?
+               std::format("array<{}>", array_element_name(ctx->expected_returns.array_elements[i])) :
+               std::string(type_name(expected));
             diag.message = std::format("return type mismatch at position {}: expected '{}', got '{}'",
-               i + 1, type_name(expected), type_name(actual.primary));
+               i + 1, expected_name, inferred_type_name(actual));
             this->record_diagnostic(std::move(diag));
          }
       }
@@ -3216,7 +3302,9 @@ void TypeAnalyser::validate_return_types(const ReturnStmtPayload &Return, Source
             actual.object_class_id IS position.concrete.object_class_id;
          const bool struct_matches = position.concrete.primary != TiriType::Struct or
             not position.concrete.struct_def or actual.struct_def IS position.concrete.struct_def;
-         if (type_matches and class_matches and struct_matches) continue;
+         const bool array_matches = position.concrete.primary != TiriType::Array or
+            not array_type_mismatch(position.concrete.array_element, actual);
+         if (type_matches and class_matches and struct_matches and array_matches) continue;
 
          TypeDiagnostic diag;
          diag.location = expression.span;
@@ -3542,20 +3630,21 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
    for (const auto &[name, info] : this->global_types_) {
       if (info.contract_policy IS GlobalContractPolicy::Variant) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Variant
+            TiriType::Any, CLASSID::NIL, nullptr, {}, GlobalContractPolicy::Variant
          };
          continue;
       }
       if (info.is_const and not info.type.is_fixed) {
          Lex.global_type_hints[name] = {
-            TiriType::Any, CLASSID::NIL, nullptr, GlobalContractPolicy::Enforced
+            TiriType::Any, CLASSID::NIL, nullptr, {}, GlobalContractPolicy::Enforced
          };
          continue;
       }
       if (not info.type.is_fixed) continue;
       if (info.contract_policy IS GlobalContractPolicy::Enforced) {
          Lex.global_type_hints[name] = {
-            info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Enforced
+            info.type.primary, info.type.object_class_id, info.type.struct_def, info.type.array_element,
+            GlobalContractPolicy::Enforced
          };
          continue;
       }
@@ -3564,7 +3653,8 @@ void TypeAnalyser::publish_global_type_hints(LexState &Lex) const
          case TiriType::Object:
          case TiriType::Array:
             Lex.global_type_hints[name] = {
-               info.type.primary, info.type.object_class_id, info.type.struct_def, GlobalContractPolicy::Advisory
+               info.type.primary, info.type.object_class_id, info.type.struct_def, info.type.array_element,
+               GlobalContractPolicy::Advisory
             };
             break;
          default:

--- a/src/tiri/jit/src/parser/type_checker.cpp
+++ b/src/tiri/jit/src/parser/type_checker.cpp
@@ -1,6 +1,7 @@
 #include "parser/type_checker.h"
 
-void TypeCheckScope::declare_parameter(GCstr *Name, TiriType Type, struct_record *StructDef, SourceSpan Location)
+void TypeCheckScope::declare_parameter(GCstr *Name, TiriType Type, struct_record *StructDef,
+   const ArrayElementDescriptor &ArrayElement, SourceSpan Location)
 {
    VariableInfo info;
    info.name = Name;
@@ -8,6 +9,7 @@ void TypeCheckScope::declare_parameter(GCstr *Name, TiriType Type, struct_record
    info.type.is_constant = false;
    info.type.is_nullable = false;
    info.type.struct_def = StructDef;
+   info.type.array_element = ArrayElement;
    info.location = Location;
    info.is_parameter = true;
    info.is_used = false;
@@ -64,7 +66,8 @@ const FunctionExprPayload* TypeCheckScope::lookup_function(GCstr *Name) const
    return nullptr;
 }
 
-void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef)
+void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectClassId, struct_record *StructDef,
+   const ArrayElementDescriptor &ArrayElement)
 {
    for (auto it = this->variables_.rbegin(); it != this->variables_.rend(); ++it) {
       if (it->name IS Name and not it->is_parameter) {
@@ -72,6 +75,7 @@ void TypeCheckScope::fix_local_type(GCstr *Name, TiriType Type, CLASSID ObjectCl
          it->type.is_fixed = true;
          it->type.object_class_id = ObjectClassId;
          it->type.struct_def = StructDef;
+         it->type.array_element = ArrayElement;
          return;
       }
    }

--- a/src/tiri/jit/src/parser/type_checker.h
+++ b/src/tiri/jit/src/parser/type_checker.h
@@ -15,6 +15,7 @@ struct InferredType {
    bool requires_destination_type = false; // Dynamic ingress cannot be replaced by a concrete type without annotation
    CLASSID object_class_id = CLASSID::NIL;  // CLASSID for Object types
    struct_record *struct_def = nullptr; // Resolved layout for Struct types and definition callables
+   ArrayElementDescriptor array_element{}; // Resolved native-array member identity
 
    InferredType() = default;
    explicit InferredType(TiriType Primary, bool IsConstant = false, bool IsNullable = false, bool IsFixed = false,
@@ -92,11 +93,12 @@ struct UnusedVariableInfo {
 
 class TypeCheckScope {
 public:
-   void declare_parameter(GCstr *, TiriType Type, struct_record *StructDef, SourceSpan Location = {});
+   void declare_parameter(GCstr *, TiriType Type, struct_record *StructDef,
+      const ArrayElementDescriptor &ArrayElement = {}, SourceSpan Location = {});
    void declare_local(GCstr *, const InferredType &, SourceSpan Location = {}, bool IsConst = false);
    void declare_function(GCstr *, const FunctionExprPayload *, SourceSpan Location = {});
    void fix_local_type(GCstr *, TiriType Type, CLASSID ObjectClassId = CLASSID::NIL,
-      struct_record *StructDef = nullptr);
+      struct_record *StructDef = nullptr, const ArrayElementDescriptor &ArrayElement = {});
    void mark_dynamic_ingress(GCstr *);
 
    // Mark a variable as used (called when variable is referenced)

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -9,7 +9,8 @@
 #include <cstdint>
 #include <string_view>
 
-inline constexpr uint8_t TIRI_CONTRACT_VERSION = 2;
+inline constexpr uint8_t TIRI_CONTRACT_VERSION = 3;
+inline constexpr uint8_t TIRI_CONTRACT_OBJECT_VERSION = 2;
 inline constexpr uint8_t TIRI_CONTRACT_LEGACY_VERSION = 1;
 
 enum class ContractBoundary : uint8_t {
@@ -49,6 +50,8 @@ struct RuntimeContractEntry {
    uint8_t flags = 0;
    uint8_t position = 0;
    CLASSID object_class_id = CLASSID::NIL;
+   AET array_element_type = AET::MAX;
+   std::string_view array_struct_name;
    std::string_view struct_name;
    std::string_view label;
 };
@@ -156,7 +159,8 @@ private:
    uint8_t version;
    uint8_t boundary;
    if (not reader.read_byte(version) or
-       (version != TIRI_CONTRACT_LEGACY_VERSION and version != TIRI_CONTRACT_VERSION) or
+       (version != TIRI_CONTRACT_LEGACY_VERSION and version != TIRI_CONTRACT_OBJECT_VERSION and
+        version != TIRI_CONTRACT_VERSION) or
        not reader.read_byte(boundary) or boundary < uint8_t(ContractBoundary::Parameter) or
        boundary > uint8_t(ContractBoundary::Global) or not reader.read_byte(Result.flags) or
        (Result.flags & ~(contract_flag(ContractDescriptorFlag::DynamicCount) |
@@ -170,6 +174,7 @@ private:
    for (uint8_t i = 0; i < Result.contract_count; ++i) {
       auto &entry = Result.entries[i];
       uint8_t type;
+      uint8_t array_element_type = uint8_t(AET::MAX);
       uint32_t object_class_id = 0;
       if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
           not reader.read_byte(entry.flags) or
@@ -177,12 +182,16 @@ private:
              contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
              contract_flag(ContractEntryFlag::Initialising))) != 0 or
           not reader.read_byte(entry.position) or entry.position IS 0 or
-          (version IS TIRI_CONTRACT_VERSION and not reader.read_uleb32(object_class_id)) or
+          (version >= TIRI_CONTRACT_OBJECT_VERSION and not reader.read_uleb32(object_class_id)) or
+          (version IS TIRI_CONTRACT_VERSION and
+           (not reader.read_byte(array_element_type) or array_element_type > uint8_t(AET::MAX) or
+            not reader.read_text(entry.array_struct_name))) or
           not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
          return fail(RuntimeContractDecodeError::Entry);
       }
       entry.type = TiriType(type);
       entry.object_class_id = CLASSID(object_class_id);
+      entry.array_element_type = AET(array_element_type);
       bool is_const = contract_entry_is_const(entry);
       bool is_initialising = contract_entry_is_initialising(entry);
       if ((is_const and Result.boundary != ContractBoundary::Global) or
@@ -193,6 +202,13 @@ private:
          return fail(RuntimeContractDecodeError::Entry);
       }
       if (entry.object_class_id != CLASSID::NIL and entry.type != TiriType::Object) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
+      if (entry.type != TiriType::Array and
+          (entry.array_element_type != AET::MAX or not entry.array_struct_name.empty())) {
+         return fail(RuntimeContractDecodeError::Entry);
+      }
+      if (not entry.array_struct_name.empty() and entry.array_element_type != AET::STRUCT) {
          return fail(RuntimeContractDecodeError::Entry);
       }
    }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -663,7 +663,21 @@ namespace {
       case TiriType::Num:     return tvisnumber(Value);
       case TiriType::Str:     return tvisstr(Value);
       case TiriType::Table:   return tvistab(Value);
-      case TiriType::Array:   return tvisarray(Value);
+      case TiriType::Array: {
+         if (not tvisarray(Value)) return false;
+         if (Entry.array_element_type IS AET::MAX or Entry.array_element_type IS AET::ANY) return true;
+         GCarray *array = arrayV(Value);
+         auto string_storage = [](AET Storage) {
+            return Storage IS AET::CSTR or Storage IS AET::STR_CPP or Storage IS AET::STR_GC;
+         };
+         if (string_storage(Entry.array_element_type) and string_storage(array->elemtype)) return true;
+         if (array->elemtype != Entry.array_element_type) return false;
+         if (Entry.array_element_type IS AET::STRUCT and not Entry.array_struct_name.empty()) {
+            struct_record *definition = find_struct(L, Entry.array_struct_name);
+            return definition and array->structdef IS definition;
+         }
+         return true;
+      }
       case TiriType::Func:    return contract_is_callable(L, Value);
       case TiriType::Struct: {
          if (not tvisstruct(Value)) return false;
@@ -683,6 +697,12 @@ namespace {
    return false;
 }
 
+[[nodiscard]] static bool contract_is_variant(const RuntimeContractEntry &Entry) noexcept
+{
+   return Entry.type IS TiriType::Any or
+      (Entry.type IS TiriType::Array and Entry.array_element_type IS AET::ANY);
+}
+
 [[nodiscard]] static const char * contract_boundary_name(ContractBoundary Boundary)
 {
    switch (Boundary) {
@@ -697,6 +717,34 @@ namespace {
 
 static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractEntry &Entry)
 {
+   if (Entry.type IS TiriType::Array and Entry.array_element_type != AET::MAX) {
+      const char *element_name = "unknown";
+      switch (Entry.array_element_type) {
+         case AET::BYTE: element_name = "byte"; break;
+         case AET::INT16: element_name = "int16"; break;
+         case AET::INT32: element_name = "int"; break;
+         case AET::INT64: element_name = "int64"; break;
+         case AET::FLOAT: element_name = "float"; break;
+         case AET::DOUBLE: element_name = "double"; break;
+         case AET::CSTR:
+         case AET::STR_CPP:
+         case AET::STR_GC: element_name = "string"; break;
+         case AET::TABLE: element_name = "table"; break;
+         case AET::ARRAY: element_name = "array"; break;
+         case AET::ANY: element_name = "any"; break;
+         case AET::STRUCT: element_name = "struct"; break;
+         case AET::OBJECT: element_name = "object"; break;
+         case AET::PTR: element_name = "pointer"; break;
+         case AET::MAX: break;
+      }
+      if (Entry.array_element_type IS AET::STRUCT and not Entry.array_struct_name.empty()) {
+         std::snprintf(Buffer, Size, "array<struct<%.*s>>", int(Entry.array_struct_name.size()),
+            Entry.array_struct_name.data());
+      }
+      else std::snprintf(Buffer, Size, "array<%s>", element_name);
+      return;
+   }
+
    if (Entry.type IS TiriType::Object and Entry.object_class_id != CLASSID::NIL) {
       if (CSTRING class_name = ResolveClassID(Entry.object_class_id)) {
          std::snprintf(Buffer, Size, "obj<%s>", class_name);
@@ -744,6 +792,15 @@ static void contract_type_name(char *Buffer, size_t Size, const RuntimeContractE
    else if (tvisstruct(Value) and structV(Value)->def) {
       const auto &name = structV(Value)->def->Name;
       std::snprintf(actual, sizeof(actual), "struct<%.*s>", int(name.size()), name.data());
+   }
+   else if (tvisarray(Value)) {
+      RuntimeContractEntry actual_entry;
+      actual_entry.type = TiriType::Array;
+      actual_entry.array_element_type = arrayV(Value)->elemtype;
+      if (arrayV(Value)->elemtype IS AET::STRUCT and arrayV(Value)->structdef) {
+         actual_entry.array_struct_name = arrayV(Value)->structdef->Name;
+      }
+      contract_type_name(actual, sizeof(actual), actual_entry);
    }
    else if (contract_is_range(L, Value)) std::snprintf(actual, sizeof(actual), "range");
    else std::snprintf(actual, sizeof(actual), "%s", lj_typename(Value));
@@ -817,8 +874,8 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
             // place.  BC_GSET validates the same value against that existing policy before the post-store const
             // descriptor commits the transition.
          }
-         else if (incoming.type IS TiriType::Any) {
-            // An explicit 'any' declaration is the only ordinary operation that relaxes a sticky global contract.
+         else if (contract_is_variant(incoming)) {
+            // Explicit 'any' and array<any> declarations relax their respective sticky global contracts.
             lj_tab_set_global_contract(L, environment, global_name, Descriptor);
          }
          else if (current) {

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -875,8 +875,9 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
             // descriptor commits the transition.
          }
          else if (contract_is_variant(incoming)) {
-            // Explicit 'any' and array<any> declarations relax their respective sticky global contracts.
-            lj_tab_set_global_contract(L, environment, global_name, Descriptor);
+            // Explicit 'any' and array<any> declarations relax their respective sticky global contracts only after
+            // the declaration value passes this descriptor.  A caught failure must preserve the previous policy.
+            publish_global_contract = true;
          }
          else if (current) {
             // Bytecode may outlive the declaration policy it was compiled against.  The environment policy is

--- a/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
+++ b/src/tiri/jit/src/runtime/unit_tests_arrays.cpp
@@ -897,7 +897,7 @@ static bool test_lib_array_new(kt::Log &Log)
 
    // Test array.new via Lua
    const char* code = R"(
-      local arr:array = array.new(100, "int")
+      local arr:array<int> = array.new(100, "int")
       return arr != nil and #arr is 100 and array.type(arr) is "int"
    )";
 
@@ -926,7 +926,7 @@ static bool test_lib_array_index(kt::Log &Log)
 
    // Test array indexing via library metamethods
    const char* code = R"(
-      local arr:array = array.new(10, "int")
+      local arr:array<int> = array.new(10, "int")
       arr[0] = 100
       arr[5] = 500
       arr[9] = 900
@@ -958,7 +958,7 @@ static bool test_lib_array_table(kt::Log &Log)
 
    // Test array.table conversion
    const char* code = R"(
-      local arr:array = array.new(5, "int")
+      local arr:array<int> = array.new(5, "int")
       arr[0] = 10
       arr[1] = 20
       arr[2] = 30
@@ -993,8 +993,8 @@ static bool test_lib_array_copy(kt::Log &Log)
 
    // Test array.copy
    const char* code = R"(
-      local src:array = array.new(5, "int")
-      local dst:array = array.new(5, "int")
+      local src:array<int> = array.new(5, "int")
+      local dst:array<int> = array.new(5, "int")
       src[0] = 100
       src[1] = 200
       src[2] = 300
@@ -1029,7 +1029,7 @@ static bool test_lib_array_string(kt::Log &Log)
 
    // Test array.getString and setString
    const char* code = R"(
-      local arr:array = array.new(10, "char")
+      local arr:array<byte> = array.new(10, "char")
       array.setString(arr, "hello")
       local s:str = array.getString(arr, 0, 5)
       return s is "hello"
@@ -1060,7 +1060,7 @@ static bool test_lib_array_fill(kt::Log &Log)
 
    // Test array.fill
    const char* code = R"(
-      local arr:array = array.new(10, "int")
+      local arr:array<int> = array.new(10, "int")
       array.fill(arr, 42)
       local ok = true
       for i in {0 into 9} do
@@ -1094,7 +1094,7 @@ static bool test_lib_array_len_operator(kt::Log &Log)
 
    // Test # operator via __len metamethod
    const char* code = R"(
-      local arr:array = array.new(42, "double")
+      local arr:array<double> = array.new(42, "double")
       return #arr is 42
    )";
 
@@ -1123,7 +1123,7 @@ static bool test_lib_array_double_type(kt::Log &Log)
 
    // Test double array type
    const char* code = R"(
-      local arr:array = array.new(5, "double")
+      local arr:array<double> = array.new(5, "double")
       arr[0] = 3.14159
       arr[2] = -2.71828
       arr[4] = 1.41421

--- a/src/tiri/tests/test_array_typed_syntax.tiri
+++ b/src/tiri/tests/test_array_typed_syntax.tiri
@@ -368,8 +368,8 @@ end
 end
 
 @Test function ArrayTypedReassignment()
-   -- Reassigning array variable
-   arr = array<int> { 1, 2, 3 }
+   -- A wildcard member annotation permits reassignment to another array member type.
+   local arr:array<any> = array<int> { 1, 2, 3 }
    assert(#arr is 3, "Initial array should have 3 elements")
 
    arr = array<double> { 1.5, 2.5 }
@@ -379,7 +379,7 @@ end
 
 @Test function ArrayTypedAsReturnValue()
    -- Function returning typed array
-   function makeNumbers(n):array
+   function makeNumbers(n):array<any>
       result = array<int, n>
       for i in {0 to n} do
          result[i] = i + 1

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -266,6 +266,33 @@ end
    end
 end
 
+@Test function FailedGlobalArrayWildcardRedeclarationPreservesPolicy()
+   global glGTFailedWildcardArray:array<int> = array<int> { 11 }
+
+   try
+      global glGTFailedWildcardArray:array<any> = { 'not an array' }
+      error('A wildcard array redeclaration should reject an ordinary table')
+   except e
+      assert(e.message:find('expected array<any>') != nil,
+         'The failed wildcard redeclaration should report its incoming contract: ' .. e.message)
+   end
+
+   assert(glGTFailedWildcardArray[0] is 11,
+      'A failed wildcard redeclaration must preserve the previous global value')
+
+   local writer = exec('return function(Value) glGTFailedWildcardArray = Value end')
+   try
+      writer(array<string> { 'wrong' })
+      error('A failed wildcard redeclaration must not relax the existing concrete policy')
+   except e
+      assert(e.message:find('expected array<int>') != nil,
+         'The original concrete policy should survive the failed wildcard redeclaration: ' .. e.message)
+   end
+
+   assert(glGTFailedWildcardArray[0] is 11,
+      'A store rejected by the preserved concrete policy must leave the value unchanged')
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- A local variable shadowing a typed global name must not inherit the global's type.
 

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -229,6 +229,43 @@ end
       'Global array indexing should emit AGETB/AGETV, got:\n' .. disasm)
 end
 
+@Test function GlobalArrayMemberContract()
+   global glGTMemberArray:array<int> = array<int> { 7 }
+   local writer = exec('return function(Value) glGTMemberArray = Value end')
+
+   writer(array<int> { 9 })
+   assert(glGTMemberArray[0] is 9, 'A matching cross-chunk array member type should pass')
+
+   try
+      writer(array<string> { 'wrong' })
+      error('A conflicting cross-chunk array member type should raise')
+   except e
+      assert(e.message:find('expected array<int>') != nil,
+         'The global contract should identify array<int>: ' .. e.message)
+      assert(e.message:find('got array<string>') != nil,
+         'The global contract should identify array<string>: ' .. e.message)
+   end
+   assert(glGTMemberArray[0] is 9, 'A rejected global array store must preserve the previous value')
+end
+
+@Test function GlobalArrayWildcardRedeclaration()
+   global glGTWildcardArray:array<int> = array<int> { 1 }
+   global glGTWildcardArray:array<any> = array<string> { 'open' }
+   assert(glGTWildcardArray[0] is 'open', 'array<any> should relax a concrete global member contract')
+
+   local writer = exec('return function(Value) glGTWildcardArray = Value end')
+   writer(array<double> { 2.5 })
+   assert(glGTWildcardArray[0] is 2.5, 'A wildcard global should accept another array member type')
+
+   try
+      writer({ 3 })
+      error('array<any> should continue to reject ordinary tables')
+   except e
+      assert(e.message:find('expected array<any>') != nil,
+         'The wildcard contract should remain an array contract: ' .. e.message)
+   end
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- A local variable shadowing a typed global name must not inherit the global's type.
 

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -41,7 +41,7 @@ end
 function numberPresent(Value:num):bool return Value?? end
 function stringPresent(Value:str):bool return Value?? end
 function booleanPresent(Value:bool):bool return Value?? end
-function arrayPresent(Value:array):bool return Value?? end
+function arrayPresent(Value:array<any>):bool return Value?? end
 function tablePresent(Value:table):bool return Value?? end
 function anyPresent(Value:any):bool return Value?? end
 ]] })
@@ -137,15 +137,15 @@ end
 
 @Test function ArrayParameterAndLengthRangeBytecode()
    local script = obj.new('tiri', { statement=[[
-global glBytecodeValues:array = array<int> { 1, 2, 3 }
+global glBytecodeValues:array<any> = array<int> { 1, 2, 3 }
 
-function increment(Array:array)
+function increment(Array:array<any>)
    for index in {0 to #Array} do
       Array[index] += 1
    end
 end
 
-function incrementInTry(Array:array)
+function incrementInTry(Array:array<any>)
    try
       for index in {0 to #Array} do
          Array[index] += 1
@@ -292,7 +292,7 @@ function canonical_array_try_workload(Count):str
    return values:concat(',', '%d')
 end
 
-global glCanonicalArrayRangeValues:array = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
+global glCanonicalArrayRangeValues:array<any> = array<int> { 1, 2, 3, 4, 5, 6, 7, 8 }
 
 function canonical_global_array_workload(Count)
    local total = 0
@@ -320,7 +320,7 @@ function find_array_bounds_trace(MaxTraceNo)
    return nil, nil, 0
 end
 
-function resize_during_array_loop(Array:array, Shrink:bool)
+function resize_during_array_loop(Array:array<any>, Shrink:bool)
    local alias = Array
    for index in {0 to #Array} do
       if Shrink and index is 16 then alias:resize(8) end
@@ -328,7 +328,7 @@ function resize_during_array_loop(Array:array, Shrink:bool)
    end
 end
 
-function clear_during_array_loop(Array:array, Clear:bool)
+function clear_during_array_loop(Array:array<any>, Clear:bool)
    local alias = Array
    for index in {0 to #Array} do
       if Clear and index is 16 then alias:clear() end
@@ -336,14 +336,14 @@ function clear_during_array_loop(Array:array, Clear:bool)
    end
 end
 
-function reassign_during_array_loop(Array:array, Reassign:bool)
+function reassign_during_array_loop(Array:array<any>, Reassign:bool)
    for index in {0 to #Array} do
       if Reassign and index is 16 then Array = array<int, 8> end
       Array[index] += 1
    end
 end
 
-function push_during_array_loop(Array:array):<num, num, num>
+function push_during_array_loop(Array:array<any>):<num, num, num>
    local original_length = #Array
    for index in {0 to #Array} do
       if index is 0 then Array:push(99) end
@@ -2042,11 +2042,11 @@ end
    jit.flush()
    jit.opt.start("hotloop=1", "hotexit=1", "minstitch=0")
 
-   function typ12_hot_push(Array:array, Value:any)
+   function typ12_hot_push(Array:array<any>, Value:any)
       Array:push(Value)
    end
 
-   function typ12_hot_store(Array:array, Value:any)
+   function typ12_hot_store(Array:array<any>, Value:any)
       Array[0] = Value
    end
 
@@ -2076,6 +2076,32 @@ end
    typ12_hot_store(stored, 3000000000)
    assert(stored[0] is -1294967296,
       'an out-of-machine-range hot store should side-exit to defined integer wrapping')
+end
+
+@Test(hotpath=80) function JITArrayMemberContractRejectsTypeChanges()
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   function typ13_dynamic(Value:any):any return Value end
+   function typ13_first(Array:array<int>):num return Array[0] end
+
+   local numbers = array<int> { 7 }
+   for i in {1 into 80} do
+      assert(typ13_first(typ13_dynamic(numbers)) is 7,
+         'A matching member contract should remain valid while tracing')
+   end
+
+   try
+      typ13_first(typ13_dynamic(array<string> { 'wrong' }))
+   except e
+      assert(e.message:find('expected array<int>') != nil,
+         'The traced contract should retain the expected member type: ' .. e.message)
+      assert(e.message:find('got array<string>') != nil,
+         'The traced contract should report the incoming member type: ' .. e.message)
+   success
+      error('A hot concrete array contract should reject a different member type')
+   end
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_pipe_iteration.tiri
+++ b/src/tiri/tests/test_pipe_iteration.tiri
@@ -188,7 +188,7 @@ end
 end
 
 @Test function ArrayPipeIterationChaining()
-   -- Chaining: array |> func1 |> func2
+   -- Chaining: array<any> |> func1 |> func2
    log1 = {}
    log2 = {}
    array<int> { 5, 10, 15 } |> function(v) log1[#log1] = v end

--- a/src/tiri/tests/test_type_annotations.tiri
+++ b/src/tiri/tests/test_type_annotations.tiri
@@ -79,7 +79,7 @@ end
 @Test function MistypedArrayArgumentRaisesCleanly()
    -- Annotated parameters emit specialised bytecode, so passing a mismatched value must raise a
    -- catchable error rather than crash or silently operate on the wrong type.
-   function increment(Values:array)
+   function increment(Values:array<any>)
       for index in {0 to #Values} do
          Values[index] += 1
       end
@@ -93,4 +93,49 @@ end
       assert(e.message != nil, "The mistyped argument error should carry a message")
    end
    assert(plain_table[0] is 1, "A rejected table argument should remain unmodified")
+end
+
+@Test function ArrayMemberAnnotations()
+   function first_word(Values:array<string>):str
+      return Values[0]
+   end
+
+   function make_numbers():array<int>
+      return array<int> { 3, 5 }
+   end
+
+   function words_and_count():<array<string>,num>
+      return array<string> { 'one', 'two' }, 2
+   end
+
+   local words:array<string> = array<string> { 'alpha', 'beta' }
+   assert(first_word(words) is 'alpha', 'A matching array<string> parameter should pass')
+   assert(make_numbers()[1] is 5, 'A matching array<int> result should pass')
+   local returned_words, returned_count = words_and_count()
+   assert(returned_words[1] is 'two' and returned_count is 2,
+      'A member-specialised array should work in a multi-result annotation')
+
+   function count_values(Values:array<any>):num return #Values end
+   assert(count_values(array<int> { 1, 2 }) is 2, 'array<any> should accept numeric arrays')
+   assert(count_values(array<string> { 'one' }) is 1, 'array<any> should accept string arrays')
+end
+
+@Test function IncompleteArrayAnnotationsRejected()
+   try
+      exec('function rejected(Value:array) return Value end')
+   success
+      error('A bare array annotation should be rejected')
+   end
+
+   try
+      exec('function rejected(Value:array<int, 4>) return Value end')
+   success
+      error('An array annotation should not accept a constructor size')
+   end
+
+   try
+      exec('function rejected(Value:array<array<string>>) return Value end')
+   success
+      error('Nested array member specialisation should be rejected explicitly')
+   end
 end

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -76,7 +76,7 @@ end
    function accept_num(Value:num) return Value end
    function accept_str(Value:str) return Value end
    function accept_table(Value:table) return Value end
-   function accept_array(Value:array) return Value end
+   function accept_array(Value:array<any>) return Value end
    function accept_func(Value:func) return Value end
    function accept_struct(Value:struct) return Value end
    function accept_obj(Value:obj) return Value end
@@ -133,6 +133,38 @@ end
    local bravo = struct<ContractBravo> { Value=7 }
    assert(accept_alpha(alpha) is 7, 'Matching named structure should pass')
    expect_contract_failure(function() accept_alpha(dynamic_value(bravo)) end, 'parameter')
+end
+
+@Test function ArrayMemberIdentity()
+   function accept_int_array(Value:array<int>):array<int> return Value end
+   function accept_any_array(Value:array<any>):array<any> return Value end
+
+   local numbers = array<int> { 4, 8 }
+   local words = array<string> { 'four', 'eight' }
+   assert(accept_int_array(numbers) is numbers, 'A matching concrete member type should pass')
+   assert(accept_any_array(numbers) is numbers, 'array<any> should accept array<int>')
+   assert(accept_any_array(words) is words, 'array<any> should accept array<string>')
+
+   expect_contract_failure(
+      function() accept_int_array(dynamic_value(words)) end, 'array member parameter')
+
+   local sticky = array<int> { 1 }
+   expect_contract_failure(
+      function() sticky = dynamic_value(words) end, 'inferred array member store')
+   assert(sticky[0] is 1, 'A rejected member-type store must preserve the previous array')
+
+   function wrong_result():any return words end
+   function checked_result():array<int> return wrong_result() end
+   expect_contract_failure(function() checked_result() end, 'array member result')
+
+   local alpha = struct<ContractAlpha> { Value=3 }
+   local bravo = struct<ContractBravo> { Value=5 }
+   local alpha_values = array<struct<ContractAlpha>> { alpha }
+   local bravo_values = array<struct<ContractBravo>> { bravo }
+   function accept_alpha_array(Value:array<struct<ContractAlpha>>):num return Value[0].Value end
+   assert(accept_alpha_array(alpha_values) is 3, 'A matching named-structure array should pass')
+   expect_contract_failure(
+      function() accept_alpha_array(dynamic_value(bravo_values)) end, 'named-structure array member')
 end
 
 @Test function NilMissingAndExtraArguments()
@@ -198,7 +230,7 @@ end
 end
 
 @Test function GuardPrecedesSpecialisedMutation()
-   function increment(Values:array)
+   function increment(Values:array<any>)
       Values[0] += 1
    end
 
@@ -246,7 +278,7 @@ end
    function checked_num(Value:any):num return dynamic_value(Value) end
    function checked_str(Value:any):str return dynamic_value(Value) end
    function checked_table(Value:any):table return dynamic_value(Value) end
-   function checked_array(Value:any):array return dynamic_value(Value) end
+   function checked_array(Value:any):array<any> return dynamic_value(Value) end
    function checked_func(Value:any):func return dynamic_value(Value) end
    function checked_struct(Value:any):struct return dynamic_value(Value) end
    function checked_alpha(Value:any):struct<ContractAlpha> return dynamic_value(Value) end
@@ -632,7 +664,7 @@ end
    expect_contract_failure(function() exec("glContractNumber = 'wrong'") end, 'global')
    assert(glContractNumber is 3, 'A rejected store from a separately compiled chunk must preserve the global value')
 
-   global glContractArray:array = array<int> { 4, 8 }
+   global glContractArray:array<any> = array<int> { 4, 8 }
    function read_contract_array():num
       return glContractArray[1]
    end
@@ -1065,7 +1097,7 @@ end
 
 @Test function ContractDisassemblyOrder()
    local script = obj.new('tiri', { statement = [[
-function first(Values:array):any
+function first(Values:array<any>):any
    return Values[0]
 end
 ]] })

--- a/src/tiri/tests/test_type_guided_emission.tiri
+++ b/src/tiri/tests/test_type_guided_emission.tiri
@@ -27,7 +27,7 @@ function make_point_pair():<str, struct<EmissionPoint>>
    return 'point', struct<EmissionPoint> { Value=37 }
 end
 
-function make_number_array():array
+function make_number_array():array<int>
    return array<int> { 5, 10, 15 }
 end
 
@@ -143,11 +143,11 @@ end
 end
 
 @Test function ArrayDescriptorInvalidation()
-   local values = array<int> { 1 }
+   local values:array<any> = array<int> { 1 }
    values = array<string> { 'changed' }
    assert(values[0] is 'changed', 'Conflicting array reassignment must not retain a stale numeric descriptor')
 
-   local branch_values = array<int> { 2 }
+   local branch_values:array<any> = array<int> { 2 }
    if true then branch_values = array<table> { { value=23 } } end
    assert(branch_values[0].value is 23, 'A conflicting branch assignment must degrade the element descriptor')
 end

--- a/tools/idl/include/doc.tiri
+++ b/tools/idl/include/doc.tiri
@@ -276,7 +276,7 @@ setAction('Query', {
 setAction('Read', {
    comment   = 'Reads raw data information from objects.',
    prototype = 'ERR acRead(*Object, std::span<int8_t> Buffer, INT *Result)',
-   tiriPrototype = 'err, Result:num = Object.acRead(Buffer:array)',
+   tiriPrototype = 'err, Result:num = Object.acRead(Buffer:array<byte>)',
    params    = {
       { name='Buffer', type='std::span<int8_t>', comment='A mutable buffer that will receive the data.' },
       { name='Result', type='INT', comment='The Read action will write this parameter with the total number of bytes read into the Buffer.' }

--- a/tools/idl/include/parser.tiri
+++ b/tools/idl/include/parser.tiri
@@ -69,7 +69,7 @@ global glOfficialTags = {
 ----------------------------------------------------------------------------------------------------------------------
 -- Parse and validate comma or newline-separated documentation tags for the supplied context.
 
-function parseTags(Tags:str, Context:str):array
+function parseTags(Tags:str, Context:str):array<string>
    result = array<string>
    Tags ?! return result
 
@@ -91,7 +91,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function addTag(Tags:array, Tag:str):array
+global function addTag(Tags:array<string>, Tag:str):array<string>
    Tags ?= array<string>
 
    for existing_tag in values(Tags) do
@@ -105,7 +105,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags to a tag list based on a field definition.
 
-global function getTagsFromField(Field:table, Tags:array):array
+global function getTagsFromField(Field:table, Tags:array<string>):array<string>
    Field ?! return Tags
    Tags ?= array<string>
 
@@ -122,7 +122,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Apply automatic documentation tags for every field or parameter in a collection.
 
-global function getTagsFromCollection(Tags:array, Fields:any):array
+global function getTagsFromCollection(Tags:array<string>, Fields:any):array<string>
    Tags ?= array<string>
    Fields ?! return Tags
 

--- a/tools/tiri_lsp/include/lsp_cache.tiri
+++ b/tools/tiri_lsp/include/lsp_cache.tiri
@@ -118,7 +118,7 @@ function extractChildAttr(Content:str, TagName:str, AttrName:str):str
    return content
 end
 
-function extractSources(Content:str):array
+function extractSources(Content:str):array<table>
    sources = array<table>
    sourceMatch = extractXMLElement(Content, 'source', 0)
    sourceMatch ?! return sources
@@ -140,7 +140,7 @@ function extractSources(Content:str):array
    return sources
 end
 
-function extractInputParams(Content:str):array
+function extractInputParams(Content:str):array<table>
    params = array<table>
    inputMatch = extractXMLElement(Content, 'input', 0)
    inputMatch ?! return params

--- a/tools/tiri_lsp/include/lsp_definition.tiri
+++ b/tools/tiri_lsp/include/lsp_definition.tiri
@@ -181,7 +181,7 @@ function makeXmlLocation(Entry:table, ByteStart:num, ByteEnd:num):table
    return makeOffsetLocation(glDocCache.sdkPath .. Entry.file, ByteStart or Entry.byteStart or 0, ByteEnd or Entry.byteEnd or 0)
 end
 
-function pushLocation(Locations:array, Location:table)
+function pushLocation(Locations:array<table>, Location:table)
    if Location then Locations:push(Location) end
 end
 
@@ -268,7 +268,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Current Document Symbols
 
-function addSymbol(Symbols:array, Name:str, Kind:str, Line:num, StartChar:num, EndChar:num)
+function addSymbol(Symbols:array<table>, Name:str, Kind:str, Line:num, StartChar:num, EndChar:num)
    if not Name or Name is '' then return end
    Symbols:push({
       name = Name,
@@ -283,7 +283,7 @@ function addSymbol(Symbols:array, Name:str, Kind:str, Line:num, StartChar:num, E
    })
 end
 
-function addFunctionParameters(Symbols:array, Params:str, LineText:str, Line:num, SearchFrom:num)
+function addFunctionParameters(Symbols:array<table>, Params:str, LineText:str, Line:num, SearchFrom:num)
    Params ?! return
    scan_from = SearchFrom or 0
 
@@ -319,7 +319,7 @@ end
 
 -- Add 'StructName.FieldName' symbols for the struct fields present in LineCode.
 
-function addStructFieldSymbols(Symbols:array, StructName:str, LineCode:str, LineText:str, Line:num, SearchFrom:num)
+function addStructFieldSymbols(Symbols:array<table>, StructName:str, LineCode:str, LineText:str, Line:num, SearchFrom:num)
    scan_from = SearchFrom or 0
 
    for segment in values(LineCode:split(',')) do
@@ -336,7 +336,7 @@ function addStructFieldSymbols(Symbols:array, StructName:str, LineCode:str, Line
    end
 end
 
-global function extractDefinitionSymbols(Doc:table):array
+global function extractDefinitionSymbols(Doc:table):array<table>
    symbols = array<table>
    total_lines = getTotalLines(Doc)
    in_block_comment = false
@@ -472,7 +472,7 @@ function symbolNameMatches(SymbolName:str, TokenInfo:table):bool
    return false
 end
 
-function resolveDocumentSymbolDefinition(Doc:table, TokenInfo:table, Position:table):array
+function resolveDocumentSymbolDefinition(Doc:table, TokenInfo:table, Position:table):array<table>
    TokenInfo ?! return nil
 
    symbols = extractDefinitionSymbols(Doc)
@@ -557,7 +557,7 @@ function resolveScriptImport(Doc:table, Name:str):table
    return nil
 end
 
-function resolveLoaderDefinition(Doc:table, Position:table):array
+function resolveLoaderDefinition(Doc:table, Position:table):array<table>
    string_info = getLoaderStringAtPosition(Doc, Position)
    string_info ?! return nil
 
@@ -606,7 +606,7 @@ function buildDefinitionTypeMap(Doc:table):table
    return type_map
 end
 
-function addSourceFallback(Locations:array, ApiEntry:table)
+function addSourceFallback(Locations:array<table>, ApiEntry:table)
    if not ApiEntry or not ApiEntry.sources or not ApiEntry.module then return end
 
    module_folder = ApiEntry.module:lower()
@@ -622,7 +622,7 @@ function addSourceFallback(Locations:array, ApiEntry:table)
    end
 end
 
-function resolveClassDefinition(ClassName:str):array
+function resolveClassDefinition(ClassName:str):array<table>
    class_name = normaliseClassName(ClassName)
    class_name ?! return nil
 
@@ -633,7 +633,7 @@ function resolveClassDefinition(ClassName:str):array
    return #locations > 0 and locations or nil
 end
 
-function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
+function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array<table>
    if not TokenInfo or not TokenInfo.object or not glDocCache then return nil end
 
    token = TokenInfo.text
@@ -707,7 +707,7 @@ function resolveApiMemberDefinition(Doc:table, TokenInfo:table):array
    return nil
 end
 
-function resolveApiDefinition(Doc:table, Position:table, TokenInfo:table):array
+function resolveApiDefinition(Doc:table, Position:table, TokenInfo:table):array<table>
    obj_new_string = getObjNewStringAtPosition(Doc, Position)
    if obj_new_string then
       class_locations = resolveClassDefinition(obj_new_string.text)
@@ -730,7 +730,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Public Resolver
 
-global function resolveDefinition(Doc:table, Position:table):array
+global function resolveDefinition(Doc:table, Position:table):array<table>
    Doc ?! return nil
    Position ?! return nil
 

--- a/tools/tiri_lsp/include/lsp_parsing.tiri
+++ b/tools/tiri_lsp/include/lsp_parsing.tiri
@@ -34,7 +34,7 @@ MULTIBYTE_OPERATORS = {
 -- Tokenize a Tiri source file and return semantic tokens
 -- Returns array of tokens: { line, startChar, length, tokenType, tokenModifiers }
 
-global function tokenizeTiri(Source:str):array
+global function tokenizeTiri(Source:str):array<table>
    tokens = array<table>
    line = 0
    col = 0
@@ -845,7 +845,7 @@ end
 -- Extract folding ranges from Tiri source
 -- Returns array of FoldingRange objects for code folding
 
-global function extractFoldingRanges(Doc:table):array
+global function extractFoldingRanges(Doc:table):array<table>
    ranges = array<table>
    total_lines = getTotalLines(Doc)
    block_stack = array<table>  -- Stack of { line, kind } for nested blocks
@@ -973,7 +973,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Encode tokens into LSP semantic tokens format (delta-encoded integers)
 
-global function encodeSemanticTokens(Tokens:array):array
+global function encodeSemanticTokens(Tokens:array<table>):array<int>
    data = array<int>
    prev_line = 0
    prev_char = 0
@@ -999,7 +999,7 @@ end
 -- Compute semantic token edits between old and new data arrays
 -- Returns array of SemanticTokensEdit: { start, deleteCount, data? }
 
-global function computeTokenEdits(OldData:array, NewData:array):array
+global function computeTokenEdits(OldData:array<int>, NewData:array<int>):array<table>
    old_len = #OldData
    new_len = #NewData
 

--- a/tools/tiri_lsp/include/lsp_signature.tiri
+++ b/tools/tiri_lsp/include/lsp_signature.tiri
@@ -107,7 +107,7 @@ end
 
 -- Add a call frame to the parser stack for an opening parenthesis.
 
-function signaturePushFrame(Stack:array, Content:str, Pos:num)
+function signaturePushFrame(Stack:array<table>, Content:str, Pos:num)
    call = signatureReadCallName(Content, Pos)
    Stack:push({
       name = call?.name,
@@ -233,7 +233,7 @@ end
 
 -- Convert internal parameter records to LSP ParameterInformation records.
 
-function signatureBuildParameterInfo(Params:any):array
+function signatureBuildParameterInfo(Params:any):array<table>
    result = array<table>
    for param in values(Params or array<table>) do
       label = param.label or signatureParamLabel(param)
@@ -267,7 +267,7 @@ end
 
 -- Split a prototype parameter string while ignoring commas inside nested expressions.
 
-function signatureSplitParams(ParamText:str):array
+function signatureSplitParams(ParamText:str):array<table>
    params = array<table>
    current = ''
    paren_depth = 0
@@ -301,7 +301,7 @@ end
 
 -- Extract raw parameter labels from the first parenthesised parameter list in a prototype.
 
-function signatureParamsFromPrototype(Prototype:str):array
+function signatureParamsFromPrototype(Prototype:str):array<table>
    Prototype ?! return array<table>
    open_pos = Prototype:find('(', 0, true)
    close_pos = Prototype:find(')', open_pos or 0, true)
@@ -490,7 +490,7 @@ end
 
 -- Extract API parameters from a generated XML prototype.
 
-function signatureXmlParamsFromPrototype(Prototype:str):array
+function signatureXmlParamsFromPrototype(Prototype:str):array<table>
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
       params:push(signatureParamFromPrototypeLabel(param.label))
@@ -500,7 +500,7 @@ end
 
 -- Extract Tiri parameters from a generated Tiri prototype.
 
-function signatureTiriParamsFromPrototype(Prototype:str):array
+function signatureTiriParamsFromPrototype(Prototype:str):array<table>
    params = array<table>
    for param in values(signatureParamsFromPrototype(Prototype)) do
       params:push(signatureParamFromTiriLabel(param.label))
@@ -528,7 +528,7 @@ end
 
 -- Copy parameter documentation from generated API metadata onto parsed prototype parameters.
 
-function signatureCopyParamDocs(Params:array, SourceParams:any):array
+function signatureCopyParamDocs(Params:array<table>, SourceParams:any):array<table>
    if not SourceParams then return Params end
 
    for param in values(Params or array<table>) do
@@ -556,7 +556,7 @@ end
 
 -- Build visible API parameters, optionally hiding the generated receiver argument.
 
-function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array
+function signatureXmlParams(MethodDoc:table, HideReceiver:bool):array<table>
    source_params = MethodDoc.params
    if not source_params or #source_params is 0 then
       source_params = signatureXmlParamsFromPrototype(MethodDoc.prototype)
@@ -580,7 +580,7 @@ end
 
 -- Build the display label for a signature sourced from XML API metadata.
 
-function signatureXmlLabel(DisplayName:str, Params:array):str
+function signatureXmlLabel(DisplayName:str, Params:array<table>):str
    labels = array<string>
    for param in values(Params or array<table>) do
       labels:push(signatureParamLabel(param))

--- a/tools/tiri_lsp/include/lsp_symbols.tiri
+++ b/tools/tiri_lsp/include/lsp_symbols.tiri
@@ -60,14 +60,14 @@ function symbolCountChar(LineCode:str, Char:str):num
    return count
 end
 
-function symbolCurrentParent(Stack:array):table
+function symbolCurrentParent(Stack:array<table>):table
    for i in {#Stack - 1 into 0 by -1} do
       if Stack[i].symbol then return Stack[i].symbol end
    end
    return nil
 end
 
-function symbolAddChild(Roots:array, Stack:array, Symbol:table)
+function symbolAddChild(Roots:array<table>, Stack:array<table>, Symbol:table)
    parent = symbolCurrentParent(Stack)
    if parent then
       parent.children:push(Symbol)
@@ -90,7 +90,7 @@ function symbolMakeRange(LineNo:num, StartChar:num, EndChar:num):table
    }
 end
 
-function symbolAnnotationLabels(Annotations:array):array
+function symbolAnnotationLabels(Annotations:array<table>):array<string>
    labels = array<string>
    for anno in values(Annotations or array<table>) do
       labels:push('@' .. anno.name)
@@ -98,14 +98,14 @@ function symbolAnnotationLabels(Annotations:array):array
    return labels
 end
 
-function symbolHasAnnotation(Annotations:array, Name:str):bool
+function symbolHasAnnotation(Annotations:array<table>, Name:str):bool
    for anno in values(Annotations or array<table>) do
       if anno.name is Name then return true end
    end
    return false
 end
 
-function symbolBuildDetail(Base:str, Annotations:array):str
+function symbolBuildDetail(Base:str, Annotations:array<table>):str
    parts = array<string>
    if Base and Base != '' then parts:push(Base) end
    for label in values(symbolAnnotationLabels(Annotations)) do
@@ -115,7 +115,7 @@ function symbolBuildDetail(Base:str, Annotations:array):str
    return parts:concat(' ')
 end
 
-function symbolMergeAnnotations(Left:array, Right:array):array
+function symbolMergeAnnotations(Left:array<table>, Right:array<table>):array<table>
    merged = array<table>
    for anno in values(Left or array<table>) do merged:push(anno) end
    for anno in values(Right or array<table>) do merged:push(anno) end
@@ -169,7 +169,7 @@ function symbolReadAnnotationArgs(Text:str, Pos:num):<str,num>
    return Text:sub(start_pos + 1), Pos
 end
 
-function symbolParseAnnotationPrefix(LineText:str):<array,num>
+function symbolParseAnnotationPrefix(LineText:str):<array<table>,num>
    annotations = array<table>
    pos = 0
 
@@ -208,7 +208,7 @@ function symbolParseAnnotationPrefix(LineText:str):<array,num>
    return annotations, pos
 end
 
-function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, NameStart:num, Detail:str, Annotations:array):table
+function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, NameStart:num, Detail:str, Annotations:array<table>):table
    name_start = NameStart or 0
    symbol = {
       name = Name,
@@ -229,7 +229,7 @@ function symbolMakeDocumentSymbol(Name:str, Kind:num, LineNo:num, LineText:str, 
    return symbol
 end
 
-function symbolDetectFunction(LineCode:str, LineText:str, LineNo:num, Annotations:array):table
+function symbolDetectFunction(LineCode:str, LineText:str, LineNo:num, Annotations:array<table>):table
    start_pos, stop_pos, cap = rx_symbol_named_function.findFirst(LineCode)
    if start_pos then
       scope = nil
@@ -343,7 +343,7 @@ function symbolAddStructFields(Symbol:table, LineCode:str, LineText:str, LineNo:
    end
 end
 
-function symbolPushBlockFrames(Stack:array, LineCode:str, FunctionFrame:table)
+function symbolPushBlockFrames(Stack:array<table>, LineCode:str, FunctionFrame:table)
    function_count = symbolCountBlockKeyword(LineCode, 'function') + symbolCountBlockKeyword(LineCode, 'thunk')
    if FunctionFrame and function_count > 0 then function_count -= 1 end
 
@@ -380,7 +380,7 @@ function symbolPushBlockFrames(Stack:array, LineCode:str, FunctionFrame:table)
    end
 end
 
-function symbolCloseBlockFrames(Stack:array, LineCode:str, LineNo:num, LineText:str)
+function symbolCloseBlockFrames(Stack:array<table>, LineCode:str, LineNo:num, LineText:str)
    close_count = symbolCountBlockKeyword(LineCode, 'end') + symbolCountBlockKeyword(LineCode, 'until')
    for i in {1 to close_count+1} do
       if #Stack > 0 then
@@ -394,7 +394,7 @@ function symbolIsBraceFrame(Frame:table):bool
    return Frame.kind is 'table'
 end
 
-function symbolFindTopTableFrame(Stack:array):table
+function symbolFindTopTableFrame(Stack:array<table>):table
    for i in {#Stack - 1 into 0 by -1} do
       frame = Stack[i]
       if symbolIsBraceFrame(frame) then
@@ -404,7 +404,7 @@ function symbolFindTopTableFrame(Stack:array):table
    return nil
 end
 
-function symbolCloseTables(Stack:array, LineCode:str, LineNo:num, LineText:str)
+function symbolCloseTables(Stack:array<table>, LineCode:str, LineNo:num, LineText:str)
    table_frame = symbolFindTopTableFrame(Stack)
    if not table_frame then return end
 
@@ -437,7 +437,7 @@ end
 ----------------------------------------------------------------------------------------------------------------------
 -- Extract document symbols from Tiri source.
 
-global function extractDocumentSymbols(Doc:table):array
+global function extractDocumentSymbols(Doc:table):array<table>
    symbols = array<table>
    total_lines = getTotalLines(Doc)
    stack = array<table>

--- a/tools/tiri_lsp/tests/test_definition.tiri
+++ b/tools/tiri_lsp/tests/test_definition.tiri
@@ -22,13 +22,13 @@ function makeDoc(Content:str):table
    }
 end
 
-function assertLocationLine(Locations:array, Line:num, Message:str)
+function assertLocationLine(Locations:array<table>, Line:num, Message:str)
    assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
    assert(Locations[0].range.start.line is Line,
       f'{Message}: expected line {Line}, got {Locations[0].range.start.line}')
 end
 
-function assertUriContains(Locations:array, Needle:str, Message:str)
+function assertUriContains(Locations:array<table>, Needle:str, Message:str)
    assert(Locations and #Locations > 0, Message .. ': expected at least one location.')
    uri = Locations[0].uri:replace('\\', '/'):lower()
    assert(uri:find(Needle:lower(), 0, true), f'{Message}: expected URI to contain {Needle}, got {Locations[0].uri}')

--- a/tools/tiri_lsp/tests/test_document_symbols.tiri
+++ b/tools/tiri_lsp/tests/test_document_symbols.tiri
@@ -21,7 +21,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findSymbol(Symbols:array, Name:str):table
+function findSymbol(Symbols:array<table>, Name:str):table
    for symbol in values(Symbols) do
       if symbol.name is Name then return symbol end
    end

--- a/tools/tiri_lsp/tests/test_folding.tiri
+++ b/tools/tiri_lsp/tests/test_folding.tiri
@@ -21,7 +21,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findRange(Ranges:array, StartLine:num, EndLine:num):table
+function findRange(Ranges:array<table>, StartLine:num, EndLine:num):table
    for range in values(Ranges) do
       if range.startLine is StartLine and range.endLine is EndLine then return range end
    end

--- a/tools/tiri_lsp/tests/test_semantic_tokens.tiri
+++ b/tools/tiri_lsp/tests/test_semantic_tokens.tiri
@@ -24,7 +24,7 @@ function makeDoc(Content:str):table
    }
 end
 
-function findToken(Tokens:array, Line:num, Char:num, Text:str):table
+function findToken(Tokens:array<table>, Line:num, Char:num, Text:str):table
    for token in values(Tokens) do
       if token.line is Line and token.char is Char and token.length is #Text then
          return token
@@ -32,12 +32,12 @@ function findToken(Tokens:array, Line:num, Char:num, Text:str):table
    end
 end
 
-function assertOperatorToken(Tokens:array, Line:num, Char:num, Text:str, Message:str)
+function assertOperatorToken(Tokens:array<table>, Line:num, Char:num, Text:str, Message:str)
    token = findToken(Tokens, Line, Char, Text)
    assert(token and token.type is 1, Message)
 end
 
-function assertNoToken(Tokens:array, Line:num, Char:num, Text:str, Message:str)
+function assertNoToken(Tokens:array<table>, Line:num, Char:num, Text:str, Message:str)
    token = findToken(Tokens, Line, Char, Text)
    assert(not token, Message)
 end


### PR DESCRIPTION
* Added array element descriptors across parser analysis, bytecode and runtime validation
* Added JIT guards and persistent global contract handling for typed arrays
* [Script] Specialised array annotations across applications, libraries, examples and tools
* [Test] Expanded parser, runtime, global and JIT coverage for array member contracts