### PR TITLE
[Tiri] Corrected dynamic value and struct error handling

### DIFF
--- a/apps/paintbox.tiri
+++ b/apps/paintbox.tiri
@@ -46,23 +46,23 @@ Examples:
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function clamp(Value, Min, Max)
+function clamp(Value, Min, Max):num
    if Value < Min then return Min end
    if Value > Max then return Max end
    return Value
 end
 
-function normaliseHue(Hue)
+function normaliseHue(Hue):num
    Hue = Hue % 360
    if Hue < 0 then Hue += 360 end
    return Hue
 end
 
-function channelToByte(Value)
+function channelToByte(Value):num
    return math.floor((clamp(Value, 0, 1) * 255) + 0.5)
 end
 
-function hexFromRGB(RGB)
+function hexFromRGB(RGB):str
    local r = channelToByte(RGB.r)
    local g = channelToByte(RGB.g)
    local b = channelToByte(RGB.b)
@@ -72,7 +72,7 @@ function hexFromRGB(RGB)
       string.format('#%02x%02x%02x%02x', r, g, b, a)
 end
 
-function hslToRGB(H, S, L, A)
+function hslToRGB(H, S, L, A):table
    H = normaliseHue(H) / 360
    S = clamp(S, 0, 1)
    L = clamp(L, 0, 1)
@@ -82,7 +82,7 @@ function hslToRGB(H, S, L, A)
       return gui.nrgb(L, L, L, A)
    end
 
-   hue2rgb = function(P, Q, T)
+   hue2rgb = function(P, Q, T):num
       if T < 0 then T++ end
       if T > 1 then T -= 1 end
       if T < (1 / 6) then return P + ((Q - P) * 6 * T) end

--- a/examples/benchmark_particles.tiri
+++ b/examples/benchmark_particles.tiri
@@ -137,7 +137,7 @@ function newParticle()
          })
       end
    elseif glMode is MODE_DIRECTVECTOR then
