### PR TITLE
[Tiri] Eliminated duplicate global store contracts

### DIFF
--- a/src/tiri/jit/src/lj_ircall.h
+++ b/src/tiri/jit/src/lj_ircall.h
@@ -240,6 +240,7 @@ typedef struct CCallInfo {
   _(ANY,        jit_object_getobj, 4, S, NIL, CCI_L|CCI_T) \
   /* Environment mutation boundary */ \
   _(ANY,        lj_env_check,      4, S, NIL, CCI_L|CCI_T) \
+  _(ANY,        lj_env_check_override, 5, S, NIL, CCI_L|CCI_T) \
   \
   // End of list.
 
@@ -275,3 +276,5 @@ extern "C" void lj_try_leave(lua_State *L);
 
 // Environment mutation boundary (see lj_meta.cpp).
 extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value);
+extern "C" void lj_env_check_override(
+   lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value, GCstr *DeclarationOverride);

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -566,6 +566,24 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
 }
 
 //********************************************************************************************************************
+// Return the incoming variant descriptor for a declaration store immediately following its initialising contract.
+// The interpreter derives the same override from its saved PC in lj_vm_envcheck().
+
+static GCstr * rec_global_declaration_override(jit_State *J, const BCIns *PC, const GCstr *Name)
+{
+   const BCIns *begin = proto_bc(J->pt) + 1;
+   if (PC <= begin or bc_op(PC[-1]) != BC_CONTRACT) return nullptr;
+
+   GCstr *candidate = gco_to_string(proto_kgc(J->pt, ~(ptrdiff_t)bc_d(PC[-1])));
+   RuntimeContractDescriptor descriptor;
+   if (not decode_runtime_contract(candidate, descriptor) or
+       not contract_descriptor_is_global_variant_initialiser(descriptor, Name)) {
+      return nullptr;
+   }
+   return candidate;
+}
+
+//********************************************************************************************************************
 // Get TRef for current function.
 
 static TRef getcurrf(jit_State *J)
@@ -2021,7 +2039,12 @@ handlemm:
          TRef value_slot = rec_stack_slot_addr(J, irb, int32_t(J->baseslot) + ix->val_slot);
          rec_emit_tvalue_store(J, value_slot, ix->val);
          emitir_raw(IRT(IR_XBAR, IRT_NIL), 0, 0);
-         lj_ir_call(J, IRCALL_lj_env_check, ix->tab, lj_ir_kstr(J, strV(&ix->keyv)), value_slot);
+         TRef key = lj_ir_kstr(J, strV(&ix->keyv));
+         if (ix->declaration_override) {
+            lj_ir_call(J, IRCALL_lj_env_check_override, ix->tab, key, value_slot,
+               lj_ir_kstr(J, ix->declaration_override));
+         }
+         else lj_ir_call(J, IRCALL_lj_env_check, ix->tab, key, value_slot);
          J->needsnap = 1;
       }
       else irb.guard_eq(marker, irb.knull(IRT_TAB), IRT_TAB);
@@ -2651,6 +2674,7 @@ static void rec_decode_operands(jit_State *J, cTValue *lbase, RecordOps *ops)
    ops->ra = bc_a(ins);
    ops->ix.val = 0;
    ops->ix.val_slot = -1;
