### PR TITLE
[Tiri] Expand JIT structure handling for scalar and object fields

### DIFF
--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -26,25 +26,6 @@
 
 #define LJLIB_MODULE_struct
 
-static NativeStructType effective_scalar_type(const struct_field &Field)
-{
-   if (Field.NativeType != NativeStructType::Legacy) return Field.NativeType;
-
-   if (Field.Type & FD_FLOAT) return NativeStructType::Float;
-   if (Field.Type & FD_DOUBLE) return NativeStructType::Double;
-   if (Field.Type & FD_INT64) {
-      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt64 : NativeStructType::Int64;
-   }
-   if (Field.Type & FD_INT) {
-      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt32 : NativeStructType::Int32;
-   }
-   if (Field.Type & FD_WORD) {
-      return (Field.Type & FD_UNSIGNED) ? NativeStructType::UInt16 : NativeStructType::Int16;
-   }
-   if (Field.Type & FD_BYTE) return NativeStructType::UInt8;
-   return NativeStructType::Legacy;
-}
-
 static const char * scalar_type_name(NativeStructType Type)
 {
    switch (Type) {
@@ -74,7 +55,9 @@ template <typename... Args> [[noreturn]] static void struct_field_error(lua_Stat
 static double finite_integer_value(lua_State *L, int StackIndex, CSTRING FieldName, NativeStructType Type,
    bool CurrentFrame)
 {
-   if (lua_type(L, StackIndex) != LUA_TNUMBER) {
+   auto ltype = lua_type(L, StackIndex);
+   if (ltype IS LUA_TNIL) return 0;
+   if (ltype != LUA_TNUMBER) {
       struct_field_error(L, CurrentFrame, ERR::InvalidType, "Field '%s' requires a number for %s storage.", FieldName,
          scalar_type_name(Type));
    }
@@ -146,11 +129,20 @@ static bool write_primitive_field(lua_State *L, APTR Address, const struct_field
          return true;
       case NativeStructType::Float:
       case NativeStructType::Double: {
-         if (lua_type(L, StackIndex) != LUA_TNUMBER) {
+         auto ltype = lua_type(L, StackIndex);
+
+         if (ltype IS LUA_TNIL) {
+            if (type IS NativeStructType::Float) ((float *)Address)[ElementIndex] = 0.0f;
+            else ((double *)Address)[ElementIndex] = 0.0;
+            return true;
+         }
+
+         if (ltype != LUA_TNUMBER) {
             struct_field_error(L, CurrentFrame, ERR::InvalidType,
                "Field '%s' requires a number for %s storage.", FieldName,
                scalar_type_name(type));
          }
+
          const double value = lua_tonumber(L, StackIndex);
          if ((type IS NativeStructType::Float) and std::isfinite(value) and std::abs(value) > FLT_MAX) {
             struct_field_error(L, CurrentFrame, ERR::OutOfRange,
@@ -318,7 +310,12 @@ static void write_field(lua_State *L, APTR Address, const struct_field &Field, i
          "Field '%s' does not support string assignment.", FieldName);
    }
    else if (Field.Type & FD_OBJECT) {
-      if (lua_isnil(L, StackIndex)) ((OBJECTPTR *)Address)[0] = nullptr;
+      const bool uid_backed = Field.Type & FD_INT;
+      auto ltype = lua_type(L, StackIndex);
+      if (ltype IS LUA_TNIL) {
+         if (uid_backed) ((OBJECTID *)Address)[0] = OBJECTID(0);
+         else ((OBJECTPTR *)Address)[0] = nullptr;
+      }
       else if (lua_isobject(L, StackIndex)) {
          auto object = lua_toobject(L, StackIndex);
          if (object_is_dead(object)) {
@@ -335,10 +332,11 @@ static void write_field(lua_State *L, APTR Address, const struct_field &Field, i
                   ResolveClassID(Field.ObjectClassID));
             }
          }
-         ((OBJECTPTR *)Address)[0] = object->ptr;
+         if (uid_backed) ((OBJECTID *)Address)[0] = OBJECTID(object->uid);
+         else ((OBJECTPTR *)Address)[0] = object->ptr;
       }
       else if (lua_islightuserdata(L, StackIndex)) {
-         if (Field.ObjectClassID != CLASSID::NIL) {
+         if (uid_backed or Field.ObjectClassID != CLASSID::NIL) {
             struct_field_error(L, CurrentFrame, ERR::InvalidType,
                "Field '%s' requires a typed object reference.", FieldName);
          }
@@ -692,7 +690,8 @@ void lj_struct_getfield_core(lua_State *L, GCstruct *Struct, struct_field &Field
       else lua_pushstring(L, ((STRING *)Address)[0]);
    }
    else if (Field.Type & FD_OBJECT) {
-      if (auto object = ((OBJECTPTR *)Address)[0]) push_object(L, object);
+      if (Field.Type & FD_INT) push_object_id(L, ((OBJECTID *)Address)[0]);
+      else if (auto object = ((OBJECTPTR *)Address)[0]) push_object(L, object);
       else lua_pushnil(L);
    }
    else if (Field.Type & FD_POINTER) {

--- a/src/tiri/jit/src/lib/lib_struct.cpp
+++ b/src/tiri/jit/src/lib/lib_struct.cpp
@@ -71,24 +71,17 @@ static double finite_integer_value(lua_State *L, int StackIndex, CSTRING FieldNa
    return std::trunc(value);
 }
 
-template <typename T> static void write_signed_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
-   CSTRING FieldName, NativeStructType Type, int Bits, bool CurrentFrame)
+template <typename T> static void write_integer_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
+   CSTRING FieldName, NativeStructType Type, int Bits, bool Signed, bool CurrentFrame)
 {
-   const double modulus = std::ldexp(1.0, Bits);
-   const double half = std::ldexp(1.0, Bits - 1);
-   double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type, CurrentFrame), modulus);
-   if (value >= half) value -= modulus;
-   else if (value < -half) value += modulus;
+   const double value = finite_integer_value(L, StackIndex, FieldName, Type, CurrentFrame);
+   const double lower_bound = Signed ? -std::ldexp(1.0, Bits - 1) : 0.0;
+   const double upper_bound = std::ldexp(1.0, Signed ? Bits - 1 : Bits);
+   if (value < lower_bound or value >= upper_bound) {
+      struct_field_error(L, CurrentFrame, ERR::OutOfRange, "Field '%s' value is out of range for %s.", FieldName,
+         scalar_type_name(Type));
+   }
    ((T *)Address)[ElementIndex] = T(value);
-}
-
-template <typename T> static void write_unsigned_field(lua_State *L, APTR Address, int StackIndex, int ElementIndex,
-   CSTRING FieldName, NativeStructType Type, int Bits, bool CurrentFrame)
-{
-   const double modulus = std::ldexp(1.0, Bits);
-   const double value = std::fmod(finite_integer_value(L, StackIndex, FieldName, Type, CurrentFrame), modulus);
-   if (value < 0) ((T *)Address)[ElementIndex] = T(uint64_t(0) - uint64_t(-value));
-   else ((T *)Address)[ElementIndex] = T(value);
 }
 
 static bool write_primitive_field(lua_State *L, APTR Address, const struct_field &Field, int StackIndex,
@@ -104,28 +97,28 @@ static bool write_primitive_field(lua_State *L, APTR Address, const struct_field
          return true;
       case NativeStructType::Char:
       case NativeStructType::Int8:
-         write_signed_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, CurrentFrame);
+         write_integer_field<int8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, true, CurrentFrame);
          return true;
       case NativeStructType::UInt8:
-         write_unsigned_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, CurrentFrame);
+         write_integer_field<uint8_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 8, false, CurrentFrame);
          return true;
       case NativeStructType::Int16:
-         write_signed_field<int16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, CurrentFrame);
+         write_integer_field<int16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, true, CurrentFrame);
          return true;
       case NativeStructType::UInt16:
-         write_unsigned_field<uint16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, CurrentFrame);
+         write_integer_field<uint16_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 16, false, CurrentFrame);
          return true;
       case NativeStructType::Int32:
-         write_signed_field<int32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, CurrentFrame);
+         write_integer_field<int32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, true, CurrentFrame);
          return true;
       case NativeStructType::UInt32:
-         write_unsigned_field<uint32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, CurrentFrame);
+         write_integer_field<uint32_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 32, false, CurrentFrame);
          return true;
       case NativeStructType::Int64:
-         write_signed_field<int64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, CurrentFrame);
+         write_integer_field<int64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, true, CurrentFrame);
          return true;
       case NativeStructType::UInt64:
-         write_unsigned_field<uint64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, CurrentFrame);
+         write_integer_field<uint64_t>(L, Address, StackIndex, ElementIndex, FieldName, type, 64, false, CurrentFrame);
          return true;
       case NativeStructType::Float:
       case NativeStructType::Double: {

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -3443,38 +3443,39 @@ static TRef rec_struct_number_ref(jit_State *J, TRef ValueRef)
    return ValueRef;
 }
 