-      particle.colour = glColours[(math.floor(math.random() * #glColours))]
+      particle.colour = glVectorColours[(math.floor(math.random() * #glVectorColours))]
       local err:num
       if glShape is 'star' then
          err, particle.path = lVec.GeneratePath(makeStarSequence(particle.x+particle.radius, particle.y+particle.radius, particle.radius))
@@ -336,7 +336,7 @@ end
 
       glSurface.mtAddCallback(drawDirectVector)
 
-      glColours = array<object> {
+      global glVectorColours = array<object> {
         obj.new('VectorColour', { red=0.8,   green=0,   blue=0 }),
         obj.new('VectorColour', { red=1.0,   green=0.8, blue=0 }),
         obj.new('VectorColour', { red=0.666, green=1.0, blue=0 }),

--- a/examples/gamepad.tiri
+++ b/examples/gamepad.tiri
@@ -90,7 +90,7 @@ Gamepad demonstration
    err, ball_squash_matrix = ballVP.mtNewMatrix(false)
    err, ball_spin_matrix = ballInnerVP.mtNewMatrix(false)
 
-function clamp(Value, MinValue, MaxValue)
+function clamp(Value, MinValue, MaxValue):num
    if Value < MinValue then
       return MinValue
    elseif Value > MaxValue then

--- a/examples/gradients.tiri
+++ b/examples/gradients.tiri
@@ -494,7 +494,7 @@ end
 
    buildScene()
 
-   button_held = false
+   button_held = 0
    check gradientVP.mtSubscribeInput(JTYPE_MOVEMENT | JTYPE_BUTTON, function(Viewport, Events)
       ev = Events
       while ev do

--- a/examples/gradients.tiri
+++ b/examples/gradients.tiri
@@ -29,7 +29,7 @@ local MAX_GAMMA <const> = 5
 -- Corner colours for the Gouraud quad, mutated interactively then rebuilt into the mesh.  Each entry is
 -- { r, g, b }.  Order: top-left, top-right, bottom-left, bottom-right.
 
-gouraudColours = array<array> {
+gouraudColours = array<array<double>> {
    array<double> { 1.0, 0.0, 0.0 }, -- red
    array<double> { 0.0, 1.0, 0.0 }, -- green
    array<double> { 0.0, 0.0, 1.0 }, -- blue
@@ -38,7 +38,7 @@ gouraudColours = array<array> {
 
 ----------------------------------------------------------------------------------------------------------------------
 
-function createGradient(ClassName:str, Options:table)
+function createGradient(ClassName:str, Options:table):obj
    global glRegisteredGradients ?= { }
 
    local gradient = glRegisteredGradients[ClassName]

--- a/scripts/gui/columnview.tiri
+++ b/scripts/gui/columnview.tiri
@@ -10,8 +10,8 @@ Documentation is available in the Kotuku Wiki.
    namespace 'gui'
 
 lDate = nil
-VSPACING  <const> = 2
-EDGE      <const> = 4 -- Whitespace around the page
+VSPACING <const> = 2
+EDGE     <const> = 4 -- Whitespace around the page
 
 rx_datetime <const> = <{ regex.new([[^(\d{4}-\d{1,2}-\d{1,2})[\sT]?(.*)$]]) }>
 rx_date <const> = <{ regex.new([[^(\d+)-(\d+)-(\d+)$]]) }>
@@ -60,13 +60,14 @@ function columnText(Value:any, Type:str):any
 
       if not lDate then lDate = struct.new('DateTime') end
       day, time = rx_datetime.extract(Value)
-      lDate.year, lDate.month, lDate.day = rx_date.extract(day)
+      local y, m, d = rx_date.extract(day)
+      lDate.year, lDate.month, lDate.day = tonumber(y), tonumber(m), tonumber(d)
 
-      h, min, sec = rx_time.extract(time)
+      local h, min, sec = rx_time.extract(time)
       if h then
-         lDate.hour   = h
-         lDate.minute = min
-         lDate.second = sec
+         lDate.hour   = tonumber(h ?? '0')
+         lDate.minute = tonumber(min ?? '0')
+         lDate.second = tonumber(sec ?? '0')
       end
 
       return string.format('%4d-%02d-%02d %02d:%02d', lDate.year, lDate.month, lDate.day, lDate.hour, lDate.minute)

--- a/src/tiri/jit/src/debug/lj_err.cpp
+++ b/src/tiri/jit/src/debug/lj_err.cpp
@@ -1363,6 +1363,17 @@ LJ_NOINLINE void lj_err_callermsg(lua_State *L, CSTRING msg)
    lj_err_run(L);
 }
 
+// Error in the context of the active Tiri frame.  VM helpers use this path because they execute C++ code without
+// adding the C frame that lj_err_callermsg() normally skips.
+
+LJ_NORET LJ_NOINLINE static void err_currentmsg(lua_State *L, CSTRING Message)
+{
+   auto frame = L->base - 1;
+   err_record_pending_exception(L, Message, frame, nullptr);
+   lj_debug_addloc(L, Message, frame, nullptr);
+   lj_err_run(L);
+}
+
 //********************************************************************************************************************
 // Formatted error in context of caller. Use this for errors raised from C library functions (lua_* API, lib_*.cpp).
 // Do NOT use for VM helper functions called from assembler - use lj_err_msgv() instead, which adjusts L->top for
@@ -1551,6 +1562,16 @@ static CSTRING luaL_push_error_string(lua_State *L, std::string &Message)
    auto msg = lj_strfmt_pushvf(L, Format, argp);
    va_end(argp);
    lj_err_callermsg(L, msg);
+}
+
+[[noreturn]] extern void luaL_error_current(lua_State *L, ERR ErrorCode, CSTRING Format, ...)
+{
+   L->CaughtError = ErrorCode;
+   va_list argp;
+   va_start(argp, Format);
+   auto msg = lj_strfmt_pushvf(L, Format, argp);
+   va_end(argp);
+   err_currentmsg(L, msg);
 }
 
 [[noreturn]] extern void luaL_error(lua_State *L, ERR ErrorCode, std::string Message)

--- a/src/tiri/jit/src/lauxlib.h
+++ b/src/tiri/jit/src/lauxlib.h
@@ -41,6 +41,7 @@ extern void luaL_where(lua_State *, int lvl);
 [[noreturn]] extern void luaL_error(lua_State *, ERR);
 [[noreturn]] extern void luaL_error(lua_State *, ERR, const char *, ...);
 [[noreturn]] extern void luaL_error(lua_State *, ERR, std::string);
+[[noreturn]] extern void luaL_error_current(lua_State *, ERR, const char *, ...);
 extern int luaL_checkoption(lua_State *, int, const char *, const char *const lst[]);
 extern TValue * resolve_index(lua_State *L, int);
 

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -15,7 +15,6 @@
 #include "lj_proto_registry.h"
 #include "lib.h"
 
-#include <format>
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
@@ -65,86 +64,97 @@ static const char * scalar_type_name(NativeStructType Type)
    }
 }
 
-static double finite_integer_value(lua_State *L, int StackIndex, CSTRING FieldName, NativeStructType Type)
+template <typename... Args> [[noreturn]] static void struct_field_error(lua_State *L, bool CurrentFrame,
+   ERR ErrorCode, CSTRING Format, Args... Arguments)
+{
+   if (CurrentFrame) luaL_error_current(L, ErrorCode, Format, Arguments...);
+   luaL_error(L, ErrorCode, Format, Arguments...);
+}
+
+static double finite_integer_value(lua_State *L, int StackIndex, CSTRING FieldName, NativeStructType Type,
+   bool CurrentFrame)
 {
    if (lua_type(L, StackIndex) != LUA_TNUMBER) {
-      luaL_error(L, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
+      struct_field_error(L, CurrentFrame, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
          scalar_type_name(Type));
    }
 
    const double value = lua_tonumber(L, StackIndex);
    if (not std::isfinite(value)) {
-      luaL_error(L, ERR::OutOfRange, "Field '%s' requires a finite number for %s storage.", FieldName,
+      struct_field_error(L, CurrentFrame, ERR::OutOfRange, "Field '%s' requires a finite number for %s storage.",
+         FieldName,
          scalar_type_name(Type));
    }
    return std::trunc(value);
 }
 
 template <typename T> static void write_signed_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
-   CSTRING FieldName, NativeStructType Type, int Bits)
+   CSTRING FieldName, NativeStructType Type, int Bits, bool CurrentFrame)
 {
    const double modulus = std::ldexp(1.0, Bits);
    const double half = std::ldexp(1.0, Bits - 1);
-   double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type), modulus);
+   double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type, CurrentFrame), modulus);
    if (value >= half) value -= modulus;
    else if (value < -half) value += modulus;
    ((T *)Address)[ElementIndex] = T(value);
 }
 
 template <typename T> static void write_unsigned_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
-   CSTRING FieldName, NativeStructType Type, int Bits)
+   CSTRING FieldName, NativeStructType Type, int Bits, bool CurrentFrame)
 {
    const double modulus = std::ldexp(1.0, Bits);
-   const double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type), modulus);
+   const double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type, CurrentFrame), modulus);
    if (value < 0) ((T *)Address)[ElementIndex] = T(uint64_t(0) - uint64_t(-value));
    else ((T *)Address)[ElementIndex] = T(value);
 }
 
 static bool write_primitive_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex,
