### PR TITLE
[Tiri] Batched and cached runtime contracts

### DIFF
--- a/src/tiri/jit/src/bytecode/lj_bcread.cpp
+++ b/src/tiri/jit/src/bytecode/lj_bcread.cpp
@@ -15,6 +15,7 @@
 #include "lj_bcdump.h"
 #include "lj_state.h"
 #include "lj_strfmt.h"
+#include "lj_meta.h"
 
 // Reuse some lexer fields for our own purposes.
 
@@ -598,6 +599,7 @@ GCproto *lj_bcread_proto(LexState *State)
       setmref(pt->uvinfo, nullptr);
       setmref(pt->varinfo, nullptr);
    }
+   lj_contract_build_cache(State->L, pt);
    return pt;
 }
 

--- a/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_function.cpp
@@ -200,6 +200,8 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
    // Parameter contracts execute inside the callee after local bindings exist and before any user statement.
    // Blank parameters still have a boundary and must be checked.
 
+   std::vector<RuntimeContractSlot> parameter_contracts;
+   parameter_contracts.reserve(param_count.raw());
    for (auto i = BCReg(0); i < param_count; ++i) {
       const FunctionParameter &param = Payload.parameters[i.raw()];
       if (param.type IS TiriType::Unknown or param.type IS TiriType::Any) continue;
@@ -214,8 +216,12 @@ ParserResult<ExpDesc> IrEmitter::emit_function_expr(const FunctionExprPayload &P
          .nullable = true,
          .required = false
       };
-      bcemit_contract(&child_state, base + i, std::span(&contract, 1), 1);
+      parameter_contracts.push_back(RuntimeContractSlot{
+         .register_index = BCREG(base.raw() + i.raw()),
+         .contract = contract
+      });
    }
+   bcemit_contracts(&child_state, parameter_contracts);
 
    // Copy explicit return types to the function state BEFORE emitting the body.
    // This ensures emit_return_stmt can see the types when deciding whether to use tail-calls

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1329,6 +1329,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
    // Declaration initialisers are placed directly into their local slots, so they do not pass through
    // bcemit_store().  Validate every concrete annotation after result-count adjustment and before publishing the
    // binding's checked metadata.  This also covers values supplied by calls, varargs and result filters.
+   std::vector<RuntimeContractSlot> local_contracts;
+   local_contracts.reserve(nvars.raw());
    for (auto i = BCReg(0); i < nvars; ++i) {
       const Identifier &identifier = Payload.names[i.raw()];
       if (identifier.type IS TiriType::Unknown or identifier.type IS TiriType::Any) continue;
@@ -1363,8 +1365,12 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          .boundary = ContractBoundary::Local,
          .position = uint8_t(base.raw() + i.raw() + 1)
       };
-      bcemit_contract(&this->func_state, base + i, std::span(&contract, 1), 1);
+      local_contracts.push_back(RuntimeContractSlot{
+         .register_index = BCREG(base.raw() + i.raw()),
+         .contract = contract
+      });
    }