+   ops->ix.declaration_override = nullptr;
 
    switch (bcmode_a(op)) {
       case BCMvar:
@@ -3560,6 +3584,9 @@ static TRef rec_table_op(jit_State *J, RecordOps *ops, const BCIns *pc)
          settabV(J->L, &ix->tabv, tabref(J->fn->l.env));
          ix->tab = emitir(IRT(IR_FLOAD, IRT_TAB), getcurrf(J), IRFL_FUNC_ENV);
          ix->idxchain = LJ_MAX_IDXCHAIN;
+         if (op IS BC_GSET) {
+            ix->declaration_override = rec_global_declaration_override(J, pc, strV(&ix->keyv));
+         }
          return lj_record_idx(J, ix);
 
       case BC_TGETB: case BC_TSETB:

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -199,6 +199,7 @@ struct RecordOps {
 
 enum class RecordedContract : uint8_t {
    Basic,
+   SideEffect,
    Complex,
    Mismatch,
    Invalid
@@ -495,6 +496,16 @@ static RecordedContract rec_contract_record(jit_State *J, BCREG Base, GCstr *Enc
    RuntimeContractDescriptor descriptor;
    if (not decode_runtime_contract(Encoded, descriptor)) return RecordedContract::Invalid;
    if (descriptor.dynamic_count()) return RecordedContract::Complex;
+
+   if (descriptor.boundary IS ContractBoundary::Global and descriptor.contract_count IS 1 and
+       contract_entry_is_global_hint(descriptor.entries[0])) {
+      const RuntimeContractEntry &entry = descriptor.entries[0];
+      if (entry.label.empty()) return RecordedContract::Invalid;
+      GCtab *environment = tabref(curr_func(J->L)->c.env);
+      GCstr *global_name = lj_str_new(J->L, entry.label.data(), entry.label.size());
+      if (lj_tab_get_global_contract(environment, global_name)) return RecordedContract::Basic;
+      return RecordedContract::SideEffect;
+   }
 
    for (uint8_t i = 0; i < descriptor.static_value_count; ++i) {
       const RuntimeContractEntry *entry = descriptor.entry_for(i);
@@ -4179,6 +4190,10 @@ void lj_record_ins(jit_State *J)
       if (contract IS RecordedContract::Basic) {
          J->needsnap = 1;
          break;
+      }
+      if (contract IS RecordedContract::SideEffect) {
+         setintV(&J->errinfo, int32_t(op));
+         lj_trace_err_info(J, LJ_TRERR_NYIBC);
       }
       if (contract IS RecordedContract::Complex) {
          J->pt->flags |= PROTO_NOJIT;

--- a/src/tiri/jit/src/lj_record.h
+++ b/src/tiri/jit/src/lj_record.h
@@ -26,6 +26,7 @@ typedef struct RecordIndex {
    TRef mobj;        //  Metamethod object reference.
    int idxchain;              //  Index indirections left or 0 for raw lookup.
    int32_t val_slot = -1;     //  Lua stack slot for a stored value, or -1 if the value is not stack-backed.
+   GCstr* declaration_override = nullptr; // Incoming variant policy for a recorded global declaration store.
 } RecordIndex;
 
 LJ_FUNC int lj_record_objcmp(jit_State* J, TRef a, TRef b, cTValue* av, cTValue* bv);

--- a/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_global.cpp
@@ -19,7 +19,7 @@
       .boundary = ContractBoundary::Global,
       .position = 1,
       .is_const = Identifier.has_const,
-      .initialising = Identifier.has_const
+      .initialising = true
    };
 }
 

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -569,9 +569,17 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       }
    }
 
+   bool has_global_hint = false;
+   for (const RuntimeContract &contract : Contracts) {
+      if (contract.global_hint) {
+         has_global_hint = true;
+         break;
+      }
+   }
+
    std::string descriptor;
    descriptor.reserve(5 + Contracts.size() * 8);
-   descriptor.push_back(char(TIRI_CONTRACT_VERSION));
+   descriptor.push_back(char(has_global_hint ? TIRI_CONTRACT_GLOBAL_HINT_VERSION : TIRI_CONTRACT_VERSION));
    descriptor.push_back(char(uint8_t(Contracts.front().boundary)));
 
    uint8_t descriptor_flags = 0;
@@ -588,6 +596,7 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
       if (contract.required) entry_flags |= contract_flag(ContractEntryFlag::Required);
       if (contract.is_const) entry_flags |= contract_flag(ContractEntryFlag::Const);
       if (contract.initialising) entry_flags |= contract_flag(ContractEntryFlag::Initialising);
+      if (contract.global_hint) entry_flags |= contract_flag(ContractEntryFlag::GlobalHint);
       descriptor.push_back(char(entry_flags));
       descriptor.push_back(char(contract.position));
       CLASSID object_class_id = contract.type IS TiriType::Object ? contract.object_class_id : CLASSID::NIL;
@@ -683,9 +692,9 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
    const RuntimeContract *GlobalDeclarationContract, bool IsGlobalDeclaration)
 {
    BCIns ins;
-   RuntimeContract global_const_finaliser;
-   BCREG global_const_base = 0;
-   bool finalise_global_const = false;
+   RuntimeContract global_declaration_finaliser;
+   BCREG global_declaration_base = 0;
+   bool finalise_global_declaration = false;
    if (LHS->k IS ExpKind::Local) {
       fs->ls->vstack[LHS->u.s.aux].info |= VarInfoFlag::VarReadWrite;
       VarInfo *vinfo = &fs->ls->vstack[LHS->u.s.aux];
@@ -743,24 +752,18 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
             .array_element = found->second.array_element,
             .label = LHS->u.sval,
             .boundary = ContractBoundary::Global,
-            .position = 1
+            .position = 1,
+            .global_hint = true
          };
          bcemit_value_contract(fs, RHS, contract, true);
       }
-      else if (GCstr *contract = lj_tab_get_global_contract(tabref(fs->L->env), LHS->u.sval)) {
-         BCREG source = expr_toanyreg(fs, RHS);
-         ExpDesc descriptor(contract);
-         bcemit_AD(fs, BC_CONTRACT, source, const_str(fs, &descriptor));
-         RHS->k = ExpKind::NonReloc;
-         RHS->u.s.info = source;
-      }
       BCREG ra = expr_toanyreg(fs, RHS);
       ins = BCINS_AD(BC_GSET, ra, const_str(fs, LHS));
-      if (GlobalDeclarationContract and GlobalDeclarationContract->is_const) {
-         global_const_finaliser = *GlobalDeclarationContract;
-         global_const_finaliser.initialising = false;
-         global_const_base = ra;
-         finalise_global_const = true;
+      if (GlobalDeclarationContract) {
+         global_declaration_finaliser = *GlobalDeclarationContract;
+         global_declaration_finaliser.initialising = false;
+         global_declaration_base = ra;
+         finalise_global_declaration = true;
       }
    }
    else if (LHS->k IS ExpKind::IndexedArray or LHS->k IS ExpKind::SafeIndexedArray) {
@@ -829,8 +832,8 @@ static void bcemit_store(FuncState *fs, ExpDesc *LHS, ExpDesc *RHS,
       }
    }
    bcemit_INS(fs, ins);
-   if (finalise_global_const) {
-      bcemit_contract(fs, global_const_base, std::span(&global_const_finaliser, 1), 1);
+   if (finalise_global_declaration) {
+      bcemit_contract(fs, global_declaration_base, std::span(&global_declaration_finaliser, 1), 1);
    }
    expr_free(fs, RHS);
 }

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -97,6 +97,7 @@ struct RuntimeContract {
    bool required = false;
    bool is_const = false;
    bool initialising = false;
+   bool global_hint = false;
 };
 
 // Concept for flag types that support bitwise operations

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -1877,7 +1877,10 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       "local value = obj.new('time')\n"
       "value = dynamic(value)\n"
       "local values:array<int> = array<int> { 1 }\n"
-      "values = dynamic(values)\n";
+      "values = dynamic(values)\n"
+      "global glContractRoundtrip = 'first'\n"
+      "local global_value:any = 'second'\n"
+      "glContractRoundtrip = global_value\n";
    if (lua_load(L, source, "contract-roundtrip")) {
       Log.error("failed to compile contract source: %s", lua_tostring(L, -1));
       return false;
@@ -1942,6 +1945,23 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
       return false;
    };
    bool array_survived = has_int_array_contract(has_int_array_contract, restored_proto);
+   auto has_global_hint_contract = [](auto &Self, GCproto *Proto) -> bool {
+      for (uint32_t i = 1; i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (decode_runtime_contract(encoded, descriptor) and descriptor.contract_count > 0 and
+             contract_entry_is_global_hint(descriptor.entries[0])) return true;
+      }
+      GCRef *constant = mref<GCRef>(Proto->k) - 1;
+      for (uint32_t i = 0; i < Proto->sizekgc; ++i, --constant) {
+         GCobj *child = gcref(*constant);
+         if (child->gch.gct IS ~LJ_TPROTO and Self(Self, gco_to_proto(child))) return true;
+      }
+      return false;
+   };
+   bool global_hint_survived = has_global_hint_contract(has_global_hint_contract, restored_proto);
    lua_pop(L, 1);
    if (not class_survived) {
       Log.error("reloaded bytecode lost the multi-byte object class constraint in BC_CONTRACT");
@@ -1949,6 +1969,10 @@ static bool test_contract_bytecode_roundtrip(kt::Log &Log)
    }
    if (not array_survived) {
       Log.error("reloaded bytecode lost the array member constraint in BC_CONTRACT");
+      return false;
+   }
+   if (not global_hint_survived) {
+      Log.error("reloaded bytecode lost the global-hint contract mode");
       return false;
    }
    return true;
@@ -1980,7 +2004,7 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
          char(1)
       };
       if (Version >= TIRI_CONTRACT_OBJECT_VERSION) append_uleb(result, uint32_t(ObjectClassId));