-   CSTRING FieldName, int ElementIndex = 0)
+   CSTRING FieldName, bool CurrentFrame, int ElementIndex = 0)
 {
    const auto type = effective_scalar_type(Field);
    switch (type) {
       case NativeStructType::Bool:
          if (lua_type(L, StackIndex) != LUA_TBOOLEAN) {
-            luaL_error(L, ERR::InvalidType, "Field '%s' requires a bool value.", FieldName);
+            struct_field_error(L, CurrentFrame, ERR::InvalidType, "Field '%s' requires a bool value.", FieldName);
          }
          ((bool *)Address)[ElementIndex] = lua_toboolean(L, StackIndex);
          return true;
       case NativeStructType::Char:
       case NativeStructType::Int8:
-         write_signed_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8);
+         write_signed_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, CurrentFrame);
          return true;
       case NativeStructType::UInt8:
-         write_unsigned_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8);
+         write_unsigned_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, CurrentFrame);
          return true;
       case NativeStructType::Int16:
-         write_signed_field<int16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16);
+         write_signed_field<int16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, CurrentFrame);
          return true;
       case NativeStructType::UInt16:
-         write_unsigned_field<uint16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16);
+         write_unsigned_field<uint16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, CurrentFrame);
          return true;
       case NativeStructType::Int32:
-         write_signed_field<int32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32);
+         write_signed_field<int32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, CurrentFrame);
          return true;
       case NativeStructType::UInt32:
-         write_unsigned_field<uint32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32);
+         write_unsigned_field<uint32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, CurrentFrame);
          return true;
       case NativeStructType::Int64:
-         write_signed_field<int64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64);
+         write_signed_field<int64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, CurrentFrame);
          return true;
       case NativeStructType::UInt64:
