### PR TITLE
[Tiri] Elide redundant runtime contracts from proved values

### DIFF
--- a/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/emit_assignment.cpp
@@ -607,8 +607,20 @@ ParserResult<IrEmitUnit> IrEmitter::emit_compound_assignment(AssignmentOperator 
       rhs = list.value_ref();
       ExpDesc infix = working;
 
+      StaticValueDescriptor operation_descriptor;
+      if (working.static_value and rhs.static_value) {
+         operation_descriptor = describe_arithmetic_result(
+            this->ctx.descriptors().value(working.static_value),
+            this->ctx.descriptors().value(rhs.static_value));
+      }
+
       // Use OperatorEmitter for arithmetic compound assignments (+=, -=, *=, /=, %=)
       this->operator_emitter.emit_binary_arith(mapped.value(), ExprValue(&infix), rhs);
+
+      infix.static_value = this->ctx.descriptors().add_value(operation_descriptor);
+      infix.static_results = 0;
+      infix.object_class_id = CLASSID::NIL;
+      infix.struct_def = nullptr;
 
       bcemit_store(&this->func_state, &target.storage, &infix);
    }

--- a/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
+++ b/src/tiri/jit/src/parser/ir_emitter/ir_emitter.cpp
@@ -1063,6 +1063,59 @@ ParserResult<IrEmitUnit> IrEmitter::emit_conditional_shorthand_stmt(const Condit
 //********************************************************************************************************************
 // Emit bytecode for a return statement, handling zero, single, or multiple return values.
 
+static StaticValueDescriptor return_value_descriptor(
+   const ParserContext &Context, const ReturnStmtPayload &Payload, size_t Position, bool &Dynamic)
+{
+   StaticValueDescriptor result;
+   if (Payload.values.empty()) {
+      result.primary = TiriType::Nil;
+      result.proof = StaticProof::Closed;
+      result.nullable = true;
+      return result;
+   }
+
+   size_t tail_position = Payload.values.size() - 1;
+   if (Position < tail_position) {
+      const ExprNode &value = *Payload.values[Position];
+      return Context.descriptors().value(value.static_value);
+   }
+
+   const ExprNode &tail = *Payload.values.back();
+   if (tail.static_results) {
+      const StaticResultSet &results = Context.descriptors().results(tail.static_results);
+      if (results.dynamic or results.variadic) Dynamic = true;
+      return results.value_at(Position - tail_position);
+   }
+   if (Position IS tail_position) return Context.descriptors().value(tail.static_value);
+
+   result.primary = TiriType::Nil;
+   result.proof = StaticProof::Closed;
+   result.nullable = true;
+   return result;
+}
+
+static bool fixed_return_contract_is_proved(
+   const ParserContext &Context, const FuncState &State, const ReturnStmtPayload &Payload)
+{
+   if (not State.return_contract_explicit or State.return_contract_variadic) return false;
+
+   bool dynamic = false;
+   for (uint8_t i = 0; i < State.return_contract_count; ++i) {
+      RuntimeContract contract{
+         .type = State.return_types[i],
+         .struct_def = State.return_struct_defs[i],
+         .boundary = ContractBoundary::Result,
+         .position = uint8_t(i + 1),
+         .nullable = true,
+         .required = false
+      };
+      if (contract.type IS TiriType::Unknown or contract.type IS TiriType::Any) continue;
+      StaticValueDescriptor value = return_value_descriptor(Context, Payload, i, dynamic);
+      if (dynamic or not static_value_satisfies_contract(value, contract)) return false;
+   }
+   return true;
+}
+
 ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Payload)
 {
    BCIns ins;
@@ -1082,6 +1135,8 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
 
    bool truncate_return_results =
       this->func_state.return_contract_explicit and not this->func_state.return_contract_variadic;
+   bool return_contract_elided = has_return_contract and
+      fixed_return_contract_is_proved(this->ctx, this->func_state, Payload);
    BCREG cleanup_temp_regs = return_cleanup_temp_regs(&this->func_state);
    BCREG multres_slot = BCREG(this->func_state.varmap.size() + cleanup_temp_regs);
    if (cleanup_temp_regs > 0) return_allocator.reserve(BCReg(cleanup_temp_regs + 1));
@@ -1219,7 +1274,7 @@ ParserResult<IrEmitUnit> IrEmitter::emit_return_stmt(const ReturnStmtPayload &Pa
    if (this->func_state.flags & PROTO_CHILD) bcemit_AJ(&this->func_state, BC_UCLO, 0, 0);
    if (preserve_multres) bcemit_AD(&this->func_state, BC_MRRESTORE, multres_slot, 0);
 
-   if (has_return_contract and bc_op(ins) != BC_RET0) {
+   if (has_return_contract and not return_contract_elided and bc_op(ins) != BC_RET0) {
       std::array<RuntimeContract, MAX_RETURN_TYPES> contracts;
       for (uint8_t i = 0; i < this->func_state.return_contract_count; ++i) {
          contracts[i] = RuntimeContract{
@@ -1323,18 +1378,16 @@ ParserResult<IrEmitUnit> IrEmitter::emit_local_decl_stmt(const LocalDeclStmtPayl
          else if (value.static_value) initialiser = this->ctx.descriptors().value(value.static_value);
       }
 
-      bool matching_type = initialiser.primary IS TiriType::Nil or initialiser.primary IS identifier.type;
-      bool matching_struct = identifier.type != TiriType::Struct or initialiser.primary IS TiriType::Nil or
-         initialiser.struct_def IS identifier.struct_def;
-      if (initialiser.proved() and matching_type and matching_struct) continue;
-
+      const VarInfo &variable = this->func_state.var_get(base.raw() + i.raw());
       RuntimeContract contract{
          .type = identifier.type,
-         .struct_def = identifier.struct_def,
+         .object_class_id = variable.object_class_id,
+         .struct_def = variable.struct_def ? variable.struct_def : identifier.struct_def,
          .label = is_blank_symbol(identifier) ? nullptr : identifier.symbol,
          .boundary = ContractBoundary::Local,
          .position = uint8_t(base.raw() + i.raw() + 1)
       };
+      if (static_value_satisfies_contract(initialiser, contract)) continue;
       local_contracts.push_back(RuntimeContractSlot{
          .register_index = BCREG(base.raw() + i.raw()),
          .contract = contract

--- a/src/tiri/jit/src/parser/parse_regalloc.cpp
+++ b/src/tiri/jit/src/parser/parse_regalloc.cpp
@@ -650,11 +650,11 @@ static void bcemit_contracts(FuncState *Fs, std::span<const RuntimeContractSlot>
 }
 
 //********************************************************************************************************************
-// Literal values are closed proofs.  Every other ExpDesc type is advisory and receives a runtime check.
+// Literal values are closed proofs.  Descriptor-backed values may also suppress a compatible runtime check.
 
 [[nodiscard]] static bool contract_literal_proved(FuncState *fs, ExpDesc *Value, TiriType Expected)
 {
-   if (Value->k IS ExpKind::Nil) return true;
+   if (Value->k IS ExpKind::Nil) return false;
 
    TiriType actual = TiriType::Unknown;
    if (Value->k IS ExpKind::False or Value->k IS ExpKind::True) actual = TiriType::Bool;
@@ -679,16 +679,18 @@ static void bcemit_value_contract(
       Value->u.s.info = source;
       return;
    }
+   if (Value->k IS ExpKind::Nil and not ForceRuntimeCheck) {
+      StaticValueDescriptor descriptor{
+         .primary = TiriType::Nil,
+         .proof = StaticProof::Closed,
+         .nullable = true
+      };
+      if (static_value_satisfies_contract(descriptor, Contract)) return;
+   }
    if (contract_literal_proved(fs, Value, Contract.type) and not ForceRuntimeCheck) return;
    if (Value->static_value and fs->ls->active_context) {
       const auto &descriptor = fs->ls->active_context->descriptors().value(Value->static_value);
-      bool same_type = descriptor.primary IS Contract.type;
-      bool same_object_class = Contract.type != TiriType::Object or Contract.object_class_id IS CLASSID::NIL or
-         descriptor.object_class_id IS Contract.object_class_id;
-      bool same_struct = Contract.type != TiriType::Struct or descriptor.struct_def IS Contract.struct_def;
-      bool same_nullability = descriptor.nullable IS Contract.nullable;
-      if (same_type and same_object_class and same_struct and same_nullability and descriptor.proved() and
-          not ForceRuntimeCheck) return;
+      if (static_value_satisfies_contract(descriptor, Contract) and not ForceRuntimeCheck) return;
    }
 
    BCREG source = expr_toanyreg(fs, Value);

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -4597,8 +4597,49 @@ static bool test_type_guided_emission(kt::Log &Log)
       "return update\n";
    snapshot = compile_snapshot(L, retained_arithmetic_contract, true, error);
    if (not snapshot or snapshot->children.empty() or
-       count_opcode(snapshot->children.front(), BC_CONTRACT) != 1) {
-      Log.error("dynamic compound arithmetic did not retain exactly its sticky-store contract: %s", error.c_str());
+       count_opcode(snapshot->children.front(), BC_CONTRACT) != 2) {
+      Log.error("dynamic compound arithmetic did not retain its sticky-store and result contracts: %s",
+         error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view variant_mutation_contracts =
+      "local function compound(Operand:any):num\n"
+      "   local source:any = 1\n"
+      "   source += Operand\n"
+      "   local target = 0\n"
+      "   target = source\n"
+      "   return target\n"
+      "end\n"
+      "local function if_empty():num\n"
+      "   local source:any = 0\n"
+      "   source ?" "?= 'wrong'\n"
+      "   local target = 0\n"
+      "   target = source\n"
+      "   return target\n"
+      "end\n"
+      "local function if_nil():num\n"
+      "   local source:any = nil\n"
+      "   source ?= 'wrong'\n"
+      "   local target = 0\n"
+      "   target = source\n"
+      "   return target\n"
+      "end\n"
+      "local function unchanged():num\n"
+      "   local source:any = 1\n"
+      "   local target = 0\n"
+      "   target = source\n"
+      "   return target\n"
+      "end\n"
+      "return compound, if_empty, if_nil, unchanged\n";
+   snapshot = compile_snapshot(L, variant_mutation_contracts, true, error);
+   if (not snapshot or snapshot->children.size() != 4 or
+       count_opcode(snapshot->children[0], BC_CONTRACT) != 2 or
+       count_opcode(snapshot->children[1], BC_CONTRACT) != 2 or
+       count_opcode(snapshot->children[2], BC_CONTRACT) != 2 or
+       count_opcode(snapshot->children[3], BC_CONTRACT) != 0) {
+      Log.error("variant mutation descriptors did not retain only the required store and result contracts: %s",
+         error.c_str());
       return false;
    }
 

--- a/src/tiri/jit/src/parser/parser_unit_tests.cpp
+++ b/src/tiri/jit/src/parser/parser_unit_tests.cpp
@@ -2063,8 +2063,9 @@ static bool test_runtime_contract_decoder(kt::Log &Log)
    }
 
    constexpr std::string_view wide_source =
-      "return function():<num,num,num,num,num,num,num,num,str>\n"
-      "   return 1,2,3,4,5,6,7,8,'ninth',false\n"
+      "return function(A:any,B:any,C:any,D:any,E:any,F:any,G:any,H:any,I:any):"
+      "<num,num,num,num,num,num,num,num,str>\n"
+      "   return A,B,C,D,E,F,G,H,I,false\n"
       "end\n";
    if (lua_load(lua, wide_source, "wide-runtime-contract")) {
       Log.error("failed to compile a wide runtime contract: %s", lua_tostring(lua, -1));
@@ -3374,6 +3375,59 @@ static bool test_static_descriptor_model(kt::Log &Log)
       return false;
    }
 
+   RuntimeContract nullable_number{
+      .type = TiriType::Num,
+      .nullable = true
+   };
+   RuntimeContract required_number = nullable_number;
+   required_number.nullable = false;
+   required_number.required = true;
+   if (not static_value_satisfies_contract(number, nullable_number) or
+       not static_value_satisfies_contract(number, required_number) or
+       static_value_satisfies_contract(checked_number, required_number)) {
+      Log.error("static contract satisfaction lost directional nullability");
+      return false;
+   }
+
+   StaticValueDescriptor advisory_number = number;
+   advisory_number.proof = StaticProof::Advisory;
+   if (static_value_satisfies_contract(advisory_number, nullable_number)) {
+      Log.error("an advisory descriptor satisfied a runtime contract");
+      return false;
+   }
+
+   StaticValueDescriptor nil_value{
+      .primary = TiriType::Nil,
+      .proof = StaticProof::Closed,
+      .nullable = true
+   };
+   if (not static_value_satisfies_contract(nil_value, nullable_number) or
+       static_value_satisfies_contract(nil_value, required_number)) {
+      Log.error("nil descriptor did not respect optional and required contracts");
+      return false;
+   }
+
+   auto *struct_a = (struct_record *)(uintptr_t(1));
+   auto *struct_b = (struct_record *)(uintptr_t(2));
+   StaticValueDescriptor exact_struct{
+      .primary = TiriType::Struct,
+      .struct_def = struct_a,
+      .proof = StaticProof::Trusted
+   };
+   RuntimeContract exact_struct_contract{
+      .type = TiriType::Struct,
+      .struct_def = struct_a
+   };
+   if (not static_value_satisfies_contract(exact_struct, exact_struct_contract)) {
+      Log.error("an exact proved structure did not satisfy its matching contract");
+      return false;
+   }
+   exact_struct.struct_def = struct_b;
+   if (static_value_satisfies_contract(exact_struct, exact_struct_contract)) {
+      Log.error("a mismatched structure identity satisfied an exact contract");
+      return false;
+   }
+
    struct ArrayMapping {
       std::string_view name;
       AET storage;
@@ -4030,8 +4084,8 @@ static bool test_tail_call_eligibility(kt::Log &Log)
    auto contracted = compile_snapshot(L, contract_source, true, error);
    if (not contracted or count_opcode_tree(*contracted, BC_CALLT) != 0 or
        count_opcode_tree(*contracted, BC_CALLMT) != 0 or count_opcode_tree(*contracted, BC_CALL) IS 0 or
-       count_opcode_tree(*contracted, BC_CONTRACT) IS 0) {
-      Log.error("a fixed explicit result contract was incorrectly tail lowered: %s", error.c_str());
+       count_opcode_tree(*contracted, BC_CONTRACT) != 0) {
+      Log.error("a proved fixed result changed truncating call lowering or retained a contract: %s", error.c_str());
       return false;
    }
 
@@ -4482,6 +4536,72 @@ static bool test_type_guided_emission(kt::Log &Log)
       return false;
    }
 
+   constexpr std::string_view proved_contract_elision =
+      "extern struct\n"
+      "struct ContractElisionFields\n"
+      "   Integer:int\n"
+      "   Wide:int64\n"
+      "   Float:float\n"
+      "   Double:double\n"
+      "end\n"
+      "global glContractElisionValue = struct<ContractElisionFields> {\n"
+      "   integer=1, wide=2, float=3.5, double=4.5\n"
+      "}\n"
+      "local function accumulate():num\n"
+      "   local count = 0\n"
+      "   count += glContractElisionValue.integer + glContractElisionValue.wide +\n"
+      "      glContractElisionValue.float + glContractElisionValue.double\n"
+      "   return count\n"
+      "end\n"
+      "return accumulate\n";
+   snapshot = compile_snapshot(L, proved_contract_elision, true, error);
+   if (not snapshot or snapshot->children.empty()) {
+      Log.error("failed to compile proved contract-elision fixture: %s", error.c_str());
+      return false;
+   }
+   const BytecodeSnapshot &accumulate = snapshot->children.front();
+   if (count_opcode(accumulate, BC_STGETF) != 4 or count_opcode(accumulate, BC_CONTRACT) != 0) {
+      Log.error("proved structure arithmetic retained a redundant local or result contract: %s",
+         error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view fixed_return_elision =
+      "local function literal():num return 1 end\n"
+      "local function identifier():num local value = 1 return value end\n"
+      "local function pair():<num, str> return 1, 'two', false end\n"
+      "return literal, identifier, pair\n";
+   snapshot = compile_snapshot(L, fixed_return_elision, true, error);
+   if (not snapshot or count_opcode_tree(*snapshot, BC_CONTRACT) != 0) {
+      Log.error("proved fixed returns retained a redundant result contract: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view retained_return_contract =
+      "local function source(Value:any):any return Value end\n"
+      "local function dynamic(Value:any):num return source(Value) end\n"
+      "return dynamic\n";
+   snapshot = compile_snapshot(L, retained_return_contract, true, error);
+   if (not snapshot or snapshot->children.size() < 2 or
+       count_opcode_tree(*snapshot, BC_CONTRACT) IS 0) {
+      Log.error("an advisory fixed return incorrectly lost its result contract: %s", error.c_str());
+      return false;
+   }
+
+   constexpr std::string_view retained_arithmetic_contract =
+      "local function update(Value:any):num\n"
+      "   local result = 1\n"
+      "   result += Value\n"
+      "   return result\n"
+      "end\n"
+      "return update\n";
+   snapshot = compile_snapshot(L, retained_arithmetic_contract, true, error);
+   if (not snapshot or snapshot->children.empty() or
+       count_opcode(snapshot->children.front(), BC_CONTRACT) != 1) {
+      Log.error("dynamic compound arithmetic did not retain exactly its sticky-store contract: %s", error.c_str());
+      return false;
+   }
+
    constexpr std::string_view member_inference =
       "extern struct\n"
       "struct DescriptorMember Value: int end\n"
@@ -4503,8 +4623,9 @@ static bool test_type_guided_emission(kt::Log &Log)
       "local callable = {}\n"
       "return accept(callable)\n";
    snapshot = compile_snapshot(L, callable_table, true, error);
-   if (not snapshot or count_opcode_tree(*snapshot, BC_CONTRACT) < 2) {
-      Log.error("callable-table compatibility bypassed runtime func contracts: %s", error.c_str());
+   if (not snapshot or count_opcode_tree(*snapshot, BC_CONTRACT) != 1) {
+      Log.error("callable-table compatibility lost its parameter contract or retained a proved result contract: %s",
+         error.c_str());
       return false;
    }
    return true;

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1233,11 +1233,33 @@ private:
                value = join_static_descriptors(
                   this->descriptor_of(*payload.left), this->descriptor_of(*payload.right));
             }
+            else if ((payload.op IS AstBinaryOperator::Add or payload.op IS AstBinaryOperator::Subtract or
+                      payload.op IS AstBinaryOperator::Multiply or payload.op IS AstBinaryOperator::Divide or
+                      payload.op IS AstBinaryOperator::Modulo or payload.op IS AstBinaryOperator::Power) and
+                     payload.left and payload.right) {
+               value = describe_arithmetic_result(
+                  this->descriptor_of(*payload.left), this->descriptor_of(*payload.right));
+            }
             else {
                TiriType inferred = infer_expression_type(Expression);
                if (inferred != TiriType::Unknown) {
                   value.primary = inferred;
                   value.proof = StaticProof::Advisory;
+               }
+            }
+            break;
+         }
+         case AstNodeKind::UnaryExpr: {
+            auto &payload = std::get<UnaryExprPayload>(Expression.data);
+            if (payload.op IS AstUnaryOperator::Negate and payload.operand) {
+               value = describe_unary_numeric_result(this->descriptor_of(*payload.operand));
+            }
+            else {
+               TiriType inferred = infer_expression_type(Expression);
+               if (inferred != TiriType::Unknown) {
+                  value.primary = inferred;
+                  value.proof = payload.op IS AstUnaryOperator::Not ?
+                     StaticProof::Closed : StaticProof::Advisory;
                }
             }
             break;

--- a/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
+++ b/src/tiri/jit/src/parser/static_descriptor_analysis.cpp
@@ -1345,6 +1345,35 @@ private:
       binding.callable = 0;
       reference.identifier.static_value = binding.value;
       Target.static_value = binding.value;
+
+      lj_assertX(Assigned.proved() or not this->catalogue_.value(binding.value).proved(),
+         "an advisory assignment retained a proved binding descriptor");
+   }
+
+   [[nodiscard]] StaticValueDescriptor compound_assignment_descriptor(
+      AssignmentOperator Operator, const ExprNode &Target, const ExprNode &Value) const
+   {
+      StaticValueDescriptor current = this->descriptor_of(Target);
+      StaticValueDescriptor operand = this->descriptor_of(Value);
+      switch (Operator) {
+         case AssignmentOperator::Add:
+         case AssignmentOperator::Subtract:
+         case AssignmentOperator::Multiply:
+         case AssignmentOperator::Divide:
+         case AssignmentOperator::Modulo:
+            return describe_arithmetic_result(current, operand);
+
+         case AssignmentOperator::Concat:
+            if (current.primary IS TiriType::Array and current.proved() and not current.nullable) return current;
+            return StaticValueDescriptor{
+               .primary = current.primary,
+               .proof = StaticProof::Advisory,
+               .nullable = current.nullable or operand.nullable
+            };
+
+         default:
+            return {};
+      }
    }
 
    void propagate_function(
@@ -1480,22 +1509,19 @@ private:
             auto &payload = std::get<AssignmentStmtPayload>(Statement.data);
             for (auto &value : payload.values) if (value) this->propagate_expression(*value);
             for (auto &target : payload.targets) if (target) this->propagate_expression(*target);
-            if (payload.op IS AssignmentOperator::Plain or
-                payload.op IS AssignmentOperator::IfEmpty or payload.op IS AssignmentOperator::IfNil) {
+            if (payload.op IS AssignmentOperator::Plain or payload.op IS AssignmentOperator::IfEmpty or
+                payload.op IS AssignmentOperator::IfNil) {
                for (size_t i = 0; i < payload.targets.size(); ++i) {
                   if (not payload.targets[i] or payload.values.empty()) continue;
                   size_t source = std::min(i, payload.values.size() - 1);
-                  bool update = payload.op IS AssignmentOperator::Plain;
                   bool initialises_binding = false;
                   if (payload.targets[i]->kind IS AstNodeKind::IdentifierExpr) {
                      const auto &reference = std::get<NameRef>(payload.targets[i]->data);
                      if (reference.binding_id) {
                         const auto &binding = this->catalogue_.binding(reference.binding_id);
                         initialises_binding = binding.initialiser IS payload.values[source].get();
-                        if (not update) update = initialises_binding;
                      }
                   }
-                  if (not update) continue;
                   StaticValueDescriptor assigned;
                   if (source IS payload.values.size() - 1 and i >= payload.values.size() and
                       payload.values[source]->static_results) {
@@ -1513,6 +1539,16 @@ private:
                      payload.targets[i]->static_value = binding.value;
                   }
                   else this->update_assigned_binding(*payload.targets[i], assigned);
+               }
+            }
+            else if (payload.op IS AssignmentOperator::Add or payload.op IS AssignmentOperator::Subtract or
+                     payload.op IS AssignmentOperator::Multiply or payload.op IS AssignmentOperator::Divide or
+                     payload.op IS AssignmentOperator::Modulo or payload.op IS AssignmentOperator::Concat) {
+               if (payload.targets.size() IS 1 and payload.values.size() IS 1 and
+                   payload.targets.front() and payload.values.front()) {
+                  StaticValueDescriptor assigned = this->compound_assignment_descriptor(
+                     payload.op, *payload.targets.front(), *payload.values.front());
+                  this->update_assigned_binding(*payload.targets.front(), assigned);
                }
             }
             break;

--- a/src/tiri/jit/src/parser/static_type_descriptor.cpp
+++ b/src/tiri/jit/src/parser/static_type_descriptor.cpp
@@ -8,6 +8,7 @@
 #include <kotuku/objects.h>
 
 #include "ast/nodes.h"
+#include "parse_types.h"
 #include "../runtime/lj_struct.h"
 
 bool StaticValueDescriptor::constrained() const noexcept
@@ -163,6 +164,58 @@ StaticValueDescriptor join_static_descriptors(
    if (Left.module != Right.module) result.module = nullptr;
    if (not (Left.array_element IS Right.array_element)) result.array_element = {};
    return result;
+}
+
+StaticValueDescriptor describe_arithmetic_result(
+   const StaticValueDescriptor &Left, const StaticValueDescriptor &Right)
+{
+   StaticValueDescriptor result;
+   if (Left.primary IS TiriType::Num and Right.primary IS TiriType::Num and Left.proved() and Right.proved() and
+       not Left.nullable and not Right.nullable) {
+      result.primary = TiriType::Num;
+      result.proof = StaticProof::Closed;
+   }
+   else {
+      result.primary = TiriType::Num;
+      result.proof = StaticProof::Advisory;
+      result.nullable = Left.nullable or Right.nullable;
+   }
+   return result;
+}
+
+StaticValueDescriptor describe_unary_numeric_result(const StaticValueDescriptor &Operand)
+{
+   StaticValueDescriptor result;
+   result.primary = TiriType::Num;
+   if (Operand.primary IS TiriType::Num and Operand.proved() and not Operand.nullable) {
+      result.proof = StaticProof::Closed;
+   }
+   else {
+      result.proof = StaticProof::Advisory;
+      result.nullable = Operand.nullable;
+   }
+   return result;
+}
+
+bool static_value_satisfies_contract(
+   const StaticValueDescriptor &Value, const RuntimeContract &Contract)
+{
+   if (Contract.type IS TiriType::Unknown or Contract.type IS TiriType::Any) return true;
+   if (not Value.proved()) return false;
+
+   if (Value.primary IS TiriType::Nil) return Contract.nullable and not Contract.required;
+   if (Value.nullable and (Contract.required or not Contract.nullable)) return false;
+   if (Value.primary != Contract.type) return false;
+
+   switch (Contract.type) {
+      case TiriType::Object:
+         return Contract.object_class_id IS CLASSID::NIL or
+            Value.object_class_id IS Contract.object_class_id;
+      case TiriType::Struct:
+         return not Contract.struct_def or Value.struct_def IS Contract.struct_def;
+      default:
+         return true;
+   }
 }
 
 StaticResultSet map_static_result_filter(

--- a/src/tiri/jit/src/parser/static_type_descriptor.h
+++ b/src/tiri/jit/src/parser/static_type_descriptor.h
@@ -17,6 +17,7 @@ struct FunctionField;
 struct FunctionExprPayload;
 struct struct_field;
 struct struct_record;
+struct RuntimeContract;
 
 using StaticValueHandle = uint32_t;
 using StaticResultSetHandle = uint32_t;
@@ -125,6 +126,11 @@ private:
 
 [[nodiscard]] StaticValueDescriptor join_static_descriptors(
    const StaticValueDescriptor &, const StaticValueDescriptor &);
+[[nodiscard]] StaticValueDescriptor describe_arithmetic_result(
+   const StaticValueDescriptor &, const StaticValueDescriptor &);
+[[nodiscard]] StaticValueDescriptor describe_unary_numeric_result(const StaticValueDescriptor &);
+[[nodiscard]] bool static_value_satisfies_contract(
+   const StaticValueDescriptor &, const RuntimeContract &);
 [[nodiscard]] StaticResultSet map_static_result_filter(
    const StaticResultSet &, uint64_t KeepMask, uint8_t ExplicitCount, bool TrailingKeep);
 enum class ObjectCallMemberKind : uint8_t {

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -630,6 +630,30 @@ end
    assert(value is 1, 'A rejected overloaded compound result must preserve the sticky local')
 end
 
+@Test function VariantMutationInvalidatesStaticProof()
+   local overloaded:any = setmetatable({}, {
+      __add = function(Left, Right):str return 'wrong' end
+   })
+
+   local compound_source:any = 1
+   compound_source += overloaded
+   local compound_target = 0
+   expect_contract_failure(function() compound_target = compound_source end, 'variant compound result')
+   assert(compound_target is 0, 'A rejected variant compound result must preserve the sticky destination')
+
+   local empty_source:any = 0
+   empty_source ??= 'wrong'
+   local empty_target = 0
+   expect_contract_failure(function() empty_target = empty_source end, 'variant if-empty result')
+   assert(empty_target is 0, 'A rejected variant if-empty result must preserve the sticky destination')
+
+   local nil_source:any = nil
+   nil_source ?= 'wrong'
+   local nil_target = 0
+   expect_contract_failure(function() nil_target = nil_source end, 'variant if-nil result')
+   assert(nil_target is 0, 'A rejected variant if-nil result must preserve the sticky destination')
+end
+
 @Test function ObjectClassLocalAndUpvalueContracts()
    local value = obj.new('time')
    value = dynamic_value(obj.new('time'))

--- a/src/tiri/tests/test_type_contracts.tiri
+++ b/src/tiri/tests/test_type_contracts.tiri
@@ -603,6 +603,33 @@ end
    assert(captured is 2, 'A rejected upvalue store must preserve the previous value')
 end
 
+@Test function ProvedNumericStoreAndResultContracts()
+   function accumulate():num
+      local value = 1
+      for i in {0 to 200} do
+         value += i + 1
+      end
+      return value
+   end
+
+   jit.off()
+   assert(accumulate() is 20101, 'Proved numeric stores and results should remain correct in the interpreter')
+
+   jit.on()
+   jit.flush()
+   jit.opt.start('hotloop=1', 'hotexit=1', 'minstitch=0')
+   for i in {0 to 20} do
+      assert(accumulate() is 20101, 'Proved numeric stores and results should remain correct on compiled traces')
+   end
+
+   local value = 1
+   local overloaded:any = setmetatable({}, {
+      __add = function(Left, Right):str return 'wrong' end
+   })
+   expect_contract_failure(function() value += overloaded end, 'overloaded compound assignment')
+   assert(value is 1, 'A rejected overloaded compound result must preserve the sticky local')
+end
+
 @Test function ObjectClassLocalAndUpvalueContracts()
    local value = obj.new('time')
    value = dynamic_value(obj.new('time'))

--- a/tools/benchmark/benchmark_struct.tiri
+++ b/tools/benchmark/benchmark_struct.tiri
@@ -10,7 +10,7 @@ end
 struct BenchmarkNarrowStruct
    Word:int
    Byte:int8
-   UnsignedWord:uint
+   UnsignedWord:uint16
    UnsignedByte:uint8
 end
 


### PR DESCRIPTION
* Centralised static contract satisfaction across local, upvalue and fixed-result boundaries
* Derived sound numeric operation descriptors while retaining checks for dynamic and overloaded paths
* Added parser and Flute coverage for bytecode shape, atomic failures and interpreter/JIT parity