+   bcemit_contracts(&this->func_state, local_contracts);
 
    for (auto i = BCReg(0); i < nvars; ++i) {
       const Identifier& identifier = Payload.names[i.raw()];

--- a/src/tiri/jit/src/parser/parse_internal.h
+++ b/src/tiri/jit/src/parser/parse_internal.h
@@ -100,6 +100,7 @@ static void bcreg_free(FuncState *, BCREG reg);
 static void expr_free(FuncState *, ExpDesc* e);
 static void bcemit_contract(FuncState *, BCREG, std::span<const RuntimeContract>, BCREG, bool = false,
    bool = false);
+static void bcemit_contracts(FuncState *, std::span<const RuntimeContractSlot>);
 
 // Bytecode emission (lj_parse_regalloc.cpp)
 

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -628,6 +628,46 @@ static void bcemit_contract(FuncState *fs, BCREG Base, std::span<const RuntimeCo
 }
 
 //********************************************************************************************************************
+// Emit maximal dense runs of fixed runtime contracts.  Descriptor entries are ordinal, so an unchecked register gap
+// starts a new instruction.  The descriptor entry limit is shared with return contracts and splits wider runs.
+
+static void bcemit_contracts(FuncState *Fs, std::span<const RuntimeContractSlot> Contracts)
+{
+   if (Contracts.empty()) return;
+
+   std::array<RuntimeContract, MAX_RETURN_TYPES> batch;
+   BCREG batch_base = 0;
+   BCREG previous_register = 0;
+   uint8_t batch_count = 0;
+
+   auto flush = [&]() {
+      if (not batch_count) return;
+      bcemit_contract(Fs, batch_base, std::span(batch.data(), batch_count), BCREG(batch_count));
+      batch_count = 0;
+   };
+
+   for (size_t i = 0; i < Contracts.size(); ++i) {
+      const RuntimeContractSlot &slot = Contracts[i];
+      if (i > 0) {
+         lj_assertX(slot.register_index > previous_register, "runtime contract registers are not increasing");
+         lj_assertX(slot.contract.position > Contracts[i - 1].contract.position,
+            "runtime contract positions are not increasing");
+      }
+
+      if (batch_count and (slot.register_index != BCREG(previous_register + 1) or
+          batch_count IS MAX_RETURN_TYPES or slot.contract.boundary != batch[0].boundary)) {
+         flush();
+      }
+      if (not batch_count) batch_base = slot.register_index;
+
+      batch[batch_count++] = slot.contract;
+      previous_register = slot.register_index;
+   }
+
+   flush();
+}
+
+//********************************************************************************************************************
 // Literal values are closed proofs.  Every other ExpDesc type is advisory and receives a runtime check.
 
 [[nodiscard]] static bool contract_literal_proved(FuncState *fs, ExpDesc *Value, TiriType Expected)

--- a/src/tiri/jit/src/parser/parse_scope.cpp
+++ b/src/tiri/jit/src/parser/parse_scope.cpp
@@ -1073,6 +1073,7 @@ GCproto * LexState::fs_finish(BCLine Line)
    fs_fixup_uv1(fs, pt, (uint16_t*)((char*)pt + ofsuv));
    fs_fixup_line(fs, pt, (void*)((char*)pt + ofsli), numline);
    this->fs_fixup_var(pt, (uint8_t*)((char*)pt + ofsdbg), ofsvar);
+   lj_contract_build_cache(L, pt);
 
    lj_vmevent_send(L, BC,
       setprotoV(L, L->top++, pt);

--- a/src/tiri/jit/src/parser/parse_types.h
+++ b/src/tiri/jit/src/parser/parse_types.h
@@ -100,6 +100,14 @@ struct RuntimeContract {
    bool global_hint = false;
 };
 
+// Associates a transient contract with the register it validates.  Dense batching uses the register separately from
+// RuntimeContract::position because the latter is stable diagnostic metadata rather than a relative stack offset.
+
+struct RuntimeContractSlot {
+   BCREG register_index = 0;
+   RuntimeContract contract;
+};
+
 // Concept for flag types that support bitwise operations
 template<typename Flag>
 concept FlagType = std::same_as<Flag, ExprFlag> or

--- a/src/tiri/jit/src/parser/parser.cpp
+++ b/src/tiri/jit/src/parser/parser.cpp
@@ -19,6 +19,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "lj_vm.h"
+#include "lj_meta.h"
 #include "lj_vmevent.h"
 #include "field_type_lookup.h"
 #include "../../../defs.h"

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2189,6 +2189,166 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    return true;
 }
 
+static bool test_runtime_contract_batching(kt::Log &Log)
+{
+   struct ContractInstruction {
+      BCREG base = 0;
+      RuntimeContractDescriptor descriptor;
+   };
+
+   LuaStateHolder state;
+   lua_State *lua = state.get();
+   bool decode_failed = false;
+   auto read_contracts = [&decode_failed](GCproto *Proto, ContractBoundary Boundary) {
+      std::vector<ContractInstruction> result;
+      for (uint32_t i = 1; Proto and i < Proto->sizebc; ++i) {
+         BCIns instruction = proto_bc(Proto)[i];
+         if (bc_op(instruction) != BC_CONTRACT) continue;
+
+         GCstr *encoded = gco_to_string(proto_kgc(Proto, ~(ptrdiff_t)bc_d(instruction)));
+         RuntimeContractDescriptor descriptor;
+         if (not decode_runtime_contract(encoded, descriptor)) {
+            decode_failed = true;
+            continue;
+         }
+         if (descriptor.boundary IS Boundary) {
+            result.push_back(ContractInstruction{
+               .base = bc_a(instruction),
+               .descriptor = descriptor
+            });
+         }
+      }
+      return result;
+   };
+   auto compile_child = [lua, &Log](std::string_view Source, const char *Label) -> GCproto * {
+      if (lua_load(lua, Source, Label)) {
+         Log.error("failed to compile %s: %s", Label, lua_tostring(lua, -1));
+         return nullptr;
+      }
+      return first_child_proto(funcproto(funcV(lua->top - 1)));
+   };
+
+   GCproto *dense = compile_child(
+      "return function(A:num, B:str, C:bool, D:table) return A end\n", "dense-parameter-contracts");
+   auto dense_contracts = read_contracts(dense, ContractBoundary::Parameter);
+   if (not dense or decode_failed or dense_contracts.size() != 1 or dense_contracts[0].base != 0 or
+       dense_contracts[0].descriptor.static_value_count != 4 or
+       dense_contracts[0].descriptor.contract_count != 4 or not proto_contract_cache(dense) or
+       proto_contract_cache(dense)->record_count != 1 or proto_contract_cache(dense)->entry_count != 4) {
+      Log.error("four adjacent parameter contracts did not batch into one descriptor");
+      return false;
+   }
+   constexpr std::array<TiriType, 4> dense_types{
+      TiriType::Num, TiriType::Str, TiriType::Bool, TiriType::Table
+   };
+   constexpr std::array<std::string_view, 4> dense_labels{ "A", "B", "C", "D" };
+   for (uint8_t i = 0; i < dense_types.size(); ++i) {
+      const RuntimeContractEntry &entry = dense_contracts[0].descriptor.entries[i];
+      if (entry.type != dense_types[i] or entry.position != i + 1 or entry.label != dense_labels[i]) {
+         Log.error("dense parameter contract entry %u lost its type, position or label", unsigned(i + 1));
+         return false;
+      }
+   }
+   lua_pop(lua, 1);
+
+   GCproto *wide = compile_child(
+      "return function(A:num, B:num, C:num, D:num, E:num, F:num, G:num, H:num, I:num) return A end\n",
+      "wide-parameter-contracts");
+   auto wide_contracts = read_contracts(wide, ContractBoundary::Parameter);
+   if (not wide or decode_failed or wide_contracts.size() != 2 or wide_contracts[0].base != 0 or
+       wide_contracts[0].descriptor.static_value_count != MAX_RETURN_TYPES or
+       wide_contracts[0].descriptor.contract_count != MAX_RETURN_TYPES or wide_contracts[1].base != 8 or
+       wide_contracts[1].descriptor.static_value_count != 1 or wide_contracts[1].descriptor.contract_count != 1 or
+       wide_contracts[1].descriptor.entries[0].position != 9 or wide_contracts[1].descriptor.entries[0].label != "I") {
+      Log.error("nine adjacent parameter contracts did not split at the descriptor entry limit");
+      return false;
+   }
+   lua_pop(lua, 1);
+
+   GCproto *fragmented = compile_child(
+      "return function(A:num, B:any, C:str) return A end\n", "fragmented-parameter-contracts");
+   auto fragmented_contracts = read_contracts(fragmented, ContractBoundary::Parameter);
+   if (not fragmented or decode_failed or fragmented_contracts.size() != 2 or
+       fragmented_contracts[0].base != 0 or fragmented_contracts[0].descriptor.contract_count != 1 or
+       fragmented_contracts[0].descriptor.entries[0].position != 1 or fragmented_contracts[1].base != 2 or
+       fragmented_contracts[1].descriptor.contract_count != 1 or
+       fragmented_contracts[1].descriptor.entries[0].position != 3 or proto_contract_cache(fragmented)) {
+      Log.error("an unchecked parameter gap did not split dense contract runs");
+      return false;
+   }
+   lua_pop(lua, 1);
+
+   constexpr std::string_view combined_source =
+      "local function Dynamic():<any,any,any,any> return 1,'text',true,{} end\n"
+      "return function(A:num, B:str, C:bool, D:table)\n"
+      "   local E:num, F:str, G:bool, H:table = Dynamic()\n"
+      "   return A\n"
+      "end\n";
+   if (lua_load(lua, combined_source, "grouped-contract-roundtrip")) {
+      Log.error("failed to compile grouped contract round-trip source: %s", lua_tostring(lua, -1));
+      return false;
+   }
+
+   auto find_four_parameter_proto = [](auto &Self, GCproto *Proto) -> GCproto * {
+      if (Proto->numparams IS 4) return Proto;
+      for (ptrdiff_t i = -ptrdiff_t(Proto->sizekgc); i < 0; ++i) {
+         GCobj *object = proto_kgc(Proto, i);
+         if (object->gch.gct != uint8_t(~LJ_TPROTO)) continue;
+         if (GCproto *result = Self(Self, gco_to_proto(object))) return result;
+      }
+      return nullptr;
+   };
+
+   GCproto *root = funcproto(funcV(lua->top - 1));
+   GCproto *combined = find_four_parameter_proto(find_four_parameter_proto, root);
+   auto combined_parameters = read_contracts(combined, ContractBoundary::Parameter);
+   auto combined_locals = read_contracts(combined, ContractBoundary::Local);
+   if (not combined or decode_failed or combined_parameters.size() != 1 or combined_locals.size() != 1 or
+       combined_parameters[0].descriptor.contract_count != 4 or
+       combined_locals[0].descriptor.contract_count != 4 or combined_locals[0].base != 4 or
+       not proto_contract_cache(combined) or proto_contract_cache(combined)->record_count != 2 or
+       proto_contract_cache(combined)->entry_count != 8) {
+      Log.error("parameter and local declaration runs did not batch in one prototype");
+      return false;
+   }
+
+   std::string dump;
+   if (lua_dump(lua, bytecode_writer, &dump) != 0) {
+      Log.error("failed to dump grouped contract bytecode");
+      return false;
+   }
+   std::string stripped_dump;
+   if (lj_bcwrite(lua, root, bytecode_writer, &stripped_dump, 1) != 0) {
+      Log.error("failed to dump stripped grouped contract bytecode");
+      return false;
+   }
+   lua_pop(lua, 1);
+
+   auto verify_dump = [&](const std::string &Dump, const char *Label) {
+      if (lua_load(lua, std::string_view(Dump.data(), Dump.size()), Label)) {
+         Log.error("failed to reload %s: %s", Label, lua_tostring(lua, -1));
+         return false;
+      }
+
+      GCproto *loaded_root = funcproto(funcV(lua->top - 1));
+      GCproto *loaded = find_four_parameter_proto(find_four_parameter_proto, loaded_root);
+      auto parameters = read_contracts(loaded, ContractBoundary::Parameter);
+      auto locals = read_contracts(loaded, ContractBoundary::Local);
+      const RuntimeContractCache *cache = loaded ? proto_contract_cache(loaded) : nullptr;
+      bool valid = loaded and not decode_failed and parameters.size() IS 1 and locals.size() IS 1 and
+         parameters[0].descriptor.contract_count IS 4 and locals[0].descriptor.contract_count IS 4 and cache and
+         cache->record_count IS 2 and cache->entry_count IS 8;
+      lua_pop(lua, 1);
+      return valid;
+   };
+   if (not verify_dump(dump, "grouped-contract-roundtrip") or
+       not verify_dump(stripped_dump, "stripped-grouped-contract-roundtrip")) {
+      Log.error("grouped parameter or local contracts did not survive bytecode round-trip");
+      return false;
+   }
+   return true;
+}
+
 static bool test_complex_contract_jit_eligibility(kt::Log &Log)
 {
    LuaStateHolder state;
@@ -3583,6 +3743,27 @@ static bool test_native_prototype_result_descriptors(kt::Log &Log)
       return false;
    }
 
+   // Untyped table reads yield 'any' because element types are not tracked.  Reassigning such a local must stay
+   // legal: an annotation would only add a CONTRACT guard without unlocking a specialised opcode, and ':any' would
+   // restore exactly the type the local already had.
+
+   constexpr std::string_view table_read_reassignment =
+      "local source = { Value = 1.5 }\n"
+      "local direct = source.Value\n"
+      "direct = direct * 2\n"
+      "local indexed = source['Value']\n"
+      "indexed = 5\n"
+      "local same_source = source.Value\n"
+      "same_source = source.Value\n"
+      "local defaulted = source.Missing ?? 1.96\n"
+      "defaulted = defaulted * 2\n"
+      "return direct, indexed, same_source, defaulted\n";
+   error.clear();
+   if (not compile_snapshot(L, table_read_reassignment, true, error)) {
+      Log.error("reassigning a local initialised from an untyped table read was rejected: %s", error.c_str());
+      return false;
+   }
+
    return true;
 }
 