-         write_unsigned_field<uint64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64);
+         write_unsigned_field<uint64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, CurrentFrame);
          return true;
       case NativeStructType::Float:
       case NativeStructType::Double: {
          if (lua_type(L, StackIndex) != LUA_TNUMBER) {
-            luaL_error(L, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
+            struct_field_error(L, CurrentFrame, ERR::InvalidType,
+               "Field '%s' requires a number for %s storage.", FieldName,
                scalar_type_name(type));
          }
          const double value = lua_tonumber(L, StackIndex);
          if ((type IS NativeStructType::Float) and std::isfinite(value) and std::abs(value) > FLT_MAX) {
-            luaL_error(L, ERR::OutOfRange, "Field '%s' value is out of range for float.", FieldName);
+            struct_field_error(L, CurrentFrame, ERR::OutOfRange,
+               "Field '%s' value is out of range for float.", FieldName);
          }
          if (type IS NativeStructType::Float) ((float *)Address)[ElementIndex] = float(value);
          else ((double *)Address)[ElementIndex] = value;
@@ -162,7 +172,8 @@ template <typename T> static void copy_array_to_vector(APTR Address, GCarray *So
    if (Source->len) std::memcpy(dest.data(), Source->arraydata(), size_t(Source->len) * sizeof(T));
 }
 
-static void write_array_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName)
+static void write_array_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName,
+   bool CurrentFrame)
 {
    if ((Field.Type & FD_CUSTOM) and (Field.Type & FD_BYTE) and (not (Field.Type & FD_VECTOR)) and
          lua_type(L, StackIndex) IS LUA_TSTRING) {
@@ -175,7 +186,7 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
    }
 
    if (not lua_isarray(L, StackIndex)) {
-      luaL_error(L, ERR::InvalidType, "Array field '%s' requires a native array.", FieldName);
+      struct_field_error(L, CurrentFrame, ERR::InvalidType, "Array field '%s' requires a native array.", FieldName);
    }
 
    auto source = lua_toarray(L, StackIndex);
@@ -183,15 +194,18 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
 
    if ((Field.Type & FD_VECTOR) and (Field.Type & FD_STRUCT) and (not (Field.Type & FD_PTR))) {
       if (not Field.TrivialElements) {
-         luaL_error(L, ERR::NoSupport, "Array field '%s' has a non-trivial legacy struct element type.", FieldName);
+         struct_field_error(L, CurrentFrame, ERR::NoSupport,
+            "Array field '%s' has a non-trivial legacy struct element type.", FieldName);
       }
       auto field_def = Field.StructDefinition;
       if (not field_def) {
-         luaL_error(L, ERR::Search, "Array field '%s' has an unresolved struct element type.", FieldName);
+         struct_field_error(L, CurrentFrame, ERR::Search,
+            "Array field '%s' has an unresolved struct element type.", FieldName);
       }
       if (source->elemtype IS AET::STRUCT) {
          if ((source->structdef != field_def) or (source->elemsize != Field.ElementStride)) {
-            luaL_error(L, ERR::InvalidType, "Array field '%s' requires '%s' struct elements.", FieldName,
+            struct_field_error(L, CurrentFrame, ERR::InvalidType,
+               "Array field '%s' requires '%s' struct elements.", FieldName,
                field_def->Name.c_str());
          }
          assign_trivial_struct_vector(Address, source->arraydata(), source->len, Field.ElementStride);
@@ -215,19 +229,23 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
                return;
             }
          }
-         luaL_error(L, conversion, "Array field '%s' contains an invalid struct table.", FieldName);
+         struct_field_error(L, CurrentFrame, conversion,
+            "Array field '%s' contains an invalid struct table.", FieldName);
       }
-      luaL_error(L, ERR::InvalidType, "Array field '%s' requires struct elements.", FieldName);
+      struct_field_error(L, CurrentFrame, ERR::InvalidType,
+         "Array field '%s' requires struct elements.", FieldName);
    }
 
    if ((Field.Type & FD_STRING) and (not (Field.Type & FD_CPP))) {
-      luaL_error(L, ERR::NoSupport, "Raw C string array field '%s' does not support assignment.", FieldName);
+      struct_field_error(L, CurrentFrame, ERR::NoSupport,
+         "Raw C string array field '%s' does not support assignment.", FieldName);
    }
 
    if ((Field.Type & FD_STRING) and (Field.Type & FD_VECTOR)) {
       if ((source->elemtype != AET::STR_GC) and (source->elemtype != AET::CSTR) and
             (source->elemtype != AET::STR_CPP)) {
-         luaL_error(L, ERR::InvalidType, "Array field '%s' requires string elements.", FieldName);
+         struct_field_error(L, CurrentFrame, ERR::InvalidType,
+            "Array field '%s' requires string elements.", FieldName);
       }
 
       auto &dest = ((kt::vector<std::string> *)Address)[0];
@@ -244,7 +262,8 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
    }
 
    if (source->elemtype != expected_type) {
-      luaL_error(L, ERR::InvalidType, "Array field '%s' has an incompatible element type.", FieldName);
+      struct_field_error(L, CurrentFrame, ERR::InvalidType,
+         "Array field '%s' has an incompatible element type.", FieldName);
    }
 
    if (Field.Type & FD_VECTOR) {
@@ -254,12 +273,13 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
       else if (Field.Type & FD_INT) copy_array_to_vector<int>(Address, source);
       else if (Field.Type & FD_WORD) copy_array_to_vector<int16_t>(Address, source);
       else if (Field.Type & FD_BYTE) copy_array_to_vector<uint8_t>(Address, source);
-      else luaL_error(L, ERR::NoSupport, "Array field '%s' uses an unsupported vector type.", FieldName);
+      else struct_field_error(L, CurrentFrame, ERR::NoSupport,
+         "Array field '%s' uses an unsupported vector type.", FieldName);
    }
    else {
       if (source->len > MSize(Field.ArraySize)) {
-         luaL_error(L, ERR::OutOfRange, "Array assignment for field '%s' exceeds its fixed size of %d.", FieldName,
-            Field.ArraySize);
+         struct_field_error(L, CurrentFrame, ERR::OutOfRange,
+            "Array assignment for field '%s' exceeds its fixed size of %d.", FieldName, Field.ArraySize);
       }
       const auto copied_bytes = size_t(source->len) * source->elemsize;
       const auto remaining_bytes = (size_t(Field.ArraySize) - source->len) * source->elemsize;
@@ -268,44 +288,50 @@ static void write_array_field(lua_State *L, APTR Address, const struct_field &Fi
    }
 }
 