-      if (Version IS TIRI_CONTRACT_VERSION) {
+      if (Version >= TIRI_CONTRACT_VERSION) {
          result.push_back(char(uint8_t(ArrayElementType)));
          result.push_back(char(uint8_t(ArrayStructName.size())));
          result.append(ArrayStructName);
@@ -2059,6 +2083,19 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
       return false;
    }
 
+   uint8_t global_hint_flags = contract_flag(ContractEntryFlag::Nullable) |
+      contract_flag(ContractEntryFlag::GlobalHint);
+   std::string global_hint_encoded = build_descriptor(
+      TIRI_CONTRACT_GLOBAL_HINT_VERSION, TiriType::Str, CLASSID::NIL, {}, "GlobalValue", global_hint_flags);
+   GCstr *global_hint_descriptor = lj_str_new(lua, global_hint_encoded.data(), global_hint_encoded.size());
+   RuntimeContractDescriptor global_hint_decoded;
+   if (not decode_runtime_contract(global_hint_descriptor, global_hint_decoded) or
+       global_hint_decoded.boundary != ContractBoundary::Global or
+       not contract_entry_is_global_hint(global_hint_decoded.entries[0])) {
+      Log.error("version-4 global-hint contract did not round-trip through the shared decoder");
+      return false;
+   }
+
    std::string legacy = build_descriptor(
       TIRI_CONTRACT_LEGACY_VERSION, TiriType::Object, CLASSID::TIME, {}, "Legacy", const_flags);
    GCstr *legacy_descriptor = lj_str_new(lua, legacy.data(), legacy.size());
@@ -2073,7 +2110,20 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    std::string invalid_entry_flags = encoded;
    invalid_entry_flags[6] = char(0x80);
    std::string invalid_initialising_flag = encoded;
+   invalid_initialising_flag[1] = char(uint8_t(ContractBoundary::Local));
    invalid_initialising_flag[6] = char(contract_flag(ContractEntryFlag::Initialising));
+   std::string invalid_legacy_global_hint = build_descriptor(
+      TIRI_CONTRACT_VERSION, TiriType::Str, CLASSID::NIL, {}, "Value", global_hint_flags);
+   std::string invalid_local_global_hint = global_hint_encoded;
+   invalid_local_global_hint[1] = char(uint8_t(ContractBoundary::Local));
+   std::string invalid_const_global_hint = build_descriptor(
+      TIRI_CONTRACT_GLOBAL_HINT_VERSION, TiriType::Str, CLASSID::NIL, {}, "Value",
+      global_hint_flags | contract_flag(ContractEntryFlag::Const));
+   std::string invalid_unmarked_version_four = build_descriptor(
+      TIRI_CONTRACT_GLOBAL_HINT_VERSION, TiriType::Str, CLASSID::NIL, {}, "Value",
+      contract_flag(ContractEntryFlag::Nullable));
+   std::string invalid_unlabelled_global_hint = build_descriptor(
+      TIRI_CONTRACT_GLOBAL_HINT_VERSION, TiriType::Str, CLASSID::NIL, {}, {}, global_hint_flags);
    std::string invalid_position = encoded;
    invalid_position[7] = char(0);
    std::string invalid_scalar_class = build_descriptor(
@@ -2096,10 +2146,13 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    std::string trailing = encoded + "x";
    std::string truncated = encoded.substr(0, encoded.size() - 1);
    std::string unknown_version = encoded;
-   unknown_version[0] = char(TIRI_CONTRACT_VERSION + 1);
+   unknown_version[0] = char(TIRI_CONTRACT_GLOBAL_HINT_VERSION + 1);
 
    if (not rejected(invalid_descriptor_flags) or not rejected(invalid_entry_flags) or
        not rejected(invalid_initialising_flag) or
+       not rejected(invalid_legacy_global_hint) or not rejected(invalid_local_global_hint) or
+       not rejected(invalid_const_global_hint) or not rejected(invalid_unmarked_version_four) or
+       not rejected(invalid_unlabelled_global_hint) or
        not rejected(invalid_position) or not rejected(invalid_scalar_class) or not rejected(invalid_struct_class) or
        not rejected(invalid_scalar_array_member) or not rejected(invalid_named_non_struct_array) or
        not rejected(truncated_class) or not rejected(over_wide_class) or not rejected(trailing) or
@@ -3349,6 +3402,26 @@ static bool test_environment_store_boundary(kt::Log &Log)
    lua_pop(L, 1);
    if (not value_kept) {
       Log.error("the rejected store mutated the declared global");
+      return false;
+   }
+
+   // A separately compiled direct assignment must rely on BC_GSET instead of copying the persisted descriptor into a
+   // preceding BC_CONTRACT.
+   constexpr std::string_view assignment_source =
+      "extern glUnitEnvBoundary\n"
+      "glUnitEnvBoundary = 'compiled'\n";
+   if (lua_load(L, assignment_source, "=envboundary-assignment")) {
+      Log.error("compiling the persisted-policy assignment failed: %s", lua_tostring(L, -1));
+      return false;
+   }
+   BytecodeSnapshot assignment = snapshot_proto(funcproto(funcV(L->top - 1)));
+   if (count_opcode_tree(assignment, BC_CONTRACT) != 0 or count_opcode_tree(assignment, BC_GSET) != 1) {
+      Log.error("persisted-policy assignment emitted %zu contracts and %zu global stores",
+         count_opcode_tree(assignment, BC_CONTRACT), count_opcode_tree(assignment, BC_GSET));
+      return false;
+   }
+   if (lua_pcall(L, 0, 0, 0)) {
+      Log.error("executing the persisted-policy assignment failed: %s", lua_tostring(L, -1));
       return false;
    }
 

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <string_view>
 
 inline constexpr uint8_t TIRI_CONTRACT_VERSION = 3;
@@ -96,6 +97,23 @@ struct RuntimeContractDescriptor {
 [[nodiscard]] constexpr inline bool contract_entry_is_global_hint(const RuntimeContractEntry &Entry) noexcept
 {
    return (Entry.flags & contract_flag(ContractEntryFlag::GlobalHint)) != 0;
+}
+
+[[nodiscard]] constexpr inline bool contract_entry_is_variant(const RuntimeContractEntry &Entry) noexcept
+{
+   return Entry.type IS TiriType::Any or
+      (Entry.type IS TiriType::Array and Entry.array_element_type IS AET::ANY);
+}
+
+[[nodiscard]] inline bool contract_descriptor_is_global_variant_initialiser(
+   const RuntimeContractDescriptor &Descriptor, const GCstr *Name) noexcept
+{
+   if (Descriptor.boundary != ContractBoundary::Global or Descriptor.contract_count != 1) return false;
+
+   const RuntimeContractEntry &entry = Descriptor.entries[0];
+   return contract_entry_is_initialising(entry) and not contract_entry_is_const(entry) and
+      contract_entry_is_variant(entry) and entry.label.size() IS Name->len and
+      not std::memcmp(entry.label.data(), strdata(Name), Name->len);
 }
 
 enum class RuntimeContractDecodeError : uint8_t {

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -10,6 +10,7 @@
 #include <string_view>
 
 inline constexpr uint8_t TIRI_CONTRACT_VERSION = 3;
+inline constexpr uint8_t TIRI_CONTRACT_GLOBAL_HINT_VERSION = 4;
 inline constexpr uint8_t TIRI_CONTRACT_OBJECT_VERSION = 2;
 inline constexpr uint8_t TIRI_CONTRACT_LEGACY_VERSION = 1;
 
@@ -32,7 +33,8 @@ enum class ContractEntryFlag : uint8_t {
    Nullable = 1 << 0,
    Required = 1 << 1,
    Const = 1 << 2,
-   Initialising = 1 << 3
+   Initialising = 1 << 3,
+   GlobalHint = 1 << 4
 };
 
 [[nodiscard]] constexpr inline uint8_t contract_flag(ContractDescriptorFlag Flag) noexcept
@@ -89,6 +91,11 @@ struct RuntimeContractDescriptor {
 [[nodiscard]] constexpr inline bool contract_entry_is_initialising(const RuntimeContractEntry &Entry) noexcept
 {
    return (Entry.flags & contract_flag(ContractEntryFlag::Initialising)) != 0;
+}
+
+[[nodiscard]] constexpr inline bool contract_entry_is_global_hint(const RuntimeContractEntry &Entry) noexcept
+{
+   return (Entry.flags & contract_flag(ContractEntryFlag::GlobalHint)) != 0;
 }
 
 enum class RuntimeContractDecodeError : uint8_t {
@@ -160,7 +167,7 @@ private:
    uint8_t boundary;
    if (not reader.read_byte(version) or
        (version != TIRI_CONTRACT_LEGACY_VERSION and version != TIRI_CONTRACT_OBJECT_VERSION and
-        version != TIRI_CONTRACT_VERSION) or
+        version != TIRI_CONTRACT_VERSION and version != TIRI_CONTRACT_GLOBAL_HINT_VERSION) or
        not reader.read_byte(boundary) or boundary < uint8_t(ContractBoundary::Parameter) or
        boundary > uint8_t(ContractBoundary::Global) or not reader.read_byte(Result.flags) or
        (Result.flags & ~(contract_flag(ContractDescriptorFlag::DynamicCount) |
@@ -170,20 +177,25 @@ private:
       return fail(RuntimeContractDecodeError::Descriptor);
    }
    Result.boundary = ContractBoundary(boundary);
+   bool has_global_hint = false;
 
    for (uint8_t i = 0; i < Result.contract_count; ++i) {
       auto &entry = Result.entries[i];
       uint8_t type;
       uint8_t array_element_type = uint8_t(AET::MAX);
       uint32_t object_class_id = 0;
+      uint8_t allowed_entry_flags = contract_flag(ContractEntryFlag::Nullable) |
+         contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
+         contract_flag(ContractEntryFlag::Initialising);
+      if (version IS TIRI_CONTRACT_GLOBAL_HINT_VERSION) {
+         allowed_entry_flags |= contract_flag(ContractEntryFlag::GlobalHint);
+      }
       if (not reader.read_byte(type) or type > uint8_t(TiriType::Unknown) or
           not reader.read_byte(entry.flags) or
-          (entry.flags & ~(contract_flag(ContractEntryFlag::Nullable) |
-             contract_flag(ContractEntryFlag::Required) | contract_flag(ContractEntryFlag::Const) |
-             contract_flag(ContractEntryFlag::Initialising))) != 0 or
+          (entry.flags & ~allowed_entry_flags) != 0 or
           not reader.read_byte(entry.position) or entry.position IS 0 or
           (version >= TIRI_CONTRACT_OBJECT_VERSION and not reader.read_uleb32(object_class_id)) or
-          (version IS TIRI_CONTRACT_VERSION and
+          (version >= TIRI_CONTRACT_VERSION and
            (not reader.read_byte(array_element_type) or array_element_type > uint8_t(AET::MAX) or
             not reader.read_text(entry.array_struct_name))) or
           not reader.read_text(entry.struct_name) or not reader.read_text(entry.label)) {
@@ -194,8 +206,14 @@ private:
       entry.array_element_type = AET(array_element_type);
       bool is_const = contract_entry_is_const(entry);
       bool is_initialising = contract_entry_is_initialising(entry);
+      bool is_global_hint = contract_entry_is_global_hint(entry);
+      if (is_global_hint) has_global_hint = true;
       if ((is_const and Result.boundary != ContractBoundary::Global) or
-          (is_initialising and not is_const)) {
+          (is_initialising and Result.boundary != ContractBoundary::Global) or
+          (is_global_hint and
+             (Result.boundary != ContractBoundary::Global or Result.static_value_count != 1 or
+              Result.contract_count != 1 or entry.position != 1 or entry.label.empty() or is_const or
+              is_initialising))) {
          return fail(RuntimeContractDecodeError::Entry);
       }
       if (not entry.struct_name.empty() and entry.type != TiriType::Struct) {
@@ -213,6 +231,9 @@ private:
       }
    }
 
+   if ((version IS TIRI_CONTRACT_GLOBAL_HINT_VERSION) != has_global_hint) {
+      return fail(RuntimeContractDecodeError::Descriptor);
+   }
    if (not reader.at_end()) return fail(RuntimeContractDecodeError::Descriptor);
    return true;
 }

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -617,7 +617,8 @@ void lj_meta_istype(lua_State *L, BCREG ra, BCREG tp)
 
 //********************************************************************************************************************
 // Exact runtime type contracts.  The descriptor is an interned byte string, so it remains portable across bytecode
-// dump/write/read boundaries.  New descriptors use the version-3 layout:
+// dump/write/read boundaries.  Version-3 descriptors use this layout, and version 4 adds the global-hint entry flag
+// for same-chunk bootstrap policy:
 //
 //   version, boundary, descriptor_flags, static_value_count, contract_count,
 //   repeated { type, entry_flags, position, object_class_id_uleb32, array_element_type,
@@ -857,6 +858,11 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
          global_name = lj_str_new(L, incoming.label.data(), incoming.label.size());
 
          GCstr *current = lj_tab_get_global_contract(environment, global_name);
+         if (current and contract_entry_is_global_hint(incoming)) {
+            // A same-chunk hint only bootstraps policy before declaration publication.  Once any environment policy
+            // exists, BC_GSET owns validation against that authoritative descriptor.
+            return;
+         }
          if (current) {
             RuntimeContractDescriptor current_descriptor;
             decode_contract_or_error(L, current, current_descriptor);
@@ -874,8 +880,14 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
          }
          if (contract_entry_is_initialising(incoming)) {
             // Validate the declaration that will be published while leaving the current environment contract in
-            // place.  BC_GSET validates the same value against that existing policy before the post-store const
-            // descriptor commits the transition.
+            // place.  BC_GSET validates the same value against that existing policy before the post-store descriptor
+            // commits the transition.  This keeps ordinary and const declaration publication transactional when an
+            // environment __newindex handler rejects the store.
+         }
+         else if (contract_entry_is_global_hint(incoming)) {
+            // No environment policy exists yet.  Validate and publish the hint so type-guided reads and indirect
+            // stores retain the same runtime invariant even when the declaration has not executed.
+            publish_global_contract = true;
          }
          else if (contract_is_variant(incoming)) {
             // Explicit 'any' and array<any> declarations relax their respective sticky global contracts only after
@@ -943,7 +955,8 @@ extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t Dyna
 // Value must reference a rooted Lua stack slot and L->top must be valid.  The recorder materialises JIT values in
 // their corresponding Lua stack slot before emitting this call.
 
-extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
+static void env_check_contract(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
+   GCstr *DeclarationOverride)
 {
    TValue checked;
    copyTV(L, &checked, Value);
@@ -953,7 +966,8 @@ extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
       lj_err_callermsg(L, message);
    }
 
-   if (GCstr *persisted = lj_tab_get_global_contract(Environment, Name)) {
+   GCstr *persisted = DeclarationOverride ? DeclarationOverride : lj_tab_get_global_contract(Environment, Name);
+   if (persisted) {
       RuntimeContractDescriptor descriptor;
       decode_contract_or_error(L, persisted, descriptor);
       if (descriptor.contract_count >= 1) {
@@ -974,6 +988,11 @@ extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
          }
       }
    }
+}
+
+extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value)
+{
+   env_check_contract(L, Environment, Name, Value, nullptr);
 }
 
 //********************************************************************************************************************
@@ -998,7 +1017,27 @@ extern "C" void lj_env_store(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
 extern "C" GCstr * lj_vm_envcheck(lua_State *L, GCtab *Environment, GCstr *Name, TValue *Value)
 {
    L->top = curr_topL(L);
-   lj_env_check(L, Environment, Name, Value);
+   GCstr *declaration_override = nullptr;
+   const BCIns *pc = cframe_Lpc(L);
+   GCproto *prototype = funcproto(curr_func(L));
+   const BCIns *begin = proto_bc(prototype) + 1;
+   if (pc >= begin + 2 and bc_op(pc[-1]) IS BC_GSET and bc_op(pc[-2]) IS BC_CONTRACT) {
+      GCstr *candidate = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(pc[-2])));
+      RuntimeContractDescriptor descriptor;
+      if (decode_runtime_contract(candidate, descriptor) and descriptor.boundary IS ContractBoundary::Global and
+          descriptor.contract_count IS 1) {
+         const RuntimeContractEntry &entry = descriptor.entries[0];
+         if (contract_entry_is_initialising(entry) and not contract_entry_is_const(entry) and
+             contract_is_variant(entry) and entry.label.size() IS Name->len and
+             not std::memcmp(entry.label.data(), strdata(Name), Name->len)) {
+            // A variant redeclaration deliberately replaces the existing concrete policy.  Validate BC_GSET against
+            // the incoming descriptor without publishing it; the following CONTRACT commits only after the ordinary
+            // store path (including __newindex dispatch) succeeds.
+            declaration_override = candidate;
+         }
+      }
+   }
+   env_check_contract(L, Environment, Name, Value, declaration_override);
    return Name;
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -701,12 +701,6 @@ namespace {
    return false;
 }
 
-[[nodiscard]] static bool contract_is_variant(const RuntimeContractEntry &Entry) noexcept
-{
-   return Entry.type IS TiriType::Any or
-      (Entry.type IS TiriType::Array and Entry.array_element_type IS AET::ANY);
-}
-
 [[nodiscard]] static const char * contract_boundary_name(ContractBoundary Boundary)
 {
    switch (Boundary) {
@@ -889,7 +883,7 @@ extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCou
             // stores retain the same runtime invariant even when the declaration has not executed.
             publish_global_contract = true;
          }
-         else if (contract_is_variant(incoming)) {
+         else if (contract_entry_is_variant(incoming)) {
             // Explicit 'any' and array<any> declarations relax their respective sticky global contracts only after
             // the declaration value passes this descriptor.  A caught failure must preserve the previous policy.
             publish_global_contract = true;
@@ -995,6 +989,12 @@ extern "C" void lj_env_check(lua_State *L, GCtab *Environment, GCstr *Name, cTVa
    env_check_contract(L, Environment, Name, Value, nullptr);
 }
 
+extern "C" void lj_env_check_override(lua_State *L, GCtab *Environment, GCstr *Name, cTValue *Value,
+   GCstr *DeclarationOverride)
+{
+   env_check_contract(L, Environment, Name, Value, DeclarationOverride);
+}
+
 //********************************************************************************************************************
 // Checked raw environment store.  Value must reference a Lua stack slot so it can be recovered after policy checks
 // and table allocation resize the stack.  Non-raw paths call lj_env_check() and then resume normal metamethod dispatch.
@@ -1024,20 +1024,15 @@ extern "C" GCstr * lj_vm_envcheck(lua_State *L, GCtab *Environment, GCstr *Name,
    if (pc >= begin + 2 and bc_op(pc[-1]) IS BC_GSET and bc_op(pc[-2]) IS BC_CONTRACT) {
       GCstr *candidate = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(pc[-2])));
       RuntimeContractDescriptor descriptor;
-      if (decode_runtime_contract(candidate, descriptor) and descriptor.boundary IS ContractBoundary::Global and
-          descriptor.contract_count IS 1) {
-         const RuntimeContractEntry &entry = descriptor.entries[0];
-         if (contract_entry_is_initialising(entry) and not contract_entry_is_const(entry) and
-             contract_is_variant(entry) and entry.label.size() IS Name->len and
-             not std::memcmp(entry.label.data(), strdata(Name), Name->len)) {
-            // A variant redeclaration deliberately replaces the existing concrete policy.  Validate BC_GSET against
-            // the incoming descriptor without publishing it; the following CONTRACT commits only after the ordinary
-            // store path (including __newindex dispatch) succeeds.
-            declaration_override = candidate;
-         }
+      if (decode_runtime_contract(candidate, descriptor) and
+          contract_descriptor_is_global_variant_initialiser(descriptor, Name)) {
+         // A variant redeclaration deliberately replaces the existing concrete policy.  Validate BC_GSET against the
+         // incoming descriptor without publishing it; the following CONTRACT commits only after the ordinary store
+         // path (including __newindex dispatch) succeeds.
+         declaration_override = candidate;
       }
    }
-   env_check_contract(L, Environment, Name, Value, declaration_override);
+   lj_env_check_override(L, Environment, Name, Value, declaration_override);
    return Name;
 }
 

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -36,6 +36,7 @@ extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
 extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
 extern "C" void lj_env_check(lua_State *, GCtab *, GCstr *, cTValue *);
+extern "C" void lj_env_check_override(lua_State *, GCtab *, GCstr *, cTValue *, GCstr *);
 extern "C" void lj_env_store(lua_State *, GCtab *, GCstr *, cTValue *);
 extern "C" GCstr * lj_vm_envcheck(lua_State *, GCtab *, GCstr *, TValue *);
 extern "C" void lj_meta_call(lua_State* L, TValue* func, TValue* top);

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -25,7 +25,8 @@ local function assert_global_contract_before_store(Statement, Context)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Inferred scalar globals must emit sticky contracts for their declaration and later dynamic stores.
+-- Inferred scalar globals emit a declaration contract and retain a bootstrap hint for stores that may execute before
+-- declaration publication.  Once policy exists, the environment boundary owns semantic validation.
 
 @Test function InferredScalarGlobalContractBytecode()
    local disasm = disassemble([[
@@ -33,10 +34,80 @@ global glGTSticky = 'first'
 local dynamic:any = 'second'
 glGTSticky = dynamic
 ]])
-   assert(disasm:count('CONTRACT') is 2,
-      'An inferred global declaration and dynamic store must each emit CONTRACT, got:\n' .. disasm)
+   assert(disasm:count('CONTRACT') is 3,
+      'An inferred declaration must validate and publish around its store, then retain a bootstrap-capable hint, got:\n' ..
+      disasm)
    assert(disasm:count('GSET') is 2,
       'The inferred global declaration and reassignment should each emit GSET, got:\n' .. disasm)
+end
+
+@Test function BootstrapHintProtectsSkippedDeclaration()
+   local trapped = false
+   try
+      exec([[
+if false then global glGTBootstrapArray:array<int> = array<int> { 1 } end
+local dynamic:any = array<string> { 'wrong' }
+glGTBootstrapArray = dynamic
+]])
+   except e
+      trapped = true
+      assert(e.message:find('expected array<int>') != nil,
+         'The bootstrap hint should preserve the exact array policy: ' .. e.message)
+   end
+
+   assert(trapped, 'A store before declaration publication must still cross the bootstrap contract')
+   assert(rawget(_G, 'glGTBootstrapArray') is nil,
+      'A rejected bootstrap store must not publish a value')
+end
+
+@Test function ExistingEnvironmentPolicyOverridesBootstrapHint()
+   global glGTAuthoritativePolicy = 'first'
+
+   exec([[
+if false then global glGTAuthoritativePolicy = 1 end
+local dynamic:any = 'updated'
+glGTAuthoritativePolicy = dynamic
+]])
+   assert(glGTAuthoritativePolicy is 'updated',
+      'The existing string policy should override a conflicting same-chunk bootstrap hint')
+
+   try
+      rawset(_G, 'glGTAuthoritativePolicy', 42)
+      error('The original environment policy should remain authoritative')
+   except e
+      assert(e.message:find('expected str') != nil,
+         'The preserved environment policy should report its string contract: ' .. e.message)
+   end
+   assert(glGTAuthoritativePolicy is 'updated',
+      'A rejected store must preserve the value governed by the environment policy')
+end
+
+@Test function FailedGlobalDeclarationCanRetryWithDifferentType()
+   local previous_metatable = getmetatable(_G)
+   local trapped = false
+
+   setmetatable(_G, { __newindex = function(Table, Key, Value) error('blocked global store') end })
+   defer
+      setmetatable(_G, previous_metatable)
+      rawset(_G, 'glGTFailedDeclaration', nil)
+   end
+
+   try
+      exec([[global glGTFailedDeclaration = 'first']])
+   except e
+      trapped = true
+      assert(e.message:find('blocked global store') != nil,
+         'The failed declaration should preserve the environment store error: ' .. e.message)
+   end
+   setmetatable(_G, previous_metatable)
+
+   assert(trapped, 'The environment should reject the first global declaration store')
+   assert(rawget(_G, 'glGTFailedDeclaration') is nil,
+      'A rejected declaration must not publish its value')
+
+   exec([[global glGTFailedDeclaration = 42]])
+   assert(glGTFailedDeclaration is 42,
+      'A rejected declaration must not leave a stale type policy that prevents retry')
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -116,8 +187,8 @@ try
    declare_value()
 end
 ]], 'nested declaration')
-   assert(nested:count('CONTRACT') is 1,
-      'A nested reduced declaration should emit exactly one contract, got:\n' .. nested)
+   assert(nested:count('CONTRACT') is 2,
+      'A nested reduced declaration should validate and publish around its store, got:\n' .. nested)
 
    local multi = disassemble([[
 local function pair():<num, str> return 2, 'text' end
@@ -125,8 +196,8 @@ try
    global glGTReducedNumber, glGTReducedText = pair()
 end
 ]])
-   assert(multi:count('CONTRACT') >= 2,
-      'Both reduced multi-result positions must emit contracts in addition to callable contracts, got:\n' .. multi)
+   assert(multi:count('CONTRACT') >= 4,
+      'Both reduced multi-result positions must validate and publish in addition to callable contracts, got:\n' .. multi)
    assert(multi:count('GSET') is 2,
       'Both reduced multi-result positions must emit stores, got:\n' .. multi)
 

--- a/src/tiri/tests/test_global_types.tiri
+++ b/src/tiri/tests/test_global_types.tiri
@@ -110,6 +110,52 @@ end
       'A rejected declaration must not leave a stale type policy that prevents retry')
 end
 
+@Test function JitVariantDeclarationPreservesEnvironmentStoreError()
+   global glGTJitVariantOverride:array<int> = array<int> { 1 }
+   rawset(_G, 'glGTJitVariantOverride', nil)
+
+   local previous_metatable = getmetatable(_G)
+   setmetatable(_G, { __newindex = function(Table, Key, Value) error('blocked JIT variant store') end })
+   defer
+      setmetatable(_G, previous_metatable)
+      rawset(_G, 'glGTJitVariantOverride', nil)
+      jit.on()
+      jit.flush()
+      jit.opt.start()
+   end
+
+   function redeclare_variant()
+      global glGTJitVariantOverride:array<any> = array<string> { 'open' }
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+
+   local blocked = 0
+   local contract_errors = 0
+   for _ in {1 into 200} do
+      try
+         redeclare_variant()
+      except e
+         if e.message:find('blocked JIT variant store') != nil then blocked++
+         else contract_errors++ end
+      end
+   end
+
+   jit.off()
+   local traces = 0
+   for trace_no in {1 into 100} do
+      if jit.util.traceInfo(trace_no) != nil then traces++ end
+   end
+
+   assert(traces > 0, 'The variant declaration regression must exercise a compiled trace')
+   assert(blocked is 200,
+      'Interpreter and JIT stores must preserve the environment error, got ' .. blocked .. ' blocked stores')
+   assert(contract_errors is 0,
+      'A recorded variant declaration must not validate against the superseded concrete policy')
+end
+
 -----------------------------------------------------------------------------------------------------------------------
 -- Direct global callable declarations must publish the same persistent binding contract as global variables.
 


### PR DESCRIPTION
* Made environment policy authoritative for ordinary writes and added versioned same-chunk bootstrap hints
* Made global declaration policy publication transactional across failed stores and variant redeclarations
* Added bytecode, descriptor and rollback regression coverage