### PR TITLE
[Tiri] Simplified canonical type metadata

### DIFF
--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -193,9 +193,9 @@ struct RecordOps {
 };
 
 //********************************************************************************************************************
-// Classify a runtime contract while recording.  Exact TValue tag checks are already represented by trace slot
-// specialisation.  Identity and metatable predicates require dedicated IR guards, so prototypes containing those
-// predicates remain interpreter-only for now.
+// Classify a runtime contract while recording.  Exact TValue tag checks use trace slot specialisation, while refined
+// range, callable, structure, object, userdata and array predicates emit dedicated guards.  Contracts whose dynamic or
+// identity requirements cannot be represented safely are classified as complex and remain interpreter-only.
 
 enum class RecordedContract : uint8_t {
    Basic,

--- a/src/tiri/jit/src/parser/ast/builder.cpp
+++ b/src/tiri/jit/src/parser/ast/builder.cpp
@@ -58,7 +58,6 @@ static std::unique_ptr<FunctionExprPayload> move_function_payload(ExprNodePtr &N
    result->parameters        = std::move(payload->parameters);
    result->is_vararg         = payload->is_vararg;
    result->is_thunk          = payload->is_thunk;
-   result->thunk_return_type = payload->thunk_return_type;
    result->return_types      = payload->return_types;  // Copy return type information
    result->body              = std::move(payload->body);
    result->annotations = std::move(payload->annotations);

--- a/src/tiri/jit/src/parser/ast/expressions.cpp
+++ b/src/tiri/jit/src/parser/ast/expressions.cpp
@@ -628,7 +628,13 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          auto body = make_block(span, std::move(body_stmts));
 
          // Build anonymous thunk function (no parameters, is_thunk=true)
-         ExprNodePtr thunk_func = make_function_expr(span, {}, false, std::move(body), true, inferred_type);
+         FunctionReturnTypes return_types;
+         if (inferred_type != TiriType::Any and inferred_type != TiriType::Unknown) {
+            return_types.types[0] = inferred_type;
+            return_types.count = 1;
+            return_types.has_thunk_type = true;
+         }
+         ExprNodePtr thunk_func = make_function_expr(span, {}, false, std::move(body), true, return_types);
 
          // Build immediate call to thunk (no arguments)
          ExprNodeList call_args;
@@ -784,7 +790,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
                auto body = make_block(span, std::move(body_stmts));
 
                // Build anonymous function (no parameters)
-               ExprNodePtr anon_func = make_function_expr(span, {}, false, std::move(body), false, TiriType::Any);
+               ExprNodePtr anon_func = make_function_expr(span, {}, false, std::move(body));
 
                // Build immediate call to function (no arguments)
                ExprNodeList call_args;
@@ -904,7 +910,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_primary()
          return_types.count = 1;
          return_types.is_explicit = true;
          ExprNodePtr thunk_func = make_function_expr(
-            span, {}, false, std::move(body), true, explicit_type, return_types);
+            span, {}, false, std::move(body), true, return_types);
 
          // Build immediate call to thunk (no arguments)
          ExprNodeList call_args;
@@ -1001,7 +1007,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_arrow_function(ExprNodeList paramete
    else function_span = combine_spans(arrow_token.span(), body->span);
 
    ExprNodePtr node = make_function_expr(function_span, std::move(parsed_params), false, std::move(body),
-      false, TiriType::Any, return_types);
+      false, return_types);
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
 

--- a/src/tiri/jit/src/parser/ast/literals.cpp
+++ b/src/tiri/jit/src/parser/ast/literals.cpp
@@ -32,12 +32,6 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
    if (not type_result.ok()) return ParserResult<ExprNodePtr>::failure(type_result.error_ref());
    FunctionReturnTypes return_types = type_result.value_ref();
 
-   // For thunk compatibility: extract single return type for thunk_return_type field
-   TiriType thunk_return_type = TiriType::Any;
-   if (IsThunk and return_types.count > 0) {
-      thunk_return_type = return_types.types[0];
-   }
-
    const TokenKind terms[] = { TokenKind::EndToken };
    FunctionNameScope function_name_scope(*this, FunctionName);
    ++this->function_depth;
@@ -47,7 +41,7 @@ ParserResult<ExprNodePtr> AstBuilder::parse_function_literal(
 
    this->ctx.consume(TokenKind::EndToken, ParserErrorCode::ExpectedToken);
    ExprNodePtr node = make_function_expr(FunctionToken.span(), std::move(params.value_ref().parameters),
-      params.value_ref().is_vararg, std::move(body.value_ref()), IsThunk, thunk_return_type, return_types);
+      params.value_ref().is_vararg, std::move(body.value_ref()), IsThunk, return_types);
    return ParserResult<ExprNodePtr>::success(std::move(node));
 }
 