-static void write_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName)
+static void write_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex, CSTRING FieldName,
+   bool CurrentFrame)
 {
    if (Field.Type & FD_POINTER) {
       if ((not lua_isnil(L, StackIndex)) and (not lua_islightuserdata(L, StackIndex))) {
-         luaL_error(L, ERR::InvalidType, "Field '%s' requires lightuserdata or nil.", FieldName);
+         struct_field_error(L, CurrentFrame, ERR::InvalidType,
+            "Field '%s' requires lightuserdata or nil.", FieldName);
       }
       ((APTR *)Address)[0] = lua_touserdata(L, StackIndex);
       return;
    }
    else if (Field.Type & (FD_ARRAY|FD_VECTOR)) {
-      write_array_field(L, Address, Field, StackIndex, FieldName);
+      write_array_field(L, Address, Field, StackIndex, FieldName, CurrentFrame);
       return;
    }
    else if (Field.Type & FD_STRING) {
       if ((Field.Type & FD_CPP) and (not (Field.Type & FD_VECTOR))) {
          if (lua_type(L, StackIndex) != LUA_TSTRING) {
-            luaL_error(L, ERR::InvalidType, "Field '%s' requires a string value.", FieldName);
+            struct_field_error(L, CurrentFrame, ERR::InvalidType,
+               "Field '%s' requires a string value.", FieldName);
          }
          size_t length;
          auto value = lua_tolstring(L, StackIndex, &length);
          ((std::string *)Address)[0].assign(value, length);
          return;
       }
-      luaL_error(L, ERR::InvalidType, "Field '%s' does not support string assignment.", FieldName);
+      struct_field_error(L, CurrentFrame, ERR::InvalidType,
+         "Field '%s' does not support string assignment.", FieldName);
    }
    else if (Field.Type & FD_OBJECT) {
       if (lua_isnil(L, StackIndex)) ((OBJECTPTR *)Address)[0] = nullptr;
       else if (lua_isobject(L, StackIndex)) {
          auto object = lua_toobject(L, StackIndex);
          if (object_is_dead(object)) {
-            luaL_error(L, ERR::DoesNotExist, "Cannot assign detached object to field '%s'.", FieldName);
+            struct_field_error(L, CurrentFrame, ERR::DoesNotExist,
+               "Cannot assign detached object to field '%s'.", FieldName);
          }
          if (Field.ObjectClassID != CLASSID::NIL) {
             // Sub-classes satisfy a base class constraint, so both identifiers are eligible for the match.
             auto class_ptr = object->classptr;
             if ((not class_ptr) or ((class_ptr->ClassID != Field.ObjectClassID) and
                 (class_ptr->BaseClassID != Field.ObjectClassID))) {
-               luaL_error(L, ERR::InvalidType, "Field '%s' requires an object of class '%s'.", FieldName,
+               struct_field_error(L, CurrentFrame, ERR::InvalidType,
+                  "Field '%s' requires an object of class '%s'.", FieldName,
                   ResolveClassID(Field.ObjectClassID));
             }
          }
@@ -313,16 +339,19 @@ static void write_field(lua_State *L, APTR Address, const struct_field &Field, i
       }
       else if (lua_islightuserdata(L, StackIndex)) {
          if (Field.ObjectClassID != CLASSID::NIL) {
-            luaL_error(L, ERR::InvalidType, "Field '%s' requires a typed object reference.", FieldName);
+            struct_field_error(L, CurrentFrame, ERR::InvalidType,
+               "Field '%s' requires a typed object reference.", FieldName);
          }
          ((OBJECTPTR *)Address)[0] = (OBJECTPTR)lua_touserdata(L, StackIndex);
       }
-      else luaL_error(L, ERR::InvalidType, "Field '%s' requires an object, lightuserdata or nil.", FieldName);
+      else struct_field_error(L, CurrentFrame, ERR::InvalidType,
+         "Field '%s' requires an object, lightuserdata or nil.", FieldName);
       return;
    }
-   else if (write_primitive_field(L, Address, Field, StackIndex, FieldName)) return;
+   else if (write_primitive_field(L, Address, Field, StackIndex, FieldName, CurrentFrame)) return;
 
-   luaL_error(L, ERR::InvalidType, "Field '%s' does not support assignment (type %x).", FieldName, Field.Type);
+   struct_field_error(L, CurrentFrame, ERR::InvalidType,
+      "Field '%s' does not support assignment (type %x).", FieldName, Field.Type);
 }
 
 static bool struct_has_unsupported_cpp_arrays(lua_State *L, const struct_record &Def)
@@ -474,7 +503,7 @@ static int push_new_struct(lua_State *L, CSTRING StructName, int InitialiserInde
          if (auto field_opt = find_field(result, field_name)) {
             auto &field = field_opt->get();
             APTR address = (int8_t *)result->data + field.Offset;
-            write_field(L, address, field, -1, field_name);
+            write_field(L, address, field, -1, field_name, false);
          }
          else {
             lua_pop(L, 2);
@@ -566,7 +595,7 @@ static int struct_tostring(lua_State *L)
    return 1;
 }
 
-void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field, APTR Address)
+void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field, APTR Address, bool CurrentFrame)
 {
    int array_size = (not Field.ArraySize) ? -1 : Field.ArraySize;
    struct_record *field_def = Field.StructDefinition;
@@ -577,7 +606,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
    if ((Field.Type & FD_VECTOR) and (Field.StructRef != 0) and
          (not (Field.Type & FD_PTR))) {
       if (not field_def) {
-         luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+         struct_field_error(L, CurrentFrame, ERR::Search,
+            "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
       make_struct_array(L, field_def->Name, int(trivial_struct_vector_size(Address)),
          trivial_struct_vector_data(Address), Field.ElementStride, field_def);
@@ -585,7 +615,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
    else if ((Field.Type & FD_STRUCT) and (Field.Type & FD_PTR) and (Field.StructRef != 0)) {
       if (((APTR *)Address)[0]) {
          if (not field_def) {
-            luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+            struct_field_error(L, CurrentFrame, ERR::Search,
+               "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
          }
          if (Field.Type & (FD_ARRAY|FD_VECTOR)) {
             if (Field.Type & FD_VECTOR) {
@@ -599,14 +630,16 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
          }
          else if (not push_external_struct(L, ((APTR *)Address)[0], field_def->Name, field_def,
                Struct->lifecycle)) {
-            luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+            struct_field_error(L, CurrentFrame, ERR::Search,
+               "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
          }
       }
       else lua_pushnil(L);
    }
    else if ((Field.Type & FD_STRUCT) and (Field.Type & (FD_ARRAY|FD_VECTOR))) {
       if (not field_def) {
-         luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+         struct_field_error(L, CurrentFrame, ERR::Search,
+            "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
       if (Field.Type & FD_VECTOR) {
          make_struct_array(L, field_def->Name, int(trivial_struct_vector_size(Address)),
@@ -627,11 +660,13 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
       else if (Field.Type & FD_INT) push_vector_array<int>(L, Address, AET::INT32);
       else if (Field.Type & FD_WORD) push_vector_array<int16_t>(L, Address, AET::INT16);
       else if (Field.Type & FD_BYTE) push_vector_array<uint8_t>(L, Address, AET::BYTE);
-      else luaL_error(L, ERR::NoSupport, "Vector field '%s' uses an unsupported element type.", Field.Name.c_str());
+      else struct_field_error(L, CurrentFrame, ERR::NoSupport,
+         "Vector field '%s' uses an unsupported element type.", Field.Name.c_str());
    }
    else if (Field.Type & FD_STRUCT) {
       if (not field_def) {
-         luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+         struct_field_error(L, CurrentFrame, ERR::Search,
+            "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
       GCstruct *parent = nullptr;
       if (not Struct->is_lifecycle_bound()) {
@@ -641,7 +676,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
          else parent = Struct;
       }
       if (not push_external_struct(L, Address, field_def->Name, field_def, Struct->lifecycle, parent)) {
-         luaL_error(L, ERR::Search, "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
+         struct_field_error(L, CurrentFrame, ERR::Search,
+            "Failed to find struct referenced by field '%s'.", Field.Name.c_str());
       }
    }
    else if (Field.Type & FD_STRING) {
@@ -665,13 +701,13 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
    }
    else if (Field.Type & FD_FUNCTION) lua_pushnil(L);
    else if (read_primitive_field(L, Address, Field, array_size));
-   else luaL_error(L, ERR::InvalidType,
-      std::format("Field '{}' does not use a supported type of {:x}", Field.Name, Field.Type));
+   else struct_field_error(L, CurrentFrame, ERR::InvalidType,
+      "Field '%s' does not use a supported type of %x", Field.Name.c_str(), Field.Type);
 }
 
-void lj_struct_setfield_core(lua_State *L, GCstruct *, struct_field &Field, APTR Address)
+void lj_struct_setfield_core(lua_State *L, GCstruct *, struct_field &Field, APTR Address, bool CurrentFrame)
 {
-   write_field(L, Address, Field, -1, Field.Name.c_str());
+   write_field(L, Address, Field, -1, Field.Name.c_str(), CurrentFrame);
    lua_pop(L, 1);
 }
 
@@ -691,7 +727,7 @@ static int struct_get(lua_State *L)
    if (auto field_opt = find_field(value, field_name)) {
       auto &field = field_opt->get();
       APTR address = (int8_t *)value->data + field.Offset;
-      lj_struct_getfield_core(L, value, field, address);
+      lj_struct_getfield_core(L, value, field, address, false);
       return 1;
    }
    luaL_error(L, ERR::FieldNotFound, "Field '%s' does not exist in structure.", field_name);
@@ -709,7 +745,7 @@ static int struct_set(lua_State *L)
       auto &field = field_opt->get();
       APTR address = (int8_t *)value->data + field.Offset;
       lua_pushvalue(L, 3);
-      lj_struct_setfield_core(L, value, field, address);
+      lj_struct_setfield_core(L, value, field, address, false);
       return 0;
    }
    luaL_error(L, "Invalid field reference '%s'", field_name);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3743,6 +3743,29 @@ static bool test_native_prototype_result_descriptors(kt::Log &Log)
       return false;
    }
 
+   // Untyped table reads yield 'any' because element types are not tracked.  Reassigning such a local must stay
+   // legal: an annotation would only add a CONTRACT guard without unlocking a specialised opcode, and ':any' would
+   // restore exactly the type the local already had.
+
+   constexpr std::string_view table_read_reassignment =
+      "local source = { Value = 1.5 }\n"
+      "local direct = source.Value\n"
+      "direct = direct * 2\n"
+      "local indexed = source['Value']\n"
+      "indexed = 5\n"
+      "local same_source = source.Value\n"
+      "same_source = source.Value\n"
+      "local defaulted = source.Missing ?? 1.96\n"
+      "defaulted = defaulted * 2\n"
+      "local arithmetic = 0.5 + source.Value\n"
+      "arithmetic = 11\n"
+      "return direct, indexed, same_source, defaulted, arithmetic\n";
+   error.clear();
+   if (not compile_snapshot(L, table_read_reassignment, true, error)) {
+      Log.error("reassigning a local initialised from an untyped table read was rejected: %s", error.c_str());
+      return false;
+   }
+
    return true;
 }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -3759,7 +3759,9 @@ static bool test_native_prototype_result_descriptors(kt::Log &Log)
       "defaulted = defaulted * 2\n"
       "local arithmetic = 0.5 + source.Value\n"
       "arithmetic = 11\n"
-      "return direct, indexed, same_source, defaulted, arithmetic\n";
+      "local negated = -source.Value\n"
+      "negated = 5\n"
+      "return direct, indexed, same_source, defaulted, arithmetic, negated\n";
    error.clear();
    if (not compile_snapshot(L, table_read_reassignment, true, error)) {
       Log.error("reassigning a local initialised from an untyped table read was rejected: %s", error.c_str());

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -113,6 +113,13 @@
             (payload->right and is_table_read_expression(*payload->right));
       }
 
+      // Unary negation can remain dynamic when its operand is a table read because the value may overload '-'.
+
+      case AstNodeKind::UnaryExpr: {
+         const auto *payload = std::get_if<UnaryExprPayload>(&Expr.data);
+         return payload and payload->operand and is_table_read_expression(*payload->operand);
+      }
+
       default:
          return false;
    }

--- a/src/tiri/jit/src/parser/type_analysis.cpp
+++ b/src/tiri/jit/src/parser/type_analysis.cpp
@@ -88,6 +88,36 @@
    return Function.body and Function.body->statements.empty();
 }
 
+// Reads from an untyped table yield 'any' because element types are not tracked.  Such a value is dynamic by nature
+// rather than by an unresolved ingress, so it must not lock the destination into requiring an annotation; demanding
+// one would only add a CONTRACT guard without unlocking a specialised opcode.  Struct fields and typed array elements
+// infer concrete types and never reach this path.
+
+[[nodiscard]] static bool is_table_read_expression(const ExprNode &Expr)
+{
+   switch (Expr.kind) {
+      case AstNodeKind::MemberExpr:
+      case AstNodeKind::IndexExpr:
+      case AstNodeKind::SafeMemberExpr:
+      case AstNodeKind::SafeIndexExpr:
+         return true;
+
+      // Binary expressions yield 'any' when a table read can invoke an overloaded operator.  This includes defaulted
+      // reads such as t[k] ?? fallback and arithmetic such as 0.5 + t.value.  Recurse so the exemption follows the
+      // value's origin.
+
+      case AstNodeKind::BinaryExpr: {
+         const auto *payload = std::get_if<BinaryExprPayload>(&Expr.data);
+         if (not payload) return false;
+         return (payload->left and is_table_read_expression(*payload->left)) or
+            (payload->right and is_table_read_expression(*payload->right));
+      }
+
+      default:
+         return false;
+   }
+}
+
 [[nodiscard]] static std::optional<std::string> function_signature_mismatch(
    const FunctionExprPayload &Expected, const FunctionExprPayload &Actual)
 {
@@ -1464,7 +1494,8 @@ void TypeAnalyser::analyse_assignment(const AssignmentStmtPayload &Payload)
                else inferred = this->infer_call_return_type(*Payload.values[source], result_position);
 
                inferred.requires_destination_type =
-                  inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown;
+                  (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
+                  not (result_position IS 0 and is_table_read_expression(*Payload.values[source]));
                inferred.is_fixed = inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and
                   inferred.primary != TiriType::Unknown;
                if (Payload.op != AssignmentOperator::Plain and not inferred.requires_destination_type) {
@@ -1654,6 +1685,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
       InferredType inferred;
       InferredType value_type;
       bool have_value_type = false;
+      const ExprNode *initialiser = nullptr;  // Direct initialiser, excluding trailing multi-return positions
 
       // Determine the value type for this variable
       if (value_index < Payload.values.size()) {
@@ -1661,6 +1693,7 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
          const ExprNode& value_expr = *Payload.values[value_index];
          value_type = this->infer_expression_type(value_expr);
          have_value_type = true;
+         initialiser = &value_expr;
 
          // If this is the last value and it can provide multiple results, retain it for later declaration positions.
          if (value_index IS Payload.values.size() - 1 and
@@ -1739,7 +1772,8 @@ void TypeAnalyser::analyse_local_decl(const LocalDeclStmtPayload &Payload)
          inferred = value_type;
 
          inferred.requires_destination_type = not name.is_blank and
-            (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown);
+            (inferred.primary IS TiriType::Any or inferred.primary IS TiriType::Unknown) and
+            not (initialiser and is_table_read_expression(*initialiser));
 
          // Non-nil, non-any initial values fix the type
          if (inferred.primary != TiriType::Nil and inferred.primary != TiriType::Any and

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -122,9 +122,13 @@ bool lj_struct_stale(GCstruct *s)
 //********************************************************************************************************************
 // Guard access to a struct view whose payload is owned by a Kotuku object.
 
-void lj_struct_check_lifecycle(lua_State *L, GCstruct *Struct, const char *FieldName)
+void lj_struct_check_lifecycle(lua_State *L, GCstruct *Struct, const char *FieldName, bool CurrentFrame)
 {
    if (lj_struct_stale(Struct)) {
+      if (CurrentFrame) {
+         luaL_error_current(L, ERR::DoesNotExist,
+            "Cannot access field '%s'; the object providing this struct has been destroyed.", FieldName);
+      }
       luaL_error(L, ERR::DoesNotExist, "Cannot access field '%s'; the object providing this struct has been destroyed.",
          FieldName);
    }
@@ -207,21 +211,21 @@ extern "C" void bc_struct_getfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
       return;
    }
 
-   lj_struct_check_lifecycle(L, Struct, field_name);
+   lj_struct_check_lifecycle(L, Struct, field_name, true);
    if (not Struct->data) {
-      luaL_error(L, ERR::Failed, "Cannot reference field '%s' because struct address is NULL.", field_name);
+      luaL_error_current(L, ERR::Failed, "Cannot reference field '%s' because struct address is NULL.", field_name);
    }
 
    if (auto field = find_cached_field(Struct, Key, Ins)) {
       auto address = (int8_t *)Struct->data + field->Offset;
-      lj_struct_getfield_core(L, Struct, *field, address);
+      lj_struct_getfield_core(L, Struct, *field, address, true);
       copyTV(L, Dest, L->top - 1);
       L->base = saved_base;
       L->top = saved_top;
       return;
    }
 
-   luaL_error(L, ERR::FieldNotFound, "Field '%s' does not exist in structure.", field_name);
+   luaL_error_current(L, ERR::FieldNotFound, "Field '%s' does not exist in structure.", field_name);
 }
 
 //********************************************************************************************************************
@@ -259,16 +263,18 @@ extern "C" void bc_struct_setfield(lua_State *L, GCstruct *Struct, GCstr *Key, T
    }
 
    const auto field_name = strdata(Key);
-   lj_struct_check_lifecycle(L, Struct, field_name);
-   if (not Struct->data) luaL_error(L, "Cannot reference field '%s' because struct address is NULL.", field_name);
+   lj_struct_check_lifecycle(L, Struct, field_name, true);
+   if (not Struct->data) {
+      luaL_error_current(L, ERR::Exception, "Cannot reference field '%s' because struct address is NULL.", field_name);
+   }
 
    if (auto field = find_cached_field(Struct, Key, Ins)) {
       auto address = (int8_t *)Struct->data + field->Offset;
-      lj_struct_setfield_core(L, Struct, *field, address);
+      lj_struct_setfield_core(L, Struct, *field, address, true);
       L->base = saved_base;
       L->top = saved_top;
       return;
    }
 
-   luaL_error(L, "Invalid field reference '%s'", field_name);
+   luaL_error_current(L, ERR::Exception, "Invalid field reference '%s'", field_name);
 }

--- a/src/tiri/jit/src/runtime/lj_struct.h
+++ b/src/tiri/jit/src/runtime/lj_struct.h
@@ -14,9 +14,9 @@ extern GCstruct * lj_struct_new_external(lua_State *, struct struct_record &, vo
 extern void lj_struct_free(global_State *, GCstruct *);
 extern bool lj_struct_stale(GCstruct *);
 
-extern void lj_struct_check_lifecycle(lua_State *, GCstruct *, const char *);
-extern void lj_struct_getfield_core(lua_State *, GCstruct *, struct_field &, void *);
-extern void lj_struct_setfield_core(lua_State *, GCstruct *, struct_field &, void *);
+extern void lj_struct_check_lifecycle(lua_State *, GCstruct *, const char *, bool CurrentFrame = false);
+extern void lj_struct_getfield_core(lua_State *, GCstruct *, struct_field &, void *, bool CurrentFrame = false);
+extern void lj_struct_setfield_core(lua_State *, GCstruct *, struct_field &, void *, bool CurrentFrame = false);
 extern void lj_struct_push_size_closure(lua_State *, GCstruct *);
 
 // Fast path bytecode handlers for BC_STGETF and BC_STSETF.

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -861,17 +861,44 @@ end
    MAKESTRUCT('FastFieldErrors', 'lValue')
    local value = struct.new('FastFieldErrors')
 
+   local expected_read_line = @SourceLine + 3
+
    try
       local missing = value.unknown
       assert(missing is nil, 'Unknown struct field access should not return normally')
+   except error_value when ERR_FieldNotFound
+      assert(error_value.source:find('test_struct.tiri'),
+         'Fast struct reads should retain the access source, got ' .. tostring(error_value.source))
+      assert(error_value.line is expected_read_line,
+         f'Fast struct reads should retain access line {expected_read_line}, got {error_value.line}')
    success
       error('Unknown struct field access should raise through STGETF')
    end
 
+   local expected_write_line = @SourceLine + 3
+
    try
       value.unknown = 1
+   except error_value
+      assert(error_value.source:find('test_struct.tiri'),
+         'Fast struct writes should retain the assignment source, got ' .. tostring(error_value.source))
+      assert(error_value.line is expected_write_line,
+         f'Fast struct writes should retain assignment line {expected_write_line}, got {error_value.line}')
    success
       error('Unknown struct field assignment should raise through STSETF')
+   end
+
+   local expected_line = @SourceLine + 3
+
+   try
+      value.value = nil
+   except error_value when ERR_InvalidType
+      assert(error_value.source:find('test_struct.tiri'),
+         'Fast struct field errors should retain the assignment source, got ' .. tostring(error_value.source))
+      assert(error_value.line is expected_line,
+         f'Fast struct field errors should retain assignment line {expected_line}, got {error_value.line}')
+   success
+      error('Invalid struct field assignment should raise through STSETF')
    end
 
    assert(value.structSize() > 0, 'structSize() should continue to resolve through the struct metatable')


### PR DESCRIPTION
* Allowed locals initialised from untyped table reads to remain dynamically reassignable
* Reported native struct access failures at the active Tiri source location
* Updated affected scripts and examples for strict typed value handling