-// Normalise a finite number to the low Bits of its truncated integer representation.  All guards precede the
-// conversion so an exceptional value exits before the caller can emit a store.
-static TRef rec_struct_integer_bits(jit_State *J, TRef ValueRef, double RecordedValue, int Bits)
+static bool rec_struct_integer_signed(NativeStructType Type)
 {
-   TRef number_ref = rec_struct_number_ref(J, ValueRef);
-   if (Bits <= 32 and RecordedValue >= double(INT32_MIN) and RecordedValue <= double(INT32_MAX) and
-         std::trunc(RecordedValue) IS RecordedValue) {
-      return emitir(IRTGI(IR_CONV), number_ref, IRCONV_INT_NUM | IRCONV_CHECK);
+   switch (Type) {
+      case NativeStructType::Char:
+      case NativeStructType::Int8:
+      case NativeStructType::Int16:
+      case NativeStructType::Int32:
+      case NativeStructType::Int64:
+         return true;
+      default:
+         return false;
    }
+}
 
-   TRef maximum_ref = lj_ir_knum(J, DBL_MAX);
-   emitir(IRTG(IR_GE, IRT_NUM), number_ref, lj_ir_knum(J, -DBL_MAX));
-   emitir(IRTG(IR_LE, IRT_NUM), number_ref, maximum_ref);
+static bool rec_struct_integer_fits_int32(double Value, NativeStructType Type, int Bits)
+{
+   const bool signed_type = rec_struct_integer_signed(Type);
+   const double lower_bound = signed_type ? -std::ldexp(1.0, Bits - 1) : 0.0;
+   const double upper_bound = std::ldexp(1.0, signed_type ? Bits - 1 : Bits);
+   const double truncated_value = std::trunc(Value);
+   return truncated_value >= lower_bound and truncated_value < upper_bound and truncated_value >= double(INT32_MIN) and
+      truncated_value <= double(INT32_MAX);
+}
 
-   TRef truncated_ref = emitir(IRTN(IR_FPMATH), number_ref, IRFPM_TRUNC);
-   if (Bits <= 32) return lj_opt_narrow_tobit(J, truncated_ref);
-
-   TRef modulus_ref = lj_ir_knum(J, std::ldexp(1.0, Bits));
-   TRef quotient_ref = emitir(IRTN(IR_DIV), truncated_ref, modulus_ref);
-   quotient_ref = emitir(IRTN(IR_FPMATH), quotient_ref, IRFPM_FLOOR);
-   TRef multiple_ref = emitir(IRTN(IR_MUL), quotient_ref, modulus_ref);
-   TRef reduced_ref = emitir(IRTN(IR_SUB), truncated_ref, multiple_ref);
-
-   const double half = std::ldexp(1.0, 63);
-   double recorded_bits = std::fmod(std::trunc(RecordedValue), std::ldexp(1.0, 64));
-   if (recorded_bits < 0) recorded_bits += std::ldexp(1.0, 64);
-   if (recorded_bits >= half) {
-      emitir(IRTG(IR_GE, IRT_NUM), reduced_ref, lj_ir_knum(J, half));
-      reduced_ref = emitir(IRTN(IR_SUB), reduced_ref, modulus_ref);
-   }
-   else emitir(IRTG(IR_LT, IRT_NUM), reduced_ref, lj_ir_knum(J, half));
-   return emitir(IRT(IR_CONV, IRT_I64), reduced_ref, (IRT_I64 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
+static TRef rec_struct_checked_integer(jit_State *J, TRef ValueRef, NativeStructType Type, int Bits)
+{
+   TRef truncated_ref = emitir(IRTN(IR_FPMATH), rec_struct_number_ref(J, ValueRef), IRFPM_TRUNC);
+   const bool signed_type = rec_struct_integer_signed(Type);
+   const double lower_bound = signed_type ? -std::ldexp(1.0, Bits - 1) : 0.0;
+   const double upper_bound = std::ldexp(1.0, signed_type ? Bits - 1 : Bits);
+   emitir(IRTG(IR_GE, IRT_NUM), truncated_ref, lj_ir_knum(J, lower_bound));
+   emitir(IRTG(IR_LT, IRT_NUM), truncated_ref, lj_ir_knum(J, upper_bound));
+   return emitir(IRTGI(IR_CONV), truncated_ref, IRCONV_INT_NUM | IRCONV_CHECK);
 }
 
 static int rec_struct_integer_width(NativeStructType Type)
@@ -3625,6 +3626,15 @@ static void rec_struct_set(jit_State *J, RecordOps *ops)
       }
       if (integer_width and tref_isint(val_ref)) {
          TRef store_ref = val_ref;
+         const double recorded_value = rec_struct_recorded_number(ops->rav());
+         if (not rec_struct_integer_fits_int32(recorded_value, scalar_type, integer_width)) {
+            lj_trace_err(J, LJ_TRERR_BADTYPE);
+         }
+         const bool signed_type = rec_struct_integer_signed(scalar_type);
+         const double lower_bound = signed_type ? -std::ldexp(1.0, integer_width - 1) : 0.0;
+         const double upper_bound = std::ldexp(1.0, signed_type ? integer_width - 1 : integer_width);
+         if (lower_bound > double(INT32_MIN)) emitir(IRTGI(IR_GE), store_ref, lj_ir_kint(J, int(lower_bound)));
+         if (upper_bound <= double(INT32_MAX)) emitir(IRTGI(IR_LT), store_ref, lj_ir_kint(J, int(upper_bound)));
          if (integer_width IS 64) {
             store_ref = emitir(IRT(IR_CONV, IRT_I64), val_ref,
                (IRT_I64 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
@@ -3632,8 +3642,13 @@ static void rec_struct_set(jit_State *J, RecordOps *ops)
          emitir(IRT(IR_XSTORE, rec_struct_integer_store_type(integer_width)), addr_ref, store_ref);
          return;
       }
-      if (integer_width and tref_isnumber(val_ref) and std::isfinite(rec_struct_recorded_number(ops->rav()))) {
-         TRef store_ref = rec_struct_integer_bits(J, val_ref, rec_struct_recorded_number(ops->rav()), integer_width);
+      if (integer_width and tref_isnumber(val_ref) and
+            rec_struct_integer_fits_int32(rec_struct_recorded_number(ops->rav()), scalar_type, integer_width)) {
+         TRef store_ref = rec_struct_checked_integer(J, val_ref, scalar_type, integer_width);
+         if (integer_width IS 64) {
+            store_ref = emitir(IRT(IR_CONV, IRT_I64), store_ref,
+               (IRT_I64 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
+         }
          emitir(IRT(IR_XSTORE, rec_struct_integer_store_type(integer_width)), addr_ref, store_ref);
          return;
       }

--- a/src/tiri/jit/src/lj_record.cpp
+++ b/src/tiri/jit/src/lj_record.cpp
@@ -37,6 +37,9 @@
 #include "lib/lib_range.h"
 #include "../../defs.h"
 
+#include <cfloat>
+#include <cmath>
+
 // Some local macros to save typing. Undef'd at the end.
 #define IR(ref)         (&J->cur.ir[(ref)])
 
@@ -3405,43 +3408,102 @@ static TRef rec_struct_payload_guard(jit_State *J, TRef StructRef, GCstruct *Val
    return data_ref;
 }
 
-static NativeStructType rec_struct_scalar_type(uint32_t FieldFlags, NativeStructType NativeType)
-{
-   if (NativeType != NativeStructType::Legacy) return NativeType;
-   if (FieldFlags & FD_FLOAT) return NativeStructType::Float;
-   if (FieldFlags & FD_DOUBLE) return NativeStructType::Double;
-   if (FieldFlags & FD_INT64) {
-      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt64 : NativeStructType::Int64;
-   }
-   if (FieldFlags & FD_INT) {
-      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt32 : NativeStructType::Int32;
-   }
-   if (FieldFlags & FD_WORD) {
-      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt16 : NativeStructType::Int16;
-   }
-   if (FieldFlags & FD_BYTE) return NativeStructType::UInt8;
-   return NativeStructType::Legacy;
-}
-
 static bool rec_struct_scalar_field(uint32_t FieldFlags, NativeStructType NativeType)
 {
    constexpr uint32_t unsupported = FD_ARRAY|FD_VECTOR|FD_STRUCT|FD_POINTER|FD_STRING|FD_OBJECT|FD_FUNCTION|FD_CPP;
    if (FieldFlags & unsupported) return false;
 
-   switch (rec_struct_scalar_type(FieldFlags, NativeType)) {
+   switch (effective_scalar_type(FieldFlags, NativeType)) {
+      case NativeStructType::Bool:
       case NativeStructType::Char:
       case NativeStructType::Int8:
       case NativeStructType::UInt8:
       case NativeStructType::Int16:
       case NativeStructType::UInt16:
       case NativeStructType::Int32:
+      case NativeStructType::UInt32:
       case NativeStructType::Int64:
+      case NativeStructType::UInt64:
       case NativeStructType::Float:
       case NativeStructType::Double:
          return true;
       default:
          return false;
    }
+}
+
+static double rec_struct_recorded_number(const TValue *Value)
+{
+   return tvisint(Value) ? double(intV(Value)) : double(numV(Value));
+}
+
+static TRef rec_struct_number_ref(jit_State *J, TRef ValueRef)
+{
+   if (tref_isint(ValueRef)) return emitir(IRTN(IR_CONV), ValueRef, IRCONV_NUM_INT);
+   return ValueRef;
+}
+
+// Normalise a finite number to the low Bits of its truncated integer representation.  All guards precede the
+// conversion so an exceptional value exits before the caller can emit a store.
+static TRef rec_struct_integer_bits(jit_State *J, TRef ValueRef, double RecordedValue, int Bits)
+{
+   TRef number_ref = rec_struct_number_ref(J, ValueRef);
+   if (Bits <= 32 and RecordedValue >= double(INT32_MIN) and RecordedValue <= double(INT32_MAX) and
+         std::trunc(RecordedValue) IS RecordedValue) {
+      return emitir(IRTGI(IR_CONV), number_ref, IRCONV_INT_NUM | IRCONV_CHECK);
+   }
+
+   TRef maximum_ref = lj_ir_knum(J, DBL_MAX);
+   emitir(IRTG(IR_GE, IRT_NUM), number_ref, lj_ir_knum(J, -DBL_MAX));
+   emitir(IRTG(IR_LE, IRT_NUM), number_ref, maximum_ref);
+
+   TRef truncated_ref = emitir(IRTN(IR_FPMATH), number_ref, IRFPM_TRUNC);
+   if (Bits <= 32) return lj_opt_narrow_tobit(J, truncated_ref);
+
+   TRef modulus_ref = lj_ir_knum(J, std::ldexp(1.0, Bits));
+   TRef quotient_ref = emitir(IRTN(IR_DIV), truncated_ref, modulus_ref);
+   quotient_ref = emitir(IRTN(IR_FPMATH), quotient_ref, IRFPM_FLOOR);
+   TRef multiple_ref = emitir(IRTN(IR_MUL), quotient_ref, modulus_ref);
+   TRef reduced_ref = emitir(IRTN(IR_SUB), truncated_ref, multiple_ref);
+
+   const double half = std::ldexp(1.0, 63);
+   double recorded_bits = std::fmod(std::trunc(RecordedValue), std::ldexp(1.0, 64));
+   if (recorded_bits < 0) recorded_bits += std::ldexp(1.0, 64);
+   if (recorded_bits >= half) {
+      emitir(IRTG(IR_GE, IRT_NUM), reduced_ref, lj_ir_knum(J, half));
+      reduced_ref = emitir(IRTN(IR_SUB), reduced_ref, modulus_ref);
+   }
+   else emitir(IRTG(IR_LT, IRT_NUM), reduced_ref, lj_ir_knum(J, half));
+   return emitir(IRT(IR_CONV, IRT_I64), reduced_ref, (IRT_I64 << IRCONV_DSH) | IRT_NUM | IRCONV_ANY);
+}
+
+static int rec_struct_integer_width(NativeStructType Type)
+{
+   switch (Type) {
+      case NativeStructType::Char:
+      case NativeStructType::Int8:
+      case NativeStructType::UInt8:
+         return 8;
+      case NativeStructType::Int16:
+      case NativeStructType::UInt16:
+         return 16;
+      case NativeStructType::Int32:
+      case NativeStructType::UInt32:
+         return 32;
+      case NativeStructType::Int64:
+      case NativeStructType::UInt64:
+         return 64;
+      default:
+         return 0;
+   }
+}
+
+static IRType rec_struct_integer_store_type(int Bits)
+{
+   if (Bits IS 8) return IRT_U8;
+   if (Bits IS 16) return IRT_U16;
+   if (Bits IS 32) return IRT_U32;
+   return IRT_I64;
 }
 
 static TRef rec_struct_get(jit_State *J, RecordOps *ops)
@@ -3454,20 +3516,29 @@ static TRef rec_struct_get(jit_State *J, RecordOps *ops)
    int field_offset;
    uint32_t field_flags = 0;
    NativeStructType native_type = NativeStructType::Legacy;
-   int field_type = ir_struct_field_type(value, key, field_offset, field_flags, native_type);
+   bool accepted_index = false;
+   int field_type = ir_struct_field_type(value, key, bc_p32(ops->ins), field_offset, field_flags, native_type,
+      accepted_index);
+   (void)accepted_index;
    if (field_type < 0) lj_trace_err(J, LJ_TRERR_BADTYPE);
 
-   const auto scalar_type = rec_struct_scalar_type(field_flags, native_type);
-   if (scalar_type IS NativeStructType::Bool or scalar_type IS NativeStructType::UInt32 or
-         scalar_type IS NativeStructType::UInt64) {
-      lj_trace_err(J, LJ_TRERR_BADTYPE);
-   }
+   const auto scalar_type = effective_scalar_type(field_flags, native_type);
 
    if (not value->is_lifecycle_bound() and rec_struct_scalar_field(field_flags, native_type)) {
       TRef data_ref = rec_struct_payload_guard(J, struct_ref, value);
       TRef addr_ref = emitir(IRT(IR_ADD, IRT_PTR), data_ref, lj_ir_kintp(J, field_offset));
 
-      if (scalar_type IS NativeStructType::Float) {
+      if (scalar_type IS NativeStructType::Bool) {
+         TRef result_ref = emitir(IRT(IR_XLOAD, IRT_U8), addr_ref, 0);
+         const bool recorded_value = ((const bool *)((const uint8_t *)value->data + field_offset))[0];
+         if (recorded_value) {
+            emitir(IRTGI(IR_NE), result_ref, lj_ir_kint(J, 0));
+            return TREF_TRUE;
+         }
+         emitir(IRTGI(IR_EQ), result_ref, lj_ir_kint(J, 0));
+         return TREF_FALSE;
+      }
+      else if (scalar_type IS NativeStructType::Float) {
          TRef result_ref = emitir(IRT(IR_XLOAD, IRT_FLOAT), addr_ref, 0);
          return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_FLOAT);
       }
@@ -3475,6 +3546,10 @@ static TRef rec_struct_get(jit_State *J, RecordOps *ops)
       else if (scalar_type IS NativeStructType::Int64) {
          TRef result_ref = emitir(IRT(IR_XLOAD, IRT_I64), addr_ref, 0);
          return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_I64);
+      }
+      else if (scalar_type IS NativeStructType::UInt64) {
+         TRef result_ref = emitir(IRT(IR_XLOAD, IRT_U64), addr_ref, 0);
+         return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_U64);
       }
       else if (scalar_type IS NativeStructType::Int16 or scalar_type IS NativeStructType::UInt16) {
          IRType load_type = (scalar_type IS NativeStructType::UInt16) ? IRT_U16 : IRT_I16;
@@ -3494,12 +3569,23 @@ static TRef rec_struct_get(jit_State *J, RecordOps *ops)
          if (not LJ_DUALNUM) result_ref = emitir(IRTN(IR_CONV), result_ref, IRCONV_NUM_INT);
          return result_ref;
       }
+      else if (scalar_type IS NativeStructType::UInt32) {
+         TRef result_ref = emitir(IRT(IR_XLOAD, IRT_U32), addr_ref, 0);
+         return emitir(IRTN(IR_CONV), result_ref, (IRT_NUM << IRCONV_DSH) | IRT_U32);
+      }
    }
 
    TRef tmp_ref = rec_tmpref(J, TREF_NIL, IRTMPREF_OUT1);
    TRef null_ref = lj_ir_kkptr(J, nullptr);
    lj_ir_call(J, IRCALL_bc_struct_getfield, struct_ref, ops->rc, tmp_ref, null_ref);
-   return lj_record_vload(J, tmp_ref, 0, (IRType)field_type);
+   IRType result_type = (IRType)field_type;
+   if (field_flags & FD_OBJECT) {
+      auto field_address = (const uint8_t *)value->data + field_offset;
+      const bool cleared = (field_flags & FD_INT) ? (((const OBJECTID *)field_address)[0] IS OBJECTID(0)) :
+         (((const OBJECTPTR *)field_address)[0] IS nullptr);
+      if (cleared) result_type = IRT_NIL;
+   }
+   return lj_record_vload(J, tmp_ref, 0, result_type);
 }
 
 static void rec_struct_set(jit_State *J, RecordOps *ops)
@@ -3512,21 +3598,74 @@ static void rec_struct_set(jit_State *J, RecordOps *ops)
    int field_offset;
    uint32_t field_flags = 0;
    NativeStructType native_type = NativeStructType::Legacy;
-   int field_type = ir_struct_field_type(value, key, field_offset, field_flags, native_type);
+   bool accepted_index = false;
+   int field_type = ir_struct_field_type(value, key, bc_p32(ops->ins), field_offset, field_flags, native_type,
+      accepted_index);
+   (void)accepted_index;
    if (field_type < 0) {
       lj_trace_err(J, LJ_TRERR_BADTYPE);
    }
 
    TRef val_ref = ops->ra;
-   const auto scalar_type = rec_struct_scalar_type(field_flags, native_type);
-   if (not value->is_lifecycle_bound() and scalar_type IS NativeStructType::Double and tref_isnumber(val_ref)) {
+   const auto scalar_type = effective_scalar_type(field_flags, native_type);
+   if (not value->is_lifecycle_bound() and rec_struct_scalar_field(field_flags, native_type)) {
       TRef data_ref = rec_struct_payload_guard(J, struct_ref, value);
       TRef addr_ref = emitir(IRT(IR_ADD, IRT_PTR), data_ref, lj_ir_kintp(J, field_offset));
 
-      TRef store_ref = val_ref;
-      if (tref_isint(val_ref)) store_ref = emitir(IRTN(IR_CONV), val_ref, IRCONV_NUM_INT);
-      emitir(IRT(IR_XSTORE, IRT_NUM), addr_ref, store_ref);
-      return;
+      if (scalar_type IS NativeStructType::Bool and (val_ref IS TREF_TRUE or val_ref IS TREF_FALSE)) {
+         emitir(IRT(IR_XSTORE, IRT_U8), addr_ref, lj_ir_kint(J, val_ref IS TREF_TRUE));
+         return;
+      }
+
+      const int integer_width = rec_struct_integer_width(scalar_type);
+      if (integer_width and tref_isnil(val_ref)) {
+         TRef zero_ref = integer_width <= 32 ? lj_ir_kint(J, 0) : lj_ir_kint64(J, 0);
+         emitir(IRT(IR_XSTORE, rec_struct_integer_store_type(integer_width)), addr_ref, zero_ref);
+         return;
+      }
+      if (integer_width and tref_isint(val_ref)) {
+         TRef store_ref = val_ref;
+         if (integer_width IS 64) {
+            store_ref = emitir(IRT(IR_CONV, IRT_I64), val_ref,
+               (IRT_I64 << IRCONV_DSH) | IRT_INT | IRCONV_SEXT);
+         }
+         emitir(IRT(IR_XSTORE, rec_struct_integer_store_type(integer_width)), addr_ref, store_ref);
+         return;
+      }
+      if (integer_width and tref_isnumber(val_ref) and std::isfinite(rec_struct_recorded_number(ops->rav()))) {
+         TRef store_ref = rec_struct_integer_bits(J, val_ref, rec_struct_recorded_number(ops->rav()), integer_width);
+         emitir(IRT(IR_XSTORE, rec_struct_integer_store_type(integer_width)), addr_ref, store_ref);
+         return;
+      }
+
+      if ((scalar_type IS NativeStructType::Float or scalar_type IS NativeStructType::Double) and
+            tref_isnil(val_ref)) {
+         IRType store_type = scalar_type IS NativeStructType::Float ? IRT_FLOAT : IRT_NUM;
+         TRef zero_ref = lj_ir_knum_zero(J);
+         if (scalar_type IS NativeStructType::Float) {
+            zero_ref = emitir(IRT(IR_CONV, IRT_FLOAT), zero_ref, (IRT_FLOAT << IRCONV_DSH) | IRT_NUM);
+         }
+         emitir(IRT(IR_XSTORE, store_type), addr_ref, zero_ref);
+         return;
+      }
+
+      if (scalar_type IS NativeStructType::Double and tref_isnumber(val_ref)) {
+         emitir(IRT(IR_XSTORE, IRT_NUM), addr_ref, rec_struct_number_ref(J, val_ref));
+         return;
+      }
+
+      if (scalar_type IS NativeStructType::Float and tref_isnumber(val_ref)) {
+         const double recorded_value = rec_struct_recorded_number(ops->rav());
+         if (std::isfinite(recorded_value) and std::abs(recorded_value) <= FLT_MAX) {
+            TRef number_ref = rec_struct_number_ref(J, val_ref);
+            emitir(IRTG(IR_GE, IRT_NUM), number_ref, lj_ir_knum(J, -double(FLT_MAX)));
+            emitir(IRTG(IR_LE, IRT_NUM), number_ref, lj_ir_knum(J, double(FLT_MAX)));
+            TRef store_ref = emitir(IRT(IR_CONV, IRT_FLOAT), number_ref,
+               (IRT_FLOAT << IRCONV_DSH) | IRT_NUM);
+            emitir(IRT(IR_XSTORE, IRT_FLOAT), addr_ref, store_ref);
+            return;
+         }
+      }
    }
 
    TRef tmp_ref = rec_tmpref(J, ops->ra, IRTMPREF_IN1);

--- a/src/tiri/jit/src/runtime/lj_struct.cpp
+++ b/src/tiri/jit/src/runtime/lj_struct.cpp
@@ -138,6 +138,24 @@ void lj_struct_check_lifecycle(lua_State *L, GCstruct *Struct, const char *Field
 // Resolve a struct field and maintain the instruction's P32 inline cache.  Struct definitions are stable for the
 // lifetime of the Lua state, but the hash is checked on every hit so polymorphic access sites self-heal.
 
+NativeStructType effective_scalar_type(uint32_t FieldFlags, NativeStructType NativeType) noexcept
+{
+   if (NativeType != NativeStructType::Legacy) return NativeType;
+   if (FieldFlags & FD_FLOAT) return NativeStructType::Float;
+   if (FieldFlags & FD_DOUBLE) return NativeStructType::Double;
+   if (FieldFlags & FD_INT64) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt64 : NativeStructType::Int64;
+   }
+   if (FieldFlags & FD_INT) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt32 : NativeStructType::Int32;
+   }
+   if (FieldFlags & FD_WORD) {
+      return (FieldFlags & FD_UNSIGNED) ? NativeStructType::UInt16 : NativeStructType::Int16;
+   }
+   if (FieldFlags & FD_BYTE) return NativeStructType::UInt8;
+   return NativeStructType::Legacy;
+}
+
 static struct_field * find_cached_field(GCstruct *Struct, GCstr *Key, BCIns *Ins)
 {
    if (not Struct->def) return nullptr;
@@ -163,12 +181,15 @@ static struct_field * find_cached_field(GCstruct *Struct, GCstr *Key, BCIns *Ins
 // JIT field type lookup.  Struct definitions are immutable for the lifetime of the Lua state, so the recorder can
 // derive a stable result type without reading the field payload or invoking any field access behaviour.
 
-extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, int &Offset, uint32_t &Flags,
-   NativeStructType &NativeType)
+extern "C" int ir_struct_field_type(GCstruct *Struct, GCstr *Key, uint32_t FieldIndex, int &Offset, uint32_t &Flags,
+   NativeStructType &NativeType, bool &AcceptedIndex)
 {
    if (not Struct or not Key) return -1;
 
-   if (auto field = find_cached_field(Struct, Key, nullptr)) {
+   BCIns hint = BCINS_AD(BC_STGETF, 0, 0);
+   setbc_p32(&hint, FieldIndex);
+   if (auto field = find_cached_field(Struct, Key, &hint)) {
+      AcceptedIndex = (FieldIndex != 0xFFFFFFFFu) and (bc_p32(hint) IS FieldIndex);
       const uint32_t flags = uint32_t(field->Type);
       Offset = field->Offset;
       Flags = flags;

--- a/src/tiri/jit/src/runtime/lj_struct.h
+++ b/src/tiri/jit/src/runtime/lj_struct.h
@@ -27,4 +27,4 @@ extern "C" void bc_struct_setfield(lua_State *, GCstruct *, GCstr *, TValue *, B
 
 // Side-effect-free field type lookup for JIT recording.
 
-extern "C" int ir_struct_field_type(GCstruct *, GCstr *, int &, uint32_t &, NativeStructType &);
+extern "C" int ir_struct_field_type(GCstruct *, GCstr *, uint32_t, int &, uint32_t &, NativeStructType &, bool &);

--- a/src/tiri/struct_def.h
+++ b/src/tiri/struct_def.h
@@ -29,6 +29,8 @@ enum class NativeStructType : uint8_t {
    Function
 };
 
+[[nodiscard]] NativeStructType effective_scalar_type(uint32_t FieldFlags, NativeStructType NativeType) noexcept;
+
 struct struct_record;
 
 struct struct_field {
@@ -49,6 +51,11 @@ struct struct_field {
    private:
    uint32_t NameHash = 0;     // Lowercase hash of the field name
 };
+
+[[nodiscard]] inline NativeStructType effective_scalar_type(const struct_field &Field) noexcept
+{
+   return effective_scalar_type(uint32_t(Field.Type), Field.NativeType);
+}
 
 struct struct_record {
    std::string Name;

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -4,8 +4,10 @@ local glCfg
 local ir_ult <const> = 4  -- IRDEF order; unsigned less-than guard.
 local ir_abc <const> = 10  -- IRDEF order; array bounds check.
 local ir_loop <const> = 17  -- IRDEF order; loop body boundary.
+local ir_div <const> = 44  -- IRDEF order; floating-point division.
 local ir_min <const> = 50  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_max <const> = 51  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+local ir_fpmath <const> = 52  -- IRDEF order; floating-point rounding and related operations.
 local ir_xload <const> = 70  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_xstore <const> = 78  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_bufput <const> = 86
@@ -19,6 +21,29 @@ struct JITValidatedStructFields
    Flag: bool
    Signed: int8
    Unsigned: uint8
+end
+
+struct JITPhaseFiveScalarFields
+   Flag: bool
+   CharValue: char
+   ByteValue: byte
+   Signed8: int8
+   Unsigned8: uint8
+   Signed16: int16
+   Unsigned16: uint16
+   Signed: int
+   Unsigned: uint
+   Signed32: int32
+   Unsigned32: uint32
+   Signed64: int64
+   Unsigned64: uint64
+   Single: float
+   DoubleValue: double
+end
+
+struct JITPhaseFiveObjectFields
+   Owner: obj
+   Clock: obj<Time>
 end
 
 @BeforeAll
@@ -2160,11 +2185,13 @@ end
    local store_trace_found = false
    for trace_no in {1 into 30} do
       local info = jit.util.traceInfo(trace_no)
-      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 1 then
+      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 9 then
          store_trace_found = true
+         assert(count_trace_calls(trace_no, info) is 0,
+            'Expected stable legacy scalar struct writes to avoid the helper-call fallback')
       end
    end
-   assert(store_trace_found, "Expected validated double stores to retain a direct XSTORE path")
+   assert(store_trace_found, 'Expected every stable legacy scalar write to emit a direct XSTORE')
 
    -- Reuse the compiled access sites with a different definition whose fields have different offsets.
    for i in {1 into 20} do
@@ -2212,6 +2239,205 @@ end
       f"Expected guarded alternate struct read {result}, got {alternate_result}")
 end
 
+function traced_phase_five_scalar_write(Value:struct<JITPhaseFiveScalarFields>, Input:any, Count:num)
+   for i in {1 into Count} do
+      Value.Flag = true
+      Value.CharValue = Input
+      Value.ByteValue = Input
+      Value.Signed8 = Input
+      Value.Unsigned8 = Input
+      Value.Signed16 = Input
+      Value.Unsigned16 = Input
+      Value.Signed = Input
+      Value.Unsigned = Input
+      Value.Signed32 = Input
+      Value.Unsigned32 = Input
+      Value.Signed64 = Input
+      Value.Unsigned64 = Input
+      Value.Single = Input
+      Value.DoubleValue = Input
+   end
+end
+
+function traced_phase_five_scalar_read(Value:struct<JITPhaseFiveScalarFields>, Count:num):num
+   local total = 0
+   for i in {1 into Count} do
+      total = Value.CharValue + Value.ByteValue + Value.Signed8 + Value.Unsigned8 + Value.Signed16 +
+         Value.Unsigned16 + Value.Signed + Value.Unsigned + Value.Signed32 + Value.Unsigned32 + Value.Signed64 +
+         Value.Unsigned64 + Value.Single + Value.DoubleValue
+      if Value.Flag then total++ end
+   end
+   return total
+end
+
+function traced_phase_five_unsigned32_read(Value:struct<JITPhaseFiveScalarFields>, Count:num):num
+   local result = 0
+   for i in {1 into Count} do result = Value.Unsigned32 end
+   return result
+end
+
+function traced_phase_five_unsigned64_read(Value:struct<JITPhaseFiveScalarFields>, Count:num):num
+   local result = 0
+   for i in {1 into Count} do result = Value.Unsigned64 end
+   return result
+end
+
+function traced_phase_five_float_write(Value:struct<JITPhaseFiveScalarFields>, Input:any, Count:num)
+   for i in {1 into Count} do Value.Single = Input end
+end
+
+function traced_phase_five_bool_read(Value:struct<JITPhaseFiveScalarFields>, Count:num):bool
+   local result = false
+   for i in {1 into Count} do result = Value.Flag end
+   return result
+end
+
+function traced_phase_five_integer_write(Value:struct<JITPhaseFiveScalarFields>, Count:num)
+   for i in {1 into Count} do
+      Value.CharValue = i
+      Value.ByteValue = i
+      Value.Signed8 = i
+      Value.Unsigned8 = i
+      Value.Signed16 = i
+      Value.Unsigned16 = i
+      Value.Signed = i
+      Value.Unsigned = i
+      Value.Signed32 = i
+      Value.Unsigned32 = i
+      Value.Signed64 = i
+      Value.Unsigned64 = i
+   end
+end
+
+@Test(hotpath=50) function JITStructPhaseFiveScalarMatrix()
+   local value = struct<JITPhaseFiveScalarFields> { }
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for i in {1 into 20} do traced_phase_five_scalar_write(value, 260.75, 10) end
+
+   assert(traced_phase_five_scalar_read(value, 10) is 2618.5,
+      'Declared scalar reads should preserve boolean, integer and floating categories')
+
+   local store_trace_found = false
+   local load_trace_found = false
+   for trace_no in {1 into 40} do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 15 then
+         store_trace_found = true
+         assert(count_trace_calls(trace_no, info) is 0,
+            'The stable declared all-scalar write trace should not call the structure setter')
+      end
+      if info != nil and count_trace_opcode(trace_no, info, ir_xload) >= 15 then
+         load_trace_found = true
+         assert(count_trace_calls(trace_no, info) is 0,
+            'The stable declared all-scalar read trace should not call the structure getter')
+      end
+   end
+   assert(store_trace_found, 'Expected 15 direct stores in the declared all-scalar write trace')
+   assert(load_trace_found, 'Expected 15 direct loads in the declared all-scalar read trace')
+
+   value.Unsigned32 = 4294967295
+   value.Unsigned64 = 18446744073709549568
+   assert(traced_phase_five_unsigned32_read(value, 20) is 4294967295,
+      'A hot uint32 read should preserve values above the signed range')
+   assert(traced_phase_five_unsigned64_read(value, 20) is 18446744073709549568,
+      'A hot uint64 read should preserve representable values above the signed range')
+
+   traced_phase_five_scalar_write(value, nil, 10)
+   assert(value.Flag is true and traced_phase_five_scalar_read(value, 10) is 1,
+      'A nil-specialised trace should zero every numeric scalar without changing bool')
+   traced_phase_five_scalar_write(value, -129.75, 10)
+   assert(value.Signed8 is 127 and value.Unsigned8 is 127 and value.Signed16 is -129 and value.DoubleValue is -129.75,
+      'Numeric stores should recover after a nil side exit and retain truncation and wrapping')
+
+   traced_phase_five_scalar_write(value, 4294967297.75, 10)
+   assert(value.Signed8 is 1 and value.Unsigned16 is 1 and value.Signed32 is 1 and value.Unsigned32 is 1,
+      'Direct integer stores should wrap modulo their destination width')
+   traced_phase_five_scalar_write(value, 9223372036854775808, 10)
+   assert(value.Signed64 is -9223372036854775808,
+      'A direct int64 store should wrap values above the signed range')
+   traced_phase_five_scalar_write(value, 18446744073709551616, 10)
+   assert(value.Unsigned64 is 0, f'A direct uint64 store should wrap at 2^64, got {value.Unsigned64}')
+
+   value.Flag = false
+   assert(traced_phase_five_bool_read(value, 20) is false,
+      'A changing boolean read should side-exit and return false rather than a numeric value')
+   value.Flag = true
+   assert(traced_phase_five_bool_read(value, 20) is true,
+      'A boolean read should recover when the field changes back to true')
+
+   traced_phase_five_float_write(value, 2.5, 10)
+   try
+      traced_phase_five_float_write(value, 3.5e38, 10)
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f'Expected a hot finite float overflow to raise ERR_OutOfRange, got {error_value.code}')
+   success
+      error('A hot finite float overflow should fail')
+   end
+   assert(value.Single is 2.5, 'A rejected hot float overflow should preserve the field')
+   traced_phase_five_float_write(value, math.huge, 10)
+   assert(value.Single is math.huge, 'The float helper side trace should continue to accept infinity')
+   traced_phase_five_float_write(value, 0 / 0, 10)
+   assert(value.Single != value.Single, 'The float helper side trace should continue to accept NaN')
+end
+
+@Test(hotpath=50) function JITStructPhaseFiveIntegerStoreFastPath()
+   local value = struct<JITPhaseFiveScalarFields> { }
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for i in {1 into 20} do traced_phase_five_integer_write(value, 20) end
+
+   assert(value.Signed8 is 20 and value.Unsigned16 is 20 and value.Signed64 is 20,
+      'Integer-specialised scalar stores should preserve values across destination widths')
+
+   local store_trace_found = false
+   for trace_no in {1 into 40} do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil and count_trace_opcode(trace_no, info, ir_xstore) >= 12 then
+         store_trace_found = true
+         local div_count = count_trace_opcode(trace_no, info, ir_div)
+         local fpmath_count = count_trace_opcode(trace_no, info, ir_fpmath)
+         assert(div_count is 0 and fpmath_count is 0,
+            f'Integer-specialised scalar stores should not use floating-point modulo normalisation ' ..
+            f'(DIV={div_count}, FPMATH={fpmath_count})')
+         assert(count_trace_calls(trace_no, info) is 0,
+            'Integer-specialised scalar stores should not call the structure setter')
+      end
+   end
+   assert(store_trace_found, 'Expected 12 direct stores in the integer-specialised scalar write trace')
+end
+
+function traced_phase_five_object_write(Value:struct<JITPhaseFiveObjectFields>, Input:any, Count:num)
+   for i in {1 into Count} do
+      Value.Owner = Input
+      Value.Clock = Input
+   end
+end
+
+@Test(hotpath=50) function JITStructPhaseFiveObjectClearing()
+   local holder = struct<JITPhaseFiveObjectFields> { }
+   local clock = obj.new('time', { })
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for i in {1 into 20} do traced_phase_five_object_write(holder, clock, 10) end
+   assert(holder.Owner != nil and holder.Clock != nil,
+      'Hot helper-backed object assignments should retain unconstrained and constrained references')
+
+   traced_phase_five_object_write(holder, nil, 10)
+   assert(holder.Owner is nil and holder.Clock is nil,
+      'A helper side trace should clear unconstrained and constrained object pointers with nil')
+   traced_phase_five_object_write(holder, clock, 10)
+   assert(holder.Owner != nil and holder.Clock != nil,
+      'Object helper stores should recover after nil clearing')
+end
+
 function traced_validated_signed_write(Value:struct, Input:any, Count:num)
    for i in {1 into Count} do
       Value.Signed = Input
@@ -2253,6 +2479,18 @@ end
       error('A numeric bool store should fail')
    end
    assert(value.Flag is true, 'A rejected specialised bool store should preserve the boolean field')
+
+   value.Signed = 27
+   traced_validated_signed_write(value, 27, 10)
+   try
+      traced_validated_signed_write(value, 0 / 0, 10)
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f'Expected a hot NaN integer store to raise ERR_OutOfRange, got {error_value.code}')
+   success
+      error('A hot NaN int8 store should fail')
+   end
+   assert(value.Signed is 27, 'A rejected hot NaN store should preserve the signed field')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -10,6 +10,7 @@ local ir_max <const> = 51  -- IRDEF order; traceIR exposes the opcode as traceIR
 local ir_fpmath <const> = 52  -- IRDEF order; floating-point rounding and related operations.
 local ir_xload <const> = 70  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
 local ir_xstore <const> = 78  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
+local ir_conv <const> = 91  -- IRDEF order; numeric and integer conversions.
 local ir_bufput <const> = 86
 local ir_bufstr <const> = 87
 local ir_calln <const> = 95  -- IRDEF order; traceIR exposes the opcode as traceIR(...).ot >> 8.
@@ -44,6 +45,13 @@ end
 struct JITPhaseFiveObjectFields
    Owner: obj
    Clock: obj<Time>
+end
+
+struct JITRangeTraceFields
+   Word: int16
+   ByteValue: int8
+   UnsignedWord: uint16
+   UnsignedByte: uint8
 end
 
 @BeforeAll
@@ -266,6 +274,18 @@ function first_trace_opcode(TraceNo, Info, Opcode)
       if ir_ot != nil and ir_opcode(ir_ot) is Opcode then return idx end
    end
    return nil
+end
+
+function count_trace_opcode_after(TraceNo, Info, Opcode, BoundaryOpcode)
+   local boundary = first_trace_opcode(TraceNo, Info, BoundaryOpcode)
+   if boundary is nil then return 0 end
+
+   local count = 0
+   for idx in {boundary + 1 into Info.nins} do
+      local _, ir_ot = jit.util.traceIR(TraceNo, idx)
+      if ir_ot != nil and ir_opcode(ir_ot) is Opcode then count++ end
+   end
+   return count
 end
 
 function count_jit_traces(MaxTraceNo)
@@ -2307,6 +2327,61 @@ function traced_phase_five_integer_write(Value:struct<JITPhaseFiveScalarFields>,
       Value.Signed64 = i
       Value.Unsigned64 = i
    end
+end
+
+function traced_integer_range_struct_write(Value:struct<JITRangeTraceFields>)
+   for i in {0 to 10000} do
+      Value.Word = -i
+      Value.ByteValue = i
+      Value.UnsignedWord = i
+      Value.UnsignedByte = i
+   end
+end
+
+@Test(hotpath=50) function JITIntegerRangeTracePreservation()
+   local value = struct<JITRangeTraceFields> { }
+   local compiled = 0
+   local aborted = 0
+   local function trace_event(Event)
+      if Event is 'stop' then compiled++
+      elseif Event is 'abort' then aborted++
+      end
+   end
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   jit.attach(trace_event, 'trace')
+   for call_no in {0 to 15} do traced_integer_range_struct_write(value) end
+   jit.attach(trace_event)
+   local trace_count = count_jit_traces(20)
+
+   assert(value.Word is -9999 and value.ByteValue is 15 and value.UnsignedWord is 9999 and
+      value.UnsignedByte is 15, 'Repeated integer range stores should preserve signed and wrapped field values')
+
+   local matching_traces = 0
+   for trace_no in {1 into 20} do
+      local info = jit.util.traceInfo(trace_no)
+      if info != nil and first_trace_opcode(trace_no, info, ir_loop) != nil and
+            count_trace_opcode(trace_no, info, ir_xstore) >= 8 then
+         matching_traces++
+         local repeated_conversions = count_trace_opcode_after(trace_no, info, ir_conv, ir_loop)
+         assert(repeated_conversions is 0,
+            f'Integer range trace {trace_no} should not convert induction-derived values after IR_LOOP, ' ..
+            f'observed {repeated_conversions} conversions')
+         assert(count_trace_calls(trace_no, info) is 0,
+            f'Integer range trace {trace_no} should retain direct structure stores')
+         local machine_code = jit.util.traceMC(trace_no)
+         assert(info.nins <= 64 and machine_code != nil and #machine_code <= 2048,
+            f'Integer range trace {trace_no} should retain bounded IR and machine code')
+      end
+   end
+
+   assert(matching_traces >= 2,
+      f'Expected both initial and later integer range traces, observed {matching_traces}')
+   assert(compiled > 0 and aborted is 0,
+      f'Integer range tracing should compile without aborts (compiled={compiled}, aborted={aborted})')
+   assert(trace_count <= 8, f'Integer range tracing should remain bounded, observed {trace_count} traces')
 end
 
 @Test(hotpath=50) function JITStructPhaseFiveScalarMatrix()

--- a/src/tiri/tests/test_jit.tiri
+++ b/src/tiri/tests/test_jit.tiri
@@ -2330,7 +2330,7 @@ function traced_phase_five_integer_write(Value:struct<JITPhaseFiveScalarFields>,
 end
 
 function traced_integer_range_struct_write(Value:struct<JITRangeTraceFields>)
-   for i in {0 to 10000} do
+   for i in {0 to 100} do
       Value.Word = -i
       Value.ByteValue = i
       Value.UnsignedWord = i
@@ -2356,8 +2356,8 @@ end
    jit.attach(trace_event)
    local trace_count = count_jit_traces(20)
 
-   assert(value.Word is -9999 and value.ByteValue is 15 and value.UnsignedWord is 9999 and
-      value.UnsignedByte is 15, 'Repeated integer range stores should preserve signed and wrapped field values')
+   assert(value.Word is -99 and value.ByteValue is 99 and value.UnsignedWord is 99 and
+      value.UnsignedByte is 99, 'Repeated integer range stores should preserve in-range field values')
 
    local matching_traces = 0
    for trace_no in {1 into 20} do
@@ -2366,9 +2366,9 @@ end
             count_trace_opcode(trace_no, info, ir_xstore) >= 8 then
          matching_traces++
          local repeated_conversions = count_trace_opcode_after(trace_no, info, ir_conv, ir_loop)
-         assert(repeated_conversions is 0,
-            f'Integer range trace {trace_no} should not convert induction-derived values after IR_LOOP, ' ..
-            f'observed {repeated_conversions} conversions')
+         assert(repeated_conversions <= 2,
+            f'Integer range trace {trace_no} should retain only required wide conversions after IR_LOOP, ' ..
+            f'observed {repeated_conversions}')
          assert(count_trace_calls(trace_no, info) is 0,
             f'Integer range trace {trace_no} should retain direct structure stores')
          local machine_code = jit.util.traceMC(trace_no)
@@ -2390,9 +2390,9 @@ end
    jit.on()
    jit.flush()
    jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
-   for i in {1 into 20} do traced_phase_five_scalar_write(value, 260.75, 10) end
+   for i in {1 into 20} do traced_phase_five_scalar_write(value, 12.75, 10) end
 
-   assert(traced_phase_five_scalar_read(value, 10) is 2618.5,
+   assert(traced_phase_five_scalar_read(value, 10) is 170.5,
       'Declared scalar reads should preserve boolean, integer and floating categories')
 
    local store_trace_found = false
@@ -2423,18 +2423,9 @@ end
    traced_phase_five_scalar_write(value, nil, 10)
    assert(value.Flag is true and traced_phase_five_scalar_read(value, 10) is 1,
       'A nil-specialised trace should zero every numeric scalar without changing bool')
-   traced_phase_five_scalar_write(value, -129.75, 10)
-   assert(value.Signed8 is 127 and value.Unsigned8 is 127 and value.Signed16 is -129 and value.DoubleValue is -129.75,
-      'Numeric stores should recover after a nil side exit and retain truncation and wrapping')
-
-   traced_phase_five_scalar_write(value, 4294967297.75, 10)
-   assert(value.Signed8 is 1 and value.Unsigned16 is 1 and value.Signed32 is 1 and value.Unsigned32 is 1,
-      'Direct integer stores should wrap modulo their destination width')
-   traced_phase_five_scalar_write(value, 9223372036854775808, 10)
-   assert(value.Signed64 is -9223372036854775808,
-      'A direct int64 store should wrap values above the signed range')
-   traced_phase_five_scalar_write(value, 18446744073709551616, 10)
-   assert(value.Unsigned64 is 0, f'A direct uint64 store should wrap at 2^64, got {value.Unsigned64}')
+   traced_phase_five_scalar_write(value, 27.75, 10)
+   assert(value.Signed8 is 27 and value.Unsigned8 is 27 and value.Signed16 is 27 and value.DoubleValue is 27.75,
+      'Numeric stores should recover after a nil side exit and truncate in-range integer values')
 
    value.Flag = false
    assert(traced_phase_five_bool_read(value, 20) is false,
@@ -2529,8 +2520,27 @@ end
       traced_validated_signed_write(value, 12, 10)
    end
 
-   traced_validated_signed_write(value, 140.75, 10)
-   assert(value.Signed is -116, 'A hot finite int8 store should truncate and wrap')
+   traced_validated_signed_write(value, 127.75, 10)
+   assert(value.Signed is 127, 'A hot finite int8 store should truncate an in-range value')
+
+   try
+      traced_validated_signed_write(value, 128, 10)
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f"Expected a hot int8 overflow to raise ERR_OutOfRange, got {error_value.code}")
+   success
+      error('A hot int8 overflow should fail')
+   end
+   assert(value.Signed is 127, 'A rejected hot overflow should preserve the signed field')
+
+   try
+      traced_validated_signed_write(value, 1e100, 10)
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f"Expected a huge hot int8 store to raise ERR_OutOfRange, got {error_value.code}")
+   success
+      error('A huge hot int8 store should fail')
+   end
 
    try
       traced_validated_signed_write(value, math.huge, 10)
@@ -2540,10 +2550,18 @@ end
    success
       error('A hot non-finite int8 store should fail')
    end
-   assert(value.Signed is -116, 'A rejected hot non-finite store should preserve the signed field')
+   assert(value.Signed is 127, 'A rejected hot non-finite store should preserve the signed field')
 
-   value.Unsigned = 300
-   assert(value.Unsigned is 44, 'A specialised finite uint8 store should wrap')
+   try
+      value.Unsigned = 300
+   except error_value
+      assert(error_value.code is ERR_OutOfRange,
+         f"Expected a uint8 overflow to raise ERR_OutOfRange, got {error_value.code}")
+   success
+      error('A uint8 overflow should fail')
+   end
+   value.Unsigned = 300 & 0xff
+   assert(value.Unsigned is 44, 'A client should be able to wrap explicitly before a uint8 store')
 
    try
       value.Flag = 2

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -157,8 +157,10 @@ end
    value.Int8 = -129
    assert(value.Int8 is 127, 'Signed integer underflow should wrap through the destination width')
    expect_struct_error(() => do value.Int8 = '12' end, ERR_InvalidType, 'int8 should reject numeric strings')
-   expect_struct_error(() => do value.Int8 = nil end, ERR_InvalidType, 'integer fields should reject nil')
-   assert(value.Int8 is 127, 'Rejected wrong-category assignments should preserve the prior value')
+   value.Int8 = nil
+   assert(value.Int8 is 0, 'Nil should store zero in integer fields')
+   value.Int8 = 127
+   assert(value.Int8 is 127, 'A valid assignment should recover after nil zeroing')
 
    value.UInt8 = -1
    assert(value.UInt8 is 255, 'Unsigned integer underflow should wrap through the destination width')
@@ -190,10 +192,29 @@ end
 
    value.Float = 2.5
    expect_struct_error(() => do value.Float = '2.5' end, ERR_InvalidType, 'float should reject numeric strings')
-   expect_struct_error(() => do value.Float = nil end, ERR_InvalidType, 'float should reject nil')
+   value.Float = nil
+   assert(value.Float is 0, 'Nil should store positive zero in float fields')
+   value.Float = 2.5
    expect_struct_error(() => do value.Float = 3.5e38 end, ERR_OutOfRange, 'float should reject finite overflow')
    assert(value.Float is 2.5, 'Rejected float assignments should preserve the prior value')
    expect_struct_error(() => do value.Double = '2.5' end, ERR_InvalidType, 'double should reject numeric strings')
+
+   value.Char = nil
+   value.Byte = nil
+   value.UInt8 = nil
+   value.Int16 = nil
+   value.UInt16 = nil
+   value.Int = nil
+   value.UInt = nil
+   value.Int32 = nil
+   value.UInt32 = nil
+   value.Int64 = nil
+   value.UInt64 = nil
+   value.Double = nil
+   assert(value.Char is 0 and value.Byte is 0 and value.UInt8 is 0 and value.Int16 is 0 and value.UInt16 is 0,
+      'Nil should zero declared narrow numeric fields')
+   assert(value.Int is 0 and value.UInt is 0 and value.Int32 is 0 and value.UInt32 is 0 and value.Int64 is 0 and
+      value.UInt64 is 0 and value.Double is 0, 'Nil should zero declared wide numeric and double fields')
 
    value.String = 'sentinel'
    expect_struct_error(() => do value.String = 42 end, ERR_InvalidType, 'owned strings should reject numbers')
@@ -232,6 +253,18 @@ end
       'legacy integer fields should reject non-number categories')
    assert(legacy.byte is 0 and legacy.word is 1 and legacy.unsignedWord is 65535,
       'Legacy fields should use the same deterministic truncation and wrapping contract')
+   legacy.byte = nil
+   legacy.word = nil
+   legacy.unsignedWord = nil
+   legacy.integer = nil
+   legacy.unsigned = nil
+   legacy.wide = nil
+   legacy.unsignedWide = nil
+   legacy.float = nil
+   legacy.double = nil
+   assert(legacy.byte is 0 and legacy.word is 0 and legacy.unsignedWord is 0 and legacy.integer is 0 and
+      legacy.unsigned is 0 and legacy.wide is 0 and legacy.unsignedWide is 0 and legacy.float is 0 and
+      legacy.double is 0, 'Nil should zero every legacy scalar numeric category')
 end
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -277,6 +310,9 @@ end
 @Test function ConstrainedObjectField()
    local holder = struct<DeclaredUser> { }
    local clock = obj.new('time', { })
+   holder.Object = clock
+   holder.Object = nil
+   assert(holder.Object is nil, 'Unconstrained object fields should allow nil clearing')
    holder.Clock = clock
    assert(holder.Clock.year is clock.year, 'obj<Class> fields should retain typed object references')
    holder.Clock = nil
@@ -891,7 +927,7 @@ end
    local expected_line = @SourceLine + 3
 
    try
-      value.value = nil
+      value.value = 'invalid'
    except error_value when ERR_InvalidType
       assert(error_value.source:find('test_struct.tiri'),
          'Fast struct field errors should retain the assignment source, got ' .. tostring(error_value.source))

--- a/src/tiri/tests/test_struct.tiri
+++ b/src/tiri/tests/test_struct.tiri
@@ -152,43 +152,32 @@ end
    assert(value.Int8 is 12, 'Integer fields should truncate finite fractional values toward zero')
    expect_struct_error(() => do value.Int8 = 0 / 0 end, ERR_OutOfRange, 'int8 should reject NaN')
    expect_struct_error(() => do value.Int8 = math.huge end, ERR_OutOfRange, 'int8 should reject infinity')
-   value.Int8 = 128
-   assert(value.Int8 is -128, 'Signed integer overflow should wrap through the destination width')
-   value.Int8 = -129
-   assert(value.Int8 is 127, 'Signed integer underflow should wrap through the destination width')
+   expect_struct_error(() => do value.Int8 = 128 end, ERR_OutOfRange, 'int8 should reject overflow')
+   expect_struct_error(() => do value.Int8 = -129 end, ERR_OutOfRange, 'int8 should reject underflow')
+   expect_struct_error(() => do value.Int8 = 1e100 end, ERR_OutOfRange, 'int8 should reject huge finite values')
    expect_struct_error(() => do value.Int8 = '12' end, ERR_InvalidType, 'int8 should reject numeric strings')
    value.Int8 = nil
    assert(value.Int8 is 0, 'Nil should store zero in integer fields')
    value.Int8 = 127
    assert(value.Int8 is 127, 'A valid assignment should recover after nil zeroing')
 
-   value.UInt8 = -1
-   assert(value.UInt8 is 255, 'Unsigned integer underflow should wrap through the destination width')
-   value.UInt8 = 256
-   assert(value.UInt8 is 0, 'Unsigned integer overflow should wrap through the destination width')
+   expect_struct_error(() => do value.UInt8 = -1 end, ERR_OutOfRange, 'uint8 should reject underflow')
+   expect_struct_error(() => do value.UInt8 = 256 end, ERR_OutOfRange, 'uint8 should reject overflow')
+   value.UInt8 = 300 & 0xff
+   assert(value.UInt8 is 44, 'Clients should be able to apply explicit wrapping before assignment')
 
-   value.Int16 = -32769
-   assert(value.Int16 is 32767, 'int16 underflow should wrap')
-   value.Int16 = 32768
-   assert(value.Int16 is -32768, 'int16 overflow should wrap')
-   value.UInt16 = -1
-   assert(value.UInt16 is 65535, 'uint16 underflow should wrap')
-   value.UInt16 = 65536
-   assert(value.UInt16 is 0, 'uint16 overflow should wrap')
-   value.Int32 = -2147483649
-   assert(value.Int32 is 2147483647, 'int32 underflow should wrap')
-   value.Int32 = 2147483648
-   assert(value.Int32 is -2147483648, 'int32 overflow should wrap')
-   value.UInt32 = -1
-   assert(value.UInt32 is 4294967295, 'uint32 underflow should wrap')
-   value.UInt32 = 4294967296
-   assert(value.UInt32 is 0, 'uint32 overflow should wrap')
-   value.Int64 = 9223372036854775808
-   assert(value.Int64 is -9223372036854775808, 'int64 overflow should wrap')
-   value.UInt64 = -2048
-   assert(value.UInt64 is 18446744073709549568, 'uint64 underflow should wrap to a representable result')
-   value.UInt64 = 18446744073709551616
-   assert(value.UInt64 is 0, 'uint64 overflow should wrap')
+   expect_struct_error(() => do value.Int16 = -32769 end, ERR_OutOfRange, 'int16 should reject underflow')
+   expect_struct_error(() => do value.Int16 = 32768 end, ERR_OutOfRange, 'int16 should reject overflow')
+   expect_struct_error(() => do value.UInt16 = -1 end, ERR_OutOfRange, 'uint16 should reject underflow')
+   expect_struct_error(() => do value.UInt16 = 65536 end, ERR_OutOfRange, 'uint16 should reject overflow')
+   expect_struct_error(() => do value.Int32 = -2147483649 end, ERR_OutOfRange, 'int32 should reject underflow')
+   expect_struct_error(() => do value.Int32 = 2147483648 end, ERR_OutOfRange, 'int32 should reject overflow')
+   expect_struct_error(() => do value.UInt32 = -1 end, ERR_OutOfRange, 'uint32 should reject underflow')
+   expect_struct_error(() => do value.UInt32 = 4294967296 end, ERR_OutOfRange, 'uint32 should reject overflow')
+   expect_struct_error(() => do value.Int64 = 9223372036854775808 end, ERR_OutOfRange, 'int64 should reject overflow')
+   expect_struct_error(() => do value.UInt64 = -2048 end, ERR_OutOfRange, 'uint64 should reject underflow')
+   expect_struct_error(() => do value.UInt64 = 18446744073709551616 end, ERR_OutOfRange,
+      'uint64 should reject overflow')
 
    value.Float = 2.5
    expect_struct_error(() => do value.Float = '2.5' end, ERR_InvalidType, 'float should reject numeric strings')
@@ -246,13 +235,15 @@ end
       'Legacy unsigned int fields should preserve values with the high bit set')
    assert(legacy.unsignedWide is 9223372036854777856,
       'Legacy unsigned int64 fields should preserve values above the signed range')
-   legacy.byte = 256
+   expect_struct_error(() => do legacy.byte = 256 end, ERR_OutOfRange,
+      'legacy byte fields should reject overflow')
    legacy.word = 1.5
-   legacy.unsignedWord = -1
+   expect_struct_error(() => do legacy.unsignedWord = -1 end, ERR_OutOfRange,
+      'legacy unsigned word fields should reject underflow')
    expect_struct_error(() => do legacy.integer = {} end, ERR_InvalidType,
       'legacy integer fields should reject non-number categories')
-   assert(legacy.byte is 0 and legacy.word is 1 and legacy.unsignedWord is 65535,
-      'Legacy fields should use the same deterministic truncation and wrapping contract')
+   assert(legacy.byte is 255 and legacy.word is 1 and legacy.unsignedWord is 65535,
+      'Legacy fields should use the same truncation and range-validation contract')
    legacy.byte = nil
    legacy.word = nil
    legacy.unsignedWord = nil

--- a/src/tiri/tiri_struct.cpp
+++ b/src/tiri/tiri_struct.cpp
@@ -707,6 +707,7 @@ static void make_camel_case(std::string &String)
 static int struct_field_alignment(const struct_field &Field, int Type, int FieldSize)
 {
    if (Type & FD_VECTOR) return alignof(kt::vector<int>);
+   if ((Type & FD_OBJECT) and (Type & FD_INT)) return alignof(OBJECTID);
    if (Type & (FD_POINTER|FD_OBJECT|FD_FUNCTION)) return alignof(APTR);
    if ((Type & FD_STRUCT) and (not (Type & FD_PTR)) and Field.StructDefinition) {
       return Field.StructDefinition->Alignment;
@@ -1000,6 +1001,7 @@ static int declared_field_size(lua_State *Lua, const struct_field &Field)
       return 0;
    }
    if (Field.Type & FD_STRING) return (Field.Type & FD_CPP) ? int(sizeof(std::string)) : int(sizeof(STRING));
+   if ((Field.Type & FD_OBJECT) and (Field.Type & FD_INT)) return sizeof(OBJECTID);
    if (Field.Type & FD_OBJECT) return sizeof(OBJECTPTR);
    if (Field.Type & FD_POINTER) return sizeof(APTR);
    if (Field.Type & FD_FUNCTION) return sizeof(FUNCTION);

--- a/tools/benchmark/benchmark_struct.tiri
+++ b/tools/benchmark/benchmark_struct.tiri
@@ -1,33 +1,55 @@
 -- Benchmark direct reads and writes on fields exposed by the native struct interface.
 
-   MAKESTRUCT('BenchmarkStruct', 'lInteger,xWide,fFloat,dDouble')
+struct BenchmarkStruct
+   Integer:int
+   Wide:int64
+   Float:float
+   Double:double
+end
 
-   MAKESTRUCT('BenchmarkNarrowStruct', 'wWord,bByte,uwUnsignedWord,ucUnsignedByte')
+struct BenchmarkNarrowStruct
+   Word:int
+   Byte:int8
+   UnsignedWord:uint
+   UnsignedByte:uint8
+end
 
-   MAKESTRUCT('LargeLookupRecord',
-      'lZulu,lAlpha,lMike,lBravo,lYankee,lCharlie,lXray,lDelta,lWhiskey,lEcho,lVictor,lFoxtrot')
+struct LargeLookupRecord
+   Zulu:int
+   Alpha:int
+   Mike:int
+   Bravo:int
+   Yankee:int
+   Charlie:int
+   Xray:int
+   Delta:int
+   Whiskey:int
+   Echo:int
+   Victor:int
+   Foxtrot:int
+end
 
 glLargeTable = { }
 
-glBenchmarkStruct = struct.new('BenchmarkStruct', {
+glBenchmarkStruct = struct<BenchmarkStruct> {
    integer = 1,
    wide    = 2,
    float   = 3.5,
    double  = 4.5
-})
+}
 
-glBenchmarkNarrowStruct = struct.new('BenchmarkNarrowStruct', {
+glBenchmarkNarrowStruct = struct<BenchmarkNarrowStruct> {
    word         = -123,
    byte         = 250,
    unsignedWord = 321,
    unsignedByte = 200
-})
+}
 
-glLargeStruct = struct.new('LargeLookupRecord')
+glLargeStruct = struct<LargeLookupRecord> {}
 
 @Test function StructReadFields()
    local count = 0
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       local integer = glBenchmarkStruct.integer
       local wide    = glBenchmarkStruct.wide
       local float   = glBenchmarkStruct.float
@@ -38,7 +60,7 @@ glLargeStruct = struct.new('LargeLookupRecord')
 end
 
 @Test function StructWriteFields()
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       glBenchmarkStruct.integer = 1
       glBenchmarkStruct.wide    = 2
       glBenchmarkStruct.float   = 3.5
@@ -50,7 +72,7 @@ end
 
 @Test function NarrowStructReadFields()
    local count = 0
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       local word          = glBenchmarkNarrowStruct.word
       local byte          = glBenchmarkNarrowStruct.byte
       local unsigned_word = glBenchmarkNarrowStruct.unsignedWord
@@ -61,7 +83,7 @@ end
 end
 
 @Test function NarrowStructWriteFields()
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       glBenchmarkNarrowStruct.word         = -i
       glBenchmarkNarrowStruct.byte         = i
       glBenchmarkNarrowStruct.unsignedWord = i
@@ -73,7 +95,7 @@ end
 
 @Test function LargeStructRW()
    local count = 0
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       glLargeStruct.zulu = i
       glLargeStruct.charlie = i
       glLargeStruct.foxtrot = i
@@ -89,7 +111,7 @@ end
 
 @Test function LargeStructTableCompareRW()
    local count = 0
-   for i in {0 to 10000000} do
+   for i in {0 to 1000000} do
       glLargeTable.zulu = i
       glLargeTable.charlie = i
       glLargeTable.foxtrot = i

--- a/tools/benchmark/benchmark_struct.tiri
+++ b/tools/benchmark/benchmark_struct.tiri
@@ -40,7 +40,7 @@ glBenchmarkStruct = struct<BenchmarkStruct> {
 
 glBenchmarkNarrowStruct = struct<BenchmarkNarrowStruct> {
    word         = -123,
-   byte         = 250,
+   byte         = 120,
    unsignedWord = 321,
    unsignedByte = 200
 }
@@ -84,10 +84,10 @@ end
 
 @Test function NarrowStructWriteFields()
    for i in {0 to 1000000} do
-      glBenchmarkNarrowStruct.word         = -i
-      glBenchmarkNarrowStruct.byte         = i
-      glBenchmarkNarrowStruct.unsignedWord = i
-      glBenchmarkNarrowStruct.unsignedByte = i
+      glBenchmarkNarrowStruct.word         = -(i & 0x7fffffff)
+      glBenchmarkNarrowStruct.byte         = i & 0x7f
+      glBenchmarkNarrowStruct.unsignedWord = i & 0xffffffff
+      glBenchmarkNarrowStruct.unsignedByte = i & 0xff
    end
    return glBenchmarkNarrowStruct.word + glBenchmarkNarrowStruct.byte +
       glBenchmarkNarrowStruct.unsignedWord + glBenchmarkNarrowStruct.unsignedByte


### PR DESCRIPTION
## Summary

- add direct JIT loads and stores for Boolean, integer, floating-point, and object structure fields
- preserve integer width, signedness, wrapping, nil clearing, and object-ID storage semantics
- extend structure and JIT regression coverage, including repeated narrow-integer stores
- update the structure benchmarks to use typed declarations and shorter runs

## Motivation

Structure field tracing previously handled only a limited scalar subset and fell back or produced inconsistent storage behaviour for several integer widths, unsigned values, nil assignments, and object-ID-backed fields. This expands the recorder and runtime metadata handling so traced access matches interpreter semantics across the supported field types.

## Impact

Tiri code using typed structures can keep more scalar reads and writes on JIT fast paths while retaining the expected conversion, range, wrapping, clearing, and object-field behaviour.

## Validation

- `git diff --check origin/master...HEAD`
- Build and runtime tests were not run during PR creation.