--- a/src/tiri/jit/src/parser/ast/nodes.cpp
+++ b/src/tiri/jit/src/parser/ast/nodes.cpp
@@ -819,8 +819,6 @@ ExprNodePtr make_member_expr(SourceSpan Span, ExprNodePtr Table, Identifier memb
 {
    assert_node(ensure_operand(Table), "member expression requires table value");
    MemberExprPayload payload;
-   // Infer base type before moving the table expression
-   payload.base_type = infer_expression_type(*Table);
    payload.table = std::move(Table);
    payload.member = member;
    payload.uses_method_dispatch = uses_method_dispatch;
@@ -848,8 +846,6 @@ ExprNodePtr make_safe_member_expr(SourceSpan Span, ExprNodePtr Table, Identifier
 {
    assert_node(ensure_operand(Table), "safe member expression requires table value");
    SafeMemberExprPayload payload;
-   // Infer base type before moving the table expression
-   payload.base_type = infer_expression_type(*Table);
    payload.table = std::move(Table);
    payload.member = Member;
    ExprNodePtr node = std::make_unique<ExprNode>();
@@ -900,16 +896,16 @@ ExprNodePtr make_table_expr(SourceSpan Span, std::vector<TableField> fields, boo
    return node;
 }
 
-ExprNodePtr make_function_expr(SourceSpan Span, std::vector<FunctionParameter> parameters, bool is_vararg, std::unique_ptr<BlockStmt> body, bool IsThunk, TiriType ThunkReturnType, FunctionReturnTypes ReturnTypes)
+ExprNodePtr make_function_expr(SourceSpan Span, std::vector<FunctionParameter> Parameters, bool IsVararg,
+   std::unique_ptr<BlockStmt> Body, bool IsThunk, FunctionReturnTypes ReturnTypes)
 {
-   assert_node(body != nullptr, "function literal body required");
+   assert_node(Body != nullptr, "function literal body required");
    FunctionExprPayload payload;
-   payload.parameters = std::move(parameters);
-   payload.is_vararg = is_vararg;
+   payload.parameters = std::move(Parameters);
+   payload.is_vararg = IsVararg;
    payload.is_thunk = IsThunk;
-   payload.thunk_return_type = ThunkReturnType;
    payload.return_types = ReturnTypes;
-   payload.body = std::move(body);
+   payload.body = std::move(Body);
    ExprNodePtr node = std::make_unique<ExprNode>();
    node->kind = AstNodeKind::FunctionExpr;
    node->span = Span;
@@ -975,17 +971,16 @@ ExprNodePtr make_choose_expr_tuple(SourceSpan Span, ExprNodeList ScrutineeTuple,
    return node;
 }
 
-std::unique_ptr<FunctionExprPayload> make_function_payload(std::vector<FunctionParameter> parameters,
-   bool is_vararg, std::unique_ptr<BlockStmt> body, bool IsThunk, TiriType ThunkReturnType, FunctionReturnTypes ReturnTypes)
+std::unique_ptr<FunctionExprPayload> make_function_payload(std::vector<FunctionParameter> Parameters,
+   bool IsVararg, std::unique_ptr<BlockStmt> Body, bool IsThunk, FunctionReturnTypes ReturnTypes)
 {
-   assert_node(body != nullptr, "function body required");
+   assert_node(Body != nullptr, "function body required");
    auto payload = std::make_unique<FunctionExprPayload>();
-   payload->parameters = std::move(parameters);
-   payload->is_vararg = is_vararg;
+   payload->parameters = std::move(Parameters);
+   payload->is_vararg = IsVararg;
    payload->is_thunk = IsThunk;
-   payload->thunk_return_type = ThunkReturnType;
    payload->return_types = ReturnTypes;
-   payload->body = std::move(body);
+   payload->body = std::move(Body);
    return payload;
 }
 

--- a/src/tiri/jit/src/parser/ast/nodes.h
+++ b/src/tiri/jit/src/parser/ast/nodes.h
@@ -64,16 +64,21 @@ struct FunctionReturnTypes {
    std::array<struct_record *, MAX_RETURN_TYPES> struct_defs{}; // Resolved layouts for struct<Name> results
    std::array<ArrayElementDescriptor, MAX_RETURN_TYPES> array_elements{}; // Array member constraints
    std::array<StaticValueHandle, MAX_RETURN_TYPES> descriptors{};
-   uint8_t count = 0;           // Number of declared types (0 = not declared)
+   uint8_t count = 0;           // Number of stored result types (0 = none)
    bool is_variadic = false;    // True if declaration ends with ... (last type repeats)
    bool is_explicit = false;    // True if explicitly declared, false if inferred
    bool is_inferred = false;    // True when semantic analysis validated every returned position
+   bool has_thunk_type = false; // First result also supplies an advisory runtime type for a synthetic thunk
 
    [[nodiscard]] bool is_void() const { return count IS 0 and is_explicit; }
    [[nodiscard]] bool is_any() const { return count IS 1 and types[0] IS TiriType::Any; }
    [[nodiscard]] TiriType type_at(size_t Index) const {
       if (Index >= count) return is_variadic ? types[count - 1] : TiriType::Unknown;
       return types[Index];
+   }
+   [[nodiscard]] TiriType thunk_type() const {
+      if (count IS 0 or (not is_explicit and not has_thunk_type)) return TiriType::Unknown;
+      return types[0];
    }
 };
 
@@ -442,7 +447,6 @@ struct MemberExprPayload {
    Identifier member;
    bool uses_method_dispatch = false;
    bool is_call_target = false;                       // True if this expression is the callee of a function call
-   mutable TiriType base_type = TiriType::Unknown;  // Known type of the base (table/object) expression
    mutable CLASSID class_id = CLASSID::NIL;           // CLASSID if base is Object
    ~MemberExprPayload();
 };
@@ -455,7 +459,6 @@ struct IndexExprPayload {
    IndexExprPayload& operator=(IndexExprPayload&&) noexcept = default;
    ExprNodePtr table;
    ExprNodePtr index;
-   mutable TiriType base_type = TiriType::Unknown;  // Known type of the base (table/array) expression
    ~IndexExprPayload();
 };
 
@@ -468,7 +471,6 @@ struct SafeMemberExprPayload {
    ExprNodePtr table;
    Identifier member;
    bool is_call_target = false;                       // True if this expression is the callee of a function call
-   mutable TiriType base_type = TiriType::Unknown;  // Known type of the base (table/object) expression
    mutable CLASSID class_id = CLASSID::NIL;           // CLASSID if base is Object
    ~SafeMemberExprPayload();
 };
@@ -481,7 +483,6 @@ struct SafeIndexExprPayload {
    SafeIndexExprPayload& operator=(SafeIndexExprPayload&&) noexcept = default;
    ExprNodePtr table;
    ExprNodePtr index;
-   mutable TiriType base_type = TiriType::Unknown;  // Known type of the base (table/array) expression
    ~SafeIndexExprPayload();
 };
 
@@ -534,8 +535,7 @@ struct FunctionExprPayload {
    std::vector<FunctionParameter> parameters;
    bool is_vararg = false;
    bool is_thunk = false;              // Marks function as thunk
-   TiriType thunk_return_type = TiriType::Any;  // Return type for thunk (kept for IR emission compatibility)
-   mutable FunctionReturnTypes return_types{};    // Declared or validated inferred result metadata
+   mutable FunctionReturnTypes return_types{}; // Declared, validated inferred or advisory result metadata
    mutable StaticCallableHandle callable = 0;
    std::unique_ptr<BlockStmt> body;
    std::vector<AnnotationEntry> annotations;  // Annotations attached to this function
@@ -1088,13 +1088,15 @@ ExprNodePtr make_safe_member_expr(SourceSpan span, ExprNodePtr table, Identifier
 ExprNodePtr make_safe_index_expr(SourceSpan span, ExprNodePtr table, ExprNodePtr index);
 ExprNodePtr make_result_filter_expr(SourceSpan span, ExprNodePtr expression, uint64_t keep_mask, uint8_t explicit_count, bool trailing_keep);
 ExprNodePtr make_table_expr(SourceSpan span, std::vector<TableField> fields, bool has_array_part);
-ExprNodePtr make_function_expr(SourceSpan span, std::vector<FunctionParameter> parameters, bool is_vararg, std::unique_ptr<BlockStmt> body, bool is_thunk = false, TiriType thunk_return_type = TiriType::Any, FunctionReturnTypes return_types = {});
+ExprNodePtr make_function_expr(SourceSpan Span, std::vector<FunctionParameter> Parameters, bool IsVararg,
+   std::unique_ptr<BlockStmt> Body, bool IsThunk = false, FunctionReturnTypes ReturnTypes = {});
 ExprNodePtr make_deferred_expr(SourceSpan span, ExprNodePtr inner, TiriType type = TiriType::Unknown, bool type_explicit = false);
 ExprNodePtr make_range_expr(SourceSpan span, ExprNodePtr start, ExprNodePtr stop, bool inclusive,
    ExprNodePtr step = nullptr);
 ExprNodePtr make_choose_expr(SourceSpan span, ExprNodePtr scrutinee, std::vector<ChooseCase> cases, size_t inferred_arity = 0);
 ExprNodePtr make_choose_expr_tuple(SourceSpan span, ExprNodeList scrutinee_tuple, std::vector<ChooseCase> cases);
-std::unique_ptr<FunctionExprPayload> make_function_payload(std::vector<FunctionParameter> parameters, bool is_vararg, std::unique_ptr<BlockStmt> body, bool is_thunk = false, TiriType thunk_return_type = TiriType::Any, FunctionReturnTypes return_types = {});
+std::unique_ptr<FunctionExprPayload> make_function_payload(std::vector<FunctionParameter> Parameters, bool IsVararg,
+   std::unique_ptr<BlockStmt> Body, bool IsThunk = false, FunctionReturnTypes ReturnTypes = {});
 std::unique_ptr<BlockStmt> make_block(SourceSpan span, StmtNodeList statements);
 StmtNodePtr make_assignment_stmt(SourceSpan span, AssignmentOperator op, ExprNodeList targets, ExprNodeList values);
 StmtNodePtr make_local_decl_stmt(SourceSpan span, std::vector<Identifier> names, ExprNodeList values);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_call.cpp
@@ -509,7 +509,11 @@ void IrEmitter::optimise_assert(ExprNodeList &Args)
       body_stmts.push_back(std::move(return_stmt));
       auto body = make_block(span, std::move(body_stmts));
 
-      ExprNodePtr thunk_func = make_function_expr(span, {}, false, std::move(body), true, TiriType::Str);
+      FunctionReturnTypes return_types;
+      return_types.types[0] = TiriType::Str;
+      return_types.count = 1;
+      return_types.has_thunk_type = true;
+      ExprNodePtr thunk_func = make_function_expr(span, {}, false, std::move(body), true, return_types);
 
       ExprNodeList call_args;
       msg_arg = make_call_expr(span, std::move(thunk_func), std::move(call_args), false);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -39,7 +39,7 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
          inner_body->statements.push_back(std::move(const_cast<StmtNodePtr&>(stmt)));
       }
 
-      ExprNodePtr inner_fn = make_function_expr(span, {}, false, std::move(inner_body), false, TiriType::Any);
+      ExprNodePtr inner_fn = make_function_expr(span, {}, false, std::move(inner_body));
 
       // Create call to __create_thunk(inner_fn, type_tag)
       NameRef create_thunk_ref;
@@ -51,8 +51,9 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
       // Logical type argument.  A VM tag cannot distinguish range from full userdata or represent both full and
       // light userdata, so deferred values retain the language-level type.
 
-      uint8_t logical_type = (Payload.thunk_return_type IS TiriType::Any or
-         Payload.thunk_return_type IS TiriType::Unknown) ? 0xff : uint8_t(Payload.thunk_return_type);
+      TiriType thunk_type = Payload.return_types.thunk_type();
+      uint8_t logical_type = (thunk_type IS TiriType::Any or
+         thunk_type IS TiriType::Unknown) ? 0xff : uint8_t(thunk_type);
       ExprNodePtr type_arg = make_literal_expr(span, LiteralValue::number(double(logical_type)));
 
       // Build argument list
@@ -437,9 +438,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          key.u.sval = payload.member.symbol;
          expr_index(&this->func_state, &table, &key);
 
-         // Propagate known base type information for downstream optimizations.
-         // When base_type is Object, emit specialised BC_OBSETF bytecodes via IndexedObject.
-         // Check both AST-level base_type AND emitted expression's result_type.
+         // A dominating static descriptor proof selects specialised object or structure store bytecodes.
          bool proved_object = can_use_static_receiver(
             this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
          bool proved_struct = can_use_static_receiver(
@@ -495,8 +494,7 @@ ParserResult<ExpDesc> IrEmitter::emit_lvalue_expr(const ExprNode &Expr, bool All
          key = key_toval_idx.legacy();
          expr_index(&this->func_state, &table, &key);
 
-         // Propagate known base type information for downstream optimizations.
-         // Check both AST-level base_type AND emitted expression's result_type.
+         // Select specialised store bytecodes only when the receiver's static descriptor proves its category.
          bool proved_array = can_use_static_receiver(
             this->ctx.descriptors(), receiver_descriptor, TiriType::Array, true);
          bool proved_object = can_use_static_receiver(

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -3291,7 +3291,7 @@ ParserResult<ExpDesc> IrEmitter::emit_presence_expr(const PresenceExprPayload &P
 
 //********************************************************************************************************************
 // Emit bytecode for a member access expression (table.field), indexing a table with a string key.
-// base_type and class_id are tracked for potential future optimizations (Object-specific bytecode paths).
+// Receiver specialisation uses its static descriptor; object class metadata supports field-type resolution.
 
 static void apply_struct_field_metadata(ExpDesc &Expression, struct_record *StructDef, GCstr *FieldName)
 {
@@ -3349,10 +3349,8 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
    ExpDesc key(Payload.member.symbol);
    expr_index(&this->func_state, &table, &key);
 
-   // Propagate known base type information for downstream optimizations.
-   // When base_type is Object, emit specialised BC_OBGETF/BC_OBSETF bytecodes by changing the expression kind
-   // to IndexedObject.  Check both AST-level base_type AND emitted expression's result_type (the latter captures
-   // type info from variable declarations like `fl = obj.new(...)`).
+   // A dominating static descriptor proof selects specialised object or structure bytecodes.  The descriptor includes
+   // type information propagated from declarations and other statically known expressions.
 
    bool proved_object = can_use_static_receiver(
       this->ctx.descriptors(), table.static_value, TiriType::Object, true);
@@ -3376,7 +3374,6 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
          if (is_field) {
             table.result_type = field_info->type;
             table.object_class_id = field_info->object_class_id;
-            table.type_confirmed = true;  // Type is confirmed from class dictionary lookup
          }
          else if (not Payload.is_call_target) {
             // Field not found in dictionary and not being called as a function - raise parse error
@@ -3405,7 +3402,7 @@ ParserResult<ExpDesc> IrEmitter::emit_member_expr(const MemberExprPayload &Paylo
 //********************************************************************************************************************
 // Emit bytecode for an index expression (table[key]), indexing a table or array with an arbitrary key.
 // Special case: if key is a range expression, emit a call to table.slice() instead.
-// If base_type is TiriType::Array, emits array-specific bytecodes (BC_AGETV/BC_AGETB).
+// A proved array receiver uses array-specific bytecodes (BC_AGETV/BC_AGETB).
 
 ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload)
 {
@@ -3436,8 +3433,7 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
    key = key_toval.legacy();
    expr_index(&this->func_state, &table, &key);
 
-   // If base type is known to be an array, use array-specific bytecodes
-   // Check both AST-level base_type AND emitted expression's result_type.
+   // Select specialised bytecodes only when the receiver's static descriptor proves its category.
    bool proved_array = can_use_static_receiver(
       this->ctx.descriptors(), table.static_value, TiriType::Array, true);
    bool proved_object = can_use_static_receiver(
@@ -3452,8 +3448,7 @@ ParserResult<ExpDesc> IrEmitter::emit_index_expr(const IndexExprPayload &Payload
          table.k = ExpKind::IndexedArray;
       }
    }
-   // If base type is known to be an object with a string key, use object-specific bytecodes
-   // Check both AST-level base_type AND emitted expression's result_type.
+   // A proved object receiver with a string key uses object-specific bytecodes.
    else if (proved_object) {
       // Objects use string field access - only change kind for string const keys
       // (aux < 0 means string const key)
@@ -3533,7 +3528,7 @@ ParserResult<ExpDesc> IrEmitter::emit_table_slice_call(const IndexExprPayload &P
 
 //********************************************************************************************************************
 // Emit bytecode for a safe member access expression (table?.field), returning nil if the table is nil.
-// base_type and class_id are tracked for potential future optimizations (Object-specific bytecode paths).
+// Receiver specialisation uses the static descriptor captured before nil short-circuit lowering.
 
 ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPayload &Payload)
 {
@@ -3553,8 +3548,8 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
    ExpDesc key(Payload.member.symbol);
    expr_index(&this->func_state, &table, &key);
 
-   // Propagate known base type information for downstream optimizations.
-   // When base_type is Object and class_id is set, field-level type resolution may be possible.
+   // A dominating static descriptor proof selects specialised object or structure handling and supplies exact object
+   // class metadata for field-type resolution when available.
    bool proved_object = can_use_static_receiver(
       this->ctx.descriptors(), receiver_descriptor, TiriType::Object, true);
    bool proved_struct = can_use_static_receiver(
@@ -3582,7 +3577,6 @@ ParserResult<ExpDesc> IrEmitter::emit_safe_member_expr(const SafeMemberExprPaylo
          if (is_field) {
             table.result_type     = field_info->type;
             table.object_class_id = field_info->object_class_id;
-            table.type_confirmed  = true;  // Type is confirmed from class dictionary lookup
          }
          else if (not Payload.is_call_target) {
             auto *meta_class = FindClass(class_id);

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -241,7 +241,6 @@ struct ExpDesc {
    StaticValueHandle static_value = 0;
    StaticResultSetHandle static_results = 0;
    uint32_t struct_field_index = 0xFFFFFFFFu; // Pre-resolved field index for STGETF/STSETF
-   bool type_confirmed = false;  // True if result_type is confirmed from class dictionary lookup
    BCPOS t;        // True condition jump list.
    BCPOS f;        // False condition jump list.
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -617,11 +617,14 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 
 //********************************************************************************************************************
 // Exact runtime type contracts.  The descriptor is an interned byte string, so it remains portable across bytecode
-// dump/write/read boundaries.  Version-2 layout:
+// dump/write/read boundaries.  New descriptors use the version-3 layout:
 //
 //   version, boundary, descriptor_flags, static_value_count, contract_count,
-//   repeated { type, entry_flags, position, object_class_id_uleb32, struct_name_length, struct_name_bytes,
-//              label_length, label_bytes }
+//   repeated { type, entry_flags, position, object_class_id_uleb32, array_element_type,
+//              array_struct_name_length, array_struct_name_bytes,
+//              struct_name_length, struct_name_bytes, label_length, label_bytes }
+//
+// The shared decoder also accepts legacy version-1 and version-2 descriptors, whose entries omit newer fields.
 
 namespace {
 

--- a/src/tiri/tests/test_thunks.tiri
+++ b/src/tiri/tests/test_thunks.tiri
@@ -266,6 +266,7 @@ end
    end
 
    val = untyped_thunk()
+   assert(type(val) is "userdata", "Thunk without a return annotation should retain the default userdata type")
    -- Direct comparison now works transparently
    assert(val is "default", "Untyped thunk should work")
 end


### PR DESCRIPTION
* Removed unused AST base type snapshots and expression confirmation state
* Normalised thunk logical types through canonical function return metadata without strengthening contracts
* Added regression coverage for unannotated thunk runtime identity