@@ -4216,7 +4397,7 @@ static bool test_type_guided_emission(kt::Log &Log)
 
 extern void parser_unit_tests(int &Passed, int &Total)
 {
-   constexpr std::array<TestCase, 48> tests = { {
+   constexpr std::array<TestCase, 49> tests = { {
       { "parser_profiler_captures_stages", test_parser_profiler_captures_stages },
       { "parser_profiler_disabled_noop", test_parser_profiler_disabled_noop },
       { "literal_binary_expr", test_literal_binary_expr },
@@ -4245,6 +4426,7 @@ extern void parser_unit_tests(int &Passed, int &Total)
       { "malformed_signature_rejected", test_malformed_signature_rejected },
       { "contract_bytecode_roundtrip", test_contract_bytecode_roundtrip },
       { "runtime_contract_decoder", test_runtime_contract_decoder },
+      { "runtime_contract_batching", test_runtime_contract_batching },
       { "complex_contract_jit_eligibility", test_complex_contract_jit_eligibility },
       { "parser_diagnostics_reset_per_load", test_parser_diagnostics_reset_per_load },
       { "userdata_type_annotations", test_userdata_type_annotations },

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -88,6 +88,35 @@
    return Function.body and Function.body->statements.empty();
 }
 
+// Reads from an untyped table yield 'any' because element types are not tracked.  Such a value is dynamic by nature
+// rather than by an unresolved ingress, so it must not lock the destination into requiring an annotation; demanding
+// one would only add a CONTRACT guard without unlocking a specialised opcode.  Struct fields and typed array elements
+// infer concrete types and never reach this path.
+
+[[nodiscard]] static bool is_table_read_expression(const ExprNode &Expr)
+{
+   switch (Expr.kind) {
+      case AstNodeKind::MemberExpr:
+      case AstNodeKind::IndexExpr:
+      case AstNodeKind::SafeMemberExpr:
+      case AstNodeKind::SafeIndexExpr:
+         return true;
+
+      // '??' yields 'any' whenever either operand is dynamic, so a defaulted table read (t[k] ?? fallback) reports
+      // the same untracked element type one level removed.  Recurse so the exemption follows the value's origin.
+
+      case AstNodeKind::BinaryExpr: {
+         const auto *payload = std::get_if<BinaryExprPayload>(&Expr.data);
+         if (not payload or payload->op != AstBinaryOperator::IfEmpty) return false;
+         return (payload->left and is_table_read_expression(*payload->left)) or
+            (payload->right and is_table_read_expression(*payload->right));
+      }
+
+      default:
+         return false;
+   }
+}
+
 [[nodiscard]] static std::optional<std::string> function_signature_mismatch(
    const FunctionExprPayload &Expected, const FunctionExprPayload &Actual)
 {
@@ -1464,7 +1493,8 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                else inferred = this->infer_call_return_type(*Payload.values[source], result_position);
 
                inferred.requires_destination_type =
-                  inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown;
+                  (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
+                  not (result_position IS 0 and is_table_read_expression(*Payload.values[source]));
                inferred.is_fixed = inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and
                   inferred.primary != TiriType::Unknown;
                if (Payload.op != AssignmentOperator::Plain and not inferred.requires_destination_type) {
@@ -1654,6 +1684,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       InferredType inferred;
       InferredType value_type;
       bool have_value_type = false;
+      const ExprNode *initialiser = nullptr;  // Direct initialiser, excluding trailing multi-return positions
 
       // Determine the value type for this variable
       if (value_index < Payload.values.size()) {
@@ -1661,6 +1692,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
          const ExprNode& value_expr = *Payload.values[value_index];
          value_type = this->infer_expression_type(value_expr);
          have_value_type = true;
+         initialiser = &value_expr;
 
          // If this is the last value and it can provide multiple results, retain it for later declaration positions.
          if (value_index IS Payload.values.size() - 1 and
@@ -1739,7 +1771,8 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
          inferred = value_type;
 
          inferred.requires_destination_type = not name.is_blank and
-            (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown);
+            (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
+            not (initialiser and is_table_read_expression(*initialiser));
 
          // Non-nil, non-any initial values fix the type
          if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and

--- a/src/tiri/jit/src/runtime/lj_contract.h
+++ b/src/tiri/jit/src/runtime/lj_contract.h
@@ -84,6 +84,73 @@ struct RuntimeContractDescriptor {
    }
 };
 
+// Compact, prototype-owned derivative of grouped portable descriptors.  Text offsets address the first text byte in
+// the rooted GCstr descriptor; its preceding byte remains the canonical length.  Single-entry descriptors use the
+// portable decoder directly because caching them would add lifetime memory without amortising batching work.
+
+struct CachedRuntimeContractEntry {
+   uint32_t object_class_id;
+   uint16_t array_struct_offset;
+   uint16_t struct_offset;
+   uint16_t label_offset;
+   TiriType type;
+   uint8_t flags;
+   uint8_t position;
+   AET array_element_type;
+};
+
+struct CachedRuntimeContractRecord {
+   uint32_t bytecode_position;
+   ContractBoundary boundary;
+   uint8_t flags;
+   uint8_t static_value_count;
+   uint8_t contract_count;
+   uint16_t entry_index;
+};
+
+struct RuntimeContractCache {
+   uint32_t byte_size;
+   uint16_t record_count;
+   uint16_t entry_count;
+};
+
+static_assert(sizeof(CachedRuntimeContractEntry) IS 16, "cached runtime contract entries must remain compact");
+static_assert(sizeof(CachedRuntimeContractRecord) IS 12, "cached runtime contract records must remain compact");
+static_assert(sizeof(RuntimeContractCache) IS 8, "runtime contract cache header must remain compact");
+
+[[nodiscard]] inline CachedRuntimeContractRecord * runtime_contract_cache_records(
+   RuntimeContractCache *Cache) noexcept
+{
+   return (CachedRuntimeContractRecord *)(Cache + 1);
+}
+
+[[nodiscard]] inline const CachedRuntimeContractRecord * runtime_contract_cache_records(
+   const RuntimeContractCache *Cache) noexcept
+{
+   return (const CachedRuntimeContractRecord *)(Cache + 1);
+}
+
+[[nodiscard]] inline CachedRuntimeContractEntry * runtime_contract_cache_entries(RuntimeContractCache *Cache) noexcept
+{
+   return (CachedRuntimeContractEntry *)(runtime_contract_cache_records(Cache) + Cache->record_count);
+}
+
+[[nodiscard]] inline const CachedRuntimeContractEntry * runtime_contract_cache_entries(
+   const RuntimeContractCache *Cache) noexcept
+{
+   return (const CachedRuntimeContractEntry *)(runtime_contract_cache_records(Cache) + Cache->record_count);
+}
+
+[[nodiscard]] inline RuntimeContractCache * proto_contract_cache(GCproto *Proto) noexcept
+{
+   return Proto->contract_cache.get<RuntimeContractCache>();
+}
+
+[[nodiscard]] inline const RuntimeContractCache * proto_contract_cache(const GCproto *Proto) noexcept
+{
+   return Proto->contract_cache.get<const RuntimeContractCache>();
+}
+
 [[nodiscard]] constexpr inline bool contract_entry_is_const(const RuntimeContractEntry &Entry) noexcept
 {
    return (Entry.flags & contract_flag(ContractEntryFlag::Const)) != 0;

--- a/src/tiri/jit/src/runtime/lj_func.cpp
+++ b/src/tiri/jit/src/runtime/lj_func.cpp
@@ -10,6 +10,7 @@
 #include "lj_obj.h"
 #include "lj_gc.h"
 #include "lj_func.h"
+#include "lj_contract.h"
 #include "lj_trace.h"
 #include "lj_vm.h"
 
@@ -17,6 +18,8 @@
 
 void lj_func_freeproto(global_State *g, GCproto *pt)
 {
+   if (auto cache = proto_contract_cache(pt)) lj_mem_free(g, cache, cache->byte_size);
+
    // Free try-except metadata if present
    if (pt->try_blocks) lj_mem_free(g, pt->try_blocks, pt->try_block_count * sizeof(TryBlockDesc));
    if (pt->try_handlers) lj_mem_free(g, pt->try_handlers, pt->try_handler_count * sizeof(TryHandlerDesc));

--- a/src/tiri/jit/src/runtime/lj_meta.cpp
+++ b/src/tiri/jit/src/runtime/lj_meta.cpp
@@ -827,6 +827,88 @@ static void decode_contract_or_error(lua_State *L, GCstr *Descriptor, RuntimeCon
    else lj_err_callermsg(L, "invalid runtime type-contract descriptor");
 }
 
+[[nodiscard]] static uint16_t cached_contract_text_offset(
+   const GCstr *Descriptor, std::string_view Text) noexcept
+{
+   if (Text.empty()) return 0;
+   ptrdiff_t offset = Text.data() - strdata(Descriptor);
+   lj_assertX(offset > 0 and uint64_t(offset) <= UINT16_MAX, "runtime contract text offset is out of range");
+   return uint16_t(offset);
+}
+
+[[nodiscard]] static std::string_view cached_contract_text(
+   const GCstr *Descriptor, uint16_t Offset) noexcept
+{
+   if (not Offset) return {};
+   const char *text = strdata(Descriptor) + Offset;
+   return std::string_view(text, uint8_t(text[-1]));
+}
+
+[[nodiscard]] static const CachedRuntimeContractRecord * find_cached_contract(
+   const GCproto *Prototype, uint32_t BytecodePosition, const CachedRuntimeContractEntry *&Entries) noexcept
+{
+   const RuntimeContractCache *cache = proto_contract_cache(Prototype);
+   if (not cache) return nullptr;
+
+   const CachedRuntimeContractRecord *records = runtime_contract_cache_records(cache);
+   uint32_t lower = 0;
+   uint32_t upper = cache->record_count;
+   while (lower < upper) {
+      uint32_t middle = lower + ((upper - lower) >> 1);
+      if (records[middle].bytecode_position < BytecodePosition) lower = middle + 1;
+      else upper = middle;
+   }
+   if (lower >= cache->record_count or records[lower].bytecode_position != BytecodePosition) return nullptr;
+
+   const CachedRuntimeContractRecord *record = &records[lower];
+   Entries = runtime_contract_cache_entries(cache) + record->entry_index;
+   return record;
+}
+
+static void apply_cached_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor,
+   const CachedRuntimeContractRecord &Record, const CachedRuntimeContractEntry *Entries)
+{
+   L->top = curr_topL(L);
+   uint32_t value_count = (Record.flags & contract_flag(ContractDescriptorFlag::DynamicCount)) ?
+      DynamicCount + Record.static_value_count : Record.static_value_count;
+   bool variadic = (Record.flags & contract_flag(ContractDescriptorFlag::Variadic)) != 0;
+   ptrdiff_t base_offset = savestack(L, Base);
+
+   for (uint32_t i = 0; i < value_count; ++i) {
+      uint32_t entry_index;
+      if (i < Record.contract_count) entry_index = i;
+      else if (variadic and Record.contract_count > 0) entry_index = Record.contract_count - 1;
+      else continue;
+
+      const CachedRuntimeContractEntry &cached = Entries[entry_index];
+      RuntimeContractEntry entry{
+         .type = cached.type,
+         .flags = cached.flags,
+         .position = cached.position,
+         .object_class_id = CLASSID(cached.object_class_id),
+         .array_element_type = cached.array_element_type,
+         .array_struct_name = cached_contract_text(Descriptor, cached.array_struct_offset),
+         .struct_name = cached_contract_text(Descriptor, cached.struct_offset),
+         .label = cached_contract_text(Descriptor, cached.label_offset)
+      };
+      if (entry.type IS TiriType::Any or entry.type IS TiriType::Unknown) continue;
+
+      Base = restorestack(L, base_offset);
+      TValue *value = Base + i;
+      if (lj_is_thunk(value)) {
+         TValue *resolved = lj_thunk_resolve(L, udataV(value));
+         Base = restorestack(L, base_offset);
+         value = Base + i;
+         copyTV(L, value, resolved);
+      }
+
+      if (not contract_matches(L, value, entry)) {
+         uint32_t position = Record.boundary IS ContractBoundary::Result ? i + 1 : entry.position;
+         contract_error(L, value, Record.boundary, entry, position);
+      }
+   }
+}
+
 [[noreturn]] static void const_global_error(lua_State *L, const GCstr *Name)
 {
    CSTRING message = lj_strfmt_pushf(L, "cannot assign to const global '%s'", strdata(Name));
@@ -834,6 +916,84 @@ static void decode_contract_or_error(lua_State *L, GCstr *Descriptor, RuntimeCon
 }
 
 } // namespace
+
+void lj_contract_build_cache(lua_State *L, GCproto *Prototype)
+{
+   lj_assertX(not proto_contract_cache(Prototype), "runtime contract cache was built twice");
+
+   uint16_t record_count = 0;
+   uint16_t entry_count = 0;
+   for (uint32_t i = 1; i < Prototype->sizebc; ++i) {
+      BCIns instruction = proto_bc(Prototype)[i];
+      if (bc_op(instruction) != BC_CONTRACT) continue;
+
+      GCobj *constant = proto_kgc(Prototype, ~(ptrdiff_t)bc_d(instruction));
+      if (constant->gch.gct != uint8_t(~LJ_TSTR)) continue;
+      RuntimeContractDescriptor descriptor;
+      if (not decode_runtime_contract(gco_to_string(constant), descriptor) or descriptor.contract_count < 2 or
+          descriptor.boundary IS ContractBoundary::Global) {
+         continue;
+      }
+      if (record_count IS UINT16_MAX or entry_count > UINT16_MAX - descriptor.contract_count) return;
+      record_count++;
+      entry_count += descriptor.contract_count;
+   }
+   if (not record_count) return;
+
+   size_t byte_size = sizeof(RuntimeContractCache) + record_count * sizeof(CachedRuntimeContractRecord) +
+      entry_count * sizeof(CachedRuntimeContractEntry);
+   if (byte_size > UINT32_MAX) return;
+
+   auto cache = (RuntimeContractCache *)lj_mem_new(L, byte_size);
+   memset(cache, 0, byte_size);
+   cache->byte_size = uint32_t(byte_size);
+   cache->record_count = record_count;
+   cache->entry_count = entry_count;
+
+   CachedRuntimeContractRecord *records = runtime_contract_cache_records(cache);
+   CachedRuntimeContractEntry *entries = runtime_contract_cache_entries(cache);
+   uint16_t record_index = 0;
+   uint16_t entry_index = 0;
+   for (uint32_t i = 1; i < Prototype->sizebc; ++i) {
+      BCIns instruction = proto_bc(Prototype)[i];
+      if (bc_op(instruction) != BC_CONTRACT) continue;
+
+      GCobj *constant = proto_kgc(Prototype, ~(ptrdiff_t)bc_d(instruction));
+      if (constant->gch.gct != uint8_t(~LJ_TSTR)) continue;
+      GCstr *encoded = gco_to_string(constant);
+      RuntimeContractDescriptor descriptor;
+      if (not decode_runtime_contract(encoded, descriptor) or descriptor.contract_count < 2 or
+          descriptor.boundary IS ContractBoundary::Global) {
+         continue;
+      }
+
+      records[record_index++] = CachedRuntimeContractRecord{
+         .bytecode_position = i,
+         .boundary = descriptor.boundary,
+         .flags = descriptor.flags,
+         .static_value_count = descriptor.static_value_count,
+         .contract_count = descriptor.contract_count,
+         .entry_index = entry_index
+      };
+      for (uint8_t j = 0; j < descriptor.contract_count; ++j) {
+         const RuntimeContractEntry &source = descriptor.entries[j];
+         entries[entry_index++] = CachedRuntimeContractEntry{
+            .object_class_id = uint32_t(source.object_class_id),
+            .array_struct_offset = cached_contract_text_offset(encoded, source.array_struct_name),
+            .struct_offset = cached_contract_text_offset(encoded, source.struct_name),
+            .label_offset = cached_contract_text_offset(encoded, source.label),
+            .type = source.type,
+            .flags = source.flags,
+            .position = source.position,
+            .array_element_type = source.array_element_type
+         };
+      }
+   }
+
+   lj_assertX(record_index IS record_count and entry_index IS entry_count,
+      "runtime contract cache sizing changed while building");
+   setmref(Prototype->contract_cache, cache);
+}
 
 extern "C" void lj_meta_contract(lua_State *L, TValue *Base, uint32_t DynamicCount, GCstr *Descriptor)
 {
@@ -933,6 +1093,13 @@ extern "C" void lj_meta_contract_pc(lua_State *L, const BCIns *PC, uint32_t Dyna
       BCIns instruction = *--cursor;
       if (bc_op(instruction) IS BC_CONTRACT) {
          GCstr *descriptor = gco_to_string(proto_kgc(prototype, ~(ptrdiff_t)bc_d(instruction)));
+         const CachedRuntimeContractEntry *entries = nullptr;
+         uint32_t bytecode_position = uint32_t(cursor - proto_bc(prototype));
+         if (const CachedRuntimeContractRecord *record =
+               find_cached_contract(prototype, bytecode_position, entries)) {
+            apply_cached_contract(L, L->base + bc_a(instruction), DynamicCount, descriptor, *record, entries);
+            return;
+         }
          lj_meta_contract(L, L->base + bc_a(instruction), DynamicCount, descriptor);
          return;
       }

--- a/src/tiri/jit/src/runtime/lj_meta.h
+++ b/src/tiri/jit/src/runtime/lj_meta.h
@@ -35,6 +35,7 @@ extern "C" [[nodiscard]] TValue* lj_meta_comp(lua_State* L, cTValue* o1, cTValue
 extern "C" void lj_meta_istype(lua_State* L, BCREG ra, BCREG tp);
 extern "C" void lj_meta_contract(lua_State *, TValue *, uint32_t, GCstr *);
 extern "C" void lj_meta_contract_pc(lua_State *, const BCIns *, uint32_t);
+LJ_FUNC void lj_contract_build_cache(lua_State *, GCproto *);
 extern "C" void lj_env_check(lua_State *, GCtab *, GCstr *, cTValue *);
 extern "C" void lj_env_check_override(lua_State *, GCtab *, GCstr *, cTValue *, GCstr *);
 extern "C" void lj_env_store(lua_State *, GCtab *, GCstr *, cTValue *);

--- a/src/tiri/jit/src/runtime/lj_obj.h
+++ b/src/tiri/jit/src/runtime/lj_obj.h
@@ -733,7 +733,7 @@ typedef struct GCproto {
    uint8_t  numparams; //  Number of parameters.
    uint8_t  framesize; //  Fixed frame size.
    MSize    sizebc;    //  Number of bytecode instructions.
-   uint32_t unused_gc64; // Padding for 64-bit alignment
+   MRef     contract_cache; // Optional immutable decoded runtime-contract cache.
    GCRef    gclist;
    MRef     k;        //  Split constant array (points to the middle).
    MRef     uv;       //  Upvalue list. local slot|0x8000 or parent uv idx.
@@ -855,6 +855,7 @@ inline constexpr uint16_t PROTO_UV_IMMUTABLE = 0x4000;   //  Immutable upvalue.
 
 inline void proto_metadata_init(GCproto *Proto) noexcept
 {
+   setmref(Proto->contract_cache, nullptr);
    Proto->file_source_idx = 0;
    setmref(Proto->lineinfo, nullptr);
    setmref(Proto->uvinfo, nullptr);

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -53,6 +53,20 @@ function expect_diagnostic_failure(Callback:func)
    assert(failed, 'Expected a diagnostic contract failure')
 end
 
+function expect_batched_contract_failure(Callback:func, Boundary:str, Position:num, Label:str)
+   local failed = false
+   try
+      Callback()
+   except e
+      failed = true
+      assert(e.message:find(Boundary .. ' ' .. Position) != nil,
+         'The message should identify the failing contract position: ' .. e.message)
+      assert(e.message:find("('" .. Label .. "')") != nil,
+         'The message should identify the failing contract label: ' .. e.message)
+   end
+   assert(failed, 'Expected a batched contract failure')
+end
+
 function expect_userdata_diagnostic(Callback:func, Actual:str)
    local failed = false
    try
@@ -389,6 +403,48 @@ end
    expect_diagnostic_failure(function() diagnostic(dynamic_value('wrong')) end)
 end
 
+@Test function BatchedContractDiagnostics()
+   function checked_parameters(A:num, B:str, C:bool, D:table)
+      return A
+   end
+   local parameter_alias:any = checked_parameters
+   expect_batched_contract_failure(
+      function() parameter_alias(1, 'valid', dynamic_value('wrong'), {}) end, 'parameter', 3, 'C')
+
+   function dynamic_local_values():<any, any, any, any>
+      return 1, 'valid', 'wrong', {}
+   end
+   function checked_locals()
+      local first:num, second:str, third:bool, fourth:table = dynamic_local_values()
+      return first, second, third, fourth
+   end
+   expect_batched_contract_failure(checked_locals, 'local', 3, 'third')
+
+   local alpha = struct<ContractAlpha> { Value=3 }
+   local bravo = struct<ContractBravo> { Value=5 }
+   local alpha_values = array<struct<ContractAlpha>> { alpha }
+   local bravo_values = array<struct<ContractBravo>> { bravo }
+   local time_object = obj.new('time')
+   function checked_refined(Record:struct<ContractAlpha>, Values:array<struct<ContractAlpha>>, Clock:obj)
+      return Record.Value + Values[0].Value, Clock
+   end
+   local refined_value, refined_clock = checked_refined(alpha, alpha_values, time_object)
+   assert(refined_value is 6 and refined_clock is time_object,
+      'Batched refined contracts should preserve matching structure, array and object identities')
+
+   local refined_failed = false
+   try
+      checked_refined(alpha, dynamic_value(bravo_values), time_object)
+   except e
+      refined_failed = true
+      assert(e.message:find('parameter 2') != nil and e.message:find("('Values')") != nil,
+         'A cached refined diagnostic should preserve its position and label: ' .. e.message)
+      assert(e.message:find('array<struct<ContractAlpha>>') != nil,
+         'A cached refined diagnostic should preserve its exact expected type: ' .. e.message)
+   end
+   assert(refined_failed, 'A cached refined array contract should reject the wrong structure member type')
+end
+
 ----------------------------------------------------------------------------------------------------------------------
 -- Other approved write boundaries.
 
@@ -464,6 +520,19 @@ end
       }))
    end, 'to-be-closed local initialiser')
    assert(closed, 'A rejected local initialiser must unwind its <close> value')
+
+   local grouped_closed = false
+   function dynamic_close_pair():<any, any>
+      return setmetatable({}, {
+         __close = function(Self, Error)
+            grouped_closed = true
+         end
+      }), 'wrong'
+   end
+   expect_batched_contract_failure(function()
+      local resource <close>:table, value:num = dynamic_close_pair()
+   end, 'local', 2, 'value')
+   assert(grouped_closed, 'A later failure in a grouped local contract must unwind an earlier <close> value')
 
    local initialiser_deferred = false
    function fail_initialiser()

--- a/tools/benchmark/benchmark_func.tiri
+++ b/tools/benchmark/benchmark_func.tiri
@@ -5,27 +5,27 @@
 
 @Test function FunctionLocalCalls()
    -- Define local functions with varying argument counts
-   local function noArgs()
+   local function noArgs():num
       return 42
    end
 
-   local function oneArg(a)
+   local function oneArg(a):num
       return a * 2
    end
 
-   local function twoArgs(a, b)
+   local function twoArgs(a, b):num
       return a + b
    end
 
-   local function threeArgs(a, b, c)
+   local function threeArgs(a, b, c):num
       return a + b + c
    end
 
-   local function fiveArgs(a, b, c, d, e)
+   local function fiveArgs(a, b, c, d, e):num
       return a + b + c + d + e
    end
 
-   local function returnsMultiple(x)
+   local function returnsMultiple(x):<num, num, num>
       return x, x * 2, x * 3
    end
 
@@ -183,26 +183,26 @@ end
       local numbers = { 1, 2, 3, 4, 5 }
       local mapped = {}
       for idx, n in ipairs(numbers) do
-         mapped[idx] = (x => x * 2)(n)
+         mapped[idx] = (x => num: x * 2)(n)
          checksum += mapped[idx]
       end
 
       -- Immediately invoked arrow function
-      local result = (x => x * x)(i)
+      local result = (x => num: x * x)(i)
 
       -- Arrow functions as callbacks (simulated)
-      local apply = function(fn, val)
+      local apply = function(fn, val):any
          return fn(val)
       end
-      local v3 = apply((x => x + 10), i)
-      local v4 = apply((x => x * 3), i)
+      local v3 = apply((x => num: x + 10), i)
+      local v4 = apply((x => num: x * 3), i)
 
       -- Nested arrow functions
-      local compose = function(f, g)
-         return (x => f(g(x)))
+      local compose = function(f:func, g:func):any
+         return (x => num: f(g(x)))
       end
-      local addOne = (x => x + 1)
-      local timesTwo = (x => x * 2)
+      local addOne = (x => num: x + 1)
+      local timesTwo = (x => num: x * 2)
       local composed = compose(addOne, timesTwo)
       local v5 = composed(i)
 
@@ -290,19 +290,19 @@ end
    -- Create object-like tables with methods
    local Counter = {
       value = 0,
-      increment = function(self)
+      increment = function(self):num
          self.value++
          return self.value
       end,
-      decrement = function(self)
+      decrement = function(self):num
          self.value -= 1
          return self.value
       end,
-      add = function(self, n)
+      add = function(self, n):num
          self.value += n
          return self.value
       end,
-      getValue = function(self)
+      getValue = function(self):num
          return self.value
       end,
       reset = function(self)


### PR DESCRIPTION
* Grouped adjacent parameter and local guards into dense descriptors while preserving precise diagnostics
* Added immutable prototype-owned decode caches rebuilt after parsing and bytecode loading
* Kept values from untyped table reads dynamically reassignable without redundant annotations
* Added parser, Flute, benchmark and bytecode round-trip coverage